### PR TITLE
chore: cut 0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.2] — 2026-08-02
+
+A dependency patch, and the first release cut through the path 0.0.1 built.
+
+### Changed
+
+- `tavily-python` 0.7.26 → 0.7.27, which is what the `web_research` capability
+  searches with.
+
 ## [0.0.1] — 2026-08-02
 
 First tagged version. The platform is usable end to end — build an agent in the
@@ -192,5 +201,6 @@ installed hook did nothing.
   codebase has diverged from the generator past the point where a 3-way merge
   helps.
 
-[Unreleased]: https://github.com/vstorm-co/agenticos/compare/v0.0.1...HEAD
+[Unreleased]: https://github.com/vstorm-co/agenticos/compare/v0.0.2...HEAD
+[0.0.2]: https://github.com/vstorm-co/agenticos/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/vstorm-co/agenticos/releases/tag/v0.0.1

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.1"
+version = "0.0.2"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.1"
+version = "0.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
One dependency patch — `tavily-python` 0.7.26 → 0.7.27, which is what the `web_research` capability searches with (#102, merged).

Thin for a version, and that is rather the point of cutting it: 0.0.1 built the release path, and this is the first walk through it with nothing else going on.

## What it demonstrates

The version moves in **one place** — `backend/pyproject.toml` — and everything downstream followed without being touched:

```
app.__version__     = 0.0.2
OpenAPI /docs       = 0.0.2
agenticos --version = 0.0.2
```

That is the property the 0.0.1 release was cleaning up for. Before it, those were three literals that all said `0.1.0` while `pyproject.toml` said `0.0.1`.

`frontend/package.json` moves with it. It is not published anywhere, but a frontend claiming a different version than the API it ships beside is a question somebody has to answer twice.

## After this merges

Tag `v0.0.2` and a GitHub Release from the CHANGELOG section. The tag ruleset added with 0.0.1 makes it immutable once pushed — verified then by trying to move and delete `v0.0.1`, both refused.
