### PR TITLE
refactor(runs): read run history through the service, not the repo

### DIFF
--- a/backend/app/api/routes/v1/runs.py
+++ b/backend/app/api/routes/v1/runs.py
@@ -9,10 +9,8 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query
 
-from app.api.deps import AgentRunnerSvc, ApprovalSvc, Auth, DBSession, require
-from app.core.exceptions import NotFoundError
+from app.api.deps import AgentRunnerSvc, ApprovalSvc, Auth, require
 from app.core.permissions import Perm
-from app.repositories import agent_run_repo
 from app.schemas.agent import AgentRunResult
 from app.schemas.agent_run import (
     AgentRunList,
@@ -31,7 +29,7 @@ router = APIRouter()
 
 @router.get("/runs", response_model=AgentRunList, dependencies=[Depends(require(Perm.RUNS_VIEW))])
 async def list_runs(
-    db: DBSession,
+    service: AgentRunnerSvc,
     ctx: Auth,
     agent_id: UUID | None = Query(None),
     parent_run_id: UUID | None = Query(
@@ -45,12 +43,11 @@ async def list_runs(
 ) -> Any:
     """Runs for the organization, newest first, optionally for one agent.
 
-    Top-level runs only by default - see `list_runs` for why a delegated row
+    Top-level runs only by default - see the service for why a delegated row
     and a run somebody started are never summed down one column.
     """
-    items, total = await agent_run_repo.list_runs(
-        db,
-        organization_id=ctx.organization_id,
+    items, total = await service.list_runs(
+        ctx,
         agent_id=agent_id,
         parent_run_id=parent_run_id,
         include_delegations=include_delegations,
@@ -63,12 +60,9 @@ async def list_runs(
 @router.get(
     "/runs/{run_id}", response_model=AgentRunRead, dependencies=[Depends(require(Perm.RUNS_VIEW))]
 )
-async def get_run(run_id: UUID, db: DBSession, ctx: Auth) -> Any:
+async def get_run(run_id: UUID, service: AgentRunnerSvc, ctx: Auth) -> Any:
     """One run. The step-by-step trace lives in Logfire under its trace id."""
-    run = await agent_run_repo.get_run(db, run_id, organization_id=ctx.organization_id)
-    if run is None:
-        raise NotFoundError(message="Run not found", details={"run_id": str(run_id)})
-    return run
+    return await service.get_run(ctx, run_id)
 
 
 @router.post(

--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -2484,6 +2484,50 @@ class AgentRunnerService:
 
         return output, prepared.run
 
+    async def list_runs(
+        self,
+        ctx: AuthContext,
+        *,
+        agent_id: UUID | None = None,
+        parent_run_id: UUID | None = None,
+        include_delegations: bool = False,
+        skip: int = 0,
+        limit: int = 50,
+    ) -> tuple[list[AgentRun], int]:
+        """Runs for the organization, newest first, optionally for one agent.
+
+        Scoped to the caller's organization here rather than in the route, so
+        run history is read through the same tenant boundary the rest of this
+        service enforces - there is no second place a listing could widen.
+
+        Top-level runs only by default: a delegated row and a run somebody
+        started are never summed down one column, because a parent's cost
+        already contains its children's. `parent_run_id` lists one run's own
+        delegations; `include_delegations` keeps them in an agent's own history.
+        """
+        return await agent_run_repo.list_runs(
+            self.db,
+            organization_id=ctx.organization_id,
+            agent_id=agent_id,
+            parent_run_id=parent_run_id,
+            include_delegations=include_delegations,
+            skip=skip,
+            limit=limit,
+        )
+
+    async def get_run(self, ctx: AuthContext, run_id: UUID) -> AgentRun:
+        """One run in the caller's organization.
+
+        A run belonging to another organization reads as absent, not forbidden:
+        the repository filters on `organization_id`, so a foreign id returns no
+        row and this raises the same `NotFoundError` an unknown id would - a
+        tenant cannot tell a neighbour's run from one that never existed.
+        """
+        run = await agent_run_repo.get_run(self.db, run_id, organization_id=ctx.organization_id)
+        if run is None:
+            raise NotFoundError(message="Run not found", details={"run_id": str(run_id)})
+        return run
+
     async def monthly_spend(self, ctx: AuthContext, *, agent_id: UUID | None = None) -> Decimal:
         """Spend so far this calendar month, for the org or one agent.
 

--- a/backend/tests/test_agent_runner.py
+++ b/backend/tests/test_agent_runner.py
@@ -454,6 +454,68 @@ class TestSpendReporting:
         assert timedelta(days=7) <= looked_back < timedelta(days=7, seconds=30)
 
 
+class TestReadingRunHistory:
+    """The two reads behind the run-history surface, scoped in the service so
+    the route never touches the repository - and so the tenant boundary has one
+    home rather than two."""
+
+    @pytest.mark.anyio
+    async def test_listing_runs_scopes_to_the_callers_organization(self):
+        """A listing is read for the caller's org, never for all of them, and the
+        filter and page pass straight through."""
+        ctx = _ctx()
+        agent_id = uuid.uuid4()
+        rows = ([MagicMock(), MagicMock()], 2)
+
+        with patch(
+            "app.services.agent_runner.agent_run_repo.list_runs",
+            new=AsyncMock(return_value=rows),
+        ) as listed:
+            items, total = await AgentRunnerService(_db()).list_runs(
+                ctx, agent_id=agent_id, skip=10, limit=25
+            )
+
+        assert (items, total) == rows
+        assert listed.call_args.kwargs["organization_id"] == ctx.organization_id
+        assert listed.call_args.kwargs["agent_id"] == agent_id
+        assert listed.call_args.kwargs["skip"] == 10
+        assert listed.call_args.kwargs["limit"] == 25
+
+    @pytest.mark.anyio
+    async def test_getting_a_run_reads_it_within_the_callers_organization(self):
+        """The single read carries the org id so it can only ever return a row
+        the caller's organization owns."""
+        ctx = _ctx()
+        run_id = uuid.uuid4()
+        run = MagicMock(id=run_id)
+
+        with patch(
+            "app.services.agent_runner.agent_run_repo.get_run",
+            new=AsyncMock(return_value=run),
+        ) as fetched:
+            got = await AgentRunnerService(_db()).get_run(ctx, run_id)
+
+        assert got is run
+        assert fetched.call_args.args[1] == run_id
+        assert fetched.call_args.kwargs["organization_id"] == ctx.organization_id
+
+    @pytest.mark.anyio
+    async def test_a_run_in_another_organization_is_not_found(self):
+        """The repository filters on organization, so a foreign id returns no row
+        - and a tenant cannot tell a neighbour's run from one that never was."""
+        ctx = _ctx()
+        run_id = uuid.uuid4()
+
+        with (
+            patch(
+                "app.services.agent_runner.agent_run_repo.get_run",
+                new=AsyncMock(return_value=None),
+            ),
+            pytest.raises(NotFoundError),
+        ):
+            await AgentRunnerService(_db()).get_run(ctx, run_id)
+
+
 class TestWhatAParkedCallRecords:
     """Enough for a surface to put the decision in front of somebody.
 


### PR DESCRIPTION
## What this fixes

`list_runs` and `get_run` in `runs.py` imported `agent_run_repo` and called it
directly, which the layering rule in `CLAUDE.md` and `.claude/rules/architecture.md`
forbids: routes call services only. Every other handler in the same file already goes
through `AgentRunnerSvc` or `ApprovalSvc` — these two were the outliers, and the `db:
DBSession` parameter was the tell.

Closes #197.

## What changed

- `app/services/agent_runner.py` — two new read methods on `AgentRunnerService`:
  `list_runs` (scopes to the caller's org, passes the filter and page through) and
  `get_run` (raises `NotFoundError` for an absent or foreign run, so the tenant
  boundary lives in the service, not the route).
- `app/api/routes/v1/runs.py:32` / `:47` — both handlers now take `service:
  AgentRunnerSvc` and delegate; `get_run` drops its own `None` check, since the service
  raises. Removes the now-unused `DBSession`, `agent_run_repo` and `NotFoundError`
  imports.

## How it failed before

Not a runtime failure — a layering violation. Run-history reads had two homes for a
rule (tenant scope), and the repository-side one is invisible to the service tests. A
scope or spend rule added to run history could land in the route and never be exercised
by `AgentRunnerService`'s suite.

## Testing

- `tests/test_agent_runner.py::TestReadingRunHistory` — three new service tests: a
  listing is scoped to the caller's org with filter/page passthrough; a single read
  carries the org id; a run in another organization raises `NotFoundError` (reads as
  absent, not forbidden).
- `rg 'agent_run_repo' backend/app/api/` returns nothing — the issue's stated bar.
- `make test` (backend + 100% platform coverage gate), `ruff`, `ruff format`, `ty` all
  green on the touched files.
- The permission-gate sweep in `tests/api/test_platform_routes.py` still passes: the
  routes keep their `Perm.RUNS_VIEW` gate unchanged.

## Docs

`scripts/docs_drift.py` flags `docs/architecture.md` because `runs.py` changed, but the
page describes the layering rule generically and never named these handlers — the
change makes the code match what the page already says. No behaviour a page describes
has changed, so nothing is owed.

## Noticed, not fixed

Nothing adjacent. The other handlers in `runs.py` already route through services.
