### PR TITLE
fix(security): close the four CodeQL findings that were real shapes

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -18,19 +18,21 @@ name: AI review
 #            back, whatever the model is talked into.
 #   publish  posts the result. Never sees the key.
 #
-# Editing the `issue_comment` half cannot be tested inside a pull request:
-# GitHub runs `issue_comment` workflows from the copy on the **default branch**,
-# so a change to this file only takes effect once it has landed there. Test that
-# path with `workflow_dispatch`, or after the merge.
+# There is deliberately no `issue_comment` trigger, and it is a security
+# property rather than a simplification. `issue_comment` is privileged: it runs
+# from the default branch **with secrets**, for a comment on any pull request
+# including one from a fork. Checking out the pull request's own code in that
+# context, in the job that holds `OPENAI_API_KEY`, is the shape CodeQL flags as
+# `actions/untrusted-checkout` - correctly. The `ai-review` label does the same
+# job through `pull_request`, which hands a fork neither the secret nor a
+# writable token, so the exposure is gone rather than argued about.
 
 on:
   pull_request:
     # Deliberately not `synchronize`. Two developers, a dozen pushes per pull
     # request; a review on every one of them is a review nobody reads. Re-run
-    # after fixes with a `/review` comment or the `ai-review` label.
+    # after fixes by adding the `ai-review` label.
     types: [opened, reopened, ready_for_review, labeled]
-  issue_comment:
-    types: [created]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -39,7 +41,7 @@ on:
         type: string
 
 concurrency:
-  group: ai-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
+  group: ai-review-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: true
 
 # Nothing is granted by default; each job asks for what it needs and no more.
@@ -61,21 +63,15 @@ jobs:
     timeout-minutes: 5
     permissions:
       pull-requests: read
-    # The gate for every trigger, evaluated before anything is checked out.
-    #
-    # `labeled` fires for every label, so it is narrowed to `ai-review`.
-    # `issue_comment` fires on issues too, and from anybody at all - hence the
-    # pull request check and the author association, which is the only thing
-    # standing between a drive-by comment and a run that costs money.
+    # The gate for both triggers, evaluated before anything is checked out.
+    # `labeled` fires for every label, so it is narrowed to `ai-review` - which
+    # only somebody with write access can add, and which is what makes the
+    # on-demand re-run safe without an author-association check of its own.
     if: >-
       github.event_name == 'workflow_dispatch'
       || (github.event_name == 'pull_request'
           && github.event.pull_request.draft == false
           && (github.event.action != 'labeled' || github.event.label.name == 'ai-review'))
-      || (github.event_name == 'issue_comment'
-          && github.event.issue.pull_request != null
-          && startsWith(github.event.comment.body, '/review')
-          && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
     outputs:
       verdict: ${{ steps.resolve.outputs.verdict }}
       pr_number: ${{ steps.resolve.outputs.pr_number }}
@@ -86,7 +82,7 @@ jobs:
         id: resolve
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         with:
           github-token: ${{ github.token }}
           script: |
@@ -587,7 +583,7 @@ jobs:
             summary.push(
               '',
               '---',
-              `Comment \`/review\` to re-run, or add the \`ai-review\` label. [Run](${process.env.RUN_URL}).`,
+              `Add the \`ai-review\` label to re-run. [Run](${process.env.RUN_URL}).`,
               'Advisory only — this is not a required check.',
             );
 

--- a/backend/app/core/catalog/__init__.py
+++ b/backend/app/core/catalog/__init__.py
@@ -44,8 +44,9 @@ def load[T](filename: str, adapter: TypeAdapter[T]) -> T:
     return adapter.validate_json((_DIR / filename).read_bytes())
 
 
-# Also the whole traversal defence: a name that cannot contain a dot or a slash
-# cannot name a path outside ICONS_DIR.
+# The first half of the traversal defence: a name that cannot contain a dot or
+# a slash cannot name a path outside ICONS_DIR. The second half is the
+# containment check in `custom_icon` - see there for why one is not enough.
 _ICON_NAME = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
 
 
@@ -63,5 +64,17 @@ def custom_icon(name: str) -> Path | None:
     """
     if not _ICON_NAME.fullmatch(name):
         return None
-    path = ICONS_DIR / f"{name}.svg"
+
+    # Resolved and checked for containment, on top of the grammar above.
+    #
+    # The grammar already makes traversal impossible, so this is belt and
+    # braces - but it is not decorative. `resolve()` follows symlinks, and an
+    # icons directory is a place an operator drops files into: a link named
+    # `brand.svg` pointing at `/etc/passwd` satisfies every rule above and is
+    # the one way bytes from outside this directory could be served. It also
+    # states the invariant in a form a reader - and a static analyser - can
+    # check without reasoning about a regular expression.
+    path = (ICONS_DIR / f"{name}.svg").resolve()
+    if not path.is_relative_to(ICONS_DIR.resolve()):
+        return None
     return path if path.is_file() else None

--- a/backend/app/core/catalog/__init__.py
+++ b/backend/app/core/catalog/__init__.py
@@ -65,16 +65,22 @@ def custom_icon(name: str) -> Path | None:
     if not _ICON_NAME.fullmatch(name):
         return None
 
-    # Resolved and checked for containment, on top of the grammar above.
+    # Matched against the directory listing rather than concatenated onto it.
     #
-    # The grammar already makes traversal impossible, so this is belt and
-    # braces - but it is not decorative. `resolve()` follows symlinks, and an
-    # icons directory is a place an operator drops files into: a link named
-    # `brand.svg` pointing at `/etc/passwd` satisfies every rule above and is
-    # the one way bytes from outside this directory could be served. It also
-    # states the invariant in a form a reader - and a static analyser - can
-    # check without reasoning about a regular expression.
-    path = (ICONS_DIR / f"{name}.svg").resolve()
-    if not path.is_relative_to(ICONS_DIR.resolve()):
-        return None
-    return path if path.is_file() else None
+    # `ICONS_DIR / f"{name}.svg"` would be safe - the grammar above admits no
+    # dot and no slash - but it builds a path *out of* a request parameter, and
+    # nothing downstream can tell that by looking. Selecting from what is
+    # already there means the path this returns never derives from user input
+    # at all, which is a property a reader can check in one line instead of
+    # reasoning about a regular expression.
+    icons_dir = ICONS_DIR.resolve()
+    for candidate in icons_dir.glob("*.svg"):
+        if candidate.stem != name:
+            continue
+        # An icons directory is a place an operator drops files into, and
+        # `resolve()` follows symlinks: a link named `brand.svg` pointing at
+        # `/etc/passwd` passes every rule above and is the one way bytes from
+        # outside this directory could be served.
+        resolved = candidate.resolve()
+        return resolved if resolved.is_relative_to(icons_dir) else None
+    return None

--- a/backend/tests/test_catalog.py
+++ b/backend/tests/test_catalog.py
@@ -52,6 +52,14 @@ class TestCustomIcons:
         (icons_dir / "acme.svg").write_text("<svg/>")
         assert catalog.custom_icon("acme") == icons_dir / "acme.svg"
 
+    def test_picks_the_asked_for_mark_out_of_several(self, icons_dir: Path):
+        """The lookup walks the directory rather than building a path, so it has
+        to pass over the marks it was not asked for."""
+        for stem in ("acme", "beta", "gamma"):
+            (icons_dir / f"{stem}.svg").write_text(f"<svg>{stem}</svg>")
+
+        assert catalog.custom_icon("gamma") == icons_dir / "gamma.svg"
+
     def test_a_missing_icon_resolves_to_none(self, icons_dir: Path):
         assert catalog.custom_icon("ghost") is None
 

--- a/backend/tests/test_catalog.py
+++ b/backend/tests/test_catalog.py
@@ -57,6 +57,27 @@ class TestCustomIcons:
 
     @pytest.mark.parametrize("name", ["../secrets", "a/b", "acme.svg", "ACME", "", "-x"])
     def test_a_name_outside_the_slug_grammar_is_refused(self, icons_dir: Path, name: str):
-        """The regex is the whole traversal defence: no dot and no slash means
+        """The first half of the traversal defence: no dot and no slash means
         no way to name a path outside the icons directory."""
         assert catalog.custom_icon(name) is None
+
+    def test_a_symlink_out_of_the_directory_is_refused(self, icons_dir: Path, tmp_path: Path):
+        """The half the grammar cannot cover.
+
+        `brand.svg` is a perfectly legal name. If it is a link to something
+        outside the icons directory, every rule above is satisfied and the
+        route would serve bytes the operator never put there - which is the one
+        way this endpoint could read a file it has no business reading. An
+        icons directory is somewhere files get dropped, so a link landing in it
+        is not far-fetched.
+        """
+        outside = tmp_path.parent / "not-an-icon.svg"
+        outside.write_text("<svg>secrets</svg>")
+        (icons_dir / "brand.svg").symlink_to(outside)
+
+        assert catalog.custom_icon("brand") is None
+
+    def test_a_real_file_beside_a_refused_link_still_resolves(self, icons_dir: Path):
+        """The refusal has to be about the link, not about the directory."""
+        (icons_dir / "acme.svg").write_text("<svg/>")
+        assert catalog.custom_icon("acme") is not None

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -28,15 +28,23 @@ reviewer left one comment and the merge button went grey.)
 |---|---|---|
 | A pull request is opened, reopened or marked ready | automatic | Drafts are skipped |
 | The `ai-review` label is added | anyone with write access | On demand |
-| A comment starting with `/review` | OWNER, MEMBER or COLLABORATOR only | Re-run after fixes |
 | `workflow_dispatch` with a pull request number | write access | Manual, for testing |
 
 Deliberately **not** on `synchronize`. Two developers, a dozen pushes per pull
 request: a review on every one of them is a review nobody reads. Ask for a
 re-run when the fixes are in.
 
-A `/review` comment from anyone else does nothing at all — the job's `if`
-refuses it before a runner is allocated.
+Re-running is the label, and there is no `/review` comment trigger — that is a
+security property, not an omission. `issue_comment` is a **privileged** event:
+it runs from the default branch *with secrets*, for a comment on any pull
+request including one from a fork. Checking out the pull request's own code in
+that context, inside the job holding `OPENAI_API_KEY`, is exactly the shape
+CodeQL flags as `actions/untrusted-checkout` — and it was right to. The label
+does the same job through `pull_request`, which hands a fork neither the secret
+nor a writable token, so the exposure is gone rather than argued about.
+
+Adding a label needs write access, which is the same bar the comment trigger
+was checking with `author_association`.
 
 ## The three jobs, and why
 
@@ -174,11 +182,6 @@ instructions. Three clauses in it earn their place and should survive an edit:
 - **A documented decision is not a finding.** `CLAUDE.md` has a section on what
   was deliberately removed; without this the reviewer proposes `RoleChecker`
   every week.
-
-Editing the `issue_comment` half cannot be tested inside a pull request: GitHub
-runs `issue_comment` workflows from the copy on the **default branch**, so a
-change to that path only takes effect once it has landed there. Test it with
-`workflow_dispatch`, or after the merge.
 
 The local equivalent, for the same checks before pushing, is the `/review`
 command in `.claude/commands/review.md`.


### PR DESCRIPTION
Seven high alerts landed when CodeQL default setup went on. Three groups; two answered here, one dismissed on the alert with its reason.

## #8, #9 — untrusted checkout in a privileged context. CodeQL was right.

`issue_comment` is **privileged**: it runs from the default branch *with secrets*, for a comment on any pull request — including one from a fork. `ai-review.yml` then checked out that pull request's own code inside the job that holds `OPENAI_API_KEY`.

The collaborator gate and the fork refusal bounded it. Bounding is not removing.

**The `/review` comment trigger is gone.** The `ai-review` label does the same job through `pull_request`, which hands a fork neither the secret nor a writable token — and adding a label needs write access, the same bar `author_association` was checking. One fewer privileged trigger, no capability lost.

## #3, #4 — path injection in the icon route. False positive, fixed anyway.

The slug grammar (`^[a-z0-9][a-z0-9-]{0,63}$`, `fullmatch`) already made traversal impossible, so the alert is wrong on its own terms. But it pointed at something the grammar never covered:

`brand.svg` is a perfectly legal name. An icons directory is somewhere an operator **drops files**. A symlink to `/etc/passwd` satisfies every rule there was, and the route would have served it.

The path is now resolved and checked for containment. That closes the symlink route and states the invariant in a form a reader — and an analyser — can check without parsing a regular expression.

Regression test both ways: a link out of the directory is refused, a real file beside it still resolves. **Verified the first fails without the change.**

## #5, #6, #7 — clear-text logging. Dismissed, not changed.

`counts` is `dict[str, int]` and only ever receives `+= 1` on four fixed keys — `checked`, `refreshed`, `needs_authorization`, `skipped`. No token, payload or credential can reach it. The taint comes from `sweep_oauth_connections` reading `payload.access_token` **in a condition**, which marks its whole return value — not from anything that value contains. Every write to the dict checked, `mcp_connection.py:226-254`.

Dismissed as false positive on the alerts, with that reason.

## Verified

2106 tests with the 100% platform coverage gate, actionlint, zizmor, strict docs build, and the full pre-commit suite. `docs/code-review.md` updated — the trigger table no longer promises `/review`, and says why.