### PR TITLE
docs(activity): reconcile the design with delegated runs

### DIFF
--- a/docs/design/activity-mockup.html
+++ b/docs/design/activity-mockup.html
@@ -318,6 +318,26 @@
   pre { font: 11.5px/1.5 var(--mono); padding: 4px 10px 8px; overflow-x: auto; white-space: pre-wrap; overflow-wrap: anywhere; }
   .notice { border: 1px solid oklch(62% 0.136 68 / 0.3); background: var(--warn-bg); border-radius: 8px; padding: 10px 12px; font-size: 12.5px; color: oklch(43% 0.1 68); }
 
+  /* A delegation is a run of its own, and the only way to it is the run it came
+     from - the table is top-level only so that its count and cost agree with the
+     month figure above it. */
+  .deleg { margin-top: 14px; border-top: 1px dashed var(--border); padding-top: 12px; }
+  .deleg-head { font-size: 12.5px; font-weight: 600; margin-bottom: 8px; }
+  .deleg-head .sub { font-weight: 450; }
+  .drow {
+    display: flex; align-items: center; gap: 8px; width: 100%; text-align: left;
+    font: inherit; font-size: 12.5px; color: var(--text); cursor: pointer;
+    background: var(--card); border: 1px solid var(--border); border-radius: 8px;
+    padding: 8px 11px; margin-bottom: 6px; flex-wrap: wrap;
+  }
+  .drow:hover { border-color: var(--brand-line); background: var(--brand-subtle); }
+  .drow .dnum { margin-left: auto; color: var(--muted); font-variant-numeric: tabular-nums; white-space: nowrap; }
+  /* Who is asking, when it is not the agent whose run it is. In a delegation the
+     thing being approved is often more consequential than the agent the approver
+     has in mind, so the actor sits beside the tool name, not a click away. */
+  .asked { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; color: var(--muted); }
+  .asked b, .asked a { font-weight: 550; }
+
   /* ---- approvals ---- */
   .approval { border: 1px solid var(--border); border-radius: 8px; padding: 13px 14px; margin-bottom: 10px; }
   .approval:last-child { margin-bottom: 0; }
@@ -501,6 +521,18 @@ const USERS = [
   { id: "u4", name: "j.wisniewski@initech.example", org: "initech" },
 ];
 
+/* A delegation is a run of its own - agent_runs.parent_run_id, #200 - and is
+   deliberately NOT in the list: run history is top-level only, so its count and its
+   cost column agree with the month figure above them. The only way to a delegated run
+   is the run it came from, which is what the detail view answers.
+   `agentId: null` is an inline specialist: defined inside its parent's spec, with no
+   row in `agents` and nothing to link to. */
+const SPECIALISTS = [
+  { name: "researcher", agentId: "a7", agentName: "Research specialist" },
+  { name: "summariser", agentId: null, agentName: null },
+  { name: "invoice-checker", agentId: "a8", agentName: "Invoice checker" },
+];
+
 /* agent_runs.exposure_id: surface says "slack", the exposure says which Slack
    workspace. ExposureSurface is only slack | telegram | mattermost. */
 const EXPOSURES = [
@@ -529,7 +561,7 @@ const PAGE_SIZE = 25;
 
 let current = {
   identity: IDENTITIES[1], state: "normal", annotations: "on",
-  org: ORGS[0], tab: "approvals", page: 1, openRun: null,
+  org: ORGS[0], tab: "approvals", page: 1, openRun: null, openDeleg: null,
   // The runs tab's own filters. null = every value.
   period: { preset: "30d" }, status: null, surface: null, agent: "", user: "",
   env: "", exposure: "", version: "",
@@ -699,6 +731,25 @@ function genRuns([from, to]) {
           : status === "budget_exceeded" ? `Agent monthly cap of $${(agent.cap ?? 2).toFixed(2)} reached` : null,
         script: SCRIPTS[Math.floor(rnd() * SCRIPTS.length) % SCRIPTS.length],
         conversation: NO_CONVERSATION.has(surface) ? null : "c-" + Math.floor(rnd() * 900 + 100),
+        // Its own rows, hanging off this one. Note `env: null` - record_delegated_run
+        // leaves environment_id NULL on purpose, because a delegate's version comes
+        // from a pin rather than from an environment resolving it.
+        delegations: rnd() < 0.22
+          ? Array.from({ length: 1 + (rnd() < 0.35 ? 1 : 0) }, (_, k) => {
+              const spec = SPECIALISTS[Math.floor(rnd() * SPECIALISTS.length) % SPECIALISTS.length];
+              const dtin = 200 + Math.floor(rnd() * 4000);
+              const dtout = 30 + Math.floor(rnd() * 700);
+              return {
+                id: Math.floor(rnd() * 0xffffff).toString(16).padStart(6, "0"),
+                task: "task-" + (k + 1), spec, env: null,
+                version: 1 + Math.floor(rnd() * 4),
+                status: rnd() < 0.9 ? "completed" : "failed",
+                tin: dtin, tout: dtout,
+                cost: (dtin * 3e-6 + dtout * 1.5e-5),
+                ms: 400 + Math.floor(rnd() * 9000),
+              };
+            })
+          : [],
       });
     }
   }
@@ -715,6 +766,11 @@ function genApprovals() {
   return genRuns(last30()).filter((r) => r.status === "awaiting_approval").slice(0, 4).map((r, i) => ({
     id: "ap-" + i, run: r, tool: r.script.tool, args: r.script.args,
     waited: ["2 h", "5 h", "1 d", "3 d"][i], waitedH: [2, 5, 26, 74][i],
+    // ApprovalRead.subagent_name / subagent_agent_id (#200). A gated tool inside a
+    // delegation writes its approval against the PARENT's run, so two specialists
+    // calling the same tool queue two rows with one name between them. Null means the
+    // run's own agent asked - nothing is rendered, because agent_id already says that.
+    subagent: i === 1 ? SPECIALISTS[0] : i === 3 ? SPECIALISTS[1] : null,
   }));
 }
 
@@ -773,6 +829,8 @@ const ICON_PATHS = {
   "circle-check": '<circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/>',
   "eye-off": '<path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.5 13.5 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><path d="m2 2 20 20"/><path d="M14.12 14.12a3 3 0 1 1-4.24-4.24"/>',
   calendar: '<path d="M8 2v4"/><path d="M16 2v4"/><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M3 10h18"/>',
+  users: '<path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/>',
+  "corner-up-left": '<polyline points="9 14 4 9 9 4"/><path d="M20 20v-7a4 4 0 0 0-4-4H4"/>',
 };
 const icon = (name, size = 16) =>
   `<svg viewBox="0 0 24 24" width="${size}" height="${size}" fill="none" stroke="currentColor"
@@ -996,6 +1054,11 @@ function approvalsTab(queue) {
   else body = median + list.map((a) => `<div class="approval">
     <div class="approval-head">
       <span class="tn">${esc(a.tool)}</span>
+      ${a.subagent ? `<span class="asked">${icon("users", 13)}
+        ${a.subagent.agentId
+          ? `<a href="#">asked by ${esc(a.subagent.name)}</a>`
+          : `<b>asked by ${esc(a.subagent.name)}</b>`}
+        ${a.subagent.agentId ? "" : `<span class="pill">inline specialist</span>`}</span>` : ""}
       ${deciding
         ? `<span class="pill ${a.waitedH >= 24 ? "err" : "warn"}">waiting ${esc(a.waited)}</span>`
         : `<span class="pill ${a.decision === "approved" ? "ok" : "err"}">${a.decision}</span>`}
@@ -1116,10 +1179,14 @@ function runsTab(rows, total) {
   const head = `<div class="card-head"><div>
       <h3>Run history</h3>
       <div class="hd">Every run records the agent <em>version</em> it executed, so what happened
-        last week stays answerable after the agent has been rewritten.</div>
-    </div>${anno(["GET /api/v1/runs?skip&limit&agent_id"],
+        last week stays answerable after the agent has been rewritten. <b>Top-level runs
+        only</b> — a delegation is a run of its own and is reached from the run it came from,
+        which is what keeps this count and its cost column agreeing with the month figure
+        above.</div>
+    </div>${anno(["GET /api/v1/runs?skip&limit&agent_id&include_delegations"],
       ["status, surface, user, date range, environment, channel and version do not exist yet as params",
-       "embed & mattermost need the recording widening #37 settled — today they are stamped web / api"])}</div>`;
+       "embed & mattermost need the recording widening #37 settled — today they are stamped web / api",
+       "parent_run_id & include_delegations arrive with #200"])}</div>`;
   const filters = runsFilterBar() + versionStrip();
 
   if (current.state === "error") {
@@ -1161,7 +1228,12 @@ function runsTab(rows, total) {
       <span>Page <b>${current.page}</b> of <b>${fmt(pages)}</b></span>
       <button class="btn small" data-page="next"${current.page >= pages ? " disabled" : ""}>Next</button>
     </div>
-    ${current.openRun ? runDetail(rows.find((r) => r.id === current.openRun)) : ""}
+    ${current.openRun ? (() => {
+      const run = rows.find((r) => r.id === current.openRun);
+      if (!run) return "";
+      const d = current.openDeleg && (run.delegations || []).find((x) => x.id === current.openDeleg);
+      return d ? delegationDetail(run, d) : runDetail(run);
+    })() : ""}
     <div class="card-foot"><span class="gate">shown because: runs:view</span>
       <span class="gate">rows are the organization's, whoever ran them</span></div>
   </div>`;
@@ -1172,7 +1244,8 @@ function runRow(r) {
   return `<tr data-run="${r.id}" aria-selected="${current.openRun === r.id}">
     <td><span style="display:inline-flex;align-items:center"><span class="dot ${s.cls}"></span>${s.label}</span></td>
     ${isAllOrgs() ? `<td>${esc(orgOf(r.org).name)}</td>` : ""}
-    <td>${esc(r.agent.name)} <span class="sub">v${r.version}</span></td>
+    <td>${esc(r.agent.name)} <span class="sub">v${r.version}</span>${
+      (r.delegations || []).length ? ` <span class="pill brand">+${r.delegations.length} delegated</span>` : ""}</td>
     <td class="sub">${r.surface}${r.env === "staging" ? ` <span class="pill">staging</span>` : ""}</td>
     <td class="sub">${r.user ? esc(r.user.name.split("@")[0]) : "—"}</td>
     <td class="mono">${r.model}</td>
@@ -1250,6 +1323,25 @@ function runDetail(r) {
     missing = ["messages.run_id"];
   }
 
+  // A parent's transcript does not contain what its delegate did - the delegation is a
+  // run of its own, absent from the list, and this is the only way to it.
+  const kids = r.delegations || [];
+  const delegated = kids.length ? `<div class="deleg">
+    <div class="deleg-head">Delegated to ${kids.length === 1 ? "a specialist" : kids.length + " specialists"}
+      <span class="sub">— its own run each, already counted inside this run's cost</span></div>
+    ${kids.map((d) => `<button class="drow" data-deleg="${d.id}">
+      <span class="dot ${d.status === "completed" ? "ok" : "err"}"></span>
+      <b>${esc(d.spec.name)}</b>
+      ${d.spec.agentId ? `<span class="pill">v${d.version}</span>` : `<span class="pill">inline specialist</span>`}
+      <span class="sub">${esc(d.task)}</span>
+      <span class="dnum">${fmt(d.tin + d.tout)} tok · ${money(d.cost)} · ${(d.ms / 1000).toFixed(1)}s</span>
+    </button>`).join("")}
+    <div class="sub" style="margin-top:7px">A delegated run is not in the table above:
+      run history is top-level only, so its count and its cost agree with the month figure.
+      <span class="anno">Every one of these carries <span class="chip">environment_id = NULL</span>
+      — a delegate's version comes from a pin, so no environment resolved it.</span></div>
+  </div>` : "";
+
   return `<div class="detail">
     <div class="detail-head">
       <div><h4><span class="dot ${s.cls}"></span>What this run did</h4>
@@ -1259,7 +1351,44 @@ function runDetail(r) {
       ${anno(["GET /api/v1/conversations/{id}/messages"], missing)}
     </div>
     <dl class="facts">${facts}</dl>
-    ${err}${body}
+    ${err}${body}${delegated}
+  </div>`;
+}
+
+/**
+ * One delegated run, reached from the run it came from.
+ *
+ * Both directions are asked, so both are answered: down from a parent to what it
+ * delegated, and up from a delegate to where its cost was actually charged. Arriving
+ * at a specialist's row and finding no way back is the dead end #200's `FocusedRun`
+ * exists to avoid.
+ */
+function delegationDetail(parent, d) {
+  const facts = [
+    ["Run", `<span class="mono">${d.id}</span>`],
+    ["Delegate", d.spec.agentId
+      ? `${esc(d.spec.agentName)} <span class="sub">v${d.version}</span>`
+      : `${esc(d.spec.name)} <span class="sub">inline specialist — no agent of its own</span>`],
+    ["Delegation", `<span class="mono">${esc(d.task)}</span>`],
+    ["Environment", `<span class="sub">none — a delegate's version comes from a pin</span>`],
+    ["Tokens", `${fmt(d.tin)} in / ${fmt(d.tout)} out`],
+    ["Cost", `${money(d.cost)} <span class="sub">already inside the parent's</span>`],
+    ["Took", (d.ms / 1000).toFixed(1) + "s"],
+  ].map(([k, v]) => `<div class="fact"><dt>${esc(k)}</dt><dd>${v}</dd></div>`).join("");
+
+  return `<div class="detail">
+    <div class="detail-head">
+      <div><h4><span class="dot ${d.status === "completed" ? "ok" : "err"}"></span>What this delegation did</h4>
+        <div class="sub" style="margin-top:3px">A run of its own
+          (<span class="chip">parent_run_id</span>), which is why it is not in the table.</div></div>
+      ${anno(["GET /api/v1/runs/{id}", "GET /api/v1/runs?parent_run_id="], ["messages.run_id"])}
+    </div>
+    <button class="btn small" data-up="1" style="margin-bottom:12px">
+      ${icon("corner-up-left", 13)} Back to the run it came from</button>
+    <dl class="facts">${facts}</dl>
+    <div class="notice">A delegate's steps are recorded against its own run, so the
+      transcript lands here once <span class="chip">messages.run_id</span> is written on the
+      delegation path too — not only on the parent's.</div>
   </div>`;
 }
 
@@ -1369,7 +1498,7 @@ document.addEventListener("click", (e) => {
 document.addEventListener("keydown", (e) => { if (e.key === "Escape") closePopovers(); });
 
 function repaint({ resetPage = true } = {}) {
-  if (resetPage) { current.page = 1; current.openRun = null; }
+  if (resetPage) { current.page = 1; current.openRun = null; current.openDeleg = null; }
   writeHash(); closePopovers(); renderAll();
 }
 
@@ -1382,11 +1511,18 @@ function wireTabs() {
   }));
   document.querySelectorAll("[data-page]").forEach((b) => b.addEventListener("click", () => {
     current.page += b.dataset.page === "next" ? 1 : -1;
-    current.openRun = null; writeHash(); renderAll();
+    current.openRun = null; current.openDeleg = null; writeHash(); renderAll();
   }));
   document.querySelectorAll("tr[data-run]").forEach((tr) => tr.addEventListener("click", () => {
     current.openRun = current.openRun === tr.dataset.run ? null : tr.dataset.run;
+    current.openDeleg = null;
     writeHash(); renderAll();
+  }));
+  document.querySelectorAll("[data-deleg]").forEach((b) => b.addEventListener("click", () => {
+    current.openDeleg = b.dataset.deleg; writeHash(); renderAll();
+  }));
+  document.querySelectorAll("[data-up]").forEach((b) => b.addEventListener("click", () => {
+    current.openDeleg = null; writeHash(); renderAll();
   }));
   document.querySelectorAll("[data-retry]").forEach((b) => b.addEventListener("click", () => {
     current.state = "normal"; repaint();
@@ -1568,9 +1704,9 @@ function calMonth(first, side) {
   const nav = side === "left"
     ? `<button class="cal-nav prev" aria-label="Previous month">‹</button>`
     : `<button class="cal-nav next" aria-label="Next month"${atNow ? " disabled" : ""}>›</button>`;
-  const dows = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"].map((x) => `<span class="dow">${x}</span>`).join("");
+  const weekdays = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"].map((x) => `<span class="dow">${x}</span>`).join("");
   const title = first.toLocaleDateString("en-GB", { month: "long", year: "numeric" });
-  return `<div class="cal-month"><div class="cal-head">${nav}${title}</div><div class="cal-grid">${dows}${days}</div></div>`;
+  return `<div class="cal-month"><div class="cal-head">${nav}${title}</div><div class="cal-grid">${weekdays}${days}</div></div>`;
 }
 
 /* ---- demo controls ---- */
@@ -1593,7 +1729,7 @@ function renderControls() {
       (id) => {
         current.identity = IDENTITIES.find((i) => i.id === id);
         if (!current.identity.isAppAdmin && current.org.id === "all") current.org = ORGS[0];
-        current.page = 1; current.openRun = null;
+        current.page = 1; current.openRun = null; current.openDeleg = null;
       },
       // Muted rather than brand-coloured: these two see no version of the page.
       (i) => !(i.isAppAdmin || (ROLE_PERMS[i.role] || []).includes("runs:view")));

--- a/docs/design/activity-mockup.html
+++ b/docs/design/activity-mockup.html
@@ -486,10 +486,6 @@ const PRESETS = [
 const last30 = () => [addDays(today0(), -29), today0()];
 const monthToDate = () => { const t = today0(); return [new Date(t.getFullYear(), t.getMonth(), 1), t]; };
 
-/* The day `messages.run_id` starts being written. Runs older than this have a
-   conversation but no way to name their own slice of it. */
-const RUN_ID_SINCE = addDays(today0(), -6);
-
 const STATUSES = [
   { id: "completed", label: "completed", cls: "ok" },
   { id: "running", label: "running", cls: "run" },
@@ -1259,9 +1255,14 @@ function runRow(r) {
 /**
  * The drill-down, from our own rows - not a link into Logfire.
  *
- * Three cases, each of which says which one it is: the steps we recorded, a run
- * whose messages predate `messages.run_id`, and a surface that never had a
- * conversation to record.
+ * Two cases, each of which says which one it is: the steps we recorded, and a
+ * surface that never had a conversation to record.
+ *
+ * A third was drawn here - a run whose messages predate `messages.run_id`, with
+ * copy explaining that its steps were never linked. It is gone: no deployment
+ * holds runs worth preserving yet, so the migration backfills or the rows are
+ * expendable either way, and a permanently unreachable branch is dead weight
+ * rather than a graceful degradation.
  */
 function runDetail(r) {
   if (!r) return "";
@@ -1292,12 +1293,6 @@ function runDetail(r) {
     body = `<div class="notice">The <b>${r.surface}</b> surface ran this without a conversation,
       so there is no transcript to show. Status, cost and any error are all there is — and all
       there ever was.</div>`;
-  } else if (r.started < RUN_ID_SINCE) {
-    body = `<div class="notice">Steps were not recorded for runs before
-      <b>${fmtDay(RUN_ID_SINCE)}</b>, when <span class="chip">messages.run_id</span> started being
-      written. The run and its cost are complete; the transcript exists but is not linked to this
-      run. <a href="#">Open conversation ${r.conversation}</a> to read the whole thread.</div>`;
-    missing = ["messages.run_id"];
   } else {
     const sc = r.script;
     const toolStatus = r.status === "failed" ? "failed" : r.status === "awaiting_approval" ? "pending" : "completed";

--- a/docs/design/activity-plan.md
+++ b/docs/design/activity-plan.md
@@ -21,6 +21,10 @@ Four findings, in the order that matters:
    client's own project. Linking correctly would mean a project slug on the spec — a
    `SPEC_VERSION` bump touching every stored spec and every client's exported YAML.
    Disproportionate for a hyperlink.
+   **This bullet has since lost most of its weight**: nothing is in real use, so there are
+   no stored specs to migrate and no client YAML to break — the bump costs what the code
+   change costs. Findings 1, 2 and 4 stand as written, and the deep link was reinstated at
+   sign-off; #206 prices it without the compatibility tax assumed here.
 4. **We already store, and already serve, what the trace would show.** `messages` carries
    `role`, `content`, `thinking`, `model_name`, `agent_version` and `tokens_used`;
    `tool_calls` carries `tool_name`, `args`, `result`, `status`, `duration_ms`.
@@ -47,8 +51,17 @@ migration and it is quietly wrong — two concurrent runs in one conversation in
 and a run that never set `ended_at` yields an empty window. A drill-down whose errors are
 invisible to its reader is worse than one that admits a gap.
 
-Rows written before the migration keep `run_id = NULL`. The detail view says so — *"steps
-were not recorded for runs before <date>"* — rather than falling back to a time window.
+**No degraded case for rows written before the migration.** An earlier draft of this
+section kept `run_id = NULL` on old rows and had the detail view explain itself — *"steps
+were not recorded for runs before <date>"*. There is no deployment holding runs worth
+preserving, so that branch protects nothing and can never be reached: the migration
+backfills what exists or the rows are expendable, and either way the detail view has one
+case fewer, one piece of copy fewer, and no state that only appears on old data. A branch
+that cannot be reached gets deleted rather than tested.
+
+The same goes for anything else on this page that reads as a compatibility concession.
+There are no clients with an exported spec to break and no history to keep honest, so the
+question to ask of a fallback here is not "is it graceful" but "can it ever run".
 
 ## 2a. Delegated runs — the page is built on a table that now holds two kinds of row
 

--- a/docs/design/activity-plan.md
+++ b/docs/design/activity-plan.md
@@ -50,15 +50,76 @@ invisible to its reader is worse than one that admits a gap.
 Rows written before the migration keep `run_id = NULL`. The detail view says so — *"steps
 were not recorded for runs before <date>"* — rather than falling back to a time window.
 
+## 2a. Delegated runs — the page is built on a table that now holds two kinds of row
+
+This section was added after the rest of the plan, reconciling it with #200
+(`feat/delegated-run-history`), which lands a second kind of `agent_runs` row and was open
+while §1–§9 were being written. Four of the items priced below are already built there.
+
+**A delegation writes its own run row.** `parent_run_id` and `subagent_task_id` join the
+run row, and `record_delegated_run` writes a delegated run *finished* — it has a status, a
+cost and both ends of its window before any row exists. So run history stops being a list
+of one thing, and the two must not be read the same way: **a parent's `cost_usd` already
+contains its children's**, which is why `sum_cost_since` counts only
+`parent_run_id IS NULL` and why summing a page of rows bills the organization twice for
+one request.
+
+### What #200 already ships, so this plan should stop pricing it
+
+| This plan said | #200 |
+|---|---|
+| The run detail view is the central new deliverable (§1, §3 item 1) | Built: `?run=<id>` and `FocusedRun`, which shows one run plus the delegations it made, links **upwards** to the parent, and tells a 404 apart from a failed request |
+| The "Runs" figure renders `runs.length`; fix it to `total` (§3 item 5) | Done, from an unnarrowed `useRuns()`, with a caption saying delegations are counted in their parent |
+| The three tabs land as separate components (§9) | `RunTable` is already extracted |
+| `ApprovalRead` carries no agent name and no triggering user (§3 item 3) | Adds `subagent_name` and `subagent_agent_id`, rendered by `ApprovalDelegate` with its own integration test. The agent name and triggering user remain this plan's work |
+
+### What this plan has to decide, because #200 does not
+
+**The list is top-level only.** `list_runs` gains `parent_run_id` and
+`include_delegations`, defaulting to top-level rows — which is what makes the count and the
+cost column agree with the month-to-date figure beside them. So the Run history table draws
+top-level runs, and a delegated run is reached by naming it, never by paging to it. The
+table says so once rather than leaving a reader to wonder where the fan-out went.
+
+**A delegated run carries no environment.** `record_delegated_run` leaves `environment_id`
+NULL deliberately: that column says which environment resolved the version this run
+answered with, and a delegate's version comes from a pin. The top-level list is therefore
+unaffected — but **every view that deliberately includes delegations loses them the moment
+an environment narrows the query**, and there are two on this page:
+
+- the **version strip** (§6), when the agent selected is one that other agents delegate
+  to — all of its runs are delegated rows;
+- the **per-agent spend tile** (§6), because `cost_breakdown` includes delegations on
+  purpose: a delegate's rows are the only record of its own spend.
+
+Both either leave the environment filter out of their query or say that a delegated run has
+no environment. Silently dropping the rows is the option this section exists to refuse.
+
+**The version strip has to pick a side of `include_delegations`, and say which.** Runs,
+success rate and p50 are per-version questions and want the delegate's own rows; cost per
+run summed across both kinds counts a delegation twice, once inside its parent. The strip's
+caption names the choice, the way #200's Runs figure names its own.
+
+**The run detail view gains a second half.** A parent's transcript does not contain what its
+delegate did, so a run that delegated shows the delegations beneath its own steps, each
+linking to its own detail — and a delegated run links up to the run it came from, because
+that is where its cost was charged. This is `FocusedRun`'s shape; the detail view here
+should be the same component's home rather than a second answer to the same question.
+
+**The approvals queue names the delegate.** A gated tool inside a delegation writes its
+approval against the *parent's* run, so two specialists both calling `send_email` produce
+two rows with the same tool name and nothing to choose between them. The delegate is the
+fact that decides the answer, and it belongs beside the tool name rather than a click away.
+
 ## 3. The six items in #45, reassessed against the code
 
 | # | #45 said | Verdict |
 |---|---|---|
-| 1 | A run does not link to its trace — *smallest change, largest gain* | **Replaced.** It was the largest item, not the smallest (§1). Ships as the run detail view instead |
+| 1 | A run does not link to its trace — *smallest change, largest gain* | **Replaced.** It was the largest item, not the smallest (§1). Ships as the run detail view instead — **which #200 has already built** as `?run=` plus `FocusedRun` (§2a). What is left here is the transcript inside it, off `messages.run_id` |
 | 2 | Cost rendered without its caveat | **Already shipped** — `runs/page.tsx:219` marks `cost_is_partial`. Remaining work is honesty of presentation: a bare `+` in a `title=` attribute is invisible to a screen reader and easy to miss. Becomes a visible marker with text |
-| 3 | An approval has no context | **Half shipped** — `tool_args` is rendered in full (`runs/page.tsx:141`). Missing is the agent and the triggering user, and `ApprovalRead` carries neither. Backend change, not UI |
+| 3 | An approval has no context | **Half shipped** — `tool_args` is rendered in full (`runs/page.tsx:141`), and #200 adds the **delegate** that asked (§2a). Missing is the agent and the triggering user; `ApprovalRead` carries neither. Backend change, not UI |
 | 4 | Filtering is agent-only | **Do it.** `agent_run_repo.list_runs` accepts only `agent_id` |
-| 5 | Pagination | **Do it**, and fix what it hides: the "Runs" figure renders `runs.length` — at most 50 — as the organization's run count, while the hook already returns an unused `total` |
+| 5 | Pagination | **Do it.** The figure it hides is already fixed by #200 (`total`, top-level only, captioned) — what remains is #198, filed: the count reads *all time* while the spend beside it reads one calendar month, so the two invite a comparison that is wrong by however old the organization is. Each figure names its own window, and this work closes #198 |
 | 6 | `failed` and `budget_exceeded` look alike | **Already shipped** — different tone and the label "stopped by budget" (`components/agents/status-badge.tsx:41`). No work |
 
 ## 4. Who sees this page — all seven identities, answered from `ROLE_PERMS`
@@ -188,8 +249,10 @@ the two pages read as one product:
   `exposure_id`, not surface: surface says *slack*, the channel says *which* Slack
   workspace, and an org with three bots needs the second. Environment is
   `environment_id`, so staging noise can be kept out of what a steward reads — staging
-  rows also wear a pill in the table. All three came out of #149's review, which fixed
-  the dimension vocabulary with this page in the room. An active filter tints its
+  rows also wear a pill in the table. It narrows the top-level list safely; where it must
+  **not** be applied is any query that deliberately includes delegations, because a
+  delegated run carries no environment at all (§2a). All three came out of #149's review,
+  which fixed the dimension vocabulary with this page in the room. An active filter tints its
   button; a **Clear filters** link appears only when something is narrowed. The bar
   renders inside the Run history card in every state — an empty result whose way out
   (Clear) has vanished is a dead end.
@@ -207,6 +270,11 @@ the two pages read as one product:
   screen, which is what "did v4 actually behave better than v3" needs to be
   answerable rather than arguable. Fed by #37's `group_by=version` (§5's one
   exception); absent until an agent is picked, so the default page stays a rows page.
+  **Two things it has to settle about delegation** (§2a): it counts a delegate's own
+  rows — otherwise an agent used only as a delegate has no strip at all — which means it
+  cannot carry the environment filter, and its **cost per run** must exclude delegated
+  rows or it counts a delegation twice, once inside the parent it was charged to. The
+  caption says which, the way #200's Runs figure does.
 - **Approvals** — a **Triggered by** filter and a sort (oldest ↔ newest). Oldest first
   stays the default, because the queue drains from the top. `GET /approvals` today has
   only `skip`/`limit` and a fixed oldest-first order — the filter and the sort are
@@ -232,6 +300,14 @@ the two pages read as one product:
   `agent_runs.cost_is_partial` (stored per run today, not yet returned as a count —
   priced in §7). A spend page that renders floors as facts is the `title=`-attribute
   bug from §3 again, one level up.
+- **By provider and By key are blocked on #170, and this tab is where it shows.** Both
+  cards are `spend_by_provider` and `spend_by_key` verbatim, and neither carries the
+  `parent_run_id IS NULL` filter that `sum_cost_since` has — so on any deployment using
+  delegation they render inflated vendor and key totals *next to* a correctly computed
+  month-to-date, and the page fails to reconcile against itself. A breakdown totalling
+  more than the total above it is exactly the failure that default exists to prevent, so
+  this tab either waits for #170 or says on screen that the two cards over-count a
+  delegation. Not silently.
 - **"By agent" is a tile per agent, telling two truths apart.** Each tile leads with
   what the agent spent in the selected range (with the floor marker when a cost is
   partial), and underneath it a cap meter — the agent against its own
@@ -241,7 +317,12 @@ the two pages read as one product:
   card's footer names both. This is the per-agent *cause* under the org-level figure
   the month KPI shows — the dashboard's headroom card features the top agents; the
   full set lives here, where the steward investigating spend already is. Priced
-  in §7.
+  in §7. **This tile is the one place that counts delegated rows on purpose** —
+  `cost_breakdown` includes them because a delegate's rows are the only record of its own
+  spend, and "the researcher cost $40 this month" is unanswerable without them. Which is
+  also why the tile cannot carry the environment filter (§2a), and why its total is
+  deliberately not the same question as the org figure above it: the footer already names
+  two windows and now names two scopes.
 - The three **figures** stay above the tabs and follow no tab's filters; each names its
   own window in its caption (calendar month · the runs period · right now) and is a
   door — clicking a figure opens its tab. The month figure also carries the **budget**
@@ -299,19 +380,27 @@ organization, and the sidebar switcher owns that.
 
 ## 7. Backend work this implies, so the estimate is honest
 
+**Four rows below shrank when #200 landed its branch** — the run detail view, the `total`
+fix, the component split and the delegate on `ApprovalRead` (§2a). They are marked rather
+than deleted, so the estimate reads as a corrected one instead of a smaller claim.
+
 | Change | Cost |
 |---|---|
 | `messages.run_id` — column, FK, write path on every surface | Alembic migration + `agent_runner` and the chat write path |
-| `list_runs` — `status` (a **list**: `failed,budget_exceeded` is also #37's Recent-failures query), `surface`, `user_id`, `started_from`, `started_to`, `environment_id`, `exposure_id`, `agent_version_id` | Repository + route + `AgentRunList` unchanged; every column already on the run row |
+| `list_runs` — `status` (a **list**: `failed,budget_exceeded` is also #37's Recent-failures query), `surface`, `user_id`, `started_from`, `started_to`, `environment_id`, `exposure_id`, `agent_version_id` | Repository + route + `AgentRunList` unchanged; every column already on the run row. Composes with #200's `parent_run_id` / `include_delegations`, which already default the list to top-level |
+| The run detail view, `?run=` and the delegation tree | **Already built** — #200's `FocusedRun`, `useRun`, `useDelegatedRuns`. What is left is the transcript inside it, off `messages.run_id` |
+| The "Runs" figure as `total`, top-level only | **Already built** — #200. What is left is #198: the window it counts (§3 item 5) |
+| `ApprovalRead` — the delegate that asked | **Already built** — #200's `subagent_name` / `subagent_agent_id` and `ApprovalDelegate`. **Do not rebuild the approval card without it** |
 | Surface recording widening — `RunSurface.EMBED` stamped by `embed_session.py`, `mattermost` added to `_SURFACES` in `channels/mentions.py` | Two small service changes. Shared with #37's stage 2 — whichever branch lands first ships it, the other inherits |
 | `ApprovalRead` — agent name, triggering user | Schema + approval service join. No migration |
 | `/approvals` — `user_id` filter, `sort` (oldest/newest; oldest stays the default) | Repository + route. No migration |
 | `/approvals` — the decided view: a `status` param (today the route serves `list_pending` only), and the decider's **name** (`ApprovalRead` already carries `decided_by_user_id` and `decided_at` — a bare UUID, the same class of gap as the missing agent name) | Repository + route; the name rides the same `ApprovalRead` join as the row above. No migration |
-| Version strip — per-version runs, success, p50, cost under an agent filter | Nothing new here — the second consumer of #37's `/stats/usage?group_by=version` |
+| Version strip — per-version runs, success, p50, cost under an agent filter | Nothing new here — the second consumer of #37's `/stats/usage?group_by=version`. It does need `/stats/usage` to expose the `include_delegations` choice §2a describes, or a delegate-only agent has no strip |
 | `/spend` — accept `from`/`to` alongside `days`, so the range control is honest | Route + `agent_runner` cost queries |
 | `/spend` — a partial-cost run count, so "every total below is a floor" has a number | Aggregate `cost_is_partial` in the existing cost query. No migration |
 | `CostByAgent` — agent **name** alongside `agent_id`, **one row per agent** (today `cost_breakdown` splits an agent across its models), plus the agent's **monthly cap** and **month-to-date** so the cap column is honest | Schema + join + grouping; cap from the spec's `budget.monthly_usd`, MTD from the query `/spend` already runs. No migration |
-| `AgentRunRead` | Nothing new needed |
+| `AgentRunRead` | Nothing new needed — and #200 adds `parent_run_id` and `subagent_task_id` to it, which is what lets the table and the detail view tell the two kinds of row apart |
+| `spend_by_provider` / `spend_by_key` — the `parent_run_id IS NULL` filter they lack | **Not this plan's work: #170.** But the By provider and By key cards are those two queries, so this tab over-counts a delegation until it lands (§6) |
 | Budget context on the month figure | Nothing new — `organizations.monthly_budget_usd` is already on `GET /orgs/{org_id}` |
 | "All organizations" mode (§6a) — `organization_id`-optional `/runs`, `/approvals`, `/spend`, refused for anyone but an app admin | Route + repository on all three; the one honestly droppable line here |
 
@@ -321,9 +410,10 @@ Everything else is frontend.
 
 - **`AgentRunRead.logfire_trace_id` is documented as *"Deep-link into the full trace"* and
   is always `null`** (`app/schemas/agent_run.py:29`). The public API promises something it
-  never delivers. Independent of this page. Removal is the likely fix: the only candidate
-  consumer, #52, independently rejected the same Logfire assumption and plans to work from
-  stored rows — so nothing waits on this field being written.
+  never delivers. Independent of this page. **Filed as #206** — and the disposition there
+  is *wire it*, not remove it: the deep link was reinstated at sign-off, which makes this
+  the first of three pieces rather than a deletion. §1's four findings still hold and are
+  the reason that issue is priced the way it is.
 
 A second find — "Spend by agent" listing model labels because `CostByAgent` carries no
 name (`runs/page.tsx:285`) — started here, but the mockup shows it fixed and the change
@@ -338,6 +428,13 @@ is one join, so it moved into scope: §7 prices it.
 - the new `list_runs` filters proven against a real database: a staging run absent when
   `environment_id` narrows to production, a `status` list returning both `failed` and
   `budget_exceeded` rows, a version filter returning only the rows that executed it
+- **delegation, against a real database** (§2a): the top-level list excludes a delegated
+  run while the run it came from is present; a run that delegated shows its delegations in
+  the detail view and a delegated run links back to its parent; the version strip of an
+  agent used *only* as a delegate is not empty, and its cost-per-run does not count a
+  delegation twice; and no environment-narrowed query silently loses a delegated row
+- the approvals queue names the delegate — `ApprovalDelegate` still renders and its
+  integration test still passes after the tab is rebuilt as three components
 - the decided view proven: a decided approval renders its decider and is refused a
   second decision; the pending queue and the decided list never share a row
 - the three tabs land as separate components — the 342-line page is already over the


### PR DESCRIPTION
## Summary

Reconciles the Activity design with #200, so that stage 2 does not start against a document describing a run history that holds one kind of row. **This targets `feat/activity-page`, not `main`** — it is your design, so it comes as a pull request you review rather than commits pushed onto your branch. Close it if you disagree with a call; the reasoning is in the commit body.

I did this rather than asking you to, for one reason: the reconciliation needs #200's diff read in full, and I had just read it doing the review. That is a few hours of your week spent deriving something already derived, and it was the item blocking everything else.

## Why it was needed

A delegation now writes its own `agent_runs` row (`parent_run_id`, `subagent_task_id`), and **a parent's `cost_usd` already contains its children's** — which is why `sum_cost_since` counts only `parent_run_id IS NULL`, and why summing a page of rows bills an organization twice for one request. The plan and mockup were written while that branch was open.

**Four items §7 prices as new work are already built there**, and saying so is most of the value in this change:

| §7 said | #200 |
|---|---|
| The run detail view is the central new deliverable | Built: `?run=` plus `FocusedRun`, both directions |
| Fix the Runs figure from `runs.length` to `total` | Done, top-level only, captioned |
| The tabs land as separate components | `RunTable` extracted |
| `ApprovalRead` carries no delegate | `subagent_name` / `subagent_agent_id`, rendered by `ApprovalDelegate` with its own test |

They are marked rather than deleted, so §7 reads as a corrected estimate instead of a smaller claim.

## What the design now decides, because #200 does not

- **The list is top-level only.** The table says so once, rather than leaving a reader to wonder where a fan-out went.
- **A delegated run carries no environment.** `record_delegated_run` leaves `environment_id` NULL on purpose — a delegate's version comes from a pin. I stated this too broadly in my review comment ("the Environment filter drops every delegation"): the top-level list is fine, because delegated rows are not in it. Where it actually bites is the two views that include delegations deliberately — the version strip when the selected agent is one others delegate to, and the per-agent spend tile. The plan says it that way.
- **The version strip has to pick a side of `include_delegations` and say which.** It counts a delegate's own rows, or an agent used only as a delegate has no strip at all; its cost per run must exclude them, or a delegation is counted twice.
- **#170 is recorded where it lands.** By provider and By key are `spend_by_provider` and `spend_by_key` verbatim, and neither has that filter — so the Spend tab over-counts a delegation next to a correctly computed month-to-date. It waits for #170 or says so on screen.

## Mockup

The delegation paths are drawn so they can be reviewed rather than imagined:

- The **approval card names the delegate** — linked when it is a published agent, said out loud as an inline specialist when it has no row in `agents`. This is the one that mattered most: building the tab to the previous mockup would have deleted `ApprovalDelegate` and its integration test.
- A run that delegated **lists its delegations under its own steps**, each opening its own detail with a way back to the run its cost was charged to.
- The table carries a **`+n delegated`** marker, so the count and the month figure visibly agree for a reason.

Try it from this branch: `activity-mockup.html#identity=operator&tab=runs` and open a row with the marker.

## Verified

Exercised the generator and every render path headlessly (a throwaway script, not committed): 22% of generated runs delegate, the parent detail renders a clickable delegation block, the child renders its up-link and its "already inside the parent" cost, the approval card names both a linked delegate and an inline specialist, and a run with no delegations renders no block. `node --check` on the extracted script.

**Not run:** `make docs-build`. Both files are already orphan pages on the branch this was cut from, so the build behaviour is unchanged — but that is reasoning, not a green run.

## One thing your branch needs regardless of this PR

`make lint-spelling` landed on `main` **after** the merge commit this branch carries, and codespell reads the calendar's old three-letter day-of-week local as a misspelling. **The `lint` job will go red the moment you catch up with `main`.** Renamed here to `weekdays`; if you rebase instead of taking this PR, do that rename yourself.

## Deliberately not in this change

The three decisions reversed at sign-off — the Logfire deep link, a per-person breakdown, a user-arranged dashboard. §8 gains only a pointer to #206 so the document stops contradicting the issue. Those are decisions and this is a reconciliation; mixing them would make both harder to review. They are listed in the sign-off comment on #202 and in the stage-2 checklist in #45.

Part-of #45 · Refs #200, #198, #170, #206
