### PR TITLE
ci(migrations): make alembic check a usable gate

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -36,8 +36,9 @@ make lint               # ruff, ruff format, ty, eslint, prettier, tsc, the two 
 make test               # backend + the 100% gate on the platform layer
 make test-frontend-cov  # frontend + its gate: 100% lines/stmts/funcs, 97.5% branches
 make test-integration   # only if the change is near the database
-make check              # every CI job except e2e - lint, test, test-frontend-cov,
-                        # build-frontend, docs-build, audit. About five minutes.
+make check              # every CI job except e2e - lint, test, db-check,
+                        # test-frontend-cov, build-frontend, docs-build, audit.
+                        # About five minutes.
 ```
 
 `make check` is CI, not an approximation of it: `.github/workflows/ci.yml` calls

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,14 @@ jobs:
         # on a laptop it points at whatever `backend/.env` says.
         run: make test-migrations
 
+      - name: Verify the models and the migrations still agree
+        # `alembic check` fails if the models declare something no migration
+        # creates - the gate that catches "edited a model, forgot the
+        # migration". `test-migrations` above leaves the database at head, which
+        # is what this needs; it never downgrades, so it is safe to run in
+        # `make check` too, where `test-migrations` is not.
+        run: make db-check
+
       - name: Run tests with the coverage gate
         # --cov with no argument uses the include list in pyproject.toml: the
         # platform layer, held at 100%. Template-inherited subsystems are

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,7 @@ make check                                        # every CI job but e2e — bef
 | `make test-frontend` / `make test-frontend-cov` | vitest / vitest with the gate CI applies |
 | `make test-e2e` | Playwright — needs a backend and its seed |
 | `make test-migrations` | the whole chain forwards and back |
+| `make db-check` | `alembic check` — a model change with no migration fails here (in `make check`) |
 | `make db-migrate` / `make db-upgrade` | autogenerate / apply |
 | `make docs` / `make docs-build` | serve on :8001 (`DOCS_PORT=` to move it) / `--strict` |
 | `uv run agenticos cmd doctor` | can this deployment actually run an agent? |

--- a/Makefile
+++ b/Makefile
@@ -381,7 +381,7 @@ test-e2e:
 #     laptop is the database with your own work in it.
 CHECK_DB_PORT ?= 5432
 
-check: lint test test-frontend-cov build-frontend docs-build audit
+check: lint test db-check test-frontend-cov build-frontend docs-build audit
 	@echo ""
 	@echo "All checks passed — every CI job except e2e."
 	@if ! python3 -c 'import socket; socket.create_connection(("127.0.0.1", $(CHECK_DB_PORT)), 1).close()' 2>/dev/null; then \
@@ -414,6 +414,26 @@ test-migrations:
 	uv run --directory backend alembic downgrade base
 	uv run --directory backend alembic upgrade head
 	@echo "Migration chain applies and rolls back cleanly."
+
+# Do the models and the migrations still agree? `alembic check` autogenerates
+# against the database and fails if anything is left over - the gate that catches
+# "somebody edited a model and forgot the migration", the one question
+# `test-migrations` (which only proves the chain applies and rolls back) does not
+# answer.
+#
+# Unlike `test-migrations` this belongs in `make check`: it reflects the schema
+# and diffs it, it never downgrades, so it cannot empty a laptop's working
+# database. It does need one at head - `make dev` keeps it there - and is skipped
+# rather than failed when none is reachable, the same bargain `check` strikes for
+# the integration suite. CI always has a database, so there it runs for real,
+# after `test-migrations` has left it at head.
+db-check:
+	@if python3 -c 'import socket; socket.create_connection(("127.0.0.1", $(CHECK_DB_PORT)), 1).close()' 2>/dev/null; then \
+		uv run --directory backend alembic check; \
+	else \
+		echo "⚠  No database on 127.0.0.1:$(CHECK_DB_PORT), so 'alembic check' was skipped"; \
+		echo "   — and CI's test job has one, so it did not. 'make docker-db' closes that gap."; \
+	fi
 
 
 # === Database ===

--- a/backend/alembic/versions/0009_align_index_names.py
+++ b/backend/alembic/versions/0009_align_index_names.py
@@ -1,0 +1,60 @@
+"""Rename the indexes 0002-0004 named the old way
+
+Revision ID: 0009_align_index_names
+Revises: 0008_approval_delegate
+Create Date: 2026-08-05
+
+`0001_baseline` moved every index name onto `Base.metadata.naming_convention`
+(`<table>_<col>_idx`) to end the drift that made `alembic revision --autogenerate`
+emit four hundred lines of noise. The three migrations added after the squash -
+`0002_agent_workspaces`, `0003_sandbox_connections`, `0004_skill_proposals` -
+reintroduced exactly that noise: each wrote `op.create_index(op.f("ix_<table>_<col>"))`,
+the hand-written `ix_*` of the old chain, while the models declare `index=True` and so
+resolve to `<table>_<col>_idx`. Twelve indexes disagreed with the models, so
+`alembic check` failed on `main` for reasons unrelated to any change under test - which
+is why it could not be added to `make check` as the gate that catches "a model changed
+and the migration did not".
+
+This renames those twelve to what the models declare. A rename, not a drop-and-create:
+the index is preserved, and the name is the only thing wrong. The composite
+`ix_skill_proposals_pending` is *not* touched - the model names it explicitly, so the
+database already agrees with it.
+
+`ALTER INDEX ... RENAME TO ...` is a catalog-only operation in PostgreSQL - no rebuild,
+no lock beyond the brief one it takes on the index. `downgrade()` restores the old
+names so the chain round-trips.
+"""
+
+from alembic import op
+
+# (old ix_* name, convention <table>_<col>_idx name) for the twelve indexes that
+# migrations 0002-0004 created under the pre-baseline naming.
+RENAMES: list[tuple[str, str]] = [
+    ("ix_agent_workspaces_agent_id", "agent_workspaces_agent_id_idx"),
+    ("ix_agent_workspaces_connection_id", "agent_workspaces_connection_id_idx"),
+    ("ix_agent_workspaces_conversation_id", "agent_workspaces_conversation_id_idx"),
+    ("ix_agent_workspaces_organization_id", "agent_workspaces_organization_id_idx"),
+    ("ix_agent_workspaces_owner_ref", "agent_workspaces_owner_ref_idx"),
+    ("ix_agent_workspaces_scope_key", "agent_workspaces_scope_key_idx"),
+    ("ix_sandbox_connections_organization_id", "sandbox_connections_organization_id_idx"),
+    ("ix_sandbox_connections_secret_id", "sandbox_connections_secret_id_idx"),
+    ("ix_skill_proposals_agent_id", "skill_proposals_agent_id_idx"),
+    ("ix_skill_proposals_organization_id", "skill_proposals_organization_id_idx"),
+    ("ix_skill_proposals_skill_id", "skill_proposals_skill_id_idx"),
+    ("ix_skill_proposals_status", "skill_proposals_status_idx"),
+]
+
+revision = "0009_align_index_names"
+down_revision = "0008_approval_delegate"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    for old_name, new_name in RENAMES:
+        op.execute(f"ALTER INDEX {old_name} RENAME TO {new_name}")
+
+
+def downgrade() -> None:
+    for old_name, new_name in RENAMES:
+        op.execute(f"ALTER INDEX {new_name} RENAME TO {old_name}")

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -39,7 +39,7 @@ than repeating their commands, and `backend/tests/test_ci_parity.py` fails if a
 gating job grows a step `check` does not run — or the reverse.
 
 ```bash
-make check   # lint, test, test-frontend-cov, build-frontend, docs-build, audit
+make check   # lint, test, db-check, test-frontend-cov, build-frontend, docs-build, audit
 ```
 
 About five minutes, serial, on a warm cache. What it deliberately leaves out:
@@ -64,6 +64,7 @@ first if the change is anywhere near the database.
 | `make db-init` | Start PostgreSQL + create initial migration + apply |
 | `make db-migrate` | Create new migration (prompts for message) |
 | `make db-upgrade` | Apply pending migrations |
+| `make db-check` | `alembic check` — fail if a model change has no migration. Non-destructive (it never downgrades), so unlike `test-migrations` it runs inside `make check`; needs a database at head, and skips rather than fails when none answers on 5432 |
 | `make db-downgrade` | Rollback last migration |
 | `make db-current` | Show current migration revision |
 | `make db-history` | Show full migration history |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,6 +19,7 @@ Once, before pushing — `make check` runs all of it, in this order:
 ```bash
 make lint               # ruff, ruff format, ty, eslint, prettier, tsc, and the two guards
 make test               # the suite plus the 100% gate on the platform layer
+make db-check           # alembic check — a model change with no migration fails here
 make test-frontend-cov  # the frontend suite plus its own gate
 make build-frontend     # next build — the route tree, which tsc and vitest do not see
 make docs-build         # mkdocs --strict — a dead link is a failure


### PR DESCRIPTION
## What this fixes

`uv run alembic check` failed on `main`, so the one tool that catches "somebody
edited a model and forgot the migration" could not be used as a gate. This fixes
the drift and wires the check into `make check` and CI. `Closes #183`.

## What changed

- `backend/alembic/versions/0009_align_index_names.py` — renames twelve indexes on
  `agent_workspaces`, `sandbox_connections` and `skill_proposals` from the
  hand-written `ix_<table>_<col>` to the `<table>_<col>_idx` the models' naming
  convention produces. `ALTER INDEX ... RENAME`, so the index is preserved.
- `Makefile:417` — new `db-check` target running `alembic check`; added to the
  `check` prerequisites (`Makefile:384`).
- `.github/workflows/ci.yml` — a `make db-check` step in the `test` job, right after
  `make test-migrations` leaves the database at head.
- `docs/commands.md`, `docs/testing.md`, `.claude/rules/testing.md`, `CLAUDE.md` —
  the `make check` step list and a `db-check` row.

## How it failed before

`0001_baseline` deliberately moved every index name onto
`Base.metadata.naming_convention` (`<table>_<col>_idx`) to kill the autogenerate
noise that used to hide real changes. The three migrations added *after* the squash
reintroduced the old `op.f("ix_...")` naming, while their models declare `index=True`
and so resolve to `<table>_<col>_idx`. Twelve indexes disagreed with the models, and
`alembic check` reported them on every run.

Confirmed against a database rebuilt from the chain (the local dev DB was stale from
another branch and had to be dropped first — the drift only reproduces faithfully on
a fresh migrate): `alembic check` reported exactly those twelve before, and "No new
upgrade operations detected." after.

## Design notes

- **A rename, not a new naming convention.** The issue asked which side matches
  production; the models are the source of truth (per `0001_baseline`'s docstring and
  the `alembic-migration` skill), and the rest of the chain already uses
  `<table>_<col>_idx`. Renaming the DB indexes to match is the fix; there are no
  deployed databases to migrate carefully around.
- **`db-check` lives in `make check`, `test-migrations` does not.** `alembic check`
  never downgrades, so it cannot empty a laptop's working database — the reason
  `test-migrations` is CI-only does not apply. It needs a database at head and is
  skipped (not failed) when none answers on 5432, matching how `check` already treats
  the integration suite. In CI the database is always present, so the gate is real.

## Testing

- `alembic check` — reproduced the 12-index drift on a fresh migrate; clean after 0009.
- `tests/test_migrations.py` — 4 passed (chain forwards and back, including 0009).
- `tests/test_ci_parity.py` — 16 passed (db-check reachable from `check` and invoked
  by a gating job, both directions).
- `tests/test_coverage_gate.py` — 10 passed.
- `make lint-backend` (exit 0), `make docs-build` (`--strict`), `python3
  scripts/docs_drift.py` (no drift), `make db-check` (clean).

## Noticed, not fixed

- The repo had no `.worktreeinclude` and did not gitignore `.claude/worktrees/`. I
  added both **in the main checkout** (not on this branch) so worktree work stops
  breaking on the missing `backend/.env`. Worth committing separately if you want it.
- `ty check` reports 64 diagnostics on template-inherited code (`app/services/rag`,
  `app/repositories/knowledge_base.py`); pre-existing, non-gating, none in these files.
