### PR TITLE
ci(deps): try the newest of everything, not five named packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,10 @@
 # Everything else batches monthly. A PR per patch bump to a transitive
 # dependency is a PR nobody reads.
 #
-# `framework-freshness.yml` runs the same upgrade on a schedule and reports what
-# breaks, so a red Dependabot PR is rarely the first anyone hears of it.
+# `dependency-freshness.yml` goes further on a schedule: it upgrades the whole
+# lock, transitive packages included, and opens an issue when the newest release
+# breaks the suite. So a red Dependabot PR is rarely the first anyone hears of
+# it - and a transitive dependency Dependabot never proposes still gets tried.
 
 version: 2
 
@@ -19,7 +21,7 @@ updates:
   # per-group, so any delay on `uv` also delays the four frameworks it groups - and
   # a stale `genai-prices` means budgets computed from stale prices, which is a
   # correctness bug rather than a maintenance chore. The freshness workflow is
-  # what covers the risk a cooldown would: it runs the same upgrade on a
+  # what covers the risk a cooldown would: it tries the newest of everything on a
   # schedule and reports what breaks.
   - package-ecosystem: uv # zizmor: ignore[dependabot-cooldown]
     directory: /backend

--- a/.github/workflows/dependency-freshness.yml
+++ b/.github/workflows/dependency-freshness.yml
@@ -1,21 +1,23 @@
-# Are we still compatible with the newest FastAPI, Pydantic AI, Logfire and
-# genai-prices?
+# Are we still compatible with the newest release of everything?
 #
-# This platform tracks those four rather than pinning them: the subject matter
-# moves at their pace, and genai-prices is the price snapshot budgets are computed
-# from. Uncapping them in `pyproject.toml` is only half the job - the lockfile
-# still pins exact versions, so without something that tries the newest release we
-# would find out from a Dependabot PR nobody had time to read.
+# Nothing in `pyproject.toml` is capped, so the lockfile is the only thing
+# holding versions still. Without something that tries the newest of each, the
+# first anyone hears of a breaking change is a Dependabot pull request nobody
+# had time to read - or, for a transitive dependency Dependabot does not
+# propose at all, a failure in production.
 #
-# So: upgrade just those packages, run the whole suite, and open an issue when it
-# breaks. Nothing is committed - the lockfile change is thrown away with the
-# runner. Dependabot still opens the PR; this exists to make sure the PR is not
-# the first anyone hears of a breaking change.
+# So: upgrade the whole lock, run the whole suite, open an issue when it breaks.
+# Nothing is committed - the lockfile change is thrown away with the runner.
 #
-# It has caught one already: FastAPI 0.141 stopped flattening included routers
-# into `app.routes`, which silently reduced every route sweep in
-# `tests/api/test_platform_routes.py` to zero routes.
-name: Framework freshness
+# This used to upgrade five named packages, on the reasoning that the four
+# frameworks are the ones that move. They are, and they still fail loudest -
+# but five of fifty-seven direct dependencies is a canary that watches one
+# corner of the mine, and the transitive set it never touched is larger still.
+#
+# It has caught one already while narrow: FastAPI 0.141 stopped flattening
+# included routers into `app.routes`, which silently reduced every route sweep
+# in `tests/api/test_platform_routes.py` to zero routes.
+name: Dependency freshness
 
 on:
   schedule:
@@ -28,7 +30,7 @@ permissions:
 
 jobs:
   newest:
-    name: newest FastAPI / Pydantic AI / Logfire / genai-prices
+    name: the newest release of everything
     runs-on: ubuntu-latest
     timeout-minutes: 25
     permissions:
@@ -82,18 +84,19 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
-      - name: Upgrade the four to their newest releases
+      - name: Upgrade everything to its newest release
         id: upgrade
+        # What moved, not what is installed. `uv lock --upgrade` reports each
+        # change as `Updated <name> vA -> vB`, which is the useful half of a
+        # three-hundred-package lockfile - a full `pip list` in the issue is a
+        # wall nobody reads, and the point is to name the version that broke us.
         run: |
-          uv lock --upgrade-package fastapi \
-                  --upgrade-package pydantic-ai-slim \
-                  --upgrade-package pydantic-ai-skills \
-                  --upgrade-package logfire \
-                  --upgrade-package genai-prices
+          set -euo pipefail
+          uv lock --upgrade 2>&1 | tee /tmp/upgrade.log
           uv sync --dev
           {
             echo 'versions<<EOF'
-            uv pip list | grep -Ei '^(fastapi|pydantic-ai-slim|pydantic-ai-skills|pydantic-graph|logfire|genai-prices) '
+            grep -E '^(Updated|Added|Removed) ' /tmp/upgrade.log | sort || echo '(nothing moved)'
             echo EOF
           } >> "$GITHUB_OUTPUT"
         working-directory: backend
@@ -133,26 +136,26 @@ jobs:
           script: |
             const versions = (process.env.VERSIONS ?? '').trim();
             const run = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const title = 'Framework freshness: the newest release breaks the suite';
+            const title = 'Dependency freshness: the newest release breaks the suite';
 
             const open = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
-              labels: 'framework-freshness',
+              labels: 'dependency-freshness',
             });
             const body = [
-              'The scheduled upgrade of FastAPI, Pydantic AI, Logfire and genai-prices',
-              'to their newest releases failed.',
+              'The scheduled upgrade of every dependency to its newest release',
+              'failed. What moved:',
               '',
               '```',
-              versions || '(resolution failed before the versions could be listed)',
+              versions || '(resolution failed before the changes could be listed)',
               '```',
               '',
               `Run: ${run}`,
               '',
               'The lockfile in the repository is untouched — this job throws its',
-              'upgrade away. Reproduce locally with `make deps-upgrade`.',
+              'upgrade away. Reproduce locally with `make deps-upgrade-all`.',
             ].join('\n');
 
             if (open.data.length > 0) {
@@ -169,5 +172,5 @@ jobs:
               repo: context.repo.repo,
               title,
               body,
-              labels: ['framework-freshness', 'dependencies'],
+              labels: ['dependency-freshness', 'dependencies'],
             });

--- a/.github/workflows/dependency-freshness.yml
+++ b/.github/workflows/dependency-freshness.yml
@@ -93,12 +93,16 @@ jobs:
         run: |
           set -euo pipefail
           uv lock --upgrade 2>&1 | tee /tmp/upgrade.log
-          uv sync --dev
+          # Written before the sync, not after. `uv sync` can fail installing
+          # one of the very packages this is meant to name, and with `set -e`
+          # that would leave the issue saying the changes could not be listed
+          # when they are sitting in the log.
           {
             echo 'versions<<EOF'
             grep -E '^(Updated|Added|Removed) ' /tmp/upgrade.log | sort || echo '(nothing moved)'
             echo EOF
           } >> "$GITHUB_OUTPUT"
+          uv sync --dev
         working-directory: backend
 
       - name: What it resolved to
@@ -155,7 +159,10 @@ jobs:
               `Run: ${run}`,
               '',
               'The lockfile in the repository is untouched — this job throws its',
-              'upgrade away. Reproduce locally with `make deps-upgrade-all`.',
+              'upgrade away. Reproduce from `backend/`, which is all this job',
+              'touches: `uv lock --upgrade && uv sync --dev`, then `make test`.',
+              '(`make deps-upgrade-all` does the same and updates the frontend',
+              'too, which would add failures this job never saw.)',
             ].join('\n');
 
             if (open.data.length > 0) {

--- a/Makefile
+++ b/Makefile
@@ -194,10 +194,11 @@ upgrade upgrade-dry-run upgrade-new-features upgrade-finalize:
 	@exit 1
 
 # === Dependencies ===
-# FastAPI, Pydantic AI, Logfire and genai-prices are uncapped and meant to track
-# their newest release. This is the local half of that: bump them, then run the
-# suite, because the upgrade is only done when it still passes. The
-# `framework-freshness` workflow does the same on a schedule and opens an issue.
+# Nothing is capped, so the lockfile is what holds versions still. Two targets:
+# `deps-upgrade` moves the four frameworks this platform tracks, which is the
+# one you want mid-week; `deps-upgrade-all` moves everything, which is what the
+# `dependency-freshness` workflow runs on a schedule. Either way the upgrade is
+# only done when the suite still passes.
 FRAMEWORKS := fastapi pydantic-ai-slim pydantic-ai-skills logfire genai-prices
 
 deps-upgrade:
@@ -207,7 +208,8 @@ deps-upgrade:
 		print(f'fastapi {fastapi.__version__} | logfire {logfire.__version__} | pydantic-ai {pydantic_ai.__version__}')"
 	@echo "▶ Now run 'make test' — an upgrade that breaks the suite is not done."
 
-# Everything, not just the four. Use before a release; expect more fallout.
+# Everything, not just the four - the same thing the scheduled freshness job
+# does, so a red issue from it reproduces here. Expect more fallout.
 deps-upgrade-all:
 	uv lock --directory backend --upgrade
 	uv sync --directory backend --dev

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,9 +13,9 @@ dependencies = [
     # the newest release: this platform's whole subject matter moves at their
     # pace, and genai-prices in particular *is* the model price snapshot, so an
     # old one means budgets computed from stale prices. `make deps-upgrade`
-    # bumps them, the `framework-freshness` workflow tries the latest on a
-    # schedule, and Dependabot opens the PR. A cap here (it was `<0.137`) turns
-    # all three into no-ops.
+    # bumps them, the `dependency-freshness` workflow tries the newest of
+    # everything on a schedule, and Dependabot opens the PR. A cap here (it was
+    # `<0.137`) turns all three into no-ops.
     "fastapi>=0.135.3",
     "uvicorn[standard]>=0.52.0",
     "pydantic[email]>=2.13.4",

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -52,6 +52,14 @@ The backend runs weekly, with the agent frameworks grouped apart from everything
 else — they move fast and this codebase is meant to track them. The frontend
 runs monthly, after a seven-day cooldown.
 
+Dependabot proposes updates for **direct** dependencies. Everything under them
+moves only when a direct one drags it along, which is why
+`.github/workflows/dependency-freshness.yml` exists: once a week it upgrades the
+entire lock — transitive packages included — runs the whole suite against it,
+and opens an issue if that breaks. Nothing is committed; the upgrade is thrown
+away with the runner. `make deps-upgrade-all` is the same thing locally, and is
+how a red issue from it reproduces.
+
 Two things about it are not obvious, and both cost time before they were
 understood:
 


### PR DESCRIPTION
The scheduled freshness check upgraded five named packages — `fastapi`, `pydantic-ai-slim`, `pydantic-ai-skills`, `logfire`, `genai-prices`. **Five of fifty-seven direct dependencies**, and none of the transitive set at all: a canary watching one corner of the mine.

Dependabot does not cover the rest either, not really. It proposes updates for **direct** dependencies, so anything underneath moves only when something above drags it along. Between the two, most of the lockfile was never tried against its newest release until something failed.

## The change

`uv lock --upgrade` — which is what `make deps-upgrade-all` already did locally, so the concept existed; only the scheduled check was narrow.

Measured on today's lock, **24 packages move**:

```
Updated cryptography v49.0.0 -> v50.0.0     ← a major
Updated cachetools   v7.1.6  -> v7.1.7      ← transitive, no PR would name it
Updated virtualenv   v21.7.0 -> v21.7.1     ← same
Updated anthropic    v0.120.0 -> v0.120.2
…
```

The issue it opens now reports **what moved** rather than what is installed. `uv lock --upgrade` prints `Updated <name> vA -> vB` per change; a three-hundred-package `pip list` is a wall nobody reads when the point is to name the version that broke us.

## Renamed

`framework-freshness.yml` → `dependency-freshness.yml`, with the issue label to match. "Framework freshness" stopped being true, and no issue carries the old label, so the rename costs nothing.

## Verified by running what the job runs

Not by reading it: upgrade, sync, `ty check`, and the whole suite against the upgraded lock.

**2107 passed**, so this lands green rather than opening an issue on Monday out of the gate. The lockfile in the repository is untouched — the job throws its upgrade away, and so did I.

## Not changed, because it was already right

`dependabot.yml`'s backend group is `patterns: ["*"]` with the four frameworks excluded into their own group — it does cover every direct dependency, including the `dev` and `docs` groups (the last run bumped `ty` and `mkdocstrings`). The narrowness was in the freshness job, not there. The comments in both files now say which does what.
