### PR TITLE
fix(agents): make bootstrap ensure the profile it names, not any it finds

### DIFF
--- a/backend/app/commands/bootstrap.py
+++ b/backend/app/commands/bootstrap.py
@@ -150,21 +150,33 @@ async def _resolve_organization(db, owner_id: uuid.UUID, name: str):
 async def _resolve_model(
     db, ctx: AuthContext, provider: str, api_key: str | None, model_id: str | None
 ) -> uuid.UUID | None:
-    """A default model profile, when a key was supplied to build it from.
+    """The default model profile bootstrap names, built from a supplied key.
 
-    Nothing is created without one. A keyless profile is a row that can never
-    run and that nothing repoints: models are keyed from the vault now, and the
-    only way to give one a key is to add the model again. It showed up in the
-    Builder as `openai default · no key`, an option whose sole effect was to
-    make an agent fail at its first message.
+    Idempotent on the profile it *names*, not on whatever the organization
+    happens to hold. It used to adopt the first profile it found, so on a
+    developer database that already had one - an unrelated `OpenRouter ·
+    openai/gpt-5.1`, or a profile a failed spec leaked - it reused that and
+    never created `openai default`. Idempotence that reuses whatever it finds is
+    not idempotence: the promise of `make platform-bootstrap` is a *known*
+    starting point, and that only holds if the profile it guarantees is the one
+    it created. So it looks for `<provider> default`, and reuses only that.
+
+    Nothing keyless is created. A keyless profile is a row that can never run
+    and that nothing repoints: models are keyed from the vault now, and the only
+    way to give one a key is to add the model again. It showed up in the Builder
+    as `openai default · no key`, an option whose sole effect was to make an
+    agent fail at its first message.
 
     Returns None when there is no key, and the caller leaves the demo agent as
     a draft rather than publishing something that cannot answer.
     """
-    existing = await credential_repo.list_profiles(db, organization_id=ctx.organization_id)
-    if existing:
-        info(f"Using model {existing[0].label}")
-        return existing[0].id
+    label = f"{provider} default"
+    existing = await credential_repo.get_profile_by_label(
+        db, label, organization_id=ctx.organization_id
+    )
+    if existing is not None:
+        info(f"Using model {existing.label}")
+        return existing.id
 
     if api_key is None:
         info(f"No {provider} key given - add one in the vault, then add a model")
@@ -185,7 +197,7 @@ async def _resolve_model(
     model = model_id or DEFAULT_MODELS[provider]
     profile = await ModelProfileService(db).create_profile(
         ctx,
-        label=f"{provider} default",
+        label=label,
         provider=provider,
         model=model,
         secret_id=secret.id,

--- a/backend/tests/test_bootstrap.py
+++ b/backend/tests/test_bootstrap.py
@@ -75,16 +75,44 @@ class TestOrganization:
 
 class TestModel:
     @pytest.mark.anyio
-    async def test_an_existing_model_is_reused(self):
-        """Re-running bootstrap is what people do when unsure it worked; a
-        second model called "openai default" would be refused on its label
-        anyway, which is a confusing way to learn nothing was wrong."""
-        existing = MagicMock(id=uuid.uuid4(), label="GPT-4.1")
+    async def test_the_profile_it_already_created_is_reused(self):
+        """Re-running bootstrap is what people do when unsure it worked; the
+        profile it names is unique on its label, so a second run adopts the one
+        the first left rather than creating a duplicate it would be refused."""
+        existing = MagicMock(id=uuid.uuid4(), label="openai default")
         with patch(
-            "app.commands.bootstrap.credential_repo.list_profiles",
-            new=AsyncMock(return_value=[existing]),
-        ):
+            "app.commands.bootstrap.credential_repo.get_profile_by_label",
+            new=AsyncMock(return_value=existing),
+        ) as by_label:
             assert await _resolve_model(MagicMock(), _ctx(), "openai", None, None) == existing.id
+        assert by_label.await_args.args[1] == "openai default"
+
+    @pytest.mark.anyio
+    async def test_an_unrelated_profile_is_not_adopted(self):
+        """The bug this command was carrying: it reused the *first* profile it
+        found, so a developer database already holding an unrelated one - or a
+        profile a failed spec leaked - was adopted and `openai default` never
+        created. `make platform-bootstrap` promises a known starting point, and
+        that only holds if the profile it guarantees is the one it names."""
+        created = MagicMock(id=uuid.uuid4(), label="openai default")
+        with (
+            patch(
+                "app.commands.bootstrap.credential_repo.get_profile_by_label",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "app.commands.bootstrap.OrganizationSecretService.create",
+                new=AsyncMock(return_value=MagicMock(id=uuid.uuid4(), hint="1234")),
+            ),
+            patch(
+                "app.commands.bootstrap.ModelProfileService.create_profile",
+                new=AsyncMock(return_value=created),
+            ) as create_profile,
+        ):
+            result = await _resolve_model(MagicMock(), _ctx(), "openai", "sk-test-1234", None)
+
+        assert result == created.id
+        assert create_profile.call_args.kwargs["label"] == "openai default"
 
     @pytest.mark.anyio
     async def test_a_key_is_stored_and_the_profile_points_at_it(self):
@@ -93,8 +121,8 @@ class TestModel:
 
         with (
             patch(
-                "app.commands.bootstrap.credential_repo.list_profiles",
-                new=AsyncMock(return_value=[]),
+                "app.commands.bootstrap.credential_repo.get_profile_by_label",
+                new=AsyncMock(return_value=None),
             ),
             patch(
                 "app.commands.bootstrap.OrganizationSecretService.create",
@@ -118,8 +146,8 @@ class TestModel:
         agent fail at its first message."""
         with (
             patch(
-                "app.commands.bootstrap.credential_repo.list_profiles",
-                new=AsyncMock(return_value=[]),
+                "app.commands.bootstrap.credential_repo.get_profile_by_label",
+                new=AsyncMock(return_value=None),
             ),
             patch(
                 "app.commands.bootstrap.ModelProfileService.create_profile",
@@ -136,8 +164,8 @@ class TestModel:
         profile = MagicMock(id=uuid.uuid4(), label="x")
         with (
             patch(
-                "app.commands.bootstrap.credential_repo.list_profiles",
-                new=AsyncMock(return_value=[]),
+                "app.commands.bootstrap.credential_repo.get_profile_by_label",
+                new=AsyncMock(return_value=None),
             ),
             patch(
                 "app.commands.bootstrap.OrganizationSecretService.create",


### PR DESCRIPTION
## What this fixes

`agenticos cmd bootstrap` adopted **any** existing model profile instead of ensuring the one it names. On a database that had been used before, that meant `openai default` never got created — and the E2E suite, which selects models by name, failed. `Closes #172`.

## What changed

- `backend/app/commands/bootstrap.py:150` — `_resolve_model` now looks up the profile by the label it would create (`<provider> default`, unique per org via `credential_repo.get_profile_by_label`) and reuses **only** that. It no longer adopts the first profile it happens to find.

## How it failed before

`_resolve_model` did `existing = list_profiles(...)` then `if existing: return existing[0].id`. Two ways that bit, both surfacing only on a reused database (CI uses a fresh throwaway DB, which is why this was invisible there):

1. A developer DB already holding an unrelated profile — `OpenRouter · openai/gpt-5.1` — was adopted, so the documented `openai default` never existed. `agents.spec.ts:249`, `models.spec.ts:37/68`, `refusals.spec.ts:75` all select a model by name and found nothing.
2. A failed `models.spec.ts` leaks an `e2e-keyless-*` profile; the next `bootstrap` adopted *that*, so one failure became a permanently drifted database and the failure looked intermittent when it was sticky.
3. Skipping adoption also skipped storing the `<provider> (bootstrap)` key, so the org had a single OpenAI key and `#add-model-key` never rendered — the third, smaller symptom the issue records. All three are the same root cause.

The fix matches the issue's recommended decision: bootstrap **guarantees the profile it names exists and ignores profiles it did not create**, which satisfies both "done when" bullets — a leaked keyless profile is now harmless, and a pre-existing unrelated profile no longer displaces the seed.

## Testing

- `backend/tests/test_bootstrap.py::TestModel::test_an_unrelated_profile_is_not_adopted` — new regression: an unrelated profile is not adopted and `openai default` is created regardless. Fails on the pre-fix source.
- `test_the_profile_it_already_created_is_reused` — the former "reuse" test, flipped to assert the *named* profile is reused (it used to assert any profile named `GPT-4.1` was adopted, i.e. it encoded the bug).
- `tests/test_bootstrap.py` — 17 passed; `bootstrap.py` stays at **100%** coverage. `ruff`, `ruff format`, `ty` clean.
- Not run locally: `make test-e2e` — it needs a seeded backend and a reused database to exercise the original reproduction. CI's e2e job runs against a fresh DB, so it was green before and stays green; the failure only reproduces on a database that has been used before.

## Noticed, not fixed

From the same issue, recorded for whoever debugs the E2E harness next (out of scope here, and none is a code defect in this repo):

- A containerised backend cannot reach the E2E stub model server on `127.0.0.1:4010`; the suite must run the backend on the host with uvicorn, as CI does.
- The backend image predates `subagents-pydantic-ai` and crashes on import until rebuilt.
- `sharing.spec.ts:55` flakiness is #154, not this.
