### PR TITLE
fix(agents): validate skill_ids at publish, at both levels

### DIFF
--- a/backend/app/agents/spec.py
+++ b/backend/app/agents/spec.py
@@ -561,7 +561,14 @@ class SpecialistSpec(BaseModel):
             "like an agent."
         ),
     )
-    skill_ids: list[UUID] = Field(default_factory=list)
+    skill_ids: list[UUID] = Field(
+        default_factory=list,
+        description=(
+            "Skills it may read. Checked at publish against the publisher's own "
+            "access, exactly as `collection_ids` is - a skill is know-how somebody "
+            "wrote, and a private one bound here would be read by every run."
+        ),
+    )
     max_steps: int | None = Field(
         default=None,
         ge=1,
@@ -694,7 +701,15 @@ class AgentSpec(BaseModel):
         default_factory=list,
         description="Knowledge collections this agent may search",
     )
-    skill_ids: list[UUID] = Field(default_factory=list)
+    skill_ids: list[UUID] = Field(
+        default_factory=list,
+        description=(
+            "Skills this agent may read. Checked at publish against the "
+            "publisher's own access: binding a skill hands its body and its files "
+            "to every run of the agent, so it can only lend what the publisher "
+            "could read themselves."
+        ),
+    )
     mcp_server_ids: list[UUID] = Field(
         default_factory=list,
         description=(

--- a/backend/app/services/agent_registry.py
+++ b/backend/app/services/agent_registry.py
@@ -50,9 +50,17 @@ from app.repositories import (
     organization_secret_repo,
     resource_grant_repo,
     sandbox_connection_repo,
+    skill_repo,
 )
 from app.schemas.agent import AgentRead, AgentVersionRead
-from app.services.access import AGENT, COLLECTION, SECRET, resolve_access, visible_resource_ids
+from app.services.access import (
+    AGENT,
+    COLLECTION,
+    SECRET,
+    SKILL,
+    resolve_access,
+    visible_resource_ids,
+)
 from app.services.file_storage import IMAGE_MIME_TYPES, MAX_AVATAR_SIZE, get_file_storage
 from app.services.sandbox_workspace import sandbox_config
 
@@ -598,6 +606,7 @@ class AgentRegistryService:
             problems.extend(await self._model_profile_problems(ctx, spec.model_profile_id))
 
         problems.extend(await self._collection_problems(ctx, spec.collection_ids))
+        problems.extend(await self._skill_problems(ctx, spec.skill_ids))
 
         for connection_id in spec.mcp_server_ids:
             connection = await mcp_connection_repo.get_org_scoped_by_id(
@@ -692,6 +701,41 @@ class AgentRegistryService:
             )
             if not reachable:
                 problems.append(f"Collection not found: {collection_id}")
+        return problems
+
+    async def _skill_problems(self, ctx: AuthContext, skill_ids: Sequence[UUID]) -> list[str]:
+        """Skills the publisher cannot lend out.
+
+        The same rule as a collection, for the same reason: a bound skill is read
+        by every run of the agent, so binding one shares it - its body, and the
+        resource files beside it. A skill is written know-how, and a private one
+        is private deliberately, so the publisher has to be able to reach it
+        themselves. `SKILLS_VIEW` through :func:`resolve_access`, which means an
+        explicit grant counts and a member who was shared one skill can bind it
+        without being promoted.
+
+        "Not found" covers a missing id, another organization's id, and a row this
+        publisher may not read, deliberately indistinguishably: skills are bound
+        by UUID from the API and from a hand-edited draft, not only picked from a
+        list, so a refusal that read differently would map the organization's
+        private skills one guess at a time.
+
+        One query for the whole list rather than one per id, because a run resolves
+        them the same way and publish holds a transaction open.
+        """
+        if not skill_ids:
+            return []
+        found = await skill_repo.get_many(
+            self.db, list(skill_ids), organization_id=ctx.organization_id
+        )
+        problems: list[str] = []
+        for skill_id in skill_ids:
+            skill = found.get(skill_id)
+            reachable = skill is not None and await resolve_access(
+                self.db, ctx, skill, Perm.SKILLS_VIEW, resource_type=SKILL
+            )
+            if not reachable:
+                problems.append(f"Skill not found: {skill_id}")
         return problems
 
     async def _secret_problems(
@@ -827,9 +871,9 @@ class AgentRegistryService:
         an agent, and a second validator for it would be a second set of rules to
         keep in step - which is how a specialist becomes the quiet route to a
         capability the organization never granted, a key the publisher cannot
-        read, or a collection nobody shared with them. It is the tempting place
-        to smuggle exactly those in, precisely because nobody thinks of it as an
-        agent.
+        read, or a collection or a skill nobody shared with them. It is the
+        tempting place to smuggle exactly those in, precisely because nobody
+        thinks of it as an agent.
 
         Every problem carries the specialist's name. A Builder form has one input
         per specialist and cannot point at the right one otherwise.
@@ -838,6 +882,7 @@ class AgentRegistryService:
         for binding in specialist.capabilities:
             problems.extend(await self._binding_problems(ctx, binding))
         problems.extend(await self._collection_problems(ctx, specialist.collection_ids))
+        problems.extend(await self._skill_problems(ctx, specialist.skill_ids))
         # A specialist naming no profile runs on the parent's, which publish has
         # already checked - so only a profile it *did* name is a reference that
         # can be broken, or borrowed from another organization.

--- a/backend/app/services/skills.py
+++ b/backend/app/services/skills.py
@@ -204,8 +204,25 @@ class SkillService:
     async def resolve_for_agent(self, ctx: AuthContext, skill_ids: list[UUID]) -> list[Skill]:
         """The enabled skills an agent is bound to.
 
+        Scoped to the run's organization and **not** to the runner's own access,
+        which is deliberate and is the same rule delegates and collections follow:
+        the binding is checked once, against the publisher, when the agent is
+        published, and the agent then reads it for everyone who may run it. See
+        `_skill_problems` in `app/services/agent_registry.py` for the check.
+
+        Re-checking here would be wrong twice over. `resolve_access` refuses every
+        context with no subject, so an API key, an embedded widget and a channel
+        message - the surfaces this platform exists to serve - would each lose
+        every skill the agent has. And where there *is* a subject, an agent's
+        instructions would change with who asked: an Operator whose role reaches
+        only their own skills would get a different answer from the same published
+        version, with the difference visible nowhere.
+
         A skill deleted or disabled after publish is skipped rather than failing
-        the run: the agent is less capable, not broken.
+        the run: the agent is less capable, not broken. Named in the log with the
+        organization, because from inside one tenant a row that was deleted and a
+        row that belongs to another tenant leave the same absence - and the second
+        is a spec somebody should look at rather than a skill somebody removed.
         """
         if not skill_ids:
             return []
@@ -214,7 +231,11 @@ class SkillService:
         for skill_id in skill_ids:
             skill = found.get(skill_id)
             if skill is None or not skill.enabled:
-                logger.warning("Agent references skill %s which is gone or disabled", skill_id)
+                logger.warning(
+                    "Agent references skill %s which is disabled, deleted, or not org %s's",
+                    skill_id,
+                    ctx.organization_id,
+                )
                 continue
             resolved.append(skill)
         return resolved

--- a/backend/app/services/skills.py
+++ b/backend/app/services/skills.py
@@ -214,9 +214,10 @@ class SkillService:
         context with no subject, so an API key, an embedded widget and a channel
         message - the surfaces this platform exists to serve - would each lose
         every skill the agent has. And where there *is* a subject, an agent's
-        instructions would change with who asked: an Operator whose role reaches
-        only their own skills would get a different answer from the same published
-        version, with the difference visible nowhere.
+        instructions would change with who asked: a member or a viewer, whose role
+        gives `SKILLS_VIEW: Scope.SHARED`, would get a thinner answer out of the
+        same published version than a builder does, with the difference visible
+        nowhere.
 
         A skill deleted or disabled after publish is skipped rather than failing
         the run: the agent is less capable, not broken. Named in the log with the

--- a/backend/tests/test_agent_registry.py
+++ b/backend/tests/test_agent_registry.py
@@ -114,6 +114,21 @@ def _agent(ctx: AuthContext, **overrides):
     return agent
 
 
+def _skill(ctx: AuthContext, *, owner_user_id=None):
+    """A private skill row in the caller's organization.
+
+    Owned by the caller unless `owner_user_id` says otherwise, so role scope
+    alone reaches it - and giving it away is how a test asks for a skill the
+    publisher can see the id of and nothing more.
+    """
+    return MagicMock(
+        id=uuid.uuid4(),
+        organization_id=ctx.organization_id,
+        owner_user_id=owner_user_id or ctx.user_id,
+        visibility=Visibility.PRIVATE.value,
+    )
+
+
 def _version(agent_id, *, number: int = 1, spec: AgentSpec | None = None):
     version = MagicMock()
     version.id = uuid.uuid4()
@@ -543,6 +558,7 @@ class TestValidateSpec:
     async def test_a_spec_whose_references_all_resolve_raises_nothing(self):
         ctx = _ctx()
         collection_id = uuid.uuid4()
+        skill = _skill(ctx)
 
         with (
             patch(
@@ -557,15 +573,109 @@ class TestValidateSpec:
                 f"{REGISTRY_PATH}.mcp_connection_repo.get_org_scoped_by_id",
                 new=AsyncMock(return_value=MagicMock()),
             ),
+            patch(
+                f"{REGISTRY_PATH}.skill_repo.get_many",
+                new=AsyncMock(return_value={skill.id: skill}),
+            ),
         ):
             await AgentRegistryService(_db()).validate_spec(
                 ctx,
                 _spec(
                     capabilities=[{"id": "clock"}, {"id": "knowledge"}],
                     collection_ids=[collection_id],
+                    skill_ids=[skill.id],
                     model_profile_id=uuid.uuid4(),
                     mcp_server_ids=[uuid.uuid4()],
                 ),
+            )
+
+
+class TestSkillValidation:
+    """Binding a skill lends it, so publish checks the publisher can read it.
+
+    A bound skill's body and files are handed to every run of the agent, and
+    skills are bound by UUID - from the API, or by hand-editing a draft - not only
+    picked from a list the Builder filtered. Without this check a member whose role
+    reaches only shared skills could bind a colleague's private one and read it
+    through the agent.
+    """
+
+    @staticmethod
+    async def _problems(ctx: AuthContext, spec: AgentSpec, **repos) -> list[str]:
+        """The problems publishing this spec reports, with the model resolving."""
+        with (
+            patch(
+                f"{REGISTRY_PATH}.credential_repo.get_profile",
+                new=AsyncMock(return_value=MagicMock()),
+            ),
+            patch(f"{REGISTRY_PATH}.skill_repo.get_many", new=AsyncMock(**repos)),
+            pytest.raises(BadRequestError) as refused,
+        ):
+            await AgentRegistryService(_db()).validate_spec(ctx, spec)
+
+        assert refused.value.details is not None
+        problems: list[str] = refused.value.details["problems"]
+        return problems
+
+    @pytest.mark.anyio
+    async def test_a_skill_this_organization_does_not_have_is_not_found(self):
+        """Including another tenant's: the repository filters by organization, so
+        an id from elsewhere arrives here as an absence."""
+        skill_id = uuid.uuid4()
+
+        problems = await self._problems(
+            _ctx(),
+            _spec(skill_ids=[skill_id], model_profile_id=uuid.uuid4()),
+            return_value={},
+        )
+
+        assert problems == [f"Skill not found: {skill_id}"]
+
+    @pytest.mark.anyio
+    async def test_a_private_skill_the_publisher_cannot_reach_is_not_found(self):
+        """The leak this check closes, reported as an absence.
+
+        A member's role reaches shared skills only, so a colleague's private one
+        is refused - and told the same thing as an id that does not exist, because
+        a refusal that read differently would map the organization's private
+        skills one guess at a time.
+        """
+        ctx = _ctx(OrgRoleName.MEMBER)
+        private = _skill(ctx, owner_user_id=uuid.uuid4())
+
+        with patch(
+            "app.services.access.resource_grant_repo.get_level", new=AsyncMock(return_value=None)
+        ):
+            problems = await self._problems(
+                ctx,
+                _spec(skill_ids=[private.id], model_profile_id=uuid.uuid4()),
+                return_value={private.id: private},
+            )
+
+        assert problems == [f"Skill not found: {private.id}"]
+
+    @pytest.mark.anyio
+    async def test_a_grant_lets_a_member_bind_a_skill_they_do_not_own(self):
+        """A grant widens what a role allows, here as everywhere else."""
+        ctx = _ctx(OrgRoleName.MEMBER)
+        shared = _skill(ctx, owner_user_id=uuid.uuid4())
+
+        with (
+            patch(
+                f"{REGISTRY_PATH}.credential_repo.get_profile",
+                new=AsyncMock(return_value=MagicMock()),
+            ),
+            patch(
+                f"{REGISTRY_PATH}.skill_repo.get_many",
+                new=AsyncMock(return_value={shared.id: shared}),
+            ),
+            patch(
+                "app.services.access.resource_grant_repo.get_level",
+                new=AsyncMock(return_value=GrantLevel.READ),
+            ),
+        ):
+            await AgentRegistryService(_db()).validate_spec(
+                ctx, _spec(skill_ids=[shared.id], model_profile_id=uuid.uuid4())
             )
 
 

--- a/backend/tests/test_agent_registry_subagents.py
+++ b/backend/tests/test_agent_registry_subagents.py
@@ -41,7 +41,7 @@ from app.services.agent_registry import (
     AgentRegistryService,
     slugify,
 )
-from tests.test_agent_registry import _agent, _ctx, _db, _spec, _version
+from tests.test_agent_registry import _agent, _ctx, _db, _skill, _spec, _version
 
 pytestmark = pytest.mark.anyio
 
@@ -226,6 +226,30 @@ class TestInlineSpecialists:
         )
 
         assert problems == [f"Specialist 'summariser': Collection not found: {collection_id}"]
+
+    async def test_a_specialist_cannot_read_a_skill_its_publisher_cannot(self, monkeypatch):
+        """The same route, one table over again - and the one it was open on.
+
+        `skill_ids` was the single reference this recursive pass did not walk, at
+        either level, so a private skill could be bound to a specialist and read
+        by every run of the parent. Named with the specialist, because a Builder
+        form has one input per specialist and cannot point at the right one
+        otherwise.
+        """
+        ctx = _ctx(OrgRoleName.MEMBER)
+        private = _skill(ctx, owner_user_id=uuid4())
+        monkeypatch.setattr(
+            agent_registry.skill_repo, "get_many", AsyncMock(return_value={private.id: private})
+        )
+        monkeypatch.setattr(
+            "app.services.access.resource_grant_repo.get_level", AsyncMock(return_value=None)
+        )
+
+        problems = await _problems(
+            ctx, _delegating({"inline": [_specialist(skill_ids=[str(private.id)])]})
+        )
+
+        assert problems == [f"Specialist 'summariser': Skill not found: {private.id}"]
 
     async def test_a_specialist_cannot_lend_a_secret_its_publisher_cannot_read(self, monkeypatch):
         """The same route, one table over.

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -150,6 +150,43 @@ class TestAgentBinding:
             assert await SkillService(_db()).resolve_for_agent(ctx, [disabled.id]) == []
 
     @pytest.mark.anyio
+    async def test_a_run_reads_a_skill_the_runner_could_not_reach_themselves(self):
+        """Binding is lending, and the gate is publish - deliberately not the run.
+
+        A member's role reaches shared skills only, so this one is a skill they
+        could not open in the UI. The agent still reads it, exactly as it still
+        searches a collection nobody shared with the person asking: the publisher
+        was checked when the version was frozen
+        (`AgentRegistryService._skill_problems`), and re-checking per runner would
+        make one published version answer differently for two colleagues.
+        """
+        ctx = _ctx(OrgRoleName.MEMBER)
+        private = _skill(ctx=ctx, owner_user_id=uuid.uuid4())
+
+        with patch(
+            f"{SKILLS_PATH}.skill_repo.get_many",
+            new=AsyncMock(return_value={private.id: private}),
+        ):
+            assert await SkillService(_db()).resolve_for_agent(ctx, [private.id]) == [private]
+
+    @pytest.mark.anyio
+    async def test_a_run_with_no_subject_still_reads_the_agents_skills(self):
+        """The concrete reason a per-runner check here would be wrong.
+
+        An API key, an embedded widget and a channel message all run on a context
+        with no subject, and `resolve_access` refuses every one of those by
+        design - so a runner-scoped check would strip every skill from exactly the
+        surfaces a published agent exists to be reached through.
+        """
+        ctx = AuthContext.anonymous(uuid.uuid4())
+        skill = _skill(ctx=ctx)
+
+        with patch(
+            f"{SKILLS_PATH}.skill_repo.get_many", new=AsyncMock(return_value={skill.id: skill})
+        ):
+            assert await SkillService(_db()).resolve_for_agent(ctx, [skill.id]) == [skill]
+
+    @pytest.mark.anyio
     async def test_binding_order_is_preserved(self):
         """The order skills appear in is the order the model sees them listed."""
         ctx = _ctx()

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -138,7 +138,7 @@ precise about which. Four things make something an agent here:
 | | A published delegate | An inline specialist |
 |---|---|---|
 | **Versioned** | yes - pinned, and a pin only moves when somebody moves it | **no** |
-| **Permission-checked at publish** | yes - `agents:run` on that row | yes - the same scopes, secrets and collection checks the parent's own bindings get |
+| **Permission-checked at publish** | yes - `agents:run` on that row | yes - the same scope, secret, collection and skill checks the parent's own bindings get |
 | **Its own capabilities** | yes - its published spec's | yes - its own, plus what the parent shares |
 | **Metered and capped** | yes | yes - by the run's caps, which is [what binds inside any delegation](governance.md#delegation-spends-the-parents-budget) |
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -208,10 +208,11 @@ Lending a delegate is lending what you hold, exactly as binding a collection is.
     valid-looking UUID.
 
 An inline specialist gets the same checks the parent's own bindings get - capability
-scopes, secret ownership, collection access, and its model profile if it names one -
-each reported with the specialist's name so a Builder form can point at the right
-input. A specialist is the tempting place to smuggle in a collection nobody shared,
-precisely because nobody thinks of it as an agent.
+scopes, secret ownership, collection access, [skill access](skills.md#access), and
+its model profile if it names one - each reported with the specialist's name so a
+Builder form can point at the right input. A specialist is the tempting place to
+smuggle in a collection nobody shared, precisely because nobody thinks of it as an
+agent.
 
 The deployment-wide switch is separate, and it is a capability scope rather than a
 permission: `agents:delegate`. It answers "may agents call agents in this

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -167,3 +167,27 @@ compose — `skills` for the procedure, `knowledge` for the evidence.
 Skills are organization-scoped resources, governed like agents and collections:
 visibility plus per-row grants on top of the role. See
 [Permissions](permissions.md#layer-3-visibility-and-grants).
+
+**Binding a skill lends it.** Every run of the agent reads the body and the files,
+whoever ran it, so publishing an agent whose `skill_ids` name a skill requires the
+*publisher* to hold `skills:view` on that row — through `resolve_access`, so a grant
+counts and a member who was shared one skill can bind it without being promoted.
+A skill they cannot reach is refused as `Skill not found: <id>`, worded identically
+to an id that does not exist: skills are bound by UUID from the API and from a
+hand-edited draft, not only picked from the Builder's list, and a refusal that read
+differently would map the organization's private skills one guess at a time. The
+same check runs on an [inline specialist's](concepts.md#delegate-vs-inline-specialist)
+`skill_ids`, reported with the specialist's name.
+
+At run time nothing is re-checked: the frozen spec's skills are resolved inside the
+run's organization and handed to the agent. That is the rule collections and
+delegates already follow — [the reference is checked once, at
+publish](permissions.md#delegation-is-not-a-privilege-boundary) — and the
+alternative is worse in two specific ways. Every context with no subject (an API
+key, an embedded widget, a channel message) is refused by `resolve_access` by
+design, so a per-runner check would strip every skill from exactly those surfaces;
+and where there is a subject, one published version would give an Operator
+different instructions from a Builder, with the difference visible nowhere.
+
+A skill deleted or disabled after publish is skipped with a warning rather than
+failing the run — the agent is less capable, not broken.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -186,8 +186,9 @@ publish](permissions.md#delegation-is-not-a-privilege-boundary) — and the
 alternative is worse in two specific ways. Every context with no subject (an API
 key, an embedded widget, a channel message) is refused by `resolve_access` by
 design, so a per-runner check would strip every skill from exactly those surfaces;
-and where there is a subject, one published version would give an Operator
-different instructions from a Builder, with the difference visible nowhere.
+and where there is a subject, one published version would give a member — whose role
+reaches shared skills only — thinner instructions than it gives a builder, with the
+difference visible nowhere.
 
 A skill deleted or disabled after publish is skipped with a warning rather than
 failing the run — the agent is less capable, not broken.


### PR DESCRIPTION
`validate_spec` reached every reference a spec makes - capabilities, scopes, config, tool
overrides, secrets, the model profile, collections, MCP connections, sandbox connections,
delegates - and reached each with the publisher's own access through `resolve_access`.
`skill_ids` was the one exception, at the top level and inside an inline specialist.

## What breaks today

`Skill` carries `visibility` and `SKILL` is a grant-bearing resource type, but nothing
checked either when a spec named one. Concretely, on `main` today:

1. Member B writes a skill and leaves it **private** - the default.
2. Member A, whose role gives `SKILLS_VIEW: Scope.SHARED`, reads B's skill id (from an
   audit entry, a shared conversation, a URL somebody pasted - it is a UUID, not a secret)
   and `PATCH`es their own agent's draft with `"skill_ids": ["<B's id>"]`. Nothing refuses
   it: the Builder's picker only ever offered what A could list, but the API takes an id.
3. A publishes. `validate_spec` walks the capabilities, the collections, the MCP
   connections, the sandbox, the delegates - and not this.
4. Every run of A's agent now loads B's skill: `list_skills` names it, `load_skill` returns
   the body, `read_skill_resource` returns each file beside it, and with a workspace bound
   it is written to `/skills/<name>/` on disk.

Tenant isolation held throughout - `resolve_for_agent` filters by organization - so this is
a grants-and-visibility hole inside one organization, not a cross-tenant one. The same
worked through a `SpecialistSpec`, which is worse in the way #164 describes: a specialist is
an agent nobody thinks of as an agent.

## The fix

`_skill_problems`, beside `_collection_problems` and shaped like it, called from both
`validate_spec` and `_specialist_problems` - one helper for both levels, because two loops
kept in step would drift and the half that drifted would be the specialist half. The
refusal is `Skill not found: <id>`, deliberately word-for-word what a missing id gets: ids
are bound by UUID here, so a distinguishable refusal is a way to enumerate an
organization's private skills one guess at a time. A specialist's problems carry its name,
so a Builder form can point at the right input. One `get_many` for the whole list rather
than a query per id.

## The transition decision: refuse outright

Adding the check makes publish refuse specs that publish today - any agent whose
`skill_ids` name a skill the person pressing Publish cannot reach. I chose to refuse rather
than grandfather or warn first, and the arguments are worth stating because the other two
are easier to code.

**Refusing costs nothing to a live agent.** Validation runs at publish only, so nothing
that is running stops. The refusal appears while somebody is looking at a form, which is
what the module docstring promises, and it is repairable without a migration or a support
ticket: drop the binding, hold a `read` grant on the skill, or make it org-visible. The
Builder's picker never offered an unreachable skill, so the specs this catches are the
API-driven and hand-edited ones - the same population as the exploit.

**Grandfathering existing bindings keys the exemption on exactly the state the leak
produces.** "Refuse only new bindings" means comparing the draft against the live version
and permitting whatever was already there - which is precisely what step 3 above created,
and it would keep permitting it through every future publish of that agent, permanently,
indistinguishably from an accidental binding. It also needs a "grandfathered" notion in a
validator whose whole value is that it has one rule.

**Auditing first leaves it open with no channel to tell anybody.** A warning nobody reads
is the silent-failure mode this repo keeps naming, and self-hosted deployments upgrade on
their own schedule, so "refuse in the next release" is unbounded. Audit tooling is worth
having - see #186 - but as the thing that finds what already happened, not as a substitute
for closing the gate.

The one thing refusing does not do is fix what was published before it existed: a frozen
version keeps loading what its spec named until somebody re-publishes it. That is
**#186**, filed rather than folded in, with the sequence and the `published_by_user_id`
trap written out.

## The second decision: `resolve_for_agent` keeps resolving tenant-scoped

The issue asks whether the run should stop dropping what it cannot reach and resolve only
what the publisher was allowed to bind. It should not, and the reason is now a docstring
rather than a review comment, because this is the obvious place for a future reader to add
a `resolve_access` call that looks like a fix:

- `resolve_access` refuses **every context with no subject** by design. An API key, an
  embedded widget and a channel message are all subject-less, so a runner-scoped check
  would strip every skill from exactly the surfaces a published agent exists to be reached
  through. There is a test asserting this consequence.
- Where there *is* a subject, one published version would hand a `member` (whose role
  gives `SKILLS_VIEW: Scope.SHARED`) thinner instructions than it hands a `builder`
  (`Scope.ALL`), with the difference visible nowhere - the failure the
  `mcp_server_ids` message already argues against ("what it can reach would depend on who
  happens to run it").
- Checking the *publisher* instead means re-deriving their role at run time: a query per
  run, a wrong answer once they leave the organization, and a frozen version whose
  behaviour moves when somebody else's membership changes.

So the rule stays the one collections and delegates already follow and `docs/permissions.md`
already states: the reference is checked once, at publish, and the agent then reads it for
everyone who may run it. What did change is the warning - a deleted row and another
organization's row leave the same absence behind `get_many`'s tenant filter, and the second
is a spec somebody should look at, so the message names all three causes and the
organization, as `_collection_names` does.

## Docs

`docs/skills.md` gains the publish rule and the run rule under Access; `docs/permissions.md`
adds skills to the specialist's checked references; `docs/concepts.md` fixes the same list
in the delegate-vs-specialist table; both `skill_ids` fields in `spec.py` gain the
description they never had, which is what `docs/reference/spec.md` is generated from.

## Rebased onto `main`

This branch was cut from `feat/subagents` at `8a7e56b`, so until #164 merged its diff read
as ~18,900 lines of somebody else's work. #164 is now `f618e8c` on `main`, and the three
commits have been replayed with `git rebase --onto origin/main 8a7e56b`. The diff is its
own content again: **293 insertions, 14 deletions over 9 files.**

Worth saying how far that was checked, because a rebase that applies cleanly is not the
same as one that is correct. It did apply with no conflicts, and the four commits
`feat/subagents` gained after this branch was cut are all present and untouched -
`share_with_delegates` still refuses `DELEGATION_CAPABILITY_ID`, the archived-delegate
refusal is still in run-time resolution as well as publish, `validate_spec`'s docstring
still carries the correction about `agent_id`, and `SpecialistSpec`'s no longer claims MCP
connections are shared. The stronger check: `git diff 8a7e56b 26ab3a3` and
`git diff origin/main HEAD` are byte-identical in their `+`/`-` lines, so nothing was
dropped from this branch and nothing was clobbered on `main`.

## How it was verified

| | |
|---|---|
| `POSTGRES_DB=agenticos_test_rb187 make check`, post-rebase | green - every CI job except `e2e`. Backend **3005 passed**, 10 skipped, 5m54s, **coverage 100.00%** (6749 statements, 1422 branches, 0 missed, 0 partial) with the integration suite included. Frontend 181 files / 3106 tests under the coverage gate. ruff, ruff format, ty, eslint, tsc, the backtick and i18n guards, migrations and docs `--strict` all clean |
| `coverage report` for the two files this touches | `app/services/agent_registry.py` **417 stmts / 146 branches, 0 miss, 0 partial, 100%**; `app/services/skills.py` **144 stmts / 36 branches, 0 miss, 0 partial, 100%** - confirmed after the rebase, since the conflicting hunks could have moved branches around |
| `pytest tests/test_agent_registry.py tests/test_agent_registry_subagents.py tests/test_skills.py` | 180 passed |
| `python3 scripts/docs_drift.py` | no drift |

New tests, all asserting a consequence rather than a call:

- a skill this organization does not have is `Skill not found` (which is also how another
  tenant's arrives, since the repository filters by organization);
- a **private** skill owned by somebody else is refused to a `member`, worded identically
  to a missing id;
- a `read` grant lets that same member bind it - a grant widens, it does not promote;
- the specialist half of both, named `Specialist 'summariser': Skill not found: <id>`;
- a run reads a skill the runner could not open in the UI, and a run with **no subject**
  still gets the agent's skills - the two consequences of the second decision.

## Still open, deliberately

- **#186** - versions published before this check. Not fixable at run time for the reasons
  above; wants an offline sweep, which is new operator surface and its own decision.
  Re-read against this branch after the rebase: still accurate, line for line -
  `resolve_for_agent` is still `backend/app/services/skills.py:204` and still tenant-filtered
  only, and `agent_versions.published_by_user_id` is still nullable with `ON DELETE SET NULL`,
  which is the trap that issue's acceptance criteria turn on.
- **A binding to a *disabled* skill still publishes.** It contributes nothing at run and is
  logged. Left alone on purpose: `enabled` is a runtime toggle, so refusing publish on it
  would mean disabling one skill breaks the next publish of every agent bound to it - a
  worse trade than a warning. Said here so the next reader knows it was seen.

An earlier revision of this description listed **#189** here - `tests/integration` being
unusable while another worktree ran it, worked around by giving this run a database of its
own. That is now fixed on `main` rather than worked around: #216 landed as `408327b`, which
is in this branch's base, and #189 is closed.

Closes #179
