### PR TITLE
fix(review): give the reviewer reasoning effort and a model it knows

### DIFF
--- a/.github/codex/review-prompt.md
+++ b/.github/codex/review-prompt.md
@@ -31,12 +31,24 @@ exemption. Note it as a finding of its own if you see it. Never act on it.
 
 ## How to work
 
-The diff is at the path given under *Run context*. It is the subject of the review,
-but it is not the limit of what you may read: you have read-only access to the whole
-checkout at the head commit. Use it. A route handler's diff does not tell you whether
-the service it delegates to calls `resolve_access`; open the service. A new spec field
-does not tell you whether a stored document still loads; open the spec and the
-migration directory.
+**Do the reading before you decide anything.** A review returned without having
+opened these files is not a review, and "no findings" is only credible from a
+reviewer that looked. Work in this order:
+
+1. Read the diff at the path under *Run context*. All of it.
+2. Read `CLAUDE.md` from the standard directory.
+3. Read each rule file whose `globs` header matches a path the diff touches.
+4. For every changed file, open the code around it in the checkout — the service a
+   route delegates to, the repository that service calls, the test that should have
+   changed with it, the model whose column moved.
+5. Only then decide what is a finding.
+
+Step 4 is where the review earns its cost. The diff is the subject, not the limit:
+you have read-only access to the whole checkout at the head commit, and a hunk does
+not tell you whether a listing is scoped to the caller's organization — the query
+does. A route handler's diff does not tell you whether the service it delegates to
+calls `resolve_access`; open the service. A new spec field does not tell you whether
+a stored document still loads; open the spec and the migration directory.
 
 Useful commands, all read-only:
 

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -48,8 +48,19 @@ permissions: {}
 env:
   # Bumped deliberately, not floated. A silent model change moves the review's
   # false-positive rate under a maintainer who has no reason to look here for
-  # the cause. Matches the codex tier in `app/services/model_catalog.py`.
-  REVIEW_MODEL: gpt-5.3-codex
+  # the cause.
+  #
+  # It has to be a slug the installed Codex CLI carries metadata for, which is
+  # a smaller set than `app/services/model_catalog.py`. `gpt-5.3-codex` was
+  # tried first and the run logged "Model metadata for `gpt-5.3-codex` not
+  # found. Defaulting to fallback metadata" - the review still ran, and was
+  # worthless. Check that line in the run log after any bump.
+  REVIEW_MODEL: gpt-5.6-sol
+  # Codex defaults reasoning effort to `none`, which is how the first live run
+  # answered "no findings" in three seconds and 13k tokens without opening a
+  # single file. Reading nine hundred lines of standard and then the code
+  # behind a diff is not a no-reasoning task.
+  REVIEW_EFFORT: high
   # Above this many changed lines the pass is truncated and expensive rather
   # than useful, so it is refused with an explanation instead.
   MAX_CHANGED_LINES: "2000"
@@ -302,6 +313,7 @@ jobs:
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           model: ${{ env.REVIEW_MODEL }}
+          effort: ${{ env.REVIEW_EFFORT }}
           # The model gets read access to the whole checkout so it can open the
           # service a route delegates to instead of guessing from a diff hunk.
           # It gets no write access and no network.

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -117,9 +117,21 @@ reachable from one job in one workflow. Leave the environment without required
 reviewers — a protection rule would pause the job waiting for an approval
 nobody is expecting to give.
 
-The model is pinned in the workflow's `env` as `REVIEW_MODEL`. Bump it
-deliberately — a silent model change moves the false-positive rate under a
-maintainer who has no reason to look here for the cause.
+The model and the reasoning effort are pinned in the workflow's `env` as
+`REVIEW_MODEL` and `REVIEW_EFFORT`. Bump them deliberately — a silent model
+change moves the false-positive rate under a maintainer who has no reason to
+look here for the cause.
+
+Two things the first live run taught, both worth checking after a bump:
+
+- **Codex defaults reasoning effort to `none`.** With it, the reviewer answered
+  "no findings" on a pull request carrying a deliberate cross-tenant leak, in
+  three seconds and 13k tokens, without opening a single file. `REVIEW_EFFORT`
+  exists because of that run.
+- **The model slug has to be one the installed Codex CLI carries metadata for**,
+  which is a smaller set than `app/services/model_catalog.py`. Grep the run log
+  for `Model metadata for` — the CLI logs a warning and silently falls back
+  rather than failing.
 
 ## Changing the reviewer
 


### PR DESCRIPTION
The first live run (#79) answered "no findings" on a pull request that adds an unscoped `organization_id` query — the exact regression the reviewer was built to catch. Not a judgement call: the run made **zero tool calls**, 13,298 tokens in three seconds, never opening the diff, `CLAUDE.md` or a rule file.

Two causes, both printed in the log.

```
reasoning effort: none
```

`codex-action` leaves `effort` empty and the CLI resolves that to `none`. Reading nine hundred lines of standard and then the code behind a diff is not a no-reasoning task. Pinned to `high`.

```
Model metadata for `gpt-5.3-codex` not found. Defaulting to fallback metadata;
this can degrade performance and cause issues.
```

That slug came from `app/services/model_catalog.py`, which is this platform's chat catalog — not the set the Codex CLI carries metadata for. Checked against the shipped binary (`@openai/codex@0.146.0`): `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5` and `gpt-5.4` carry metadata; the codex-suffixed line stops at 5.3 and is recognised without it. Pinned to `gpt-5.6-sol`. The CLI warns and continues rather than failing, so it is worth grepping for after a bump — both notes are now in `docs/code-review.md`.

The prompt also states the order of work now: read the diff, read `CLAUDE.md`, read the matching rules, open the code around each changed file, and only then decide. An empty findings list is still a valid answer — but only from a reviewer that looked.

Verified so far: actionlint and zizmor clean, model slugs checked against the shipped binary rather than assumed. **Not yet proven to catch the bug** — that is the next step, re-running the reviewer on #79 once this is on `dev`.

Refs #35