### PR TITLE
test(chat): put the chat wire format behind the gate at 100%

### DIFF
--- a/backend/app/services/agent_session.py
+++ b/backend/app/services/agent_session.py
@@ -14,7 +14,6 @@ from pydantic_ai import (
     PartDeltaEvent,
     PartStartEvent,
     TextPartDelta,
-    ToolCallPartDelta,
 )
 from pydantic_ai.messages import (
     TextPart,
@@ -376,7 +375,15 @@ class AgentSession:
                 await send_event(self.websocket, "call_tools_start", {})
                 async with node.stream(agent_run.ctx) as handle_stream:
                     await self._stream_tool_events(handle_stream, collected_tool_calls)
-            elif Agent.is_end_node(node) and agent_run.result is not None:
+            else:
+                # The end node, and the only kind left: the graph yields a
+                # user-prompt, a model-request, a call-tools or an `End` node and
+                # nothing else. `result` is populated the moment `End` is
+                # returned, so `is_end_node(node) and agent_run.result is not
+                # None` was a condition that could not be false - and had it
+                # ever been, it would have dropped the frame carrying the answer
+                # without saying anything. A node kind the library adds later
+                # raises here instead, which reaches the client as `error`.
                 await send_event(
                     self.websocket,
                     "final_result",
@@ -410,25 +417,33 @@ class AgentSession:
                         {"index": event.index, "content": event.part.content},
                     )
             elif isinstance(event, PartDeltaEvent):
-                if isinstance(event.delta, TextPartDelta):
+                delta = event.delta
+                if isinstance(delta, TextPartDelta):
                     await send_event(
                         self.websocket,
                         "text_delta",
-                        {"index": event.index, "content": event.delta.content_delta},
+                        {"index": event.index, "content": delta.content_delta},
                     )
-                elif isinstance(event.delta, ThinkingPartDelta):
-                    if event.delta.content_delta:
-                        collected_thinking.append(event.delta.content_delta)
+                elif isinstance(delta, ThinkingPartDelta):
+                    # A signature delta carries no content - the provider's proof
+                    # it produced the reasoning - and forwarding it would put
+                    # base64 in the reasoning pane and in the stored trace.
+                    if delta.content_delta:
+                        collected_thinking.append(delta.content_delta)
                         await send_event(
                             self.websocket,
                             "thinking_delta",
-                            {"index": event.index, "content": event.delta.content_delta},
+                            {"index": event.index, "content": delta.content_delta},
                         )
-                elif isinstance(event.delta, ToolCallPartDelta):
+                else:
+                    # A tool-call delta, and the only kind left:
+                    # `ModelResponsePartDelta` is text, thinking or tool-call, so
+                    # an `isinstance` here was a third condition that could not be
+                    # false.
                     await send_event(
                         self.websocket,
                         "tool_call_delta",
-                        {"index": event.index, "args_delta": event.delta.args_delta},
+                        {"index": event.index, "args_delta": delta.args_delta},
                     )
             elif isinstance(event, FinalResultEvent):
                 await send_event(

--- a/backend/app/services/agent_session.py
+++ b/backend/app/services/agent_session.py
@@ -376,14 +376,17 @@ class AgentSession:
                 async with node.stream(agent_run.ctx) as handle_stream:
                     await self._stream_tool_events(handle_stream, collected_tool_calls)
             else:
-                # The end node, and the only kind left: the graph yields a
-                # user-prompt, a model-request, a call-tools or an `End` node and
-                # nothing else. `result` is populated the moment `End` is
-                # returned, so `is_end_node(node) and agent_run.result is not
-                # None` was a condition that could not be false - and had it
-                # ever been, it would have dropped the frame carrying the answer
-                # without saying anything. A node kind the library adds later
-                # raises here instead, which reaches the client as `error`.
+                # The end node, and the only kind left. Iterating an `AgentRun`
+                # yields a user-prompt, a model-request or a call-tools node, or
+                # `End` - `AgentRun._task_to_node` has no fourth answer, and the
+                # graph's one other node is reachable only through
+                # `agent_run.next()`, which this does not use. `End` also means
+                # the graph run holds its `EndMarker`, so `agent_run.result` is
+                # populated there. `is_end_node(node) and agent_run.result is not
+                # None` was therefore a condition that could not be false, and
+                # had it ever been it would have dropped the frame carrying the
+                # answer without saying anything. Whatever made it false now
+                # raises instead, and reaches the client as `error`.
                 await send_event(
                     self.websocket,
                     "final_result",
@@ -425,8 +428,9 @@ class AgentSession:
                         {"index": event.index, "content": delta.content_delta},
                     )
                 elif isinstance(delta, ThinkingPartDelta):
-                    # A signature delta carries no content - the provider's proof
-                    # it produced the reasoning - and forwarding it would put
+                    # Only when there is something to show. A reasoning delta can
+                    # carry a `signature_delta` alone - the provider's proof it
+                    # produced the reasoning - and forwarding that would put
                     # base64 in the reasoning pane and in the stored trace.
                     if delta.content_delta:
                         collected_thinking.append(delta.content_delta)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -328,6 +328,7 @@ include = [
     "app/services/agent_exposure.py",
     "app/services/agent_registry.py",
     "app/services/agent_runner.py",
+    "app/services/agent_session.py",
     "app/repositories/agent_workspace.py",
     "app/repositories/sandbox_connection.py",
     "app/repositories/skill_proposal.py",
@@ -440,6 +441,10 @@ include = [
     "app/services/agent_exposure.py",
     "app/services/agent_registry.py",
     "app/services/agent_runner.py",
+    # The whole dashboard chat wire format: every frame the WebSocket sends and
+    # every frame it accepts. It sat outside both gates while `use-chat.ts`
+    # switched on its names, which is the drift #144 describes.
+    "app/services/agent_session.py",
     "app/repositories/agent_workspace.py",
     "app/repositories/sandbox_connection.py",
     "app/repositories/skill_proposal.py",

--- a/backend/tests/test_agent_session.py
+++ b/backend/tests/test_agent_session.py
@@ -1,13 +1,22 @@
-"""Tests for the chat WebSocket session's agent-only contract.
+"""Tests for the chat WebSocket session - every frame it sends, and every frame
+it accepts.
+
+`app/services/agent_session.py` decides the whole dashboard chat wire format, and
+it is now in the coverage gate and under strict `ty` (#165). It had been in
+neither, which is why the file it shares that format with - `use-chat.ts` - has
+twice been left switching on a name the backend had changed. So these tests are
+written against the *frames*: what reaches `websocket.send_json`, in what order,
+with which keys. A test that executes the translation without reading its output
+is what let a third of this module go unmeasured while looking tested.
 
 The template's general assistant used to answer any frame that named no agent.
 It is gone: the factory is the only way to get a runnable agent, so a frame
 without an `agent_id` is refused before anything is persisted. These pin the
 refusal - the transcript must not collect messages nothing will answer.
 
-`TestForwardingToolEvents` is here for a different reason: this module is not in
-the coverage gate, and the one field it reads off a Pydantic AI event was renamed
-under it. Nothing noticed until every tool call in web chat answered "❌ Error:
+`TestForwardingToolEvents` is here for a different reason: the one field it reads
+off a Pydantic AI event was renamed under it while this module was ungated.
+Nothing noticed until every tool call in web chat answered "❌ Error:
 'FunctionToolResultEvent' object has no attribute 'result'".
 
 `TestForwardingDelegationFrames` is here for the third reason: the delegation
@@ -30,6 +39,8 @@ accounting sweep - runs while a `CancelledError` is already propagating.
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import logging
 from collections.abc import AsyncIterator, Iterator
 from contextlib import contextmanager
 from decimal import Decimal
@@ -39,14 +50,34 @@ from uuid import UUID, uuid4
 
 import anyio
 import pytest
+from fastapi import WebSocketDisconnect
 from pydantic_ai import Agent as PydanticAgent
-from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart, ToolCallPart, ToolReturnPart
+from pydantic_ai.messages import (
+    BinaryContent,
+    FinalResultEvent,
+    FunctionToolCallEvent,
+    FunctionToolResultEvent,
+    ModelMessage,
+    ModelResponse,
+    OutputToolCallEvent,
+    PartDeltaEvent,
+    PartEndEvent,
+    PartStartEvent,
+    RetryPromptPart,
+    TextPart,
+    TextPartDelta,
+    ThinkingPart,
+    ThinkingPartDelta,
+    ToolCallPart,
+    ToolCallPartDelta,
+    ToolReturnPart,
+)
 from pydantic_ai.models.function import AgentInfo, DeltaToolCall, DeltaToolCalls, FunctionModel
 from pydantic_ai.tools import DeferredToolRequests
 from subagents_pydantic_ai import TaskStatus
 
 from app.agents.capabilities import CapabilityBinding, build
-from app.agents.capabilities.budget import SpendEntry, SpendLedger
+from app.agents.capabilities.budget import BudgetExceeded, BudgetScope, SpendEntry, SpendLedger
 from app.agents.capabilities.subagents import Delegation
 from app.agents.deps import AgentDeps
 from app.agents.subagent_events import (
@@ -61,10 +92,16 @@ from app.agents.subagent_runtime import (
     ResolvedSubagent,
     SubagentRuntime,
 )
+from app.core.exceptions import AuthorizationError, BadRequestError
 from app.db.models.agent_run import RunStatus
+from app.services.agent_chat import ChatTurn
+from app.services.agent_runner import ParkedApproval
 from app.services.agent_session import AgentSession
+from app.services.usage_report import UsageReport
 
 pytestmark = pytest.mark.anyio
+
+_CONVERSATION = "11111111-1111-1111-1111-111111111111"
 
 
 def _session() -> AgentSession:
@@ -80,6 +117,87 @@ def _sent_events(session: AgentSession) -> list[tuple[str, dict]]:
         (call.args[0]["type"], call.args[0]["data"])
         for call in session.websocket.send_json.call_args_list
     ]
+
+
+def _frame_types(session: AgentSession) -> list[str]:
+    return [event_type for event_type, _data in _sent_events(session)]
+
+
+def _message(text: str = "how many are open?", **extra: Any) -> dict[str, Any]:
+    """A bare frame naming an agent - what a client sends to start a turn."""
+    return {"message": text, "agent_id": str(uuid4()), **extra}
+
+
+def _finished_turn(
+    *,
+    output: str = "Two are open.",
+    parked: tuple[ParkedApproval, ...] = (),
+    usage: UsageReport | None = None,
+) -> ChatTurn:
+    return ChatTurn(
+        output=output,
+        model_label="gpt-4.1",
+        agent_id=uuid4(),
+        agent_version_id=uuid4(),
+        run_id=uuid4(),
+        parked=parked,
+        usage=usage,
+    )
+
+
+@contextmanager
+def _chat(
+    run: AsyncMock,
+    *,
+    conversation: str | None = _CONVERSATION,
+    newly_created: bool = False,
+    message_id: str | None = "saved-1",
+) -> Iterator[None]:
+    """The session's collaborators, stubbed at the seam this module owns.
+
+    `ChatAgentRunner.run` is `agent_chat.py`'s contract - gated there, and driven
+    for real by `TestStoppingATurnMidDelegation` below. What is under test here is
+    the *frames* this session puts on the wire for a turn that ended a particular
+    way, so the runner is where the stub goes and `run` is how a test says how the
+    turn ended.
+    """
+    with (
+        patch(
+            "app.services.agent_session.persist_user_turn",
+            new=AsyncMock(return_value=(conversation, newly_created)),
+        ),
+        patch(
+            "app.services.agent_session.persist_assistant_turn",
+            new=AsyncMock(return_value=message_id),
+        ),
+        patch("app.services.agent_session.get_db_context") as db_context,
+        patch("app.services.agent_session.ChatAgentRunner") as runner_cls,
+    ):
+        db_context.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+        db_context.return_value.__aexit__ = AsyncMock(return_value=False)
+        runner_cls.return_value.run = run
+        yield
+
+
+def _next_frame(session: AgentSession) -> asyncio.Event:
+    """An event set when the session next writes to the socket.
+
+    A turn running as a background task has to be *waited* for rather than slept
+    past, and this is the only signal that means "the frames up to here are out".
+    """
+    sent = asyncio.Event()
+
+    async def record(*_args: Any, **_kwargs: Any) -> None:
+        sent.set()
+
+    session.websocket.send_json.side_effect = record
+    return sent
+
+
+async def _wait(event: asyncio.Event) -> None:
+    """Wait, with a bound - so a broken test fails rather than hanging the suite."""
+    with anyio.fail_after(5):
+        await event.wait()
 
 
 class TestFramesWithoutAnAgent:
@@ -124,6 +242,762 @@ class TestFramesWithoutAnAgent:
         assert events == [("error", {"message": "Empty message"})]
 
 
+class TestControlFrames:
+    """What `handle_frame` does with each `type` a client can send.
+
+    Only a *bare* frame is a message. Everything with a `type` is protocol, and
+    the wrong answer to an unknown one is to run it as a prompt.
+    """
+
+    async def test_a_control_frame_nothing_recognises_starts_no_turn(self):
+        """A named frame is a client saying something about itself. Answering it
+        out loud would put a piece of protocol in the transcript."""
+        session = _session()
+
+        await session.handle_frame({"type": "ping", "message": "hello"})
+
+        assert _sent_events(session) == []
+        assert session._turn_task is None
+
+    async def test_stopping_when_no_turn_is_running_says_nothing(self):
+        """The composer's stop button races the turn's last frame, so a `stop`
+        routinely arrives after the turn is over. A second terminal frame then
+        would end the *next* turn on the client the moment it started."""
+        session = _session()
+
+        await session.handle_frame({"type": "stop"})
+
+        assert _sent_events(session) == []
+
+    async def test_a_message_arriving_while_a_turn_is_in_flight_is_ignored(self):
+        """Two turns on one socket interleave their deltas into one message and
+        race the in-memory history the next turn's `message_history` is built
+        from. The second frame is dropped rather than queued: the client's
+        composer is disabled while a turn runs, so a second bare frame is a bug
+        somewhere rather than something a user did."""
+        session = _session()
+        running = asyncio.Event()
+        release = asyncio.Event()
+
+        async def blocks_until_released(**_kwargs: Any) -> ChatTurn:
+            running.set()
+            await release.wait()
+            return _finished_turn()
+
+        with _chat(AsyncMock(side_effect=blocks_until_released)):
+            await session.handle_frame(_message("first"))
+            turn_task = session._turn_task
+            assert turn_task is not None
+            await _wait(running)
+
+            await session.handle_frame(_message("second"))
+            release.set()
+            await turn_task
+
+        assert _frame_types(session) == ["user_prompt", "message_saved", "complete"]
+        assert _sent_events(session)[0] == ("user_prompt", {"content": "first"})
+
+    async def test_a_message_arriving_after_the_previous_turn_ended_starts_a_new_one(self):
+        """The slot is freed by a done callback, which runs a loop iteration after
+        the task ended - so a frame can arrive with `_turn_task` still holding a
+        finished task. Reading `done()` rather than the slot is what keeps that
+        from looking like a turn in flight."""
+        session = _session()
+
+        with _chat(AsyncMock(return_value=_finished_turn())):
+            await session.handle_frame(_message("first"))
+            first = session._turn_task
+            assert first is not None
+            await first
+            session._turn_task = first  # as the callback has not run yet
+
+            await session.handle_frame(_message("second"))
+            second = session._turn_task
+            assert second is not None and second is not first
+            await second
+
+        assert [
+            data["content"] for event, data in _sent_events(session) if event == "user_prompt"
+        ] == [
+            "first",
+            "second",
+        ]
+
+
+class TestATurnThatFinished:
+    """The frames a completed turn puts on the wire, and their order.
+
+    Order is part of the contract: `conversation_created` carries the id the
+    `complete` frame's usage is filed under, and `tool_approval_required` has to
+    arrive while the turn is still on screen.
+    """
+
+    async def test_a_turn_that_started_a_conversation_announces_it_first(self):
+        session = _session()
+
+        with _chat(AsyncMock(return_value=_finished_turn()), newly_created=True):
+            await session.process_message(_message())
+
+        assert _frame_types(session) == [
+            "conversation_created",
+            "user_prompt",
+            "message_saved",
+            "complete",
+        ]
+        assert _sent_events(session)[0] == (
+            "conversation_created",
+            {"conversation_id": _CONVERSATION},
+        )
+        assert _sent_events(session)[2] == (
+            "message_saved",
+            {"message_id": "saved-1", "conversation_id": _CONVERSATION},
+        )
+
+    async def test_a_turn_in_an_existing_conversation_does_not_announce_one(self):
+        """The client creates a thread in its sidebar on this frame, so a second
+        one for a conversation it is already in would duplicate the entry."""
+        session = _session()
+
+        with _chat(AsyncMock(return_value=_finished_turn())):
+            await session.process_message(_message())
+
+        assert "conversation_created" not in _frame_types(session)
+
+    async def test_what_the_turn_cost_arrives_on_the_frame_that_ends_it(self):
+        """Its own event would be one the client could receive *after* `complete`
+        and draw against the next turn. Every number is a JSON number: the chat
+        draws a bar from them, and `Decimal` serialises as a string."""
+        session = _session()
+        report = UsageReport(
+            input_tokens=1200,
+            output_tokens=340,
+            cost_usd=Decimal("0.0042"),
+            period_spend_usd=Decimal("5.00"),
+            budget_usd=Decimal("20.00"),
+        )
+
+        with _chat(AsyncMock(return_value=_finished_turn(usage=report))):
+            await session.process_message(_message())
+
+        assert _sent_events(session)[-1] == (
+            "complete",
+            {
+                "conversation_id": _CONVERSATION,
+                "usage": {
+                    "input_tokens": 1200,
+                    "output_tokens": 340,
+                    "cost_usd": 0.0042,
+                    "budget_percent": 25,
+                    "agent_budget_percent": None,
+                    "sandbox": None,
+                },
+            },
+        )
+
+    async def test_a_turn_nobody_could_measure_reports_no_usage_rather_than_zero(self):
+        """Assembling the report is not allowed to lose an answer, so it can come
+        back `None`. Nothing measured and nothing spent are different things to
+        draw, and the strip leaves the previous turn's number alone for `None`."""
+        session = _session()
+
+        with _chat(AsyncMock(return_value=_finished_turn(usage=None))):
+            await session.process_message(_message())
+
+        assert _sent_events(session)[-1] == (
+            "complete",
+            {"conversation_id": _CONVERSATION, "usage": None},
+        )
+
+    async def test_a_turn_whose_conversation_was_never_persisted_still_ends(self):
+        """`persist_user_turn` logs and swallows a write failure, deliberately - a
+        lost row must not lose an answer somebody is waiting for. There is then
+        nothing to save the assistant message against, but the client still has to
+        be told the turn is over or its composer never comes back."""
+        session = _session()
+        persist_assistant = AsyncMock(return_value=None)
+
+        with (
+            _chat(AsyncMock(return_value=_finished_turn()), conversation=None),
+            patch("app.services.agent_session.persist_assistant_turn", new=persist_assistant),
+        ):
+            await session.process_message(_message())
+
+        assert _frame_types(session) == ["user_prompt", "complete"]
+        assert _sent_events(session)[-1] == ("complete", {"conversation_id": None, "usage": None})
+        persist_assistant.assert_not_called()
+
+    async def test_an_assistant_message_that_did_not_save_is_not_announced_as_saved(self):
+        """`message_saved` is what swaps the client's temporary id for the real
+        one. Sending it without an id would leave the message unratable and
+        unreloadable, pointing at `null`."""
+        session = _session()
+
+        with _chat(AsyncMock(return_value=_finished_turn()), message_id=None):
+            await session.process_message(_message())
+
+        assert _frame_types(session) == ["user_prompt", "complete"]
+
+    async def test_the_turn_is_remembered_for_the_next_one(self):
+        """In-memory history is what the next turn's `message_history` is built
+        from, and it is appended only after a complete run."""
+        session = _session()
+
+        with _chat(AsyncMock(return_value=_finished_turn(output="Two are open."))):
+            await session.process_message(_message("how many are open?"))
+
+        assert session.conversation_history == [
+            {"role": "user", "content": "how many are open?"},
+            {"role": "assistant", "content": "Two are open."},
+        ]
+
+    async def test_a_parked_call_is_put_in_front_of_whoever_is_looking(self):
+        """The approvals queue and the email carry the same rows; this frame is the
+        shortcut for somebody already on the tab. It arrives *before* `complete` so
+        the panel is drawn while the turn is still on screen, and `allow_edit` is
+        false on purpose: the arguments were recorded on the row the approver is
+        deciding about, so letting the chat rewrite them would approve something
+        other than what was asked."""
+        session = _session()
+        approval_id = uuid4()
+        parked = (
+            ParkedApproval(
+                approval_id=approval_id,
+                tool_call_id="call-1",
+                tool_name="send_email",
+                tool_args={"to": "ops@example.com"},
+            ),
+        )
+        turn = _finished_turn(parked=parked)
+
+        with _chat(AsyncMock(return_value=turn)):
+            await session.process_message(_message())
+
+        assert _frame_types(session) == [
+            "user_prompt",
+            "message_saved",
+            "tool_approval_required",
+            "complete",
+        ]
+        assert _sent_events(session)[2] == (
+            "tool_approval_required",
+            {
+                "run_id": str(turn.run_id),
+                "action_requests": [
+                    {
+                        "id": str(approval_id),
+                        "tool_call_id": "call-1",
+                        "tool_name": "send_email",
+                        "args": {"to": "ops@example.com"},
+                    }
+                ],
+                "review_configs": [{"tool_name": "send_email", "allow_edit": False}],
+            },
+        )
+
+
+class TestATurnThatDidNotFinish:
+    """Every way a turn can end without an answer.
+
+    `error` is the frame that clears the client's processing state, so a refusal
+    that sent nothing would leave a spinner running until the tab is reloaded.
+    There is deliberately no `complete` after it: that frame means the turn
+    produced something.
+    """
+
+    async def test_a_conversation_belonging_to_another_organization_is_refused(self):
+        """The socket authenticated against one organization; resuming a thread
+        from another would read one org's history while billing a second."""
+        session = _session()
+        refusal = AuthorizationError(
+            message="Conversation belongs to a different organization",
+            details={"conversation_id": _CONVERSATION},
+        )
+
+        with patch(
+            "app.services.agent_session.persist_user_turn", new=AsyncMock(side_effect=refusal)
+        ):
+            await session.process_message(_message(conversation_id=_CONVERSATION))
+
+        assert _sent_events(session) == [
+            ("error", {"message": "Conversation belongs to a different organization"})
+        ]
+
+    async def test_a_refused_run_is_reported_and_not_answered_by_anything_else(self):
+        """An unpublished or archived agent, or one that is not theirs to see. The
+        platform working, so it is said plainly - and nothing answers in the named
+        agent's place."""
+        session = _session()
+
+        with _chat(AsyncMock(side_effect=BadRequestError(message="That agent is not published"))):
+            await session.process_message(_message())
+
+        assert _frame_types(session) == ["user_prompt", "error"]
+        assert _sent_events(session)[-1] == ("error", {"message": "That agent is not published"})
+        assert session.conversation_history == []
+
+    async def test_a_budget_stop_says_why_the_answer_stopped(self):
+        """A run cut off by a cap looks identical to a broken agent unless
+        somebody says so."""
+        session = _session()
+        stopped = BudgetExceeded(
+            limit_usd=Decimal("20.00"),
+            spent_usd=Decimal("20.0100"),
+            scope=BudgetScope.ORGANIZATION,
+        )
+
+        with _chat(AsyncMock(side_effect=stopped)):
+            await session.process_message(_message())
+
+        assert _frame_types(session) == ["user_prompt", "error"]
+        assert _sent_events(session)[-1] == (
+            "error",
+            {"message": "Organization monthly budget exhausted: $20.0100 spent of $20.00 limit"},
+        )
+
+    async def test_an_unexpected_failure_still_reaches_the_client(self):
+        """A provider that answered 500 is not a refusal and not a bug in the
+        spec, and the person sitting there gets told either way."""
+        session = _session()
+
+        with _chat(AsyncMock(side_effect=RuntimeError("the provider answered 503"))):
+            await session.process_message(_message())
+
+        assert _frame_types(session) == ["user_prompt", "error"]
+        assert _sent_events(session)[-1] == ("error", {"message": "the provider answered 503"})
+
+    async def test_a_disconnect_is_not_reported_to_the_socket_that_left(self):
+        """A `WebSocketDisconnect` surfacing from inside the turn is re-raised
+        rather than turned into an `error` frame: there is nobody to read it, and
+        the turn task's callback logs a disconnect instead of a crash."""
+        session = _session()
+
+        with (
+            _chat(AsyncMock(side_effect=WebSocketDisconnect(code=1006))),
+            pytest.raises(WebSocketDisconnect),
+        ):
+            await session.process_message(_message())
+
+        assert _frame_types(session) == ["user_prompt"]
+
+
+class TestATurnTaskThatEnded:
+    """`asyncio.create_task` swallows the exception of a task nobody awaits, and
+    the turn task is never awaited on the success path - so this callback is the
+    only place a crashed turn is ever heard about."""
+
+    @staticmethod
+    async def _ran(coro: Any) -> asyncio.Task[None]:
+        task = asyncio.create_task(coro)
+        with contextlib.suppress(Exception):
+            await task
+        return task
+
+    async def test_a_crashed_turn_is_logged_with_its_traceback(self, caplog):
+        session = _session()
+
+        async def crash() -> None:
+            raise RuntimeError("the run row was written twice")
+
+        task = await self._ran(crash())
+
+        with caplog.at_level(logging.ERROR, logger="app.services.agent_session"):
+            session._on_turn_done(task)
+
+        assert "Agent turn task crashed" in caplog.text
+        assert "the run row was written twice" in caplog.text
+
+    async def test_a_disconnect_is_not_logged_as_a_crash(self, caplog):
+        """A tab closed mid-turn is how most sessions end. An error-level line for
+        it is noise an operator learns to skip past, which is how the next real
+        one gets skipped too."""
+        session = _session()
+
+        async def disconnect() -> None:
+            raise WebSocketDisconnect(code=1001)
+
+        task = await self._ran(disconnect())
+
+        with caplog.at_level(logging.INFO, logger="app.services.agent_session"):
+            session._on_turn_done(task)
+
+        assert "Client disconnected during agent turn" in caplog.text
+        assert "crashed" not in caplog.text
+
+    async def test_a_turn_that_ended_cleanly_frees_its_slot(self):
+        session = _session()
+        task = await self._ran(asyncio.sleep(0))
+        session._turn_task = task
+
+        session._on_turn_done(task)
+
+        assert session._turn_task is None
+
+    async def test_a_cancelled_turn_is_not_asked_what_went_wrong(self):
+        """`task.exception()` re-raises `CancelledError` on a cancelled task, and
+        it would raise it inside a done callback, where nothing is waiting to
+        catch it - the loop would report it against no turn at all."""
+        session = _session()
+        task = asyncio.create_task(asyncio.sleep(30))
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+        session._turn_task = task
+
+        session._on_turn_done(task)
+
+        assert session._turn_task is None
+
+    async def test_a_callback_for_an_earlier_turn_does_not_free_a_later_one(self):
+        """The callback runs a loop iteration after its task ended, so a second
+        frame can already have taken the slot. Clearing it then would let a third
+        frame run concurrently with the second."""
+        session = _session()
+        earlier = await self._ran(asyncio.sleep(0))
+        later = asyncio.create_task(asyncio.sleep(30))
+        session._turn_task = later
+
+        session._on_turn_done(earlier)
+
+        assert session._turn_task is later
+        later.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await later
+
+
+class TestAskingTheUser:
+    """The pause an agent can put in the middle of a run.
+
+    Only a live surface can hold a question open, and holding it open means a
+    future nothing else will complete - so every way the answer can be malformed
+    has to release it, or the turn parks forever with the composer showing
+    questions and no way to stop it.
+    """
+
+    _QUESTIONS = [{"question": "Which region?", "options": ["eu", "us"], "allow_custom": True}]
+
+    async def test_an_answer_reaches_the_run_that_is_waiting_for_it(self):
+        session = _session()
+        asked = _next_frame(session)
+
+        asking = asyncio.create_task(session._ask_user(self._QUESTIONS))
+        await _wait(asked)
+
+        assert _sent_events(session) == [("ask_user", {"questions": self._QUESTIONS})]
+
+        await session.handle_frame(
+            {"type": "ask_user_response", "answers": [{"answer": "eu", "skipped": False}]}
+        )
+
+        assert await asking == [{"answer": "eu", "skipped": False}]
+        # Cleared, or the next question resolves against a future already done.
+        assert session._ask_user_future is None
+
+    async def test_an_answers_payload_that_is_not_a_list_releases_the_run_anyway(self):
+        """A client that sent `null`, or an object, would otherwise leave the run
+        parked on a future nobody completes. Empty answers render as "(no answer)"
+        for the model, which is a turn that goes on."""
+        session = _session()
+        asked = _next_frame(session)
+
+        asking = asyncio.create_task(session._ask_user(self._QUESTIONS))
+        await _wait(asked)
+
+        await session.handle_frame({"type": "ask_user_response", "answers": None})
+
+        assert await asking == []
+
+    async def test_an_answer_to_a_question_nobody_asked_is_ignored(self):
+        session = _session()
+
+        await session.handle_frame({"type": "ask_user_response", "answers": [{"answer": "eu"}]})
+
+        assert _sent_events(session) == []
+        assert session._ask_user_future is None
+
+    async def test_a_second_answer_to_the_same_question_does_not_replace_the_first(self):
+        """Two frames can arrive before the run resumes - a double-submit, or a
+        reconnect replaying. `Future.set_result` on a resolved future raises
+        `InvalidStateError`, which would crash the frame dispatcher rather than
+        the turn."""
+        session = _session()
+        asked = _next_frame(session)
+
+        asking = asyncio.create_task(session._ask_user(self._QUESTIONS))
+        await _wait(asked)
+
+        await session.handle_frame({"type": "ask_user_response", "answers": [{"answer": "eu"}]})
+        await session.handle_frame({"type": "ask_user_response", "answers": [{"answer": "us"}]})
+
+        assert await asking == [{"answer": "eu"}]
+
+
+class TestAttachedFiles:
+    async def test_a_frame_carrying_only_a_file_is_not_an_empty_message(self):
+        """ "Have a look at this" with the sentence left off is an ordinary way to
+        send a file, and the attachment *is* the message. The rows go to the
+        runner rather than into a prompt built here: where a file lands depends on
+        whether the agent has a workspace, which only `prepare` knows."""
+        session = _session()
+        rows = [MagicMock(), MagicMock()]
+        run = AsyncMock(return_value=_finished_turn())
+
+        with (
+            _chat(run),
+            patch(
+                "app.services.agent_session.load_attached_files",
+                new=AsyncMock(return_value=rows),
+            ),
+        ):
+            await session.process_message(
+                {"message": "", "agent_id": str(uuid4()), "file_ids": ["f1", "f2"]}
+            )
+
+        assert _frame_types(session) == ["user_prompt", "message_saved", "complete"]
+        assert run.await_args is not None
+        assert run.await_args.kwargs["attachments"] == rows
+
+
+class TestStreamingAModelResponse:
+    """Every model-request event, translated into the frame the chat reads.
+
+    Constructed from `pydantic_ai.messages` rather than mocked for the reason
+    `TestForwardingToolEvents` gives: a `MagicMock` satisfies every `isinstance`
+    this translation asks about, so a test built on one proves nothing about the
+    shapes the library actually sends.
+    """
+
+    @staticmethod
+    async def _stream(session: AgentSession, *events: Any) -> list[str]:
+        """Drive the translation over `events`, returning the collected thinking."""
+
+        async def _events() -> AsyncIterator[Any]:
+            for event in events:
+                yield event
+
+        thinking: list[str] = []
+        await session._stream_request_events(_events(), thinking)
+        return thinking
+
+    async def test_a_part_that_starts_with_text_already_in_it_forwards_that_text(self):
+        """Some providers put the first chunk inside the part rather than sending
+        it as a delta. The client only appends on `text_delta`, so without this
+        the opening words of an answer are silently dropped."""
+        session = _session()
+
+        await self._stream(session, PartStartEvent(index=0, part=TextPart(content="Two ")))
+
+        assert _sent_events(session) == [
+            ("part_start", {"index": 0, "part_type": "TextPart"}),
+            ("text_delta", {"index": 0, "content": "Two "}),
+        ]
+
+    async def test_a_part_that_starts_empty_sends_no_delta(self):
+        session = _session()
+
+        await self._stream(session, PartStartEvent(index=0, part=TextPart(content="")))
+
+        assert _frame_types(session) == ["part_start"]
+
+    async def test_a_tool_call_starting_says_only_that_a_part_started(self):
+        """A tool call's name and arguments arrive on `tool_call`, from the
+        handle-response stream. Drawing anything from this one would draw a card
+        twice."""
+        session = _session()
+
+        await self._stream(
+            session,
+            PartStartEvent(
+                index=1, part=ToolCallPart(tool_name="count_open", args={}, tool_call_id="c1")
+            ),
+        )
+
+        assert _sent_events(session) == [("part_start", {"index": 1, "part_type": "ToolCallPart"})]
+
+    async def test_reasoning_reaches_both_the_client_and_the_transcript(self):
+        """The pane is drawn from the frame; the persisted `thinking` is drawn from
+        what is collected. One without the other is a reasoning trace that
+        disappears on reload, or one that was never shown."""
+        session = _session()
+
+        thinking = await self._stream(
+            session, PartStartEvent(index=0, part=ThinkingPart(content="Counting the open ones"))
+        )
+
+        assert _sent_events(session) == [
+            ("part_start", {"index": 0, "part_type": "ThinkingPart"}),
+            ("thinking_delta", {"index": 0, "content": "Counting the open ones"}),
+        ]
+        assert thinking == ["Counting the open ones"]
+
+    async def test_a_second_block_of_reasoning_is_separated_from_the_first(self):
+        """The pieces are joined into one string for persistence, so two blocks
+        run together into one word without this."""
+        session = _session()
+
+        thinking = await self._stream(
+            session,
+            PartStartEvent(index=0, part=ThinkingPart(content="Counting.")),
+            PartStartEvent(index=2, part=ThinkingPart(content="Now checking.")),
+        )
+
+        assert "".join(thinking) == "Counting. Now checking."
+
+    async def test_reasoning_that_starts_empty_is_neither_shown_nor_recorded(self):
+        session = _session()
+
+        thinking = await self._stream(
+            session, PartStartEvent(index=0, part=ThinkingPart(content=""))
+        )
+
+        assert _frame_types(session) == ["part_start"]
+        assert thinking == []
+
+    async def test_a_text_delta_is_forwarded_with_the_part_it_extends(self):
+        session = _session()
+
+        await self._stream(
+            session, PartDeltaEvent(index=0, delta=TextPartDelta(content_delta="are open."))
+        )
+
+        assert _sent_events(session) == [("text_delta", {"index": 0, "content": "are open."})]
+
+    async def test_a_reasoning_delta_is_forwarded_and_recorded(self):
+        session = _session()
+
+        thinking = await self._stream(
+            session, PartDeltaEvent(index=0, delta=ThinkingPartDelta(content_delta="Counting"))
+        )
+
+        assert _sent_events(session) == [("thinking_delta", {"index": 0, "content": "Counting"})]
+        assert thinking == ["Counting"]
+
+    async def test_a_reasoning_delta_carrying_only_a_signature_is_not_shown(self):
+        """A signature is the provider's proof it produced the reasoning, sent as
+        its own delta with no content. Forwarding it would put base64 in the
+        reasoning pane and in the persisted trace."""
+        session = _session()
+
+        thinking = await self._stream(
+            session, PartDeltaEvent(index=0, delta=ThinkingPartDelta(signature_delta="c2ln"))
+        )
+
+        assert _sent_events(session) == []
+        assert thinking == []
+
+    async def test_tool_arguments_are_forwarded_as_they_arrive(self):
+        session = _session()
+
+        await self._stream(
+            session, PartDeltaEvent(index=1, delta=ToolCallPartDelta(args_delta='{"team": '))
+        )
+
+        assert _sent_events(session) == [
+            ("tool_call_delta", {"index": 1, "args_delta": '{"team": '})
+        ]
+
+    async def test_the_frame_that_says_the_answer_has_started(self):
+        session = _session()
+
+        await self._stream(session, FinalResultEvent(tool_name=None, tool_call_id=None))
+
+        assert _sent_events(session) == [("final_result_start", {"tool_name": None})]
+
+    async def test_a_part_ending_needs_no_frame(self):
+        """The client redraws from the deltas it already applied, so a `part_end`
+        it does not switch on would be a frame sent for nobody to read."""
+        session = _session()
+
+        await self._stream(session, PartEndEvent(index=0, part=TextPart(content="Two are open.")))
+
+        assert _sent_events(session) == []
+
+
+def _answering_agent(*, tools: list[Any] | None = None) -> PydanticAgent[Any, Any]:
+    """An agent that answers in two chunks, optionally calling one tool first.
+
+    `output_type` matches what the factory builds, because the approval gate needs
+    `DeferredToolRequests` in the union - a run driven through a different output
+    type would take a different path out of the graph.
+    """
+
+    def answered(messages: list[ModelMessage]) -> bool:
+        return any(
+            isinstance(part, ToolReturnPart) for message in messages for part in message.parts
+        )
+
+    async def respond(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[TextPart("Two are open.")])
+
+    async def stream(
+        messages: list[ModelMessage], _info: AgentInfo
+    ) -> AsyncIterator[str | DeltaToolCalls]:
+        if tools is None or answered(messages):
+            yield "Two "
+            yield "are open."
+        else:
+            yield {
+                0: DeltaToolCall(
+                    name="count_open", json_args='{"team": "sales"}', tool_call_id="call-1"
+                )
+            }
+
+    return PydanticAgent(
+        FunctionModel(respond, stream_function=stream),
+        output_type=[str, DeferredToolRequests],
+        tools=tools or [],
+    )
+
+
+def count_open(team: str) -> int:
+    """How many are open for one team."""
+    return 2
+
+
+class TestDrivingTheRun:
+    """The node dispatch, over a real `Agent.iter`.
+
+    A hand-written iterator would say nothing about whether `node.stream(...)` is
+    reached, and that is where every delta in the transcript comes from.
+    """
+
+    async def test_a_turn_that_calls_a_tool_and_then_answers(self):
+        session = _session()
+        tool_calls: list[dict[str, Any]] = []
+
+        async with _answering_agent(tools=[count_open]).iter("how many are open?") as agent_run:
+            await session._stream_agent_run(agent_run, "how many are open?", tool_calls, [])
+
+        types = _frame_types(session)
+        assert types[0] == "user_prompt_processed"
+        assert types.count("model_request_start") == 2
+        assert types.count("call_tools_start") == 2
+        assert types[-1] == "final_result"
+        assert _sent_events(session)[-1] == ("final_result", {"output": "Two are open."})
+        assert tool_calls == [
+            {
+                "tool_call_id": "call-1",
+                "tool_name": "count_open",
+                "args": {"team": "sales"},
+                "result": "2",
+            }
+        ]
+
+    async def test_the_prompt_reported_is_the_sentence_that_was_typed(self):
+        """With an attachment the assembled prompt is a list of content objects,
+        and `BinaryContent` holds the file's bytes. Forwarding that would put a
+        `repr` of a PNG in the transcript where the sentence belongs."""
+        session = _session()
+        prompt = ["have a look at this", BinaryContent(data=b"\x89PNG", media_type="image/png")]
+
+        async with _answering_agent().iter(prompt) as agent_run:
+            await session._stream_agent_run(agent_run, "have a look at this", [], [])
+
+        assert _sent_events(session)[0] == (
+            "user_prompt_processed",
+            {"prompt": "have a look at this"},
+        )
+
+
 class TestForwardingToolEvents:
     """What a tool call looks like on the wire, read off real event objects.
 
@@ -133,13 +1007,6 @@ class TestForwardingToolEvents:
     """
 
     async def test_a_tool_result_is_forwarded_with_its_content(self):
-        from pydantic_ai.messages import (
-            FunctionToolCallEvent,
-            FunctionToolResultEvent,
-            ToolCallPart,
-            ToolReturnPart,
-        )
-
         session = _session()
         collected: list[dict] = []
 
@@ -164,13 +1031,6 @@ class TestForwardingToolEvents:
     async def test_the_result_is_kept_on_the_call_it_belongs_to(self):
         """The transcript persists one row per call, so a result that did not find
         its call is a tool call recorded as never having returned."""
-        from pydantic_ai.messages import (
-            FunctionToolCallEvent,
-            FunctionToolResultEvent,
-            ToolCallPart,
-            ToolReturnPart,
-        )
-
         session = _session()
         collected: list[dict] = []
 
@@ -191,8 +1051,6 @@ class TestForwardingToolEvents:
     async def test_a_retry_is_reported_rather_than_swallowed(self):
         """A tool that raised sends a `RetryPromptPart` down the same stream. It
         carries `content` too, and a card that never resolved would spin forever."""
-        from pydantic_ai.messages import FunctionToolResultEvent, RetryPromptPart
-
         session = _session()
 
         async def _events():
@@ -204,6 +1062,25 @@ class TestForwardingToolEvents:
 
         [(_type, data)] = [event for event in _sent_events(session) if event[0] == "tool_result"]
         assert data == {"tool_call_id": "t9", "content": "path must be absolute"}
+
+    async def test_the_models_submit_final_answer_call_is_not_drawn_as_a_tool(self):
+        """`OutputToolCallEvent` arrives on this same stream and shares a base class
+        with the function-tool event. Matching the base would put a card named
+        after the output schema in every turn, and persist one per message."""
+        session = _session()
+        collected: list[dict] = []
+
+        async def _events():
+            yield OutputToolCallEvent(
+                part=ToolCallPart(
+                    tool_name="final_result", args={"output": "Two"}, tool_call_id="o1"
+                )
+            )
+
+        await session._stream_tool_events(_events(), collected)
+
+        assert _sent_events(session) == []
+        assert collected == []
 
 
 class TestForwardingDelegationFrames:
@@ -333,8 +1210,6 @@ Two dollars, and the number is the point: a cancelled run that spent it and
 recorded zero is the hole cancellation opens, and nothing about it looks like an
 error.
 """
-
-_CONVERSATION = "11111111-1111-1111-1111-111111111111"
 
 
 def _delegating_parent() -> FunctionModel:

--- a/backend/tests/test_agent_session.py
+++ b/backend/tests/test_agent_session.py
@@ -309,7 +309,9 @@ class TestControlFrames:
             first = session._turn_task
             assert first is not None
             await first
-            session._turn_task = first  # as the callback has not run yet
+            # Put it back: awaiting it here ran the callback, which is the one
+            # thing a client's frame cannot wait for.
+            session._turn_task = first
 
             await session.handle_frame(_message("second"))
             second = session._turn_task
@@ -412,19 +414,18 @@ class TestATurnThatFinished:
         """`persist_user_turn` logs and swallows a write failure, deliberately - a
         lost row must not lose an answer somebody is waiting for. There is then
         nothing to save the assistant message against, but the client still has to
-        be told the turn is over or its composer never comes back."""
-        session = _session()
-        persist_assistant = AsyncMock(return_value=None)
+        be told the turn is over or its composer never comes back.
 
-        with (
-            _chat(AsyncMock(return_value=_finished_turn()), conversation=None),
-            patch("app.services.agent_session.persist_assistant_turn", new=persist_assistant),
-        ):
+        The frame list is what pins it: `persist_assistant_turn` is stubbed to
+        answer with an id, so a write attempted against no conversation would show
+        up here as a `message_saved` pointing at `null`."""
+        session = _session()
+
+        with _chat(AsyncMock(return_value=_finished_turn()), conversation=None):
             await session.process_message(_message())
 
         assert _frame_types(session) == ["user_prompt", "complete"]
         assert _sent_events(session)[-1] == ("complete", {"conversation_id": None, "usage": None})
-        persist_assistant.assert_not_called()
 
     async def test_an_assistant_message_that_did_not_save_is_not_announced_as_saved(self):
         """`message_saved` is what swaps the client's temporary id for the real

--- a/backend/tests/test_coverage_gate.py
+++ b/backend/tests/test_coverage_gate.py
@@ -77,6 +77,7 @@ PLATFORM_MODULES = (
     "app/services/agent_exposure.py",
     "app/services/agent_registry.py",
     "app/services/agent_runner.py",
+    "app/services/agent_session.py",
     "app/services/approvals.py",
     "app/services/channels/mentions.py",
     "app/services/collection_access.py",


### PR DESCRIPTION
`backend/app/services/agent_session.py` decides every frame the dashboard chat WebSocket sends and every frame it accepts, and it was in **neither** `[tool.coverage.run] include` nor `[[tool.ty.overrides]] include` in `backend/pyproject.toml` — only its sibling `agent_chat.py` was. It is now in both, verbatim and in the same order, plus `PLATFORM_MODULES` in `tests/test_coverage_gate.py` so the pairing is asserted rather than assumed.

This was cut from `feat/subagents` so the module would be covered in its final shape rather than in one that went stale the moment delegation landed. #164 has since merged as `f618e8c`, and this is now rebased onto `main` — the diff is its own **4 files, 935 insertions, 34 deletions**, where before the rebase it replayed the whole delegation branch and read as 19,570 lines.

`agent_session.py` is byte-identical between the old base and `main`, so the 100% still holds without a line of new work: the six `subagent_*` frames and the event sink were already in the module when this measured it. The rebase merged cleanly in `tests/test_agent_session.py` and both sets of tests survive — `TestForwardingDelegationFrames` from here and `TestStoppingATurnMidDelegation` from #164, including its `sync`-mode cancellation test and the `parent_task_id: None` assertion #164 added to the delegation-frame test.

### Before and after

| | Stmts | Miss | Branch | BrPart | Cover |
|---|---|---|---|---|---|
| Before, on `main` | 195 | 61 | 76 | 15 | **63%** |
| After | 194 | 0 | 72 | 0 | **100%** |

31% is the figure in #165, measured before `TestStoppingATurnMidDelegation` existed; 63% is what it reads on `main` today. What was missing was not incidental: `process_message` from the run onward — the `tool_approval_required` frame, the terminal `complete` carrying a turn's cost, every error branch — plus the whole delta/tool-event translation and the node dispatch's end node.

`make test` reports the platform layer at **100% of 6930 statements and 1488 branches** with this module in the gate.

### The tests read frames, not lines

57 tests in `tests/test_agent_session.py`, 42 of them added here, each asserting what reached `send_json` — the type, the order, the keys. A test that executes a translation without asserting its output is exactly what let a third of this module go unmeasured while looking tested. So:

- **both terminal `complete` frames** — the happy path with `usage` asserted as a whole dict of JSON numbers (it is what `TurnUsage` in `types/chat.ts` reads), and the cancelled path with `stopped: true`;
- **`tool_approval_required`** — the whole payload, `action_requests` and `review_configs`, `allow_edit: false`, and its position *before* `complete`;
- **every error branch**, each asserting `error` and **no** `complete`: the frontend clears `isProcessing` on `error`, and a `complete` after it would claim the turn produced an answer. Covers a conversation belonging to another organization, a refused agent, a budget stop, an unexpected provider failure, and a disconnect (re-raised rather than written to a socket that has gone);
- **`ask_user` and its reply**, including an `answers` payload that is not a list and a second reply to an already-resolved question — either would otherwise park the run on a future nobody completes, with the composer showing questions and no way to stop it;
- **`stop`, `shutdown`, an unknown control frame, and a bare frame arriving while a turn is in flight**;
- **the delta translation off real `pydantic_ai.messages` objects**, not mocks — a `MagicMock` satisfies every `isinstance` this code asks about, so a test built on one proves nothing about the shapes the library sends. Thinking deltas included, plus the signature-only `ThinkingPartDelta` that must not reach the reasoning pane, and `PartEndEvent` / `OutputToolCallEvent`, which must produce no frame at all;
- **`_stream_agent_run` over a real `Agent.iter`** — the only way to know `node.stream(agent_run.ctx)` is reached, which is where every delta comes from.

`ChatAgentRunner.run` is the seam the stub goes at: it is `agent_chat.py`'s contract, already gated, and driven for real by `TestStoppingATurnMidDelegation` in the same file.

### Verified by mutation, not only by coverage

100% is a claim about lines executed, not about tests that would notice. So 19 mutations of the module were applied one at a time — each frame name renamed, `allow_edit` flipped, `stopped` flipped, `usage` blanked, the signature guard opened, the turn-in-flight check disabled, the file-only-frame check narrowed, the disconnect re-raise swallowed, the done-callback slot check widened, the reasoning collector removed, the prompt forwarded verbatim, a tool result's `pending.get` made a `[]` lookup. **All 19 caught; no surviving mutant.**

## Two dead branches removed

Neither could ever have been false, and the gate cannot be met with either:

1. `elif Agent.is_end_node(node) and agent_run.result is not None:` — `AgentRun._task_to_node` answers with an agent node or `End` and has no third answer, and `End` implies the graph run holds its `EndMarker`, so `output` and therefore `agent_run.result` are populated there (checked against pydantic-ai 2.21, and probed). Had the second half ever been false it would have dropped the frame carrying the answer and said nothing. Now the `else`; whatever made it false raises instead, and reaches the client as `error`.

   Worth recording because the first pass got it wrong: `_agent_graph.py` registers a **fifth** node, `SetFinalResult`, so "the graph yields four kinds and nothing else" is not true. It is constructed at one call site inside `Agent.run_stream` and reached through `agent_run.next()`, which this code does not use — which is the narrower fact the `else` actually rests on. The second commit corrects the comment.
2. The third `isinstance` in the part-delta chain — `ModelResponsePartDelta` is text, thinking or tool-call, and the first two are handled above. `event.delta` is bound to a local so `ty` narrows it in the `else`.

Both are behaviour-preserving for every input that occurs. `docs/` describes neither at this altitude and `scripts/docs_drift.py` agrees nothing is owed.

## Found while covering it, and not fixed

`use-chat.ts` and `WSEventType` name **five frames no backend surface emits** — `llm_started`, `llm_completed`, `todo_event`, `context_usage`, `context_compacted` — two of them with live `case` arms and a test asserting they behave. That is #144 in the opposite direction, and the same union carries the warning against it four lines above the offending entries. **Filed as #195** rather than folded in: it is a frontend change, in the Frontend surfaces cluster of #168.

Also seen and deliberately left: `except WebSocketDisconnect: raise` in `process_message` and the matching `isinstance` in `_on_turn_done` are defensive — nothing in this module raises `WebSocketDisconnect` today (`send_event` catches it, and the route's `receive_json` raises outside the session). They are covered rather than deleted because deleting them would log a disconnect as a crash and try to write an `error` frame to a socket that has gone.

## How it was verified

```
cd backend && uv run pytest tests/test_agent_session.py --cov=app.services.agent_session
  57 passed · 194 stmts, 0 miss · 72 branches, 0 partial · 100%

POSTGRES_DB=agenticos_test_rb196 make check
  All checks passed — every CI job except e2e
  make test: 3041 passed, 10 skipped · platform layer 100% of 6930 stmts / 1488 branches
```

**Nothing is knowingly red.** The earlier run of this branch reported 2 failures and 16 errors across `tests/integration/` from a Postgres container shared with other worktrees; #216 has since given every integration run a database of its own, and the post-rebase `make check` above is clean end to end.

The seven open CodeQL threads are all one alert, `py/ineffectual-statement` on a bare `await <task>` statement, and all are false positives — awaiting a task runs it to completion and propagates its exception, which in several of them is the only reason the line is there. Answered on each thread rather than worked around.

Closes #165
Refs #144, #164, #168, #195
