### PR TITLE
docs(review): write down the CodeQL half, and adjudicate its blind spots

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -416,6 +416,13 @@ If the reviewer is wrong — and it is, sometimes; it does not always know what 
 file's surrounding code already does — say so in the commit body or the pull
 request, with the reason, rather than churning the code to silence it.
 
+`github-code-quality[bot]` opens threads on the same ruleset and cannot be
+filtered. Three of its findings are **already adjudicated** in
+`docs/code-review.md` — a bare `await <task>`, `...` as a `Protocol` body, and a
+`pytest.fail` fall-through. Resolve those with a pointer to that section; do not
+write a fresh essay per thread, and do not rewrite the cancellation idiom to
+satisfy a query that does not model `await`.
+
 ### A bug you find is a bug you file
 
 **Every defect found along the way gets a GitHub issue** — `gh issue create`,

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -100,7 +100,8 @@ somebody has to mark the thread resolved before the merge button comes back. See
 [code-review.md](code-review.md).
 
 CodeQL's quality half opens threads on the same terms, as
-`github-code-quality[bot]`, and cannot be filtered or told to stop —
-[code-review.md](code-review.md#codeql-and-the-findings-that-block-a-merge) lists
-the findings already adjudicated so that resolving one costs a click rather than
-an essay.
+`github-code-quality[bot]`. It cannot be filtered by rule or by path — the only
+switch is off, for a whole language, which is not a trade worth making —
+so [code-review.md](code-review.md#codeql-and-the-findings-that-block-a-merge)
+lists the findings already adjudicated instead, and resolving one of those costs a
+click rather than an essay.

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -98,3 +98,9 @@ a required check, so it cannot fail a build — but its findings are review
 threads, and the ruleset above requires those resolved. Replying is not enough —
 somebody has to mark the thread resolved before the merge button comes back. See
 [code-review.md](code-review.md).
+
+CodeQL's quality half opens threads on the same terms, as
+`github-code-quality[bot]`, and cannot be filtered or told to stop —
+[code-review.md](code-review.md#codeql-and-the-findings-that-block-a-merge) lists
+the findings already adjudicated so that resolving one costs a click rather than
+an essay.

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -22,6 +22,12 @@ to be made rather than skipped.
 (Found the hard way, on the first pull request to run under that ruleset: the
 reviewer left one comment and the merge button went grey.)
 
+It is also not the only bot that opens a thread. CodeQL runs on every pull
+request too, and its quality half posts one review thread per finding — under the
+same ruleset, with the same consequence, and with no configuration surface to
+tune it. [CodeQL, and the findings that block a merge](#codeql-and-the-findings-that-block-a-merge)
+is the second half of this page.
+
 ## When it runs
 
 | Trigger | Who | Note |
@@ -214,3 +220,122 @@ instructions. Three clauses in it earn their place and should survive an edit:
 
 The local equivalent, for the same checks before pushing, is the `/review`
 command in `.claude/commands/review.md`.
+
+## CodeQL, and the findings that block a merge
+
+Two CodeQL analyses run on every pull request and neither has a workflow file in
+this repository. Both come from **default setup**: GitHub generates the workflow
+and runs it on a `dynamic` event, so `.github/workflows/` is not where to look for
+them — the Actions tab is. Both land there as `CodeQL`; the quality one's runs are
+the ones titled `Code Quality: …`.
+
+| Analysis | Languages | Where a finding lands | What a false positive costs |
+|---|---|---|---|
+| Code scanning | `actions`, `javascript-typescript`, `python` | The Security tab, and an annotation on the diff | Dismiss it once, with a reason. Three are dismissed today, all `py/clear-text-logging-sensitive-data` in `mcp_tasks.py` |
+| Code Quality | `javascript-typescript`, `python` | A **review thread** from `github-code-quality[bot]` | The merge is blocked until somebody resolves the thread |
+
+The second row is the expensive one, for exactly the reason the reviewer's inline
+findings are: the ruleset requires every review thread resolved, so a finding
+nobody agrees with still has to be handled by hand. #196 paid eight threads for
+one alert, all of them the same false positive.
+
+### There is no filter to reach for (checked 2026-08-05)
+
+Three mechanisms suggest themselves. None of them works on the analysis that
+posts the threads.
+
+**A repository configuration file is not read.** Default setup passes its
+configuration to `codeql-action/init` inline and never passes `config-file`, so
+`.github/codeql/codeql-config.yml` has no reader. The generated workflow says so
+in a comment:
+
+```yaml
+queries: "" # No query customization supported
+```
+
+Checked rather than inferred, on a throwaway branch carrying that file with a
+`py/ineffectual-statement` exclusion in it: a freshly added bare `await task` drew
+the thread anyway, and the run printed the configuration CodeQL actually
+received — GitHub's own incremental filter, and nothing of ours.
+
+```yaml
+disable-default-queries: true
+queries:
+  - uses: code-quality
+query-filters:
+  - exclude:
+      tags: exclude-from-incremental
+```
+
+**Owning the workflow is not the way round it.** Running the quality suite
+ourselves needs `codeql-action`'s `analysis-kinds` input, which its own CHANGELOG
+introduces as part of an internal experiment: "Do not use this in production as it
+is subject to change at any time."
+
+**Inline suppression comments do not survive.** CodeQL's `AlertSuppression.ql`
+understands `# codeql[py/ineffectual-statement]` on the line before an alert and a
+trailing `# lgtm[…]`, and the SARIF it produces carries the suppression. The
+review-thread path ignores it: both forms were flagged anyway on the same branch.
+ruff reads the first as commented-out code (`ERA001`), so it would need a `# noqa`
+to sit in a file at all — a suppression that needs suppressing.
+
+GitHub's own answer, on the public-preview discussion (@carogalvin, 2 April 2026):
+"Disabling rules and excluding paths is on our roadmap, but unfortunately won't be
+available by GA (June) - more likely later in 2026."
+
+That leaves two levers: turn Code Quality off for a whole language, or adjudicate
+the finding. Turning it off buys a quiet merge and gives up the hundred and one
+Python quality queries the suite runs, which is the wrong trade for a repository
+whose argument is that its value is in what it refuses. #220 holds the exclusion
+to apply on the day there is somewhere to apply it.
+
+### Three findings already adjudicated
+
+These have been read. The query is wrong about this codebase, and the reason does
+not change per occurrence — so **resolve the thread and point at this section.**
+Do not rewrite the code to satisfy the query, and do not write a fresh
+justification each time.
+
+| Finding | The shape | Why it is wrong here |
+|---|---|---|
+| `py/ineffectual-statement` | a bare `await <task>` statement | `Await` is not modelled as side-effecting. Awaiting a task suspends until it finishes and re-raises whatever it raised, which is the entire point of the line |
+| `py/ineffectual-statement` | `...` as the body of a `Protocol` method | PEP 544's canonical body. `pass` has no more effect and reads worse |
+| `py/mixed-returns` | a loop whose fall-through is `pytest.fail(...)` | `pytest.fail` is `NoReturn`, so the implicit return the query is describing cannot happen |
+
+The first is not a test-file quirk. Fifteen statements under `backend/` are that
+shape, and the five in production code — `agent_session.py` and the Slack, Telegram
+and Mattermost adapters — are all the documented cancellation idiom, where the
+`await` is what makes the cancellation deterministic rather than hopeful:
+
+```python
+task.cancel()
+with contextlib.suppress(asyncio.CancelledError):
+    await task
+```
+
+The ten in tests are that, plus the other honest use of a bare `await`: running a
+task to completion so the assertion after it is about a finished task, or letting
+`pytest.raises` catch what it raised.
+
+`py/mixed-returns` stays on, and would not be excluded even if it could be: a
+function that returns a value on one path and `None` by falling off the end is a
+real defect, and this is one site rather than a pattern.
+
+### What the query is right about, ruff already refuses
+
+Nobody has to defend the cancellation idiom to keep the coverage
+`py/ineffectual-statement` exists for. ruff's `B018` and `B015` are the same check
+without the blind spot, they are selected for every Python file in the repository,
+and they run both in pre-commit and in `make lint`:
+
+```python
+obj.__class__    # B018  Found useless expression
+len              # B018  Found useless expression
+1 == 2           # B015  Pointless comparison
+
+await task       # not flagged, correctly
+```
+
+So the honest description of the exclusion in #220 is not "we stopped looking at
+ineffectual statements" — it is "we stopped looking at them twice, once with a
+checker that understands `await` and once with a checker that does not."

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -325,8 +325,7 @@ real defect, and this is one site rather than a pattern.
 
 Nobody has to defend the cancellation idiom to keep the coverage
 `py/ineffectual-statement` exists for. ruff's `B018` and `B015` are the same check
-without the blind spot, they are selected for every Python file in the repository,
-and they run both in pre-commit and in `make lint`:
+without the blind spot, and both run in pre-commit and in `make lint-backend`:
 
 ```python
 obj.__class__    # B018  Found useless expression
@@ -336,6 +335,13 @@ len              # B018  Found useless expression
 await task       # not flagged, correctly
 ```
 
-So the honest description of the exclusion in #220 is not "we stopped looking at
-ineffectual statements" — it is "we stopped looking at them twice, once with a
-checker that understands `await` and once with a checker that does not."
+With one gap worth knowing, because it is what the exclusion in #220 would cost:
+ruff is pointed at `app tests cli`, so `backend/alembic/` (9 files) and the
+repository's `scripts/` (3) are outside it, and for this class of mistake CodeQL is
+their only reader. Twelve files against 480 — small, and the reason the eventual
+filter is a trade to state rather than an obvious win. #229 is the gap itself.
+
+So the honest description of that exclusion is not "we stopped looking at
+ineffectual statements" — it is "we stopped looking at them twice in the files ruff
+reads, once with a checker that understands `await` and once with a checker that
+does not."


### PR DESCRIPTION
## What changed

`docs/code-review.md` gains its second half: the CodeQL side of code review, which
was documented nowhere despite being able to block a merge. It says how both
analyses arrive (two default-setup runs per push — code scanning to the Security
tab, Code Quality as review threads from `github-code-quality[bot]`), that the
ruleset's thread-resolution requirement is what turns a quality finding into a
merge blocker, that there is no configuration surface to tune it, and — the part
that pays for itself — three findings already adjudicated with the reason each one
is wrong for this codebase's idioms.

`docs/branching.md` names the second thread source in its *Reviews* section, which
previously read as though the Codex reviewer were the only bot that could grey out
the merge button. `CLAUDE.md` gains six lines in the reviewer section, because the
expensive mistake is available to a session that never opens the docs: rewriting

```python
task.cancel()
with contextlib.suppress(asyncio.CancelledError):
    await task
```

to satisfy a query that does not model `await`.

## Why it is not the config file #220 asked for

#220 asked for `.github/codeql/codeql-config.yml` with a `query-filters`
exclusion, pointed at from the `Analyze` job. That file has no reader here, and
shipping it would have looked like an adjudication while changing nothing. Four
checks, in the order they were made — the long version is
[on the issue](https://github.com/vstorm-co/agenticos/issues/220#issuecomment-5191791828).

1. **Both analyses run on default setup.** No workflow file exists because GitHub
   generates one and runs it on a `dynamic` event. Decoding
   `CODE_SCANNING_WORKFLOW_FILE` from the run log gives the generated workflow,
   which passes `queries: "" # No query customization supported` and an inline
   `config:` — never `config-file:`.
2. **Verified, not inferred.** #224 (throwaway, closed) carried that config file
   excluding `py/ineffectual-statement`, plus a freshly added bare `await task`.
   The thread arrived anyway, and the `Analyze (python)` log printed the
   configuration CodeQL actually received: `query-filters:` holding GitHub's own
   `exclude-from-incremental` tag and nothing of ours.
3. **Inline suppression does not survive.** On the same branch,
   `# codeql[py/ineffectual-statement]` on the preceding line and a trailing
   `# lgtm[py/ineffectual-statement]` were both flagged. CodeQL's
   `AlertSuppression.ql` understands both and the SARIF carries the suppression;
   the review-thread path ignores it. ruff reads the first as commented-out code
   (`ERA001`), so it needs a `# noqa` to sit in a file at all.
4. **Owning the workflow is not the way round it.** Running the quality suite
   ourselves needs `codeql-action`'s `analysis-kinds` input, which its CHANGELOG
   introduces as part of an internal experiment: *"Do not use this in production
   as it is subject to change at any time."*

GitHub's own answer, on the public-preview discussion (@carogalvin, 2 April 2026):
*"Disabling rules and excluding paths is on our roadmap, but unfortunately won't
be available by GA (June) - more likely later in 2026."*

## What is suppressed, what is left reporting

Nothing is suppressed, because nothing can be. What is **adjudicated** — read
once, with the reason recorded — is:

| Finding | Shape | Why it is wrong here |
|---|---|---|
| `py/ineffectual-statement` | a bare `await <task>` statement | `Await` is not modelled as side-effecting. Awaiting a task suspends until it finishes and re-raises what it raised. 15 statements under `backend/`, 5 of them production, all the documented cancellation idiom |
| `py/ineffectual-statement` | `...` as a `Protocol` method body | PEP 544's canonical body; `pass` has no more effect and reads worse |
| `py/mixed-returns` | a loop whose fall-through is `pytest.fail(...)` | `pytest.fail` is `NoReturn`, so the implicit return the query describes cannot happen |

`py/mixed-returns` **stays on and would not be excluded even if it could be**: it
fires once, and a function that returns a value on one path and `None` by falling
off the end is a real defect. The other hundred Python quality queries stay on
too — disabling Code Quality for Python would have closed #220 today and bought a
quiet merge with the coverage.

And the reason excluding `py/ineffectual-statement` would not be going deaf, which
the page now states so nobody rewrites the cancellation idiom to keep it: ruff's
`B018` and `B015` are the same check without the blind spot, selected for every
Python file, run in pre-commit and in `make lint`. Checked locally — they flag
`obj.__class__`, `len` and `1 == 2`, and leave `await task`, `...` and a bare
string alone.

## How it was verified

- `make docs-build` (mkdocs `--strict`) is green, and the anchor both
  cross-references use (`#codeql-and-the-findings-that-block-a-merge`) exists in
  the built page — checked in `site/code-review/index.html` rather than assumed.
- `make check` green locally. Note for the next person in a fresh worktree: it
  fails at `lint-frontend` with `eslint: command not found` until `bun install`
  has been run in `frontend/`, which is an absent `node_modules`, not a defect.
- The three claims about the tooling are the checks listed above, all made against
  live runs on this repository rather than from documentation.

## What is still open

#220 stays open, deliberately: the alert still blocks merges, so this is
adjudicated rather than fixed. It closes when GitHub ships rule filtering for Code
Quality — at which point the exclusion is `py/ineffectual-statement` and nothing
else — or when we decide to move the quality queries into an advanced-setup **code
scanning** workflow (`queries: security-and-quality` plus a real `config-file`)
with Code Quality turned off. That trades untunable review threads for dismissible
alerts and costs us ownership of the workflow; it is a decision worth making on
purpose, not as a side effect of this branch. #168 records both, and that #220 is
the first blocker on the map that is not ours.

Refs #220
