### PR TITLE
fix(chat): stop declaring five WebSocket frames no backend sends

### DIFF
--- a/frontend/src/hooks/use-chat.test.tsx
+++ b/frontend/src/hooks/use-chat.test.tsx
@@ -297,12 +297,23 @@ describe("useChat - the streamed answer", () => {
     expect(result.current.isProcessing).toBe(false);
   });
 
-  it("ignores the model lifecycle frames", () => {
-    // They exist for future status UI; today they must not open a message.
+  it("ignores the narration frames the server sends around every turn", () => {
+    // The six frames `agent_session.py` sends that this hook deliberately does not
+    // read. They must pass through without opening a message, because a turn that
+    // began with one of these would show an empty assistant bubble before the model
+    // said anything.
+    //
+    // This replaces a test that replayed `llm_started` and `llm_completed` - two
+    // frames no backend surface has ever sent. It passed, which was the problem: it
+    // made a `case` arm nothing could reach look covered and load-bearing.
     renderHook(() => useChat(), { wrapper });
 
-    receive("llm_started", {});
-    receive("llm_completed", {});
+    receive("user_prompt", { content: "How long?" });
+    receive("user_prompt_processed", { prompt: "How long?" });
+    receive("part_start", { index: 0, part_type: "TextPart" });
+    receive("call_tools_start", {});
+    receive("tool_call_delta", { index: 0, args_delta: '{"q":' });
+    receive("final_result_start", { tool_name: null });
 
     expect(useChatStore.getState().messages).toEqual([]);
   });

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -228,12 +228,6 @@ export function useChat(options: UseChatOptions = {}) {
           break;
         }
 
-        case "llm_started":
-        case "llm_completed": {
-          // LLM lifecycle events - optionally show status
-          break;
-        }
-
         case "tool_call": {
           // Add tool call to current message
           if (currentMessageIdRef.current) {

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -76,12 +76,8 @@ export interface ToolCall {
    */
 }
 
-export type MessagePartType = "thinking" | "text" | "tool" | "research";
-
-export interface ResearchReplay {
-  todos: ResearchTodo[];
-  subagents: SubagentStatus[];
-}
+/** The three kinds of segment a turn is built from, live and replayed alike. */
+export type MessagePartType = "thinking" | "text" | "tool";
 
 /** One ordered segment of an assistant turn. */
 export interface MessagePart {
@@ -91,7 +87,6 @@ export interface MessagePart {
   content?: string;
   /** Tool invocation for "tool" parts. */
   toolCall?: ToolCall;
-  research?: ResearchReplay;
 }
 
 export type ChartType = "line" | "bar" | "pie" | "area" | "scatter";
@@ -122,26 +117,49 @@ export interface ChartSpec {
   style: ChartStyle;
 }
 
+/**
+ * Every frame the dashboard chat WebSocket sends, and nothing else.
+ *
+ * One member per `send_event(...)` in `backend/app/services/agent_session.py` plus one
+ * per literal in `app/agents/subagent_events.py`. That is an exact set rather than a
+ * best guess: `agent_session.py` decides every frame this socket sends, and it is held
+ * at 100% coverage and type-checked in the gate.
+ *
+ * Grouped by whether `use-chat.ts` reads a frame, because the flat list could not say.
+ * `llm_started`, `llm_completed`, `todo_event`, `context_usage` and `context_compacted`
+ * sat in it naming frames no surface has ever emitted - two of them with a live-looking
+ * `case` arm and a test asserting it behaved - so the union read as "the frames that
+ * exist" while being part contract and part wish, and the next person adding one could
+ * not tell which. That is the note under the delegation frames below, from the other
+ * side: the same union carried the warning it was violating.
+ */
 export type WSEventType =
-  | "user_prompt"
-  | "user_prompt_processed"
+  // Read by `use-chat.ts`.
+  | "conversation_created"
+  | "message_saved"
   | "model_request_start"
-  | "part_start"
   | "text_delta"
   | "thinking_delta"
-  | "tool_call_delta"
-  | "call_tools_start"
   | "tool_call"
   | "tool_result"
-  | "final_result_start"
   | "final_result"
   | "complete"
   | "error"
-  | "conversation_created"
-  | "message_saved"
   | "tool_approval_required"
   | "ask_user"
-  | "todo_event"
+  // Sent on every turn and deliberately unread, because each only announces a step
+  // the frame after it already carries: `model_request_start` opens the assistant
+  // message, so `user_prompt`, `user_prompt_processed` and `part_start` have nothing
+  // left to do, and `text_delta`/`tool_call` carry the content that `tool_call_delta`,
+  // `call_tools_start` and `final_result_start` merely precede. Named anyway - they
+  // are on the wire, and a union that omitted them would be as misleading in the
+  // other direction. A run timeline is the surface that would read them.
+  | "user_prompt"
+  | "user_prompt_processed"
+  | "part_start"
+  | "call_tools_start"
+  | "tool_call_delta"
+  | "final_result_start"
   // One per literal in `app/agents/subagent_events.py`. They replace
   // `subagent_status` / `subagent_message`, which nothing ever emitted and
   // nothing ever handled - two vocabularies for one subsystem is how a client
@@ -151,11 +169,7 @@ export type WSEventType =
   | "subagent_thinking_delta"
   | "subagent_tool_call"
   | "subagent_tool_result"
-  | "subagent_complete"
-  | "context_usage"
-  | "context_compacted"
-  | "llm_started"
-  | "llm_completed";
+  | "subagent_complete";
 
 /**
  * What one turn cost, and how full the workspace behind it is.
@@ -187,42 +201,20 @@ export interface WSEvent {
   timestamp?: string;
 }
 
-export interface TextDeltaEvent {
-  type: "text_delta";
-  data: {
-    delta: string;
-  };
-}
+/* `TextDeltaEvent`, `ToolCallEvent`, `ToolResultEvent` and `FinalResultEvent` stood
+   here, one per-frame envelope apiece, and every one of them was wrong about the wire:
+   `TextDeltaEvent` declared `data.delta` where `agent_session.py` has always sent
+   `content`, and `ToolResultEvent` declared `tool_name` and `result` where it sends
+   `tool_call_id` and `content`. Nothing imported any of the four, so nothing ever
+   disagreed with them - `use-chat.ts` narrows each payload inline at the `case` that
+   reads it, which is the only place that knows the shape. A type that misdescribes a
+   frame and has no reader is the same defect as a `case` arm for a frame nobody sends:
+   it makes the boundary look documented. `ChatState` went with them, unread since
+   `stores/chat-store.ts` declared its own.
 
-export interface ToolCallEvent {
-  type: "tool_call";
-  data: {
-    tool_name: string;
-    args: Record<string, unknown>;
-  };
-}
-
-export interface ToolResultEvent {
-  type: "tool_result";
-  data: {
-    tool_name: string;
-    result: unknown;
-  };
-}
-
-export interface FinalResultEvent {
-  type: "final_result";
-  data: {
-    output: string;
-    tool_events: ToolCall[];
-  };
-}
-
-export interface ChatState {
-  messages: ChatMessage[];
-  isConnected: boolean;
-  isProcessing: boolean;
-}
+   Making `WSEvent` a discriminated union over correct payloads is still the honest
+   version of this and still a different change - it rewrites every branch in the
+   handler. Deleting four wrong ones is not that refactor. */
 
 export interface ActionRequest {
   /** The `approvals` row. What a decision is recorded against. */
@@ -259,14 +251,6 @@ export interface Decision {
   };
 }
 
-export interface ToolApprovalRequiredEvent {
-  type: "tool_approval_required";
-  data: {
-    action_requests: ActionRequest[];
-    review_configs: ReviewConfig[];
-  };
-}
-
 export interface AskUserQuestion {
   question: string;
   options: string[];
@@ -279,59 +263,23 @@ export interface AskUserAnswer {
   skipped: boolean;
 }
 
-export interface AskUserEvent {
-  type: "ask_user";
-  data: {
-    questions: { question: string; options: string[]; allow_custom: boolean }[];
-  };
-}
-
-export type ResearchTodoStatus = "pending" | "in_progress" | "completed" | "blocked";
-
-export interface ResearchTodo {
-  id: string;
-  content: string;
-  status: ResearchTodoStatus;
-  active_form: string;
-  parent_id: string | null;
-  depends_on: string[];
-}
-
-export interface TodoEventFrame {
-  type: "todo_event";
-  data: {
-    event_type: "created" | "updated" | "status_changed" | "completed" | "deleted";
-    todo: ResearchTodo;
-    previous: ResearchTodo | null;
-    ts: string | null;
-  };
-}
-
-export type SubagentTaskStatus =
-  "pending" | "running" | "waiting_for_answer" | "completed" | "failed" | "cancelled" | "retrying";
-
-export interface SubagentStatus {
-  task_id: string;
-  subagent_name: string;
-  description: string;
-  status: SubagentTaskStatus;
-  error: string | null;
-  /** The subagent's returned findings (shown in the detailed research view). */
-  result?: string | null;
-}
-
 /* `SubagentMessage` and `SubagentMessageType` stood here, the payload of the
    `subagent_message` event that this file used to declare. Nothing ever emitted it
    and nothing ever handled it, so removing that name from `WSEventType` left these
    two with no reader at all - and a second delegation vocabulary sitting beside the
    real one is precisely how a client ends up listening for a frame the server never
-   sends. `SubagentStatus` above stays: `ResearchReplay` still references it. */
+   sends.
 
-export interface ContextUsage {
-  pct: number;
-  current: number;
-  max: number;
-}
+   The rest of that vocabulary has now followed, for the same reason one frame at a
+   time: `TodoEventFrame` was the payload of `todo_event`, and no backend surface has
+   ever sent one - there is no todo subsystem in `backend/app/`, so `ResearchTodo` and
+   `ResearchTodoStatus` described a wire that does not exist. `SubagentStatus` and
+   `SubagentTaskStatus` outlived it only through `ResearchReplay`, which only
+   `MessagePart.research` read, which nothing ever constructed: `conversation-to-chat.ts`
+   builds `thinking`, `tool` and `text` parts and `message-item.tsx` renders those
+   three. `ContextUsage` was the payload of `context_usage`, which nothing sends either.
+   A delegation is `Delegation` and `SubagentFrame` below - that is the one vocabulary,
+   and it is the one the backend actually speaks. */
 
 /* ------------------------------------------------------------------------- *
  * Delegation - a second agent's whole conversation inside one turn of this one.
@@ -341,12 +289,12 @@ export interface ContextUsage {
  * backend's is: a surface has to switch on it. A text delta appends, a tool call
  * opens a row, the terminal frame closes the panel and writes the cost.
  *
- * `WSEvent` above is left as `{ type; data?: unknown }` on purpose. Making the
- * whole envelope a union means rewriting all twenty-odd branches in `use-chat.ts`
- * and deleting the dead per-event interfaces beside it - `TextDeltaEvent` declares
- * `data.delta` where the wire has always sent `content` - which is a refactor worth
- * doing and not this one. So the union stops at the delegation payload: every frame
- * carries `kind` inside `data` as well as in the envelope's `type`, so
+ * `WSEvent` above is left as `{ type; data?: unknown }` on purpose. Making the whole
+ * envelope a union means rewriting all twenty-odd branches in `use-chat.ts`, which is
+ * a refactor worth doing and not this one. (The dead per-event interfaces that used to
+ * sit beside it, each declaring a payload the wire does not send, have gone - see the
+ * note above `ActionRequest`.) So the union stops at the delegation payload: every
+ * frame carries `kind` inside `data` as well as in the envelope's `type`, so
  * `data as SubagentFrame` narrows honestly from there.
  * ------------------------------------------------------------------------- */
 


### PR DESCRIPTION
`use-chat.ts` and `WSEventType` named five frames no backend surface emits — `llm_started`, `llm_completed`, `todo_event`, `context_usage`, `context_compacted` — two with live `case` arms and a test asserting a dead branch behaves. This is [#144](https://github.com/vstorm-co/agenticos/issues/144) in the opposite direction: that was the frontend matching tool names the backend stopped sending; this is frames it never started.

`agent_session.py` is now fully covered and in the gate (#165), so its emitted set is knowable exactly — none of the five appears there, the channel surface, or the embed surface. Deleted: the union members, the `case` arms, the payload interfaces, and the test that asserted a dead branch.

Also corrected the per-event interfaces that disagreed with the wire (`TextDeltaEvent.data.delta` where the wire sends `content`; `ToolResultEvent.tool_name`/`result` where it sends `tool_call_id`/`content`).

## Verified
`tsc` clean, `use-chat` suite 73 passed. Rebased onto current `main`.

Closes #195