### PR TITLE
ci: make `make check` run every job CI runs

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -77,10 +77,11 @@ failures. While writing, run only what covers the change:
 bunx vitest run src/components/chat/usage-strip.test.tsx
 ```
 
-Once, before the push:
+Once, before the push — from the repository root, because CI's `test-frontend` job
+runs all four and `make lint-frontend` is the first three of them:
 
 ```bash
-bun run type-check && bun run lint && bun run test:coverage
+make lint-frontend && make test-frontend-cov && make build-frontend
 ```
 
 **`test:coverage`, not `test:run`.** The job CI runs measures coverage and fails under

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -31,12 +31,25 @@ after an edit it answers the same question thirty times slower.
 Then, once, before the push:
 
 ```bash
-make lint               # ruff, ty, eslint, tsc, and scripts/check_i18n.py
+make lint               # ruff, ruff format, ty, eslint, prettier, tsc, and the two guards
 make test               # backend + the 100% gate on the platform layer
 make test-frontend-cov  # frontend + its gate: 100% lines/stmts/funcs, 97.5% branches
 make test-integration   # only if the change is near the database
-make check              # all of the above, which is what CI runs
+make check              # every CI job except e2e - lint, test, test-frontend-cov,
+                        # build-frontend, docs-build, audit. About five minutes.
 ```
+
+`make check` is CI, not an approximation of it: `.github/workflows/ci.yml` calls
+those targets rather than repeating their commands, and `tests/test_ci_parity.py`
+fails if a gating job grows a step `check` does not run - or if `check` grows one
+CI does not. It has drifted four times, all four found by #143.
+
+Three things `check` leaves out, on purpose: `e2e` (needs a seeded backend), the
+image scan (push to `main` only), and `make test-migrations` - CI cycles the chain
+against a throwaway database, and `alembic downgrade base` on a laptop points at
+the one with your own work in it. `check` also says at the end when
+`tests/integration/` skipped itself for want of a database, because CI's `test`
+job always has one.
 
 Traps, each of which has cost a red job here:
 

--- a/.claude/skills/backend-tests/SKILL.md
+++ b/.claude/skills/backend-tests/SKILL.md
@@ -16,7 +16,7 @@ make test-integration   # only the tests that need a real database
 make test-cov           # HTML at backend/htmlcov/index.html
 make coverage-all        # includes template-inherited code (informational)
 make test-migrations    # the whole chain forwards and back against Postgres
-make check              # what CI runs — before opening a PR
+make check              # every CI job except e2e — before opening a PR
 ```
 
 ## Which layer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,19 +35,15 @@ jobs:
       - name: Install dependencies
         run: uv sync --directory backend --dev
 
-      - name: Run ruff check
-        run: uv run --directory backend ruff check app tests cli
-
-      - name: Run ruff format check
-        run: uv run --directory backend ruff format app tests cli --check
-
-      - name: Run ty
-        run: uv run --directory backend ty check
-
-      # `make lint` runs this too. When CI omits a step the Makefile has, green
-      # locally stops meaning green here, which is the whole value of `make check`.
-      - name: Check for double backticks
-        run: python3 scripts/check_backticks.py
+      # ruff check, ruff format --check, ty, and the two guard scripts - the
+      # target, not a second copy of its commands. Every step this job used to
+      # spell out was also spelled out in the Makefile, and the pair drifted:
+      # `scripts/check_i18n.py` was in `make lint` and never here, so hardcoded
+      # copy failed locally and passed the build. Calling the target is how the
+      # two stay equal rather than how they are asserted to be equal - and
+      # `backend/tests/test_ci_parity.py` catches whatever this still misses.
+      - name: Lint, format-check and type-check the backend
+        run: make lint-backend
 
     # The step that used to sit here ran the entire test suite - with no
     # database, in the lint job - to grep its output for `module-not-imported`.
@@ -91,6 +87,17 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
+    # On the job rather than repeated under each step, which is how the `e2e` job
+    # below already does it. Four identical copies is four places to forget one.
+    env:
+      POSTGRES_HOST: localhost
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: test_db
+      REDIS_HOST: localhost
+      REDIS_PORT: 6379
+
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -107,62 +114,32 @@ jobs:
       - name: Install dependencies
         run: uv sync --directory backend --dev
 
-      - name: Apply migrations against a real database
+      - name: Cycle the migration chain forwards and back
         # The only way to know a migration works. Backfills, check constraints
         # and the loud failures they raise cannot be verified by importing the
-        # module — they need a database with the previous schema in it.
-        run: uv run --directory backend alembic upgrade head
-        env:
-          POSTGRES_HOST: localhost
-          POSTGRES_PORT: 5432
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: test_db
-          REDIS_HOST: localhost
-          REDIS_PORT: 6379
-
-      - name: Verify migrations roll back
-        # A downgrade nobody runs is a downgrade that does not work. Cycling the
-        # whole chain catches a missing drop long before an operator needs it.
-        run: |
-          uv run --directory backend alembic downgrade base
-          uv run --directory backend alembic upgrade head
-        env:
-          POSTGRES_HOST: localhost
-          POSTGRES_PORT: 5432
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: test_db
-          REDIS_HOST: localhost
-          REDIS_PORT: 6379
+        # module — they need a database with the previous schema in it. And a
+        # downgrade nobody runs is a downgrade that does not work, so the chain
+        # goes to base and back rather than only forwards.
+        #
+        # `make check` does not run this, and that omission is deliberate rather
+        # than drift: `downgrade base` here empties a throwaway `test_db`, while
+        # on a laptop it points at whatever `backend/.env` says.
+        run: make test-migrations
 
       - name: Run tests with the coverage gate
-        # --cov with no argument uses the source list in pyproject.toml: the
+        # --cov with no argument uses the include list in pyproject.toml: the
         # platform layer, held at 100%. Template-inherited subsystems are
         # reported by the next step but do not gate the build.
-        run: uv run --directory backend pytest tests/ -v --cov --cov-report=xml
-        env:
-          POSTGRES_HOST: localhost
-          POSTGRES_PORT: 5432
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: test_db
-          REDIS_HOST: localhost
-          REDIS_PORT: 6379
+        #
+        # `COV_REPORT=xml` is the only difference from what `make test` does on a
+        # laptop, and it is for Codecov below rather than for the gate.
+        run: make test COV_REPORT=xml
 
       - name: Report coverage of template-inherited code
         # Informational. Holding code we did not design to the platform bar
         # would mean mock-heavy tests that buy a number rather than confidence.
         if: always()
-        run: uv run --directory backend pytest tests/ -q --cov=app --cov-report=term --cov-fail-under=0
-        env:
-          POSTGRES_HOST: localhost
-          POSTGRES_PORT: 5432
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: test_db
-          REDIS_HOST: localhost
-          REDIS_PORT: 6379
+        run: make coverage-all
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -184,29 +161,23 @@ jobs:
         run: bun install --frozen-lockfile
         working-directory: frontend
 
-      - name: Run lint
-        # `bun run lint` is `eslint . --max-warnings 0`. A warning nobody has to
-        # fix is a warning everybody learns to scroll past.
-        run: bun run lint
-        working-directory: frontend
-
-      - name: Check formatting
-        run: bunx prettier --check "src/**/*.{ts,tsx}" "e2e/**/*.ts"
-        working-directory: frontend
-
-      - name: Run type check
-        run: bun run type-check
-        working-directory: frontend
+      # eslint (`--max-warnings 0`, because a warning nobody has to fix is a
+      # warning everybody learns to scroll past), prettier and tsc. `make lint`
+      # ran none of the three until #143, so a type error in a `.tsx` passed
+      # locally and stopped the build here.
+      - name: Lint, format-check and type-check the frontend
+        run: make lint-frontend
 
       - name: Run unit and integration tests with the coverage gate
-        run: bun run test:coverage
-        working-directory: frontend
+        # `test:coverage`, not `test:run`. The gate is the whole point of this
+        # step: `test:run` measures nothing and 2909 green tests still owe 100%
+        # lines, statements and functions.
+        run: make test-frontend-cov
 
       - name: Build
         # `next build` type-checks the route tree and fails on a server
         # component that cannot render — neither of which tsc or vitest sees.
-        run: bun run build
-        working-directory: frontend
+        run: make build-frontend
 
   e2e:
     # Split out of test-frontend on purpose. E2E needs Postgres, Redis, Python,
@@ -393,19 +364,12 @@ jobs:
       # queued behind it: `--require-hashes` is a flag, not a key=value, and
       # `--locked` wants a PEP 751 `pylock.toml` rather than `uv.lock`.
       #
-      # What works: export exactly what the lockfile resolves - which is what a
-      # deployment installs - and audit that. The export is fully pinned, so
-      # `--no-deps --disable-pip` skips a resolution round-trip that pip-audit
-      # would otherwise do in a throwaway virtualenv.
-      - name: Export the locked dependency set
-        run: uv export --frozen --no-emit-project --no-hashes -o requirements-audit.txt
-        working-directory: backend
-
-      - name: Audit dependencies for known vulnerabilities
-        run: >-
-          uv tool run pip-audit -r requirements-audit.txt
-          --no-deps --disable-pip --progress-spinner=off
-        working-directory: backend
+      # What works, and what `make audit` now does: export exactly what the
+      # lockfile resolves - which is what a deployment installs - and audit that.
+      # It ran only here until #143, so a dependency advisory was something a
+      # branch learned about after pushing.
+      - name: Audit the locked dependency set for known vulnerabilities
+        run: make audit
 
   docs:
     runs-on: ubuntu-latest
@@ -432,7 +396,7 @@ jobs:
         # `--strict` turns a dead internal link or a page missing from the nav
         # into a failure. Both are things a reader finds and a lenient build
         # ships.
-        run: uv run --directory backend --group docs mkdocs build -f ../mkdocs.yml --strict
+        run: make docs-build
 
   docker:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,14 +117,15 @@ silent. `.claude/README.md` lists all thirteen and explains the layout.
 ```bash
 make dev                                          # postgres, redis, api, worker, frontend
 make platform-bootstrap BOOTSTRAP_API_KEY=sk-...  # an org, an owner, a model, an agent
-make check                                        # what CI runs — before every PR
+make check                                        # every CI job but e2e — before every PR
 ```
 
 `make help` lists the rest. Day to day:
 
 | | |
 |---|---|
-| `make lint` / `make format` | ruff + ty + eslint + tsc + the i18n guard |
+| `make lint` / `make format` | ruff + ty + eslint + prettier + tsc + the two guards |
+| `make lint-backend` / `make lint-frontend` | one half of it — CI runs them in two jobs |
 | `make test-fast` | no coverage — the write-run-write loop |
 | `make test` | backend + the 100% gate on the platform layer |
 | `make test-integration` | only the tests needing a real database |
@@ -153,7 +154,10 @@ cd backend  && uv run pytest tests/api/test_workspace_routes.py -k bytes -x
 Once before the push — not after every edit — run `make lint` and the coverage gate for
 the half you touched: `make test` or `make test-frontend-cov`. **`bun run test:run` does
 not measure coverage**, so a frontend suite where every test passes still fails the job;
-that is how `test-frontend` went red on `feat/sandbox` after a green local run. Then read
+that is how `test-frontend` went red on `feat/sandbox` after a green local run. Before
+the pull request, `make check` — every CI job except `e2e`, about five minutes, and
+`backend/tests/test_ci_parity.py` is what keeps that claim true rather than aspirational
+(#143 found four divergences at once). Then read
 the answer rather than guessing at it: `gh pr checks <n>`, and
 `gh run view --job <id> --log-failed` for whatever is red. `.claude/rules/testing.md` has
 the scoped commands and the traps; the pull request reviewer is under Git below, and it is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,11 +32,15 @@ The backend needs a `VAULT_MASTER_KEY`. Without one it falls back to
 See [`CLAUDE.md`](CLAUDE.md#testing) for the full picture. The short version:
 
 ```bash
-make test           # backend, with the coverage gate
-make test-frontend  # vitest unit + integration
-make test-e2e       # playwright
-make check          # lint, format, types, everything
+make test               # backend, with the coverage gate
+make test-frontend      # vitest unit + integration, no coverage
+make test-frontend-cov  # the same, plus the gate CI applies
+make test-e2e           # playwright
+make check              # every CI job except e2e — run this before a pull request
 ```
+
+**`make test-frontend` measures no coverage, and the frontend's only gate is a
+coverage threshold.** It is the loop; `make check` is the answer.
 
 **The platform layer is held at 100% coverage** and CI enforces it. That means
 `app/agents/`, the permission catalog, the vault, and the services built on top.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install format lint test run clean help sandbox-token deps-upgrade deps-upgrade-all db-init dev dev-down dev-logs dev-rebuild dev-frontend docker-clean dev-server dev-server-down dev-server-logs dev-server-frontend stage stage-down prod prod-down prod-frontend upgrade upgrade-dry-run upgrade-new-features upgrade-finalize docs docs-build
+.PHONY: install format lint lint-backend lint-frontend check audit build-frontend test run clean help sandbox-token deps-upgrade deps-upgrade-all db-init dev dev-down dev-logs dev-rebuild dev-frontend docker-clean dev-server dev-server-down dev-server-logs dev-server-frontend stage stage-down prod prod-down prod-frontend upgrade upgrade-dry-run upgrade-new-features upgrade-finalize docs docs-build
 
 # === Environments ===========================================================
 # Three, one compose file each, with a matching frontend file beside it:
@@ -238,21 +238,46 @@ deps-upgrade-all:
 	@echo "▶ Now run 'make check'."
 
 # === Code Quality ===
-format:
-	uv run --directory backend ruff format app tests cli
-	uv run --directory backend ruff check app tests cli --fix
+# Every static check, both halves of the repository. CI splits them across two
+# jobs (`lint` and the first three steps of `test-frontend`) because they need
+# different toolchains; here they are one command with two callable halves, so a
+# Python-only change can run `lint-backend` and skip a minute of eslint.
+#
+# The frontend half was missing entirely until #143: `make lint` ran ruff, ty and
+# the two guard scripts, while CI additionally ran eslint, prettier and tsc - so
+# `make lint` passed on a branch with a type error in a `.tsx`, and CLAUDE.md's
+# "ruff + ty + eslint + tsc" described a command that ran half of that.
+lint: lint-backend lint-frontend
 
-lint:
+lint-backend:
 	uv run --directory backend ruff check app tests cli
 	uv run --directory backend ruff format app tests cli --check
 	uv run --directory backend ty check
 	python3 scripts/check_backticks.py
 	python3 scripts/check_i18n.py
 
+lint-frontend:
+	cd frontend && bun run lint
+	cd frontend && bunx prettier --check "src/**/*.{ts,tsx}" "e2e/**/*.ts"
+	cd frontend && bun run type-check
+
+# The write side of both halves. `lint-frontend` checks prettier rather than
+# applying it, so without the second line here the only way to fix a formatting
+# failure would be to let the pre-commit hook rewrite the file for you.
+format:
+	uv run --directory backend ruff format app tests cli
+	uv run --directory backend ruff check app tests cli --fix
+	cd frontend && bunx prettier --write "src/**/*.{ts,tsx}" "e2e/**/*.ts"
+
 # === Testing ===
 # `test` is the gate: it fails if platform-layer coverage drops below 100%.
+#
+# CI overrides the report because Codecov wants XML and a terminal diff is no use
+# in a log nobody reads when it is green. Same run, same gate, either way.
+COV_REPORT ?= term-missing
+
 test:
-	uv run --directory backend pytest tests/ -v --cov --cov-report=term-missing
+	uv run --directory backend pytest tests/ -v --cov --cov-report=$(COV_REPORT)
 
 # Fast loop while writing code — no coverage, no gate.
 test-fast:
@@ -278,6 +303,22 @@ test-frontend:
 test-frontend-cov:
 	cd frontend && bun run test:coverage
 
+# `next build` type-checks the route tree and fails on a server component that
+# cannot render - neither of which tsc or vitest sees, which is why CI builds on
+# every pull request and why `check` has to.
+build-frontend:
+	cd frontend && bun run build
+
+# CI's `security` job. Audits what the lockfile resolves to - which is what a
+# deployment installs - rather than whatever this machine happens to have in its
+# virtualenv. The export is fully pinned, so `--no-deps --disable-pip` skips a
+# resolution round-trip pip-audit would otherwise do in a throwaway virtualenv.
+#
+# Needs the network: the advisory database is fetched, not vendored.
+audit:
+	cd backend && uv export --frozen --no-emit-project --no-hashes -o requirements-audit.txt
+	cd backend && uv tool run pip-audit -r requirements-audit.txt --no-deps --disable-pip --progress-spinner=off
+
 # Playwright starts the frontend itself; the backend and its seed are on you.
 # Checked rather than assumed: against a backend that is not there the suite
 # fails in fifty places at once, none of which say what is actually wrong.
@@ -291,14 +332,43 @@ test-e2e:
 	fi
 	cd frontend && bun run test:e2e
 
-# What CI runs. Run this before opening a pull request.
+# Every CI job, in the order the workflow declares them, with the exceptions
+# named below. This is the one claim in this file that has to be exactly true:
+# a command advertised as CI that runs less than CI prints "All checks passed"
+# over a branch the build will refuse, and the cost is a review cycle plus
+# however long somebody spends believing the local answer.
 #
-# `test-frontend-cov`, not `test-frontend`: the CI job runs `bun run test:coverage`
-# and fails under 100% lines/statements/functions or 97.5% branches. This target
-# used to run the suite without coverage and print "All checks passed" over a
-# branch the job would refuse - which is exactly what happened on feat/sandbox.
-check: lint test test-frontend-cov
-	@echo "All checks passed."
+# The workflow calls these targets rather than repeating the commands, and
+# `backend/tests/test_ci_parity.py` fails if the two ever drift again. It has
+# drifted four times, all four found by #143:
+#
+#   - `check` ran `test-frontend`, which measures no coverage, where CI runs
+#     `test:coverage` and its 100% gate - green locally and red for every run on
+#     `feat/sandbox` after 832d647;
+#   - `lint` ran neither eslint, prettier nor tsc, all three of which gate CI;
+#   - `check` ran neither `next build`, the docs build nor the dependency audit -
+#     three whole jobs;
+#   - and in the other direction, CI never ran `scripts/check_i18n.py`, so a
+#     hardcoded string failed `make lint` and passed the build.
+#
+# Not here, deliberately:
+#
+#   - `e2e`, which needs a migrated database, a seeded organization and a running
+#     backend: `make dev && make platform-bootstrap && make test-e2e`.
+#   - the image build and Trivy scan, which CI runs only on a push to `main`.
+#   - `test-migrations`. CI cycles the chain against a throwaway database; here
+#     `alembic downgrade base` points at whatever `backend/.env` says, which on a
+#     laptop is the database with your own work in it.
+CHECK_DB_PORT ?= 5432
+
+check: lint test test-frontend-cov build-frontend docs-build audit
+	@echo ""
+	@echo "All checks passed — every CI job except e2e."
+	@if ! python3 -c 'import socket; socket.create_connection(("127.0.0.1", $(CHECK_DB_PORT)), 1).close()' 2>/dev/null; then \
+		echo ""; \
+		echo "⚠  No database on 127.0.0.1:$(CHECK_DB_PORT), so tests/integration skipped itself"; \
+		echo "   — and CI's test job has one, so it did not. 'make docker-db' closes that gap."; \
+	fi
 
 # === Documentation ===
 
@@ -505,8 +575,11 @@ help:
 	@echo "Development:"
 	@echo "  make run           Start dev server (with hot reload)"
 	@echo "  make test          Run tests"
-	@echo "  make lint          Check code quality"
-	@echo "  make format        Auto-format code"
+	@echo "  make lint          Every static check: ruff, ty, eslint, prettier, tsc, the guards"
+	@echo "  make lint-backend  Just the Python half"
+	@echo "  make lint-frontend Just the TypeScript half"
+	@echo "  make format        Auto-format code (ruff + prettier)"
+	@echo "  make check         Every CI job except e2e - before opening a pull request"
 	@echo ""
 	@echo "Database:"
 	@echo "  make db-init       Initialize database (start + migrate)"

--- a/README.md
+++ b/README.md
@@ -163,15 +163,23 @@ make docs-build   # build with --strict, which is what CI runs
 ## Development
 
 ```bash
-make check          # what CI runs: lint, types, backend tests, frontend tests
+make check          # every CI job except e2e — about five minutes
 make test           # backend + the 100% coverage gate on the platform layer
 make test-fast      # no coverage, for the write-run-write loop
-make test-frontend  # vitest
+make test-frontend  # vitest, no coverage — the loop, not the gate
+make test-frontend-cov  # vitest + the gate CI applies
+make lint           # ruff, ty, eslint, prettier, tsc, and the two guard scripts
 make test-e2e       # playwright, against a running stack
 make test-migrations  # apply and roll back the whole chain
-make format         # ruff
+make format         # ruff + prettier
 make help           # everything else
 ```
+
+`make check` is `lint test test-frontend-cov build-frontend docs-build audit` —
+every job in [`ci.yml`](.github/workflows/ci.yml) except `e2e`, which needs a
+seeded backend, and the image scan, which runs only on a push to `main`. The
+workflow calls those same targets rather than repeating their commands, and
+`backend/tests/test_ci_parity.py` fails if the two drift.
 
 The **platform layer** - everything AgenticOS adds on top of the generated
 template - is held at 100% coverage and CI fails below it. The exact list is
@@ -195,7 +203,8 @@ first - the layering is enforced by tests, not by convention. Then
 [Adding a feature](docs/adding_features.md).
 
 New behaviour ships with tests; a bug ships with a regression test. Run
-`make check` before opening a pull request - it is exactly what CI runs.
+`make check` before opening a pull request - it is every CI job except the two
+named above, and a test keeps that true.
 
 Three things that trip up a first change here:
 

--- a/backend/tests/test_ci_parity.py
+++ b/backend/tests/test_ci_parity.py
@@ -1,0 +1,201 @@
+"""A test that `make check` is what CI runs, because the claim is load-bearing.
+
+`make check` is documented in four places as "what CI runs", and people believe
+it: a green `check` is what a branch is pushed on. When it runs less than CI, the
+failure mode is the expensive one - green locally, red after the push, and half
+an hour spent trusting the wrong answer. #143 found four separate divergences at
+once, none of them visible to anybody reading either file alone:
+
+  - `check` ran `test-frontend` (no coverage) where CI runs `test:coverage` and
+    its 100% gate. Every run on `feat/sandbox` after 832d647 was red while the
+    pull request reported `make check` green.
+  - `make lint` ran neither eslint, prettier nor tsc; CI's `test-frontend` job
+    runs all three.
+  - `check` ran neither `next build`, the docs build nor the dependency audit -
+    three entire CI jobs with no local equivalent at all.
+  - And in the other direction, CI never ran `scripts/check_i18n.py`, which
+    `make lint` did: a hardcoded string failed locally and passed the build.
+
+The fix is structural rather than clerical - the workflow calls the Makefile's
+targets instead of repeating their commands, so there is one definition of each
+check. This test guards the part that structure cannot: that a future step added
+to a gating job is added as a target `check` also runs, rather than as a raw
+command only CI knows about.
+
+The same shape as `test_coverage_gate.py`, and for the same reason: a gate whose
+failure mode is a green build needs something checking the checker.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+MAKEFILE = REPO_ROOT / "Makefile"
+
+# The jobs `make check` claims to reproduce. `e2e` and `docker` are out of scope
+# on purpose and the reasons are in the `check` target: e2e needs a migrated
+# database, a seeded organization and a running backend, and the image build runs
+# only on a push to `main`.
+GATING_JOBS = ("lint", "test", "test-frontend", "docs", "security")
+
+# Commands that prepare a runner rather than check anything. A laptop already has
+# these, which is why they have no Makefile equivalent and no place in `check`.
+ENVIRONMENT_SETUP = frozenset(
+    {
+        "uv python install 3.12",
+        "uv sync --directory backend --dev",
+        "uv sync --directory backend --group docs",
+        "bun install --frozen-lockfile",
+    }
+)
+
+# Targets CI runs that `check` deliberately does not, each with the reason it is
+# not drift. Anything else appearing in a gating job has to be reachable from
+# `check`.
+CI_ONLY_TARGETS = {
+    # `downgrade base` against CI's throwaway `test_db` is a rollback test;
+    # against a laptop's `backend/.env` it is somebody's afternoon.
+    "test-migrations",
+    # Informational, `if: always()`, and reported at `--cov-fail-under=0`. It
+    # gates nothing, so requiring it locally would only cost a second suite run.
+    "coverage-all",
+}
+
+_MAKE_INVOCATION = re.compile(r"^make\s+([a-z][a-z0-9-]*)((?:\s+[A-Z_]+=\S+)*)$")
+# A Makefile rule: a target list, a colon, prerequisites. Recipe lines start with
+# a tab and variable assignments carry an `=` before the colon, so both are out.
+_MAKE_RULE = re.compile(r"^(?!\t)([^\t=#:]+):(?!=)([^=]*)$")
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict[str, Any]:
+    with WORKFLOW.open() as handle:
+        loaded: dict[str, Any] = yaml.safe_load(handle)
+    return loaded
+
+
+@pytest.fixture(scope="module")
+def prerequisites() -> dict[str, list[str]]:
+    """Every Makefile target mapped to the targets it depends on."""
+    graph: dict[str, list[str]] = {}
+    for line in MAKEFILE.read_text().splitlines():
+        match = _MAKE_RULE.match(line)
+        if not match:
+            continue
+        targets, deps = match.groups()
+        for target in targets.split():
+            if target.startswith("."):
+                continue
+            graph.setdefault(target, []).extend(deps.split())
+    return graph
+
+
+@pytest.fixture(scope="module")
+def check_closure(prerequisites: dict[str, list[str]]) -> set[str]:
+    """Every target `make check` reaches, transitively."""
+    seen: set[str] = set()
+    pending = ["check"]
+    while pending:
+        target = pending.pop()
+        if target in seen:
+            continue
+        seen.add(target)
+        pending.extend(prerequisites.get(target, []))
+    return seen
+
+
+def _run_steps(workflow: dict[str, Any], job: str) -> list[str]:
+    """Every shell command a job runs, one entry per `run:` line."""
+    steps: list[str] = []
+    for step in workflow["jobs"][job]["steps"]:
+        command = step.get("run")
+        if command is not None:
+            steps.append(command.strip())
+    return steps
+
+
+def _invoked_target(command: str) -> str | None:
+    """The target a `make …` command runs, or None if it is not one."""
+    match = _MAKE_INVOCATION.match(command)
+    return match.group(1) if match else None
+
+
+class TestEveryGatingStepIsAMakeTarget:
+    """CI must not hold a check that has no name a developer can type."""
+
+    @pytest.mark.parametrize("job", GATING_JOBS)
+    def test_no_gating_job_runs_a_bare_command(self, workflow: dict[str, Any], job: str) -> None:
+        strays = [
+            command
+            for command in _run_steps(workflow, job)
+            if command not in ENVIRONMENT_SETUP and _invoked_target(command) is None
+        ]
+        assert not strays, (
+            f"the `{job}` job runs commands with no Makefile target, so `make check` "
+            f"cannot reproduce them: {strays}"
+        )
+
+    @pytest.mark.parametrize("job", GATING_JOBS)
+    def test_every_target_a_gating_job_runs_exists(
+        self, workflow: dict[str, Any], job: str, prerequisites: dict[str, list[str]]
+    ) -> None:
+        """A renamed target would otherwise fail only once the workflow ran."""
+        missing = [
+            target
+            for command in _run_steps(workflow, job)
+            if (target := _invoked_target(command)) is not None and target not in prerequisites
+        ]
+        assert not missing, f"the `{job}` job runs targets the Makefile does not define: {missing}"
+
+    @pytest.mark.parametrize("job", GATING_JOBS)
+    def test_every_target_a_gating_job_runs_is_reachable_from_check(
+        self, workflow: dict[str, Any], job: str, check_closure: set[str]
+    ) -> None:
+        unreachable = [
+            target
+            for command in _run_steps(workflow, job)
+            if (target := _invoked_target(command)) is not None
+            and target not in check_closure
+            and target not in CI_ONLY_TARGETS
+        ]
+        assert not unreachable, (
+            f"the `{job}` job runs {unreachable}, which `make check` does not - the "
+            "exact shape of #143. Add it to `check`, or to CI_ONLY_TARGETS with the "
+            "reason it belongs only in CI."
+        )
+
+
+class TestCheckRunsNothingCIDoesNot:
+    """The reverse direction, which is how `check_i18n.py` was missed for months.
+
+    A local-only check is the milder failure - it costs a developer time rather
+    than shipping a defect - but it still means the two commands disagree, and
+    the one people trust is the one that runs in CI.
+    """
+
+    def test_every_target_check_depends_on_runs_in_a_gating_job(
+        self, workflow: dict[str, Any], prerequisites: dict[str, list[str]]
+    ) -> None:
+        invoked = {
+            target
+            for job in GATING_JOBS
+            for command in _run_steps(workflow, job)
+            if (target := _invoked_target(command)) is not None
+        }
+        # Only the targets that do work. A grouping target like `lint` is
+        # satisfied by CI running both of its halves.
+        leaves = {target for target in prerequisites["check"] if not prerequisites.get(target)} | {
+            leaf for target in prerequisites["check"] for leaf in prerequisites.get(target, [])
+        }
+        missing = sorted(leaves - invoked)
+        assert not missing, (
+            f"`make check` runs {missing} and no CI job does. Either CI is missing a "
+            "gate a branch will pass locally, or the target does not belong in `check`."
+        )

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -21,11 +21,38 @@ Run these from the project root directory.
 | `make run` | Start development server with hot reload |
 | `make run-prod` | Start production server (0.0.0.0:8000) |
 | `make routes` | Show all registered API routes |
-| `make test` | Run tests with verbose output |
+| `make test` | Backend suite plus the 100% gate on the platform layer |
 | `make test-cov` | Run tests with coverage report (HTML + terminal) |
-| `make format` | Auto-format code with ruff |
-| `make lint` | Lint and type-check code (ruff + ty) |
+| `make format` | Auto-format code — ruff on the backend, prettier on the frontend |
+| `make lint` | Every static check, both halves: ruff, ruff format, ty, eslint, prettier, tsc, and the backtick and i18n guards |
+| `make lint-backend` / `make lint-frontend` | One half of the above. CI runs them in two different jobs, so either can be run on its own |
+| `make build-frontend` | `next build`. Type-checks the route tree and fails on a server component that cannot render — which neither tsc nor vitest sees |
+| `make audit` | Audit the locked dependency set for known vulnerabilities (needs the network) |
 | `make clean` | Remove cache files (__pycache__, .pytest_cache, etc.) |
+
+### Before a pull request
+
+`make check` is every CI job except one, and the equality is deliberate rather
+than approximate: `.github/workflows/ci.yml` calls these same Make targets rather
+than repeating their commands, and `backend/tests/test_ci_parity.py` fails if a
+gating job grows a step `check` does not run — or the reverse.
+
+```bash
+make check   # lint, test, test-frontend-cov, build-frontend, docs-build, audit
+```
+
+About five minutes, serial, on a warm cache. What it deliberately leaves out:
+
+| Not in `check` | Why, and what to run instead |
+|---|---|
+| `e2e` | Needs a migrated database, a seeded organization and a running backend: `make dev && make platform-bootstrap && make test-e2e` |
+| The image build and Trivy scan | CI runs those only on a push to `main` |
+| `make test-migrations` | CI cycles the chain against a throwaway `test_db`. On a laptop `alembic downgrade base` points at whatever `backend/.env` says, which is usually the database with your own work in it |
+
+One gap no command can close: CI's `test` job has a Postgres beside it, so
+`tests/integration/` runs there, and locally it skips itself when nothing answers
+on 5432. `make check` says so at the end when that happens — `make docker-db`
+first if the change is anywhere near the database.
 | `make sandbox-token` | Generate the sandbox service's own `SANDBOXD_TOKEN` into `backend/.env`, once. `make dev` runs it for you; it never regenerates, because a new token orphans every workspace the service is holding. The connection form offers to store the same value in the vault, so it does not have to be pasted anywhere |
 
 

--- a/docs/plans/frontend-coverage.md
+++ b/docs/plans/frontend-coverage.md
@@ -3,20 +3,23 @@
 Goal: 100% on both stacks, with as few exclusions as we can defend. This file is
 the running ledger - what is done, what is left, and how much of it there is.
 
-Two gates, and only one of them is in `make check`:
+Two gates, and both are in `make check`:
 
 | | Runs | Currently |
 |---|---|---|
 | Backend platform layer | `make test` / `make check` | **100%**, enforced |
 | Backend whole app | `make coverage-all` (informational) | **66%** - 4,538 of 14,814 statements uncovered |
-| Frontend, measured set | `bun run test:coverage` - **CI only** | **100%** statements, lines and functions; 98.7% branches, enforced |
+| Frontend, measured set | `make test-frontend-cov` / `make check` | **100%** statements, lines and functions; 97.5% branches, enforced |
 | Frontend, whole of `src` | informational | see the table below |
 
-`make check` runs `test:run`, not `test:coverage`. That is why the frontend gate
-sat red without anyone noticing; the thresholds are now **100/98/100/100** and the
-`include` list is what has *finished*, widened one layer at a time.
+`make check` ran `test:run`, not `test:coverage`, until #36 - which is why the
+frontend gate sat red without anyone noticing - and then ran the gate but not
+eslint, tsc, `next build`, the docs build or the dependency audit, until #143. It
+now runs every CI job except `e2e`, and `backend/tests/test_ci_parity.py` fails if
+that stops being true. The `include` list is what has *finished*, widened one layer
+at a time.
 
-Branches are gated at 98 rather than 100 for one reason: TypeScript-required
+Branches are gated below 100 for one reason: TypeScript-required
 guards whose other half no caller can reach - `event.target.files ?? []`,
 `pop() ?? "text"`, a `?? ""` on a value an early return already proved, a
 `typeof window === "undefined"` in a client module. Each is a narrowing, not a

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -14,13 +14,22 @@ uv run pytest tests/api/test_workspace_routes.py -x -v     # stop at the first f
 uv run pytest tests/integration -v --no-cov                # the ones needing a database
 ```
 
-Once, before pushing — this is what CI applies, and `make check` runs all of it:
+Once, before pushing — `make check` runs all of it, in this order:
 
 ```bash
-make lint               # ruff, ty, eslint, tsc, and the i18n guard
+make lint               # ruff, ruff format, ty, eslint, prettier, tsc, and the two guards
 make test               # the suite plus the 100% gate on the platform layer
 make test-frontend-cov  # the frontend suite plus its own gate
+make build-frontend     # next build — the route tree, which tsc and vitest do not see
+make docs-build         # mkdocs --strict — a dead link is a failure
+make audit              # the locked dependency set against the advisory database
 ```
+
+About five minutes serial, against CI's seven in parallel. The equality is
+maintained rather than asserted: the workflow calls these targets rather than
+repeating their commands, and `tests/test_ci_parity.py` fails if a gating job
+grows a step `make check` does not run. It has drifted four times — see
+[Commands](commands.md#before-a-pull-request) for what `check` leaves out and why.
 
 `make test-fast` skips coverage, which makes it the wrong last word before a push:
 the gate is most of what these commands are for. `pytest` without `uv run` picks up


### PR DESCRIPTION
`make check` is documented in six places as "what CI runs", and a green
`check` is what a branch gets pushed on. It ran three of CI's six gating jobs.

## What diverged

The frontend coverage gate — the thing #143 was filed about — was already
fixed by #119, which landed `check: lint test test-frontend-cov`. Reading the
workflow and the Makefile side by side turned up four more:

| CI step | Before this PR |
|---|---|
| `bun run lint` (eslint `--max-warnings 0`) | not in `make lint` |
| `bunx prettier --check` | not in `make lint` |
| `bun run type-check` (tsc) | not in `make lint` |
| `bun run build` (`next build`) | in no target at all |
| `mkdocs build --strict` | `make docs-build` existed; `check` never called it |
| `pip-audit` on the locked set | in no target at all |
| `scripts/check_i18n.py` | in `make lint` and **not in CI** — the reverse direction |

So `make lint` passed on a branch with a type error in a `.tsx`, and
CLAUDE.md's "ruff + ty + eslint + tsc" described a command that ran half of
that. Three whole CI jobs (`test-frontend`'s build step, `docs`,
`Security Scan`) had no local equivalent — a dead docs link or a dependency
advisory was something a branch learned about after pushing.

## What this changes

**The workflow calls the Makefile's targets** instead of holding a second copy
of their commands. That is the actual fix: two copies drift, one cannot. `lint`
splits into `lint-backend` / `lint-frontend` because CI runs the halves in
different jobs; `test` takes `COV_REPORT`, the one thing CI needs from it that a
laptop does not (Codecov wants XML). New targets: `build-frontend`, `audit`.
`make format` gains prettier, since `lint-frontend` checks formatting rather
than applying it.

```
check: lint test test-frontend-cov build-frontend docs-build audit
```

**`backend/tests/test_ci_parity.py`** guards what structure cannot: a step added
to a gating job later must be a target `check` also runs. Both directions,
verified by breaking them — dropping `build-frontend` from `check`, and
replacing `run: make lint-frontend` with `run: bun run lint`, each fail the
suite naming the target.

Three exclusions, each stated rather than omitted: `e2e` (needs a migrated
database, a seeded organization and a running backend), the image build and
Trivy scan (push to `main` only), and `make test-migrations` — CI cycles
`alembic downgrade base` against a throwaway `test_db`; on a laptop that points
at whatever `backend/.env` says. One gap no command closes: CI's `test` job has
a Postgres beside it, so `tests/integration/` runs there and skips silently
here. `check` now says so when that happens.

## What happened when the real gate first ran on `main`

Both gates it newly enforces were **already green** on `main`:

- frontend `test:coverage` — 171 files, 2952 tests, **100% statements / lines /
  functions, 97.58% branches** against a 97.5 floor. 0.08pp of headroom, so the
  next `??` fallback added without a test is the one that goes red;
- `next build`, `mkdocs --strict` and `pip-audit` all clean.

`make test` did fail on `main`, and it is not `main`'s fault: this worktree
shares one Postgres container with several others, and
`tests/integration/conftest.py` calls `drop_all` unconditionally. Two runs gave
different failure sets (6 failed / 17 errors, then 3 failed / 23 errors) — the
signature of concurrent runs destroying each other's schema. Against a private
database (`agenticos_test_i143` on the same container) the integration suite is
**216 passed**, and the whole of `make check` is green in 5m16s. Nothing about
the shared container is CI's problem: each CI job gets its own service
container — and this PR's `test` job passes in 6m44s.

Every job on this branch is green: `lint` 16s, `test` 6m44s, `test-frontend`
4m38s, `e2e` 4m1s, `docs` 18s, `Security Scan` 15s, CodeQL.

The issue's second finding — `use-mcp-tool-servers.ts` reported at 14.28%
statements / 0% functions on `feat/sandbox`, suspected v8 attribution rather
than an untested hook — **does not reproduce on `main`**. The file is at 100% in
the report. Nothing to settle; not carried into this PR.

## Timing, and why there is no fast/full split

Serial, warm caches, on a heavily contended machine:

| | |
|---|---|
| `lint-backend` | 13s |
| `lint-frontend` | 61s (eslint 49, tsc 8, prettier 4) |
| `test` | 187s (contended; ~95s uncontended) |
| `test-frontend-cov` | 80s |
| `build-frontend` | 20s |
| `docs-build` | 3s |
| `audit` | 12s |

Measured end to end: **5m16s** for the whole of `make check` — 2714 backend
tests at 100% platform coverage, the frontend gate, `next build`, the docs build
and the audit. Against CI's seven minutes in parallel, and up from roughly three
before. That
is not the cliff where people stop running it, so no `check-fast` target — the
mid-branch loop is still the scoped runs CLAUDE.md already prescribes, and
adding a second command people could mistake for the gate is how this class of
bug starts.

## Filed, not fixed

- **#188** — `pre-commit run codespell --all-files` is red on `main`
  (`frontend/src/lib/tool-steps.ts:148`, "unparseable", from #119). Nothing runs
  codespell over the tree, so it waits until somebody edits that file for an
  unrelated reason. Out of scope: a one-word edit in a frontend module does not
  belong in a diff about the Makefile and the workflow.

Closes #143
