### PR TITLE
chore: cut 0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,30 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.6] - 2026-08-04
+
+Dependencies only. No behaviour change, no schema change, `SPEC_VERSION` unchanged
+at 7 — this is here so the version literals and the lockfiles move together rather
+than drifting until somebody notices.
+
+### Changed
+
+- **TypeScript 5.9.3 → 6.0.3** (dev). A major, so it was checked rather than
+  assumed: `tsc --noEmit`, `eslint --max-warnings 0`, the coverage gate and
+  `next build` all pass with no source change.
+
+  Dependabot bumped `frontend/package.json` and left `bun.lock` alone, which two CI
+  jobs would have refused — they run `bun install --frozen-lockfile`, and that fails
+  outright when the manifest and the lock disagree. The lock is updated here, so the
+  next such bump should be checked for the same omission.
+
+- **ruff 0.15.0 → 0.16.1** (dev). Ruff is the formatter as well as the linter, so a
+  new rule or a changed format would have turned `make lint` red *after* the merge
+  rather than before it. `ruff format --check` reports 476 files already formatted
+  and `ruff check` passes, so nothing in the tree needed touching.
+
+- **boto3 1.43.59 → 1.43.62.**
+
 ## [0.0.5] - 2026-08-04
 
 **Every sign-in lands on the dashboard**, and a deep link interrupted by the login
@@ -448,7 +472,8 @@ installed hook did nothing.
   codebase has diverged from the generator past the point where a 3-way merge
   helps.
 
-[Unreleased]: https://github.com/vstorm-co/agenticos/compare/v0.0.5...HEAD
+[Unreleased]: https://github.com/vstorm-co/agenticos/compare/v0.0.6...HEAD
+[0.0.6]: https://github.com/vstorm-co/agenticos/compare/v0.0.5...v0.0.6
 [0.0.5]: https://github.com/vstorm-co/agenticos/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/vstorm-co/agenticos/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/vstorm-co/agenticos/compare/v0.0.2...v0.0.3

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.5"
+version = "0.0.6"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.5"
+version = "0.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },
@@ -5556,8 +5556,8 @@ name = "whenever"
 version = "0.10.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
-    { name = "tzlocal", marker = "sys_platform != 'darwin' and sys_platform != 'linux'" },
+    { name = "tzdata", marker = "python_full_version >= '3.13' and sys_platform == 'win32'" },
+    { name = "tzlocal", marker = "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6d/40/94856fe2439c4b8162d1a23b4cf3a48bb00bed0ed7b8d10add40988fa555/whenever-0.10.3.tar.gz", hash = "sha256:af8958c870bd178742f0089c3552d5702241cab1f4b6bdfd3b03111db4bc2150", size = 435946, upload-time = "2026-07-17T07:35:25.734Z" }
 wheels = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Dependencies only — TypeScript 6.0.3 (#118), ruff 0.16.1 and boto3 1.43.62 (#117). No behaviour change, no schema change, `SPEC_VERSION` unchanged at 7.

Cut rather than left to accumulate on `main`, because the point of a release commit here is that the three version literals and both lockfiles move together. Letting dependency merges pile up is how a lock ends up disagreeing with its manifest — which is exactly the defect #118 arrived with.

The changelog says **what was checked** for each bump rather than restating version numbers a reader can diff:

- **TypeScript 6.0 is a major** — `tsc --noEmit`, `eslint --max-warnings 0`, the coverage gate and `next build` all pass with no source change. Dependabot had left `bun.lock` untouched, which two CI jobs would have refused (`bun install --frozen-lockfile`); fixed on that PR.
- **ruff is the formatter as well as the linter** — `ruff format --check` reports 476 files already formatted and `ruff check` passes, so a changed format or a new rule would have turned `make lint` red *after* the merge rather than before it.

Reference links moved with the heading, as in 0.0.5 — verified by asserting every `## [x]` heading has a reference and every reference a heading, which is what 0.0.4 shipped without.

Verified: `make check` green — 2702 backend tests, platform gate at 100%, frontend 100/97.58/100/100.

One thing worth knowing, unrelated to this release: `journey.spec.ts` flaked on `main` at `5780012` and passed on a re-run, on a commit that was a type-only dependency bump. Filed as #162 — it is a fourth spec with the same `element(s) not found` signature as #130, #132 and #154, which together look less like four coincidences and more like the suite lacking a shared "wait until this mutation landed" primitive.