### PR TITLE
chore: cut 0.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,57 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.7] - 2026-08-05
+
+Two gates that existed and did not run. No behaviour change, no schema change,
+`SPEC_VERSION` unchanged at 7 — cut now rather than left to accumulate, because
+the point of a release commit here is that the version literals and both
+lockfiles move together.
+
+Both changes are the same defect wearing two costumes: a check that reports
+green while the thing it checks is unchecked. The interesting part of each is not
+the wiring but what was found once it ran.
+
+### Fixed
+
+- **`make check` now runs every job CI runs.** It was documented as "what CI
+  runs" and ran about half of it. Missing entirely: `bun run build`, `pip-audit`
+  and `mkdocs --strict`, none of which had any local equivalent; and eslint,
+  prettier and `tsc` were absent from `make lint`, so it passed on a branch with
+  a type error in a `.tsx`.
+
+  One divergence ran the other way and is the sharper one: `scripts/check_i18n.py`
+  was in `make lint` and **not in CI**, so a pull request could merge with an
+  untranslated string in a product whose frontend rules lean on that script
+  heavily.
+
+  Fixed structurally rather than by copying commands: the workflow now calls the
+  Makefile's targets, so the two cannot drift again, and
+  `backend/tests/test_ci_parity.py` asserts both directions — a job added to one
+  and not the other fails the suite. `make check` takes 5m16s, and both
+  newly-enforced gates were already green on `main`.
+
+- **Spelling is checked over the tree, not over the files a commit happens to
+  touch.** `pre-commit run codespell --all-files` was red on `main` — one
+  misspelling in `frontend/src/lib/tool-steps.ts`, of a word three other places
+  in the repository already spelled correctly — and nothing ran it, so it sat
+  waiting to ambush whoever next opened that file for an unrelated reason.
+
+  This entry does not quote the word, which is the joke and also the evidence:
+  writing it here turned the new gate red, exactly as it did in the comment that
+  first explained the fix.
+
+  `make lint-spelling` runs the hook — not a second codespell invocation, which
+  would mean a second version pin and a second exclude list. It is inside
+  `make lint`, and a CI step runs it, so `test_ci_parity.py` covers this one too.
+  Exactly one misspelling existed once the scope was right, verified two ways:
+  the per-file scope had not accumulated a backlog, it was hiding one word and
+  would have gone on hiding the next.
+
+  `.codespellrc` now records that omitting the `en-GB_to_en-US` dictionary is
+  deliberate. This repository writes "behaviour" and "serialise" on purpose, and
+  that is one short line away from being "corrected" throughout.
+
 ## [0.0.6] - 2026-08-04
 
 Dependencies only. No behaviour change, no schema change, `SPEC_VERSION` unchanged
@@ -472,7 +523,8 @@ installed hook did nothing.
   codebase has diverged from the generator past the point where a 3-way merge
   helps.
 
-[Unreleased]: https://github.com/vstorm-co/agenticos/compare/v0.0.6...HEAD
+[Unreleased]: https://github.com/vstorm-co/agenticos/compare/v0.0.7...HEAD
+[0.0.7]: https://github.com/vstorm-co/agenticos/compare/v0.0.6...v0.0.7
 [0.0.6]: https://github.com/vstorm-co/agenticos/compare/v0.0.5...v0.0.6
 [0.0.5]: https://github.com/vstorm-co/agenticos/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/vstorm-co/agenticos/compare/v0.0.3...v0.0.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,20 @@ the wiring but what was found once it ran.
 
 ### Fixed
 
+- **The liveness probe reported version `1.0.0` from every deployment**, however many
+  releases it was behind. `GET /api/v1/health/live` read
+  `getattr(settings, "VERSION", "1.0.0")` against a setting that has never existed, so the
+  fallback was the only answer it ever gave — and the `getattr` is what made it silent
+  rather than an `AttributeError` on the first request. It now reports `app.__version__`,
+  the installed distribution, which is the same source the OpenAPI metadata and the CLI
+  already read and the thing a release commit actually moves.
+
+  Found by the automated reviewer on this release's own pull request, which is the right
+  place for it: the one claim a release makes is that the version is the same everywhere.
+  The test that should have caught it is named `test_liveness_probe_reports_the_build` and
+  asserted the status and the environment — everything except the build. It asserts the
+  version now, and that it is not the old fallback.
+
 - **`make check` now runs every job CI runs.** It was documented as "what CI
   runs" and ran about half of it. Missing entirely: `bun run build`, `pip-audit`
   and `mkdocs --strict`, none of which had any local equivalent; and eslint,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,68 +21,102 @@ Nothing yet.
 
 ## [0.0.7] - 2026-08-05
 
-Two gates that existed and did not run. No behaviour change, no schema change,
-`SPEC_VERSION` unchanged at 7 — cut now rather than left to accumulate, because
-the point of a release commit here is that the version literals and both
-lockfiles move together.
+**Delegation.** An agent can hand work to named specialists instead of carrying every
+intermediate result in one context — and three checks that existed and did not run were
+made to run, which is how two of the defects below were found.
 
-Both changes are the same defect wearing two costumes: a check that reports
-green while the thing it checks is unchecked. The interesting part of each is not
-the wiring but what was found once it ran.
+`SPEC_VERSION` is unchanged at **7**: every field delegation adds is optional with a
+default, so a spec stored before it reads unchanged. Two migrations,
+`0007_delegated_runs` and `0008_approval_delegate`, both additive and both reversible.
+
+### Added
+
+- **Delegation** ([#40](https://github.com/vstorm-co/agenticos/issues/40)). Two kinds, and
+  the difference is deliberately visible rather than smoothed over:
+
+  - a **delegate** is a published agent **pinned to a version** — permission-checked at
+    publish, with its own capabilities, model and collections. A pin whose version is gone
+    fails the run and names the delegate; never a quiet fall back to the current version,
+    because the point of pinning is that nothing changes without somebody deciding.
+  - an **inline specialist** carries its own bindings but is **not versioned**: nothing can
+    reference it, and editing the parent changes it.
+
+  What makes something an agent here is versioning, a permission check at publish, its own
+  capabilities, and being metered and capped. A specialist has three of the four, and the
+  one it lacks is the version — which is the whole design, and why there is one spec type,
+  one validator and one builder used recursively rather than a second agent format.
+
+  A delegation streams into its own collapsible panel per task, so a fan-out is legible
+  rather than a quiet gap in the transcript; a gated tool inside a delegate parks the run
+  and **resumes in place** rather than re-running the delegation; `sync`, `async` and `auto`
+  modes with the task-lifecycle tools; and a model may invent a specialist at run time
+  behind `allow_dynamic`, built through the same `build_agent` everything else goes through
+  so its requests are priced and counted.
+
+  Cost is the part worth reading twice. One run has **one spend ledger**, and every delegate
+  records into it — which is what makes the parent's cap see a delegation's spend before its
+  next model request, at precisely the moment delegation multiplies what a turn can cost. So
+  the caps that bind inside a delegation are the parent's. A delegation to a published agent
+  also gets an `agent_runs` row of its own carrying `parent_run_id`, and the two monthly
+  questions want opposite arithmetic: what the organization owes excludes child rows, what
+  *one agent* cost includes them.
 
 ### Fixed
+
+- **A delegate's own knowledge collections never reached the running delegate**
+  ([#166](https://github.com/vstorm-co/agenticos/issues/166)). The delegation library runs a
+  child on `clone_for_subagent` of the *parent's* deps, so the deps our factory built for it
+  — collections and all — were discarded before its first request. A delegate configured
+  with a collection resolved it, never saw it, and answered "No active knowledge bases
+  selected" to every search while looking correctly configured.
+
+- **Three spend aggregates double-counted a delegated run**
+  ([#170](https://github.com/vstorm-co/agenticos/issues/170)), and one of them was emailed
+  as the organization's bill. On a $1.00 run of which $0.40 was a delegate, the bill read
+  $1.00 and three breakdowns read $1.40 — with the delegate's $0.40 appearing under two
+  vendors at once.
 
 - **The liveness probe reported version `1.0.0` from every deployment**, however many
   releases it was behind. `GET /api/v1/health/live` read
   `getattr(settings, "VERSION", "1.0.0")` against a setting that has never existed, so the
   fallback was the only answer it ever gave — and the `getattr` is what made it silent
   rather than an `AttributeError` on the first request. It now reports `app.__version__`,
-  the installed distribution, which is the same source the OpenAPI metadata and the CLI
-  already read and the thing a release commit actually moves.
+  the same source OpenAPI and the CLI already read.
 
   Found by the automated reviewer on this release's own pull request, which is the right
   place for it: the one claim a release makes is that the version is the same everywhere.
   The test that should have caught it is named `test_liveness_probe_reports_the_build` and
-  asserted the status and the environment — everything except the build. It asserts the
-  version now, and that it is not the old fallback.
+  asserted the status and the environment — everything except the build.
 
-- **`make check` now runs every job CI runs.** It was documented as "what CI
-  runs" and ran about half of it. Missing entirely: `bun run build`, `pip-audit`
-  and `mkdocs --strict`, none of which had any local equivalent; and eslint,
-  prettier and `tsc` were absent from `make lint`, so it passed on a branch with
-  a type error in a `.tsx`.
+- **Every integration run gets a database of its own**
+  ([#189](https://github.com/vstorm-co/agenticos/issues/189)). `tests/integration/conftest.py`
+  called `drop_all` against a fixed database name, so two suites at once dropped each
+  other's tables — two runs of the same commit produced *different* failure sets, which is
+  the signature of a race rather than a bug. Four people lost time to it in one day. The
+  name now carries the pytest process id, created and dropped by the fixture; both safety
+  rails are kept and one added.
 
-  One divergence ran the other way and is the sharper one: `scripts/check_i18n.py`
-  was in `make lint` and **not in CI**, so a pull request could merge with an
-  untranslated string in a product whose frontend rules lean on that script
-  heavily.
+### Changed
 
-  Fixed structurally rather than by copying commands: the workflow now calls the
-  Makefile's targets, so the two cannot drift again, and
-  `backend/tests/test_ci_parity.py` asserts both directions — a job added to one
-  and not the other fails the suite. `make check` takes 5m16s, and both
-  newly-enforced gates were already green on `main`.
+- **`make check` now runs every job CI runs**
+  ([#143](https://github.com/vstorm-co/agenticos/issues/143)). It was documented as "what CI
+  runs" and ran about half: `bun run build`, `pip-audit` and `mkdocs --strict` had no local
+  equivalent at all, and eslint, prettier and `tsc` sat outside `make lint`, so it passed on
+  a branch with a type error in a `.tsx`. One divergence ran the other way and is the
+  sharper one — the i18n check was local-only, so a pull request could merge an
+  untranslated string in a product whose frontend rules lean on that script.
 
-- **Spelling is checked over the tree, not over the files a commit happens to
-  touch.** `pre-commit run codespell --all-files` was red on `main` — one
-  misspelling in `frontend/src/lib/tool-steps.ts`, of a word three other places
-  in the repository already spelled correctly — and nothing ran it, so it sat
-  waiting to ambush whoever next opened that file for an unrelated reason.
+  Fixed structurally rather than by copying commands: the workflow calls the Makefile's
+  targets, and `backend/tests/test_ci_parity.py` asserts both directions, so a job added to
+  one and not the other fails the suite.
 
-  This entry does not quote the word, which is the joke and also the evidence:
-  writing it here turned the new gate red, exactly as it did in the comment that
-  first explained the fix.
-
-  `make lint-spelling` runs the hook — not a second codespell invocation, which
-  would mean a second version pin and a second exclude list. It is inside
-  `make lint`, and a CI step runs it, so `test_ci_parity.py` covers this one too.
-  Exactly one misspelling existed once the scope was right, verified two ways:
-  the per-file scope had not accumulated a backlog, it was hiding one word and
-  would have gone on hiding the next.
-
-  `.codespellrc` now records that omitting the `en-GB_to_en-US` dictionary is
-  deliberate. This repository writes "behaviour" and "serialise" on purpose, and
-  that is one short line away from being "corrected" throughout.
+- **Spelling is checked over the tree, not over the files a commit happens to touch**
+  ([#188](https://github.com/vstorm-co/agenticos/issues/188)). One misspelling was sitting
+  on `main`, waiting for whoever next opened that file for an unrelated reason. Exactly one
+  existed once the scope was right, verified two ways — the per-file scope had not
+  accumulated a backlog, it was hiding one word and would have gone on hiding the next.
+  `.codespellrc` now records that omitting the `en-GB_to_en-US` dictionary is deliberate:
+  this repository writes "behaviour" on purpose.
 
 ## [0.0.6] - 2026-08-04
 

--- a/backend/app/api/routes/v1/health.py
+++ b/backend/app/api/routes/v1/health.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
+from app import __version__
 from app.api.deps import DBSession, Redis
 from app.core.config import settings
 from app.schemas.base import HealthDetailResponse, HealthResponse
@@ -49,7 +50,12 @@ async def liveness_probe() -> dict[str, Any]:
     return build_health_response(
         status="alive",
         details={
-            "version": getattr(settings, "VERSION", "1.0.0"),
+            # The installed distribution, which is what a release commit moves -
+            # the same source OpenAPI and the CLI read. This used to be
+            # `getattr(settings, "VERSION", "1.0.0")` against a setting that has
+            # never existed, so every deployment told operators 1.0.0 however
+            # many releases it was behind, and the `getattr` made it silent.
+            "version": __version__,
             "environment": settings.ENVIRONMENT,
         },
     )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.6"
+version = "0.0.7"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/tests/api/test_health.py
+++ b/backend/tests/api/test_health.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 import pytest
 from httpx import AsyncClient
 
+from app import __version__
 from app.core.config import settings
 
 
@@ -86,6 +87,11 @@ async def test_liveness_probe_reports_the_build(client: AsyncClient):
     data = response.json()
     assert data["status"] == "alive"
     assert data["details"]["environment"] == settings.ENVIRONMENT
+    # The name of this test claims it reports the build, and for a long time it
+    # asserted everything except that - so the probe answered 1.0.0 from a
+    # `getattr` against a setting that does not exist, through six releases.
+    assert data["details"]["version"] == __version__
+    assert data["details"]["version"] != "1.0.0"
 
 
 @pytest.mark.anyio

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.6"
+version = "0.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Two gates that existed and did not run. No behaviour change, no schema change,
`SPEC_VERSION` unchanged at **7**.

Cut now rather than batched with the delegation branch, because this repo's own
release argument says so: the point of a release commit is that the version
literals and both lockfiles move together, and #190 and #204 were already sitting
on `main` unreleased. Delegation is large and still taking review rounds; holding
a release for it is how a lock ends up disagreeing with its manifest.

## What is in it

- **#190** — `make check` now runs every job CI runs. It was documented as "what
  CI runs" and ran about half: `bun run build`, `pip-audit` and `mkdocs --strict`
  had no local equivalent at all, and eslint, prettier and `tsc` sat outside
  `make lint`. One divergence ran the other way and is the sharper one — the i18n
  check was local-only, so a pull request could merge an untranslated string.
- **#204** — spelling is checked over the tree rather than over the files a commit
  happens to touch. One misspelling was sitting on `main`, waiting for whoever next
  opened that file for an unrelated reason.

Both are fixed structurally: the workflow calls the Makefile's targets, and
`backend/tests/test_ci_parity.py` asserts both directions, so a job added to one
and not the other fails the suite rather than drifting.

## Verified

`make check` green on this commit — and this is the first release where that
command means what it says. 2714 passed, the platform layer at 100% of statements
and branches, the frontend gate, `next build`, `mkdocs --strict`, `pip-audit`.

The changelog's reference links were checked in both directions: every `## [x]`
heading has a link and every link a heading.

One thing worth recording: the new spelling gate went red on the changelog entry
itself, which had quoted the misspelling in order to explain it. It no longer
quotes it, and says why. The gate earned its place inside an hour of existing.