### PR TITLE
fix(capabilities): stop offering a delegation tool nothing can reach

### DIFF
--- a/backend/app/agents/capabilities/_registry.py
+++ b/backend/app/agents/capabilities/_registry.py
@@ -362,8 +362,10 @@ def register(
     `tests/test_capability_registry.py`, which builds every registered
     capability and compares this list against the tools the model is actually
     offered. A capability with no tools says so with `tools=()`, and one that
-    declares a tool it deliberately does not wire names it in that test's own
-    exception table, where the reason can be a sentence.
+    declares a tool it deliberately never offers a model - because the library
+    owning it adds it unconditionally and nothing here can reach it - names that
+    tool in `DECLARED_AND_NOT_OFFERED` in the same test, where the reason can be a
+    sentence.
     """
 
     def decorator(builder: CapabilityBuilder) -> CapabilityBuilder:

--- a/backend/app/agents/capabilities/subagents/README.md
+++ b/backend/app/agents/capabilities/subagents/README.md
@@ -211,9 +211,24 @@ own message tells a model to re-delegate with.
 
 **Let a delegate ask the parent a question.** The library's `ask_parent` tool is
 injected only into agents it built itself, and every delegate here arrives
-pre-built. A specialist works autonomously and says so if it could not; a
-specialist that needs a person reaches one through its own capabilities, on the
-parent's channels, which `AgentDeps.clone_for_subagent` passes down.
+pre-built — so `task` passes `inject_ask_parent=False` for a pinned delegate and an
+inline specialist alike, and `_autonomously` closes the two dynamic entry points as
+well. A specialist works autonomously and says so if it could not; a specialist that
+needs a person reaches one through its own capabilities, on the parent's channels,
+which `AgentDeps.clone_for_subagent` passes down.
+
+So **`answer_subagent` is declared and offered to nobody** — `UNREACHABLE_TOOLS`,
+applied as a filter in `get_toolset`. It replies to a question that cannot be asked,
+and the library adds it to its toolset unconditionally, so the offered set is the
+only place the decision can be made. Declared still, because a tool absent from
+`tools=` can be neither gated by the approval policy nor renamed by a binding, and
+that half is silent; filtered, because the other half is a description in every
+turn's context inviting a call whose only answer is "that delegation is not waiting
+for an answer". Opening the path is a feature rather than a repair, and which
+channel answers depends on the mode: a `sync` question is answered by a *person*,
+through `ask_user`, and never through this tool — so it becomes reachable only for a
+background delegation, whose question the parent's own model answers while nothing
+obliges it to look. agenticos#184 has the shape and what it would take.
 
 ## Background delegation, and what it costs
 
@@ -359,11 +374,19 @@ one-shot delegation under the same mode, fan-out ceiling and recording as a
 table rather than a comparison against one name — a delegation this module does
 not see is one that escapes every decision it makes.
 
-With both wired there is nothing left for the drift check to be told about:
-`UNWIRED_TOOLS` in `tests/test_capability_registry.py` is gone, and before it a
-`CapabilityDef.drift_config` field that named a configuration nothing read. What
-stands in their place is a resource fixture wide enough — one resolved delegate
-*and* a `DynamicSpecialists` — that no capability has an excuse.
+Wiring both removed `UNWIRED_TOOLS` from `tests/test_capability_registry.py`, and
+before it a `CapabilityDef.drift_config` field that named a configuration nothing
+read. What stands in their place is a resource fixture wide enough — one resolved
+delegate *and* a `DynamicSpecialists` — that no capability has an excuse for not
+building.
+
+An exception table is back, and it is a narrower claim than either of those:
+`DECLARED_AND_NOT_OFFERED` names `answer_subagent`, subtracted from the expectation
+rather than exempting the capability, so everything else about `subagents` is still
+compared in both directions. That "nothing left to be told about" only held while a
+declared tool was declared and *unwired*; a declared tool that is declared and
+deliberately *unoffered* is a state the check has to know about, or it reads the
+filter as drift.
 
 ## The general-purpose delegate is not offered
 

--- a/backend/app/agents/capabilities/subagents/README.md
+++ b/backend/app/agents/capabilities/subagents/README.md
@@ -228,7 +228,8 @@ for an answer". Opening the path is a feature rather than a repair, and which
 channel answers depends on the mode: a `sync` question is answered by a *person*,
 through `ask_user`, and never through this tool — so it becomes reachable only for a
 background delegation, whose question the parent's own model answers while nothing
-obliges it to look. agenticos#184 has the shape and what it would take.
+obliges it to look. agenticos#184 is the sync half, worth doing on its own terms, and
+it would not make this tool reachable.
 
 ## Background delegation, and what it costs
 

--- a/backend/app/agents/capabilities/subagents/_capability.py
+++ b/backend/app/agents/capabilities/subagents/_capability.py
@@ -20,7 +20,9 @@ agree are worse than one, because the disagreement is silent.
 `SubAgentCapability` is a dataclass of twenty fields with defaults - one of them
 `include_general_purpose=True`, which this platform inverts. Registering it
 directly would mean a field added upstream arrives switched on, in every published
-agent, with nothing in this repository saying so.
+agent, with nothing in this repository saying so. It is also where a tool the
+library adds unconditionally can be withheld from the model without being taken off
+the list a person approves against - see :data:`UNREACHABLE_TOOLS`.
 
 What is deliberately *not* wrapped: the toolset's own task management, the
 cancellation of background *tasks* in `wrap_run`, and the retry behaviour. Those
@@ -39,7 +41,7 @@ from pydantic_ai import Agent as PydanticAgent
 from pydantic_ai import UsageLimits
 from pydantic_ai.agent import AgentRunResult
 from pydantic_ai.capabilities import WrapperCapability, WrapRunHandler
-from pydantic_ai.tools import RunContext
+from pydantic_ai.tools import RunContext, ToolDefinition
 from pydantic_ai.toolsets import AbstractToolset, AgentToolset
 from subagents_pydantic_ai import (
     ANSWER_SUBAGENT_DESCRIPTION,
@@ -154,21 +156,8 @@ DELEGATION_TOOLS: tuple[CapabilityToolInfo, ...] = (
         id="list_active_tasks", description=LIST_ACTIVE_TASKS_DESCRIPTION, side_effecting=False
     ),
     # A reply to a question a delegate asked, inside this run. It unblocks work
-    # rather than acting on anything outside it.
-    #
-    # Declared and offered, and **no delegation this deployment runs can ever use
-    # it**: the tool answers a task in `WAITING_FOR_ANSWER`, which is reached only
-    # through the library's `ask_parent`, and nothing here injects that tool. A
-    # configured subagent - which every pinned delegate and every inline specialist
-    # is, since all of them arrive as `SubAgentConfig["agent"]` - is compiled with
-    # `inject_ask_parent=False`, and the two registry paths that would get it are
-    # handed `can_ask_questions: False` by `_autonomously`. So the description
-    # promises the model something the deployment cannot keep, and the model will
-    # find no task to answer. It stays declared because a tool absent from this
-    # list cannot be gated by the approval policy or renamed by a binding, which is
-    # the more dangerous half. Removing it - or making it usable - belongs with
-    # whatever decides whether a delegate may ask its parent anything at all, which
-    # is a decision about the product and not about this list.
+    # rather than acting on anything outside it - and it is declared here and
+    # never offered to a model, for the reason in `UNREACHABLE_TOOLS`.
     CapabilityToolInfo(
         id="answer_subagent", description=ANSWER_SUBAGENT_DESCRIPTION, side_effecting=False
     ),
@@ -200,10 +189,12 @@ DELEGATION_TOOLS: tuple[CapabilityToolInfo, ...] = (
 )
 """Every tool delegation has, declared once.
 
-Declared rather than derived, and all ten rather than the eight a non-dynamic
+Declared rather than derived, and all ten rather than the seven a non-dynamic
 configuration offers, because a tool absent from this list cannot be gated by the
 approval policy or renamed by a binding - and the dangerous half of that is
-silent.
+silent. Which of the ten a given agent's model is actually offered is decided in
+two places: `create_agent` and `delegate` by whether the runner resolved a
+`DynamicSpecialists`, and `answer_subagent` by :data:`UNREACHABLE_TOOLS`.
 
 Eight of the descriptions are **imported, not rewritten**. A tool's description is
 the strongest prompt in the product, and `TASK_TOOL_DESCRIPTION` is two hundred
@@ -214,6 +205,50 @@ the library's describe a configuration this platform does not offer - see
 :data:`DELEGATE_DESCRIPTION`. What is declared here is what the model reads,
 exactly - see the `descriptions` argument in `build_delegation`.
 """
+
+UNREACHABLE_TOOLS: frozenset[str] = frozenset({"answer_subagent"})
+"""Declared for the Builder and the approval policy, and offered to no model.
+
+`answer_subagent` replies to a question a delegate asked, and no delegate here can
+ask one. The library injects its `ask_parent` tool only into agents it built
+itself, and every delegate on this platform arrives pre-built as
+`SubAgentConfig["agent"]` from :func:`_config_for` - so the library's `task` passes
+`inject_ask_parent=False` for a pinned delegate and an inline specialist alike, and
+:func:`~app.agents.capabilities.subagents._toolset._autonomously` closes the two
+dynamic entry points as well. `TaskStatus.WAITING_FOR_ANSWER` is therefore never
+reached, and this tool has nothing it could ever answer.
+
+*Filtered rather than left out of* :data:`DELEGATION_TOOLS`, because those are two
+different failures and only one of them is loud. A tool the model is offered and
+cannot use costs a description in every turn's context - the strongest prompt
+surface in this product - and invites a call whose only possible answer is "that
+delegation is not waiting for an answer". A tool absent from the declaration cannot
+be gated by the approval policy or renamed by a binding, and *that* half is silent.
+So it stays declared and stops being offered, which is the same shape the two
+dynamic entry points had while they were declared and unwired.
+
+*Opening the path instead was the alternative, and it is a feature rather than a
+repair.* Which channel answers a question is decided by the mode: a `sync`
+delegation is answered from `ask_callback` or `ctx.deps.ask_user` - a person, and
+never through this tool - so this tool becomes reachable only for a *background*
+delegation, whose question is answered by the parent's own model through a future
+the library's task manager holds. That is the harder half: the delegate blocks for
+up to `ask_timeout_seconds` holding a fan-out slot while nothing obliges the parent
+to look, and `wrap_run` cancels every background task when the turn ends - money
+spent on a question nobody was asked. Letting a `sync` delegate ask the person
+already waiting is agenticos#184, and this filter is what that issue removes.
+"""
+
+
+def _is_offered(_ctx: RunContext[AgentDeps], tool: ToolDefinition) -> bool:
+    """Whether the model is shown this tool at all. See :data:`UNREACHABLE_TOOLS`.
+
+    Reads the tool's name off the library's own toolset, which is where the stable
+    id is still the name: a binding's rename wraps the *capability*, outside this,
+    so renaming `answer_subagent` cannot smuggle it back into the offered set.
+    """
+    return tool.name not in UNREACHABLE_TOOLS
+
 
 _MODE_NOTE: dict[DelegationMode, str] = {
     "sync": "Each delegation blocks until the specialist answers.",
@@ -412,6 +447,11 @@ class Delegation(WrapperCapability[AgentDeps]):
     def get_toolset(self) -> AgentToolset[AgentDeps] | None:
         """The library's delegation tools, with this platform's accounting around them.
 
+        Also minus the ones no configuration here can reach. The library adds
+        `answer_subagent` to its toolset unconditionally, so filtering the offered
+        set is the only place that decision can be made - see
+        :data:`UNREACHABLE_TOOLS`.
+
         Memoised because the wrapper carries no state of its own but the journal
         it points at does, and because `BuiltAgent.capabilities` is introspected -
         two wrappers over one toolset would answer the same question twice.
@@ -421,7 +461,9 @@ class Delegation(WrapperCapability[AgentDeps]):
             # `SubAgentCapability` always returns one: it constructs its toolset
             # in `__post_init__` and holds it for the life of the instance.
             wrapped = cast(AbstractToolset[AgentDeps], super().get_toolset())
-            self._delegating = DelegatingToolset(wrapped=wrapped, journal=self.journal)
+            self._delegating = DelegatingToolset(wrapped=wrapped, journal=self.journal).filtered(
+                _is_offered
+            )
         return self._delegating
 
     def get_instructions(self) -> str:

--- a/backend/app/agents/capabilities/subagents/_capability.py
+++ b/backend/app/agents/capabilities/subagents/_capability.py
@@ -235,8 +235,10 @@ delegation, whose question is answered by the parent's own model through a futur
 the library's task manager holds. That is the harder half: the delegate blocks for
 up to `ask_timeout_seconds` holding a fan-out slot while nothing obliges the parent
 to look, and `wrap_run` cancels every background task when the turn ends - money
-spent on a question nobody was asked. Letting a `sync` delegate ask the person
-already waiting is agenticos#184, and this filter is what that issue removes.
+spent on a question nobody was asked. So agenticos#184 - letting a `sync` delegate
+ask the person already waiting - is worth doing and would **not** empty this set on
+its own: a sync answer never arrives through this tool. Only the background half
+does, which is why the two are one issue with two halves rather than one change.
 """
 
 

--- a/backend/app/agents/capabilities/subagents/_toolset.py
+++ b/backend/app/agents/capabilities/subagents/_toolset.py
@@ -38,7 +38,10 @@ what it was configured with and none of these three is expressible that way. See
 
 *A specialist never asks the parent a question.* Which is a decision about the
 arguments rather than about the call, so it is applied to them on the way past:
-see :func:`_autonomously`.
+see :func:`_autonomously`. This is the half of that decision the two dynamic entry
+points need; the library closes the configured ones itself, and
+:data:`~app.agents.capabilities.subagents._capability.UNREACHABLE_TOOLS` is what
+the two of them together mean for the tool that would have answered.
 
 Three entry points therefore reach a delegation - `task`, `delegate`, and `task`
 addressing something `create_agent` registered - and all three come through here.

--- a/backend/tests/test_capability_registry.py
+++ b/backend/tests/test_capability_registry.py
@@ -175,14 +175,42 @@ class TestToolDeclarations:
     }
     """Everything every registered capability needs in order to build.
 
-    There is deliberately no table of exceptions beside this. There was one -
-    `UNWIRED_TOOLS`, naming `create_agent` and `delegate` as declared and not
-    implemented, which they were for two phases - and before that a
-    `CapabilityDef.drift_config` field naming a configuration nothing read. Both
-    were ways of saying "this capability is partly outside the check". Wiring the
-    last two tools removed the need for either, so what stands in their place is
-    resources wide enough that no capability has an excuse.
+    Wide rather than minimal on purpose. There used to be a
+    `CapabilityDef.drift_config` field naming a configuration nothing read, and
+    then an `UNWIRED_TOOLS` table naming `create_agent` and `delegate` as declared
+    and not implemented - both ways of saying "this capability is partly outside
+    the check", and both removed by wiring the tools. What stands in their place is
+    resources wide enough that no capability has an excuse for not building.
     """
+
+    DECLARED_AND_NOT_OFFERED: dict[str, frozenset[str]] = {
+        "subagents": frozenset({"answer_subagent"}),
+    }
+    """Tools a capability declares and deliberately offers no model.
+
+    The one legitimate reason to declare a tool that never reaches a model: the
+    library owning it adds it unconditionally, nothing in this deployment can put
+    it in a state where it does anything, and dropping it from `tools=` would take
+    it out of reach of the approval policy and of a binding's rename. `subagents`
+    declares `answer_subagent` for exactly that reason -
+    `app.agents.capabilities.subagents._capability.UNREACHABLE_TOOLS` has the
+    whole of it, and agenticos#184 is what would empty this table.
+
+    Spelt out here rather than imported from the capability, and subtracted rather
+    than skipped. An imported set would make the check below a tautology, and
+    skipping the capability would put it back outside the drift test the way
+    `drift_config` and `UNWIRED_TOOLS` did - an undeclared tool could then appear
+    beside the exempt one and nothing would notice. Everything else about the
+    capability is still compared in both directions, and
+    `test_the_exemption_table_names_tools_that_are_still_declared` is what stops
+    an entry outliving its reason.
+    """
+
+    def _expected(self, definition_id: str) -> frozenset[str]:
+        """The tool ids this capability's model should be offered, exemptions applied."""
+        return get(definition_id).tool_ids - self.DECLARED_AND_NOT_OFFERED.get(
+            definition_id, frozenset()
+        )
 
     def _built(self, definition_id: str) -> Any:
         return get(definition_id).builder(
@@ -230,6 +258,23 @@ class TestToolDeclarations:
             return frozenset()
         return frozenset(await toolset.get_tools(_run_context()))
 
+    def test_the_exemption_table_names_tools_that_are_still_declared(self):
+        """An exemption that outlived its tool would quietly widen the check.
+
+        Both halves matter. An id no longer declared - renamed, or removed with the
+        capability it belonged to - subtracts nothing and reads as if it did, so the
+        next tool that *is* wrongly unoffered looks exempt. And a capability listed
+        with an empty set is an entry that says "partly outside the check" while
+        exempting nothing at all.
+
+        The other direction needs no test: a tool that becomes genuinely offered
+        while still named here fails the comparison below, because the offered set
+        then holds something the expectation subtracted.
+        """
+        for capability_id, exempt in self.DECLARED_AND_NOT_OFFERED.items():
+            assert exempt, capability_id
+            assert exempt <= get(capability_id).tool_ids, capability_id
+
     @pytest.mark.anyio
     async def test_every_builtin_declares_the_tools_it_actually_offers(self):
         """Declaration feeds the Builder; the toolset is the truth.
@@ -243,7 +288,7 @@ class TestToolDeclarations:
             built = self._built(definition.id)
             assert built is not None, definition.id
 
-            assert await self._offered(built) == get(definition.id).tool_ids, definition.id
+            assert await self._offered(built) == self._expected(definition.id), definition.id
 
     @pytest.mark.anyio
     async def test_renaming_every_tool_cannot_hide_an_undeclared_one(self):
@@ -255,6 +300,12 @@ class TestToolDeclarations:
         exists for. Instead the expectation moves with the rename: every declared
         tool must arrive under its new name, and a tool nobody declared has no new
         name to arrive under, so it still shows up as a difference.
+
+        A tool in `DECLARED_AND_NOT_OFFERED` must not arrive under either name. It
+        is renamed here like every other - a binding may name a tool the model is
+        not shown, and publishing accepts it - so this is also the check that the
+        rename cannot smuggle it back in: the filter keys on the stable id, inside
+        the wrapper that renames.
         """
         for definition in all_capabilities():
             overrides = {
@@ -268,7 +319,11 @@ class TestToolDeclarations:
             assert built, definition.id
             offered = await self._offered(built[0])
 
-            expected = frozenset(tool.name for tool in definition.effective_tools(overrides))
+            expected = frozenset(
+                tool.name
+                for tool in definition.effective_tools(overrides)
+                if tool.id in self._expected(definition.id)
+            )
             assert offered == expected, definition.id
 
 

--- a/backend/tests/test_capability_registry.py
+++ b/backend/tests/test_capability_registry.py
@@ -193,8 +193,8 @@ class TestToolDeclarations:
     it in a state where it does anything, and dropping it from `tools=` would take
     it out of reach of the approval policy and of a binding's rename. `subagents`
     declares `answer_subagent` for exactly that reason -
-    `app.agents.capabilities.subagents._capability.UNREACHABLE_TOOLS` has the
-    whole of it, and agenticos#184 is what would empty this table.
+    `app.agents.capabilities.subagents._capability.UNREACHABLE_TOOLS` has the whole
+    of it, including why agenticos#184 would not empty this table on its own.
 
     Spelt out here rather than imported from the capability, and subtracted rather
     than skipped. An imported set would make the check below a tautology, and

--- a/backend/tests/test_dynamic_specialists.py
+++ b/backend/tests/test_dynamic_specialists.py
@@ -617,7 +617,6 @@ class TestWhenTheEntryPointsAreOfferedAtAll:
             "check_task",
             "wait_tasks",
             "list_active_tasks",
-            "answer_subagent",
             "send_message_to_subagent",
             "soft_cancel_task",
             "hard_cancel_task",

--- a/backend/tests/test_subagents_capability.py
+++ b/backend/tests/test_subagents_capability.py
@@ -591,8 +591,9 @@ class TestAttaching:
 
         It stays *declared*, which is the second assertion. A tool absent from
         `tools=` can be neither gated by the approval policy nor renamed by a
-        binding, and that half of the same failure is silent. agenticos#184 is what
-        would make it reachable, and `UNREACHABLE_TOOLS` says what that would take.
+        binding, and that half of the same failure is silent. `UNREACHABLE_TOOLS`
+        says what making it reachable would take, and why agenticos#184 is only
+        half of that.
         """
         capability = a_capability(a_runtime(a_delegate()))
         toolset = capability.get_toolset()

--- a/backend/tests/test_subagents_capability.py
+++ b/backend/tests/test_subagents_capability.py
@@ -8,8 +8,9 @@ run has ended. None of those look like errors, so each one is pinned here.
 
 The background path adds three more of the same kind, and each has its own class:
 a delegation nobody collects (`TestBackgroundDelegations`), a lifecycle tool whose
-description promises something it does not do (`TestTaskLifecycle`), and a
-delegate that stops for a person nobody can ask
+description promises something it does not do (`TestTaskLifecycle` - and
+`TestAttaching`, for the one whose promise cannot be kept at all and which is
+therefore not offered), and a delegate that stops for a person nobody can ask
 (`TestApprovalInsideADelegation`). Cancellation is deliberately *not* here: the
 cancel that matters arrives from outside the run, so it is asserted through the
 surface that sends it, in
@@ -73,7 +74,7 @@ from app.agents.capabilities.approval import (
 )
 from app.agents.capabilities.budget import SpendEntry, SpendLedger
 from app.agents.capabilities.subagents import Delegation, SubagentsConfig
-from app.agents.capabilities.subagents._capability import _LazyAgent
+from app.agents.capabilities.subagents._capability import UNREACHABLE_TOOLS, _LazyAgent
 from app.agents.capabilities.subagents._events import UNNAMED_TOOL, FrameLabels, frame_for
 from app.agents.capabilities.subagents._journal import DelegationJournal
 from app.agents.capabilities.subagents._toolset import DelegatingToolset
@@ -578,6 +579,38 @@ class TestAttaching:
         assert isinstance(capability, Delegation)
         assert capability.journal.max_fanout == SubagentsConfig().max_fanout
 
+    async def test_a_delegating_agent_is_offered_no_way_to_answer_a_question(self):
+        """The exact set a delegating agent's model reads, and why one is missing.
+
+        `answer_subagent` replies to a question a delegate asked, and no delegate
+        here can ask one: the library injects its `ask_parent` tool only into agents
+        it built itself, and every delegate arrives pre-built. So the tool could only
+        ever answer "that delegation is not waiting for an answer" - from a
+        description in every turn's context, which is the strongest prompt surface in
+        this product.
+
+        It stays *declared*, which is the second assertion. A tool absent from
+        `tools=` can be neither gated by the approval policy nor renamed by a
+        binding, and that half of the same failure is silent. agenticos#184 is what
+        would make it reachable, and `UNREACHABLE_TOOLS` says what that would take.
+        """
+        capability = a_capability(a_runtime(a_delegate()))
+        toolset = capability.get_toolset()
+        assert toolset is not None
+
+        offered = frozenset(await toolset.get_tools(a_context()))
+
+        assert offered == {
+            "task",
+            "check_task",
+            "wait_tasks",
+            "list_active_tasks",
+            "send_message_to_subagent",
+            "soft_cancel_task",
+            "hard_cancel_task",
+        }
+        assert get("subagents").tool_ids >= UNREACHABLE_TOOLS
+
     async def test_allow_dynamic_in_the_config_alone_offers_no_extra_tool(self):
         """The setting has one reader, and it is not this capability.
 
@@ -594,7 +627,11 @@ class TestAttaching:
 
         offered = frozenset(await toolset.get_tools(a_context()))
 
-        assert offered == get("subagents").tool_ids - {"create_agent", "delegate"}
+        assert offered == get("subagents").tool_ids - {
+            "create_agent",
+            "delegate",
+            *UNREACHABLE_TOOLS,
+        }
 
     async def test_the_model_reads_exactly_what_the_catalog_declares(self):
         """The other half of declaring the tools: the text has to be the same text.
@@ -1259,31 +1296,6 @@ class TestTaskLifecycle:
         assert [outcome.status for outcome in recorder.outcomes] == ["completed", "completed"]
         assert {outcome.task_id for outcome in recorder.outcomes} == set(task_ids)
         assert capability.journal.in_flight() == 0
-
-    async def test_answering_a_delegate_finds_nothing_to_answer(self):
-        """`answer_subagent` is declared, offered, and inert here - deliberately.
-
-        A task only reaches `WAITING_FOR_ANSWER` through the library's `ask_parent`,
-        and nothing in this deployment injects that tool. Both halves are closed: a
-        configured subagent - which every pinned delegate and every inline
-        specialist is, since all of them arrive as `SubAgentConfig["agent"]` - is
-        compiled with `inject_ask_parent=False`, and the two registry paths that
-        would get it are handed `can_ask_questions: False` by `_autonomously`. So no
-        specialist can ask a question and this tool can never have one to answer. It
-        stays declared because a tool absent from `tools=` cannot be gated or
-        renamed, and because the shape is what would change if a delegate ever could
-        ask. What it must not do is invent an answer.
-        """
-        capability = a_capability(a_runtime(a_delegate(model=blocking())), {"mode": "async"})
-        ctx = a_context()
-        task_id = task_id_in(await delegate_to(capability, ctx))
-
-        answer = await call_tool(
-            capability, ctx, "answer_subagent", {"task_id": task_id, "answer": "in EUR"}
-        )
-
-        assert "is not waiting for an answer" in answer
-        await ends_the_run(capability, ctx)
 
     @pytest.mark.parametrize("tool", ["soft_cancel_task", "hard_cancel_task"])
     async def test_cancelling_a_delegation_that_already_finished_explains_itself(self, tool: str):

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -38,6 +38,11 @@ neither leaves anything for a person to approve, so neither declares a tool. A
 capability with genuinely no tools says so with `tools=()` rather than omitting
 the argument; see [Add a capability](../howto/add-capability.md).
 
+**This column is what a capability declares, which is not always what a model is
+offered.** Delegation is the one place the two differ: `create_agent` and `delegate`
+appear only under `allow_dynamic`, and `answer_subagent` appears to nobody at all —
+both explained under [Delegation](#delegation) below.
+
 ## Knowledge search
 
 `search_documents` — *Search the organization's documents for passages relevant to
@@ -250,11 +255,11 @@ pair it with `code_execution` or `knowledge` for that. No configuration.
 ## Delegation
 
 `task` — *hand a self-contained piece of work to one of this agent's specialists.*
-`check_task`, `wait_tasks`, `list_active_tasks`, `answer_subagent` — *following one
-that is running.*
+`check_task`, `wait_tasks`, `list_active_tasks` — *following one that is running.*
 `send_message_to_subagent`, `soft_cancel_task`, `hard_cancel_task` — *steering or
 stopping one.*
 `create_agent`, `delegate` — *a specialist the model writes for itself, when the author allows it.*
+`answer_subagent` — *declared, and offered to no model.*
 
 One agent handing part of a job to another, each on its own model with its own
 knowledge and its own step limit, addressed by name. There are two shapes of
@@ -323,6 +328,26 @@ suspends anyway — a shape the library documents as undeliverable — is record
 "still running" for as long as the process lives: its spend attributed to nothing,
 its fan-out slot never released, and the panel a surface opened never closed.
 
+**And no delegate can ask a question of its own, so `answer_subagent` is offered to no
+model.** Parking for an approval is a gated tool being reviewed, not a specialist asking
+anything. This tool replies to a question a delegate asked, and the delegation library
+injects its `ask_parent` tool only into agents it built itself — every delegate here
+arrives pre-built, published delegate and inline specialist alike, and a specialist the
+model invents has the same door closed on purpose. So the tool's only possible answer is
+"that delegation is not waiting for an answer". It stays *declared*, because a tool
+absent from the declaration cannot be gated by the approval policy or renamed by a
+binding and that half of the failure is silent; it is filtered out of the offered set,
+because the other half is a description in every turn's context describing an action
+that cannot happen, and tool descriptions are the strongest prompt in this product.
+
+Opening the path is a feature rather than a repair, and the mode decides who could
+answer: a `sync` delegation's question goes to a **person**, through the run's own
+`ask_user` channel and never through this tool, while only a *background* delegation's
+question is answered by the parent's own model — which is the harder half, since the
+delegate then blocks holding a fan-out slot while nothing obliges the parent to look
+and the turn's end cancels it. Letting a sync delegate ask the person already waiting
+is [#184](https://github.com/vstorm-co/agenticos/issues/184).
+
 **`wait_tasks` truncates, and says so.** A completed task's result is cut at
 `max_result_chars` with an explicit marker pointing at `check_task`, which always
 returns the full text. The marker is the load-bearing half: a silent cut reads as a
@@ -376,7 +401,7 @@ door. Bind it on the parent and name it here.
 **`create_agent` and `delegate` are offered only under `allow_dynamic`.** A tool
 absent from a capability's declaration cannot be gated by the approval policy or
 renamed by a binding, and the dangerous half of that is silent — so all ten are
-declared, and a default configuration offers eight.
+declared, and a default configuration offers seven.
 
 What the switch buys is a specialist the model writes itself: instructions and a
 model, and nothing else. It is built through the same `build_agent` an inline


### PR DESCRIPTION
## What the model was being told, and could not do

`answer_subagent` was offered to every delegating agent's model. It replies to a question
a delegate asked, and no delegate on this platform can ask one:

- The library injects its `ask_parent` tool only into agents it built itself, and every
  delegate here arrives pre-built as `SubAgentConfig["agent"]` from `_config_for` — so
  `SubAgentToolset.task` passes `inject_ask_parent=False` for a pinned delegate and an
  inline specialist alike, and `_compile_subagent` returns early for a config carrying
  `agent` without appending the toolset.
- For the two dynamic entry points the library *would* inject it, and `_autonomously`
  sets `can_ask_questions: False`, which it honours by not appending the toolset at all.

`TaskStatus.WAITING_FOR_ANSWER` is therefore unreachable and the tool's only possible
answer is "that delegation is not waiting for an answer" — from a description the model
reads on every turn, which is the strongest prompt surface in this product.

## The fix, and what the other one would have bought

**Filtered out of the offered set, and still declared** — `UNREACHABLE_TOOLS`, applied in
`Delegation.get_toolset`. Those are two different failures and only one of them is loud: a
tool offered and unusable costs context and invites a call that can only fail, while a tool
absent from `tools=` can be neither gated by the approval policy nor renamed by a binding.
The library adds it unconditionally, so the offered set is the only place the decision can
be made. It is the same shape `create_agent` and `delegate` had while they were declared
and unwired.

**Making asking work is #184, and it would not have closed this.** Which channel answers a
question is decided by the mode, and the two halves are different products:

| | Who answers | Reaches `answer_subagent` |
|---|---|---|
| `sync` | a **person**, through `ask_callback` / `ctx.deps.ask_user` | no |
| `async` | the **parent's own model**, through a future the task manager holds | yes |

So opening it for `sync` — the valuable half, and the one the issue names — buys a
delegate that can ask the person already waiting on the parent, and leaves this tool
exactly as unreachable as it was. Only the background half makes it reachable, and that is
the half whose reasoning still holds after revisiting it: the delegate blocks for up to
`ask_timeout_seconds` holding a fan-out slot while nothing obliges the parent to call
`check_task`, and `wrap_run` cancels every background task when the turn ends — money spent
on a question nobody was asked. On top of which `inject_ask_parent=False` is hardcoded for
the compiled path, so reaching a pinned delegate or an inline specialist at all is an
upstream change to `subagents-pydantic-ai`, as #174 is.

**What the product gives up, plainly:** no delegate can ask anything — not a person, not
its parent. A specialist works autonomously and says so if it could not. That was already
true; this change stops telling the model otherwise.

## What a delegating agent's model is offered after this

`task`, `check_task`, `wait_tasks`, `list_active_tasks`, `send_message_to_subagent`,
`soft_cancel_task`, `hard_cancel_task` — plus `create_agent` and `delegate` under
`allow_dynamic`. Seven of the ten declared, or nine.

## How the drift test stays meaningful

`tests/test_capability_registry.py` builds the delegation capability at its widest and
compares declared against offered in both directions. It now knows about one exemption,
explicitly:

- `DECLARED_AND_NOT_OFFERED` names `answer_subagent` — **spelt out in the test rather than
  imported** from the capability (an imported set makes the check a tautology), and
  **subtracted rather than skipping the capability** (skipping is what put `subagents`
  outside the check entirely before, so an undeclared tool could appear beside the exempt
  one and nothing would notice).
- A new test refuses an entry that no longer names a declared tool, or names nothing.
  Without it, an exemption outliving its reason widens the check silently — which is the
  failure mode of the `UNWIRED_TOOLS` table this one replaces. The other direction needs no
  test: a tool that becomes genuinely offered while still listed fails the comparison.
- The rename test now also proves a binding cannot smuggle it back. The filter keys on the
  stable id, inside the wrapper that renames, so `answer_subagent_as_this_agent_calls_it`
  is not offered either.

And the consequence is asserted where the configuration is: `test_subagents_capability.py`
pins the exact seven-tool set a delegating agent's model reads, and that the tool is still
declared. `test_answering_a_delegate_finds_nothing_to_answer` is gone — asserting the
library's refusal message for a tool no model can call was a test for somebody else's code.

## Rebased onto `main`, and what that took

This was branched from `feat/subagents`, which has since squash-merged as `f618e8c` after
gaining four more commits. Replaying these two onto `main` collapses the diff from ~18,800
lines to **311 across 8 files**, and four of the merged commits' changes land in files this
one also touches. All of them survive:

- `cancel_in_flight()` swept in `wrap_run`'s `finally`, and the corrected docstring saying
  the library's grace period *expires* rather than concludes;
- `_DELEGATE_MODE_NOTE` and `_override_note`, marking a delegate whose `preferred_mode`
  differs from the capability's beside its own name in the instructions;
- in `docs/reference/capabilities.md`, the paragraphs on `max_depth` binding in both
  directions and on a sync delegation parking and resuming in place.

Two conflicts, both about the same sentence being replaced rather than kept twice: the
`answer_subagent` declaration's note that the deployment cannot keep the tool's promise is
what this change makes obsolete, so it gives way to the pointer at `UNREACHABLE_TOOLS`, and
the test asserting the library's refusal message goes with the tool it called. The one
edit the rebase itself needed is in the docs: main's new "a sync delegation can stop to ask
a person" paragraph now sits directly above this one, so its opener says *no delegate can
ask a question of its own* and names the difference — parking for an approval is a gated
tool being reviewed, not a specialist asking anything.

## Verified

`make check` — every CI job except `e2e`: `make lint`, `make test` with the 100% statement
and branch gate on the platform layer, `make test-frontend-cov`, `build-frontend`,
`docs-build --strict`, and the audit. Run against a database of its own
(`POSTGRES_DB=agenticos_test_rb193`), which is what #216 now makes routine — the deadlocked
integration teardown reported here before the rebase was two runs sharing `agenticos_test`,
and it does not reproduce.

## Docs

`docs/reference/capabilities.md` — the tool line, a note under the "what ships" table that
the declared column is not always the offered set, the count corrected from eight to seven,
and a paragraph beside "a background delegation cannot stop to ask a person", which is the
same question on the same surface. `backend/app/agents/capabilities/subagents/README.md`
carries the reasoning and corrects its own earlier claim that the drift check had nothing
left to be told about — that held for a tool declared and *unwired*, not for one declared
and deliberately unoffered.

## Found along the way, deliberately not fixed

**#185** — the six background-task tools are offered to an agent configured `mode="sync"`
whose delegates override nothing, which can never have a background delegation to use them
on. Same failure as this one, under a condition that has to be computed per run rather than
stated once (`auto` resolves per delegation), so narrowing it wrongly removes a tool an
agent needs mid-turn. Pre-existing; found reviewing this.

**#184** — the feature above.

Closes #182
