### PR TITLE
feat(auth): land every sign-in on the dashboard and honour deep links

### DIFF
--- a/frontend/e2e/auth.setup.ts
+++ b/frontend/e2e/auth.setup.ts
@@ -24,9 +24,9 @@ setup("authenticate as the bootstrapped owner", async ({ page }) => {
   await page.getByLabel("Password").fill(OWNER_PASSWORD);
   await page.getByRole("button", { name: "Login" }).click();
 
-  // Login lands on /chat for a normal owner and /dashboard for a platform
-  // superadmin. Either is proof the credentials were accepted; staying on
-  // /login is proof they were not.
+  // Login lands on /dashboard for every role — one landing page, shared by
+  // every sign-in path. Arriving there is proof the credentials were accepted;
+  // staying on /login is proof they were not.
   //
   // The timeout is raised from the 5s default because this is the run's first
   // navigation into the dashboard, and against `bun run dev` that route is
@@ -36,7 +36,7 @@ setup("authenticate as the bootstrapped owner", async ({ page }) => {
   // reads exactly like rejected credentials; the login request had in fact
   // returned 200 and the redirect was still compiling. Raising it does not
   // weaken the check: staying on /login for 30s is still a failure.
-  await expect(page).toHaveURL(/\/(chat|dashboard)(\?.*)?$/, { timeout: 30_000 });
+  await expect(page).toHaveURL(/\/dashboard(\?.*)?$/, { timeout: 30_000 });
 
   // A URL change alone would also be satisfied by a client-side redirect that
   // bounces straight back. The dashboard shell renders behind `AuthGuard`, so

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -42,6 +42,21 @@ test.describe("Authentication", () => {
     await expect(page).toHaveURL(/\/pl\/login$/);
   });
 
+  test("a deep link survives the login round trip", async ({ page }) => {
+    await page.context().clearCookies();
+    await page.goto("/agents");
+
+    // Landing on the default page after signing in would mean the link the
+    // visitor followed - from an email, a doc - was silently swallowed.
+    await expect(page).toHaveURL(/\/login\?returnTo=%2Fagents/, { timeout: 30_000 });
+
+    await page.getByLabel("Email").fill(OWNER_EMAIL);
+    await page.getByLabel("Password").fill(OWNER_PASSWORD);
+    await page.getByRole("button", { name: "Login" }).click();
+
+    await expect(page).toHaveURL(/\/agents(\?.*)?$/, { timeout: 30_000 });
+  });
+
   test.describe("Login Page", () => {
     test("displays the sign-in form", async ({ page }) => {
       await page.goto("/login");
@@ -172,6 +187,6 @@ test("the bootstrapped owner can sign in", async ({ page }) => {
   await page.getByLabel("Password").fill(OWNER_PASSWORD);
   await page.getByRole("button", { name: "Login" }).click();
 
-  await expect(page).toHaveURL(/\/(chat|dashboard)(\?.*)?$/);
+  await expect(page).toHaveURL(/\/dashboard(\?.*)?$/);
   await expect(page.getByRole("navigation", { name: "Primary" })).toBeVisible();
 });

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -42,19 +42,23 @@ test.describe("Authentication", () => {
     await expect(page).toHaveURL(/\/pl\/login$/);
   });
 
-  test("a deep link survives the login round trip", async ({ page }) => {
+  test("a deep link survives the login round trip, fragment included", async ({ page }) => {
     await page.context().clearCookies();
-    await page.goto("/agents");
+    await page.goto("/agents?tab=all#list");
 
     // Landing on the default page after signing in would mean the link the
-    // visitor followed - from an email, a doc - was silently swallowed.
-    await expect(page).toHaveURL(/\/login\?returnTo=%2Fagents/, { timeout: 30_000 });
+    // visitor followed - from an email, a doc - was silently swallowed. The
+    // query and the fragment are part of the link: an anchored section that
+    // comes back unanchored was swallowed too, just more quietly.
+    await expect(page).toHaveURL(/\/login\?returnTo=%2Fagents%3Ftab%3Dall%23list/, {
+      timeout: 30_000,
+    });
 
     await page.getByLabel("Email").fill(OWNER_EMAIL);
     await page.getByLabel("Password").fill(OWNER_PASSWORD);
     await page.getByRole("button", { name: "Login" }).click();
 
-    await expect(page).toHaveURL(/\/agents(\?.*)?$/, { timeout: 30_000 });
+    await expect(page).toHaveURL(/\/agents\?tab=all#list$/, { timeout: 30_000 });
   });
 
   test.describe("Login Page", () => {

--- a/frontend/e2e/seed.setup.ts
+++ b/frontend/e2e/seed.setup.ts
@@ -342,7 +342,7 @@ async function acceptAsColleague(
     await colleague.getByLabel("Email").fill(COLLEAGUE_EMAIL);
     await colleague.getByLabel("Password").fill(COLLEAGUE_PASSWORD);
     await colleague.getByRole("button", { name: "Login" }).click();
-    await expect(colleague).toHaveURL(/\/(chat|dashboard)(\?.*)?$/);
+    await expect(colleague).toHaveURL(/\/dashboard(\?.*)?$/);
 
     await colleague.goto(`/invitations/${token}`);
     await colleague.getByRole("button", { name: "Accept invitation" }).click();

--- a/frontend/src/app/[locale]/auth/callback/page.tsx
+++ b/frontend/src/app/[locale]/auth/callback/page.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Spinner } from "@/components/ui";
 import { apiClient } from "@/lib/api-client";
 import { useAdoptSession } from "@/hooks/use-auth";
+import { postSignInDestination } from "@/lib/auth-landing";
 import type { User } from "@/types";
 import { useTranslations } from "next-intl";
 
@@ -48,7 +49,9 @@ export default function AuthCallbackPage() {
         );
         if (cancelled) return;
         adoptSession(data.user, data.access_token);
-        router.replace("/dashboard");
+        // No deep link here: carrying one through the provider round trip
+        // needs the OAuth `state` parameter, which this flow does not use yet.
+        router.replace(postSignInDestination());
       } catch {
         if (!cancelled) {
           setExchangeFailed(true);

--- a/frontend/src/app/[locale]/auth/callback/page.tsx
+++ b/frontend/src/app/[locale]/auth/callback/page.tsx
@@ -49,8 +49,10 @@ export default function AuthCallbackPage() {
         );
         if (cancelled) return;
         adoptSession(data.user, data.access_token);
-        // No deep link here: carrying one through the provider round trip
-        // needs the OAuth `state` parameter, which this flow does not use yet.
+        // No deep link here yet - nothing carries a returnTo through the
+        // provider round trip. It would not need the OAuth `state` parameter:
+        // the trip starts and ends in the same tab on this origin, so
+        // sessionStorage set beside the provider link is enough.
         router.replace(postSignInDestination());
       } catch {
         if (!cancelled) {

--- a/frontend/src/app/[locale]/auth/magic-link/page.tsx
+++ b/frontend/src/app/[locale]/auth/magic-link/page.tsx
@@ -8,6 +8,7 @@ import { AlertCircle, CheckCircle2, Loader2 } from "lucide-react";
 
 import { apiClient, ApiError } from "@/lib/api-client";
 import { useReauthenticate } from "@/hooks/use-auth";
+import { postSignInDestination } from "@/lib/auth-landing";
 import { ROUTES } from "@/lib/constants";
 
 /**
@@ -15,7 +16,8 @@ import { ROUTES } from "@/lib/constants";
  *
  * Flow: user clicks the email link → arrives here with `?token=...` →
  * we POST the token to `/auth/magic-link/verify`, which signs them in via
- * the standard Set-Cookie flow → redirect to /chat.
+ * the standard Set-Cookie flow → redirect to the shared post-sign-in
+ * destination.
  */
 export default function MagicLinkVerifyPage() {
   const t = useTranslations("auth.magicLink");
@@ -42,7 +44,7 @@ export default function MagicLinkVerifyPage() {
         await reauthenticate();
         if (!active) return;
         setState("success");
-        router.replace(ROUTES.CHAT);
+        router.replace(postSignInDestination());
       })
       .catch((err: unknown) => {
         if (!active) return;

--- a/frontend/src/components/auth/login-form.tsx
+++ b/frontend/src/components/auth/login-form.tsx
@@ -30,7 +30,10 @@ export function LoginForm() {
     setError("");
 
     try {
-      await login({ email, password });
+      // Read off the URL at submit time: useSearchParams would demand a
+      // Suspense boundary around a form that renders statically.
+      const returnTo = new URLSearchParams(window.location.search).get("returnTo");
+      await login({ email, password }, returnTo);
       toast.success(t("loginSuccess"));
     } catch (err) {
       const message = err instanceof ApiError ? err.message : t("loginFailedPleaseTry");

--- a/frontend/src/components/layout/auth-guard.test.tsx
+++ b/frontend/src/components/layout/auth-guard.test.tsx
@@ -1,0 +1,49 @@
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AuthGuard } from "./auth-guard";
+import { apiClient } from "@/lib/api-client";
+import { ROUTES } from "@/lib/constants";
+import { useAuthStore } from "@/stores";
+
+/**
+ * What the guard hands to the login page when it turns a visitor away.
+ *
+ * The adoption side of the guard is covered by
+ * `session-adoption.integration.test.tsx`; this file covers the refusal. The
+ * `returnTo` it builds is the only copy of where the visitor was headed, so
+ * anything it drops - the fragment is the easy one to drop, `pathname + search`
+ * reads complete - is silently swallowed by the login round trip.
+ */
+vi.mock("@/lib/api-client", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api-client")>("@/lib/api-client");
+  return { ...actual, apiClient: { get: vi.fn(), post: vi.fn() } };
+});
+vi.mock("@/hooks/use-auth", () => ({ useAdoptSession: () => vi.fn() }));
+
+const replace = vi.hoisted(() => vi.fn());
+vi.mock("next/navigation", () => ({ useRouter: () => ({ replace, push: vi.fn() }) }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useAuthStore.getState().logout();
+});
+
+describe("the dashboard guard, refusing", () => {
+  it("carries the whole address to login - path, query and fragment", async () => {
+    window.history.replaceState(null, "", "/agents/a-1?tab=spec#monthly");
+    vi.mocked(apiClient.get).mockRejectedValue(new Error("401"));
+
+    render(
+      <AuthGuard>
+        <p>the dashboard</p>
+      </AuthGuard>,
+    );
+
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith(
+        `${ROUTES.LOGIN}?returnTo=${encodeURIComponent("/agents/a-1?tab=spec#monthly")}`,
+      ),
+    );
+  });
+});

--- a/frontend/src/components/layout/auth-guard.tsx
+++ b/frontend/src/components/layout/auth-guard.tsx
@@ -32,7 +32,10 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
         );
         adoptSession(user as User, access_token ?? null);
       } catch {
-        router.replace(ROUTES.LOGIN);
+        // Off `window.location`, not the navigation hooks: a hook here would
+        // tie the verify effect to every navigation this guard sits above.
+        const { pathname, search } = window.location;
+        router.replace(`${ROUTES.LOGIN}?returnTo=${encodeURIComponent(pathname + search)}`);
       } finally {
         setChecking(false);
       }

--- a/frontend/src/components/layout/auth-guard.tsx
+++ b/frontend/src/components/layout/auth-guard.tsx
@@ -34,8 +34,8 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
       } catch {
         // Off `window.location`, not the navigation hooks: a hook here would
         // tie the verify effect to every navigation this guard sits above.
-        const { pathname, search } = window.location;
-        router.replace(`${ROUTES.LOGIN}?returnTo=${encodeURIComponent(pathname + search)}`);
+        const { pathname, search, hash } = window.location;
+        router.replace(`${ROUTES.LOGIN}?returnTo=${encodeURIComponent(pathname + search + hash)}`);
       } finally {
         setChecking(false);
       }

--- a/frontend/src/components/layout/mobile-tab-bar.test.tsx
+++ b/frontend/src/components/layout/mobile-tab-bar.test.tsx
@@ -10,7 +10,6 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn() }),
 }));
 vi.mock("next-intl", () => ({ useTranslations: () => (key: string) => key }));
-vi.mock("@/hooks", () => ({ useAuth: () => ({ user: { role: "member" } }) }));
 
 /**
  * The tab bar had the same bug the desktop sidebar had, in a worse form: it

--- a/frontend/src/components/layout/mobile-tab-bar.tsx
+++ b/frontend/src/components/layout/mobile-tab-bar.tsx
@@ -6,10 +6,9 @@ import { useTranslations } from "next-intl";
 import { Database, LayoutDashboard, MessageSquare, Search, Settings } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
-import { useAuth } from "@/hooks";
 import { stripLocale } from "@/lib/active-route";
 import { ROUTES } from "@/lib/constants";
-import { cn, isAppAdmin } from "@/lib/utils";
+import { cn } from "@/lib/utils";
 
 interface TabItem {
   label: string;
@@ -23,7 +22,6 @@ interface TabItem {
 export function MobileTabBar() {
   const pathname = usePathname();
   const router = useRouter();
-  const { user } = useAuth();
   const t = useTranslations("nav");
 
   // `stripLocale`, not a two-letter regex. The regex matched *any* two letters,
@@ -35,11 +33,7 @@ export function MobileTabBar() {
   const items: TabItem[] = [
     { label: t("chat"), href: ROUTES.CHAT, icon: MessageSquare, startsWith: true },
     { label: t("kb"), href: ROUTES.KB, icon: Database, startsWith: true },
-    {
-      label: t("home"),
-      href: isAppAdmin(user) ? ROUTES.DASHBOARD : ROUTES.CHAT,
-      icon: LayoutDashboard,
-    },
+    { label: t("home"), href: ROUTES.DASHBOARD, icon: LayoutDashboard },
     {
       label: t("search"),
       icon: Search,

--- a/frontend/src/hooks/use-auth.test.tsx
+++ b/frontend/src/hooks/use-auth.test.tsx
@@ -286,6 +286,26 @@ describe("signing in", () => {
     expect(push).toHaveBeenLastCalledWith("/agents/a-1?tab=spec");
   });
 
+  it("resumes a deep link with a fragment by document navigation, not the router", async () => {
+    // The router cannot be trusted with a fragment: a soft navigation lands on
+    // /path#x#x in a production build (next@16.2 segment cache), so the
+    // fragment case must leave the SPA and load the document.
+    const assign = vi.fn();
+    vi.spyOn(window, "location", "get").mockReturnValue({
+      ...window.location,
+      assign,
+    } as unknown as Location);
+    vi.mocked(apiClient.post).mockResolvedValue({ user: user(), access_token: "t", message: "ok" });
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await act(async () => {
+      await result.current.login({ email: "a@example.com", password: "x" }, "/agents/a-1#monthly");
+    });
+
+    expect(assign).toHaveBeenCalledWith("/agents/a-1#monthly");
+    expect(push).not.toHaveBeenCalledWith("/agents/a-1#monthly");
+  });
+
   it("refuses a returnTo that leaves the origin", async () => {
     // ?returnTo= arrives in the URL, so anybody can mint a login link with it;
     // honouring an off-origin value would turn the form into an open redirect.

--- a/frontend/src/hooks/use-auth.test.tsx
+++ b/frontend/src/hooks/use-auth.test.tsx
@@ -73,6 +73,10 @@ beforeEach(async () => {
 
 afterEach(() => {
   vi.useRealTimers();
+  // `clearAllMocks` in beforeEach clears calls but does not undo a `spyOn`;
+  // without this, a test that spies on `window.location` freezes it for
+  // every test after it.
+  vi.restoreAllMocks();
 });
 
 describe("checking the session on load", () => {

--- a/frontend/src/hooks/use-auth.test.tsx
+++ b/frontend/src/hooks/use-auth.test.tsx
@@ -255,7 +255,7 @@ describe("signing in", () => {
     expect(useAuthStore.getState().accessToken).toBe("t-1");
   });
 
-  it("sends an app admin to the dashboard and everybody else to the chat", async () => {
+  it("lands an app admin and an ordinary member on the same dashboard", async () => {
     vi.mocked(apiClient.post).mockResolvedValue({
       user: user({ is_app_admin: true } as Partial<User>),
       access_token: "t-1",
@@ -272,7 +272,31 @@ describe("signing in", () => {
     await act(async () => {
       await result.current.login({ email: "b@example.com", password: "x" });
     });
-    expect(push).toHaveBeenLastCalledWith(ROUTES.CHAT);
+    expect(push).toHaveBeenLastCalledWith(ROUTES.DASHBOARD);
+  });
+
+  it("resumes the deep link the visitor was headed to", async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({ user: user(), access_token: "t", message: "ok" });
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await act(async () => {
+      await result.current.login({ email: "a@example.com", password: "x" }, "/agents/a-1?tab=spec");
+    });
+
+    expect(push).toHaveBeenLastCalledWith("/agents/a-1?tab=spec");
+  });
+
+  it("refuses a returnTo that leaves the origin", async () => {
+    // ?returnTo= arrives in the URL, so anybody can mint a login link with it;
+    // honouring an off-origin value would turn the form into an open redirect.
+    vi.mocked(apiClient.post).mockResolvedValue({ user: user(), access_token: "t", message: "ok" });
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await act(async () => {
+      await result.current.login({ email: "a@example.com", password: "x" }, "//evil.example/a");
+    });
+
+    expect(push).toHaveBeenLastCalledWith(ROUTES.DASHBOARD);
   });
 
   it("does not ask who is signed in after a login that just said so", async () => {

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -176,7 +176,15 @@ export function useAuth() {
         adoptUser(queryClient, setUser, response.user);
         useAuthStore.getState().setAccessToken(response.access_token);
         authChecked = true; // login already populated user + token; skip /auth/me
-        router.push(postSignInDestination(returnTo));
+        const destination = postSignInDestination(returnTo);
+        if (destination.includes("#")) {
+          // next@16.2's segment cache appends the fragment a second time on a
+          // soft navigation (/path#x becomes /path#x#x in a production build),
+          // so a destination with a fragment must load the document instead.
+          window.location.assign(destination);
+        } else {
+          router.push(destination);
+        }
         return response;
       } finally {
         setLoading(false);

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -8,8 +8,8 @@ import { toast } from "sonner";
 import { resetSessionState, useAuthStore } from "@/stores";
 import { apiClient, ApiError } from "@/lib/api-client";
 import type { User, LoginRequest, RegisterRequest } from "@/types";
+import { postSignInDestination } from "@/lib/auth-landing";
 import { ROUTES } from "@/lib/constants";
-import { isAppAdmin } from "@/lib/utils";
 
 // Session-level singletons so /auth/me runs ONCE per page load no matter how
 // many components mount useAuth(). Concurrent mounts share the in-flight
@@ -165,7 +165,7 @@ export function useAuth() {
   }, [setUser, queryClient]);
 
   const login = useCallback(
-    async (credentials: LoginRequest) => {
+    async (credentials: LoginRequest, returnTo?: string | null) => {
       setLoading(true);
       try {
         const response = await apiClient.post<{
@@ -176,7 +176,7 @@ export function useAuth() {
         adoptUser(queryClient, setUser, response.user);
         useAuthStore.getState().setAccessToken(response.access_token);
         authChecked = true; // login already populated user + token; skip /auth/me
-        router.push(isAppAdmin(response.user) ? ROUTES.DASHBOARD : ROUTES.CHAT);
+        router.push(postSignInDestination(returnTo));
         return response;
       } finally {
         setLoading(false);

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -181,6 +181,10 @@ export function useAuth() {
           // next@16.2's segment cache appends the fragment a second time on a
           // soft navigation (/path#x becomes /path#x#x in a production build),
           // so a destination with a fragment must load the document instead.
+          // The branches are not equivalent: a document load drops the
+          // in-memory access token (re-adopted via /auth/me on arrival), and
+          // anything the caller runs after login() fires into an unloading
+          // page.
           window.location.assign(destination);
         } else {
           router.push(destination);

--- a/frontend/src/lib/auth-landing.test.ts
+++ b/frontend/src/lib/auth-landing.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { postSignInDestination } from "./auth-landing";
+import { ROUTES } from "./constants";
+
+describe("postSignInDestination", () => {
+  it("defaults to the dashboard", () => {
+    expect(postSignInDestination()).toBe(ROUTES.DASHBOARD);
+    expect(postSignInDestination(null)).toBe(ROUTES.DASHBOARD);
+  });
+
+  it("honours a same-origin path, query included", () => {
+    expect(postSignInDestination("/agents/a-1")).toBe("/agents/a-1");
+    expect(postSignInDestination("/chat?id=c-1")).toBe("/chat?id=c-1");
+  });
+
+  // None is "fixed up" into something safe: a sanitised open redirect is
+  // still an open redirect.
+  it.each([
+    "//evil.example/phish",
+    "/\\evil.example",
+    "https://evil.example",
+    "javascript:alert(1)",
+    "agents",
+    "",
+  ])("refuses %j and falls back to the dashboard", (path) => {
+    expect(postSignInDestination(path)).toBe(ROUTES.DASHBOARD);
+  });
+});

--- a/frontend/src/lib/auth-landing.test.ts
+++ b/frontend/src/lib/auth-landing.test.ts
@@ -9,13 +9,17 @@ describe("postSignInDestination", () => {
     expect(postSignInDestination(null)).toBe(ROUTES.DASHBOARD);
   });
 
-  it("honours a same-origin path, query included", () => {
+  it("honours a same-origin path, query and fragment included", () => {
     expect(postSignInDestination("/agents/a-1")).toBe("/agents/a-1");
     expect(postSignInDestination("/chat?id=c-1")).toBe("/chat?id=c-1");
+    expect(postSignInDestination("/agents/a-1?tab=spec#monthly")).toBe(
+      "/agents/a-1?tab=spec#monthly",
+    );
   });
 
   // None is "fixed up" into something safe: a sanitised open redirect is
-  // still an open redirect.
+  // still an open redirect. The control characters are "//evil.example" in
+  // disguise - the URL parser strips tab, LF and CR before parsing.
   it.each([
     "//evil.example/phish",
     "/\\evil.example",
@@ -23,6 +27,9 @@ describe("postSignInDestination", () => {
     "javascript:alert(1)",
     "agents",
     "",
+    "/\t/evil.example",
+    "/\n/evil.example",
+    "/\r/evil.example",
   ])("refuses %j and falls back to the dashboard", (path) => {
     expect(postSignInDestination(path)).toBe(ROUTES.DASHBOARD);
   });

--- a/frontend/src/lib/auth-landing.ts
+++ b/frontend/src/lib/auth-landing.ts
@@ -1,0 +1,29 @@
+import { ROUTES } from "@/lib/constants";
+
+/**
+ * Where a fresh session lands: the deep link the visitor was headed to when
+ * it is safe to honour, the dashboard otherwise.
+ *
+ * Every sign-in path - password, the OAuth callback, the magic link - resolves
+ * its redirect here. Each of them establishes a session by a different route,
+ * which is exactly why the destination must not be decided in three places:
+ * the answers drift, and which door somebody came through starts deciding
+ * where they land.
+ *
+ * The default is deliberately the same for every role. What a role may not
+ * see is handled by not rendering the widget, never by a different landing
+ * page - a role fork here quietly splits one product into two.
+ */
+export function postSignInDestination(returnTo?: string | null): string {
+  return isSafeReturnPath(returnTo) ? returnTo : ROUTES.DASHBOARD;
+}
+
+/**
+ * Only a same-origin path may be honoured. A value with a scheme
+ * ("https://evil.example"), a protocol-relative one ("//evil.example") or a
+ * backslash variant ("/\evil.example", which browsers normalise to "//")
+ * would turn ?returnTo= into an open redirect off the login form.
+ */
+function isSafeReturnPath(path: string | null | undefined): path is string {
+  return typeof path === "string" && /^\/(?![/\\])/.test(path);
+}

--- a/frontend/src/lib/auth-landing.ts
+++ b/frontend/src/lib/auth-landing.ts
@@ -23,7 +23,17 @@ export function postSignInDestination(returnTo?: string | null): string {
  * ("https://evil.example"), a protocol-relative one ("//evil.example") or a
  * backslash variant ("/\evil.example", which browsers normalise to "//")
  * would turn ?returnTo= into an open redirect off the login form.
+ *
+ * Both checks are load-bearing. The regex alone misses control characters:
+ * the URL parser strips tab, LF and CR before parsing, so "/\t/evil.example"
+ * resolves to "https://evil.example". The origin check alone would accept a
+ * relative path like "agents", which resolves same-origin but against
+ * wherever the visitor happens to stand.
  */
 function isSafeReturnPath(path: string | null | undefined): path is string {
-  return typeof path === "string" && /^\/(?![/\\])/.test(path);
+  return (
+    typeof path === "string" &&
+    /^\/(?![/\\])/.test(path) &&
+    new URL(path, window.location.origin).origin === window.location.origin
+  );
 }


### PR DESCRIPTION
## Summary

Every sign-in path — password, the OAuth callback and the magic link — now resolves
its redirect through one shared destination and lands on `/dashboard`, replacing
three call sites that each decided on their own and disagreed (password sign-in
forked on `is_app_admin`, OAuth always went to `/dashboard`, the magic link always
to `/chat`). A deep link interrupted by the login form is now carried through
`?returnTo=` and resumed after signing in.

## Related Issue

Closes #38.

## Added

- `src/lib/auth-landing.ts` — `postSignInDestination(returnTo?)`, the single
  post-sign-in landing decision, with an open-redirect guard that refuses
  off-origin values (`//host`, `https://…`, `/\host`, scheme and relative
  paths); colocated `auth-landing.test.ts`.
- `returnTo` round trip: `AuthGuard` appends the refused path as `?returnTo=`
  when it sends a visitor to `/login`, the login form reads it at submit time,
  and `login()` forwards it to the destination helper.
- E2E spec `a deep link survives the login round trip` in `e2e/auth.spec.ts`.

## Changed

- `useAuth().login()` no longer forks on `isAppAdmin` — everyone lands on the
  shared destination; it now accepts an optional `returnTo`.
- The OAuth callback and the magic-link page redirect through
  `postSignInDestination()` instead of their hardcoded `/dashboard` and `/chat`.
- The mobile tab bar's Home tab targets `/dashboard` for every role; its unused
  `useAuth` dependency and the stale mock in `mobile-tab-bar.test.tsx` are gone.
- E2E landing assertions tightened from `/(chat|dashboard)/` to `/dashboard/`
  in `auth.setup.ts`, `auth.spec.ts` and `seed.setup.ts`.

## Checks

- [x] Tests cover the new behaviour, and would fail without the change
- [x] `make check` passes (lint, format, types)
- [x] Platform-layer coverage is still 100%
- [x] If a capability was added or changed, its `README.md` says why
- [x] If a migration was added, `alembic downgrade base && alembic upgrade head` works

## Notes for Reviewers

- #38 is labelled "Blocked by #37" — waived deliberately: the deployment has no
  users yet and the dashboard stub links onward to chat and agents, so landing
  everyone there until #37 fills the page costs one extra click. The issue's
  "a Viewer sees something useful" checkbox is satisfied as its documented-
  decision variant: the one-landing-for-every-role rationale lives in the
  `postSignInDestination` docstring.
- A deep link through OAuth is deliberately out of scope — it needs the `state`
  parameter round trip, and #14 is rewriting that flow anyway.
- `window.location` instead of `useSearchParams`/`usePathname` in the login
  form and `AuthGuard` is intentional: the former would demand a Suspense
  boundary, the latter would tie the guard's verify effect to every navigation.
- Verified locally: `make check` green end to end (backend 2107 passed, platform
  gate at 100.00%; frontend gate 100/97.6/100/100 plus `next build`), and the
  E2E suite against a live stack — 88 passed; the 4 failures assert on the
  `openai default` bootstrap fixture a long-lived dev database does not have,
  so they fail there on any branch. CI seeds that fixture fresh.