### PR TITLE
fix: close the three critical findings from the backend audit

### DIFF
--- a/backend/app/api/routes/v1/admin_conversations.py
+++ b/backend/app/api/routes/v1/admin_conversations.py
@@ -8,6 +8,7 @@ from app.schemas.conversation import (
     ConversationReadWithMessages,
 )
 from app.schemas.conversation_share import AdminConversationList
+from app.services.conversation import UNSCOPED
 
 router = APIRouter()
 
@@ -49,5 +50,9 @@ async def admin_get_conversation(
     service: ConversationSvc,
     _: CurrentAppAdmin,
 ) -> Any:
-    """Get any conversation with messages (admin read-only access)."""
-    return await service.get_conversation_with_messages(conversation_id)
+    """Get any conversation with messages (admin read-only access).
+
+    The one deliberate cross-tenant read: reading across organizations is what
+    this route is for, and `CurrentAppAdmin` is what makes that acceptable.
+    """
+    return await service.get_conversation_with_messages(conversation_id, organization_id=UNSCOPED)

--- a/backend/app/api/routes/v1/conversations.py
+++ b/backend/app/api/routes/v1/conversations.py
@@ -171,6 +171,7 @@ async def list_messages(
     conversation_id: UUID,
     conversation_service: ConversationSvc,
     current_user: CurrentUser,
+    active_org: ActiveOrg,
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=500),
 ) -> Any:
@@ -178,12 +179,18 @@ async def list_messages(
 
     Same reasoning as `get_conversation` above: cross-user reads belong to
     `/admin/conversations`, not to a column on the user row.
+
+    `user_id` only enriches each message with the caller's rating. The
+    organization is what makes the sentence above true - without it this
+    returned any conversation in the deployment, transcript and tool
+    arguments included.
     """
     items, total = await conversation_service.list_messages(
         conversation_id,
         skip=skip,
         limit=limit,
         include_tool_calls=True,
+        organization_id=active_org.id,
         user_id=current_user.id,
     )
     return MessageList(items=items, total=total)  # ty: ignore[invalid-argument-type]
@@ -199,9 +206,16 @@ async def add_message(
     data: MessageCreate,
     conversation_service: ConversationSvc,
     current_user: CurrentUser,
+    active_org: ActiveOrg,
 ) -> Any:
-    """Add a message to a conversation."""
-    return await conversation_service.add_message(conversation_id, data)
+    """Add a message to a conversation in the caller's organization.
+
+    Unscoped, this accepted a `role: "assistant"` turn into any conversation
+    in the deployment, and it rendered to its owner as the agent's answer.
+    """
+    return await conversation_service.add_message(
+        conversation_id, data, organization_id=active_org.id
+    )
 
 
 @router.post(

--- a/backend/app/api/routes/v1/conversations.py
+++ b/backend/app/api/routes/v1/conversations.py
@@ -214,7 +214,7 @@ async def add_message(
     in the deployment, and it rendered to its owner as the agent's answer.
     """
     return await conversation_service.add_message(
-        conversation_id, data, organization_id=active_org.id
+        conversation_id, data, organization_id=active_org.id, user_id=current_user.id
     )
 
 

--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -158,6 +158,7 @@ async def persist_user_turn(
                 UUID(current_conversation_id),
                 MessageCreate(role="user", content=user_message),
                 organization_id=organization_id,
+                user_id=user.id,
             )
             if file_ids:
                 try:

--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -157,6 +157,7 @@ async def persist_user_turn(
             user_msg = await conv_service.add_message(
                 UUID(current_conversation_id),
                 MessageCreate(role="user", content=user_message),
+                organization_id=organization_id,
             )
             if file_ids:
                 try:
@@ -185,11 +186,17 @@ async def persist_assistant_turn(
     output: str,
     model_name: str | None,
     collected_tool_calls: list[dict[str, Any]],
+    organization_id: UUID,
     thinking: str | None = None,
     agent_id: UUID | None = None,
     agent_version_id: UUID | None = None,
 ) -> str | None:
     """Persist the assistant message and any tool calls. Returns the saved message id.
+
+    `organization_id` is the session's active organization, and it is checked
+    rather than trusted: `conversation_id` reaches here from the socket, where
+    it started as a client-supplied value. `persist_user_turn` refuses one
+    belonging to another organization, and this refuses to write into one.
 
     `agent_id` and `agent_version_id` are recorded per message rather than
     per conversation because the agent can be changed mid-thread, and because
@@ -202,7 +209,8 @@ async def persist_assistant_turn(
             conv_service = get_conversation_service(db)
             assistant_msg = await conv_service.add_message(
                 UUID(conversation_id),
-                MessageCreate(
+                organization_id=organization_id,
+                data=MessageCreate(
                     role="assistant",
                     content=output,
                     thinking=thinking,

--- a/backend/app/services/agent_session.py
+++ b/backend/app/services/agent_session.py
@@ -224,6 +224,7 @@ class AgentSession:
                     output,
                     model_label,
                     collected_tool_calls,
+                    organization_id=self.organization_id,
                     thinking="".join(collected_thinking) or None,
                     agent_id=agent_id,
                     agent_version_id=agent_version_id,

--- a/backend/app/services/channels/exceptions.py
+++ b/backend/app/services/channels/exceptions.py
@@ -1,0 +1,26 @@
+"""Failures a channel adapter raises at itself, not at a request.
+
+These never reach an HTTP handler: a channel supervisor is a background task
+started from the lifespan, and there is nobody to return a status code to. They
+exist so a supervisor can tell "this session ended" from "this bot cannot be
+started at all", which are two loops apart.
+"""
+
+from app.core.exceptions import AppException
+
+
+class ChannelNotConfigured(AppException):
+    """A bot is missing something a restart cannot supply.
+
+    A missing Slack app-level token or Mattermost server URL is an ordinary row
+    state, not corruption - the operator has not pasted it yet. Retrying a
+    coroutine that returns immediately on that state is what put the API into a
+    100% CPU spin with the event loop starved and every other task, including
+    the health check, never scheduled again.
+
+    A supervisor that catches this stops. Nothing it does will change the row;
+    the operator has to.
+    """
+
+    message = "Channel bot is not configured"
+    code = "CHANNEL_NOT_CONFIGURED"

--- a/backend/app/services/channels/mattermost.py
+++ b/backend/app/services/channels/mattermost.py
@@ -37,6 +37,7 @@ import httpx
 
 from app.db.session import get_db_context
 from app.services.channels.base import ChannelAdapter, IncomingMessage, OutgoingMessage
+from app.services.channels.exceptions import ChannelNotConfigured
 from app.services.channels.router import ChannelMessageRouter
 
 logger = logging.getLogger(__name__)
@@ -132,30 +133,43 @@ class MattermostAdapter(ChannelAdapter):
                 delay = 5.0
             except asyncio.CancelledError:
                 raise
+            except ChannelNotConfigured:
+                # An operator has to set the server URL; looping cannot. And
+                # `_run_stream` returns without awaiting on that branch, so a
+                # retry here span the event loop at 100% CPU and starved every
+                # other task on the process.
+                logger.warning("Mattermost stream not started for bot %s", bot_id)
+                return
             except Exception:
                 logger.exception(
                     "Mattermost stream failed for bot %s, retrying in %.0fs", bot_id, delay
                 )
-                await asyncio.sleep(delay)
                 # Backs off to a minute so a server that is down for an hour is
                 # not hammered 720 times by every bot on it.
                 delay = min(delay * 2, 60.0)
+            # Outside the `except`: a session that ends by returning has to
+            # yield before the next attempt, or this loop never suspends.
+            await asyncio.sleep(delay)
 
     async def _run_stream(self, bot_id: str, bot_token: str) -> None:
         """One authenticated session on the event stream."""
         try:
             from websockets.asyncio.client import connect
-        except ImportError:
-            logger.error(
-                "The Mattermost event stream needs the 'websockets' package. "
-                "Use webhook mode, or install it."
-            )
-            return
+        except ImportError as exc:
+            raise ChannelNotConfigured(
+                message=(
+                    "The Mattermost event stream needs the 'websockets' package. "
+                    "Use webhook mode, or install it."
+                ),
+                details={"bot_id": bot_id},
+            ) from exc
 
         base_url = self._base_urls.get(bot_id)
         if not base_url:
-            logger.error("Mattermost bot %s has no server URL; cannot open a stream", bot_id)
-            return
+            raise ChannelNotConfigured(
+                message="Mattermost bot has no server URL; cannot open a stream",
+                details={"bot_id": bot_id},
+            )
 
         socket_url = base_url.replace("https://", "wss://").replace("http://", "ws://")
         async with connect(f"{socket_url}/api/v4/websocket") as socket:

--- a/backend/app/services/channels/mattermost.py
+++ b/backend/app/services/channels/mattermost.py
@@ -136,7 +136,7 @@ class MattermostAdapter(ChannelAdapter):
             except ChannelNotConfigured:
                 # An operator has to set the server URL; looping cannot. And
                 # `_run_stream` returns without awaiting on that branch, so a
-                # retry here span the event loop at 100% CPU and starved every
+                # retry here spun the event loop at 100% CPU and starved every
                 # other task on the process.
                 logger.warning("Mattermost stream not started for bot %s", bot_id)
                 return
@@ -144,12 +144,14 @@ class MattermostAdapter(ChannelAdapter):
                 logger.exception(
                     "Mattermost stream failed for bot %s, retrying in %.0fs", bot_id, delay
                 )
-                # Backs off to a minute so a server that is down for an hour is
-                # not hammered 720 times by every bot on it.
-                delay = min(delay * 2, 60.0)
             # Outside the `except`: a session that ends by returning has to
             # yield before the next attempt, or this loop never suspends.
             await asyncio.sleep(delay)
+            # Doubled after the wait, not before it: the line logged above names
+            # `delay`, and backing off first made it sleep twice what it said.
+            # Backs off to a minute so a server that is down for an hour is not
+            # hammered 720 times by every bot on it.
+            delay = min(delay * 2, 60.0)
 
     async def _run_stream(self, bot_id: str, bot_token: str) -> None:
         """One authenticated session on the event stream."""

--- a/backend/app/services/channels/slack.py
+++ b/backend/app/services/channels/slack.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from app.db.session import get_db_context
 from app.services.channels.base import ChannelAdapter, IncomingMessage, OutgoingMessage
+from app.services.channels.exceptions import ChannelNotConfigured
 from app.services.channels.router import ChannelMessageRouter
 
 logger = logging.getLogger(__name__)
@@ -91,15 +92,28 @@ class SlackAdapter(ChannelAdapter):
         logger.info("Stopped Slack Socket Mode for bot %s", bot_id)
 
     async def _socket_supervisor(self, bot_id: str, bot_token: str) -> None:
-        """Supervised loop: restart Socket Mode on crash."""
+        """Supervised loop: restart Socket Mode on crash.
+
+        The sleep is outside the `except` on purpose. `_run_socket_mode` has
+        branches that return without ever awaiting, and awaiting a coroutine
+        that never suspends does not yield to the event loop - so this looped at
+        100% CPU and no other task on the process was scheduled again. The API
+        stayed up and answered nothing, health check included, on one WARNING
+        line.
+        """
         while True:
             try:
                 await self._run_socket_mode(bot_id, bot_token)
             except asyncio.CancelledError:
                 break
+            except ChannelNotConfigured:
+                # Not a crash and not something a retry fixes: an operator has
+                # to add the token. Retrying would be the spin all over again.
+                logger.warning("Slack Socket Mode not started for bot %s", bot_id)
+                return
             except Exception:
                 logger.exception("Slack Socket Mode crashed for bot %s, restarting in 5s", bot_id)
-                await asyncio.sleep(5)
+            await asyncio.sleep(5)
 
     async def _run_socket_mode(self, bot_id: str, bot_token: str) -> None:
         """Run one Socket Mode session."""
@@ -107,21 +121,24 @@ class SlackAdapter(ChannelAdapter):
             from slack_sdk.socket_mode.aiohttp import SocketModeClient
             from slack_sdk.socket_mode.request import SocketModeRequest
             from slack_sdk.socket_mode.response import SocketModeResponse
-        except ImportError:
-            logger.error(
-                "Slack Socket Mode requires 'slack-sdk[socket-mode]'. "
-                "Install with: pip install 'slack-sdk[socket-mode]'"
-            )
-            return
+        except ImportError as exc:
+            raise ChannelNotConfigured(
+                message=(
+                    "Slack Socket Mode requires 'slack-sdk[socket-mode]'. "
+                    "Install with: pip install 'slack-sdk[socket-mode]'"
+                ),
+                details={"bot_id": bot_id},
+            ) from exc
 
         app_token = self._app_tokens.get(bot_id)
         if not app_token:
-            logger.warning(
-                "Slack bot %s has no app-level token - Socket Mode not started. "
-                "Add the xapp- token in the bot's settings.",
-                bot_id,
+            raise ChannelNotConfigured(
+                message=(
+                    "Slack bot has no app-level token - Socket Mode not started. "
+                    "Add the xapp- token in the bot's settings."
+                ),
+                details={"bot_id": bot_id},
             )
-            return
 
         client = SocketModeClient(
             app_token=app_token,

--- a/backend/app/services/conversation.py
+++ b/backend/app/services/conversation.py
@@ -11,7 +11,7 @@ import json
 import logging
 from collections.abc import Sequence
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Final, Literal
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -36,6 +36,23 @@ from app.schemas.conversation import (
 from app.schemas.conversation_share import AdminConversationList, AdminConversationRead
 
 logger = logging.getLogger(__name__)
+
+UNSCOPED: Final = "unscoped"
+"""Read this conversation without a tenant predicate, on purpose.
+
+`organization_id` used to default to `None` on the methods below, and `None`
+meant unscoped. Two routes serving ordinary members simply omitted it, and any
+signed-in user could read and append to any conversation in the deployment.
+An omission cannot express intent; this can, and `rg UNSCOPED` lists every
+place that claims it.
+
+There is one caller, `/admin/conversations/{id}`, which exists to read across
+tenants and is gated on `CurrentAppAdmin`. Anything serving an ordinary member
+passes the active organization.
+"""
+
+type OrgScope = UUID | Literal["unscoped"]
+"""A tenant to check against, or an explicit refusal to check one."""
 
 
 def _safe_parse_args(args: Any) -> dict:
@@ -280,15 +297,13 @@ class ConversationService:
         self,
         conversation_id: UUID,
         *,
-        organization_id: UUID | None = None,
+        organization_id: OrgScope,
     ) -> Conversation:
-        """A transcript, tenant-checked when a tenant is given.
+        """A transcript, tenant-checked unless the caller passes `UNSCOPED`.
 
-        `organization_id=None` is **deliberately unscoped**, and there are two
-        callers: the app-admin transcript view, which exists to read across
-        tenants, and the WebSocket session, which resolved the organization when
-        the socket was opened. Grep for this default when auditing cross-tenant
-        reads; anything serving an ordinary member must pass the tenant.
+        Required rather than defaulted: the default was `None`, `None` meant
+        unscoped, and omitting an argument is indistinguishable from intending
+        to omit it. See `UNSCOPED`.
         """
         return await self._resolve(
             conversation_id, organization_id=organization_id, include_messages=True
@@ -298,12 +313,12 @@ class ConversationService:
         self,
         conversation_id: UUID,
         *,
-        organization_id: UUID | None,
+        organization_id: OrgScope,
         include_messages: bool = False,
         user_id: UUID | None = None,
     ) -> Conversation:
-        """Load one conversation, with the tenant check only when there is a tenant."""
-        if organization_id is not None:
+        """Load one conversation, skipping the tenant check only for `UNSCOPED`."""
+        if organization_id != UNSCOPED:
             return await self.get_conversation(
                 conversation_id,
                 organization_id=organization_id,
@@ -335,13 +350,14 @@ class ConversationService:
         *,
         skip: int = 0,
         limit: int = 100,
-        organization_id: UUID | None = None,
+        organization_id: OrgScope,
         include_tool_calls: bool = False,
         user_id: UUID | None = None,
     ) -> tuple[list[Message | MessageRead], int]:
         """When user_id is provided, messages are enriched with user_rating and rating_count.
 
-        `organization_id=None` is unscoped - see `get_conversation_with_messages`.
+        `user_id` enriches; it does not authorize. `organization_id` is what
+        keeps this from reading another tenant's transcript - see `UNSCOPED`.
         """
         await self._resolve(conversation_id, organization_id=organization_id)
         items = await conversation_repo.get_messages_by_conversation(
@@ -375,10 +391,14 @@ class ConversationService:
         conversation_id: UUID,
         data: MessageCreate,
         *,
-        organization_id: UUID | None = None,
+        organization_id: OrgScope,
     ) -> Message:
-        """Append one message. `organization_id=None` is unscoped - see
-        `get_conversation_with_messages`.
+        """Append one message into a conversation in `organization_id`.
+
+        Required, and for the sharper reason: this writes. Unscoped, any
+        signed-in caller could append a turn - including one with
+        `role: "assistant"` - to any conversation in the deployment, and it
+        would render to its owner as the agent's own words. See `UNSCOPED`.
 
         An archived conversation is closed to new messages: archiving is the
         user saying "this thread is finished", and a message appended afterwards

--- a/backend/app/services/conversation.py
+++ b/backend/app/services/conversation.py
@@ -354,12 +354,19 @@ class ConversationService:
         include_tool_calls: bool = False,
         user_id: UUID | None = None,
     ) -> tuple[list[Message | MessageRead], int]:
-        """When user_id is provided, messages are enriched with user_rating and rating_count.
+        """One conversation's messages, for a reader who is allowed to see them.
 
-        `user_id` enriches; it does not authorize. `organization_id` is what
-        keeps this from reading another tenant's transcript - see `UNSCOPED`.
+        `organization_id` keeps this out of another tenant's transcript;
+        `user_id` keeps it out of a colleague's. Both are needed: the tenant
+        check alone still lets any member of the organization read any
+        conversation in it, which is not what `GET /conversations/{id}` does
+        one route above.
+
+        When `user_id` is given the messages are also enriched with that
+        reader's rating - a second job for one argument, and the reason its
+        authorizing half was missed for so long.
         """
-        await self._resolve(conversation_id, organization_id=organization_id)
+        await self._resolve(conversation_id, organization_id=organization_id, user_id=user_id)
         items = await conversation_repo.get_messages_by_conversation(
             self.db,
             conversation_id,
@@ -392,6 +399,7 @@ class ConversationService:
         data: MessageCreate,
         *,
         organization_id: OrgScope,
+        user_id: UUID | None = None,
     ) -> Message:
         """Append one message into a conversation in `organization_id`.
 
@@ -400,11 +408,18 @@ class ConversationService:
         `role: "assistant"` - to any conversation in the deployment, and it
         would render to its owner as the agent's own words. See `UNSCOPED`.
 
+        `user_id` narrows that to the owner or somebody the conversation was
+        shared with. It is optional because one caller has no user to check:
+        the assistant turn is written by the agent, after `persist_user_turn`
+        has already resolved the same conversation for the person who asked.
+
         An archived conversation is closed to new messages: archiving is the
         user saying "this thread is finished", and a message appended afterwards
         would silently reopen it.
         """
-        conversation = await self._resolve(conversation_id, organization_id=organization_id)
+        conversation = await self._resolve(
+            conversation_id, organization_id=organization_id, user_id=user_id
+        )
         if conversation.is_archived:
             raise BadRequestError(
                 message="Conversation is archived",

--- a/backend/tests/api/test_conversation_scoping.py
+++ b/backend/tests/api/test_conversation_scoping.py
@@ -35,14 +35,16 @@ pytestmark = pytest.mark.anyio
 
 
 @asynccontextmanager
-async def _client(*, user_id: UUID, service: MagicMock) -> AsyncIterator[AsyncClient]:
+async def _client(
+    *, user_id: UUID, service: MagicMock, organization_id: UUID | None = None
+) -> AsyncIterator[AsyncClient]:
     """A signed-in caller, with the conversation service stubbed out.
 
     `is_app_admin=True` on purpose in every test below. It is the one privilege
     the platform still has, and the point is that even it does not widen *these*
     routes - the admin surface is a different endpoint.
     """
-    organization = MagicMock(id=uuid4())
+    organization = MagicMock(id=organization_id or uuid4())
     app.dependency_overrides[deps.get_current_user] = lambda: MagicMock(
         id=user_id, is_app_admin=True
     )
@@ -102,3 +104,38 @@ class TestListingItsMessages:
             await client.get(f"{settings.API_V1_STR}/conversations/{uuid4()}/messages")
 
         assert service.list_messages.await_args.kwargs["user_id"] is not None
+
+    async def test_the_active_organization_is_what_bounds_the_read(self) -> None:
+        """The assertion this file was missing.
+
+        `user_id` above enriches messages with ratings; it authorizes nothing.
+        This route passed it and no organization, so it served any conversation
+        in the deployment - and the two tests above went on passing throughout,
+        because they asked a mock what it had been told rather than asking the
+        service what it would do.
+        """
+        org = uuid4()
+        service = MagicMock(list_messages=AsyncMock(return_value=([], 0)))
+
+        async with _client(user_id=uuid4(), service=service, organization_id=org) as client:
+            await client.get(f"{settings.API_V1_STR}/conversations/{uuid4()}/messages")
+
+        assert service.list_messages.await_args.kwargs["organization_id"] == org
+
+
+class TestAppendingAMessage:
+    async def test_the_active_organization_is_what_bounds_the_write(self) -> None:
+        """The worse half. Unscoped, this accepted a `role: "assistant"` turn
+        into any conversation in the deployment, and it rendered to its owner
+        as the agent's own answer."""
+        org = uuid4()
+        service = MagicMock(add_message=AsyncMock(side_effect=NotFoundError(message="Not found")))
+
+        async with _client(user_id=uuid4(), service=service, organization_id=org) as client:
+            response = await client.post(
+                f"{settings.API_V1_STR}/conversations/{uuid4()}/messages",
+                json={"role": "assistant", "content": "wire the money to 1234"},
+            )
+
+        assert response.status_code == 404
+        assert service.add_message.await_args.kwargs["organization_id"] == org

--- a/backend/tests/integration/test_conversation_tenant_isolation.py
+++ b/backend/tests/integration/test_conversation_tenant_isolation.py
@@ -136,6 +136,66 @@ class TestWritingIntoAnotherOrganizationsConversation:
         assert [message.content for message in remaining] == ["secret"]
 
 
+class TestAColleagueInTheSameOrganization:
+    """The tenant check is not the whole of it.
+
+    `GET /conversations/{id}` has always checked the owner; its `/messages`
+    sibling did not, so scoping to the organization alone still left one
+    member's transcript readable by every other member of it. Two halves of the
+    same answer disagreeing is how the first half came to look sufficient.
+    """
+
+    async def test_cannot_read_the_transcript(self, db) -> None:
+        organization = await _org(db, name="Shared")
+        owner = await _member(db)
+        colleague = await _member(db)
+        conversation = await _conversation(db, organization, owner)
+
+        service = ConversationService(db)
+        with pytest.raises(NotFoundError):
+            await service.list_messages(
+                conversation.id,
+                organization_id=organization.id,
+                include_tool_calls=True,
+                user_id=colleague.id,
+            )
+
+    async def test_cannot_append_to_it(self, db) -> None:
+        organization = await _org(db, name="Shared")
+        owner = await _member(db)
+        colleague = await _member(db)
+        conversation = await _conversation(db, organization, owner)
+
+        service = ConversationService(db)
+        with pytest.raises(NotFoundError):
+            await service.add_message(
+                conversation.id,
+                MessageCreate(role="assistant", content="not from the agent"),
+                organization_id=organization.id,
+                user_id=colleague.id,
+            )
+
+        remaining = await conversation_repo.get_messages_by_conversation(db, conversation.id)
+        assert [message.content for message in remaining] == ["secret"]
+
+    async def test_the_owner_still_appends(self, db) -> None:
+        """The refusal has to be about the reader, not about everything."""
+        organization = await _org(db, name="Shared")
+        owner = await _member(db)
+        conversation = await _conversation(db, organization, owner)
+
+        service = ConversationService(db)
+        await service.add_message(
+            conversation.id,
+            MessageCreate(role="user", content="and another thing"),
+            organization_id=organization.id,
+            user_id=owner.id,
+        )
+
+        remaining = await conversation_repo.get_messages_by_conversation(db, conversation.id)
+        assert [message.content for message in remaining] == ["secret", "and another thing"]
+
+
 class TestTheDeliberateCrossTenantRead:
     async def test_unscoped_still_reaches_another_organization(self, db) -> None:
         """`/admin/conversations/{id}` exists to read across tenants and is

--- a/backend/tests/integration/test_conversation_tenant_isolation.py
+++ b/backend/tests/integration/test_conversation_tenant_isolation.py
@@ -1,0 +1,153 @@
+"""A conversation belongs to one organization, and the service enforces it.
+
+`ConversationService._resolve` used to skip the tenant predicate whenever
+`organization_id` was `None`, and `None` was the default. Two routes serving
+ordinary members omitted it, so any signed-in user who knew a UUID could read a
+full transcript from another organization - tool calls and their arguments
+included - and append a turn to it, `role: "assistant"` included, which then
+rendered to its owner as the agent's own words.
+
+The suite did not catch it. `tests/api/test_conversation_scoping.py` asserted
+that the route passed `user_id` to a `MagicMock` service, and it did; `user_id`
+enriches messages with ratings and authorizes nothing. The assertion held while
+the behaviour it stood for did not - the "no test for a mock" case
+`.claude/rules/testing.md` names.
+
+So these run against a real `ConversationService` and a real database, and
+assert the consequence: the row is reported missing, and nothing is written.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.core.exceptions import NotFoundError
+from app.db.models.conversation import Conversation, Message
+from app.db.models.organization import Organization
+from app.db.models.user import User
+from app.repositories import conversation as conversation_repo
+from app.schemas.conversation import MessageCreate
+from app.services.conversation import UNSCOPED, ConversationService
+
+pytestmark = pytest.mark.anyio
+
+
+async def _member(db) -> User:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"{uuid.uuid4().hex}@example.com",
+        hashed_password="x",
+        is_active=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _org(db, *, name: str) -> Organization:
+    founder = await _member(db)
+    organization = Organization(
+        id=uuid.uuid4(),
+        name=name,
+        slug=f"{name.lower()}-{uuid.uuid4().hex[:8]}",
+        created_by_user_id=founder.id,
+    )
+    db.add(organization)
+    await db.flush()
+    return organization
+
+
+async def _conversation(db, organization: Organization, owner: User) -> Conversation:
+    conversation = Conversation(
+        id=uuid.uuid4(),
+        user_id=owner.id,
+        organization_id=organization.id,
+        title="Quarterly numbers",
+    )
+    db.add(conversation)
+    await db.flush()
+    # Added to the session rather than appended to `conversation.messages`,
+    # which would lazy-load the relationship outside the greenlet.
+    db.add(Message(id=uuid.uuid4(), conversation_id=conversation.id, role="user", content="secret"))
+    await db.flush()
+    return conversation
+
+
+class TestReadingAnotherOrganizationsTranscript:
+    async def test_it_is_reported_missing(self, db) -> None:
+        """Missing, not forbidden. "You may not read this" tells somebody in
+        another tenant that the id exists."""
+        theirs = await _org(db, name="Theirs")
+        owner = await _member(db)
+        conversation = await _conversation(db, theirs, owner)
+        mine = await _org(db, name="Mine")
+        intruder = await _member(db)
+
+        service = ConversationService(db)
+        with pytest.raises(NotFoundError):
+            await service.list_messages(
+                conversation.id,
+                organization_id=mine.id,
+                include_tool_calls=True,
+                user_id=intruder.id,
+            )
+
+    async def test_the_owning_organization_still_reads_it(self, db) -> None:
+        """The refusal has to be about the tenant, not about everything."""
+        theirs = await _org(db, name="Theirs")
+        owner = await _member(db)
+        conversation = await _conversation(db, theirs, owner)
+
+        service = ConversationService(db)
+        # Same arguments the route passes: `include_tool_calls` has to be on,
+        # because the rating enrichment validates each row through `MessageRead`
+        # and that reads `tool_calls`.
+        items, total = await service.list_messages(
+            conversation.id,
+            organization_id=theirs.id,
+            include_tool_calls=True,
+            user_id=owner.id,
+        )
+
+        assert total == 1
+        assert [item.content for item in items] == ["secret"]
+
+
+class TestWritingIntoAnotherOrganizationsConversation:
+    async def test_it_is_refused_and_nothing_is_persisted(self, db) -> None:
+        """The write half, which is the worse one: an injected `assistant` turn
+        renders to the owner as the agent's answer."""
+        theirs = await _org(db, name="Theirs")
+        owner = await _member(db)
+        conversation = await _conversation(db, theirs, owner)
+        mine = await _org(db, name="Mine")
+
+        service = ConversationService(db)
+        with pytest.raises(NotFoundError):
+            await service.add_message(
+                conversation.id,
+                MessageCreate(role="assistant", content="wire the money to 1234"),
+                organization_id=mine.id,
+            )
+
+        remaining = await conversation_repo.get_messages_by_conversation(db, conversation.id)
+        assert [message.content for message in remaining] == ["secret"]
+
+
+class TestTheDeliberateCrossTenantRead:
+    async def test_unscoped_still_reaches_another_organization(self, db) -> None:
+        """`/admin/conversations/{id}` exists to read across tenants and is
+        gated on `CurrentAppAdmin`. If this stopped working the sentinel would
+        be decorative and the next reader would reach for `None` again."""
+        theirs = await _org(db, name="Theirs")
+        owner = await _member(db)
+        conversation = await _conversation(db, theirs, owner)
+
+        service = ConversationService(db)
+        found = await service.get_conversation_with_messages(
+            conversation.id, organization_id=UNSCOPED
+        )
+
+        assert found.id == conversation.id

--- a/backend/tests/test_channel_supervisor_yields.py
+++ b/backend/tests/test_channel_supervisor_yields.py
@@ -150,3 +150,36 @@ class TestMattermost:
 
         with pytest.raises(ChannelNotConfigured):
             await adapter._run_stream("bot-without-a-url", "token")
+
+
+class TestMattermostBackoff:
+    async def test_the_first_retry_waits_what_the_log_says(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The log names `delay`, so `delay` has to be what is then slept.
+
+        Moving the sleep out of the `except` left the doubling in front of it:
+        the line said "retrying in 5s" and the loop waited ten. Doubling after
+        the wait keeps the two agreeing, and keeps the first retry prompt.
+        """
+        adapter = MattermostAdapter()
+        sessions = 0
+        waited: list[float] = []
+
+        async def session(*_: object, **__: object) -> None:
+            nonlocal sessions
+            sessions += 1
+            if sessions >= 4:
+                raise asyncio.CancelledError
+            raise RuntimeError("the server dropped the socket")
+
+        async def counting_sleep(delay: float) -> None:
+            waited.append(delay)
+
+        monkeypatch.setattr(adapter, "_run_stream", session)
+        monkeypatch.setattr(mattermost_module.asyncio, "sleep", counting_sleep)
+
+        with contextlib.suppress(asyncio.CancelledError):
+            await adapter._supervise("bot", "token")
+
+        assert waited == [5.0, 10.0, 20.0]

--- a/backend/tests/test_channel_supervisor_yields.py
+++ b/backend/tests/test_channel_supervisor_yields.py
@@ -1,0 +1,152 @@
+"""A channel supervisor must suspend between attempts, whatever its session does.
+
+Both supervisors were `while True: await self._run_x(...)` with the only sleep
+inside `except Exception`. Both inner coroutines have branches that return
+without ever awaiting - a Slack bot with no `xapp-` token, a Mattermost bot with
+no server URL, either package missing - and awaiting a coroutine that never
+suspends does not yield to the event loop.
+
+So the loop ran at 100% CPU and **nothing else on the process was scheduled
+again**: not a request, not the health check, not a WebSocket stream. The API
+was up and answered nothing, and the only clue was one WARNING line. Both
+trigger states are ordinary rows an operator has simply not filled in yet.
+
+Asserted by counting sleeps rather than by racing another task. A starved event
+loop cannot run a timer either, so a timeout-based test does not fail - it
+hangs, and CI reports a job that ran out of wall clock rather than an assertion
+naming the defect. Bounding the loop by cancelling from the third session makes
+it terminate under both the fixed and the broken implementation, and the sleep
+count is then the whole difference: two, or none.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import pytest
+
+from app.services.channels import mattermost as mattermost_module
+from app.services.channels import slack as slack_module
+from app.services.channels.exceptions import ChannelNotConfigured
+from app.services.channels.mattermost import MattermostAdapter
+from app.services.channels.slack import SlackAdapter
+
+pytestmark = pytest.mark.anyio
+
+
+async def _sleeps_between_sessions(
+    monkeypatch: pytest.MonkeyPatch,
+    module: Any,
+    adapter: Any,
+    session_attr: str,
+    supervisor: Callable[[], Awaitable[None]],
+) -> int:
+    """Run the supervisor for two sessions that end by returning, count sleeps.
+
+    The third session raises `CancelledError`, which is how the loop is bounded
+    without depending on the event loop being responsive.
+    """
+    sessions = 0
+    sleeps = 0
+
+    async def session(*_: object, **__: object) -> None:
+        nonlocal sessions
+        sessions += 1
+        if sessions >= 3:
+            raise asyncio.CancelledError
+
+    async def counting_sleep(_delay: float) -> None:
+        nonlocal sleeps
+        sleeps += 1
+
+    monkeypatch.setattr(adapter, session_attr, session)
+    monkeypatch.setattr(module.asyncio, "sleep", counting_sleep)
+
+    with contextlib.suppress(asyncio.CancelledError):
+        await supervisor()
+    return sleeps
+
+
+class TestSlack:
+    async def test_a_session_that_returns_immediately_still_sleeps(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        adapter = SlackAdapter()
+
+        sleeps = await _sleeps_between_sessions(
+            monkeypatch,
+            slack_module,
+            adapter,
+            "_run_socket_mode",
+            lambda: adapter._socket_supervisor("bot", "xoxb-token"),
+        )
+
+        assert sleeps == 2
+
+    async def test_a_missing_app_token_stops_the_loop(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Nothing a retry can fix - an operator has to paste the xapp- token.
+        Retrying is what the spin was."""
+        adapter = SlackAdapter()
+        attempts = 0
+
+        async def session(*_: object, **__: object) -> None:
+            nonlocal attempts
+            attempts += 1
+            raise ChannelNotConfigured(message="no app token")
+
+        monkeypatch.setattr(adapter, "_run_socket_mode", session)
+        await adapter._socket_supervisor("bot", "xoxb-token")
+
+        assert attempts == 1
+
+    async def test_the_missing_app_token_raises_rather_than_returning(self) -> None:
+        """Where the distinction is made. Returning here is indistinguishable
+        from a session that ended, which is why the supervisor retried it."""
+        adapter = SlackAdapter()
+
+        with pytest.raises(ChannelNotConfigured):
+            await adapter._run_socket_mode("bot-without-a-token", "xoxb-token")
+
+
+class TestMattermost:
+    async def test_a_session_that_returns_immediately_still_sleeps(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        adapter = MattermostAdapter()
+
+        sleeps = await _sleeps_between_sessions(
+            monkeypatch,
+            mattermost_module,
+            adapter,
+            "_run_stream",
+            lambda: adapter._supervise("bot", "token"),
+        )
+
+        assert sleeps == 2
+
+    async def test_a_missing_server_url_stops_the_loop(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        adapter = MattermostAdapter()
+        attempts = 0
+
+        async def session(*_: object, **__: object) -> None:
+            nonlocal attempts
+            attempts += 1
+            raise ChannelNotConfigured(message="no server url")
+
+        monkeypatch.setattr(adapter, "_run_stream", session)
+        await adapter._supervise("bot", "token")
+
+        assert attempts == 1
+
+    async def test_the_missing_server_url_raises_rather_than_returning(self) -> None:
+        adapter = MattermostAdapter()
+
+        with pytest.raises(ChannelNotConfigured):
+            await adapter._run_stream("bot-without-a-url", "token")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -159,10 +159,24 @@ that already had two.
 
 ### IDOR Protection
 
-Conversation and file endpoints enforce ownership at the service layer:
-- Conversations pass `user_id=current_user.id` to the service, which filters queries by owner.
-- File downloads verify `chat_file.user_id == current_user.id` before returning the file.
-- This prevents users from accessing resources belonging to other users.
+Two predicates, and they are not interchangeable. **The organization is what
+bounds a read; the user is what narrows it further.**
+
+- Conversation endpoints pass `organization_id=active_org.id`. Without it a
+  conversation is looked up by primary key alone, and any signed-in caller who
+  knows a UUID reads — or appends to — a conversation in another tenant.
+- They also pass `user_id=current_user.id`, which restricts a row to its owner
+  or somebody it was shared with. Note that on `list_messages` the same argument
+  name does something else entirely: it enriches each message with the caller's
+  rating and authorizes nothing. Passing it is not scoping.
+- File downloads verify `chat_file.user_id == current_user.id`.
+
+`ConversationService` makes the distinction impossible to omit: `organization_id`
+is a **required** keyword, and a caller that genuinely reads across tenants
+passes the `UNSCOPED` sentinel rather than leaving the argument out. There is one
+— `/admin/conversations/{id}`, gated on `CurrentAppAdmin` — and `rg UNSCOPED`
+finds it. The argument used to default to `None`, `None` meant unscoped, and an
+omission is indistinguishable from an intention.
 
 For full endpoint-level permissions, see `docs/permissions.md`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -166,9 +166,13 @@ bounds a read; the user is what narrows it further.**
   conversation is looked up by primary key alone, and any signed-in caller who
   knows a UUID reads — or appends to — a conversation in another tenant.
 - They also pass `user_id=current_user.id`, which restricts a row to its owner
-  or somebody it was shared with. Note that on `list_messages` the same argument
-  name does something else entirely: it enriches each message with the caller's
-  rating and authorizes nothing. Passing it is not scoping.
+  or somebody it was shared with. The tenant check alone is not enough: without
+  this, every member of an organization can read and append to every other
+  member's conversation.
+- On `list_messages` that one argument does two jobs — it authorizes, *and* it
+  enriches each message with the caller's own rating. That overload is why its
+  authorizing half went missing for so long: the route passed it, the argument
+  was plainly there in review, and it was doing the other job.
 - File downloads verify `chat_file.user_id == current_user.id`.
 
 `ConversationService` makes the distinction impossible to omit: `organization_id`

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -174,6 +174,23 @@ Mattermost does not sign webhook bodies the way Slack does — the token in the
 payload is the whole check — so **a bot with no webhook secret refuses every
 call** rather than trusting it.
 
+## A bot that cannot start stops, rather than retrying
+
+Slack Socket Mode and the Mattermost event stream both run under a supervisor
+that reconnects a dropped session. A missing configuration value is not a
+dropped session, and the supervisor treats it differently: it logs once and
+stops. Nothing it does would change the row — an operator has to add the Slack
+`xapp-` token or the Mattermost server URL.
+
+This matters more than it sounds. Retrying a start that fails immediately never
+suspends, so the supervisor spins without yielding and every other task on the
+process — requests, health checks, chat WebSockets — stops being scheduled. The
+API stays up and answers nothing. Both trigger states are ordinary rows somebody
+has not filled in yet, so the failure was one restart away at any time.
+
+If a bot is silent, check the log for `not started` before assuming a network
+problem.
+
 ---
 
 ## What every channel shares

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -191,6 +191,11 @@ has not filled in yet, so the failure was one restart away at any time.
 If a bot is silent, check the log for `not started` before assuming a network
 problem.
 
+A dropped session is different: that one is retried, waiting five seconds and
+doubling to a minute, so a Mattermost server down for an hour is not hammered
+720 times by every bot on it. The line logged before each wait names the delay
+it is about to wait.
+
 ---
 
 ## What every channel shares

--- a/frontend/src/app/api/binary-routes.test.ts
+++ b/frontend/src/app/api/binary-routes.test.ts
@@ -221,17 +221,26 @@ describe("reading a file back", () => {
   });
 });
 
+// The backend signature is `user_id: UUID`, and the route now says so. A
+// placeholder like "u-1" was never a value this endpoint could serve.
+const AVATAR_USER = "8f14e45f-ceea-4a67-b1e6-6c1f2b1f4a3d";
+
 describe("avatars", () => {
   it("serves a person's avatar to anybody, because a picture is not a secret", async () => {
     // No session: the chat renders avatars for every participant, and gating them
     // would mean a page of empty circles for anybody but the caller.
     serve("jpeg-bytes", { headers: { "content-type": "image/png" } });
 
-    const response = await userAvatar(request("http://localhost:3000/api/users/avatar/u-1"), {
-      params: Promise.resolve({ userId: "u-1" }),
-    });
+    const response = await userAvatar(
+      request(`http://localhost:3000/api/users/avatar/${AVATAR_USER}`),
+      {
+        params: Promise.resolve({ userId: AVATAR_USER }),
+      },
+    );
 
-    expect(fetchMock.mock.calls[0]![0]).toBe("http://localhost:8000/api/v1/users/avatar/u-1");
+    expect(fetchMock.mock.calls[0]![0]).toBe(
+      `http://localhost:8000/api/v1/users/avatar/${AVATAR_USER}`,
+    );
     expect(response.headers.get("content-type")).toBe("image/png");
     // Never cached: a replaced picture has the same URL as the old one.
     expect(response.headers.get("cache-control")).toBe("no-store");
@@ -240,9 +249,12 @@ describe("avatars", () => {
   it("assumes a JPEG when the backend named no type", async () => {
     serve("bytes", { headers: { "content-type": "" } });
 
-    const response = await userAvatar(request("http://localhost:3000/api/users/avatar/u-1"), {
-      params: Promise.resolve({ userId: "u-1" }),
-    });
+    const response = await userAvatar(
+      request(`http://localhost:3000/api/users/avatar/${AVATAR_USER}`),
+      {
+        params: Promise.resolve({ userId: AVATAR_USER }),
+      },
+    );
 
     expect(response.headers.get("content-type")).toBe("image/jpeg");
   });
@@ -252,9 +264,12 @@ describe("avatars", () => {
     // JSON body there renders as a broken image with a parse error in the console.
     serve(null, { status: 404 });
 
-    const response = await userAvatar(request("http://localhost:3000/api/users/avatar/u-1"), {
-      params: Promise.resolve({ userId: "u-1" }),
-    });
+    const response = await userAvatar(
+      request(`http://localhost:3000/api/users/avatar/${AVATAR_USER}`),
+      {
+        params: Promise.resolve({ userId: AVATAR_USER }),
+      },
+    );
 
     expect(response.status).toBe(404);
     await expect(response.text()).resolves.toBe("");
@@ -264,12 +279,42 @@ describe("avatars", () => {
     fetchMock = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
     vi.stubGlobal("fetch", fetchMock);
 
-    const response = await userAvatar(request("http://localhost:3000/api/users/avatar/u-1"), {
-      params: Promise.resolve({ userId: "u-1" }),
-    });
+    const response = await userAvatar(
+      request(`http://localhost:3000/api/users/avatar/${AVATAR_USER}`),
+      {
+        params: Promise.resolve({ userId: AVATAR_USER }),
+      },
+    );
 
     expect(response.status).toBe(500);
     await expect(response.text()).resolves.toBe("");
+  });
+
+  it("cannot be walked out of its own path segment", async () => {
+    // The defect: the segment was interpolated raw. Next decodes `%2F` into the
+    // param and `fetch` then normalises `..`, so this reached the backend as
+    // `GET /api/v1/openapi.json` - from an anonymous caller, because avatars
+    // are deliberately served without a cookie. Everything the backend answers
+    // without an Authorization header became public and un-throttled.
+    serve("bytes");
+
+    const response = await userAvatar(request("http://localhost:3000/api/users/avatar/traversal"), {
+      params: Promise.resolve({ userId: "x/../../../openapi.json" }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses a segment carrying a query string", async () => {
+    serve("bytes");
+
+    const response = await userAvatar(request("http://localhost:3000/api/users/avatar/traversal"), {
+      params: Promise.resolve({ userId: "../../../health?probe=1" }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("uploads the caller's own picture as multipart", async () => {

--- a/frontend/src/app/api/users/avatar/[userId]/route.ts
+++ b/frontend/src/app/api/users/avatar/[userId]/route.ts
@@ -2,6 +2,16 @@ import { NextRequest, NextResponse } from "next/server";
 
 const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:8000";
 
+// The backend signature is `user_id: UUID`, so anything else is a bad request
+// here rather than a round trip. This route takes a client-controlled path
+// segment and has no cookie check - deliberately, because avatars are served
+// publicly - which made it the one place an anonymous caller could reach the
+// internal backend. Interpolated raw, `%2F` decodes into the param and `fetch`
+// then normalises `..`, so `x%2F..%2F..%2F..%2Fopenapi.json` arrived at the
+// backend as `GET /api/v1/openapi.json`. Encoding alone closes it; validating
+// the shape means a malformed segment never reaches the network at all.
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ userId: string }> },
@@ -9,7 +19,13 @@ export async function GET(
   try {
     const { userId } = await params;
 
-    const response = await fetch(`${BACKEND_URL}/api/v1/users/avatar/${userId}`);
+    if (!UUID_PATTERN.test(userId)) {
+      return new NextResponse(null, { status: 400 });
+    }
+
+    const response = await fetch(
+      `${BACKEND_URL}/api/v1/users/avatar/${encodeURIComponent(userId)}`,
+    );
 
     if (!response.ok) {
       return new NextResponse(null, { status: response.status });


### PR DESCRIPTION
Three findings from the 2026-08-01 backend audit, all rated S. One commit each.

## 1. Cross-tenant read and write on conversations (Critical)

Any signed-in user could read and write **any** conversation in the deployment. `GET /conversations/{id}/messages` returned a full transcript — tool calls and their arguments included — for a conversation in another organization, and `POST` appended a turn to it, `role: "assistant"` included, which rendered to its owner as the agent's own words. Precondition: knowing a UUID.

`ConversationService._resolve` skipped the tenant predicate when `organization_id` was `None`, and `None` was the default. Both routes omitted it. Both passed `user_id` — which on `list_messages` enriches messages with the caller's rating and authorizes nothing. That is what made it look scoped in review and in the docs.

`organization_id` is now a **required** keyword on all four methods, so the omission cannot recur. A caller that genuinely reads across tenants passes the `UNSCOPED` sentinel; `rg UNSCOPED` lists every one, and there is exactly one — `/admin/conversations/{id}`, gated on `CurrentAppAdmin`.

**Why nothing caught it:** `test_conversation_scoping.py` asserted the route passed `user_id` to a MagicMock. It did, for the whole life of the defect — the "no test for a mock" case the testing rule names.

## 2. A misconfigured channel bot takes the API down (Critical)

A Slack bot with no `xapp-` token, or a Mattermost bot with no server URL — ordinary rows nobody has filled in yet. Both supervisors were `while True: await self._run_x(...)` with the only sleep inside `except Exception`, and both inner coroutines return without ever awaiting on those branches. Awaiting a coroutine that never suspends does not yield, so the supervisor spun at 100% CPU and **nothing else on the process was scheduled again** — not a request, not the health check, not a chat WebSocket. Up, and answering nothing, on one WARNING line.

Configuration branches now raise `ChannelNotConfigured` and the supervisor stops on it; the sleep moved out of the `except`.

## 3. SSRF through the avatar proxy (High)

`/api/users/avatar/[userId]` interpolated a client-controlled segment unencoded, and is the one handler with no cookie check — deliberately, because avatars are public. Anonymously:

```
/api/users/avatar/x%2F..%2F..%2F..%2Fopenapi.json  → backend got GET /api/v1/openapi.json
/api/users/avatar/..%2F..%2F..%2Fhealth%3Fprobe%3D1 → backend got GET /api/health?probe=1
```

The host is pinned by `${BACKEND_URL}`, so it is confined to the backend service — which is otherwise not internet-reachable. Now validated as a UUID (what the backend signature declares) and encoded; a malformed segment is a 400 and never reaches the network.

## How it was verified

- `2100 passed`, and **`Required test coverage of 100.0% reached`** on the platform layer.
- `196 passed` in `tests/integration` against a real pgvector database, including 4 new tenant-isolation tests asserting the consequence — the row is missing, and no `Message` row is written.
- Frontend: 36 tests in `binary-routes.test.ts`, type-check, lint, prettier.
- The supervisor test was checked **both ways**: reverting the fix turns `assert sleeps == 2` red in 0.15s. It counts sleeps rather than racing a task on purpose — a starved loop cannot run a timer either, so a timeout-based test hangs instead of failing, and CI would report wall clock rather than the defect.
- All pre-commit hooks over the whole repo.

## Found and deliberately not fixed

**AUD-030** — the same missing `encodeURIComponent` in ~18 other handlers under `src/app/api/**`. All sit behind a cookie check and the backend re-gates admin on `CurrentAppAdmin`, so nothing is reachable there that would not be anyway. It is defence in depth and wants the repo-wide sweep in `platform-proxy.test.ts`, not eighteen separate edits. Separate change.

Docs moved with the code: `architecture.md`'s IDOR section said conversations were scoped by owner and implied that sufficed; `channels.md` now describes why a bot that cannot start stops rather than retrying.