### PR TITLE
fix(agents): record a cancelled run as cancelled, and commit it

### DIFF
--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -52,6 +52,7 @@ agent already resolved, and a recorder that writes one row.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections import Counter
 from collections.abc import Callable, Mapping, Sequence
@@ -2388,8 +2389,22 @@ class AgentRunnerService:
     ) -> tuple[str, AgentRun]:
         """Execute the agent and account for it, however it ends.
 
-        The one place a run is executed, so a parked call, a budget stop and a
-        crash are all recorded the same way whether the run is new or resumed.
+        The one place a run is executed, so a parked call, a budget stop, a
+        cancellation and a crash are all recorded the same way whether the run is
+        new or resumed.
+
+        **A cancellation is one of those endings, and it needs both halves.**
+        `asyncio.CancelledError` is a `BaseException`, so it reaches neither
+        handler below on its own: the status stayed at its initial `FAILED` with
+        no error text, which sends an operator filtering run history for problems
+        through runs that were working correctly and were stopped - exactly what
+        `BUDGET_EXCEEDED` was given its own status to avoid. And the commit is not
+        optional either. `get_db_session` commits on a clean exit, and a
+        propagating `BaseException` is not one, so the terminal write was rolled
+        back and the row stayed `RUNNING` for ever - taking the delegation rows
+        :meth:`finish` queues with it, which is how a delegate that spent real
+        money came to be recorded nowhere. Committing here is what makes the row
+        survive; re-raising is what lets whoever cancelled see it happen.
         """
         status = RunStatus.FAILED
         error: str | None = None
@@ -2422,6 +2437,13 @@ class AgentRunnerService:
             else:
                 output = result.output
                 status = RunStatus.COMPLETED
+        except asyncio.CancelledError:
+            # The caller went away, or a delegation this run sits under was
+            # stopped. Cancelled is not failed, and the tokens spent up to here
+            # were still spent.
+            status = RunStatus.CANCELLED
+            logger.info("Run %s cancelled", prepared.run.id)
+            raise
         except BudgetExceeded as exc:
             # Not a malfunction - the platform working. Recorded separately so
             # an operator filtering for problems does not wade through it.
@@ -2441,6 +2463,12 @@ class AgentRunnerService:
                 paused_state=paused,
                 budget_scope=budget_scope,
             )
+            # Committed here rather than left to the session context: that exit
+            # rolls back on any exception, and cancellation never reaches it at
+            # all, since `CancelledError` is not an `Exception`. A run that
+            # failed, was stopped or ran out of budget still spent money, and a
+            # run missing from history is a run nobody is accountable for.
+            await self.db.commit()
 
         return output, prepared.run
 

--- a/backend/tests/test_agent_runner.py
+++ b/backend/tests/test_agent_runner.py
@@ -6,6 +6,7 @@ failure, and a run parked on an approval can be picked up again - on the version
 it was parked on, with the spend it had already booked.
 """
 
+import asyncio
 import uuid
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
@@ -28,6 +29,7 @@ from app.services.agent_runner import (
     ApprovalChannel,
     ParkedApproval,
     PausedRunState,
+    RecordedDelegation,
     month_start,
 )
 from app.services.approvals import ApprovalService
@@ -41,6 +43,10 @@ def _db(monthly_budget_usd: Decimal | None = None):
     db = MagicMock()
     db.flush = AsyncMock()
     db.refresh = AsyncMock()
+    # `_run` commits its own terminal write rather than leaving it to the session
+    # context, because that exit rolls back on an exception and is skipped
+    # entirely by a cancellation.
+    db.commit = AsyncMock()
     # `db.get` is how the organization row - and with it the org-wide spending
     # cap the runner reads for every run - comes back. Uncapped by default,
     # which is what an organization that never opened the setting looks like.
@@ -751,6 +757,121 @@ class TestRunAccounting:
             await service.execute(_ctx(), uuid.uuid4(), "hello")
 
         assert finish.call_args.kwargs["status"] == RunStatus.FAILED.value
+
+
+class TestStoppingANonStreamingRun:
+    """A cancelled run, through `execute`.
+
+    `asyncio.CancelledError` is a `BaseException`, so neither `except` clause in
+    `_run` sees it, and both halves of the accounting failed independently: the
+    status stayed at its initial `FAILED` with no error text, and the terminal
+    write was rolled back by a session exit that only commits on a clean one -
+    leaving the row `RUNNING` for ever, and the delegations underneath it
+    recorded nowhere.
+
+    The shape is `tests/test_agent_session.py::TestStoppingATurnMidDelegation`'s:
+    the ledger matters as much as the status, because a cancelled run that spent
+    two dollars and records zero is the hole cancellation opens.
+    """
+
+    @pytest.mark.anyio
+    async def test_a_cancelled_run_is_recorded_as_cancelled_with_what_it_spent(self):
+        """Cancelled is not failed, and the tokens spent up to here were spent.
+
+        Recorded as `FAILED` with `error=None` before the fix, which is precisely
+        the confusion `BUDGET_EXCEEDED` was given its own status to avoid: an
+        operator filtering run history for problems wades through runs that were
+        working correctly and were stopped.
+        """
+        db = _db()
+        service = AgentRunnerService(db)
+        ledger = SpendLedger()
+        ledger.record("gpt-4.1", RequestUsage(input_tokens=1_000_000), "openai")
+        prepared = _prepared(ledger)
+        prepared.built.agent.run = AsyncMock(side_effect=asyncio.CancelledError)
+
+        with (
+            patch.object(service, "prepare", new=AsyncMock(return_value=prepared)),
+            patch("app.services.agent_runner.agent_run_repo.finish_run", new=AsyncMock()) as finish,
+            # Re-raised, not swallowed: whoever cancelled is entitled to see it
+            # happen, and a `CancelledError` absorbed here would leave the task
+            # that requested the stop waiting for one that never arrives.
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await service.execute(_ctx(), uuid.uuid4(), "hello")
+
+        recorded = finish.call_args.kwargs
+        assert recorded["status"] == RunStatus.CANCELLED.value
+        assert recorded["error"] is None
+        assert recorded["cost_usd"] == Decimal("2.00")
+        # And it survives. `get_db_session` commits on a clean exit, which a
+        # propagating `BaseException` is not, so without this the row above was
+        # written and then rolled straight back.
+        db.commit.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_a_cancelled_run_keeps_the_delegation_rows_underneath_it(self):
+        """Same rollback, one level down.
+
+        A delegate's row is the only record of what that agent cost, so a
+        delegation that spent money and recorded nothing is a bill nobody can
+        explain. The rows go in after the parent's - they carry `parent_run_id` -
+        so the commit has to come after both, and this asserts the order rather
+        than only that each happened.
+        """
+        db = _db()
+        service = AgentRunnerService(db)
+        moment = datetime(2026, 8, 5, 9, 0, tzinfo=UTC)
+        delegation = RecordedDelegation(
+            id=uuid.uuid4(),
+            agent_id=uuid.uuid4(),
+            agent_version_id=uuid.uuid4(),
+            task_id="4f2a1b8c",
+            status=RunStatus.CANCELLED,
+            model_label="gpt-4.1",
+            provider="openai",
+            secret_id=uuid.uuid4(),
+            input_tokens=7,
+            output_tokens=3,
+            cost_usd=Decimal("2.00"),
+            cost_is_partial=False,
+            started_at=moment,
+            ended_at=moment,
+        )
+        prepared = _prepared()
+        prepared.delegations = [delegation]
+        prepared.built.agent.run = AsyncMock(side_effect=asyncio.CancelledError)
+
+        order: list[str] = []
+
+        async def note(name: str, result: object = None):
+            async def call(*_args: Any, **_kwargs: Any) -> object:
+                order.append(name)
+                return result if result is not None else MagicMock()
+
+            return call
+
+        db.commit = AsyncMock(side_effect=await note("commit"))
+
+        with (
+            patch.object(service, "prepare", new=AsyncMock(return_value=prepared)),
+            patch(
+                "app.services.agent_runner.agent_run_repo.finish_run",
+                new=AsyncMock(side_effect=await note("parent")),
+            ),
+            patch(
+                "app.services.agent_runner.agent_run_repo.record_delegated_run",
+                new=AsyncMock(side_effect=await note("delegation")),
+            ) as write,
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await service.execute(_ctx(), uuid.uuid4(), "hello")
+
+        assert order == ["parent", "delegation", "commit"]
+        written = write.await_args.kwargs
+        assert written["run_id"] == delegation.id
+        assert written["status"] == RunStatus.CANCELLED.value
+        assert written["cost_usd"] == Decimal("2.00")
 
 
 class TestApprovals:

--- a/backend/tests/test_agent_runner.py
+++ b/backend/tests/test_agent_runner.py
@@ -8,6 +8,7 @@ it was parked on, with the spend it had already booked.
 
 import asyncio
 import uuid
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import Any
@@ -844,24 +845,24 @@ class TestStoppingANonStreamingRun:
 
         order: list[str] = []
 
-        async def note(name: str, result: object = None):
-            async def call(*_args: Any, **_kwargs: Any) -> object:
+        def note(name: str) -> Callable[..., Awaitable[MagicMock]]:
+            async def call(*_args: Any, **_kwargs: Any) -> MagicMock:
                 order.append(name)
-                return result if result is not None else MagicMock()
+                return MagicMock()
 
             return call
 
-        db.commit = AsyncMock(side_effect=await note("commit"))
+        db.commit = AsyncMock(side_effect=note("commit"))
 
         with (
             patch.object(service, "prepare", new=AsyncMock(return_value=prepared)),
             patch(
                 "app.services.agent_runner.agent_run_repo.finish_run",
-                new=AsyncMock(side_effect=await note("parent")),
+                new=AsyncMock(side_effect=note("parent")),
             ),
             patch(
                 "app.services.agent_runner.agent_run_repo.record_delegated_run",
-                new=AsyncMock(side_effect=await note("delegation")),
+                new=AsyncMock(side_effect=note("delegation")),
             ) as write,
             pytest.raises(asyncio.CancelledError),
         ):

--- a/backend/tests/test_subagent_resolution.py
+++ b/backend/tests/test_subagent_resolution.py
@@ -70,6 +70,9 @@ def _db() -> MagicMock:
     db = MagicMock()
     db.flush = AsyncMock()
     db.refresh = AsyncMock()
+    # `_run` commits its own terminal write; a cancellation never reaches the
+    # session context that would otherwise do it.
+    db.commit = AsyncMock()
     # How the organization row - and with it the org-wide cap - comes back.
     db.get = AsyncMock(return_value=MagicMock(monthly_budget_usd=None))
     return db

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -68,7 +68,10 @@ and a cost.
 
 A run that fails still records what it spent. A run that stops on its budget is
 recorded as `budget_exceeded` rather than `failed`, so an operator filtering for
-problems does not wade through the platform working correctly. A run that parks on
+problems does not wade through the platform working correctly. A run somebody
+stopped - the composer's stop button, a socket that went away, a delegation
+cancelled from above - is `cancelled` for the same reason, on every surface and
+not only the streaming one. A run that parks on
 an approval is `awaiting_approval` and is resumable - its message history is
 stored so the decision can be applied to the conversation it belongs to. A run that
 parks *inside a delegation* stores one level per agent, each with its own

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -71,8 +71,8 @@ recorded as `budget_exceeded` rather than `failed`, so an operator filtering for
 problems does not wade through the platform working correctly. A run somebody
 stopped - the composer's stop button, a socket that went away, a delegation
 cancelled from above - is `cancelled` for the same reason, on every surface and
-not only the streaming one. A run that parks on
-an approval is `awaiting_approval` and is resumable - its message history is
+not only the streaming one. A run that parks on an approval is
+`awaiting_approval` and is resumable - its message history is
 stored so the decision can be applied to the conversation it belongs to. A run that
 parks *inside a delegation* stores one level per agent, each with its own
 conversation, so approving continues the delegate that stopped rather than starting


### PR DESCRIPTION
## What changed

`AgentRunnerService._run` — the one place a run is executed, for `execute`,
`resume` and every non-streaming surface — caught `BudgetExceeded` and
`Exception` and had no `CancelledError` branch. `CancelledError` derives from
`BaseException`, so it passed through both, and a cancelled run was accounted
for wrong twice over:

- **The status.** It stayed at its initial `FAILED` with `error` at `None`, so a
  run that was working correctly and was stopped read as a malfunction with
  nothing to explain it — precisely the confusion `BUDGET_EXCEEDED` was given
  its own status to avoid.
- **The write itself.** `_run` never committed, and `get_db_session` auto-commits
  only on a clean exit, which a propagating `BaseException` is not. `finish`'s
  row was rolled back and the run stayed `RUNNING` for ever — and the delegation
  rows `_write_delegations` queues went back with it, so a delegate that spent
  real money was recorded nowhere.

`agent_chat.py` already had both halves with the reasoning beside them, so the
two files disagreed in writing. `_run` now does what `agent_chat` does: catch
`asyncio.CancelledError`, record `RunStatus.CANCELLED`, re-raise, and commit at
the end of the `finally`.

## How it was verified

Both tests fail against the unfixed module, on the two independent failures
rather than one:

```
E  AssertionError: assert 'failed' == 'cancelled'
E  AssertionError: assert ['parent', 'delegation'] == ['parent', 'delegation', 'commit']
```

The second asserts the *order* — parent row, delegation rows, then the commit —
because a commit placed before `_write_delegations` would lose exactly what the
rollback lost. The shape is borrowed from
`tests/test_agent_session.py::TestStoppingATurnMidDelegation`: the ledger is
asserted alongside the status, since a cancelled run that spent two dollars and
records zero is the hole cancellation opens.

`app/services/agent_runner.py` stays at **100% statements and branches**
(528 statements, 100 branches, 0 missed). `POSTGRES_DB=agenticos_test_i171 make
check` is green.

## Documentation

`docs/governance.md` already claimed the accounting commit was explicit "on
every surface" — true of the streaming surface only, and now true as written, so
the page needed no edit. `docs/concepts.md` enumerated the run statuses and
omitted `cancelled`; added, with the note that it holds on every surface rather
than only the streaming one.

## Also in the diff

The shared `_db()` helper in `tests/test_agent_runner.py` and
`tests/test_subagent_resolution.py` grew a `commit` AsyncMock. `_run` now
commits, and `MagicMock().commit()` cannot be awaited.

## Not fixed here

#176 (`resume` marks a run `RUNNING` before building its spec) and #169 (two
gated tool calls race the shared session) share a root with this and are in
flight separately, in the same file.

Closes #171

## Where this sits against #3

**#171 is a narrower duplicate of #3**, filed earlier and in more detail
(`AUD-003`, severity:high, assigned, milestone W5). Found while implementing
this, so it is worth being precise about which of #3's acceptance criteria this
change actually meets:

- [x] *A cancelled run records `CANCELLED`* — done, with the regression test.
- [x] *Every surface's failed run appears in history with its cost* — the commit
      in `_run`'s `finally` is what makes this true for the public API, all three
      channel surfaces, the embed widget and `resume`. Asserted at the unit
      layer only.
- [ ] *Regression test (integration, real Postgres)* — **not** done. #3 is
      explicit that a unit test asserting `finish_run` was called on an
      `AsyncMock` cannot observe a rollback, and it is right: the two tests here
      assert the commit and its ordering, which is the mechanism, not the
      outcome in a fresh session.
- [ ] *park → approve → resume with a crash after the deferred call* — not done.
- [ ] *Consolidate: move the commit into `finish` and delete `agent_chat`'s* —
      deliberately not done. #171's answered design question directs `_run` to do
      what `agent_chat` does, and consolidating is a change to a method the
      streaming surface calls around its own loop. It belongs to #3.

So this closes #171 and takes the sharp edge off #3 without finishing it. #3
stays open for the integration tests, the double-`send_invoice` case and the
consolidation.

Refs #3
