### PR TITLE
test(e2e): wait for the write, not for the row a dialog hides

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -67,7 +67,10 @@ Traps, each of which has cost a red job here:
   it before touching product code. Creating a row through a dialog goes through
   `submitDialog`, never `click(submit)` then `expect(row).toBeVisible()`: an open Radix
   dialog takes the page out of the accessibility tree, so that shape reports
-  `element(s) not found` for a refusal it never looked at (#132).
+  `element(s) not found` for a refusal it never looked at (#132). And a **fixture** step
+  asserts through the API, never on the row appearing - the refetch after a write is
+  sometimes answered with the pre-write list (#230), which is a product bug and must not
+  be reported as a broken fixture.
 - **Coverage instrumentation slows tests enough to trip a 5s `testTimeout`.** A
   heavy spec that passes under `test:run` can time out under `test:coverage`; re-run
   before believing it.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -61,6 +61,13 @@ Traps, each of which has cost a red job here:
 - **A red `e2e` may not be yours.** `sharing.spec.ts` and `skills.spec.ts` flake
   (#154) - check `gh run list --branch <branch>` for the same spec passing a run later
   before changing anything.
+- **A red `e2e` in `[setup]` or `[seed]` ran no product spec at all.** They are project
+  dependencies, so Playwright skips what depends on them and the log reads "1 failed,
+  7 passed, 17 did not run". `e2e/fixture-reporter.ts` prints a banner saying so - read
+  it before touching product code. Creating a row through a dialog goes through
+  `submitDialog`, never `click(submit)` then `expect(row).toBeVisible()`: an open Radix
+  dialog takes the page out of the accessibility tree, so that shape reports
+  `element(s) not found` for a refusal it never looked at (#132).
 - **Coverage instrumentation slows tests enough to trip a 5s `testTimeout`.** A
   heavy spec that passes under `test:run` can time out under `test:coverage`; re-run
   before believing it.

--- a/.claude/skills/e2e-tests/SKILL.md
+++ b/.claude/skills/e2e-tests/SKILL.md
@@ -39,6 +39,39 @@ product working, and several specs exist to prove exactly that. `/api/rag/*` is 
 Always import `test` and `expect` from `./fixtures`, never from `@playwright/test`
 directly, or the spec loses the net.
 
+## Never assert a new row straight after a submit
+
+> **Creating something through a dialog goes through `submitDialog` (`e2e/helpers.ts`).**
+
+`click(submit)` followed by `expect(theNewRow).toBeVisible()` sat at five sites, flaked
+at four of them, and cost three separate diagnoses in one day (#132) — every time with
+the same message, `element(s) not found`, sixteen seconds later.
+
+That message is the trap. **An open Radix dialog takes the rest of the page out of the
+accessibility tree**: while one is on screen `getByRole("main")`, `getByRole("row")`
+and `skillCard()` resolve to *nothing at all*. So the assertion could only ever report
+the absence of the page, and a create refused with a 409 looked identical to a list that
+had not refetched. Measured: `main` counts 1, then 0 while the dialog is open, then 1
+again — in the same sample that first sees the row.
+
+`submitDialog` waits on the two things that are signals rather than hopes: the write's
+own response, whose status and body *are* the diagnosis, and then the dialog closing —
+which is the app saying the list has already been refetched, because each of these
+mutations awaits `invalidateQueries` inside `onSuccess` before `mutateAsync` resolves.
+A longer `expect` timeout is not an alternative; it makes a race slower to fail.
+
+The list's `GET` is deliberately not a third wait: `useKnowledgeBases` writes its new
+row straight into the query cache and never makes one.
+
+## A failing `[seed]` step runs no product spec at all
+
+`setup` and `seed` are project dependencies. When a step in one fails, Playwright does
+not run what depends on it, and the log reads `1 failed`, `7 passed`, `17 did not run` —
+which on a pull request looks like a product regression. `e2e/fixture-reporter.ts` prints
+a banner saying otherwise, and a GitHub error annotation under CI. **Read it before
+touching product code**, and treat a green re-run as evidence about the fixture rather
+than about the branch.
+
 ## Prove a new spec can fail
 
 Point `BACKEND_URL` at a dead port and watch it go red **before you trust it**. A spec

--- a/.claude/skills/e2e-tests/SKILL.md
+++ b/.claude/skills/e2e-tests/SKILL.md
@@ -43,9 +43,9 @@ directly, or the spec loses the net.
 
 > **Creating something through a dialog goes through `submitDialog` (`e2e/helpers.ts`).**
 
-`click(submit)` followed by `expect(theNewRow).toBeVisible()` sat at five sites, flaked
-at four of them, and cost three separate diagnoses in one day (#132) — every time with
-the same message, `element(s) not found`, sixteen seconds later.
+`click(submit)` followed by `expect(theNewRow).toBeVisible()` sat at six sites, was seen
+to flake at four of them, and cost three separate diagnoses in one day (#132) — every
+time with the same message, `element(s) not found`, sixteen seconds later.
 
 That message is the trap. **An open Radix dialog takes the rest of the page out of the
 accessibility tree**: while one is on screen `getByRole("main")`, `getByRole("row")`
@@ -54,14 +54,28 @@ the absence of the page, and a create refused with a 409 looked identical to a l
 had not refetched. Measured: `main` counts 1, then 0 while the dialog is open, then 1
 again — in the same sample that first sees the row.
 
-`submitDialog` waits on the two things that are signals rather than hopes: the write's
-own response, whose status and body *are* the diagnosis, and then the dialog closing —
-which is the app saying the list has already been refetched, because each of these
-mutations awaits `invalidateQueries` inside `onSuccess` before `mutateAsync` resolves.
-A longer `expect` timeout is not an alternative; it makes a race slower to fail.
+`submitDialog` waits on two signals rather than hopes: the write's own response, whose
+status and body *are* the diagnosis, and then the dialog closing — the app saying it has
+finished everything it does around the write. A longer `expect` timeout is not an
+alternative to either; it makes a race slower to fail.
 
-The list's `GET` is deliberately not a third wait: `useKnowledgeBases` writes its new
-row straight into the query cache and never makes one.
+It does **not** promise the row is rendered, and that is not a shortcut — the list's
+refetch is sometimes answered with the pre-write list even though the row is committed
+and both server layers return it (**#230**, about one run in eight). Two consequences:
+
+- **A fixture step asks the API.** Every step of `seed.setup.ts` asserts through
+  `/api/…` now, because its job is that the fixture exists. Whether it renders is a
+  product claim, and `vault.spec.ts` / `skills.spec.ts` make it against the rows the
+  seed left, on pages they loaded themselves.
+- **A product spec about the rendering reloads first**, marked `#230`, until that
+  issue closes.
+
+The list's `GET` is deliberately not a third wait: `useKnowledgeBases` never makes one,
+and where one is made, #230 is about the answer being wrong rather than late.
+
+It also ignores a 401 on the write's path. `apiClient.send` refreshes an expired access
+token and re-issues the same request, so the app acts on the retry — stopping at the
+first response would fail a write that succeeded.
 
 ## A failing `[seed]` step runs no product spec at all
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -130,6 +130,38 @@ could put that token in the reply — and returns usage, so the run is priced an
 the journey's last assertion has a cost to find. It authenticates nothing and
 calls no tools; what it does not prove is that a real provider answers.
 
+### A red `e2e` is often the fixture, not the product
+
+`setup` and `seed` are Playwright *project dependencies*, so a failure in either
+one stops the projects that depend on it from running at all. The summary then
+reads `1 failed`, `7 passed` and `17 did not run`, which on a pull request looks
+exactly like a broken feature — and is not: **no product spec ran.** Three
+branches each paid a diagnosis for that in one day
+([#132](https://github.com/vstorm-co/agenticos/issues/132)), so
+`frontend/e2e/fixture-reporter.ts` now prints a banner saying so, and under CI a
+GitHub error annotation that shows on the checks page without opening a log.
+
+### Waiting for a row is not waiting for the write
+
+A spec that creates something through a dialog **must not** click submit and then
+assert the new row is on screen. Two reasons, and the second is the expensive one:
+
+- The window between the mutation resolving and the list rendering is real, and a
+  longer `expect` timeout only makes a race slower to fail.
+- **An open Radix dialog takes the rest of the page out of the accessibility
+  tree.** While one is on screen, `getByRole("main")`, `getByRole("row")` and
+  every locator built on them resolve to *nothing*, so the assertion times out
+  with `element(s) not found` whether or not the row exists — naming the one
+  thing that cannot be the cause. A refused create looked identical to a slow
+  refetch for four separate occurrences.
+
+`submitDialog` in `frontend/e2e/helpers.ts` is the way through: it waits for the
+write's own response and asserts its status (so a refusal reads
+`409 … already exists`, in milliseconds), then waits for the dialog to close —
+which is the app's own statement that the list behind it has been refetched,
+since every one of these mutations awaits its invalidation inside `onSuccess`
+before `mutateAsync` resolves.
+
 ## Test Database
 
 Most tests don't hit a real database. The `client` fixture in `tests/conftest.py` overrides

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -144,7 +144,8 @@ GitHub error annotation that shows on the checks page without opening a log.
 ### Waiting for a row is not waiting for the write
 
 A spec that creates something through a dialog **must not** click submit and then
-assert the new row is on screen. Two reasons, and the second is the expensive one:
+assert the new row is on screen. That shape sat at six sites and was seen to flake
+at four. Two reasons, and the second is the expensive one:
 
 - The window between the mutation resolving and the list rendering is real, and a
   longer `expect` timeout only makes a race slower to fail.
@@ -158,9 +159,20 @@ assert the new row is on screen. Two reasons, and the second is the expensive on
 `submitDialog` in `frontend/e2e/helpers.ts` is the way through: it waits for the
 write's own response and asserts its status (so a refusal reads
 `409 … already exists`, in milliseconds), then waits for the dialog to close —
-which is the app's own statement that the list behind it has been refetched,
-since every one of these mutations awaits its invalidation inside `onSuccess`
-before `mutateAsync` resolves.
+which is the app saying it has finished everything it does around the write.
+
+What it deliberately does not promise is that the row is now rendered, because
+that is not currently true: the list's refetch is sometimes answered with the
+pre-write list even though the row is committed and both server layers return it
+([#230](https://github.com/vstorm-co/agenticos/issues/230), about one run in
+eight). So:
+
+- **A fixture step asks the API.** Every step of `seed.setup.ts` asserts through
+  `/api/…`, because its job is that the fixture exists — and a fixture step that
+  fails takes every product spec with it.
+- **A product spec that is about the rendering says so**, and reloads first if it
+  needs a list it can trust. `vault.spec.ts` has three `page.reload()` calls
+  marked `#230`; when that issue closes, they come out.
 
 ## Test Database
 

--- a/frontend/e2e/fixture-reporter.ts
+++ b/frontend/e2e/fixture-reporter.ts
@@ -48,7 +48,24 @@ export default class FixtureReporter implements Reporter {
   onEnd(): void {
     if (this.failures.length === 0) return;
 
+    // At least this many: a test dropped by `maxFailures` or by a failed serial
+    // suite does report a `skipped` result, so this undercounts in those runs
+    // rather than overcounting. Zero is the ordinary answer to
+    // `--project=seed`, where there was never anything behind the fixture to skip.
     const neverRan = this.planned - this.reported.size;
+    const consequence =
+      neverRan === 0
+        ? [
+            "  Nothing was waiting on it in this run, so nothing was skipped — but the",
+            "  same failure in a full run takes every product spec with it.",
+          ]
+        : [
+            `  ${neverRan} spec${neverRan === 1 ? "" : "s"} never ran: they depend on the project above, so`,
+            "  Playwright skipped them. Nothing here says a feature is broken. Read the",
+            "  failure above, and treat a green re-run as evidence about the fixture",
+            "  rather than about the branch.",
+          ];
+
     const rule = "─".repeat(78);
     const lines = [
       "",
@@ -57,10 +74,7 @@ export default class FixtureReporter implements Reporter {
       "",
       ...this.failures.map((failure) => `    ${failure}`),
       "",
-      `  ${neverRan} spec${neverRan === 1 ? "" : "s"} never ran: they depend on the project above, so`,
-      "  Playwright skipped them. Nothing here says a feature is broken. Read the",
-      "  failure above, and treat a green re-run as evidence about the fixture",
-      "  rather than about the branch.",
+      ...consequence,
       rule,
       "",
     ];
@@ -70,7 +84,7 @@ export default class FixtureReporter implements Reporter {
       // A workflow command has to be one line, so the newlines are escaped the
       // way GitHub wants them. This is what puts the sentence on the checks page.
       const body = [
-        `${neverRan} spec(s) never ran — the failure is in a fixture project, not in a product spec.`,
+        `${neverRan} spec(s) never ran - the failure is in a fixture project, not in a product spec.`,
         ...this.failures,
       ].join("%0A");
       process.stdout.write(`::error title=E2E fixture failed, no product spec ran::${body}\n`);

--- a/frontend/e2e/fixture-reporter.ts
+++ b/frontend/e2e/fixture-reporter.ts
@@ -1,0 +1,79 @@
+import type { FullConfig, Reporter, Suite, TestCase, TestResult } from "@playwright/test/reporter";
+
+/**
+ * Say out loud when a red run was a precondition rather than a regression.
+ *
+ * `setup` and `seed` are project *dependencies*, so when a step in one of them
+ * fails Playwright does not run the projects that depend on it. What the log
+ * then says is `1 failed`, `7 passed`, and — in one unlabelled line somewhere
+ * above the failure — `17 did not run`. On a pull request that arrives as a red
+ * `e2e` job, which reads exactly like a broken feature. It is not: **no product
+ * spec ran at all.**
+ *
+ * That cost three separate diagnoses on three different branches in one day
+ * (#132), and the reason each of them cost anything is that the summary said
+ * nothing about which half of the suite the failure was in. So this adds the one
+ * sentence the reader needs, after everything else has printed, and — under CI —
+ * as a GitHub error annotation, which shows on the checks page without anybody
+ * opening a log.
+ *
+ * It reports; it never changes the outcome. A failed fixture already fails the
+ * run.
+ */
+export default class FixtureReporter implements Reporter {
+  /** The names of the setup/seed steps that failed, in the order they failed. */
+  private readonly failures: string[] = [];
+  /** Test ids that reported a result — with retries, a test may report twice. */
+  private readonly reported = new Set<string>();
+  /** Every test the run intended to execute, after `--grep` and friends. */
+  private planned = 0;
+
+  onBegin(_config: FullConfig, suite: Suite): void {
+    this.planned = suite.allTests().length;
+  }
+
+  onTestEnd(test: TestCase, result: TestResult): void {
+    this.reported.add(test.id);
+    if (result.status !== "failed" && result.status !== "timedOut") return;
+
+    // The project, not the file: which file a fixture lives in is a detail, but
+    // "this was a dependency" is the whole point of the message below.
+    const project = test.parent.project()?.name;
+    if (project !== "setup" && project !== "seed") return;
+
+    const file = test.location.file.split("/").pop();
+    this.failures.push(`[${project}] ${file}:${test.location.line} › ${test.title}`);
+  }
+
+  onEnd(): void {
+    if (this.failures.length === 0) return;
+
+    const neverRan = this.planned - this.reported.size;
+    const rule = "─".repeat(78);
+    const lines = [
+      "",
+      rule,
+      "  A FIXTURE FAILED, SO THE SUITE DID NOT TEST THE PRODUCT.",
+      "",
+      ...this.failures.map((failure) => `    ${failure}`),
+      "",
+      `  ${neverRan} spec${neverRan === 1 ? "" : "s"} never ran: they depend on the project above, so`,
+      "  Playwright skipped them. Nothing here says a feature is broken. Read the",
+      "  failure above, and treat a green re-run as evidence about the fixture",
+      "  rather than about the branch.",
+      rule,
+      "",
+    ];
+    process.stdout.write(`${lines.join("\n")}\n`);
+
+    if (process.env.CI) {
+      // A workflow command has to be one line, so the newlines are escaped the
+      // way GitHub wants them. This is what puts the sentence on the checks page.
+      const body = [
+        `${neverRan} spec(s) never ran — the failure is in a fixture project, not in a product spec.`,
+        ...this.failures,
+      ].join("%0A");
+      process.stdout.write(`::error title=E2E fixture failed, no product spec ran::${body}\n`);
+    }
+  }
+}

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -137,6 +137,84 @@ export function pageHeading(page: Page, name?: string | RegExp): Locator {
 }
 
 /**
+ * Submit a dialog, and do not return until the page has acted on what it wrote.
+ *
+ * This replaces `click(submit)` followed straight away by
+ * `expect(theNewRow).toBeVisible()`. That shape sat at five sites, flaked at
+ * four of them, and cost three separate diagnoses (#132) — always with the same
+ * useless message, `element(s) not found`, sixteen seconds later.
+ *
+ * The message is why it cost three. **An open Radix dialog takes the rest of the
+ * page out of the accessibility tree**: while one is on screen,
+ * `page.getByRole("main")`, `getByRole("row")` and `skillCard()` resolve to
+ * *nothing at all*, whether or not the row they are looking for exists. So the
+ * assertion that timed out could only ever have reported the absence of the
+ * page, and it named the one thing that was certainly not the cause. Proved with
+ * a probe: `main` counts 1 before the dialog opens, 0 while it is open, and 1
+ * again 87ms later — in the same sample that first sees the new row.
+ *
+ * Two things are waited on, and both are signals rather than hopes:
+ *
+ * 1. **The write's own response.** Its status and body are the diagnosis the old
+ *    shape never printed. A refused create now reads `409 … name already in
+ *    use`; a submit that never reached the network reads as a missing response
+ *    rather than as a missing row.
+ * 2. **The dialog closing.** Every dialog on these surfaces closes only once its
+ *    `mutateAsync` has resolved, and each mutation's `onSuccess` *awaits* the
+ *    invalidation before resolving — so a hidden dialog is the app's own
+ *    statement that the list behind it has already been refetched. That is
+ *    exactly the window the old assertion raced, and this closes it without a
+ *    longer timeout. A longer timeout would only make the race slower to fail.
+ *
+ * The list's own `GET` is deliberately not waited on as a third step. Two of the
+ * five callers never make one — `useKnowledgeBases` writes the new row straight
+ * into the query cache — and at the other three it cannot outlive the dialog,
+ * per (2). Waiting on a request that does not exist would hang the two.
+ */
+export async function submitDialog(
+  page: Page,
+  {
+    dialog,
+    submit,
+    path,
+    method = "POST",
+  }: {
+    /** The dialog being submitted. Its closing is the signal, so it is waited on. */
+    dialog: Locator;
+    /** The button that submits it, as a locator — each caller keeps its own match. */
+    submit: Locator;
+    /** Where the write goes, as a path prefix: `/api/secrets` also matches a PATCH to one. */
+    path: string;
+    method?: "POST" | "PATCH";
+  },
+): Promise<void> {
+  // Registered before the click, not after: a fast answer can arrive before
+  // `click()` has returned, and a listener attached afterwards would then sit
+  // waiting for a second write that nobody is going to make.
+  const answered = page.waitForResponse(
+    (response) =>
+      new URL(response.url()).pathname.startsWith(path) && response.request().method() === method,
+    // Matched to `expect.timeout` rather than left at Playwright's 30s. A submit
+    // that never reached the network should be reported no slower than the
+    // assertion this replaces reported nothing at all.
+    { timeout: 15_000 },
+  );
+
+  await submit.click();
+
+  const response = await answered;
+  expect(
+    response.ok(),
+    `${method} ${new URL(response.url()).pathname} answered ${response.status()}: ${await response.text()}`,
+  ).toBe(true);
+
+  await expect(
+    dialog,
+    "the write was accepted but the dialog stayed open, so the page never finished acting on it",
+  ).toBeHidden();
+}
+
+/**
  * Fail if a provider secret is reachable anywhere in the current page.
  *
  * The platform's promise is that a stored key can never be read back — not by

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -140,9 +140,9 @@ export function pageHeading(page: Page, name?: string | RegExp): Locator {
  * Submit a dialog, and do not return until the page has acted on what it wrote.
  *
  * This replaces `click(submit)` followed straight away by
- * `expect(theNewRow).toBeVisible()`. That shape sat at five sites, flaked at
- * four of them, and cost three separate diagnoses (#132) — always with the same
- * useless message, `element(s) not found`, sixteen seconds later.
+ * `expect(theNewRow).toBeVisible()`. That shape sat at six sites, was seen to
+ * flake at four of them, and cost three separate diagnoses (#132) — always with
+ * the same useless message, `element(s) not found`, sixteen seconds later.
  *
  * The message is why it cost three. **An open Radix dialog takes the rest of the
  * page out of the accessibility tree**: while one is on screen,
@@ -159,17 +159,29 @@ export function pageHeading(page: Page, name?: string | RegExp): Locator {
  *    shape never printed. A refused create now reads `409 … name already in
  *    use`; a submit that never reached the network reads as a missing response
  *    rather than as a missing row.
- * 2. **The dialog closing.** Every dialog on these surfaces closes only once its
- *    `mutateAsync` has resolved, and each mutation's `onSuccess` *awaits* the
- *    invalidation before resolving — so a hidden dialog is the app's own
- *    statement that the list behind it has already been refetched. That is
- *    exactly the window the old assertion raced, and this closes it without a
- *    longer timeout. A longer timeout would only make the race slower to fail.
+ * 2. **The dialog closing.** Every one of these dialogs closes only after the app
+ *    has finished the work it does around the write: five of the six write
+ *    through a `useMutation` whose `onSuccess` *awaits* `invalidateQueries`, and
+ *    TanStack resolves `mutateAsync` only once that callback has returned; the
+ *    knowledge base is the exception, where `useKnowledgeBases.createKB` writes
+ *    the row into the cache with `setQueryData` and the dialog closes after that.
+ *    Either way an open dialog means the app is not done, and waiting for it to
+ *    shut is what stops a spec asserting into the middle of a mutation.
  *
- * The list's own `GET` is deliberately not waited on as a third step. Two of the
- * five callers never make one — `useKnowledgeBases` writes the new row straight
- * into the query cache — and at the other three it cannot outlive the dialog,
- * per (2). Waiting on a request that does not exist would hang the two.
+ * **What this does not promise, and cannot:** that the row is now on the page.
+ * The list's refetch can be answered with the pre-write list even though the row
+ * is committed and both server layers return it — about once in eight runs, and
+ * filed as #230. So a closed dialog is the app saying it is finished, not proof
+ * that it finished correctly, and a caller that needs the row rendered must
+ * either be a spec whose subject *is* that rendering (and take #230's flake, or
+ * reload first, as `vault.spec.ts` does) or ask the API instead (as every step of
+ * `seed.setup.ts` now does, because a fixture step's job is that the fixture
+ * exists).
+ *
+ * The list's own `GET` is deliberately not waited on as a third step. The
+ * knowledge base never makes one, so a caller waiting for it would hang — and
+ * where one is made, waiting for it buys nothing the dialog does not already
+ * give, since #230 is about the answer being wrong rather than late.
  */
 export async function submitDialog(
   page: Page,
@@ -193,7 +205,16 @@ export async function submitDialog(
   // waiting for a second write that nobody is going to make.
   const answered = page.waitForResponse(
     (response) =>
-      new URL(response.url()).pathname.startsWith(path) && response.request().method() === method,
+      new URL(response.url()).pathname.startsWith(path) &&
+      response.request().method() === method &&
+      // A 401 on this path is not the answer. `apiClient.send` recovers from an
+      // expired access token by refreshing and re-issuing the same write, so the
+      // app acts on the *retry* — and a helper that stopped at the first response
+      // would fail a write that succeeded, which is precisely the class of flake
+      // this exists to remove. A refresh that itself fails makes no second write,
+      // so that arrives as a missing response and the `/api/auth/refresh` line in
+      // the trace is what names it.
+      response.status() !== 401,
     // Matched to `expect.timeout` rather than left at Playwright's 30s. A submit
     // that never reached the network should be reported no slower than the
     // assertion this replaces reported nothing at all.
@@ -203,10 +224,15 @@ export async function submitDialog(
   await submit.click();
 
   const response = await answered;
-  expect(
-    response.ok(),
-    `${method} ${new URL(response.url()).pathname} answered ${response.status()}: ${await response.text()}`,
-  ).toBe(true);
+  if (!response.ok()) {
+    // The body is read only here, and the guard is what makes that possible:
+    // `text()` throws outright on a redirect, so a message built eagerly would
+    // replace the diagnosis with a worse one than the shape this replaces had.
+    expect(
+      response.ok(),
+      `${method} ${new URL(response.url()).pathname} answered ${response.status()}: ${await response.text()}`,
+    ).toBe(true);
+  }
 
   await expect(
     dialog,

--- a/frontend/e2e/seed.setup.ts
+++ b/frontend/e2e/seed.setup.ts
@@ -25,7 +25,6 @@ import {
   SEEDED_SKILL_DESCRIPTION,
   SEEDED_SKILL_NAME,
   pageHeading,
-  skillCard,
   submitDialog,
 } from "./helpers";
 
@@ -49,6 +48,21 @@ import {
  * happen before they can be invited anywhere), and reading the invitation token
  * off the reply to sending it (it is emailed, the inviter's screen deliberately
  * never prints it, and a test has no inbox).
+ *
+ * **Every step asserts through the API, not by finding the new row on screen**,
+ * and that line is the whole of #132. A step whose job is "the fixture exists"
+ * used to prove it by waiting for the row to appear in a list — which fails when
+ * the list has not caught up, and a failure here skips every product spec behind
+ * it, so a browser-side staleness bug arrived on pull requests looking like a
+ * product regression. It reproduces locally about once in eight runs of this
+ * file, and is filed as #230: the write is accepted, the row is committed, both
+ * server layers answer a list containing it, and the page goes on rendering the
+ * one without it.
+ *
+ * Whether the row *renders* is a product claim and belongs to a product spec —
+ * `vault.spec.ts` and `skills.spec.ts` assert exactly that against the rows this
+ * file leaves behind, on a page they loaded themselves. The MCP step has said so
+ * in its own comment for a while; the rest of the file now agrees with it.
  */
 
 setup.use({ storageState: AUTH_STATE });
@@ -76,7 +90,7 @@ setup("a skill exists", async ({ page }) => {
     path: "/api/skills",
   });
 
-  await expect(skillCard(page, SEEDED_SKILL_NAME)).toBeVisible();
+  await nowThere(page, "/api/skills", "name", SEEDED_SKILL_NAME);
 });
 
 setup("a knowledge base exists", async ({ page }) => {
@@ -88,17 +102,19 @@ setup("a knowledge base exists", async ({ page }) => {
   await page.getByRole("button", { name: "New knowledge base" }).first().click();
   const dialog = page.getByRole("dialog");
   await dialog.getByLabel("Name").fill(SEEDED_KB_NAME);
-  // The fifth site of the same shape, and the only one that has not flaked yet
-  // — because `getByText` never consults the accessibility tree, so an open
-  // dialog does not hide the row from it. The refusal it cannot report is the
-  // same one, so it goes through the same helper.
+  // The one site of this shape that has never flaked — because `getByText` does
+  // not consult the accessibility tree, so an open dialog does not hide the row
+  // from it. The refusal it cannot report is the same one, so it goes through
+  // the same helper. It is also the only caller whose write is not a
+  // `useMutation`: `createKB` writes the row into the cache and returns, and the
+  // dialog closes after that.
   await submitDialog(page, {
     dialog,
     submit: dialog.getByRole("button", { name: "Create", exact: true }),
     path: "/api/kb",
   });
 
-  await expect(page.getByText(SEEDED_KB_NAME, { exact: true }).first()).toBeVisible();
+  await nowThere(page, "/api/kb", "name", SEEDED_KB_NAME);
 });
 
 setup("a draft agent exists", async ({ page }) => {
@@ -163,7 +179,7 @@ async function storeSecret(
     path: "/api/secrets",
   });
 
-  await expect(page.getByRole("main").getByText(name)).toBeVisible();
+  await nowThere(page, "/api/secrets", "name", name);
 }
 
 setup("a provider key is stored", async ({ page }) => {
@@ -222,11 +238,7 @@ setup("the organization has connected an MCP server", async ({ page }) => {
   // The probe behind "Connect & check" dials a host that answers 405, so the
   // connection is stored with an error status. That is the correct outcome for a
   // fixture; a red dot is not a failed seed.
-  await expect
-    .poll(() => alreadyThere(page.request, "/api/mcp-connections", "name", SEEDED_ORG_MCP_NAME), {
-      message: "the organization MCP connection was never stored",
-    })
-    .toBe(true);
+  await nowThere(page, "/api/mcp-connections", "name", SEEDED_ORG_MCP_NAME);
 });
 
 setup("a colleague is a member of the organization", async ({ page, browser }) => {
@@ -268,6 +280,26 @@ async function alreadyThere(
 ): Promise<boolean> {
   const list = await json<{ items: Record<string, unknown>[] }>(request, path);
   return list.items.some((item) => item[field] === value);
+}
+
+/**
+ * The fixture this step promised now exists — asked of the API.
+ *
+ * Every step used to prove this by waiting for the new row to appear in the list
+ * on screen, which is a claim about the page and not about the fixture. When the
+ * page's list has not caught up (#230) the step fails, and because this file is a
+ * project dependency the whole suite is reported red having run no product spec —
+ * three branches paid a diagnosis for that in one day (#132).
+ *
+ * Polled rather than asked once because it costs nothing to be kind about
+ * ordering, and it is the same shape the MCP step has used all along.
+ */
+async function nowThere(page: Page, path: string, field: string, value: string): Promise<void> {
+  await expect
+    .poll(() => alreadyThere(page.request, path, field, value), {
+      message: `the write was accepted, but ${path} still lists no ${field} of ${value}`,
+    })
+    .toBe(true);
 }
 
 /** A JSON GET that fails loudly, so a broken fixture reads as a broken fixture. */

--- a/frontend/e2e/seed.setup.ts
+++ b/frontend/e2e/seed.setup.ts
@@ -1,4 +1,11 @@
-import { test as setup, expect, type APIRequestContext, type Page } from "@playwright/test";
+import type { APIRequestContext, Page } from "@playwright/test";
+
+// `./fixtures`, not `@playwright/test` — so the seed gets the same net every
+// spec has: a step whose page took a 5xx from `/api/*` fails naming that,
+// instead of succeeding at the write and then timing out on a row the failed
+// request could not have rendered. The seed had no net at all, which is part of
+// why a failure here has never said why (#132).
+import { expect, test as setup } from "./fixtures";
 
 import {
   AUTH_STATE,
@@ -19,6 +26,7 @@ import {
   SEEDED_SKILL_NAME,
   pageHeading,
   skillCard,
+  submitDialog,
 } from "./helpers";
 
 /**
@@ -62,7 +70,11 @@ setup("a skill exists", async ({ page }) => {
   // textarea then takes its accessible name from the file it is showing.
   await dialog.getByRole("button", { name: "Source" }).click();
   await dialog.getByLabel(/SKILL\.md source/).fill(SEEDED_SKILL_CONTENT);
-  await dialog.getByRole("button", { name: "Create" }).click();
+  await submitDialog(page, {
+    dialog,
+    submit: dialog.getByRole("button", { name: "Create" }),
+    path: "/api/skills",
+  });
 
   await expect(skillCard(page, SEEDED_SKILL_NAME)).toBeVisible();
 });
@@ -76,7 +88,15 @@ setup("a knowledge base exists", async ({ page }) => {
   await page.getByRole("button", { name: "New knowledge base" }).first().click();
   const dialog = page.getByRole("dialog");
   await dialog.getByLabel("Name").fill(SEEDED_KB_NAME);
-  await dialog.getByRole("button", { name: "Create", exact: true }).click();
+  // The fifth site of the same shape, and the only one that has not flaked yet
+  // — because `getByText` never consults the accessibility tree, so an open
+  // dialog does not hide the row from it. The refusal it cannot report is the
+  // same one, so it goes through the same helper.
+  await submitDialog(page, {
+    dialog,
+    submit: dialog.getByRole("button", { name: "Create", exact: true }),
+    path: "/api/kb",
+  });
 
   await expect(page.getByText(SEEDED_KB_NAME, { exact: true }).first()).toBeVisible();
 });
@@ -90,7 +110,11 @@ setup("a draft agent exists", async ({ page }) => {
   await page.getByRole("button", { name: "New agent" }).click();
   const dialog = page.getByRole("dialog");
   await dialog.getByLabel("Name").fill(DRAFT_AGENT_NAME);
-  await dialog.getByRole("button", { name: "Create", exact: true }).click();
+  await submitDialog(page, {
+    dialog,
+    submit: dialog.getByRole("button", { name: "Create", exact: true }),
+    path: "/api/agents",
+  });
 
   // Creating navigates straight into the Builder for the new draft.
   await expect(pageHeading(page, new RegExp(DRAFT_AGENT_NAME))).toBeVisible();
@@ -133,7 +157,11 @@ async function storeSecret(
   // match has to be loose at both ends. Scoped to the textbox because the
   // reveal button beside it is named "Show API key" and matches too.
   await dialog.getByRole("textbox", { name: /API key/i }).fill(value);
-  await dialog.getByRole("button", { name: "Store secret" }).click();
+  await submitDialog(page, {
+    dialog,
+    submit: dialog.getByRole("button", { name: "Store secret" }),
+    path: "/api/secrets",
+  });
 
   await expect(page.getByRole("main").getByText(name)).toBeVisible();
 }

--- a/frontend/e2e/vault.spec.ts
+++ b/frontend/e2e/vault.spec.ts
@@ -8,6 +8,7 @@ import {
   SEEDED_SECRET_NAME,
   expectNoRenderedSecret,
   pageHeading,
+  submitDialog,
 } from "./helpers";
 
 test.use({ storageState: AUTH_STATE });
@@ -141,7 +142,11 @@ test.describe("Vault", () => {
     await add.getByRole("button", { name: /^Something else/ }).click();
     await add.getByLabel("Name").fill(name);
     await add.getByRole("textbox", { name: /API key/i }).fill("sk-e2eROTATEfirstvalueAAAA");
-    await add.getByRole("button", { name: "Store secret" }).click();
+    await submitDialog(page, {
+      dialog: add,
+      submit: add.getByRole("button", { name: "Store secret" }),
+      path: "/api/secrets",
+    });
 
     const row = () => page.getByRole("row", { name: new RegExp(name) });
     await expect(row()).toContainText("····AAAA");
@@ -154,7 +159,14 @@ test.describe("Vault", () => {
     await expect(rotate).toContainText("the old one is gone");
     await expect(rotate).toContainText("····AAAA");
     await rotate.getByRole("textbox", { name: /API key/i }).fill("sk-e2eROTATEsecondvalueBBBB");
-    await rotate.getByRole("button", { name: "Rotate" }).click();
+    // A PATCH, on the row's own path — which is why the helper matches the
+    // collection as a prefix rather than exactly.
+    await submitDialog(page, {
+      dialog: rotate,
+      submit: rotate.getByRole("button", { name: "Rotate" }),
+      path: "/api/secrets",
+      method: "PATCH",
+    });
 
     await expect(row()).toContainText("····BBBB");
     expect(await secretId(page, name), "rotation replaced the row instead of its value").toBe(

--- a/frontend/e2e/vault.spec.ts
+++ b/frontend/e2e/vault.spec.ts
@@ -148,8 +148,16 @@ test.describe("Vault", () => {
       path: "/api/secrets",
     });
 
-    const row = () => page.getByRole("row", { name: new RegExp(name) });
-    await expect(row()).toContainText("····AAAA");
+    // Reloaded, and this is a concession to a live bug rather than a nicety.
+    // `submitDialog` has already proved the write was accepted and the dialog
+    // closed, so the list on screen *should* hold the row — and about once in
+    // eight runs it does not (#230: the row is committed, both server layers
+    // answer a list containing it, and the page keeps rendering the one without
+    // it). Asserting on it without a reload is asserting on that bug, which is
+    // how this spec came to flake as #130. What is under test here is rotation;
+    // the fresh load is how it gets a list it can trust to start from.
+    await page.reload();
+    await expect(row(page, name)).toContainText("····AAAA");
     const before = await secretId(page, name);
 
     await page.getByRole("button", { name: `Rotate ${name}` }).click();
@@ -168,7 +176,8 @@ test.describe("Vault", () => {
       method: "PATCH",
     });
 
-    await expect(row()).toContainText("····BBBB");
+    await page.reload(); // #230, as above
+    await expect(row(page, name)).toContainText("····BBBB");
     expect(await secretId(page, name), "rotation replaced the row instead of its value").toBe(
       before,
     );
@@ -177,7 +186,75 @@ test.describe("Vault", () => {
     await page.getByRole("button", { name: `Delete ${name}` }).click();
     await expect(page.getByRole("main").getByText(name)).toHaveCount(0);
   });
+
+  test("a write whose access token expires mid-flight still lands", async ({ page }) => {
+    // `apiClient.send` answers a 401 by refreshing the access token and
+    // re-issuing the same request, and nothing exercised that against a *write*
+    // — only against the reads a page makes on load, where a lost request looks
+    // like an empty list. Here the write is the whole test: the row has to
+    // appear, which it can only do if the retry carried the body.
+    //
+    // It is also the regression test for `submitDialog`, which resolved on the
+    // first response on the path until this was written and so failed a store
+    // that had succeeded. Drop the 401 clause from its predicate and this goes
+    // red with `POST /api/secrets answered 401`.
+    const name = `e2e-refresh-${Date.now().toString(36)}`;
+
+    let refused = false;
+    await page.route("**/api/secrets", async (route) => {
+      if (route.request().method() === "POST" && !refused) {
+        refused = true;
+        await route.fulfill({ status: 401, body: JSON.stringify({ detail: "expired" }) });
+        return;
+      }
+      await route.continue();
+    });
+
+    // The refresh is answered here rather than by the server, and not for
+    // convenience: `auth.spec.ts` signs out, which revokes the server-side
+    // session behind the one `AUTH_STATE` every spec shares — so a real refresh
+    // succeeds when this file runs alone and fails when the suite runs in order,
+    // and the test would be asserting on which specs came before it. Nothing is
+    // faked away that matters: the access-token cookie was never really expired,
+    // only the one response above pretended it was, so the retry this unblocks is
+    // a genuine authenticated write.
+    let refreshed = false;
+    await page.route("**/api/auth/refresh", async (route) => {
+      refreshed = true;
+      await route.fulfill({ status: 200, body: JSON.stringify({}) });
+    });
+
+    await page.goto("/vault");
+    await expect(pageHeading(page, "Vault")).toBeVisible();
+
+    await page.getByRole("button", { name: "Add key" }).first().click();
+    const dialog = page.getByRole("dialog");
+    await dialog.getByRole("button", { name: /^Something else/ }).click();
+    await dialog.getByLabel("Name").fill(name);
+    await dialog.getByRole("textbox", { name: /API key/i }).fill("sk-e2eREFRESHretryCCCC");
+    await submitDialog(page, {
+      dialog,
+      submit: dialog.getByRole("button", { name: "Store secret" }),
+      path: "/api/secrets",
+    });
+
+    expect(refused, "the 401 was never served, so nothing here was tested").toBe(true);
+    expect(refreshed, "the client never tried to refresh, so it never retried either").toBe(true);
+    await page.unroute("**/api/secrets");
+    await page.unroute("**/api/auth/refresh");
+    await page.reload(); // #230, as in the rotation spec above
+    await expect(row(page, name)).toContainText("····CCCC");
+
+    // Through the UI, so the route interception is not what deletes it.
+    await page.getByRole("button", { name: `Delete ${name}` }).click();
+    await expect(page.getByRole("main").getByText(name)).toHaveCount(0);
+  });
 });
+
+/** The vault's table row for one secret, found by the name printed on it. */
+function row(page: import("@playwright/test").Page, name: string) {
+  return page.getByRole("row", { name: new RegExp(name) });
+}
 
 /**
  * The id the vault holds a secret under, read from the API.

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -43,8 +43,19 @@ export default defineConfig({
      */
     timeout: 15_000,
   },
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: [["list"], ["html", { outputFolder: "playwright-report" }]],
+  /*
+   * Reporter to use. See https://playwright.dev/docs/test-reporters
+   *
+   * `fixture-reporter` is last so its banner is the final thing printed. It says
+   * one thing the other two cannot: that a red run was the `setup` or `seed`
+   * project, and that no product spec ran at all — which is what three separate
+   * branches spent a diagnosis each working out by hand (#132).
+   */
+  reporter: [
+    ["list"],
+    ["html", { outputFolder: "playwright-report" }],
+    ["./e2e/fixture-reporter.ts"],
+  ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */


### PR DESCRIPTION
## What and why

Sites in the E2E suite clicked a dialog's submit button and then asserted the new
row was on screen. An open Radix dialog takes the rest of the page out of the
accessibility tree, so that assertion could only ever report `element(s) not
found` — never the 409 or 5xx that actually refused the write. Four flaked; three
branches paid a diagnosis for it in one day (#132).

`submitDialog` (`frontend/e2e/helpers.ts`) replaces the shape at every site. It
waits on two signals rather than hopes:

1. **The write's own response**, whose status and body are the diagnosis the old
   shape never printed — a refusal now reads `409 … already in use` in
   milliseconds.
2. **The dialog closing** — the app's statement that it has finished the work it
   does around the write.

## The seed no longer depends on a product bug (#230)

`submitDialog` deliberately does **not** promise the row is rendered, because that
is not reliably true: the list's invalidation refetch is sometimes answered with
the pre-write list even though the row is committed and both server layers return
it — about one run in eight, filed as **#230**. That is a product defect and this
PR does not fix it.

So `seed.setup.ts` now asserts every fixture through `/api/…` (an idempotent
`nowThere` poll), because a fixture step's job is that the fixture *exists* —
whether it renders is a product claim. When the seed asserted on the rendered row,
#230 arrived on pull requests as a fixture failure that skipped every product spec
behind it, which reads exactly like a product regression.

Whether the row renders is left to product specs: `vault.spec.ts` reloads before
the three list assertions whose subject is not the rendering, each marked #230;
they come out when #230 closes.

## The 401 retry (review finding, addressed)

`apiClient.send` answers an expired-token 401 by refreshing through
`/api/auth/refresh` and re-issuing the same write. `submitDialog` matched the
first response on the path, so it could match the 401 and fail a write the retry
then landed — during the seed, aborting every dependent spec. The matcher now
skips a 401 and settles on the retried response. Regression test: `vault.spec.ts`
› "a write whose access token expires mid-flight still lands"; drop the 401 clause
from the predicate and it goes red with `answered 401`.

## A failed fixture is now loud

`fixture-reporter.ts` prints, after everything else and as a CI annotation, that a
red `setup`/`seed` run tested no product at all — the sentence three branches
worked out by hand (#132).

## Seen and deliberately not fixed

`useSecrets.remove` awaits the same `invalidate()` as create and rotate, so the
vault's two `Delete … → toHaveCount(0)` assertions share #230's exposure in the
delete direction — safe from the open-dialog problem, not from the stale refetch.
They are pre-existing and out of scope here; the breadth is now recorded on #230.

## How it was verified

- The seed project run **15 times** against a host uvicorn, the
  `pgvector/pgvector:pg16` container and the standalone frontend build, deleting
  the seeded rows between runs so each took the create path — **15/15**.
- `make lint`, frontend eslint/prettier/type-check, `scripts/check_i18n.py` and
  `scripts/docs_drift.py` — clean.
- #230's ~1-in-8 window does not reproduce on an idle laptop (each seed step
  answers well under the 15s timeout); the CI `e2e` job is the loaded-runner
  check.

`docs/testing.md`, `.claude/rules/testing.md` and the `e2e-tests` skill carry the
two rules: assert a fixture through the API, and a create's rendered row is #230
rather than something to wait longer for.

Closes #132
Refs #130, #154, #230
