### PR TITLE
fix(tests): give every integration run a database of its own

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -92,12 +92,21 @@ pytestmark = pytest.mark.anyio   # module top
 - `mock_db_session` — an `AsyncMock`. Mock repositories, never the service under test.
 - `mock_redis`, `api_key_headers`.
 
-The conftest pins `POSTGRES_DB=agenticos_test` before `app.core.config` is imported.
-Leave it: the unit suite once emptied a developer's database through a populated `.env`.
+The conftest points `POSTGRES_DB` at `<base>_p<pid>` before `app.core.config` is
+imported — a test database, and one per pytest process. Leave both halves: the unit
+suite once emptied a developer's database through a populated `.env`, and a constant
+name meant two runs on one machine dropping each other's tables mid-test (#189).
 
-`tests/integration/conftest.py` skips when no database is reachable and refuses any
-database whose name contains neither `test` nor `ci` — it calls `drop_all`
-unconditionally.
+`tests/integration/conftest.py` creates that database at the start of the session and
+drops it at the end, even when the suite fails, so **two concurrent runs are safe and
+nothing has to be passed to make them so**. It still skips when no database is
+reachable (a laptop without Docker) and still refuses any database whose name contains
+neither `test` nor `ci`, or that is not a plain identifier — it calls `drop_all`
+unconditionally and drops the database itself afterwards.
+
+A run killed outright (`SIGKILL`) leaks its database; the next run with that pid drops
+it before creating its own. Anything else named `agenticos_*` on a shared Postgres was
+made by hand and is nobody's to clean up automatically.
 
 ## Naming
 

--- a/.claude/skills/backend-tests/SKILL.md
+++ b/.claude/skills/backend-tests/SKILL.md
@@ -53,13 +53,17 @@ in `tests/conftest.py` pins `asyncio` because that is what uvicorn uses.
   under test.
 - **`mock_redis`**, **`api_key_headers`**.
 
-The conftest also sets `POSTGRES_DB=agenticos_test` *before* anything imports
-`app.core.config`. Do not move or weaken that: running the unit suite against a
-checkout with a populated `.env` used to empty the development database.
+The conftest also sets `POSTGRES_DB` to `<base>_p<pid>` *before* anything imports
+`app.core.config`. Do not move or weaken either half: running the unit suite against a
+checkout with a populated `.env` used to empty the development database, and a constant
+name meant two runs on one machine dropping each other's tables (#189).
 
-`tests/integration/conftest.py` skips the whole module when no database is reachable,
-and **refuses to run against a database whose name contains neither `test` nor `ci`**
-— it calls `drop_all` unconditionally.
+`tests/integration/conftest.py` **creates that database for the session and drops it
+afterwards**, so two concurrent runs need nothing passed to them — `make test` and
+`uv run pytest tests/integration` are safe while another run is going. It skips the
+whole module when no database is reachable, and **refuses any database whose name
+contains neither `test` nor `ci`, or that is not a plain identifier** — it calls
+`drop_all` unconditionally and drops the database itself at the end.
 
 ## A test earns its place by failing when the behaviour changes
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -10,16 +10,31 @@ import os
 
 # Before anything imports `app.core.config`, and therefore before anything can
 # open a connection: point every database name in this process at a test
-# database. An environment variable outranks the `.env` file pydantic-settings
-# reads, so this holds even where a developer's `.env` names their working
-# database.
+# database *of its own*. An environment variable outranks the `.env` file
+# pydantic-settings reads, so this holds even where a developer's `.env` names
+# their working database.
 #
 # It is here rather than in the integration conftest because the damage was not
 # there: running the *unit* suite against a checkout with a populated `.env`
 # emptied the development database, and no test in it means to touch a database
-# at all. A default that can only ever hit `test_db` costs nothing and removes
-# the whole class of accident.
-os.environ.setdefault("POSTGRES_DB", "agenticos_test")
+# at all. A default that can only ever hit a test database costs nothing and
+# removes the whole class of accident.
+#
+# The process id is appended because the name used to be constant while
+# `tests/integration/conftest.py` calls `drop_all` unconditionally: two runs on
+# one machine - two worktrees, or one worktree and a `make test` - dropped and
+# recreated each other's tables mid-test, and reported failures belonging to
+# neither branch (#189). One database per pytest process removes the sharing
+# rather than scheduling around it; `tests/integration/conftest.py` creates it
+# and drops it again. A pid also separates `pytest-xdist` workers, which are
+# processes of their own.
+#
+# Deriving from whatever is already set, rather than defaulting, keeps two
+# properties: CI (which sets `POSTGRES_DB=test_db`) runs the same create-and-drop
+# path a laptop does, and a name that is not obviously a test database is still
+# refused by the guard in the integration conftest instead of being made to look
+# like one.
+os.environ["POSTGRES_DB"] = f"{os.environ.get('POSTGRES_DB', 'agenticos_test')}_p{os.getpid()}"
 
 from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, MagicMock

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -5,32 +5,51 @@ rejects a row, whether a cascade deletes what it should, or whether a partial
 unique index actually prevents a second default. Those are the guarantees the
 schema is supposed to provide, and the only way to know is to ask Postgres.
 
+The database belongs to this pytest process alone: it is created here and
+dropped again when the session ends. `drop_all` below is unconditional, so a
+shared name meant two runs on one machine demolishing each other's tables
+mid-test - deadlocks between one run's `DROP TABLE` and another's `CREATE
+INDEX`, a column that "does not exist" on a database that had it, and two runs
+of the same commit reporting different failures (#189). `tests/conftest.py`
+derives the per-process name; this module owns its lifecycle.
+
 The whole module is skipped when no database is reachable, so `make test` on a
 laptop without Docker still runs everything else.
 """
 
 from __future__ import annotations
 
+import asyncio
 import os
-from collections.abc import AsyncGenerator
+import re
+from collections.abc import AsyncGenerator, Iterator
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 
 from app.db.base import Base
 
+# Where to connect to issue `CREATE DATABASE` / `DROP DATABASE`, neither of
+# which can run from inside the database it names. Every Postgres image this
+# project uses ships it.
+_MAINTENANCE_DATABASE = "postgres"
 
-def _database_url() -> str:
+
+def _database_url(name: str) -> str:
     host = os.getenv("POSTGRES_HOST", "localhost")
     port = os.getenv("POSTGRES_PORT", "5432")
     user = os.getenv("POSTGRES_USER", "postgres")
     password = os.getenv("POSTGRES_PASSWORD", "postgres")
-    name = os.getenv("POSTGRES_DB", "test_db")
     return f"postgresql+asyncpg://{user}:{password}@{host}:{port}/{name}"
 
 
-async def _reachable() -> bool:
-    engine = create_async_engine(_database_url())
+async def _reachable(url: str) -> bool:
+    engine = create_async_engine(url)
     try:
         async with engine.connect():
             return True
@@ -40,32 +59,102 @@ async def _reachable() -> bool:
         await engine.dispose()
 
 
+async def _outside_a_transaction(url: str, statement: str) -> None:
+    """Run one statement with no transaction around it.
+
+    `CREATE DATABASE` and `DROP DATABASE` are refused inside one, and SQLAlchemy
+    opens a transaction for anything else.
+    """
+    engine = create_async_engine(url, isolation_level="AUTOCOMMIT")
+    try:
+        async with engine.connect() as connection:
+            await connection.exec_driver_sql(statement)
+    finally:
+        await engine.dispose()
+
+
 # Names a database is allowed to have before this suite will drop its tables.
 # The guard exists because the cost of getting it wrong is somebody's local
-# data, silently, in the middle of an ordinary `pytest` run - and the default
-# (`test_db`) is one environment variable away from being a real database.
+# data, silently, in the middle of an ordinary `pytest` run - and the name comes
+# from the environment, one variable away from being a real database.
 _TEST_DATABASE_MARKERS = ("test", "ci")
 
+# What may reach `CREATE DATABASE "…"`. The name is interpolated into DDL, so
+# anything that is not a plain identifier is refused rather than quoted and
+# hoped about.
+_PLAIN_IDENTIFIER = re.compile(r"[A-Za-z0-9_]+")
 
-def _refuse_a_real_database(url: str) -> None:
+
+def _refuse_a_real_database(name: str) -> None:
     """Refuse to run against a database that is not obviously a test one.
 
-    `drop_all` here is unconditional, so pointing this suite at a development
-    database destroys it. Nothing in the fixture can tell the difference
-    afterwards; the only moment it can be caught is before the first drop.
+    `drop_all` here is unconditional and this module drops the database itself
+    afterwards, so pointing the suite at a development database destroys it.
+    Nothing in the fixture can tell the difference once it has happened; the only
+    moment it can be caught is before the first drop. The per-process suffix is
+    appended before this runs, so what is checked is the name that will actually
+    be dropped.
     """
-    name = url.rsplit("/", 1)[-1]
+    if not _PLAIN_IDENTIFIER.fullmatch(name):
+        raise RuntimeError(
+            f"Refusing to create a database named {name!r}: the name is interpolated into "
+            "DDL, so it has to be a plain identifier - letters, digits and underscores."
+        )
     if not any(marker in name.lower() for marker in _TEST_DATABASE_MARKERS):
         raise RuntimeError(
             f"Refusing to run integration tests against {name!r}: this suite drops every "
-            "table before each test. Point POSTGRES_DB at a database whose name contains "
-            "'test' or 'ci'."
+            "table before each test, and the database itself afterwards. Point POSTGRES_DB "
+            "at a database whose name contains 'test' or 'ci'."
         )
 
 
+@pytest.fixture(scope="session")
+def database_url() -> Iterator[str]:
+    """A database created for this pytest process, and dropped when it exits.
+
+    Session-scoped and synchronous: a session-scoped *async* fixture cannot
+    depend on anyio's per-function backend fixture, and `asyncio.run` gives each
+    statement a loop of its own, so nothing is shared with the loops the tests
+    run in.
+
+    The drop before the create reclaims a leftover from an earlier run that was
+    killed outright - the only way one survives, since the teardown below runs
+    even when the suite fails.
+    """
+    name = os.environ["POSTGRES_DB"]
+    _refuse_a_real_database(name)
+
+    maintenance = _database_url(_MAINTENANCE_DATABASE)
+    if not asyncio.run(_reachable(maintenance)):
+        # Skipping is right on a laptop with no Docker. In CI it is not: the
+        # service container is declared, so an unreachable database means it
+        # failed to start - and silently skipping two hundred tests would keep
+        # the build green while nothing that needs a database ran at all. This
+        # suite is the only thing that checks constraints, cascades and
+        # cross-tenant reads, so that green would be meaningless.
+        if os.getenv("CI"):
+            raise RuntimeError(
+                f"No database reachable at {maintenance} but CI is set. The Postgres "
+                "service container did not come up; refusing to skip the integration "
+                "suite and report a green build."
+            )
+        pytest.skip("No database reachable - start one with `make docker-db`")
+
+    drop = f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)'
+    asyncio.run(_outside_a_transaction(maintenance, drop))
+    asyncio.run(_outside_a_transaction(maintenance, f'CREATE DATABASE "{name}"'))
+    try:
+        yield _database_url(name)
+    finally:
+        # FORCE because a connection outliving its engine would otherwise turn
+        # cleanup into an error and leave the database behind. Nobody else ever
+        # connects to it, so there is nobody else to disconnect.
+        asyncio.run(_outside_a_transaction(maintenance, drop))
+
+
 @pytest.fixture
-async def engine():
-    """A database engine, or skip the module.
+async def engine(database_url: str) -> AsyncGenerator[AsyncEngine, None]:
+    """An engine on that database, with the schema freshly built from the models.
 
     The schema is created from the models rather than by running migrations:
     these tests assert what the *code* believes the schema is. Whether the
@@ -77,24 +166,7 @@ async def engine():
     Recreating the schema costs a fraction of a second and buys complete
     isolation between tests.
     """
-    if not await _reachable():
-        # Skipping is right on a laptop with no Docker. In CI it is not: the
-        # service container is declared, so an unreachable database means it
-        # failed to start - and silently skipping two hundred tests would keep
-        # the build green while nothing that needs a database ran at all. This
-        # suite is the only thing that checks constraints, cascades and
-        # cross-tenant reads, so that green would be meaningless.
-        if os.getenv("CI"):
-            raise RuntimeError(
-                f"No database reachable at {_database_url()} but CI is set. The Postgres "
-                "service container did not come up; refusing to skip the integration "
-                "suite and report a green build."
-            )
-        pytest.skip("No database reachable - start one with `make docker-db`")
-
-    _refuse_a_real_database(_database_url())
-
-    engine = create_async_engine(_database_url())
+    engine = create_async_engine(database_url)
     async with engine.begin() as connection:
         await connection.run_sync(Base.metadata.drop_all)
         await connection.run_sync(Base.metadata.create_all)
@@ -103,7 +175,7 @@ async def engine():
 
 
 @pytest.fixture
-async def db(engine) -> AsyncGenerator[AsyncSession, None]:
+async def db(engine: AsyncEngine) -> AsyncGenerator[AsyncSession, None]:
     """A session rolled back after each test, so tests cannot affect each other."""
     factory = async_sessionmaker(engine, expire_on_commit=False)
     async with factory() as session:

--- a/backend/tests/integration/test_database_isolation.py
+++ b/backend/tests/integration/test_database_isolation.py
@@ -1,0 +1,23 @@
+"""The suite runs against a database of its own, not a shared one.
+
+`tests/test_integration_database_isolation.py` checks the name and the guard
+without a database. This checks the consequence: that the fixture created the
+database that name refers to and the session is connected to it. If the fixture
+ever fell back to a shared name, every other test here would still pass while
+two concurrent runs dropped each other's tables again (#189).
+"""
+
+import os
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+pytestmark = pytest.mark.anyio
+
+
+class TestTheDatabaseTheSuiteConnectsTo:
+    async def test_it_belongs_to_this_pytest_process_alone(self, db: AsyncSession) -> None:
+        connected_to = (await db.execute(text("SELECT current_database()"))).scalar_one()
+        assert connected_to == os.environ["POSTGRES_DB"]
+        assert connected_to.endswith(f"_p{os.getpid()}")

--- a/backend/tests/test_integration_database_isolation.py
+++ b/backend/tests/test_integration_database_isolation.py
@@ -1,0 +1,56 @@
+"""What keeps two integration runs on one machine out of each other's tables.
+
+`tests/integration/conftest.py` calls `drop_all` unconditionally, so everything
+that makes the suite safe to run twice at once is a name: one nobody else uses,
+and a guard on what that name is allowed to be. Both used to hold only because
+the name was constant, which is exactly what made two runs destroy each other
+(#189) - so the derivation is asserted here rather than assumed.
+
+These are unit tests on purpose. The guard has to answer before a database is
+touched, and it is the one part of the fixture a run without Postgres can still
+check.
+"""
+
+import os
+
+import pytest
+
+from app.core.config import settings
+from tests.integration.conftest import _refuse_a_real_database
+
+
+def test_the_database_this_process_uses_is_named_after_this_process() -> None:
+    """A constant name is the whole defect: two runs then share one database.
+
+    The pid is what a second run cannot collide with, and it also separates
+    `pytest-xdist` workers, which are processes of their own.
+    """
+    assert os.environ["POSTGRES_DB"].endswith(f"_p{os.getpid()}")
+
+
+def test_the_application_settings_name_the_database_the_fixture_creates() -> None:
+    """Otherwise an un-overridden `get_db_session` reaches a different database.
+
+    The engine in `app/db/session.py` is built at import time from these
+    settings, so the name has to be derived before `app.core.config` is read -
+    which is why it happens at the top of `tests/conftest.py` and not in a
+    fixture.
+    """
+    assert os.environ["POSTGRES_DB"] == settings.POSTGRES_DB
+    assert settings.DATABASE_URL.endswith(f"/{os.environ['POSTGRES_DB']}")
+
+
+def test_the_name_this_process_derived_is_one_the_guard_accepts() -> None:
+    """The suffix must not push the name past what the guard allows."""
+    _refuse_a_real_database(os.environ["POSTGRES_DB"])
+
+
+def test_a_database_without_test_or_ci_in_its_name_is_refused() -> None:
+    with pytest.raises(RuntimeError, match="Refusing to run integration tests"):
+        _refuse_a_real_database("agenticos")
+
+
+def test_a_name_that_is_not_a_plain_identifier_is_refused() -> None:
+    """The name reaches `CREATE DATABASE` as text, so it is checked as text."""
+    with pytest.raises(RuntimeError, match="plain identifier"):
+        _refuse_a_real_database('agenticos_test"; DROP DATABASE agenticos; --')

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -132,7 +132,7 @@ calls no tools; what it does not prove is that a real provider answers.
 
 ## Test Database
 
-Tests don't hit a real database. The `client` fixture in `tests/conftest.py` overrides
+Most tests don't hit a real database. The `client` fixture in `tests/conftest.py` overrides
 `get_db_session` with a mocked async session (`AsyncMock`) via FastAPI's
 `app.dependency_overrides`, so the suite runs fast and needs no Postgres container:
 
@@ -140,5 +140,17 @@ Tests don't hit a real database. The `client` fixture in `tests/conftest.py` ove
 - Overrides are registered before each test and cleared afterwards
 - Assert against the mock's calls, or stub `execute(...)` return values for the path under test
 
-For tests that need to exercise real SQL, instantiate your own async engine/session
-inside the test rather than relying on a shared fixture.
+Everything under `tests/integration/` is the exception, and it asks for the `db`
+fixture from `tests/integration/conftest.py` rather than building an engine of its
+own — that fixture is what puts the schema in place.
+
+**The database it uses belongs to the pytest process that asked for it**:
+`<POSTGRES_DB>_p<pid>`, created when the session starts and dropped when it ends,
+failure included. That is what makes two runs at once safe — two worktrees, or a
+worktree and a `make test`, against the one Postgres container — and it needs nothing
+passed on the command line. The name was constant until [#189](https://github.com/vstorm-co/agenticos/issues/189),
+and since the fixture rebuilds the schema before every test, two runs spent their time
+dropping each other's tables and reporting failures that belonged to neither branch.
+The suite still refuses any database whose name does not contain `test` or `ci`: it
+drops tables unconditionally, so the guard is the only thing between it and a
+development database.


### PR DESCRIPTION
Two integration runs on one machine no longer share a database, so nobody has to
know that running the suite twice at once is unsafe. `make test` and
`uv run pytest tests/integration` are both safe with another run already going,
with nothing passed on the command line.

Closes #189.

## The evidence

`tests/integration/conftest.py` rebuilt the schema with `drop_all` before every
test, against a database whose name was constant (`agenticos_test`). Two pytest
processes therefore dropped and recreated each other's tables mid-run.
Reproduced on this branch's base, two concurrent `pytest tests/integration -q
--no-cov` runs:

| | run A | run B |
|---|---|---|
| before | 1 failed, 4 errors, 293s | 1 failed, 9 errors, 294s |
| after | **216 passed, 117s** | **216 passed, 115s** |

The failure sets were disjoint - different tests in each run, `test_platform_flows`
and `test_schema_guarantees` in one, `test_workspace_visibility` in the other - and
78 of the failures were `asyncpg.exceptions.DeadlockDetectedError`:

```
DETAIL:  Process 67406 waits for AccessExclusiveLock on relation 56790638 …
         blocked by process 67402.
         Process 67402 waits for RowExclusiveLock on relation 56791522 …
         blocked by process 67406.
```

One run's `DROP TABLE` against the other's `INSERT`. A single run of the same
commit passes 216/216 in 92s, which is what makes this a race rather than a bug in
either branch. It also cost more than correctness: the two runs took 3.2× as long
as one, because most of what they were doing was waiting for each other's locks.

## The shape, and why this one

`tests/conftest.py` appends the process id to whatever `POSTGRES_DB` names, before
anything imports `app.core.config`; `tests/integration/conftest.py` creates that
database when the session starts and drops it when the session ends, failure
included.

- **A database per pytest process** (this change). Complete isolation, no
  contention, and it matches what CI already has - one container per job, where
  isolation costs nothing. One `CREATE DATABASE` per session.
- **A schema per run.** Cheaper to create, but `drop_all` stays pointed at a
  database other runs are also using, so the safety rail no longer describes what
  is being protected and one `search_path` mistake restores the bug.
- **An advisory lock.** Simplest, and turns two parallel runs into a queue: the
  second waits three minutes to be told what the first already knew. The suite is
  ninety seconds of schema DDL - serialising it is the cost this change removes.

Two details worth the review:

- The name is **derived from** `POSTGRES_DB` rather than defaulting when unset. CI
  sets `POSTGRES_DB=test_db`, so a `setdefault` would have left CI on the old
  fixed-name path and the new create-and-drop code would never have run in CI at
  all - the "green because the thing is not in it" failure of #143/#165.
- It is derived in `tests/conftest.py`, not the integration one, because
  `app/db/session.py` builds its engine at import time from `settings`. Deriving
  later would leave `settings.DATABASE_URL` naming a different database from the
  one the fixture created, so an integration test that forgot to override
  `get_db_session` would quietly reach the shared one.

## The rails, both kept

`_refuse_a_real_database` still refuses any name without `test` or `ci` in it -
now checking the name that will actually be dropped, suffix included - and it also
refuses a name that is not a plain identifier, since the name reaches
`CREATE DATABASE` as text. The "no database reachable" skip still works and still
raises instead of skipping when `CI` is set; the reachability probe moved to the
`postgres` maintenance database, because the per-run one does not exist yet.

## How it was verified

- **Two concurrent runs**: 216 passed each, 117s / 115s. Before the change, on the
  same commit's parent: 1F+4E and 1F+9E (table above).
- **Six pytest processes starting at the same instant**: all six created and
  dropped their own database and passed, so `CREATE DATABASE` does not contend on
  the template.
- **A deliberately failing run leaves nothing behind**: `try/finally` around the
  yield, and `pg_database` has no leftover afterwards.
- **No Postgres**: `1 skipped`. With `CI=1` and no Postgres: `RuntimeError`, naming
  the maintenance URL.
- **`make check`**: green end to end - backend 2720 passed with the platform layer
  at 100%, the frontend coverage gate, `next build`, `mkdocs --strict`, `pip-audit`.

Two issues filed rather than folded in:

- **#212** - `docs/testing.md` still documents a `tests/unit/` directory, a
  `TestClient` fixture and two others that do not exist, with sync examples that
  contradict the anyio rule. Found updating that page; only the section this change
  made wrong was fixed here.
- **#215** - the fixture rebuilds the schema before every test: 0.91s of setup per
  test measured, which is very nearly the whole 92s the suite takes. A per-process
  database is what makes a session-scoped schema safe to consider, so that
  follow-up is now unblocked - deliberately not taken here.

The one leak left is a run killed with `SIGKILL`, which cannot run its teardown;
the next run with that pid drops the leftover before creating its own.
`agenticos_baseline`, `agenticos_chain`, `agenticos_test_main`,
`agenticos_test_delegations`, `agenticos_test_subagents_svc`, `agenticos_probe` and
two more appeared while this branch was being written - hand-made private
databases, which is how everyone worked around this today, and evidence of how
easily it leaks when the workaround is manual. Left alone; they are not this
branch's to delete.

## Docs

- `.claude/rules/testing.md` and `.claude/skills/backend-tests/SKILL.md` said the
  conftest pins `POSTGRES_DB=agenticos_test` and that the integration conftest
  refuses a non-test name. Both now describe the per-process database, its
  lifecycle, that two concurrent runs are safe, and the identifier half of the
  guard.
- `docs/testing.md`'s "Test Database" section opened with "Tests don't hit a real
  database" and advised building your own engine for real SQL. It now points at the
  `db` fixture and explains what database the suite gets. The rest of that page is
  template-stale in ways out of scope here (a `tests/unit/` directory, a
  `TestClient` fixture, sync examples) - filed separately.

## Tests

- `backend/tests/test_integration_database_isolation.py` - the derivation and both
  halves of the guard, without needing a database.
- `backend/tests/integration/test_database_isolation.py` - `SELECT
  current_database()` is the per-process name, i.e. the fixture created it and the
  session is on it. Without that, a regression to a shared name would leave every
  other test here passing.
