### PR TITLE
chore: cut 0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,16 @@ Two things are versioned separately from this file and worth knowing about:
   and a client's exported YAML both carry it, so it only ever moves forward with a
   migration that keeps old documents loading. See
   [the spec reference](docs/reference/spec.md).
-- **The migration chain** — `backend/alembic/versions/`, currently through
-  `0066`. Schema changes are listed here by what they do, not by revision id.
+- **The migration chain** — `backend/alembic/versions/`, squashed to a single
+  `0001_baseline` for this first version. Revision ids named below (`0038`,
+  `0059`, `0066`) are history: they describe when something changed, not a file
+  that still exists. Schema changes are listed here by what they do.
 
 ## [Unreleased]
 
 Nothing yet.
 
-## [0.0.1] — 2026-07-31
+## [0.0.1] — 2026-08-02
 
 First tagged version. The platform is usable end to end — build an agent in the
 UI, publish it, run it from chat, an HTTP API, Slack or an embedded widget, with
@@ -125,16 +127,50 @@ installed hook did nothing.
 - **`backend/.pre-commit-config.yaml`** shadowed the repository root and carried a
   `ty` hook that failed on an argument the pinned `ty` does not accept.
 
+### Security
+
+- **A conversation was readable and writable across tenants.** `GET
+  /conversations/{id}/messages` returned a full transcript — tool calls and
+  their arguments included — for a conversation in another organization, and
+  `POST` to the same path appended a turn to it, `role: "assistant"` included,
+  which rendered to its owner as the agent's own words. `organization_id` is now
+  a required argument on every conversation read and write; a caller that
+  genuinely reads across tenants passes an explicit sentinel.
+- **The avatar proxy forwarded a path traversal to the backend.** It is the one
+  route handler served without a session, so an anonymous caller could drive
+  arbitrary `GET`s against the internal API and read the response.
+- **A channel bot missing one configuration value stalled the whole API.** The
+  Slack and Mattermost supervisors retried a start that returns without
+  awaiting, which never yields — so the event loop starved and every request,
+  health check included, stopped being answered.
+- **Icons are resolved from the directory listing**, not by joining a request
+  parameter onto a path, and a symlink out of that directory is refused.
+
+### Added — the toolchain that keeps it honest
+
+- **An automated pull request reviewer** that reads this repository's own rules
+  from the base branch rather than a generic checklist. See
+  [Code review](docs/code-review.md).
+- **`main` is protected by a ruleset** with no bypass actors: pull request
+  required, CI green, squash only, no force push. See
+  [Branches](docs/branching.md).
+- **A weekly freshness job** that upgrades the entire lockfile, transitive
+  packages included, runs the suite against it and opens an issue when the
+  newest release breaks us.
+
 ### Changed
 
 - **One compose file per environment**, with a matching frontend file beside it:
   `docker-compose.yml` (local), `docker-compose-dev.yml` (dev server),
   `docker-compose-prod.yml` (production), each with a `.frontend.yml` sibling.
   `make stage` is kept as an alias for the new `make dev-server`.
-- **CI runs on `dev`**, not only `main`, and its lint job now matches `make lint`.
-  The integration suite refuses to skip when `CI` is set: an unreachable database
-  there means the service container failed, and skipping two hundred tests to
-  report green is worse than failing.
+- **One long-lived branch.** Work reaches `main` by pull request from a
+  short-lived branch, squashed on merge. A `dev` branch existed briefly and was
+  removed; see [Branches](docs/branching.md). CI's lint job matches `make lint`,
+  and the integration suite refuses to skip when `CI` is set: an unreachable
+  database there means the service container failed, and skipping two hundred
+  tests to report green is worse than failing.
+- **Pydantic AI 2.x** is the agent runtime, and the frontend is on **Next 16**.
 - **The documentation is the single copy of how the system works**, with a
   trigger map from code path to page in `CLAUDE.md` and a `Stop` hook
   (`scripts/docs_drift.py`) that names the pages a change owes.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,3 +1,9 @@
 """OS for your agents."""
 
-__version__ = "0.1.0"
+from importlib.metadata import version
+
+# The one place a version is written down. It used to be written in three -
+# here, `main.py`'s FastAPI metadata and the CLI's `--version` - and all three
+# said 0.1.0 while `pyproject.toml` said 0.0.1. Read from the installed
+# distribution so there is nothing to keep in step.
+__version__ = version("agenticos")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,13 +4,13 @@
 import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager, suppress
-from importlib.metadata import version as installed_version
 from typing import Any, TypedDict
 
 from fastapi import FastAPI
 from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
+from app import __version__
 from app.api.exception_handlers import register_exception_handlers
 from app.api.router import api_router
 from app.agents.capabilities import load_builtins
@@ -213,11 +213,10 @@ OS for your agents.
 - [Swagger UI](/docs) - Interactive API documentation
 - [ReDoc](/redoc) - Alternative documentation view
         """.strip(),
-        # Read from the installed distribution rather than written here. It
-        # said 0.1.0 while `pyproject.toml` said 0.0.1, and the number in
-        # `/docs` and `/openapi.json` is the one a client integrates against -
-        # a second copy of a version is a copy that disagrees.
-        version=installed_version("agenticos"),
+        # `app.__version__`, which reads the installed distribution. The number
+        # in `/docs` and `/openapi.json` is the one a client integrates against,
+        # and it used to be a literal that disagreed with `pyproject.toml`.
+        version=__version__,
         openapi_url=openapi_url,
         docs_url=docs_url,
         redoc_url=redoc_url,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@
 import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager, suppress
+from importlib.metadata import version as installed_version
 from typing import Any, TypedDict
 
 from fastapi import FastAPI
@@ -212,7 +213,11 @@ OS for your agents.
 - [Swagger UI](/docs) - Interactive API documentation
 - [ReDoc](/redoc) - Alternative documentation view
         """.strip(),
-        version="0.1.0",
+        # Read from the installed distribution rather than written here. It
+        # said 0.1.0 while `pyproject.toml` said 0.0.1, and the number in
+        # `/docs` and `/openapi.json` is the one a client integrates against -
+        # a second copy of a version is a copy that disagrees.
+        version=installed_version("agenticos"),
         openapi_url=openapi_url,
         docs_url=docs_url,
         redoc_url=redoc_url,

--- a/backend/cli/commands.py
+++ b/backend/cli/commands.py
@@ -9,6 +9,7 @@ from alembic import command
 from alembic.config import Config
 from tabulate import tabulate
 
+from app import __version__
 from app.commands import register_commands
 from app.main import app
 from app.core.exceptions import AlreadyExistsError
@@ -18,7 +19,7 @@ from app.services.user import UserService
 
 
 @click.group()
-@click.version_option(version="0.1.0", prog_name="agenticos")
+@click.version_option(version=__version__, prog_name="agenticos")
 def cli():
     """agenticos management CLI."""
 


### PR DESCRIPTION
The CHANGELOG has carried a `[0.0.1]` section since July and nothing was ever tagged. This is the release catching up with the notes — and the notes catching up with the code.

## Three things disagreed with the repository

| Claim | Reality |
|---|---|
| `main.py`: `version="0.1.0"` | `pyproject.toml` says `0.0.1` |
| CHANGELOG header: migration chain "through `0066`" | A single `0001_baseline` |
| CHANGELOG: "CI runs on `dev`" | There is no `dev` |

The first is the one that mattered: that number is what `/docs` and `/openapi.json` show, so it is what a client integrates against. It now reads from the installed distribution — a second copy of a version is a copy that disagrees.

The revision ids further down the file (`0038`, `0059`, `0066`) stay, because they are history — they say *when* something changed. The header now says so, rather than reading as a claim about files that exist.

## Added what shipped since the section was written

A **Security** block, which is the part worth a reader's attention:

- A conversation was readable **and writable** across tenants — full transcripts including tool arguments, and an injected `role: "assistant"` turn that rendered to its owner as the agent's own words.
- The avatar proxy forwarded a path traversal to the backend, from the one route served without a session.
- A channel bot missing one configuration value stalled the whole API — the supervisor retried a start that never yields.
- Icons resolve from the directory listing, and a symlink out of it is refused.

Plus Pydantic AI 2.x and Next 16 under **Changed**, and the review, branch-protection and freshness machinery under **Added**.

## Verified

2107 tests with the 100% platform coverage gate, strict docs build, full pre-commit suite. `create_app().version` returns `0.0.1`.

## After this merges

Tag `v0.0.1` on `main`, a GitHub Release from the CHANGELOG section, and a tag ruleset so a released tag cannot be moved or deleted — nothing protects tags today, and a tag that can be repointed is a version number that means nothing.
