### PR TITLE
ci(lint): spell-check the whole tree, not the files a commit touched

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -31,7 +31,8 @@ after an edit it answers the same question thirty times slower.
 Then, once, before the push:
 
 ```bash
-make lint               # ruff, ruff format, ty, eslint, prettier, tsc, and the two guards
+make lint               # ruff, ruff format, ty, eslint, prettier, tsc, the two guards,
+                        # and codespell over every tracked file
 make test               # backend + the 100% gate on the platform layer
 make test-frontend-cov  # frontend + its gate: 100% lines/stmts/funcs, 97.5% branches
 make test-integration   # only if the change is near the database

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,11 @@
 [codespell]
-# Every entry here was a false positive, and each is a word this repository
+# `builtin` is left at its default (`clear,rare`) on purpose. This repository
+# writes British English throughout its prose and docstrings - behaviour,
+# serialise, prioritise, localised - and those are correct here. Adding
+# `en-GB_to_en-US` to the dictionary list would rewrite every one of them; if the
+# tool and the house style disagree, the tool loses.
+#
+# Every entry below was a false positive, and each is a word this repository
 # genuinely uses:
 #
 #   dependant  FastAPI's own attribute name (`route.dependant`). Spelling it

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,14 @@ jobs:
       - name: Lint, format-check and type-check the backend
         run: make lint-backend
 
+      # codespell over every tracked file. The pre-commit hook reads only the
+      # files a commit touches, so until #188 nothing had ever read the tree: a
+      # misspelling merged with its file, and the next person to touch that file
+      # for an unrelated reason had their commit refused by a word they did not
+      # write. This step is what keeps "the whole tree is clean" true.
+      - name: Spell-check the whole tree
+        run: make lint-spelling
+
     # The step that used to sit here ran the entire test suite - with no
     # database, in the lint job - to grep its output for `module-not-imported`.
     # That warning belongs to `[tool.coverage.run] source`, and this config

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ make check                                        # every CI job but e2e — bef
 
 | | |
 |---|---|
-| `make lint` / `make format` | ruff + ty + eslint + prettier + tsc + the two guards |
+| `make lint` / `make format` | ruff + ty + eslint + prettier + tsc + the two guards + codespell |
 | `make lint-backend` / `make lint-frontend` | one half of it — CI runs them in two jobs |
 | `make test-fast` | no coverage — the write-run-write loop |
 | `make test` | backend + the 100% gate on the platform layer |

--- a/Makefile
+++ b/Makefile
@@ -238,16 +238,17 @@ deps-upgrade-all:
 	@echo "▶ Now run 'make check'."
 
 # === Code Quality ===
-# Every static check, both halves of the repository. CI splits them across two
-# jobs (`lint` and the first three steps of `test-frontend`) because they need
-# different toolchains; here they are one command with two callable halves, so a
-# Python-only change can run `lint-backend` and skip a minute of eslint.
+# Every static check: both halves of the repository, plus the one check that
+# reads the whole tree at once. CI splits the halves across two jobs (`lint` and
+# the first three steps of `test-frontend`) because they need different
+# toolchains; here they are one command with callable parts, so a Python-only
+# change can run `lint-backend` and skip a minute of eslint.
 #
 # The frontend half was missing entirely until #143: `make lint` ran ruff, ty and
 # the two guard scripts, while CI additionally ran eslint, prettier and tsc - so
 # `make lint` passed on a branch with a type error in a `.tsx`, and CLAUDE.md's
 # "ruff + ty + eslint + tsc" described a command that ran half of that.
-lint: lint-backend lint-frontend
+lint: lint-backend lint-frontend lint-spelling
 
 lint-backend:
 	uv run --directory backend ruff check app tests cli
@@ -260,6 +261,25 @@ lint-frontend:
 	cd frontend && bun run lint
 	cd frontend && bunx prettier --check "src/**/*.{ts,tsx}" "e2e/**/*.ts"
 	cd frontend && bun run type-check
+
+# Spelling, over every tracked file rather than the ones a commit happens to
+# touch. The hook alone only ever reads changed files, so a misspelling that
+# lands with its file sits there until somebody edits that file for an unrelated
+# reason - and their commit is then refused by a word they did not write. That is
+# #188: one misspelled word reached `main` with #119, and what found it was a
+# person running the hook by hand while reconciling `make check` with CI for #143
+# - not any gate. (Spelling the word here would fail this very check.)
+#
+# It runs the hook rather than codespell directly, because a second invocation
+# would mean a second version pin and a second copy of the exclude list. The rev
+# in `.pre-commit-config.yaml` and the ignore list in `.codespellrc` stay the only
+# definitions; this target just points them at the whole tree.
+#
+# `--project backend`, not `--directory backend` as the targets above use: the
+# second changes directory, and pre-commit would then look for its config and its
+# git tree inside `backend/`.
+lint-spelling:
+	uv run --project backend pre-commit run codespell --all-files
 
 # The write side of both halves. `lint-frontend` checks prettier rather than
 # applying it, so without the second line here the only way to fix a formatting
@@ -575,9 +595,10 @@ help:
 	@echo "Development:"
 	@echo "  make run           Start dev server (with hot reload)"
 	@echo "  make test          Run tests"
-	@echo "  make lint          Every static check: ruff, ty, eslint, prettier, tsc, the guards"
+	@echo "  make lint          Every static check: ruff, ty, eslint, prettier, tsc, the guards, codespell"
 	@echo "  make lint-backend  Just the Python half"
 	@echo "  make lint-frontend Just the TypeScript half"
+	@echo "  make lint-spelling Just codespell, over every tracked file"
 	@echo "  make format        Auto-format code (ruff + prettier)"
 	@echo "  make check         Every CI job except e2e - before opening a pull request"
 	@echo ""

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -25,6 +25,13 @@ cost a second place for every change to sit, so it was removed.
 | Stale approvals dismissed on a new push | Ruleset |
 | No force push, no deletion | Ruleset |
 | No commit made while standing on `main` | `no-commit-to-branch` in `.pre-commit-config.yaml` |
+| Spelling, across every tracked file | codespell — as a hook on the files a commit touches, and as `make lint-spelling` in CI's `lint` job over the whole tree |
+
+A hook only ever reads what a commit touches, which makes it a poor gate on its
+own: a misspelling that merges with its file sits there until somebody edits that
+file for an unrelated reason, and their commit is refused by a word they did not
+write. That is why the spelling check is in the table twice — the hook is the fast
+feedback, `make lint-spelling` is what keeps the claim true for the tree.
 
 The status checks are listed individually today. They should collapse into a
 single aggregating `All Checks Passed` job, so that adding a CI job stops meaning

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -24,8 +24,9 @@ Run these from the project root directory.
 | `make test` | Backend suite plus the 100% gate on the platform layer |
 | `make test-cov` | Run tests with coverage report (HTML + terminal) |
 | `make format` | Auto-format code — ruff on the backend, prettier on the frontend |
-| `make lint` | Every static check, both halves: ruff, ruff format, ty, eslint, prettier, tsc, and the backtick and i18n guards |
+| `make lint` | Every static check: ruff, ruff format, ty, eslint, prettier, tsc, the backtick and i18n guards, and codespell over the whole tree |
 | `make lint-backend` / `make lint-frontend` | One half of the above. CI runs them in two different jobs, so either can be run on its own |
+| `make lint-spelling` | codespell over every tracked file. The pre-commit hook reads only the files a commit touches, so a misspelling that lands with its file waits there to refuse somebody else's unrelated commit |
 | `make build-frontend` | `next build`. Type-checks the route tree and fails on a server component that cannot render — which neither tsc nor vitest sees |
 | `make audit` | Audit the locked dependency set for known vulnerabilities (needs the network) |
 | `make clean` | Remove cache files (__pycache__, .pytest_cache, etc.) |

--- a/frontend/src/lib/tool-steps.ts
+++ b/frontend/src/lib/tool-steps.ts
@@ -145,7 +145,7 @@ export interface McpCall {
   server: string;
   /** The tool as the server named it, without the connection prefix. */
   action: string;
-  /** Host of the server's URL, which is what picks its logo. Null if unparseable. */
+  /** Host of the server's URL, which is what picks its logo. Null if unparsable. */
   domain: string | null;
 }
 


### PR DESCRIPTION
Two commits: the word, and the reason nobody would have found it.

## The word

`frontend/src/lib/tool-steps.ts:148`, the docstring on `McpCall.domain` — one hit, exactly what #188 named, at the line it named:

```
frontend/src/lib/tool-steps.ts:148: unparseable ==> unparsable
```

codespell is right here rather than merely opinionated: three other places in this repository already spell it the way it asks for (`chat-sources.test.ts:107`, `skill_workspace.py:247`, `tool-results.test.tsx:509`). So the fix is the word, not a reworded sentence — and no prose was bent to please a dictionary.

## Why nothing caught it

`.pre-commit-config.yaml` has no `types_or` or `files` narrowing on the codespell hook, so its scope was never the problem: point it at the tree and it reads every tracked text file. The problem was that **nothing ever pointed it at the tree.** The hook reads the files a commit touches, and no CI job ran pre-commit at all — the `lint` job runs `make lint-backend`, and `make lint` did not know codespell existed.

That makes it a fast-feedback tool wearing a gate's clothing, and the failure mode is not "a typo ships". It is that a misspelling merges with its file and then refuses **somebody else's** unrelated commit, weeks later, for a word they did not write. #143 had just made `make check` equal to CI; codespell was in neither.

## What changed about that

- **`make lint-spelling`** — `pre-commit run codespell --all-files`. It runs the hook rather than adding codespell as a dependency and calling it directly: a second invocation means a second version pin and a second copy of the exclude list, and two spelling checks that disagree is worse than one that runs in one place. The `rev` in `.pre-commit-config.yaml` and the ignore list in `.codespellrc` stay the only definitions.
- **`make lint` depends on it**, so it is inside `make check`.
- **CI's `lint` job runs it** as its own step.

Those three together are what `backend/tests/test_ci_parity.py` already asserts in both directions — a gating job may run no target `check` cannot reach, and `check` may run no target no gating job runs. So the wiring *is* the regression test: dropping the step from either side fails the suite rather than quietly restoring the gap. No new test invents a second mechanism to say the same thing.

## How many other hits appeared once the scope was right

**One — the one #188 named, and nothing else.** Two independent traversals agree: `pre-commit run codespell --all-files` over the 1284 tracked files, and a bare `codespell` walk honouring only `.codespellrc`. The per-file scope had not been hiding a backlog; it was hiding one word, and would have gone on hiding the next one.

The check earned its keep immediately, though: its first run went red on a comment **in this pull request's own Makefile hunk**, which quoted the misspelling while explaining it. That comment now says so instead of spelling it.

## British spelling

Untouched, and now defended in writing. codespell's default dictionary (`clear,rare`) has no opinion on "behaviour", "serialise" or "prioritise" — `en-GB_to_en-US` is opt-in, and `.codespellrc` now records that leaving it out is deliberate, because it is one short line for somebody to add and it would Americanise every page of the docs. Where the tool and the house style disagree, the tool loses.

## Verified

`make lint-spelling` green over the whole tree · `make lint` green (all three halves) · `backend/tests/test_ci_parity.py` 16 passed · `make test` at 100% on the platform layer, 2702 passed · `make test-frontend-cov`, `make build-frontend`, `make docs-build` and `make audit` green · `python3 scripts/docs_drift.py` clean.

**What was red, and why it is not this diff:** the `make check` run finished with one failure and eleven errors, all of them in `tests/integration/`, and the whole file passes on its own immediately afterwards (133 passed). That is **#189** — two integration runs sharing `agenticos_test` on one machine drop each other's tables. This branch contains no Python at all, so it cannot reach that code — and CI, with a database of its own, is green on every job including `test` and `e2e`. The new `Spell-check the whole tree` step ran in the `lint` job and passed, which is the part worth confirming.

## Docs

`docs/commands.md` (the `make lint` row, plus a row for the new target), `docs/branching.md` (what protects `main` — the hook and the whole-tree run are two different guarantees and the table now says both), `CLAUDE.md` and `.claude/rules/testing.md`, both of which enumerate what `make lint` runs and would otherwise have been confidently wrong the day this merged.

## Found along the way, deliberately not fixed

**#203** — `yamlfmt`, `zizmor` and the `pre-commit-hooks` basics have exactly this gap: per-file at commit time, gated by nothing over the tree. All green today, which is why it is filed rather than folded in: a `rev:` bump bringing one new `zizmor` rule reproduces #188 one tool over, and the issue works through what such a target has to skip (`no-commit-to-branch` fails by design when CI checks out `main`) and whether fixers belong in a gate at all.

Closes #188
