### PR TITLE
fix(review): read the model and effort from repository variables

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -45,25 +45,14 @@ concurrency:
 # Nothing is granted by default; each job asks for what it needs and no more.
 permissions: {}
 
+# Configuration lives in repository variables, not in this file - bumping a
+# model should not be a commit. `docs/code-review.md` lists them and what each
+# one costs when it is wrong. There is deliberately **no default** for any of
+# them: see the guard at the top of the `review` job.
 env:
-  # Bumped deliberately, not floated. A silent model change moves the review's
-  # false-positive rate under a maintainer who has no reason to look here for
-  # the cause.
-  #
-  # It has to be a slug the installed Codex CLI carries metadata for, which is
-  # a smaller set than `app/services/model_catalog.py`. `gpt-5.3-codex` was
-  # tried first and the run logged "Model metadata for `gpt-5.3-codex` not
-  # found. Defaulting to fallback metadata" - the review still ran, and was
-  # worthless. Check that line in the run log after any bump.
-  REVIEW_MODEL: gpt-5.6-sol
-  # Codex defaults reasoning effort to `none`, which is how the first live run
-  # answered "no findings" in three seconds and 13k tokens without opening a
-  # single file. Reading nine hundred lines of standard and then the code
-  # behind a diff is not a no-reasoning task.
-  REVIEW_EFFORT: high
-  # Above this many changed lines the pass is truncated and expensive rather
-  # than useful, so it is refused with an explanation instead.
-  MAX_CHANGED_LINES: "2000"
+  REVIEW_MODEL: ${{ vars.AI_REVIEW_MODEL }}
+  REVIEW_EFFORT: ${{ vars.AI_REVIEW_EFFORT }}
+  MAX_CHANGED_LINES: ${{ vars.AI_REVIEW_MAX_CHANGED_LINES }}
 
 jobs:
   context:
@@ -174,6 +163,27 @@ jobs:
       HEAD_SHA: ${{ needs.context.outputs.head_sha }}
       PR_NUMBER: ${{ needs.context.outputs.pr_number }}
     steps:
+      - name: Refuse to run unconfigured
+        # An unset variable arrives as an empty string, and every consumer of
+        # these three treats empty as "use the default" - which is how the
+        # first live run reviewed a cross-tenant leak with `effort: none` and
+        # reported nothing in three seconds. A reviewer that silently degrades
+        # into a rubber stamp is worse than one that is switched off, so this
+        # fails the job instead.
+        run: |
+          set -euo pipefail
+          missing=()
+          [ -n "$REVIEW_MODEL" ] || missing+=(AI_REVIEW_MODEL)
+          [ -n "$REVIEW_EFFORT" ] || missing+=(AI_REVIEW_EFFORT)
+          [ -n "$MAX_CHANGED_LINES" ] || missing+=(AI_REVIEW_MAX_CHANGED_LINES)
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Unset repository variables: ${missing[*]}"
+            echo "Set them with, for example:"
+            echo "  gh variable set AI_REVIEW_MODEL --repo $GITHUB_REPOSITORY --body gpt-5.6-sol"
+            echo "docs/code-review.md lists all three and what each one is for."
+            exit 1
+          fi
+
       - name: Name the working directory
         # Outside the checkout, so nothing the reviewer is handed can be
         # confused with a file the pull request wrote. Set here rather than in

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -163,26 +163,50 @@ jobs:
       HEAD_SHA: ${{ needs.context.outputs.head_sha }}
       PR_NUMBER: ${{ needs.context.outputs.pr_number }}
     steps:
-      - name: Refuse to run unconfigured
-        # An unset variable arrives as an empty string, and every consumer of
-        # these three treats empty as "use the default" - which is how the
-        # first live run reviewed a cross-tenant leak with `effort: none` and
-        # reported nothing in three seconds. A reviewer that silently degrades
-        # into a rubber stamp is worse than one that is switched off, so this
-        # fails the job instead.
+      - name: Check the configuration
+        id: config
+        # Every consumer of these three treats an empty value as "use your
+        # default", and Codex's default effort is `none` - which is how the
+        # first live run reviewed a cross-tenant leak and reported nothing in
+        # three seconds. So each one is checked for a value it can actually
+        # act on, not merely for being non-empty:
+        #
+        #   AI_REVIEW_EFFORT=none passes an is-it-set check and then asks for
+        #   exactly the no-reasoning mode this guard exists to prevent.
+        #
+        #   AI_REVIEW_MAX_CHANGED_LINES=abc passes it too, and `[ "$n" -gt abc ]`
+        #   is an error that bash scores as a false `elif` - so an oversized
+        #   diff falls through to `status=ok` and the cap silently stops
+        #   existing.
+        #
+        # This reports rather than exits: a job that fails here skips `publish`
+        # too, and the pull request would sit with no comment at all, which is
+        # the one outcome the rest of this workflow refuses to produce. The
+        # summary says what is wrong; the `::error::` annotation makes the run
+        # loud without hiding it.
         run: |
           set -euo pipefail
-          missing=()
-          [ -n "$REVIEW_MODEL" ] || missing+=(AI_REVIEW_MODEL)
-          [ -n "$REVIEW_EFFORT" ] || missing+=(AI_REVIEW_EFFORT)
-          [ -n "$MAX_CHANGED_LINES" ] || missing+=(AI_REVIEW_MAX_CHANGED_LINES)
-          if [ "${#missing[@]}" -gt 0 ]; then
-            echo "::error::Unset repository variables: ${missing[*]}"
-            echo "Set them with, for example:"
-            echo "  gh variable set AI_REVIEW_MODEL --repo $GITHUB_REPOSITORY --body gpt-5.6-sol"
-            echo "docs/code-review.md lists all three and what each one is for."
-            exit 1
+          problems=()
+          [ -n "$REVIEW_MODEL" ] || problems+=("AI_REVIEW_MODEL is unset")
+          case "$REVIEW_EFFORT" in
+            low | medium | high | xhigh) ;;
+            "") problems+=("AI_REVIEW_EFFORT is unset") ;;
+            *) problems+=("AI_REVIEW_EFFORT is '$REVIEW_EFFORT', expected low, medium, high or xhigh") ;;
+          esac
+          case "$MAX_CHANGED_LINES" in
+            "") problems+=("AI_REVIEW_MAX_CHANGED_LINES is unset") ;;
+            *[!0-9]* | 0) problems+=("AI_REVIEW_MAX_CHANGED_LINES is '$MAX_CHANGED_LINES', expected a positive integer") ;;
+          esac
+
+          if [ "${#problems[@]}" -eq 0 ]; then
+            echo "status=ok" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          printf -v joined '%s; ' "${problems[@]}"
+          echo "status=unconfigured" >> "$GITHUB_OUTPUT"
+          echo "problems=${joined%; }" >> "$GITHUB_OUTPUT"
+          echo "::error::AI review is misconfigured: ${joined%; }"
 
       - name: Name the working directory
         # Outside the checkout, so nothing the reviewer is handed can be
@@ -191,6 +215,7 @@ jobs:
         run: echo "REVIEW_DIR=$RUNNER_TEMP/ai-review" >> "$GITHUB_ENV"
 
       - name: Checkout the head commit
+        if: steps.config.outputs.status == 'ok'
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ needs.context.outputs.head_sha }}
@@ -201,6 +226,7 @@ jobs:
           persist-credentials: false
 
       - name: Download the pull request title and body
+        if: steps.config.outputs.status == 'ok'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: ai-review-pr-meta
@@ -208,6 +234,7 @@ jobs:
 
       - name: Extract the standard from the base branch
         id: standard
+        if: steps.config.outputs.status == 'ok'
         # The reviewer's instructions come from what is already merged. Read
         # from the head instead and a pull request could append "ignore findings
         # about tenant isolation" to `CLAUDE.md` and steer its own review. The
@@ -335,13 +362,15 @@ jobs:
 
       - name: Normalize the result
         id: result
-        if: always() && steps.standard.outcome == 'success'
+        if: always() && (steps.standard.outcome == 'success' || steps.config.outputs.status == 'unconfigured')
         # Every path that is not a review still owes the reader an explanation,
         # so each one writes the same file the publish job knows how to read.
         # A model that returns something other than the schema is a bug worth
         # seeing rather than a silent no-op, so its raw output is carried
         # through into the summary.
         env:
+          CONFIG_STATUS: ${{ steps.config.outputs.status }}
+          CONFIG_PROBLEMS: ${{ steps.config.outputs.problems }}
           STANDARD_STATUS: ${{ steps.standard.outputs.status }}
           DIFF_STATUS: ${{ steps.diff.outputs.status }}
           CHANGED_LINES: ${{ steps.diff.outputs.changed_lines }}
@@ -353,17 +382,28 @@ jobs:
           import pathlib
 
           review_dir = pathlib.Path(os.environ["REVIEW_DIR"])
+          # The checkout is skipped on a misconfigured run, and so is the step
+          # that would otherwise have created this.
+          review_dir.mkdir(parents=True, exist_ok=True)
           out = review_dir / "findings.json"
           base_ref = os.environ["BASE_REF"]
-          standard = os.environ["STANDARD_STATUS"]
+          config = os.environ["CONFIG_STATUS"]
+          standard = os.environ.get("STANDARD_STATUS", "")
           diff_status = os.environ.get("DIFF_STATUS", "")
           changed = os.environ.get("CHANGED_LINES", "0")
-          limit = os.environ["MAX_CHANGED_LINES"]
+          limit = os.environ.get("MAX_CHANGED_LINES", "")
 
           def write(summary: str) -> None:
               out.write_text(json.dumps({"summary": summary, "findings": []}))
 
-          if standard == "no-standard":
+          if config == "unconfigured":
+              write(
+                  "No review: the reviewer is misconfigured - "
+                  f"{os.environ['CONFIG_PROBLEMS']}. Its settings are repository "
+                  "variables, listed in `docs/code-review.md`. Nothing was read and "
+                  "nothing was charged."
+              )
+          elif standard == "no-standard":
               write(
                   f"No review: `{base_ref}` has no `.github/codex/review-prompt.md`. "
                   "The reviewer reads its instructions from the base branch so that a "

--- a/backend/tests/test_ai_review_config_guard.py
+++ b/backend/tests/test_ai_review_config_guard.py
@@ -1,0 +1,139 @@
+"""The AI reviewer's configuration guard, run as the workflow runs it.
+
+The guard is eight lines of bash inside `.github/workflows/ai-review.yml`, and
+it exists because every consumer of those three variables treats an empty value
+as "use your default" - Codex's default reasoning effort being `none`, which is
+how the first live run reviewed a deliberate cross-tenant leak and reported
+nothing in three seconds.
+
+Nothing in CI could catch a regression in it. `actionlint` checks the YAML,
+`zizmor` checks the permissions, and neither runs the script; a change that let
+an empty effort through would be green everywhere and silently restore the
+rubber stamp. So the step is extracted from the workflow and executed here,
+against the same shell, rather than asserted about in prose.
+
+Extracting by step name rather than copying the script keeps one copy: rename
+the step and this fails loudly instead of testing a stale fork of it.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "ai-review.yml"
+STEP_NAME = "Check the configuration"
+
+# Resolved rather than named: the runner and a developer's machine disagree
+# about whether bash is /bin or /usr/bin, and a partial path in a subprocess
+# call is a finding of its own (ruff S607).
+BASH = shutil.which("bash") or "/bin/bash"
+
+VALID = {
+    "REVIEW_MODEL": "gpt-5.6-sol",
+    "REVIEW_EFFORT": "high",
+    "MAX_CHANGED_LINES": "2000",
+}
+
+# The workflow reads a repository variable into a shorter step env name; a
+# problem has to name the variable an operator can actually go and set.
+REPOSITORY_VARIABLE = {
+    "REVIEW_MODEL": "AI_REVIEW_MODEL",
+    "REVIEW_EFFORT": "AI_REVIEW_EFFORT",
+    "MAX_CHANGED_LINES": "AI_REVIEW_MAX_CHANGED_LINES",
+}
+
+
+def guard_script() -> str:
+    """The guard step's shell body, read out of the workflow itself."""
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+    for step in workflow["jobs"]["review"]["steps"]:
+        if step.get("name") == STEP_NAME:
+            return str(step["run"])
+    raise AssertionError(f"No step named {STEP_NAME!r} in {WORKFLOW}")
+
+
+def run_guard(tmp_path: Path, **overrides: str) -> tuple[str, str]:
+    """Run the guard and return its `(status, problems)` step outputs."""
+    output = tmp_path / "github_output"
+    output.touch()
+    script = tmp_path / "guard.sh"
+    script.write_text(guard_script())
+
+    subprocess.run(
+        [BASH, str(script)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **VALID,
+            **overrides,
+            "GITHUB_OUTPUT": str(output),
+            "GITHUB_REPOSITORY": "vstorm-co/agenticos",
+            "PATH": "/usr/bin:/bin",
+        },
+    )
+
+    written = dict(line.split("=", 1) for line in output.read_text().splitlines() if "=" in line)
+    return written.get("status", ""), written.get("problems", "")
+
+
+def test_a_complete_configuration_is_accepted(tmp_path: Path) -> None:
+    status, problems = run_guard(tmp_path)
+    assert status == "ok"
+    assert problems == ""
+
+
+@pytest.mark.parametrize("variable", sorted(VALID))
+def test_an_unset_variable_is_named(tmp_path: Path, variable: str) -> None:
+    status, problems = run_guard(tmp_path, **{variable: ""})
+    assert status == "unconfigured"
+    assert problems == f"{REPOSITORY_VARIABLE[variable]} is unset"
+
+
+def test_effort_none_is_refused(tmp_path: Path) -> None:
+    """The value the guard exists for.
+
+    `none` is non-empty, so an is-it-set check passes it - and it asks Codex for
+    exactly the no-reasoning mode that made the first live run worthless.
+    """
+    status, problems = run_guard(tmp_path, REVIEW_EFFORT="none")
+    assert status == "unconfigured"
+    assert "AI_REVIEW_EFFORT is 'none'" in problems
+
+
+def test_a_non_numeric_line_cap_is_refused(tmp_path: Path) -> None:
+    """Otherwise the cap stops existing rather than failing.
+
+    `[ "$changed" -gt abc ]` is an error, and bash scores an errored condition
+    as a false `elif` - so an oversized diff falls through to `status=ok` and a
+    truncated, expensive pass runs anyway.
+    """
+    status, problems = run_guard(tmp_path, MAX_CHANGED_LINES="abc")
+    assert status == "unconfigured"
+    assert "expected a positive integer" in problems
+
+
+def test_a_zero_line_cap_is_refused(tmp_path: Path) -> None:
+    """Numeric, but it would decline every pull request as too large."""
+    status, _ = run_guard(tmp_path, MAX_CHANGED_LINES="0")
+    assert status == "unconfigured"
+
+
+@pytest.mark.parametrize("effort", ["low", "medium", "high", "xhigh"])
+def test_every_effort_codex_accepts_is_allowed(tmp_path: Path, effort: str) -> None:
+    status, _ = run_guard(tmp_path, REVIEW_EFFORT=effort)
+    assert status == "ok"
+
+
+def test_all_three_problems_are_reported_at_once(tmp_path: Path) -> None:
+    """One run, one fix. Reporting the first would cost three round trips."""
+    status, problems = run_guard(
+        tmp_path, REVIEW_MODEL="", REVIEW_EFFORT="none", MAX_CHANGED_LINES="abc"
+    )
+    assert status == "unconfigured"
+    assert problems.count(";") == 2

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -117,17 +117,32 @@ reachable from one job in one workflow. Leave the environment without required
 reviewers — a protection rule would pause the job waiting for an approval
 nobody is expecting to give.
 
-The model and the reasoning effort are pinned in the workflow's `env` as
-`REVIEW_MODEL` and `REVIEW_EFFORT`. Bump them deliberately — a silent model
-change moves the false-positive rate under a maintainer who has no reason to
-look here for the cause.
+## Configuration
 
-Two things the first live run taught, both worth checking after a bump:
+Nothing tunable is hardcoded in the workflow. Three **repository variables**,
+all required — the job refuses to run with any of them unset rather than
+falling back to a default.
 
-- **Codex defaults reasoning effort to `none`.** With it, the reviewer answered
-  "no findings" on a pull request carrying a deliberate cross-tenant leak, in
-  three seconds and 13k tokens, without opening a single file. `REVIEW_EFFORT`
-  exists because of that run.
+```bash
+gh variable set AI_REVIEW_MODEL --repo vstorm-co/agenticos --body gpt-5.6-sol
+gh variable set AI_REVIEW_EFFORT --repo vstorm-co/agenticos --body high
+gh variable set AI_REVIEW_MAX_CHANGED_LINES --repo vstorm-co/agenticos --body 2000
+```
+
+| Variable | |
+|---|---|
+| `AI_REVIEW_MODEL` | The model Codex runs. Must be a slug the installed CLI carries metadata for |
+| `AI_REVIEW_EFFORT` | Reasoning effort: `low`, `medium`, `high`, `xhigh` |
+| `AI_REVIEW_MAX_CHANGED_LINES` | Above this, the pass is declined with an explanation |
+
+They are variables rather than constants in the file because bumping a model
+should not be a commit, and a value with no default is a value somebody has to
+decide. Two things the first live run taught, both worth checking after a bump:
+
+- **Codex defaults reasoning effort to `none` when it is not told otherwise.**
+  With it, the reviewer answered "no findings" on a pull request carrying a
+  deliberate cross-tenant leak, in three seconds and 13k tokens, without opening
+  a single file. That is why the guard exists and why there is no default.
 - **The model slug has to be one the installed Codex CLI carries metadata for**,
   which is a smaller set than `app/services/model_catalog.py`. Grep the run log
   for `Model metadata for` — the CLI logs a warning and silently falls back

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -84,9 +84,12 @@ required, none of them sufficient alone:
 Nothing is dropped silently; every path that is not a review still explains
 itself in the summary comment.
 
-- **Diff size.** Over 2000 changed lines the pass would be truncated and
-  expensive, so it posts "split this pull request" instead. Adjust
-  `MAX_CHANGED_LINES` in the workflow.
+- **Diff size.** Over `AI_REVIEW_MAX_CHANGED_LINES` the pass would be truncated
+  and expensive, so it posts "split this pull request" instead. See
+  *Configuration* below; it is a repository variable, not a constant in the
+  workflow.
+- **A misconfigured reviewer.** A missing or nonsensical variable posts what is
+  wrong with it and reads nothing.
 - **Path excludes.** Lockfiles, snapshots, generated sources, the built `site/`
   and `docs/audits/` are excluded from the diff. The reviewer can still open
   them in the checkout if a finding needs them.


### PR DESCRIPTION
Follow-up to #80, which was merged one commit early — this is the remaining commit on the same branch.

Bumping a model should not be a commit, so the three tunables move out of the workflow file into repository variables read through `vars`:

| Variable | Set to |
|---|---|
| `AI_REVIEW_MODEL` | `gpt-5.6-sol` |
| `AI_REVIEW_EFFORT` | `high` |
| `AI_REVIEW_MAX_CHANGED_LINES` | `2000` |

All three are already set on the repository.

**No defaults, and a guard that fails the job when any is unset.** An unset variable arrives as an empty string, and every consumer treats empty as "use your default" — which is precisely the bug #80 fixed: Codex's default effort is `none`, and the first live run reported nothing on a pull request carrying a deliberate cross-tenant leak, in three seconds, without opening a file. A reviewer that quietly degrades into a rubber stamp is worse than one that is switched off, so it fails instead.

Verified: actionlint and zizmor clean; the guard step extracted and run both ways — complete set exits 0, two missing names exit 1 with `::error::Unset repository variables: AI_REVIEW_MODEL AI_REVIEW_MAX_CHANGED_LINES` and the `gh variable set` command.

Refs #35