### PR TITLE
probe: which code-quality alerts a comment can suppress (do not merge)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,5 @@
+name: "AgenticOS CodeQL configuration (probe)"
+
+query-filters:
+  - exclude:
+      id: py/ineffectual-statement

--- a/backend/tests/test_codeql_probe.py
+++ b/backend/tests/test_codeql_probe.py
@@ -1,0 +1,50 @@
+"""Throwaway probe for #220. Not for merging.
+
+Each function writes one of the shapes `github-code-quality` flags, so the pull
+request answers three questions at once: which of them actually reach the review
+thread path, and whether either inline suppression syntax (`# codeql[...]` on the
+line before, `# lgtm[...]` on the line itself) stops one arriving.
+"""
+
+import asyncio
+from typing import Protocol
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+async def _noop() -> None:
+    return None
+
+
+async def test_bare_await_with_no_suppression() -> None:
+    task = asyncio.create_task(_noop())
+    await task
+
+
+async def test_bare_await_with_codeql_comment() -> None:
+    task = asyncio.create_task(_noop())
+    # codeql[py/ineffectual-statement]  # noqa: ERA001
+    await task
+
+
+async def test_bare_await_with_lgtm_comment() -> None:
+    task = asyncio.create_task(_noop())
+    await task  # lgtm[py/ineffectual-statement]
+
+
+class _Stub(Protocol):
+    def probe(self) -> None: ...
+
+
+def _first_even(values: list[int]) -> int:
+    for value in values:
+        if value % 2 == 0:
+            return value
+    pytest.fail("no even value in the list")
+
+
+def test_a_protocol_body_and_a_no_return_fallthrough() -> None:
+    assert _first_even([1, 2]) == 2
+    assert _Stub.probe is not None

--- a/backend/tests/test_codeql_probe.py
+++ b/backend/tests/test_codeql_probe.py
@@ -34,6 +34,11 @@ async def test_bare_await_with_lgtm_comment() -> None:
     await task  # lgtm[py/ineffectual-statement]
 
 
+async def test_bare_await_with_a_repository_config_file_present() -> None:
+    task = asyncio.create_task(_noop())
+    await task
+
+
 class _Stub(Protocol):
     def probe(self) -> None: ...
 


### PR DESCRIPTION
Throwaway probe for #220, to be closed without merging.

Default setup for Code Quality passes `queries: "" # No query customization supported` to `codeql-action/init`, so a `.github/codeql/codeql-config.yml` in the repository is not read at all. Before writing a fix, this branch asks the only mechanism that could work under default setup whether it works: inline suppression comments.

`backend/tests/test_codeql_probe.py` writes four shapes:

1. a bare `await task` with no suppression - the control;
2. the same with `# codeql[py/ineffectual-statement]` on the line before;
3. the same with a trailing `# lgtm[py/ineffectual-statement]`;
4. a `Protocol` body of `...` and a loop whose fall-through is `pytest.fail`.

Whichever of these draws a thread from `github-code-quality` is the answer.

Refs #220