### PR TITLE
fix(capabilities): withhold task-lifecycle tools from a sync-only agent

### DIFF
--- a/backend/app/agents/capabilities/subagents/README.md
+++ b/backend/app/agents/capabilities/subagents/README.md
@@ -251,6 +251,16 @@ them is scoped to the run that started the task — a task id is short and appea
 in tool output, so an unscoped lookup would let one run read and kill another's
 work.
 
+These six are **offered only when a background delegation is reachable**, the same
+`get_toolset` filter that withholds `answer_subagent` — `BACKGROUND_LIFECYCLE_TOOLS`
+and `_can_delegate_in_background`. Each takes or reports on a task id, and a `sync`
+delegation returns the answer and a `chat_trace_id` and nothing else, so a
+`sync`-only agent is handed none of them and `task` alone. Reachable means the
+configured mode is `async` or `auto`, a pinned delegate prefers either, or the agent
+may invent specialists — `sync` being the default is what makes withholding them the
+common case rather than a corner. The predicate errs toward offering: removing a
+tool an agent needs mid-turn is worse than offering one it will not use.
+
 Three things about it are not obvious.
 
 **`wait_tasks` truncates.** A completed task's result is cut to

--- a/backend/app/agents/capabilities/subagents/_capability.py
+++ b/backend/app/agents/capabilities/subagents/_capability.py
@@ -34,6 +34,7 @@ which has a handle and no task - and it says what the sweep does not guarantee.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 from typing import Any, cast
 
@@ -193,8 +194,10 @@ Declared rather than derived, and all ten rather than the seven a non-dynamic
 configuration offers, because a tool absent from this list cannot be gated by the
 approval policy or renamed by a binding - and the dangerous half of that is
 silent. Which of the ten a given agent's model is actually offered is decided in
-two places: `create_agent` and `delegate` by whether the runner resolved a
-`DynamicSpecialists`, and `answer_subagent` by :data:`UNREACHABLE_TOOLS`.
+three places: `create_agent` and `delegate` by whether the runner resolved a
+`DynamicSpecialists`, `answer_subagent` by :data:`UNREACHABLE_TOOLS`, and the six
+background-lifecycle tools by whether any delegation this run could make might run
+in the background - :data:`BACKGROUND_LIFECYCLE_TOOLS`.
 
 Eight of the descriptions are **imported, not rewritten**. A tool's description is
 the strongest prompt in the product, and `TASK_TOOL_DESCRIPTION` is two hundred
@@ -242,14 +245,100 @@ does, which is why the two are one issue with two halves rather than one change.
 """
 
 
-def _is_offered(_ctx: RunContext[AgentDeps], tool: ToolDefinition) -> bool:
-    """Whether the model is shown this tool at all. See :data:`UNREACHABLE_TOOLS`.
+BACKGROUND_LIFECYCLE_TOOLS: frozenset[str] = frozenset(
+    {
+        "check_task",
+        "wait_tasks",
+        "list_active_tasks",
+        "send_message_to_subagent",
+        "soft_cancel_task",
+        "hard_cancel_task",
+    }
+)
+"""The six tools that only make sense once a delegation runs in the background.
+
+Every one of them takes, or reports on, a task id: `check_task` and `wait_tasks`
+collect a background delegation's result, `list_active_tasks` lists what is still
+running, and the three that act - `send_message_to_subagent` and the two cancels -
+steer or stop one mid-run. A `sync` delegation hands the model none of that: the
+library returns the delegate's answer and a `chat_trace_id` and nothing else, so
+there is no id to pass to the five that take one, and `list_active_tasks` would
+answer about a delegation that finished before the call returned.
+
+So an agent that can make *no* background delegation is offered none of these -
+:func:`_can_delegate_in_background` is the predicate, and `sync` being the default
+mode is what makes that the common configuration rather than a corner. `task` is
+never in this set: a sync agent still delegates, it just does not manage tasks.
+
+Filtered rather than left out of :data:`DELEGATION_TOOLS`, for the same reason
+`answer_subagent` is - see :data:`UNREACHABLE_TOOLS`. A tool absent from the
+declaration can be neither gated by the approval policy nor renamed by a binding,
+and that half is silent; withheld from the offered set, it stops costing a
+description in every turn's context while staying declarable. The difference from
+`answer_subagent` is that this set is withheld *per run*: the same agent offers all
+six under `async`, `auto`, or a delegate that prefers either, so the decision
+belongs in :meth:`Delegation.get_toolset` where the run's configuration is, not in
+a module-level constant.
+"""
+
+
+def _can_delegate_in_background(journal: DelegationJournal) -> bool:
+    """Whether any delegation this run could make might run in the background.
+
+    The narrowing that :data:`BACKGROUND_LIFECYCLE_TOOLS` turns on happens only when
+    this answers `False`, so the predicate is written to err toward `True`: getting
+    it wrong in the narrowing direction removes a tool an agent needs mid-turn, which
+    is a worse failure than offering one it will not use.
+
+    Three ways a background delegation is reachable, and the run configuration fixes
+    all three before the first request:
+
+    - **The configured mode is not `sync`.** `async` backgrounds every delegation and
+      `auto` backgrounds the ones the model describes as long-running - and `auto` is
+      resolved per delegation from what the model says about the task, so an `auto`
+      agent can go either way and keeps all six regardless.
+    - **The agent may invent specialists.** `create_agent` and `delegate` produce
+      delegations resolved per call rather than from a set that exists now, so the
+      widest configuration withholds nothing there rather than reasoning about work
+      that has not been asked for yet.
+    - **A pinned delegate prefers `async` or `auto`.** `DelegationJournal._mode_for`
+      resolves `delegate.preferred_mode or self.mode`, so one delegate overriding a
+      `sync` agent is enough to make a task id reachable for that delegation.
+    """
+    if journal.mode != "sync":
+        return True
+    if journal.runtime.dynamic is not None:
+        return True
+    return any(
+        delegate.preferred_mode in ("async", "auto") for delegate in journal.runtime.subagents
+    )
+
+
+def _hidden_tools(journal: DelegationJournal) -> frozenset[str]:
+    """Every tool this run declares and withholds from its model.
+
+    Two reasons a declared tool is withheld, and they compose. `answer_subagent` is
+    unreachable under *every* configuration (:data:`UNREACHABLE_TOOLS`); the six
+    background-lifecycle tools are unreachable under *this* one when it can make no
+    background delegation (:data:`BACKGROUND_LIFECYCLE_TOOLS`).
+    """
+    if _can_delegate_in_background(journal):
+        return UNREACHABLE_TOOLS
+    return UNREACHABLE_TOOLS | BACKGROUND_LIFECYCLE_TOOLS
+
+
+def _offered(hidden: frozenset[str]) -> Callable[[RunContext[AgentDeps], ToolDefinition], bool]:
+    """A filter that shows the model every tool but the ones this run withholds.
 
     Reads the tool's name off the library's own toolset, which is where the stable
-    id is still the name: a binding's rename wraps the *capability*, outside this,
-    so renaming `answer_subagent` cannot smuggle it back into the offered set.
+    id is still the name: a binding's rename wraps the *capability*, outside this, so
+    a withheld tool cannot be smuggled back into the offered set under a new name.
     """
-    return tool.name not in UNREACHABLE_TOOLS
+
+    def is_offered(_ctx: RunContext[AgentDeps], tool: ToolDefinition) -> bool:
+        return tool.name not in hidden
+
+    return is_offered
 
 
 _MODE_NOTE: dict[DelegationMode, str] = {
@@ -449,10 +538,14 @@ class Delegation(WrapperCapability[AgentDeps]):
     def get_toolset(self) -> AgentToolset[AgentDeps] | None:
         """The library's delegation tools, with this platform's accounting around them.
 
-        Also minus the ones no configuration here can reach. The library adds
-        `answer_subagent` to its toolset unconditionally, so filtering the offered
-        set is the only place that decision can be made - see
-        :data:`UNREACHABLE_TOOLS`.
+        Also minus the ones this run cannot reach. The library adds every tool to
+        its toolset unconditionally, so filtering the offered set is the only place
+        those decisions can be made: `answer_subagent` under every configuration
+        (:data:`UNREACHABLE_TOOLS`), and the six background-lifecycle tools under a
+        `sync`-only one that can make no background delegation
+        (:data:`BACKGROUND_LIFECYCLE_TOOLS`). The withheld set is read from the
+        journal here rather than a module constant because the second half of it is
+        a fact about *this run's* mode and delegates - see :func:`_hidden_tools`.
 
         Memoised because the wrapper carries no state of its own but the journal
         it points at does, and because `BuiltAgent.capabilities` is introspected -
@@ -464,7 +557,7 @@ class Delegation(WrapperCapability[AgentDeps]):
             # in `__post_init__` and holds it for the life of the instance.
             wrapped = cast(AbstractToolset[AgentDeps], super().get_toolset())
             self._delegating = DelegatingToolset(wrapped=wrapped, journal=self.journal).filtered(
-                _is_offered
+                _offered(_hidden_tools(self.journal))
             )
         return self._delegating
 

--- a/backend/tests/test_dynamic_specialists.py
+++ b/backend/tests/test_dynamic_specialists.py
@@ -57,7 +57,10 @@ from app.agents.capabilities.budget import (
     SpendLimit,
 )
 from app.agents.capabilities.subagents import Delegation
-from app.agents.capabilities.subagents._capability import MAX_DYNAMIC_SPECIALISTS
+from app.agents.capabilities.subagents._capability import (
+    BACKGROUND_LIFECYCLE_TOOLS,
+    MAX_DYNAMIC_SPECIALISTS,
+)
 from app.agents.deps import AgentDeps
 from app.agents.factory import build_agent
 from app.agents.model_resolver import ModelRequestSpec, ResolvedCredential
@@ -611,8 +614,15 @@ class TestHowManyOneRunMayInvent:
 class TestWhenTheEntryPointsAreOfferedAtAll:
     async def test_an_agent_whose_author_said_nothing_is_offered_neither(self):
         """Every tool in a list is context the model pays for on every turn, and a
-        tool that can only refuse is the worst of them."""
-        assert await offered(a_capability(a_runtime(a_delegate()))) == {
+        tool that can only refuse is the worst of them.
+
+        `async`, so this stays a statement about `create_agent` and `delegate`: the
+        background-lifecycle six are offered only when a background delegation is
+        reachable, so a `sync` agent with no dynamic runtime would be missing those
+        too - `TestOfferedSet` in `test_subagents_capability.py` is where that is
+        asserted.
+        """
+        assert await offered(a_capability(a_runtime(a_delegate()), {"mode": "async"})) == {
             "task",
             "check_task",
             "wait_tasks",
@@ -626,6 +636,18 @@ class TestWhenTheEntryPointsAreOfferedAtAll:
         capability = a_capability(a_runtime(a_delegate(), dynamic=dynamic()))
 
         assert {"create_agent", "delegate", "task"} <= await offered(capability)
+
+    async def test_a_dynamic_sync_agent_keeps_the_background_lifecycle_tools(self):
+        """The `dynamic is not None` branch of `_can_delegate_in_background`.
+
+        A `sync` agent that may invent specialists resolves its delegations per
+        `create_agent` or `delegate` call rather than from a set that exists now, so
+        the predicate withholds nothing there rather than reasoning about work that
+        has not been asked for yet - the safe side of a narrowing whose wrong
+        direction removes a tool an agent needs mid-turn."""
+        capability = a_capability(a_runtime(a_delegate(), dynamic=dynamic()), {"mode": "sync"})
+
+        assert await offered(capability) >= BACKGROUND_LIFECYCLE_TOOLS
 
     async def test_an_agent_with_no_delegates_but_dynamic_still_gets_the_capability(self):
         """`allow_dynamic` on its own is a complete configuration: an orchestrator

--- a/backend/tests/test_subagents_capability.py
+++ b/backend/tests/test_subagents_capability.py
@@ -74,7 +74,11 @@ from app.agents.capabilities.approval import (
 )
 from app.agents.capabilities.budget import SpendEntry, SpendLedger
 from app.agents.capabilities.subagents import Delegation, SubagentsConfig
-from app.agents.capabilities.subagents._capability import UNREACHABLE_TOOLS, _LazyAgent
+from app.agents.capabilities.subagents._capability import (
+    BACKGROUND_LIFECYCLE_TOOLS,
+    UNREACHABLE_TOOLS,
+    _LazyAgent,
+)
 from app.agents.capabilities.subagents._events import UNNAMED_TOOL, FrameLabels, frame_for
 from app.agents.capabilities.subagents._journal import DelegationJournal
 from app.agents.capabilities.subagents._toolset import DelegatingToolset
@@ -631,8 +635,14 @@ class TestAttaching:
         binding, and that half of the same failure is silent. `UNREACHABLE_TOOLS`
         says what making it reachable would take, and why agenticos#184 is only
         half of that.
+
+        `async`, so that this stays a statement about `answer_subagent` alone: it is
+        the one tool withheld under *every* configuration, whereas the six
+        background-lifecycle tools are withheld only from a `sync`-only agent - see
+        `TestOfferedSet`. At the widest set, `answer_subagent` is the only thing
+        missing.
         """
-        capability = a_capability(a_runtime(a_delegate()))
+        capability = a_capability(a_runtime(a_delegate()), {"mode": "async"})
         toolset = capability.get_toolset()
         assert toolset is not None
 
@@ -658,8 +668,12 @@ class TestAttaching:
         `SubagentRuntime.dynamic` - and a config saying yes with no resolved
         builder behind it offers nothing, rather than two tools whose factory does
         not exist. `tests/test_dynamic_specialists.py` has the other direction.
+
+        `async`, so this stays a statement about `create_agent` and `delegate`
+        being absent when nothing resolved them - not about the background-lifecycle
+        set, which a `sync` agent would also be missing (`TestOfferedSet`).
         """
-        capability = a_capability(a_runtime(a_delegate()), {"allow_dynamic": True})
+        capability = a_capability(a_runtime(a_delegate()), {"allow_dynamic": True, "mode": "async"})
         toolset = capability.get_toolset()
         assert toolset is not None
 
@@ -695,6 +709,77 @@ class TestAttaching:
         capability = a_capability(a_runtime(a_delegate()))
 
         assert capability.get_toolset() is capability.get_toolset()
+
+
+class TestOfferedSet:
+    """The six task-lifecycle tools, offered only when a background delegation is.
+
+    Every one of `check_task`, `wait_tasks`, `list_active_tasks`,
+    `send_message_to_subagent`, `soft_cancel_task` and `hard_cancel_task` takes or
+    reports on a task id, and a `sync` delegation hands the model none: the library
+    returns the answer and a `chat_trace_id` and nothing else. `sync` is the default
+    mode, so an agent that can make no background delegation is the common case, not
+    a corner - and six tool descriptions in every turn's context is the strongest
+    prompt surface in the product spent describing actions that cannot happen.
+
+    The predicate errs toward offering, because removing a tool an agent needs
+    mid-turn is worse than offering one it will not use: `async`, `auto`, a delegate
+    that prefers either, or permission to invent specialists each keep all six.
+    """
+
+    @staticmethod
+    async def _offered(capability: Delegation) -> frozenset[str]:
+        toolset = capability.get_toolset()
+        assert toolset is not None
+        return frozenset(await toolset.get_tools(a_context()))
+
+    async def test_a_sync_only_agent_is_offered_task_and_nothing_else(self):
+        """The whole of the fix: a `sync` agent with one delegate that overrides
+        nothing still delegates, it just manages no tasks. So `task`, and none of
+        the six - and none of `answer_subagent`, `create_agent` or `delegate`
+        either, which is what leaves `task` alone."""
+        offered = await self._offered(a_capability(a_runtime(a_delegate()), {"mode": "sync"}))
+
+        assert offered == {"task"}
+        assert not (offered & BACKGROUND_LIFECYCLE_TOOLS)
+
+    async def test_async_mode_offers_every_lifecycle_tool(self):
+        offered = await self._offered(a_capability(a_runtime(a_delegate()), {"mode": "async"}))
+
+        assert offered >= BACKGROUND_LIFECYCLE_TOOLS
+
+    async def test_auto_mode_offers_every_lifecycle_tool(self):
+        """`auto` is resolved per delegation from what the model says about the
+        task, so a delegation can go either way and the tools to collect a
+        background one have to be there."""
+        offered = await self._offered(a_capability(a_runtime(a_delegate()), {"mode": "auto"}))
+
+        assert offered >= BACKGROUND_LIFECYCLE_TOOLS
+
+    async def test_one_delegate_preferring_async_restores_them_for_a_sync_agent(self):
+        """`_mode_for` resolves `delegate.preferred_mode or self.mode`, so a single
+        delegate overriding a `sync` agent is enough to make a task id reachable -
+        and the tools that take one have to come back with it."""
+        capability = a_capability(
+            a_runtime(a_delegate(preferred_mode="async"), a_second_delegate()), {"mode": "sync"}
+        )
+
+        assert await self._offered(capability) >= BACKGROUND_LIFECYCLE_TOOLS
+
+    async def test_one_delegate_preferring_auto_restores_them_for_a_sync_agent(self):
+        capability = a_capability(
+            a_runtime(a_delegate(preferred_mode="auto"), a_second_delegate()), {"mode": "sync"}
+        )
+
+        assert await self._offered(capability) >= BACKGROUND_LIFECYCLE_TOOLS
+
+    async def test_a_delegate_pinned_sync_does_not_restore_them(self):
+        """A delegate that pins the mode the agent already has changes nothing: it
+        cannot background, so the predicate must not read its override as one that
+        could."""
+        capability = a_capability(a_runtime(a_delegate(preferred_mode="sync")), {"mode": "sync"})
+
+        assert not (await self._offered(capability) & BACKGROUND_LIFECYCLE_TOOLS)
 
 
 class TestRecording:
@@ -1974,8 +2059,12 @@ class TestOtherTools:
 
     async def test_they_pass_through_untouched(self):
         """Nothing here decides anything about them, and the accounting must not
-        move either: a call that starts no delegation cannot open or close one."""
-        capability = a_capability(a_runtime(a_delegate()))
+        move either: a call that starts no delegation cannot open or close one.
+
+        `async`, because these six are offered at all only when a background
+        delegation is reachable - a `sync`-only agent is handed none of them,
+        which is `TestOfferedSet`."""
+        capability = a_capability(a_runtime(a_delegate()), {"mode": "async"})
 
         answer = await call_tool(capability, a_context(), "list_active_tasks", {})
 

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -257,7 +257,8 @@ pair it with `code_execution` or `knowledge` for that. No configuration.
 `task` — *hand a self-contained piece of work to one of this agent's specialists.*
 `check_task`, `wait_tasks`, `list_active_tasks` — *following one that is running.*
 `send_message_to_subagent`, `soft_cancel_task`, `hard_cancel_task` — *steering or
-stopping one.*
+stopping one.* These six are offered only when a background delegation is reachable
+— a `sync`-only agent is handed none of them.
 `create_agent`, `delegate` — *a specialist the model writes for itself, when the author allows it.*
 `answer_subagent` — *declared, and offered to no model.*
 
@@ -291,6 +292,15 @@ running in the background. The instructions **mark that delegate**, beside its
 name — a single sentence stating the configured mode was a promise the overriding
 delegate then broke, telling the model to expect an answer and handing it a task
 id.
+
+**A `sync`-only agent is offered none of the six task-lifecycle tools.** Each of
+`check_task`, `wait_tasks`, `list_active_tasks`, `send_message_to_subagent` and the
+two cancels takes or reports on a task id, and a `sync` delegation returns the
+answer and nothing else — there is no id to pass. So they are offered only when a
+background delegation is reachable: `async` or `auto` mode, a delegate that prefers
+either, or permission to invent specialists. `sync` is the default, so this is the
+common configuration, and six tool descriptions withheld is six the model no longer
+pays for on every turn. `task` stays — a `sync` agent still delegates.
 
 **Fan-out and nesting are ceilings, not errors.** Past `max_fanout` the next
 delegation comes back as a tool result the model can act on — wait, or do the work


### PR DESCRIPTION
## What this fixes

Closes #185. The six background-task tools — `check_task`, `wait_tasks`,
`list_active_tasks`, `send_message_to_subagent`, `soft_cancel_task`,
`hard_cancel_task` — were offered to every delegating agent, including one that can
never make a background delegation. Each takes or reports on a task id, and a `sync`
delegation returns the answer and a `chat_trace_id` and nothing else, so there is no
id to pass. `sync` is the default mode, so this was the common configuration — six
tool descriptions in every turn's context describing actions that cannot happen, on
the strongest prompt surface in the product.

This generalises #182 (`answer_subagent`), which was unreachable under *every*
configuration and so filterable from one constant. This one is conditional on the
run, which is why #182 deliberately left it.

## What changed

- `backend/app/agents/capabilities/subagents/_capability.py`
  - `BACKGROUND_LIFECYCLE_TOOLS` — the six, declared once.
  - `_can_delegate_in_background(journal)` — the predicate: background is reachable
    when the configured mode is not `sync`, the agent may invent specialists
    (`dynamic is not None`), or a pinned delegate prefers `async`/`auto`. Written to
    err toward `True` — narrowing wrongly removes a tool an agent needs mid-turn,
    which is the worse failure.
  - `_hidden_tools(journal)` composes the run-conditional set with `UNREACHABLE_TOOLS`.
  - `_is_offered` became `_offered(hidden)`, a filter factory closing over the
    withheld set; `get_toolset` reads it from the journal.
- `docs/reference/capabilities.md`, `backend/.../subagents/README.md` — the offered
  set now depends on the mode; both say so.

The tools stay **declared** in `DELEGATION_TOOLS` and are only withheld from the
*offered* set — same reasoning as #182: a tool absent from the declaration can be
neither gated by the approval policy nor renamed by a binding, and that half is
silent.

## How it failed before

A `sync` agent (the default) with one pinned delegate that overrode nothing was
handed all seven lifecycle tools. `wait_tasks` alone is a substantial description,
and none of the six could ever be used: no task id is ever produced, and
`list_active_tasks` would answer about a delegation that finished before the call
returned.

## Testing

- `tests/test_subagents_capability.py::TestOfferedSet` — new. A `sync`-only agent is
  offered `task` and nothing else; `async`, `auto`, a delegate preferring either,
  each restore all six; a delegate pinned `sync` does not.
- `tests/test_dynamic_specialists.py::...::test_a_dynamic_sync_agent_keeps_the_background_lifecycle_tools`
  — new; locks the `dynamic is not None` branch.
- The drift test in `tests/test_capability_registry.py` builds the capability at its
  widest (a resolved `DynamicSpecialists`), so it keeps checking the widest set and
  needed no change.
- Three existing offered-set tests were pinned to a background-reachable mode so each
  stays a statement about its own subject (`answer_subagent`, the dynamic entry
  points) rather than being conflated with the mode narrowing.
- `make test` (platform-layer 100% gate), `make lint` (ruff/ty), docs-build.

## Noticed, not fixed

- The `dynamic is not None` branch keeps all six even under `sync`, though an
  invented specialist also runs at the configured mode and so `sync`+dynamic
  technically cannot background either. This matches #185's stated predicate and is
  the deliberate conservative side: `create_agent`/`delegate` resolve delegations
  per call from a set that does not exist at build time, and narrowing there wrongly
  is the dangerous direction. Left as the issue specified.
