### PR TITLE
fix(agents): record a delegation's own span, not its settlement

### DIFF
--- a/backend/app/agents/capabilities/subagents/_journal.py
+++ b/backend/app/agents/capabilities/subagents/_journal.py
@@ -611,6 +611,11 @@ class DelegationJournal:
                 agent_id=delegation.agent_id,
                 agent_version_id=delegation.agent_version_id,
                 error=handle.error,
+                # The delegation's own span, not this settlement. The library
+                # stamps both when the delegate starts and when it ends, which for
+                # a background one is well before the poll that collects it here.
+                started_at=handle.started_at,
+                ended_at=handle.completed_at,
             )
         )
         if sink is not None:

--- a/backend/app/agents/capabilities/subagents/_journal.py
+++ b/backend/app/agents/capabilities/subagents/_journal.py
@@ -60,6 +60,7 @@ from collections.abc import AsyncIterable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any, Literal
 from uuid import UUID, uuid4
 
@@ -251,6 +252,17 @@ class Delegation:
     continuation and nothing before it. :meth:`_spent` adds the two.
     """
 
+    carried_started_at: datetime | None = None
+    """When this delegation's delegate first began, if an earlier turn recorded it.
+
+    `None` for a delegation this run started, which is all of them until one parks -
+    and then :meth:`_span_start` takes the start off this turn's own handle, the
+    whole span. Set only on a replay, from the stash the park wrote, so the row this
+    delegation eventually writes begins at its first segment rather than at the
+    resume. Unlike :attr:`carried` it is not summed - :meth:`_span_start` keeps the
+    earlier of it and this segment's start.
+    """
+
     agent_id: UUID | None = None
     agent_version_id: UUID | None = None
     task_id: str | None = None
@@ -380,10 +392,12 @@ class DelegationJournal:
         delegated from, and that relationship is what nests a parked tree.
 
         A delegation the run is *continuing* opens here too - the replay presents
-        the same `task` call - which is why what it already spent is read here as
-        well. The ledger key allocated here is fresh, and this turn's ledger has
-        never held an entry under any other, so without `carried` the continuation
-        would be the whole of the delegation's recorded cost.
+        the same `task` call - which is why what it already spent, and when it first
+        began, are both read here. The ledger key allocated here is fresh, and this
+        turn's ledger has never held an entry under any other, so without `carried`
+        the continuation would be the whole of the delegation's recorded cost;
+        `carried_started_at` is the same fact for the clock, so the row does not
+        begin at the resume.
         """
         self._running += 1
         enclosing = _CURRENT.get()
@@ -396,6 +410,7 @@ class DelegationJournal:
             tool_call_id=tool_call_id,
             parent_task_id=None if enclosing is None else enclosing.task_id,
             carried=self.runtime.stash.already_spent(tool_call_id),
+            carried_started_at=self.runtime.stash.already_started(tool_call_id),
             agent_id=delegate.agent_id if delegate is not None else None,
             agent_version_id=delegate.agent_version_id if delegate is not None else None,
         )
@@ -439,6 +454,12 @@ class DelegationJournal:
         a delegation on its second park carries the first park's total as well. So
         the frame holds a running sum, and the turn that finally settles the
         delegation records one row for all of it - see :meth:`_spent`.
+
+        When the delegate first began is written the same way, and read back the
+        same way on the resume - but the frame keeps the *earliest* start rather
+        than a sum (:meth:`_span_start`), because the honest span of a delegation
+        that stopped and started again is its first begin to its last end, not the
+        length of any one segment.
         """
         task_id = delegation.task_id
         if task_id is None or delegation.tool_call_id is None:
@@ -464,6 +485,7 @@ class DelegationJournal:
                 # there is still a run to attribute the failure to.
                 messages=[] if history is None else list(json.loads(history)),
                 spent=self._spent(delegation),
+                started_at=self._span_start(delegation, handle),
             )
         )
 
@@ -614,7 +636,10 @@ class DelegationJournal:
                 # The delegation's own span, not this settlement. The library
                 # stamps both when the delegate starts and when it ends, which for
                 # a background one is well before the poll that collects it here.
-                started_at=handle.started_at,
+                # `_span_start` reaches past this handle to the first segment's
+                # start when the delegation parked and resumed; the end is always
+                # this handle's, the last segment to settle.
+                started_at=self._span_start(delegation, handle),
                 ended_at=handle.completed_at,
             )
         )
@@ -746,6 +771,31 @@ class DelegationJournal:
             output_tokens=delegation.carried.output_tokens + share.output_tokens,
             has_unpriced_models=delegation.carried.has_unpriced_models or share.has_unpriced_models,
         )
+
+    def _span_start(self, delegation: Delegation, handle: TaskHandle | None) -> datetime | None:
+        """When this delegation first began, across every turn it has run in.
+
+        The clock's counterpart to :meth:`_spent`, and read at the same two moments:
+        by :meth:`park`, so the frame carries the earliest start into the next turn
+        rather than restamping it, and by :meth:`settle`, so the row begins where the
+        delegate first began. Unlike the cost the segments are *not* added - a
+        delegation's honest start is its earliest, not the sum of its parts - so this
+        is the earlier of what earlier turns carried (`carried_started_at`) and this
+        segment's own (`handle.started_at`).
+
+        Either may be `None`: `carried_started_at` for a delegation that never
+        parked, and this segment's start when the handle is gone (the park branch
+        that stashes without a handle) or telemetry never stamped one. A present
+        start always wins over a missing one; both `None` reports `None`, and the
+        recorder falls back rather than write a null.
+        """
+        this_segment = None if handle is None else handle.started_at
+        carried = delegation.carried_started_at
+        if carried is None:
+            return this_segment
+        if this_segment is None:
+            return carried
+        return min(carried, this_segment)
 
     def _share(self, delegation: Delegation) -> SpendShare:
         """What this delegation booked into the run's ledger, or zeros if nothing meters.

--- a/backend/app/agents/subagent_runtime.py
+++ b/backend/app/agents/subagent_runtime.py
@@ -205,9 +205,14 @@ class DelegationOutcome:
     terminal status. They are not the moment the delegation was settled, which for
     a background one is arbitrarily later - the poll that collected it - and gave
     every background row a duration of zero placed at the wrong time
-    (agenticos#191). `None` when the handle carried no start: a delegation the
-    library refused before it began a task never ran, and the recorder falls back
-    rather than write a null into a non-null column.
+    (agenticos#191). `started_at` is `None` when a terminal handle reached its end
+    without ever starting - a delegate cancelled or failed before it executed - and
+    the recorder falls back rather than write a null into a non-null column. (A
+    library refusal *before a handle exists* - an unknown `chat_trace_id` - writes
+    no row at all: :meth:`DelegationJournal.settle` returns before building an
+    outcome.) The span is the settling turn's; a delegation that parked on an
+    approval does not yet carry its pre-park start across the resume, unlike its
+    cost - agenticos#245.
     """
 
     subagent: str

--- a/backend/app/agents/subagent_runtime.py
+++ b/backend/app/agents/subagent_runtime.py
@@ -210,9 +210,15 @@ class DelegationOutcome:
     the recorder falls back rather than write a null into a non-null column. (A
     library refusal *before a handle exists* - an unknown `chat_trace_id` - writes
     no row at all: :meth:`DelegationJournal.settle` returns before building an
-    outcome.) The span is the settling turn's; a delegation that parked on an
-    approval does not yet carry its pre-park start across the resume, unlike its
-    cost - agenticos#245.
+    outcome.)
+
+    A delegation that parked on an approval spans more than the turn that settled
+    it: its earliest start is carried across the park the way its cost is, on
+    :attr:`ParkedDelegation.started_at`, restored by the resume onto the continuing
+    delegation. The two are not summed the way the cost is - the honest answer is
+    the *first* segment's start and the *last* segment's end - so a delegate that
+    ran, parked for a person, and was resumed the next day records a row that
+    begins when it first began and ends when it finally did (agenticos#245).
     """
 
     subagent: str
@@ -322,6 +328,14 @@ class ParkedDelegation:
             *how* to continue, which is best-effort, and *what it already cost*,
             which is known either way - and a delegation re-run from the start
             still spent that money once.
+        started_at: When this delegation's delegate first began, carried so the row
+            written when it finally ends begins where it first began rather than at
+            the resume. The earliest start across every segment so far, not this
+            one's: a delegation on its second park keeps the first park's start.
+            `None` when no segment ever stamped one - telemetry on the handle is
+            best-effort - and then the recorder falls back. Kept whether or not
+            `messages` was, for the reason `spent` is: when the delegate first ran
+            is a fact independent of whether its place could be held.
     """
 
     tool_call_id: str
@@ -333,6 +347,7 @@ class ParkedDelegation:
     child_run_id: str | None
     messages: list[dict[str, Any]]
     spent: DelegationSpend
+    started_at: datetime | None
 
 
 @dataclass(frozen=True)
@@ -389,6 +404,34 @@ class DelegationStash:
     start has still spent it. Folding the weaker guarantee onto the stronger fact
     would drop the pre-park cost of exactly the delegations whose place was lost.
     """
+
+    started: dict[str, datetime | None] = field(default_factory=dict)
+    """When each delegation being continued first began, on the same key.
+
+    The companion to :attr:`spent`, and separate for the same reason: it is a fact
+    about the delegation known whether or not its conversation was kept, so it
+    rides beside `resuming` rather than inside it. Read by :meth:`already_started`,
+    which the journal folds into the delegation it opens on the replay - so the row
+    written when the delegation ends begins at its earliest segment rather than at
+    the resume.
+    """
+
+    def already_started(self, tool_call_id: str | None) -> datetime | None:
+        """When the delegation this `task` call opens first began, in an earlier turn.
+
+        `None` for a delegation this run is starting rather than continuing - which
+        is every delegation on a run that was never parked - and for one made
+        without a tool call to name it. On the ordinary path the recorder then
+        takes the start off this turn's own handle, which is the whole span.
+
+        Not consumed on read, for the reason :attr:`spent` is not: the key is the
+        `task` call, so a second delegation to the same delegate later in the run
+        has a different one and begins fresh, while the library's own retry of
+        *this* delegation carries the same start.
+        """
+        if tool_call_id is None:
+            return None
+        return self.started.get(tool_call_id)
 
     def already_spent(self, tool_call_id: str | None) -> DelegationSpend:
         """What the delegation this `task` call opens has spent in earlier turns.

--- a/backend/app/agents/subagent_runtime.py
+++ b/backend/app/agents/subagent_runtime.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from datetime import datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Literal, Protocol
 from uuid import UUID
@@ -198,6 +199,15 @@ class DelegationOutcome:
     added together - this turn's share plus :class:`DelegationSpend`, which the park
     kept, `cost_is_partial` included. One `AgentRun` row is written, once, by the
     turn that finishes the delegation.
+
+    `started_at` and `ended_at` are the delegation's *own* span, read off the task
+    handle the library stamps when the delegate starts and when it reaches a
+    terminal status. They are not the moment the delegation was settled, which for
+    a background one is arbitrarily later - the poll that collected it - and gave
+    every background row a duration of zero placed at the wrong time
+    (agenticos#191). `None` when the handle carried no start: a delegation the
+    library refused before it began a task never ran, and the recorder falls back
+    rather than write a null into a non-null column.
     """
 
     subagent: str
@@ -210,6 +220,8 @@ class DelegationOutcome:
     agent_id: UUID | None = None
     agent_version_id: UUID | None = None
     error: str | None = None
+    started_at: datetime | None = None
+    ended_at: datetime | None = None
 
 
 DelegationRecorder = Callable[[DelegationOutcome], Awaitable[UUID | None]]

--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -1831,10 +1831,13 @@ class AgentRunnerService:
         instant, which for a background delegation is the poll that collected it -
         arbitrarily later than the delegate finished, and what once gave every
         background row a duration of zero ordered after work that preceded it
-        (agenticos#191). Only when the handle carried no start - a delegation
-        refused before it began a task - does the row fall back to `now`, because
-        both columns are non-null and a delegation that never ran has no span to
-        record. The parent's row remains the authority on the run's real span.
+        (agenticos#191). A terminal handle that ended without a start - a delegate
+        cancelled or failed before executing - falls back to that end, and a handle
+        carrying neither falls back to `now`: both columns are non-null and a
+        delegation with no recorded span still has to write one. (A refusal *before*
+        a handle exists writes no row at all - :meth:`DelegationJournal.settle`
+        returns first.) The parent's row remains the authority on the run's real
+        span.
         """
 
         async def record(outcome: DelegationOutcome) -> UUID | None:

--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -1825,14 +1825,16 @@ class AgentRunnerService:
         row already contains these tokens, because a run has one ledger - and
         `agent_run_repo.sum_cost_since` is where that division lives.
 
-        The timing is honest about what it knows: a `DelegationOutcome` carries no
-        start, so both ends are the moment the delegation was reported. Queueing
-        does not make that worse - it is measured here, not at the write - and the
-        parent's row remains the authority on the run's real span. That is the one
-        thing on this row still measured at the settlement rather than at the
-        delegation: the *cost* no longer is, so a background delegation's row is
-        exact about what it spent and wrong about when it spent it -
-        agenticos#191, which the handle already carries the answer to.
+        The span is the delegation's own, off the task handle: `started_at` when
+        the delegate started and `ended_at` when it reached a terminal status,
+        carried through :class:`DelegationOutcome`. Neither is the settlement
+        instant, which for a background delegation is the poll that collected it -
+        arbitrarily later than the delegate finished, and what once gave every
+        background row a duration of zero ordered after work that preceded it
+        (agenticos#191). Only when the handle carried no start - a delegation
+        refused before it began a task - does the row fall back to `now`, because
+        both columns are non-null and a delegation that never ran has no span to
+        record. The parent's row remains the authority on the run's real span.
         """
 
         async def record(outcome: DelegationOutcome) -> UUID | None:
@@ -1850,7 +1852,14 @@ class AgentRunnerService:
                 )
                 return None
 
+            # The delegation's own span, off the handle. `now` only when the handle
+            # carried none - a delegation the library refused before it started a
+            # task never ran, and both columns are non-null. `ended_at` falls back
+            # to the start rather than to `now`, so a handle missing its end reads
+            # as a zero-duration run at the right time, never a negative span.
             now = datetime.now(UTC)
+            started_at = outcome.started_at or outcome.ended_at or now
+            ended_at = outcome.ended_at or started_at
             delegated = RecordedDelegation(
                 id=uuid4(),
                 agent_id=outcome.agent_id,
@@ -1868,8 +1877,8 @@ class AgentRunnerService:
                 # parent's row a floor and says nothing about a delegate that ran
                 # on a priced one.
                 cost_is_partial=outcome.cost_is_partial,
-                started_at=now,
-                ended_at=now,
+                started_at=started_at,
+                ended_at=ended_at,
                 error=outcome.error,
             )
             # `append` is atomic under the GIL and this coroutine never awaits, so

--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -330,6 +330,14 @@ class DelegationFrame(BaseModel):
             "per delegation now, so the turn that resumes cannot re-derive it"
         ),
     )
+    started_at: datetime | None = Field(
+        default=None,
+        description=(
+            "When this delegation's delegate first began, so the row written when it "
+            "ends begins at its first segment rather than at the resume. The earliest "
+            "start across every segment so far; null when none was ever stamped"
+        ),
+    )
     delegations: list[DelegationFrame] = Field(
         default_factory=list, description="Delegations this delegate had itself parked on"
     )
@@ -502,6 +510,7 @@ def _delegation_frames(parked: Sequence[ParkedDelegation]) -> list[DelegationFra
                 input_tokens=entry.spent.input_tokens,
                 output_tokens=entry.spent.output_tokens,
                 cost_is_partial=entry.spent.has_unpriced_models,
+                started_at=entry.started_at,
                 delegations=frames(by_parent.get(entry.task_id, [])),
             )
             for entry in entries
@@ -537,6 +546,15 @@ class _ResumePlan:
     the only place that money is attributed to the delegate's own agent.
     """
 
+    started: dict[str, datetime | None]
+    """When each delegation in the tree first began, on the same key.
+
+    The clock's companion to :attr:`spent`, and filled for every frame the same
+    way: when the delegate first ran is a fact whether or not its place was kept,
+    and the row written when the delegation ends must begin there rather than at
+    the resume that settled it.
+    """
+
 
 def _resume_plan(state: PausedRunState, decided_args: Mapping[str, dict[str, Any]]) -> _ResumePlan:
     """Split a parked run's verdicts across the agents that were waiting on them.
@@ -556,6 +574,7 @@ def _resume_plan(state: PausedRunState, decided_args: Mapping[str, dict[str, Any
 
     resuming: dict[str, ResumedDelegation] = {}
     spent: dict[str, DelegationSpend] = {}
+    started: dict[str, datetime | None] = {}
 
     def level(frames: list[DelegationFrame], own: list[str]) -> DeferredToolResults:
         results = DeferredToolResults()
@@ -565,16 +584,18 @@ def _resume_plan(state: PausedRunState, decided_args: Mapping[str, dict[str, Any
             )
         for frame in frames:
             results.approvals[frame.tool_call_id] = ToolApproved()
-            # Before the `continue` below, because what a delegation has spent is
-            # not conditional on its place having been kept: a delegation re-run
-            # from the start still spent it, and the row written when it ends is
-            # where that money reaches the delegate's own agent.
+            # Before the `continue` below, because neither what a delegation has
+            # spent nor when it first began is conditional on its place having been
+            # kept: a delegation re-run from the start still spent it and still
+            # began when it began, and the row written when it ends is where both
+            # reach the delegate's own agent.
             spent[frame.tool_call_id] = DelegationSpend(
                 cost_usd=frame.cost_usd,
                 input_tokens=frame.input_tokens,
                 output_tokens=frame.output_tokens,
                 has_unpriced_models=frame.cost_is_partial,
             )
+            started[frame.tool_call_id] = frame.started_at
             if not frame.messages:
                 # The delegate's place was not kept, so there is nothing to
                 # continue. The `task` call is still answered above - a parked call
@@ -591,6 +612,7 @@ def _resume_plan(state: PausedRunState, decided_args: Mapping[str, dict[str, Any
         results=level(state.delegations, by_delegation.get(None, [])),
         delegations=resuming,
         spent=spent,
+        started=started,
     )
 
 
@@ -1050,6 +1072,7 @@ class AgentRunnerService:
             decided={},
             resuming={},
             already_spent={},
+            already_started={},
             version_id=version_id,
             environment_id=effective_environment_id,
         )
@@ -1070,6 +1093,7 @@ class AgentRunnerService:
         decided: dict[str, ApprovalDecision],
         resuming: dict[str, ResumedDelegation],
         already_spent: dict[str, DelegationSpend],
+        already_started: dict[str, datetime | None],
         model_profile_id: UUID | None = None,
         version_id: UUID | None = None,
         environment_id: UUID | None = None,
@@ -1089,10 +1113,12 @@ class AgentRunnerService:
         into the assembly rather than into the run call: a verdict is answered by
         the approval gate of whichever agent asked, and a stashed delegate is
         continued by the delegation capability of whichever agent delegated - so
-        both have to be in place before anything is built. `already_spent` travels
-        with them because it is read at the same moment: the delegation is opened by
-        the replayed `task` call, and what it cost before the park has to be in the
-        stash by then or the row it eventually writes holds only this turn's spend.
+        both have to be in place before anything is built. `already_spent` and
+        `already_started` travel with them because all three are read at the same
+        moment: the delegation is opened by the replayed `task` call, and what it
+        cost before the park - and when it first began - have to be in the stash by
+        then or the row it eventually writes holds only this turn's spend and begins
+        at the resume.
         """
         # A caller's override wins over the spec's choice. Only the model is
         # replaced - instructions, tools, budgets and the approval gate are the
@@ -1214,7 +1240,7 @@ class AgentRunnerService:
         run_budget = _RunBudget()
         runtimes: list[SubagentRuntime] = []
         delegations: list[RecordedDelegation] = []
-        stash = DelegationStash(resuming=resuming, spent=already_spent)
+        stash = DelegationStash(resuming=resuming, spent=already_spent, started=already_started)
         runtime = await self._delegation_runtime(
             ctx,
             spec=spec,
@@ -1831,13 +1857,15 @@ class AgentRunnerService:
         instant, which for a background delegation is the poll that collected it -
         arbitrarily later than the delegate finished, and what once gave every
         background row a duration of zero ordered after work that preceded it
-        (agenticos#191). A terminal handle that ended without a start - a delegate
-        cancelled or failed before executing - falls back to that end, and a handle
-        carrying neither falls back to `now`: both columns are non-null and a
-        delegation with no recorded span still has to write one. (A refusal *before*
-        a handle exists writes no row at all - :meth:`DelegationJournal.settle`
-        returns first.) The parent's row remains the authority on the run's real
-        span.
+        (agenticos#191). A delegation that parked on an approval and resumed spans
+        both turns: `started_at` is the first segment's, carried across the park the
+        way its cost is, and `ended_at` the last (agenticos#245). A terminal handle
+        that ended without a start - a delegate cancelled or failed before executing
+        - falls back to that end, and a handle carrying neither falls back to `now`:
+        both columns are non-null and a delegation with no recorded span still has
+        to write one. (A refusal *before* a handle exists writes no row at all -
+        :meth:`DelegationJournal.settle` returns first.) The parent's row remains the
+        authority on the run's real span.
         """
 
         async def record(outcome: DelegationOutcome) -> UUID | None:
@@ -2289,6 +2317,7 @@ class AgentRunnerService:
             decided=decided,
             resuming=plan.delegations,
             already_spent=plan.spent,
+            already_started=plan.started,
         )
         prepared.built.ledger.book(_spend_already_booked(run))
 

--- a/backend/tests/test_agent_runner.py
+++ b/backend/tests/test_agent_runner.py
@@ -1024,6 +1024,7 @@ class TestParking:
                     spent=DelegationSpend(
                         cost_usd=Decimal("0.25"), input_tokens=7, output_tokens=3
                     ),
+                    started_at=datetime(2026, 8, 5, 9, 0, tzinfo=UTC),
                 )
             ]
         )
@@ -1048,6 +1049,9 @@ class TestParking:
         # work that led up to the approval.
         assert stored["delegations"][0]["cost_usd"] == "0.25"
         assert stored["delegations"][0]["input_tokens"] == 7
+        # And when the delegate first began, so the row written when it ends begins
+        # there rather than at the resume that settles it (agenticos#245).
+        assert stored["delegations"][0]["started_at"] == "2026-08-05T09:00:00Z"
         # And which agent's replay each parked approval belongs to, which is what
         # keeps a delegate's call out of the parent's continuation - Pydantic AI
         # refuses a resume whose results name a call the replay does not contain.

--- a/backend/tests/test_delegation_seams.py
+++ b/backend/tests/test_delegation_seams.py
@@ -28,6 +28,7 @@ something further out depends on being right:
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from decimal import Decimal
 from uuid import uuid4
 
@@ -215,6 +216,33 @@ def test_a_delegation_with_no_tool_call_to_name_it_carries_nothing() -> None:
     stash = DelegationStash(spent={"the-task-call": DelegationSpend(cost_usd=Decimal("0.25"))})
 
     assert stash.already_spent(None) == DelegationSpend()
+
+
+def test_a_delegation_the_run_is_starting_has_no_earlier_start() -> None:
+    """Which is every delegation until one parks, so the recorder takes this turn's.
+
+    A `task` call the stash has never seen is a delegation being started rather than
+    continued: nothing began in an earlier turn, so `_span_start` reads the whole
+    span off this turn's own handle.
+    """
+    stash = DelegationStash(started={"another-task-call": datetime(2026, 8, 5, tzinfo=UTC)})
+
+    assert stash.already_started("this-task-call") is None
+
+
+def test_a_delegation_being_continued_answers_with_when_it_first_began() -> None:
+    """The key is the parent's `task` call, which the replay presents again."""
+    began = datetime(2026, 8, 5, 9, 0, tzinfo=UTC)
+    stash = DelegationStash(started={"the-task-call": began})
+
+    assert stash.already_started("the-task-call") == began
+
+
+def test_a_delegation_with_no_tool_call_to_name_it_carries_no_start() -> None:
+    """Nothing a resume could key it by, exactly as with what it already spent."""
+    stash = DelegationStash(started={"the-task-call": datetime(2026, 8, 5, tzinfo=UTC)})
+
+    assert stash.already_started(None) is None
 
 
 def test_one_ledger_still_says_which_delegation_spent_what() -> None:

--- a/backend/tests/test_subagent_nested_resume.py
+++ b/backend/tests/test_subagent_nested_resume.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
 from uuid import UUID, uuid4
@@ -517,7 +518,7 @@ async def _resume(parked: _Parked, delegate: Callable[[DelegationStash], Resolve
     """
     decided, approved_args = _verdicts(parked.state, parked.queue)
     plan = _resume_plan(parked.state, approved_args)
-    stash = DelegationStash(resuming=plan.delegations, spent=plan.spent)
+    stash = DelegationStash(resuming=plan.delegations, spent=plan.spent, started=plan.started)
     agent, deps = _orchestrator(
         delegate(stash), stash=stash, channel=_channel(parked.queue, decided=decided)
     )
@@ -747,6 +748,7 @@ class TestWhenAPlaceCannotBeKept:
         frame out would turn a delegation that has to start again into a run nobody
         can ever finish.
         """
+        began = datetime(2026, 8, 5, 9, 0, tzinfo=UTC)
         state = PausedRunState(
             messages=[],
             tool_call_ids={},
@@ -758,6 +760,7 @@ class TestWhenAPlaceCannotBeKept:
                     cost_usd=Decimal("0.25"),
                     input_tokens=INPUT_TOKENS,
                     output_tokens=OUTPUT_TOKENS,
+                    started_at=began,
                 )
             ],
         )
@@ -777,6 +780,10 @@ class TestWhenAPlaceCannotBeKept:
                 output_tokens=OUTPUT_TOKENS,
             )
         }
+        # When it first began is carried on the same terms, and for the same reason:
+        # a delegation re-run from the start still began when it began, and the row
+        # must not read as having started at the resume.
+        assert plan.started == {"the-task-call": began}
 
 
 class TestAnOlderParkedRun:
@@ -951,7 +958,9 @@ async def _until_it_answers(
         if state is not None:
             decided, approved_args = _verdicts(state, queue)
             plan = _resume_plan(state, approved_args)
-            stash = DelegationStash(resuming=plan.delegations, spent=plan.spent)
+            stash = DelegationStash(
+                resuming=plan.delegations, spent=plan.spent, started=plan.started
+            )
             history = ModelMessagesTypeAdapter.validate_python(state.messages)
             results = plan.results
         channel = _channel(queue, decided=decided)
@@ -1135,3 +1144,110 @@ class TestWhatADelegateSpentBeforeItParked:
         (inner,) = outer.delegations
         assert (outer.subagent, inner.subagent) == (MIDDLE, SPECIALIST)
         assert inner.cost_usd == Decimal("0.25")
+
+
+class TestWhenADelegateFirstBegan:
+    """A delegation's row begins where its delegate first began, not where it settled.
+
+    The clock's half of the same shape as the cost (agenticos#180): a delegate does
+    the work, asks a person to act on the result, and parks. The turn that continues
+    it is a different process whose task handle is stamped at the *resume* - so a row
+    written off that handle alone begins when the person answered, dropping the whole
+    pre-park segment. The earliest start is carried across the park through
+    `paused_state` (agenticos#245), so the recorded span covers every turn the
+    delegate ran in.
+
+    Driven through the real capability, the real gate and the runner's real split of
+    the verdicts, and through `paused_state` as JSON each park - the trip the start
+    actually makes, so nothing here would pass on a carry that survived only in
+    memory.
+    """
+
+    async def test_a_park_and_resume_span_the_first_start_and_the_last_end(self):
+        """One park: the row begins in the turn before the approval, not after it.
+
+        Off the resume handle alone `started_at` would be the moment the person
+        answered - strictly later than the delegate first ran. Carried, it is the
+        first segment's, which is exactly the frame the first park wrote; the end is
+        the last segment's, so the span covers both turns.
+        """
+        recorder = Recorder()
+
+        parked, answer = await _until_it_answers(
+            lambda _stash, metering: _specialist_delegate(
+                gated=True, calls=[], charge=metering.charge, agent_id=uuid4()
+            ),
+            turn_costs=(Decimal("0.25"), Decimal("0.75")),
+            parent_cost=Decimal("0.10"),
+            recorder=recorder,
+        )
+
+        assert answer == "answer: weather: Krakow: 21C and clear"
+        assert len(parked) == 1
+        (first_segment,) = parked[0].delegations
+        (outcome,) = recorder.outcomes
+        # The recorded start is the first segment's, carried across the park - not
+        # the resume-turn handle's, which is strictly later and is what the bug
+        # recorded.
+        assert first_segment.started_at is not None
+        assert outcome.started_at == first_segment.started_at
+        # And the end is the last segment's, so the span is both turns, not one
+        # instant.
+        assert outcome.ended_at is not None
+        assert outcome.ended_at > outcome.started_at
+
+    async def test_two_parks_keep_the_first_start_across_both(self):
+        """The earliest start survives more than one park.
+
+        A park carries the *earliest* start rather than the turn that wrote it, the
+        way it carries a running cost total. Carrying the latest would move the start
+        forward on each park and record the third segment's - the same bug one turn
+        along, which the one-park case above would not catch.
+        """
+        recorder = Recorder()
+
+        parked, answer = await _until_it_answers(
+            lambda _stash, metering: _specialist_delegate(
+                gated=True, calls=[], cities=("Krakow", "Warsaw"), charge=metering.charge
+            ),
+            turn_costs=(Decimal("0.25"), Decimal("0.75"), Decimal("0.50")),
+            parent_cost=Decimal("0.10"),
+            recorder=recorder,
+        )
+
+        assert answer == "answer: weather: Krakow: 21C and clear | Warsaw: 21C and clear"
+        assert len(parked) == 2
+        first_start = parked[0].delegations[0].started_at
+        assert first_start is not None
+        # Both parks carry that same first start, not each turn's own - which is what
+        # keeps the second park from moving the recorded beginning forward.
+        assert [frame.started_at for state in parked for frame in state.delegations] == [
+            first_start,
+            first_start,
+        ]
+        (outcome,) = recorder.outcomes
+        assert outcome.started_at == first_start
+        assert outcome.ended_at is not None and outcome.ended_at > first_start
+
+    def test_a_resumed_delegation_keeps_its_carried_start_when_a_segment_has_none(self):
+        """A carried start wins even when the settling segment stamped none.
+
+        Telemetry on a handle is best-effort, so a resumed delegation can reach a
+        settlement whose handle carries no start of its own - or park again with its
+        handle already evicted. `_span_start` then keeps what earlier turns carried
+        rather than dropping the delegation's beginning, which is the branch the
+        park-and-resume paths above never take because their handles always stamp
+        one.
+        """
+        began = datetime(2026, 8, 5, 9, 0, tzinfo=UTC)
+        journal = _journal_mid_delegation(_specialist_delegate(gated=False, calls=[]), resuming={})
+        delegation = journal.begin(
+            delegate=None,
+            name=SPECIALIST,
+            prompt="",
+            tool_args={},
+            tool_call_id="the-task-call",
+        )
+        delegation.carried_started_at = began
+
+        assert journal._span_start(delegation, None) == began

--- a/backend/tests/test_subagent_resolution.py
+++ b/backend/tests/test_subagent_resolution.py
@@ -1228,6 +1228,65 @@ class TestRecordingADelegation:
 
         assert result.only.cost_is_partial is False
 
+    async def test_a_delegations_row_spans_its_own_start_and_end(self):
+        """agenticos#191: the span is the delegate's, not the settlement's.
+
+        Both ends used to be `now` at the moment the delegation was reported,
+        which for a background one is the poll that collected it - so its row read
+        as a zero-duration run at the wrong time. Off the handle instead, the row
+        carries the interval the delegate actually ran for.
+        """
+        version_id = uuid.uuid4()
+        started = datetime(2026, 8, 5, 9, 0, tzinfo=UTC)
+        ended = datetime(2026, 8, 5, 9, 0, 40, tzinfo=UTC)
+        outcome = _outcome(
+            agent_id=uuid.uuid4(),
+            agent_version_id=version_id,
+            started_at=started,
+            ended_at=ended,
+        )
+
+        result = await _record(outcome, attribution={version_id: _model()})
+
+        assert result.only.started_at == started
+        assert result.only.ended_at == ended
+
+    async def test_a_delegation_refused_before_it_started_records_a_zero_span(self):
+        """agenticos#191: a handle with no start must not write a null.
+
+        The library refuses a delegation before starting a task - a `chat_trace_id`
+        it does not know - and the outcome then carries no times. Both columns are
+        non-null, so the recorder falls back to `now`: a zero-duration run recorded
+        where it was reported, rather than a `NULL` the insert rejects.
+        """
+        version_id = uuid.uuid4()
+        outcome = _outcome(agent_id=uuid.uuid4(), agent_version_id=version_id)
+
+        result = await _record(outcome, attribution={version_id: _model()})
+
+        assert result.only.started_at is not None
+        assert result.only.ended_at == result.only.started_at
+
+    async def test_a_handle_with_an_end_but_no_start_reads_as_an_instant(self):
+        """A task that reached a terminal status without executing - cancelled or
+        failed before it began - has an end stamped and no start. The row takes the
+        end for both, so its span is an instant at the right time rather than one
+        that ends before it began."""
+        version_id = uuid.uuid4()
+        ended = datetime(2026, 8, 5, 9, 0, 40, tzinfo=UTC)
+        outcome = _outcome(
+            agent_id=uuid.uuid4(),
+            agent_version_id=version_id,
+            status="cancelled",
+            started_at=None,
+            ended_at=ended,
+        )
+
+        result = await _record(outcome, attribution={version_id: _model()})
+
+        assert result.only.started_at == ended
+        assert result.only.ended_at == ended
+
     async def test_an_inline_specialist_records_nothing(self):
         """It has no agent to attribute a row to: it is not versioned, nothing
         else can reference it, and its cost is already the parent's."""

--- a/backend/tests/test_subagent_resolution.py
+++ b/backend/tests/test_subagent_resolution.py
@@ -1251,13 +1251,15 @@ class TestRecordingADelegation:
         assert result.only.started_at == started
         assert result.only.ended_at == ended
 
-    async def test_a_delegation_refused_before_it_started_records_a_zero_span(self):
-        """agenticos#191: a handle with no start must not write a null.
+    async def test_an_outcome_carrying_no_times_falls_back_to_a_zero_span(self):
+        """agenticos#191: a handle with no times must not write a null.
 
-        The library refuses a delegation before starting a task - a `chat_trace_id`
-        it does not know - and the outcome then carries no times. Both columns are
-        non-null, so the recorder falls back to `now`: a zero-duration run recorded
-        where it was reported, rather than a `NULL` the insert rejects.
+        A terminal handle that carried neither a start nor an end - all the outcome
+        has to offer - leaves both columns, which are non-null, to fall back to
+        `now`: a zero-duration run recorded where it was reported, rather than a
+        `NULL` the insert rejects. (The refusal that creates no handle at all writes
+        no row; that path never reaches the recorder - see
+        `tests/test_subagents_capability.py::TestBackgroundDelegations`.)
         """
         version_id = uuid.uuid4()
         outcome = _outcome(agent_id=uuid.uuid4(), agent_version_id=version_id)

--- a/backend/tests/test_subagents_capability.py
+++ b/backend/tests/test_subagents_capability.py
@@ -29,6 +29,7 @@ import logging
 import re
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
 from uuid import UUID, uuid4
@@ -983,6 +984,39 @@ class TestBackgroundDelegations:
         # What ends a real run, and what this test would otherwise leak: the
         # second delegation is still executing in a task nobody awaits.
         await ends_the_run(capability, ctx)
+
+    async def test_a_background_row_spans_the_delegate_not_the_settlement(self):
+        """agenticos#191: the recorded span is the delegate's own, not the poll's.
+
+        A background delegation is settled when it is next polled - here, the end
+        of the run, after the parent has answered. Recorded off `now` that gave
+        every background row a duration of zero, at the moment of settlement rather
+        than the moment the delegate ran. The delegate pauses so its span is
+        genuinely non-zero, and the assertion reads the recorded times against a
+        clock read *before* the settlement - not a sleep measured after one.
+        """
+        recorder = Recorder()
+        capability = a_capability(
+            a_runtime(a_delegate(model=one_tool_call(), pause=0.02), record=recorder),
+            {"mode": "async"},
+        )
+        ctx = a_context()
+
+        started = await delegate_to(capability, ctx)
+        assert "found it" in await call_tool(
+            capability, ctx, "wait_tasks", {"task_ids": [task_id_in(started)]}
+        )
+        # The delegate has finished by now; the run that records it has not.
+        before_settlement = datetime.now(UTC)
+        assert await ends_the_run(capability, ctx) == "the parent answered"
+
+        (outcome,) = recorder.outcomes
+        assert outcome.started_at is not None and outcome.ended_at is not None
+        # It ran for a real interval, not the instant `now` collapsed it to.
+        assert outcome.ended_at > outcome.started_at
+        # And it ran before the settlement, not at it: `now` at record time would
+        # be inside `ends_the_run`, after this clock read.
+        assert outcome.ended_at <= before_settlement
 
     async def test_what_the_parent_spends_after_it_finishes_is_not_the_delegates(self):
         """The defect agenticos#180 was filed for, with its own numbers.

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -121,6 +121,15 @@ the transcript is the record.
     per row too: a parent on a model `genai-prices` does not know makes the parent's
     total a floor, and says nothing about a delegate that ran on a priced one.
 
+    A delegated row's `started_at` and `ended_at` are the delegation's **own** span,
+    read off the task handle the library stamps when the delegate starts and when it
+    ends - not the moment the row was settled. Off the settlement, a background
+    delegation read as a zero-duration run at the wrong time, ordered after work that
+    finished before it; two that genuinely overlapped were recorded at the same
+    instant with nothing to say they had. A delegation the library refused before it
+    began a task never ran, so its row falls back to a zero-length span at the time
+    it was recorded rather than claiming a duration it never had.
+
 **A delegation that parked on an approval is more than one share.** Its turns ran
 in different processes against different ledgers, and a resumed turn's ledger is a
 fresh object holding nothing from before the park - so what the child row records is

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -130,9 +130,11 @@ the transcript is the record.
     a delegate cancelled or failed before it began executing - records a zero-length
     span at that end, never a null; and where the library refuses before a handle
     exists at all - an unknown `chat_trace_id` - no delegated row is written. A
-    delegation that parked on an approval spans only the segment that settled it: its
-    pre-park span is not yet carried across the resume, tracked in
-    [#245](https://github.com/vstorm-co/agenticos/issues/245).
+    delegation that parked on an approval spans every turn it ran in: its earliest
+    start is carried across the park the way its cost is (below), so the row begins
+    when the delegate first began and ends when it finally did - not at the resume
+    that settled it. The two are not summed the way the cost is; the honest answer
+    is the first segment's start and the last segment's end.
 
 **A delegation that parked on an approval is more than one share.** Its turns ran
 in different processes against different ledgers, and a resumed turn's ledger is a

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -126,9 +126,13 @@ the transcript is the record.
     ends - not the moment the row was settled. Off the settlement, a background
     delegation read as a zero-duration run at the wrong time, ordered after work that
     finished before it; two that genuinely overlapped were recorded at the same
-    instant with nothing to say they had. A delegation the library refused before it
-    began a task never ran, so its row falls back to a zero-length span at the time
-    it was recorded rather than claiming a duration it never had.
+    instant with nothing to say they had. A terminal handle with an end but no start -
+    a delegate cancelled or failed before it began executing - records a zero-length
+    span at that end, never a null; and where the library refuses before a handle
+    exists at all - an unknown `chat_trace_id` - no delegated row is written. A
+    delegation that parked on an approval spans only the segment that settled it: its
+    pre-park span is not yet carried across the resume, tracked in
+    [#245](https://github.com/vstorm-co/agenticos/issues/245).
 
 **A delegation that parked on an approval is more than one share.** Its turns ran
 in different processes against different ledgers, and a resumed turn's ledger is a


### PR DESCRIPTION
## What this fixes

`Closes #191`. A delegated run row's `started_at` and `ended_at` were both
`datetime.now(UTC)` at the moment the delegation was *settled*, not the interval the
delegate actually ran for. `sync` delegations settle where their tool call returns, so
it was close enough there; **background** delegations settle when they are next polled
(the following `task` call, or `wrap_run`'s `finally`), so a delegate that ran for 40s
early in a turn was recorded as starting and ending in the same instant when the parent
answered — a zero-duration run at the wrong time, ordered after work that preceded it,
with overlapping delegations indistinguishable.

The information was already there and unread: `TaskHandle` carries `started_at` /
`completed_at`, stamped by the library, and `DelegationJournal.settle` holds the handle
when it builds the outcome.

## What changed

- `app/agents/subagent_runtime.py` — `DelegationOutcome` gains `started_at` / `ended_at`
  (`datetime | None`), the delegation's own span.
- `app/agents/capabilities/subagents/_journal.py:614` — `settle` reads them off the
  handle (`handle.started_at`, `handle.completed_at`).
- `app/services/agent_runner.py:1855` — the recorder writes the outcome's span instead
  of `now`. Falls back to `now` only when the handle carried no start (a delegation
  refused before it began a task — both columns are non-null), and `ended_at` falls back
  to the start so a missing end never reads as a negative span.
- `docs/governance.md` — the delegated-row section now states the span is the
  delegation's own, alongside the cost story it sits next to.

## How it failed before

`RecordedDelegation.started_at == ended_at == now`, evaluated inside the settling turn.
For a background delegation that is arbitrarily later than the delegate finished.

## Testing

- `tests/test_subagent_resolution.py::TestRecordingADelegation` — the row carries the
  handle's span; a handle with no start records a non-null zero-length span; a handle
  with an end but no start reads as an instant (no negative span). Two of these fail on
  `main`.
- `tests/test_subagents_capability.py::TestBackgroundDelegations::test_a_background_row_spans_the_delegate_not_the_settlement`
  — a background delegate that **pauses** is recorded with a non-zero duration ending
  before the settlement, asserted against a clock read *before* the run ends (not a
  sleep measured after one). Fails on `main`.
- Full backend suite green (3063 passed, 10 skipped); platform-layer coverage at 100%;
  `make lint-backend` and `make docs-build` clean.

## Noticed, not fixed

- `ty check` reports 64 non-gating diagnostics on template-inherited worker code
  (`app/worker/tasks/rag_tasks.py` and friends) — pre-existing, outside the platform
  layer, unrelated to this change.
- Nothing yet *reads* these delegated rows (#181), so the fix is invisible in the UI
  until it does; the assertion is on what the row stores.
