### PR TITLE
chore(frontend): make the tsconfig and the DOM mocks TypeScript 7 ready

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -23,7 +23,6 @@
         "name": "next"
       }
     ],
-    "baseUrl": ".",
     "paths": {
       "@/*": [
         "./src/*"

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -100,6 +100,10 @@ class MockResizeObserver implements ResizeObserver {
 class MockIntersectionObserver implements IntersectionObserver {
   readonly root = null;
   readonly rootMargin = "";
+  // Added to the DOM lib in TypeScript 7's `lib.dom.d.ts`. Declared here rather
+  // than widened away, so the next field the spec adds fails the type check
+  // instead of being silently absent from the mock.
+  readonly scrollMargin = "";
   readonly thresholds: readonly number[] = [];
   observe = vi.fn();
   unobserve = vi.fn();


### PR DESCRIPTION
Two changes, both found by installing TypeScript 7 and reading what broke.

- **`baseUrl` is gone in 7**, and it was doing nothing here: the `paths` entry is already relative (`./src/*`), which is the form the compiler's own error message suggests, and TypeScript has accepted relative `paths` without a `baseUrl` since 4.1.
- **`IntersectionObserver` gained a required `scrollMargin`** in 7's `lib.dom.d.ts`. The mock in `vitest.setup.ts` `implements IntersectionObserver` rather than casting past it, so it stopped compiling. Declared rather than widened away — the point of implementing the interface is that the next field the spec adds fails the type check instead of being quietly absent from the mock.

With both, `tsc --noEmit` is clean under `typescript@7.0.2`. Verified under `5.9.3` too, which is what ships — this is preparation, not the bump.

## Why not the bump

`typescript-eslint` refuses to load against 7 (`typescript-eslint does not support TS 7.0`) and `eslint-config-next` imports it, so lint dies before it reads a file. Separately, ESLint 10 is blocked by `eslint-plugin-react` calling a context API that 10 removed. Both confirmed by installing them, both written up in #109, which is where #97 should be closed to.

## Verified

`bun run type-check`, `bun run lint`, `bun run test:run` (2459 passed), `bun install --frozen-lockfile`.

Refs #97, #109