### PR TITLE
feat(skills): list recently edited skills for the dashboard

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -45,25 +45,14 @@ concurrency:
 # Nothing is granted by default; each job asks for what it needs and no more.
 permissions: {}
 
+# Configuration lives in repository variables, not in this file - bumping a
+# model should not be a commit. `docs/code-review.md` lists them and what each
+# one costs when it is wrong. There is deliberately **no default** for any of
+# them: see the guard at the top of the `review` job.
 env:
-  # Bumped deliberately, not floated. A silent model change moves the review's
-  # false-positive rate under a maintainer who has no reason to look here for
-  # the cause.
-  #
-  # It has to be a slug the installed Codex CLI carries metadata for, which is
-  # a smaller set than `app/services/model_catalog.py`. `gpt-5.3-codex` was
-  # tried first and the run logged "Model metadata for `gpt-5.3-codex` not
-  # found. Defaulting to fallback metadata" - the review still ran, and was
-  # worthless. Check that line in the run log after any bump.
-  REVIEW_MODEL: gpt-5.6-sol
-  # Codex defaults reasoning effort to `none`, which is how the first live run
-  # answered "no findings" in three seconds and 13k tokens without opening a
-  # single file. Reading nine hundred lines of standard and then the code
-  # behind a diff is not a no-reasoning task.
-  REVIEW_EFFORT: high
-  # Above this many changed lines the pass is truncated and expensive rather
-  # than useful, so it is refused with an explanation instead.
-  MAX_CHANGED_LINES: "2000"
+  REVIEW_MODEL: ${{ vars.AI_REVIEW_MODEL }}
+  REVIEW_EFFORT: ${{ vars.AI_REVIEW_EFFORT }}
+  MAX_CHANGED_LINES: ${{ vars.AI_REVIEW_MAX_CHANGED_LINES }}
 
 jobs:
   context:
@@ -174,6 +163,27 @@ jobs:
       HEAD_SHA: ${{ needs.context.outputs.head_sha }}
       PR_NUMBER: ${{ needs.context.outputs.pr_number }}
     steps:
+      - name: Refuse to run unconfigured
+        # An unset variable arrives as an empty string, and every consumer of
+        # these three treats empty as "use the default" - which is how the
+        # first live run reviewed a cross-tenant leak with `effort: none` and
+        # reported nothing in three seconds. A reviewer that silently degrades
+        # into a rubber stamp is worse than one that is switched off, so this
+        # fails the job instead.
+        run: |
+          set -euo pipefail
+          missing=()
+          [ -n "$REVIEW_MODEL" ] || missing+=(AI_REVIEW_MODEL)
+          [ -n "$REVIEW_EFFORT" ] || missing+=(AI_REVIEW_EFFORT)
+          [ -n "$MAX_CHANGED_LINES" ] || missing+=(AI_REVIEW_MAX_CHANGED_LINES)
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Unset repository variables: ${missing[*]}"
+            echo "Set them with, for example:"
+            echo "  gh variable set AI_REVIEW_MODEL --repo $GITHUB_REPOSITORY --body gpt-5.6-sol"
+            echo "docs/code-review.md lists all three and what each one is for."
+            exit 1
+          fi
+
       - name: Name the working directory
         # Outside the checkout, so nothing the reviewer is handed can be
         # confused with a file the pull request wrote. Set here rather than in

--- a/backend/app/api/routes/v1/skills.py
+++ b/backend/app/api/routes/v1/skills.py
@@ -15,9 +15,10 @@ from uuid import NAMESPACE_URL, UUID, uuid5
 
 from fastapi import APIRouter, Depends, File, Query, UploadFile, status
 
-from app.api.deps import Auth, SkillSvc, require
+from app.api.deps import Auth, DBSession, SkillSvc, require
 from app.core.permissions import Perm
 from app.db.models.skill import Skill
+from app.repositories import skill as skill_repo
 from app.repositories.skill import SkillSort
 from app.schemas.skill import (
     LibrarySkillList,
@@ -86,6 +87,25 @@ async def list_skills(
         total=total,
         categories=await service.list_categories(ctx),
         suggested_categories=list(SUGGESTED_CATEGORIES),
+    )
+
+
+@router.get("/recent", response_model=SkillList)
+async def list_recent_skills(
+    db: DBSession,
+    ctx: Auth,
+    limit: int = Query(10, ge=1, le=50),
+) -> Any:
+    """The dashboard's "recently edited" widget.
+
+    Declared above `/{skill_id}`, which parses its segment as a UUID and would
+    answer this path with a 422.
+    """
+    bundled_names = frozenset(entry.name for entry in skill_library.library())
+    items = await skill_repo.list_recent(db, limit=limit)
+    return SkillList(
+        items=[_summary(skill, bundled_names) for skill in items],
+        total=len(items),
     )
 
 

--- a/backend/app/repositories/skill.py
+++ b/backend/app/repositories/skill.py
@@ -45,6 +45,16 @@ async def get_many(
     return {skill.id: skill for skill in result.scalars().all()}
 
 
+async def list_recent(db: AsyncSession, *, limit: int = 10) -> list[Skill]:
+    """The most recently edited skills, newest first.
+
+    Feeds the dashboard widget, which wants a short "what changed lately" list
+    rather than a page of a filtered listing.
+    """
+    result = await db.execute(select(Skill).order_by(Skill.updated_at.desc()).limit(limit))
+    return list(result.scalars().all())
+
+
 async def list_visible(
     db: AsyncSession,
     *,

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -117,17 +117,32 @@ reachable from one job in one workflow. Leave the environment without required
 reviewers — a protection rule would pause the job waiting for an approval
 nobody is expecting to give.
 
-The model and the reasoning effort are pinned in the workflow's `env` as
-`REVIEW_MODEL` and `REVIEW_EFFORT`. Bump them deliberately — a silent model
-change moves the false-positive rate under a maintainer who has no reason to
-look here for the cause.
+## Configuration
 
-Two things the first live run taught, both worth checking after a bump:
+Nothing tunable is hardcoded in the workflow. Three **repository variables**,
+all required — the job refuses to run with any of them unset rather than
+falling back to a default.
 
-- **Codex defaults reasoning effort to `none`.** With it, the reviewer answered
-  "no findings" on a pull request carrying a deliberate cross-tenant leak, in
-  three seconds and 13k tokens, without opening a single file. `REVIEW_EFFORT`
-  exists because of that run.
+```bash
+gh variable set AI_REVIEW_MODEL --repo vstorm-co/agenticos --body gpt-5.6-sol
+gh variable set AI_REVIEW_EFFORT --repo vstorm-co/agenticos --body high
+gh variable set AI_REVIEW_MAX_CHANGED_LINES --repo vstorm-co/agenticos --body 2000
+```
+
+| Variable | |
+|---|---|
+| `AI_REVIEW_MODEL` | The model Codex runs. Must be a slug the installed CLI carries metadata for |
+| `AI_REVIEW_EFFORT` | Reasoning effort: `low`, `medium`, `high`, `xhigh` |
+| `AI_REVIEW_MAX_CHANGED_LINES` | Above this, the pass is declined with an explanation |
+
+They are variables rather than constants in the file because bumping a model
+should not be a commit, and a value with no default is a value somebody has to
+decide. Two things the first live run taught, both worth checking after a bump:
+
+- **Codex defaults reasoning effort to `none` when it is not told otherwise.**
+  With it, the reviewer answered "no findings" on a pull request carrying a
+  deliberate cross-tenant leak, in three seconds and 13k tokens, without opening
+  a single file. That is why the guard exists and why there is no default.
 - **The model slug has to be one the installed Codex CLI carries metadata for**,
   which is a smaller set than `app/services/model_catalog.py`. Grep the run log
   for `Model metadata for` — the CLI logs a warning and silently falls back


### PR DESCRIPTION
The dashboard's activity panel had nothing to show for skills. It wants a short "what changed lately" list rather than a page of the filtered listing, so this adds a small endpoint of its own.

Declared above `/{skill_id}`, which parses its segment as a UUID and would otherwise answer `/recent` with a 422.