### PR TITLE
feat(skills): sweep for frozen bindings a publisher could not reach

### DIFF
--- a/backend/app/commands/audit_skill_bindings.py
+++ b/backend/app/commands/audit_skill_bindings.py
@@ -48,7 +48,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.agents.capabilities.subagents import SubagentsConfig
 from app.agents.spec import AgentSpec
 from app.commands import command, error, info, success, warning
-from app.db.models.agent import Agent, AgentVersion
+from app.db.models.agent import Agent, AgentStatus, AgentVersion
 from app.db.models.resource_grant import Visibility
 from app.db.models.skill import Skill
 from app.db.session import get_db_context
@@ -253,6 +253,13 @@ async def _executable_versions(db: AsyncSession) -> list[tuple[Agent, AgentVersi
     environment pinned to an unsafe v1 as clean, and miss a parent still
     delegating to a delegate's unsafe pinned version. So the environments seed the
     set and the pins close it, id by id, until nothing new is reached.
+
+    A delegate whose agent has since been archived is dropped, because the runner
+    refuses to delegate to an archived agent (`_resolve_delegate` in
+    `agent_runner.py`): its pinned version can no longer load through that pin, so
+    reporting it would be flagging a binding no run can reach. The seeds cannot be
+    archived - both queries filter to published agents - so the check is only ever
+    needed on the delegates the closure reaches.
     """
     seen: dict[UUID, tuple[Agent, AgentVersion]] = {}
     frontier: list[AgentVersion] = []
@@ -270,6 +277,8 @@ async def _executable_versions(db: AsyncSession) -> list[tuple[Agent, AgentVersi
         spec = AgentSpec.model_validate(version.spec)
         pin_ids = [ref.agent_version_id for ref in spec.subagents]
         for agent, pinned in await agent_repo.get_versions_with_agents(db, pin_ids):
+            if agent.status == AgentStatus.ARCHIVED.value:
+                continue
             # A cycle (A pins B, B pins A) or two parents pinning one delegate
             # reach the same version twice; the first sighting wins and the rest
             # are skipped here, which is what makes the closure terminate.
@@ -360,7 +369,9 @@ def audit_skill_bindings() -> None:
     Example:
         agenticos cmd audit-skill-bindings
     """
-    info("Auditing every published agent's current version for out-of-reach skill bindings...")
+    info(
+        "Auditing every runnable version of every published agent for out-of-reach skill bindings..."
+    )
     exposed = asyncio.run(_run())
     if exposed:
         raise SystemExit(1)

--- a/backend/app/commands/audit_skill_bindings.py
+++ b/backend/app/commands/audit_skill_bindings.py
@@ -1,0 +1,316 @@
+"""Find published agents that lend a skill their publisher could not reach.
+
+This is the residual of #179. That change added a publish-time check: binding a
+skill hands its body and its files to every run of the agent, so the publisher
+has to be able to read it themselves (`AgentRegistryService._skill_problems`).
+Validation on this platform runs at publish and never at run time, deliberately -
+`SkillService.resolve_for_agent` resolves a frozen spec's `skill_ids` with the
+tenant filter only, because a runner-scoped check would refuse every subject-less
+context, which is every API key, embedded widget and channel message.
+
+So the check protects every *future* publish and nothing already frozen. A
+version published before it keeps handing out whatever its `skill_ids` named -
+including another member's private skill - on every run, and the only signal
+anybody gets is that the *next* publish of that agent is refused. This sweep is
+the offline half: it names those versions so an operator can decide what to do.
+It is report-only on purpose. A spec is what a client exports into their own git
+repository, so silently unbinding a skill would rewrite something outside this
+deployment; the decision stays with a person.
+
+**The answer is about the row, not about today's membership**, and that is the
+whole subtlety. Re-deriving "can the publisher reach this skill *now*" would move
+with the publisher's role: an author promoted after a bad publish would look
+innocent, and one demoted after a good one would look guilty - the same
+time-dependence that makes a run-time re-check wrong. So reachability here is
+evaluated at the floor every skill-viewing role shares (`Scope.SHARED`): a
+binding is fine only if the skill is org-visible, owned by the publisher, or
+explicitly granted to them - all facts of the rows, invariant to whatever role
+the publisher holds today. A publisher whose user row is gone
+(`published_by_user_id` is nullable, `ON DELETE SET NULL`) is reported as
+*unknown* rather than guessed either way.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, replace
+from enum import StrEnum
+from uuid import UUID
+
+from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.agents.capabilities.subagents import SubagentsConfig
+from app.agents.spec import AgentSpec
+from app.commands import command, error, info, success, warning
+from app.db.models.agent import Agent, AgentVersion
+from app.db.models.resource_grant import Visibility
+from app.db.models.skill import Skill
+from app.db.session import get_db_context
+from app.repositories import agent_repo, member_repo, resource_grant_repo, skill_repo
+from app.services.access import SKILL
+from app.services.agent_registry import delegation_binding
+
+
+class BindingStatus(StrEnum):
+    """What a sweep can conclude about one frozen skill binding.
+
+    Only the two that need reporting exist - a reachable binding produces no
+    finding at all, so there is no `OK` member to filter back out.
+    """
+
+    EXPOSED = "exposed"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class SkillBinding:
+    """One skill named by one running spec, and where in it.
+
+    `specialist` is `None` for the agent's own `skill_ids` and the specialist's
+    name for one bound inside an inline specialist - the second place a
+    `skill_id` hides, and the half of #179 easy to forget.
+    """
+
+    skill_id: UUID
+    specialist: str | None
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One binding a running spec should not be handing out, and who to ask."""
+
+    organization_id: UUID
+    agent_slug: str
+    agent_name: str
+    version_number: int
+    published_by_user_id: UUID | None
+    publisher_email: str | None
+    skill_id: UUID
+    skill_name: str
+    specialist: str | None
+    status: BindingStatus
+
+
+def _bindings(spec: AgentSpec) -> list[SkillBinding]:
+    """Every skill this spec binds - its own, and each inline specialist's.
+
+    A delegating agent carries specialists inside its delegation capability, and
+    each specialist has its own `skill_ids` that publish validates through the
+    same `_skill_problems`. A config that does not parse as `SubagentsConfig` is
+    skipped rather than guessed at: the capability would not build from it, so
+    those specialists never run and can lend nothing - the same reason
+    `_delegate_problems` stops there.
+    """
+    bindings = [SkillBinding(skill_id=skill_id, specialist=None) for skill_id in spec.skill_ids]
+    binding = delegation_binding(spec)
+    if binding is not None:
+        try:
+            config = SubagentsConfig.model_validate(binding.config)
+        except ValidationError:
+            return bindings
+        for specialist in config.inline:
+            bindings.extend(
+                SkillBinding(skill_id=skill_id, specialist=specialist.name)
+                for skill_id in specialist.skill_ids
+            )
+    return bindings
+
+
+async def _classify(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    publisher_id: UUID | None,
+    skill: Skill,
+) -> BindingStatus | None:
+    """Whether this binding is a problem, and which kind - or `None` if it is fine.
+
+    The same question publish asks through :func:`resolve_access`, pinned to the
+    `Scope.SHARED` floor so the answer is a fact about the rows and not about the
+    publisher's role today: org-visible, owned by the publisher, or granted to
+    them. SHARED is the least any role that can view skills at all is given, so
+    "not reachable at the floor" means the binding depended on the publisher's
+    role being higher than that - which is exactly the exposure, and exactly what
+    must not silently un-flag itself when that role later changes.
+    """
+    # Org-visible skills are readable by every member, so who published the spec
+    # never mattered - and still does not, even if that publisher has since left.
+    if skill.visibility == Visibility.ORG.value:
+        return None
+    # The publisher's user row is gone. Ownership and grants both key on a person
+    # and there is none, so this cannot be decided rather than guessed. A private
+    # skill with no knowable publisher is the oldest, least visible case, so it is
+    # surfaced as unknown, not silently cleared.
+    if publisher_id is None:
+        return BindingStatus.UNKNOWN
+    if skill.owner_user_id == publisher_id:
+        return None
+    # Any grant is enough. The lowest level, `READ`, already sees the skill's
+    # body, which is what a bound skill hands a run - so `resolve_access` treats
+    # any grant as sufficient for `SKILLS_VIEW`, and a level comparison here would
+    # be a tautology dressed as a check.
+    level = await resource_grant_repo.get_level(
+        db,
+        organization_id=organization_id,
+        subject_user_id=publisher_id,
+        resource_type=SKILL.key,
+        resource_id=skill.id,
+    )
+    if level is not None:
+        return None
+    return BindingStatus.EXPOSED
+
+
+async def _findings_for(db: AsyncSession, agent: Agent, version: AgentVersion) -> list[Finding]:
+    """Every problematic binding in one running spec.
+
+    A skill named by the spec but not returned by the org-scoped fetch is
+    deleted, disabled-to-deletion or another tenant's id: it loads nothing at run
+    time (`resolve_for_agent` skips it), so it is a dangling reference rather than
+    an exposure and is left to that path. Only a skill that would actually load is
+    judged here.
+    """
+    spec = AgentSpec.model_validate(version.spec)
+    bindings = _bindings(spec)
+    if not bindings:
+        return []
+
+    skills = await skill_repo.get_many(
+        db, [binding.skill_id for binding in bindings], organization_id=agent.organization_id
+    )
+    findings: list[Finding] = []
+    for binding in bindings:
+        skill = skills.get(binding.skill_id)
+        if skill is None:
+            continue
+        status = await _classify(
+            db,
+            organization_id=agent.organization_id,
+            publisher_id=version.published_by_user_id,
+            skill=skill,
+        )
+        if status is None:
+            continue
+        findings.append(
+            Finding(
+                organization_id=agent.organization_id,
+                agent_slug=agent.slug,
+                agent_name=agent.name,
+                version_number=version.version,
+                published_by_user_id=version.published_by_user_id,
+                publisher_email=None,
+                skill_id=skill.id,
+                skill_name=skill.name,
+                specialist=binding.specialist,
+                status=status,
+            )
+        )
+    return await _with_publisher_email(db, agent, version, findings)
+
+
+async def _with_publisher_email(
+    db: AsyncSession, agent: Agent, version: AgentVersion, findings: list[Finding]
+) -> list[Finding]:
+    """Fill in the publisher's email, once, for a version that has any findings.
+
+    Restricted to the organization's members, so a publisher who has left the org
+    - user row still present, membership gone - resolves to no email and is shown
+    by id. That absence is information: it is a different state from a deleted
+    user, and the report should not blur the two.
+    """
+    if not findings or version.published_by_user_id is None:
+        return findings
+    emails = await member_repo.get_emails_for_users(
+        db, organization_id=agent.organization_id, user_ids=[version.published_by_user_id]
+    )
+    email = emails.get(version.published_by_user_id)
+    if email is None:
+        return findings
+    return [replace(finding, publisher_email=email) for finding in findings]
+
+
+async def _scan(db: AsyncSession) -> list[Finding]:
+    """Every problematic binding across every published agent's current version."""
+    findings: list[Finding] = []
+    for agent, version in await agent_repo.list_current_versions(db):
+        findings.extend(await _findings_for(db, agent, version))
+    return findings
+
+
+def _publisher(finding: Finding) -> str:
+    """How to name the publisher in a report line."""
+    if finding.published_by_user_id is None:
+        return "unknown (the publisher's user was deleted)"
+    return finding.publisher_email or f"{finding.published_by_user_id} (not a current member)"
+
+
+def _location(finding: Finding) -> str:
+    """Where in the spec the binding sits."""
+    if finding.specialist is None:
+        return "agent skill_ids"
+    return f"specialist '{finding.specialist}'"
+
+
+def _line(finding: Finding) -> str:
+    return (
+        f"  {finding.agent_slug} v{finding.version_number} "
+        f"(org {finding.organization_id}) - skill '{finding.skill_name}' ({finding.skill_id}) "
+        f"in {_location(finding)}, published by {_publisher(finding)}"
+    )
+
+
+def _report(findings: list[Finding]) -> int:
+    """Print the findings grouped by kind. Returns the number that are exposures."""
+    exposed = [finding for finding in findings if finding.status is BindingStatus.EXPOSED]
+    unknown = [finding for finding in findings if finding.status is BindingStatus.UNKNOWN]
+
+    if not findings:
+        success("No published agent lends a skill its publisher could not reach.")
+        return 0
+
+    if exposed:
+        error(f"{len(exposed)} binding(s) lend a skill the publisher could not reach:")
+        for finding in exposed:
+            error(_line(finding))
+    if unknown:
+        warning(
+            f"{len(unknown)} binding(s) name a private skill whose publisher is gone - "
+            "reachability cannot be decided:"
+        )
+        for finding in unknown:
+            warning(_line(finding))
+
+    info(
+        "\nNothing was changed. A binding is exported into the agent's spec, so unbinding "
+        "one is a decision for a person: re-publishing the agent re-runs the check and "
+        "refuses it, or the skill can be shared with the publisher to make the binding legitimate."
+    )
+    return len(exposed)
+
+
+async def _run() -> int:
+    async with get_db_context() as db:
+        findings = await _scan(db)
+    return _report(findings)
+
+
+@command(
+    "audit-skill-bindings",
+    help="Find published agents that lend a skill their publisher could not reach",
+)
+def audit_skill_bindings() -> None:
+    """Report frozen skill bindings a publish-time check would refuse today.
+
+    Read-only. Exits non-zero when it finds a binding that lends a skill the
+    publisher could not reach, so it can gate a cron or a provisioning script; a
+    binding whose publisher has left is a warning, not a failure, because there is
+    nobody left to check it against.
+
+    Example:
+        agenticos cmd audit-skill-bindings
+    """
+    info("Auditing every published agent's current version for out-of-reach skill bindings...")
+    exposed = asyncio.run(_run())
+    if exposed:
+        raise SystemExit(1)

--- a/backend/app/commands/audit_skill_bindings.py
+++ b/backend/app/commands/audit_skill_bindings.py
@@ -13,6 +13,11 @@ version published before it keeps handing out whatever its `skill_ids` named -
 including another member's private skill - on every run, and the only signal
 anybody gets is that the *next* publish of that agent is refused. This sweep is
 the offline half: it names those versions so an operator can decide what to do.
+
+It scans every version a run can load, not only `current_version_id`: a named
+environment can stay pinned to an older version while the default moves on, and
+a parent can pin a delegate version by id - both execute, so both are checked.
+See :func:`_executable_versions`.
 It is report-only on purpose. A spec is what a client exports into their own git
 repository, so silently unbinding a skill would rewrite something outside this
 deployment; the decision stays with a person.
@@ -165,11 +170,12 @@ async def _classify(
 async def _findings_for(db: AsyncSession, agent: Agent, version: AgentVersion) -> list[Finding]:
     """Every problematic binding in one running spec.
 
-    A skill named by the spec but not returned by the org-scoped fetch is
-    deleted, disabled-to-deletion or another tenant's id: it loads nothing at run
-    time (`resolve_for_agent` skips it), so it is a dangling reference rather than
-    an exposure and is left to that path. Only a skill that would actually load is
-    judged here.
+    Only a skill that would actually load is judged, which is exactly what
+    `resolve_for_agent` loads: present, this organization's, and enabled. A
+    skill_id the org-scoped fetch does not return is deleted or another tenant's,
+    and a disabled one is skipped by `resolve_for_agent` too - both hand nothing
+    to a run, so both are dangling references left to that path rather than
+    reported as an exposure that would fail the audit.
     """
     spec = AgentSpec.model_validate(version.spec)
     bindings = _bindings(spec)
@@ -182,7 +188,7 @@ async def _findings_for(db: AsyncSession, agent: Agent, version: AgentVersion) -
     findings: list[Finding] = []
     for binding in bindings:
         skill = skills.get(binding.skill_id)
-        if skill is None:
+        if skill is None or not skill.enabled:
             continue
         status = await _classify(
             db,
@@ -230,10 +236,54 @@ async def _with_publisher_email(
     return [replace(finding, publisher_email=email) for finding in findings]
 
 
+async def _executable_versions(db: AsyncSession) -> list[tuple[Agent, AgentVersion]]:
+    """Every version a run can load, each with its agent, deduplicated.
+
+    Three ways a frozen version reaches a run, and only the first is
+    `current_version_id`:
+
+    - the default environment, which is `current_version_id`;
+    - any named environment, which can stay pinned to an older version while the
+      default moves on;
+    - a `SubagentRef` in an executing spec, which pins a delegate version by id
+      and is followed by the caller - transitively, since that delegate's own
+      spec can pin further.
+
+    A sweep that looked only at the current version would report a production
+    environment pinned to an unsafe v1 as clean, and miss a parent still
+    delegating to a delegate's unsafe pinned version. So the environments seed the
+    set and the pins close it, id by id, until nothing new is reached.
+    """
+    seen: dict[UUID, tuple[Agent, AgentVersion]] = {}
+    frontier: list[AgentVersion] = []
+    seeds = [
+        *await agent_repo.list_current_versions(db),
+        *await agent_repo.list_environment_versions(db),
+    ]
+    for agent, version in seeds:
+        if version.id not in seen:
+            seen[version.id] = (agent, version)
+            frontier.append(version)
+
+    while frontier:
+        version = frontier.pop()
+        spec = AgentSpec.model_validate(version.spec)
+        pin_ids = [ref.agent_version_id for ref in spec.subagents]
+        for agent, pinned in await agent_repo.get_versions_with_agents(db, pin_ids):
+            # A cycle (A pins B, B pins A) or two parents pinning one delegate
+            # reach the same version twice; the first sighting wins and the rest
+            # are skipped here, which is what makes the closure terminate.
+            if pinned.id not in seen:
+                seen[pinned.id] = (agent, pinned)
+                frontier.append(pinned)
+
+    return list(seen.values())
+
+
 async def _scan(db: AsyncSession) -> list[Finding]:
-    """Every problematic binding across every published agent's current version."""
+    """Every problematic binding across every version a run can load."""
     findings: list[Finding] = []
-    for agent, version in await agent_repo.list_current_versions(db):
+    for agent, version in await _executable_versions(db):
         findings.extend(await _findings_for(db, agent, version))
     return findings
 

--- a/backend/app/commands/audit_skill_bindings.py
+++ b/backend/app/commands/audit_skill_bindings.py
@@ -15,9 +15,11 @@ anybody gets is that the *next* publish of that agent is refused. This sweep is
 the offline half: it names those versions so an operator can decide what to do.
 
 It scans every version a run can load, not only `current_version_id`: a named
-environment can stay pinned to an older version while the default moves on, and
-a parent can pin a delegate version by id - both execute, so both are checked.
-See :func:`_executable_versions`.
+environment can stay pinned to an older version while the default moves on, a
+non-terminal run reloads the exact version it was executing, and a parent can pin
+a delegate version by id - each executes, so each is checked, and a pin is
+followed only as deep as `max_depth` lets a run reach. See
+:func:`_executable_versions`.
 It is report-only on purpose. A spec is what a client exports into their own git
 repository, so silently unbinding a skill would rewrite something outside this
 deployment; the decision stays with a person.
@@ -97,23 +99,38 @@ class Finding:
     status: BindingStatus
 
 
+def _delegation_config(spec: AgentSpec) -> SubagentsConfig | None:
+    """This spec's delegation policy, or `None` if it does not delegate.
+
+    Mirrors the runtime's `_delegation_config`: an agent delegates only through a
+    delegation binding that is *switched on*, so an absent or disabled one carries
+    no specialists, no pins and no depth cap - and the runner then follows nothing.
+    Unlike the runtime's, the config is parsed defensively rather than assumed
+    valid: this sweep reads frozen specs from before publish validation covered
+    them, and one whose config does not parse as `SubagentsConfig` could not build
+    the capability, so it too delegates to nothing rather than being guessed at.
+    """
+    binding = delegation_binding(spec)
+    if binding is None:
+        return None
+    try:
+        return SubagentsConfig.model_validate(binding.config)
+    except ValidationError:
+        return None
+
+
 def _bindings(spec: AgentSpec) -> list[SkillBinding]:
     """Every skill this spec binds - its own, and each inline specialist's.
 
     A delegating agent carries specialists inside its delegation capability, and
     each specialist has its own `skill_ids` that publish validates through the
-    same `_skill_problems`. A config that does not parse as `SubagentsConfig` is
-    skipped rather than guessed at: the capability would not build from it, so
-    those specialists never run and can lend nothing - the same reason
-    `_delegate_problems` stops there.
+    same `_skill_problems`. An agent that does not delegate - see
+    :func:`_delegation_config` - has no specialists, so only its own `skill_ids`
+    are returned.
     """
     bindings = [SkillBinding(skill_id=skill_id, specialist=None) for skill_id in spec.skill_ids]
-    binding = delegation_binding(spec)
-    if binding is not None:
-        try:
-            config = SubagentsConfig.model_validate(binding.config)
-        except ValidationError:
-            return bindings
+    config = _delegation_config(spec)
+    if config is not None:
         for specialist in config.inline:
             bindings.extend(
                 SkillBinding(skill_id=skill_id, specialist=specialist.name)
@@ -239,52 +256,109 @@ async def _with_publisher_email(
 async def _executable_versions(db: AsyncSession) -> list[tuple[Agent, AgentVersion]]:
     """Every version a run can load, each with its agent, deduplicated.
 
-    Three ways a frozen version reaches a run, and only the first is
+    Four ways a frozen version reaches a run, and only the first is
     `current_version_id`:
 
     - the default environment, which is `current_version_id`;
     - any named environment, which can stay pinned to an older version while the
       default moves on;
+    - a non-terminal run - one still `running`, or `awaiting_approval` and
+      resumable - which reloads the exact version it was executing, whatever is
+      current now (`list_active_run_versions`);
     - a `SubagentRef` in an executing spec, which pins a delegate version by id
       and is followed by the caller - transitively, since that delegate's own
       spec can pin further.
 
     A sweep that looked only at the current version would report a production
-    environment pinned to an unsafe v1 as clean, and miss a parent still
-    delegating to a delegate's unsafe pinned version. So the environments seed the
-    set and the pins close it, id by id, until nothing new is reached.
+    environment pinned to an unsafe v1 as clean, miss a parked run that will
+    resume on one, and miss a parent still delegating to a delegate's unsafe
+    pinned version. So those three seed the set and the pins close it, id by id,
+    until nothing new is reached.
 
-    A delegate whose agent has since been archived is dropped, because the runner
-    refuses to delegate to an archived agent (`_resolve_delegate` in
-    `agent_runner.py`): its pinned version can no longer load through that pin, so
-    reporting it would be flagging a binding no run can reach. The seeds cannot be
-    archived - both queries filter to published agents - so the check is only ever
-    needed on the delegates the closure reaches.
+    **The closure follows a pin no further than a run would.** Delegation is
+    bounded by `max_depth`, so following pins to unlimited depth would inspect -
+    and could flag - a grandchild the runner never loads, exposing a binding no
+    run can reach. Each pin therefore carries a *budget*, the depth still left
+    below it, mirroring `_resolve_delegate` in `agent_runner.py`: a seed follows
+    its pins at `max_depth - 1`, a delegate reached with budget `b` is inspected
+    but follows its own pins only when `b > 0` and then at
+    `min(b - 1, its own max_depth - 1)` - the lower of what the tree has left and
+    what the delegate's author allowed. A delegate reached by two paths is
+    followed as deep as the *deepest* path allows, so `followed` records the
+    greatest budget each version has already been expanded with and re-expands one
+    reached deeper. Reading a version's `max_depth` runs through
+    :func:`_delegation_config`, so a version whose delegation binding is absent,
+    disabled or unparsable follows no pins at all - exactly as the runner builds
+    it without the capability.
+
+    A pin is dropped, before its depth is even considered, whenever the runner
+    would refuse it: to a version of a *different* agent than the pin names, to
+    another organization's version, or to an *archived* agent - the three refusals
+    `_resolve_delegate` raises. A run cannot load through such a pin, so flagging
+    what it reaches would be reporting a binding no run can reach. The seeds
+    themselves are trusted: the two published-agent seeds cannot be archived, and a
+    parked run's own version is one a resume loads directly rather than through a
+    pin.
     """
     seen: dict[UUID, tuple[Agent, AgentVersion]] = {}
-    frontier: list[AgentVersion] = []
+    specs: dict[UUID, AgentSpec] = {}
+    # version id -> greatest pin-following budget it has already been expanded
+    # with, so a delegate reached again by a deeper path is followed further while
+    # one reached no deeper is not re-walked - which is also what terminates a
+    # cycle (A pins B, B pins A).
+    followed: dict[UUID, int] = {}
+    # (version, budget): the depth still left for following *this* version's pins.
+    frontier: list[tuple[AgentVersion, int]] = []
+
+    def _remember(agent: Agent, version: AgentVersion) -> AgentSpec:
+        """Record a version as executable and return its parsed spec, once."""
+        seen.setdefault(version.id, (agent, version))
+        spec = specs.get(version.id)
+        if spec is None:
+            spec = AgentSpec.model_validate(version.spec)
+            specs[version.id] = spec
+        return spec
+
     seeds = [
         *await agent_repo.list_current_versions(db),
         *await agent_repo.list_environment_versions(db),
+        *await agent_repo.list_active_run_versions(db),
     ]
     for agent, version in seeds:
-        if version.id not in seen:
-            seen[version.id] = (agent, version)
-            frontier.append(version)
+        config = _delegation_config(_remember(agent, version))
+        if config is not None:
+            # A seed is the root of its own tree: its pins are followed at its own
+            # ceiling, exactly as `_subagent_runtime` starts the runner at
+            # `max_depth - 1`.
+            frontier.append((version, config.max_depth - 1))
 
     while frontier:
-        version = frontier.pop()
-        spec = AgentSpec.model_validate(version.spec)
-        pin_ids = [ref.agent_version_id for ref in spec.subagents]
-        for agent, pinned in await agent_repo.get_versions_with_agents(db, pin_ids):
+        version, budget = frontier.pop()
+        if followed.get(version.id, -1) >= budget:
+            continue
+        followed[version.id] = budget
+        refs = {ref.agent_version_id: ref for ref in specs[version.id].subagents}
+        for agent, pinned in await agent_repo.get_versions_with_agents(db, list(refs)):
+            ref = refs[pinned.id]
+            if agent.id != ref.agent_id:
+                # The pin names one agent but this version belongs to another;
+                # `_resolve_delegate` refuses it (`version.agent_id != ref.agent_id`).
+                continue
+            if pinned.organization_id != version.organization_id:
+                # A pin across organizations: the runner resolves every delegate in
+                # the run's own tenant and finds nothing, so it too never loads.
+                continue
             if agent.status == AgentStatus.ARCHIVED.value:
                 continue
-            # A cycle (A pins B, B pins A) or two parents pinning one delegate
-            # reach the same version twice; the first sighting wins and the rest
-            # are skipped here, which is what makes the closure terminate.
-            if pinned.id not in seen:
-                seen[pinned.id] = (agent, pinned)
-                frontier.append(pinned)
+            pinned_spec = _remember(agent, pinned)
+            if budget <= 0:
+                # The edge to this delegate had no budget left, so the runner built
+                # it without delegation: it is inspected, but its pins are not
+                # followed - the grandchild the ceiling exists to keep out.
+                continue
+            pinned_config = _delegation_config(pinned_spec)
+            if pinned_config is not None:
+                frontier.append((pinned, min(budget - 1, pinned_config.max_depth - 1)))
 
     return list(seen.values())
 

--- a/backend/app/repositories/agent.py
+++ b/backend/app/repositories/agent.py
@@ -106,6 +106,32 @@ async def list_all_published(db: AsyncSession) -> list[Agent]:
     return list(result.scalars().all())
 
 
+async def list_current_versions(db: AsyncSession) -> list[tuple[Agent, AgentVersion]]:
+    """Every published agent paired with the version that actually runs.
+
+    Deliberately unscoped, like :func:`list_all_published`, and for the same
+    narrow reason: the only caller is the `audit-skill-bindings` sweep, which is
+    about the deployment rather than a tenant and must reach every organization's
+    agents. Grep for this function when auditing cross-tenant reads.
+
+    The join is on `current_version_id`, so exactly the frozen spec a run reads is
+    returned - one row per agent, not its whole history. A rollback publishes a
+    *new* current version rather than re-pointing at an old one, so the current
+    version is the whole of what any run can load; historical versions cannot be
+    reached without first becoming current, which a later sweep would then see.
+
+    Published only. A draft has no frozen version to run, and an archived agent
+    refuses new runs - neither can hand a skill to anybody.
+    """
+    result = await db.execute(
+        select(Agent, AgentVersion)
+        .join(AgentVersion, AgentVersion.id == Agent.current_version_id)
+        .where(Agent.status == AgentStatus.PUBLISHED.value)
+        .order_by(Agent.organization_id, Agent.slug)
+    )
+    return list(result.tuples().all())
+
+
 async def create(
     db: AsyncSession,
     *,

--- a/backend/app/repositories/agent.py
+++ b/backend/app/repositories/agent.py
@@ -8,11 +8,12 @@ predicate pieces the access layer resolved rather than re-deriving them here.
 from collections.abc import Sequence
 from uuid import UUID
 
-from sqlalchemy import func, or_, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models.agent import Agent, AgentStatus, AgentVersion
 from app.db.models.agent_environment import AgentEnvironment
+from app.db.models.agent_run import AgentRun, RunStatus
 from app.db.models.resource_grant import Visibility
 
 
@@ -150,6 +151,49 @@ async def list_environment_versions(db: AsyncSession) -> list[tuple[Agent, Agent
         .join(AgentVersion, AgentVersion.id == AgentEnvironment.version_id)
         .where(Agent.status == AgentStatus.PUBLISHED.value)
         .order_by(Agent.organization_id, Agent.slug)
+    )
+    return list(result.tuples().all())
+
+
+async def list_active_run_versions(db: AsyncSession) -> list[tuple[Agent, AgentVersion]]:
+    """Every version a non-terminal run still loads, each with its agent.
+
+    The third seed of the runnable set, beside :func:`list_current_versions` and
+    :func:`list_environment_versions`, and unscoped for the same reason: the
+    `audit-skill-bindings` sweep is deployment-wide. A run records the version it
+    executed in `agent_version_id`, and a run that has not ended still loads it: a
+    `running` run is executing it now, and an `awaiting_approval` run reloads it
+    when :meth:`AgentRunnerService.resume` continues it. The four terminal states -
+    `completed`, `failed`, `cancelled` and `budget_exceeded` - never load it again,
+    so there `agent_version_id` is only a historical record.
+    A parked run resumes only from stored `paused_state`; one without it can never
+    continue, so it is excluded rather than seeding a version no resume can reach.
+
+    Unlike the two companion seeds this does **not** filter to published agents.
+    `resume` re-assembles the parked version through `registry.get`, which checks
+    the agent exists and the caller may run it but not its status - so a run parked
+    before its agent was archived still resumes and still hands out that version's
+    skills. The join to `AgentVersion` drops a run whose version was deleted
+    (`agent_version_id` is `SET NULL`): there is then nothing left to reload.
+
+    A hot version with many live runs is returned once per run; the sweep
+    deduplicates by version id, exactly as it does for the default environment
+    appearing in both companion seeds.
+    """
+    result = await db.execute(
+        select(Agent, AgentVersion)
+        .select_from(AgentRun)
+        .join(AgentVersion, AgentVersion.id == AgentRun.agent_version_id)
+        .join(Agent, Agent.id == AgentVersion.agent_id)
+        .where(
+            or_(
+                AgentRun.status == RunStatus.RUNNING.value,
+                and_(
+                    AgentRun.status == RunStatus.AWAITING_APPROVAL.value,
+                    AgentRun.paused_state.isnot(None),
+                ),
+            )
+        )
     )
     return list(result.tuples().all())
 

--- a/backend/app/repositories/agent.py
+++ b/backend/app/repositories/agent.py
@@ -161,9 +161,10 @@ async def get_versions_with_agents(
 
     Unscoped and by id: the caller is the sweep resolving `SubagentRef` pins,
     which name a delegate version directly and cross no organization boundary a
-    tenant filter could express. A pinned delegate runs whatever its own agent's
-    status, so this does not filter on it - the pin, not the agent's lifecycle,
-    is what the runner loads.
+    tenant filter could express. A pure fetch that does not filter on the agent's
+    status - the agent is returned alongside precisely so the caller can apply the
+    runtime's own rule, which refuses to delegate to an archived agent
+    (`_resolve_delegate` in `agent_runner.py`).
     """
     if not version_ids:
         return []

--- a/backend/app/repositories/agent.py
+++ b/backend/app/repositories/agent.py
@@ -12,6 +12,7 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models.agent import Agent, AgentStatus, AgentVersion
+from app.db.models.agent_environment import AgentEnvironment
 from app.db.models.resource_grant import Visibility
 
 
@@ -107,27 +108,70 @@ async def list_all_published(db: AsyncSession) -> list[Agent]:
 
 
 async def list_current_versions(db: AsyncSession) -> list[tuple[Agent, AgentVersion]]:
-    """Every published agent paired with the version that actually runs.
+    """Every published agent paired with its default (current) version.
 
     Deliberately unscoped, like :func:`list_all_published`, and for the same
-    narrow reason: the only caller is the `audit-skill-bindings` sweep, which is
-    about the deployment rather than a tenant and must reach every organization's
-    agents. Grep for this function when auditing cross-tenant reads.
+    narrow reason: the callers are deployment-wide, not tenant-scoped. Grep for
+    this function when auditing cross-tenant reads.
 
-    The join is on `current_version_id`, so exactly the frozen spec a run reads is
-    returned - one row per agent, not its whole history. A rollback publishes a
-    *new* current version rather than re-pointing at an old one, so the current
-    version is the whole of what any run can load; historical versions cannot be
-    reached without first becoming current, which a later sweep would then see.
+    This is only the *default* pointer. A surface that names no environment runs
+    `current_version_id`, but a named environment can pin any other published
+    version and a parent can pin a delegate version - so this is one seed of the
+    runnable set, not all of it. See :func:`list_environment_versions`.
 
     Published only. A draft has no frozen version to run, and an archived agent
-    refuses new runs - neither can hand a skill to anybody.
+    refuses new runs - neither can hand a skill to anybody directly.
     """
     result = await db.execute(
         select(Agent, AgentVersion)
         .join(AgentVersion, AgentVersion.id == Agent.current_version_id)
         .where(Agent.status == AgentStatus.PUBLISHED.value)
         .order_by(Agent.organization_id, Agent.slug)
+    )
+    return list(result.tuples().all())
+
+
+async def list_environment_versions(db: AsyncSession) -> list[tuple[Agent, AgentVersion]]:
+    """Every version a named environment of a published agent pins.
+
+    Unscoped, for the same reason as :func:`list_current_versions`, and its
+    companion in the `audit-skill-bindings` sweep: publishing moves only the
+    *default* environment, so a "production" environment can stay pinned to an
+    older version that `current_version_id` no longer names. A run that targets
+    that environment loads exactly this version, so the sweep must see it too.
+
+    Published agents only, because an archived or draft agent refuses a run that
+    targets it directly. A version reachable only as a *delegate* is a different
+    path - pinned by version id from a parent's spec, followed by the caller.
+    """
+    result = await db.execute(
+        select(Agent, AgentVersion)
+        .join(AgentEnvironment, AgentEnvironment.agent_id == Agent.id)
+        .join(AgentVersion, AgentVersion.id == AgentEnvironment.version_id)
+        .where(Agent.status == AgentStatus.PUBLISHED.value)
+        .order_by(Agent.organization_id, Agent.slug)
+    )
+    return list(result.tuples().all())
+
+
+async def get_versions_with_agents(
+    db: AsyncSession, version_ids: Sequence[UUID]
+) -> list[tuple[Agent, AgentVersion]]:
+    """Specific versions, each with its agent, whoever owns them.
+
+    Unscoped and by id: the caller is the sweep resolving `SubagentRef` pins,
+    which name a delegate version directly and cross no organization boundary a
+    tenant filter could express. A pinned delegate runs whatever its own agent's
+    status, so this does not filter on it - the pin, not the agent's lifecycle,
+    is what the runner loads.
+    """
+    if not version_ids:
+        return []
+    result = await db.execute(
+        select(Agent, AgentVersion)
+        .select_from(AgentVersion)
+        .join(Agent, Agent.id == AgentVersion.agent_id)
+        .where(AgentVersion.id.in_(list(version_ids)))
     )
     return list(result.tuples().all())
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -317,6 +317,7 @@ invalid-type-form = "warn"
 include = [
     "app/agents/**",
     "app/commands/bootstrap.py",
+    "app/commands/audit_skill_bindings.py",
     "app/core/permissions.py",
     "app/core/catalog/**",
     "app/core/secret_kinds.py",
@@ -430,6 +431,7 @@ generated_at = "2026-07-26T18:01:04.489757+00:00"
 include = [
     "app/agents/**",
     "app/commands/bootstrap.py",
+    "app/commands/audit_skill_bindings.py",
     "app/core/permissions.py",
     "app/core/catalog/**",
     "app/core/secret_kinds.py",

--- a/backend/tests/integration/test_skill_binding_audit.py
+++ b/backend/tests/integration/test_skill_binding_audit.py
@@ -1,0 +1,181 @@
+"""The `audit-skill-bindings` sweep against a real database.
+
+#179 added a publish-time check that a bound skill is one the publisher can
+reach. This sweep is its offline half - it finds versions frozen *before* that
+check that still hand a private skill to every run. The property that cannot be
+faked with mocks, and the reason this test exists, is that the answer is about
+the rows and not about the publisher's role today: promoting the publisher after
+a bad publish must not make the exposure disappear. The unit suite in
+`tests/test_audit_skill_bindings.py` covers the decisions; this proves the whole
+scan, including the join that selects the running version, behaves that way.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.commands import audit_skill_bindings as sweep
+from app.commands.audit_skill_bindings import BindingStatus
+from app.core.permissions import OrgRoleName
+from app.db.models.agent import Agent, AgentStatus, AgentVersion
+from app.db.models.organization import Organization, OrganizationMember
+from app.db.models.resource_grant import Visibility
+from app.db.models.skill import Skill
+from app.db.models.user import User
+
+pytestmark = pytest.mark.anyio
+
+
+async def _user(db) -> User:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"{uuid.uuid4().hex}@example.com",
+        hashed_password="x",
+        is_active=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _org_with_owner(db) -> tuple[Organization, User]:
+    owner = await _user(db)
+    org = Organization(
+        id=uuid.uuid4(),
+        name="Acme",
+        slug=f"acme-{uuid.uuid4().hex[:8]}",
+        created_by_user_id=owner.id,
+    )
+    db.add(org)
+    await db.flush()
+    return org, owner
+
+
+async def _member(db, org: Organization, user: User, role: OrgRoleName) -> OrganizationMember:
+    member = OrganizationMember(
+        id=uuid.uuid4(), organization_id=org.id, user_id=user.id, role=role.value
+    )
+    db.add(member)
+    await db.flush()
+    return member
+
+
+async def _skill(db, org: Organization, owner: User, *, visibility: Visibility) -> Skill:
+    skill = Skill(
+        id=uuid.uuid4(),
+        organization_id=org.id,
+        owner_user_id=owner.id,
+        name=f"skill-{uuid.uuid4().hex[:8]}",
+        description="private know-how",
+        content="do the thing",
+        visibility=visibility.value,
+    )
+    db.add(skill)
+    await db.flush()
+    return skill
+
+
+async def _published_agent(
+    db, org: Organization, *, skill_id: uuid.UUID, publisher_id: uuid.UUID | None
+) -> Agent:
+    """A published agent whose current version binds one skill."""
+    agent = Agent(
+        id=uuid.uuid4(),
+        organization_id=org.id,
+        slug=f"agent-{uuid.uuid4().hex[:6]}",
+        name="Support",
+        description=None,
+        draft_spec={"name": "Support", "skill_ids": [str(skill_id)]},
+        status=AgentStatus.PUBLISHED.value,
+    )
+    db.add(agent)
+    await db.flush()
+    version = AgentVersion(
+        id=uuid.uuid4(),
+        agent_id=agent.id,
+        organization_id=org.id,
+        version=1,
+        spec={"name": "Support", "skill_ids": [str(skill_id)]},
+        published_by_user_id=publisher_id,
+    )
+    db.add(version)
+    await db.flush()
+    agent.current_version_id = version.id
+    await db.flush()
+    return agent
+
+
+class TestTheSweepFindsAnOutOfReachBinding:
+    async def test_a_private_skill_bound_by_a_non_owner_is_exposed(self, db) -> None:
+        org, _ = await _org_with_owner(db)
+        author = await _user(db)
+        colleague = await _user(db)
+        await _member(db, org, author, OrgRoleName.MEMBER)
+        skill = await _skill(db, org, colleague, visibility=Visibility.PRIVATE)
+        agent = await _published_agent(db, org, skill_id=skill.id, publisher_id=author.id)
+
+        findings = await sweep._scan(db)
+
+        mine = [f for f in findings if f.agent_slug == agent.slug]
+        assert len(mine) == 1
+        assert mine[0].status is BindingStatus.EXPOSED
+        assert mine[0].skill_id == skill.id
+
+    async def test_it_is_still_found_after_the_publisher_is_promoted(self, db) -> None:
+        """The heart of #186. A Builder's role reaches every skill, so re-deriving
+        access today would clear this - which is exactly the mistake. The frozen
+        binding is unchanged, so the sweep must still report it."""
+        org, _ = await _org_with_owner(db)
+        author = await _user(db)
+        colleague = await _user(db)
+        membership = await _member(db, org, author, OrgRoleName.MEMBER)
+        skill = await _skill(db, org, colleague, visibility=Visibility.PRIVATE)
+        agent = await _published_agent(db, org, skill_id=skill.id, publisher_id=author.id)
+
+        membership.role = OrgRoleName.BUILDER.value
+        await db.flush()
+
+        findings = await sweep._scan(db)
+
+        mine = [f for f in findings if f.agent_slug == agent.slug]
+        assert len(mine) == 1
+        assert mine[0].status is BindingStatus.EXPOSED
+
+    async def test_a_binding_whose_publisher_is_gone_is_unknown(self, db) -> None:
+        org, _ = await _org_with_owner(db)
+        colleague = await _user(db)
+        skill = await _skill(db, org, colleague, visibility=Visibility.PRIVATE)
+        agent = await _published_agent(db, org, skill_id=skill.id, publisher_id=None)
+
+        findings = await sweep._scan(db)
+
+        mine = [f for f in findings if f.agent_slug == agent.slug]
+        assert len(mine) == 1
+        assert mine[0].status is BindingStatus.UNKNOWN
+
+
+class TestTheSweepClearsAReachableBinding:
+    async def test_an_org_visible_skill_is_not_reported(self, db) -> None:
+        org, _ = await _org_with_owner(db)
+        author = await _user(db)
+        colleague = await _user(db)
+        await _member(db, org, author, OrgRoleName.MEMBER)
+        skill = await _skill(db, org, colleague, visibility=Visibility.ORG)
+        agent = await _published_agent(db, org, skill_id=skill.id, publisher_id=author.id)
+
+        findings = await sweep._scan(db)
+
+        assert [f for f in findings if f.agent_slug == agent.slug] == []
+
+    async def test_a_skill_the_publisher_owns_is_not_reported(self, db) -> None:
+        org, _ = await _org_with_owner(db)
+        author = await _user(db)
+        await _member(db, org, author, OrgRoleName.MEMBER)
+        skill = await _skill(db, org, author, visibility=Visibility.PRIVATE)
+        agent = await _published_agent(db, org, skill_id=skill.id, publisher_id=author.id)
+
+        findings = await sweep._scan(db)
+
+        assert [f for f in findings if f.agent_slug == agent.slug] == []

--- a/backend/tests/integration/test_skill_binding_audit.py
+++ b/backend/tests/integration/test_skill_binding_audit.py
@@ -280,6 +280,39 @@ class TestTheSweepReachesVersionsOtherThanTheDefault:
         assert mine[0].version_number == 1
         assert mine[0].skill_id == private.id
 
+    async def test_a_pin_to_an_archived_delegate_is_not_reported(self, db) -> None:
+        """The runner refuses to delegate to an archived agent, so its pinned
+        version can no longer load - the sweep must not flag it."""
+        org, _ = await _org_with_owner(db)
+        author = await _user(db)
+        colleague = await _user(db)
+        await _member(db, org, author, OrgRoleName.MEMBER)
+        private = await _skill(db, org, colleague, visibility=Visibility.PRIVATE)
+
+        delegate = await _agent(db, org, name="Researcher")
+        unsafe = await _version(
+            db, delegate, org, number=1, skill_id=private.id, publisher_id=author.id
+        )
+        delegate.current_version_id = unsafe.id
+        delegate.status = AgentStatus.ARCHIVED.value
+        await db.flush()
+
+        parent = await _agent(db, org, name="Boss")
+        parent_v = await _version(
+            db,
+            parent,
+            org,
+            number=1,
+            publisher_id=author.id,
+            subagents=[{"agent_id": str(delegate.id), "agent_version_id": str(unsafe.id)}],
+        )
+        parent.current_version_id = parent_v.id
+        await db.flush()
+
+        findings = await sweep._scan(db)
+
+        assert [f for f in findings if f.agent_slug == delegate.slug] == []
+
 
 class TestTheSweepClearsAReachableBinding:
     async def test_an_org_visible_skill_is_not_reported(self, db) -> None:

--- a/backend/tests/integration/test_skill_binding_audit.py
+++ b/backend/tests/integration/test_skill_binding_audit.py
@@ -20,6 +20,7 @@ from app.commands import audit_skill_bindings as sweep
 from app.commands.audit_skill_bindings import BindingStatus
 from app.core.permissions import OrgRoleName
 from app.db.models.agent import Agent, AgentStatus, AgentVersion
+from app.db.models.agent_environment import AgentEnvironment
 from app.db.models.organization import Organization, OrganizationMember
 from app.db.models.resource_grant import Visibility
 from app.db.models.skill import Skill
@@ -107,6 +108,65 @@ async def _published_agent(
     return agent
 
 
+async def _agent(db, org: Organization, *, name: str = "Support") -> Agent:
+    agent = Agent(
+        id=uuid.uuid4(),
+        organization_id=org.id,
+        slug=f"agent-{uuid.uuid4().hex[:6]}",
+        name=name,
+        description=None,
+        draft_spec={"name": name},
+        status=AgentStatus.PUBLISHED.value,
+    )
+    db.add(agent)
+    await db.flush()
+    return agent
+
+
+async def _version(
+    db,
+    agent: Agent,
+    org: Organization,
+    *,
+    number: int,
+    skill_id: uuid.UUID | None = None,
+    publisher_id: uuid.UUID | None = None,
+    subagents: list[dict] | None = None,
+) -> AgentVersion:
+    spec: dict = {"name": agent.name}
+    if skill_id is not None:
+        spec["skill_ids"] = [str(skill_id)]
+    if subagents is not None:
+        spec["subagents"] = subagents
+    version = AgentVersion(
+        id=uuid.uuid4(),
+        agent_id=agent.id,
+        organization_id=org.id,
+        version=number,
+        spec=spec,
+        published_by_user_id=publisher_id,
+    )
+    db.add(version)
+    await db.flush()
+    return version
+
+
+async def _environment(
+    db, agent: Agent, org: Organization, version: AgentVersion, *, name: str, is_default: bool
+) -> AgentEnvironment:
+    env = AgentEnvironment(
+        id=uuid.uuid4(),
+        organization_id=org.id,
+        agent_id=agent.id,
+        name=name,
+        version_id=version.id,
+        is_default=is_default,
+    )
+    db.add(env)
+    await db.flush()
+    return env
+
+
 class TestTheSweepFindsAnOutOfReachBinding:
     async def test_a_private_skill_bound_by_a_non_owner_is_exposed(self, db) -> None:
         org, _ = await _org_with_owner(db)
@@ -156,6 +216,71 @@ class TestTheSweepFindsAnOutOfReachBinding:
         assert mine[0].status is BindingStatus.UNKNOWN
 
 
+class TestTheSweepReachesVersionsOtherThanTheDefault:
+    """The gap #248's first pass had: a run does not always load
+    `current_version_id`. A named environment can pin an older version, and a
+    parent can pin a delegate version - both execute, so both must be scanned."""
+
+    async def test_a_named_environment_pinned_to_an_unsafe_older_version_is_found(self, db) -> None:
+        org, _ = await _org_with_owner(db)
+        author = await _user(db)
+        colleague = await _user(db)
+        await _member(db, org, author, OrgRoleName.MEMBER)
+        private = await _skill(db, org, colleague, visibility=Visibility.PRIVATE)
+        own = await _skill(db, org, author, visibility=Visibility.PRIVATE)
+
+        agent = await _agent(db, org)
+        unsafe = await _version(
+            db, agent, org, number=1, skill_id=private.id, publisher_id=author.id
+        )
+        safe = await _version(db, agent, org, number=2, skill_id=own.id, publisher_id=author.id)
+        agent.current_version_id = safe.id
+        await db.flush()
+        await _environment(db, agent, org, safe, name="default", is_default=True)
+        await _environment(db, agent, org, unsafe, name="production", is_default=False)
+
+        findings = await sweep._scan(db)
+
+        mine = [f for f in findings if f.agent_slug == agent.slug]
+        assert len(mine) == 1
+        assert mine[0].version_number == 1
+        assert mine[0].skill_id == private.id
+
+    async def test_a_delegate_version_reached_only_through_a_pin_is_found(self, db) -> None:
+        org, _ = await _org_with_owner(db)
+        author = await _user(db)
+        colleague = await _user(db)
+        await _member(db, org, author, OrgRoleName.MEMBER)
+        private = await _skill(db, org, colleague, visibility=Visibility.PRIVATE)
+
+        delegate = await _agent(db, org, name="Researcher")
+        unsafe = await _version(
+            db, delegate, org, number=1, skill_id=private.id, publisher_id=author.id
+        )
+        safe = await _version(db, delegate, org, number=2, publisher_id=author.id)
+        delegate.current_version_id = safe.id  # the delegate's own default is clean
+        await db.flush()
+
+        parent = await _agent(db, org, name="Boss")
+        parent_v = await _version(
+            db,
+            parent,
+            org,
+            number=1,
+            publisher_id=author.id,
+            subagents=[{"agent_id": str(delegate.id), "agent_version_id": str(unsafe.id)}],
+        )
+        parent.current_version_id = parent_v.id
+        await db.flush()
+
+        findings = await sweep._scan(db)
+
+        mine = [f for f in findings if f.agent_slug == delegate.slug]
+        assert len(mine) == 1
+        assert mine[0].version_number == 1
+        assert mine[0].skill_id == private.id
+
+
 class TestTheSweepClearsAReachableBinding:
     async def test_an_org_visible_skill_is_not_reported(self, db) -> None:
         org, _ = await _org_with_owner(db)
@@ -174,6 +299,21 @@ class TestTheSweepClearsAReachableBinding:
         author = await _user(db)
         await _member(db, org, author, OrgRoleName.MEMBER)
         skill = await _skill(db, org, author, visibility=Visibility.PRIVATE)
+        agent = await _published_agent(db, org, skill_id=skill.id, publisher_id=author.id)
+
+        findings = await sweep._scan(db)
+
+        assert [f for f in findings if f.agent_slug == agent.slug] == []
+
+    async def test_a_disabled_skill_is_not_a_live_exposure(self, db) -> None:
+        """`resolve_for_agent` skips a disabled skill, so no run receives it."""
+        org, _ = await _org_with_owner(db)
+        author = await _user(db)
+        colleague = await _user(db)
+        await _member(db, org, author, OrgRoleName.MEMBER)
+        skill = await _skill(db, org, colleague, visibility=Visibility.PRIVATE)
+        skill.enabled = False
+        await db.flush()
         agent = await _published_agent(db, org, skill_id=skill.id, publisher_id=author.id)
 
         findings = await sweep._scan(db)

--- a/backend/tests/integration/test_skill_binding_audit.py
+++ b/backend/tests/integration/test_skill_binding_audit.py
@@ -21,6 +21,7 @@ from app.commands.audit_skill_bindings import BindingStatus
 from app.core.permissions import OrgRoleName
 from app.db.models.agent import Agent, AgentStatus, AgentVersion
 from app.db.models.agent_environment import AgentEnvironment
+from app.db.models.agent_run import AgentRun, RunStatus
 from app.db.models.organization import Organization, OrganizationMember
 from app.db.models.resource_grant import Visibility
 from app.db.models.skill import Skill
@@ -132,12 +133,19 @@ async def _version(
     skill_id: uuid.UUID | None = None,
     publisher_id: uuid.UUID | None = None,
     subagents: list[dict] | None = None,
+    max_depth: int = 1,
 ) -> AgentVersion:
     spec: dict = {"name": agent.name}
     if skill_id is not None:
         spec["skill_ids"] = [str(skill_id)]
     if subagents is not None:
+        # Pins are only followed through a delegation binding that is switched on,
+        # exactly as the runner reads them - so a version that delegates carries
+        # the capability, with the depth ceiling under test.
         spec["subagents"] = subagents
+        spec["capabilities"] = [
+            {"id": "subagents", "enabled": True, "config": {"max_depth": max_depth}}
+        ]
     version = AgentVersion(
         id=uuid.uuid4(),
         agent_id=agent.id,
@@ -149,6 +157,67 @@ async def _version(
     db.add(version)
     await db.flush()
     return version
+
+
+async def _run(
+    db,
+    agent: Agent,
+    org: Organization,
+    version: AgentVersion,
+    *,
+    status: RunStatus,
+    paused_state: dict | None = None,
+) -> AgentRun:
+    run = AgentRun(
+        id=uuid.uuid4(),
+        organization_id=org.id,
+        agent_id=agent.id,
+        agent_version_id=version.id,
+        status=status.value,
+        paused_state=paused_state,
+    )
+    db.add(run)
+    await db.flush()
+    return run
+
+
+async def _delegation_tree(db, org, author, private_skill, *, root_depth: int) -> Agent:
+    """A root -> child -> grandchild chain where only the grandchild binds
+    `private_skill`. `root_depth` is the root's `max_depth`; the child allows one
+    nested level. Returns the grandchild agent so a test can assert on its slug.
+
+    Only the root carries a `current_version_id`: the child and grandchild
+    versions are reachable *only* through the pin chain, never as a seed of their
+    own, so what the scan reaches is decided purely by the depth ceiling."""
+    grandchild = await _agent(db, org, name=f"Grandchild-{uuid.uuid4().hex[:4]}")
+    gc_v = await _version(
+        db, grandchild, org, number=1, skill_id=private_skill.id, publisher_id=author.id
+    )
+
+    child = await _agent(db, org, name=f"Child-{uuid.uuid4().hex[:4]}")
+    child_v = await _version(
+        db,
+        child,
+        org,
+        number=1,
+        publisher_id=author.id,
+        subagents=[{"agent_id": str(grandchild.id), "agent_version_id": str(gc_v.id)}],
+        max_depth=2,
+    )
+
+    root = await _agent(db, org, name=f"Root-{uuid.uuid4().hex[:4]}")
+    root_v = await _version(
+        db,
+        root,
+        org,
+        number=1,
+        publisher_id=author.id,
+        subagents=[{"agent_id": str(child.id), "agent_version_id": str(child_v.id)}],
+        max_depth=root_depth,
+    )
+    root.current_version_id = root_v.id
+    await db.flush()
+    return grandchild
 
 
 async def _environment(
@@ -352,3 +421,149 @@ class TestTheSweepClearsAReachableBinding:
         findings = await sweep._scan(db)
 
         assert [f for f in findings if f.agent_slug == agent.slug] == []
+
+
+class TestTheSweepReachesVersionsALiveRunHolds:
+    """The second gap #248 had: a version stops being current or environment-pinned
+    the moment a newer one is published, but a run that has not finished still
+    reloads the exact version it was executing - a parked one when it resumes, a
+    running one now. Its out-of-reach binding is still live."""
+
+    async def test_a_parked_run_keeps_an_unsafe_version_reachable(self, db) -> None:
+        """A run parked awaiting approval on unsafe v1 resumes on v1 even after
+        safe v2 is published and becomes the only current and environment-pinned
+        version. `resume` reloads `agent_version_id`, so v1's binding still runs."""
+        org, _ = await _org_with_owner(db)
+        author = await _user(db)
+        colleague = await _user(db)
+        await _member(db, org, author, OrgRoleName.MEMBER)
+        private = await _skill(db, org, colleague, visibility=Visibility.PRIVATE)
+        own = await _skill(db, org, author, visibility=Visibility.PRIVATE)
+
+        agent = await _agent(db, org)
+        unsafe = await _version(
+            db, agent, org, number=1, skill_id=private.id, publisher_id=author.id
+        )
+        safe = await _version(db, agent, org, number=2, skill_id=own.id, publisher_id=author.id)
+        agent.current_version_id = safe.id
+        await db.flush()
+        await _environment(db, agent, org, safe, name="default", is_default=True)
+        await _run(
+            db,
+            agent,
+            org,
+            unsafe,
+            status=RunStatus.AWAITING_APPROVAL,
+            paused_state={"messages": []},
+        )
+
+        findings = await sweep._scan(db)
+
+        mine = [f for f in findings if f.agent_slug == agent.slug]
+        assert len(mine) == 1
+        assert mine[0].version_number == 1
+        assert mine[0].skill_id == private.id
+
+    async def test_a_finished_run_does_not_resurrect_its_old_version(self, db) -> None:
+        """A completed run never loads its version again, so it does not seed v1
+        back into the scan once safe v2 is the only reachable version."""
+        org, _ = await _org_with_owner(db)
+        author = await _user(db)
+        colleague = await _user(db)
+        await _member(db, org, author, OrgRoleName.MEMBER)
+        private = await _skill(db, org, colleague, visibility=Visibility.PRIVATE)
+        own = await _skill(db, org, author, visibility=Visibility.PRIVATE)
+
+        agent = await _agent(db, org)
+        unsafe = await _version(
+            db, agent, org, number=1, skill_id=private.id, publisher_id=author.id
+        )
+        safe = await _version(db, agent, org, number=2, skill_id=own.id, publisher_id=author.id)
+        agent.current_version_id = safe.id
+        await db.flush()
+        await _environment(db, agent, org, safe, name="default", is_default=True)
+        await _run(db, agent, org, unsafe, status=RunStatus.COMPLETED)
+
+        findings = await sweep._scan(db)
+
+        assert [f for f in findings if f.agent_slug == agent.slug] == []
+
+
+class TestTheSweepStopsAtTheDelegationCeiling:
+    """The runner bounds delegation by `max_depth`: at the ceiling a delegate is
+    built without the capability, so its own pins are never followed. A sweep that
+    chased pins to unlimited depth would flag a grandchild no run can reach."""
+
+    async def test_a_grandchild_beyond_max_depth_is_not_reported(self, db) -> None:
+        """root `max_depth=1`: the child is reached but built without delegation,
+        so the grandchild's private binding is never loaded by any run."""
+        org, _ = await _org_with_owner(db)
+        author = await _user(db)
+        colleague = await _user(db)
+        await _member(db, org, author, OrgRoleName.MEMBER)
+        private = await _skill(db, org, colleague, visibility=Visibility.PRIVATE)
+
+        grandchild = await _delegation_tree(db, org, author, private, root_depth=1)
+
+        findings = await sweep._scan(db)
+
+        assert [f for f in findings if f.agent_slug == grandchild.slug] == []
+
+    async def test_a_grandchild_within_max_depth_is_reported(self, db) -> None:
+        """root `max_depth=2`: one nested level is allowed, so the grandchild is
+        loaded and its out-of-reach binding is a real exposure."""
+        org, _ = await _org_with_owner(db)
+        author = await _user(db)
+        colleague = await _user(db)
+        await _member(db, org, author, OrgRoleName.MEMBER)
+        private = await _skill(db, org, colleague, visibility=Visibility.PRIVATE)
+
+        grandchild = await _delegation_tree(db, org, author, private, root_depth=2)
+
+        findings = await sweep._scan(db)
+
+        mine = [f for f in findings if f.agent_slug == grandchild.slug]
+        assert len(mine) == 1
+        assert mine[0].skill_id == private.id
+
+
+class TestTheTwoFixesCompose:
+    async def test_a_parked_shallow_version_is_caught_while_an_unreachable_grandchild_is_not(
+        self, db
+    ) -> None:
+        """One scan, both directions at once: a parked run on a shallow-but-unsafe
+        version is still flagged (the widening fix), while a grandchild only a
+        `max_depth=1` root could reach is not (the narrowing fix)."""
+        org, _ = await _org_with_owner(db)
+        author = await _user(db)
+        colleague = await _user(db)
+        await _member(db, org, author, OrgRoleName.MEMBER)
+        private = await _skill(db, org, colleague, visibility=Visibility.PRIVATE)
+        own = await _skill(db, org, author, visibility=Visibility.PRIVATE)
+
+        # Widening: a parked run keeps unsafe v1 reachable though v2 is current.
+        parked_agent = await _agent(db, org, name="Parked")
+        unsafe = await _version(
+            db, parked_agent, org, number=1, skill_id=private.id, publisher_id=author.id
+        )
+        safe = await _version(
+            db, parked_agent, org, number=2, skill_id=own.id, publisher_id=author.id
+        )
+        parked_agent.current_version_id = safe.id
+        await db.flush()
+        await _run(
+            db,
+            parked_agent,
+            org,
+            unsafe,
+            status=RunStatus.AWAITING_APPROVAL,
+            paused_state={"messages": []},
+        )
+
+        # Narrowing: a max_depth=1 root whose grandchild binds a private skill.
+        grandchild = await _delegation_tree(db, org, author, private, root_depth=1)
+
+        findings = await sweep._scan(db)
+
+        assert any(f.agent_slug == parked_agent.slug and f.skill_id == private.id for f in findings)
+        assert [f for f in findings if f.agent_slug == grandchild.slug] == []

--- a/backend/tests/test_audit_skill_bindings.py
+++ b/backend/tests/test_audit_skill_bindings.py
@@ -319,18 +319,76 @@ class TestFindingsFor:
         emails.assert_not_awaited()
 
 
+def _pins(*refs: tuple[uuid.UUID, uuid.UUID], max_depth: int = 1, enabled: bool = True) -> dict:
+    """A delegating spec that pins each `(agent_id, version_id)` given.
+
+    The delegation *binding* is what makes a pin followable: the runner reads pins
+    only when it is switched on, so a spec that just carried `subagents` with no
+    enabled binding delegates to nothing.
+    """
+    return {
+        "name": "Boss",
+        "subagents": [{"agent_id": str(a), "agent_version_id": str(v)} for a, v in refs],
+        "capabilities": [
+            {"id": "subagents", "enabled": enabled, "config": {"max_depth": max_depth}}
+        ],
+    }
+
+
 class TestExecutableVersions:
-    def _pair(self, spec: dict | None = None, *, status: str = AgentStatus.PUBLISHED.value):
+    ORG = uuid.uuid4()
+
+    def _pair(
+        self,
+        spec: dict | None = None,
+        *,
+        status: str = AgentStatus.PUBLISHED.value,
+        org: uuid.UUID | None = None,
+        agent_id: uuid.UUID | None = None,
+    ):
+        org = org or self.ORG
         agent = SimpleNamespace(
-            organization_id=uuid.uuid4(), slug=uuid.uuid4().hex[:6], name="A", status=status
+            id=agent_id or uuid.uuid4(),
+            organization_id=org,
+            slug=uuid.uuid4().hex[:6],
+            name="A",
+            status=status,
         )
         version = SimpleNamespace(
             id=uuid.uuid4(),
+            organization_id=org,
             version=1,
             published_by_user_id=uuid.uuid4(),
             spec=spec or {"name": "A"},
         )
         return agent, version
+
+    async def _run(self, *, current=(), environment=(), active=(), pairs=()):
+        by_version = {v.id: (a, v) for a, v in pairs}
+
+        async def resolve(_db, ids):
+            return [by_version[i] for i in ids if i in by_version]
+
+        with (
+            patch.object(
+                sweep.agent_repo, "list_current_versions", new=AsyncMock(return_value=list(current))
+            ),
+            patch.object(
+                sweep.agent_repo,
+                "list_environment_versions",
+                new=AsyncMock(return_value=list(environment)),
+            ),
+            patch.object(
+                sweep.agent_repo,
+                "list_active_run_versions",
+                new=AsyncMock(return_value=list(active)),
+            ),
+            patch.object(
+                sweep.agent_repo, "get_versions_with_agents", new=AsyncMock(side_effect=resolve)
+            ),
+        ):
+            found = await sweep._executable_versions(MagicMock())
+        return {v.id for _, v in found}
 
     @pytest.mark.anyio
     async def test_it_unions_current_and_named_environment_pins_without_duplicates(self):
@@ -338,83 +396,71 @@ class TestExecutableVersions:
         seeds - it must be counted once."""
         current = self._pair()
         named = self._pair()
-        with (
-            patch.object(
-                sweep.agent_repo,
-                "list_current_versions",
-                new=AsyncMock(return_value=[current]),
-            ),
-            patch.object(
-                sweep.agent_repo,
-                "list_environment_versions",
-                new=AsyncMock(return_value=[current, named]),
-            ),
-            patch.object(
-                sweep.agent_repo, "get_versions_with_agents", new=AsyncMock(return_value=[])
-            ),
-        ):
-            found = await sweep._executable_versions(MagicMock())
-        assert sorted(v.id for _, v in found) == sorted({current[1].id, named[1].id})
+        found = await self._run(current=[current], environment=[current, named])
+        assert found == {current[1].id, named[1].id}
 
     @pytest.mark.anyio
-    async def test_it_follows_a_pinned_delegate_version_a_named_environment_reaches(self):
-        """The delegate version is reachable only through the parent's pin, not
-        through any environment of its own."""
+    async def test_a_version_only_a_live_run_holds_is_seeded(self):
+        """A run still executing or parked reloads its version even when nothing
+        current or environment-pinned points to it any more."""
+        parked = self._pair()
+        found = await self._run(active=[parked])
+        assert parked[1].id in found
+
+    @pytest.mark.anyio
+    async def test_it_follows_a_pinned_delegate_version(self):
+        """A delegate version is reachable only through the parent's pin. Its own
+        spec binds no further delegate, so the closure stops at it."""
         delegate = self._pair()
-        parent = self._pair(
-            {
-                "name": "Parent",
-                "subagents": [
-                    {"agent_id": str(uuid.uuid4()), "agent_version_id": str(delegate[1].id)}
-                ],
-            }
-        )
-        with (
-            patch.object(
-                sweep.agent_repo, "list_current_versions", new=AsyncMock(return_value=[parent])
-            ),
-            patch.object(
-                sweep.agent_repo, "list_environment_versions", new=AsyncMock(return_value=[])
-            ),
-            patch.object(
-                sweep.agent_repo,
-                "get_versions_with_agents",
-                new=AsyncMock(side_effect=[[delegate], []]),
-            ),
-        ):
-            found = await sweep._executable_versions(MagicMock())
-        assert delegate[1].id in {v.id for _, v in found}
+        parent = self._pair(_pins((delegate[0].id, delegate[1].id), max_depth=2))
+        found = await self._run(current=[parent], pairs=[delegate])
+        assert delegate[1].id in found
 
     @pytest.mark.anyio
-    async def test_a_pin_to_an_already_seen_version_does_not_loop(self):
-        """A pins B and B pins A: the closure must terminate, each seen once."""
+    async def test_a_grandchild_beyond_the_depth_ceiling_is_not_reached(self):
+        """root `max_depth=1`: its direct delegate is inspected, but that
+        delegate's own pinned grandchild is not - the runner builds the delegate
+        without delegation at the ceiling, so no run loads the grandchild."""
+        grandchild = self._pair()
+        child = self._pair(_pins((grandchild[0].id, grandchild[1].id), max_depth=2))
+        root = self._pair(_pins((child[0].id, child[1].id), max_depth=1))
+        found = await self._run(current=[root], pairs=[child, grandchild])
+        assert child[1].id in found
+        assert grandchild[1].id not in found
+
+    @pytest.mark.anyio
+    async def test_a_grandchild_within_the_depth_ceiling_is_reached(self):
+        """root `max_depth=2`: one nested level is allowed, so the grandchild the
+        delegate pins is loaded and must be inspected."""
+        grandchild = self._pair()
+        child = self._pair(_pins((grandchild[0].id, grandchild[1].id), max_depth=2))
+        root = self._pair(_pins((child[0].id, child[1].id), max_depth=2))
+        found = await self._run(current=[root], pairs=[child, grandchild])
+        assert grandchild[1].id in found
+
+    @pytest.mark.anyio
+    async def test_a_delegates_own_ceiling_caps_the_budget_it_passes_down(self):
+        """A caller cannot buy a delegate more nesting than its author allowed:
+        root `max_depth=3` reaches the child and its grandchild, but the child's
+        own `max_depth=1` stops the tree there - the great-grandchild is out."""
+        great = self._pair()
+        grandchild = self._pair(_pins((great[0].id, great[1].id), max_depth=2))
+        child = self._pair(_pins((grandchild[0].id, grandchild[1].id), max_depth=1))
+        root = self._pair(_pins((child[0].id, child[1].id), max_depth=3))
+        found = await self._run(current=[root], pairs=[child, grandchild, great])
+        assert grandchild[1].id in found
+        assert great[1].id not in found
+
+    @pytest.mark.anyio
+    async def test_a_cycle_terminates_and_each_version_is_seen_once(self):
+        """A pins B and B pins A, both at a depth that would recurse forever: the
+        closure must terminate, each version expanded only at its deepest budget."""
         a = self._pair()
         b = self._pair()
-        a[1].spec = {
-            "name": "A",
-            "subagents": [{"agent_id": str(uuid.uuid4()), "agent_version_id": str(b[1].id)}],
-        }
-        b[1].spec = {
-            "name": "B",
-            "subagents": [{"agent_id": str(uuid.uuid4()), "agent_version_id": str(a[1].id)}],
-        }
-
-        async def _resolve(_db, ids):
-            return [b] if b[1].id in ids else [a] if a[1].id in ids else []
-
-        with (
-            patch.object(
-                sweep.agent_repo, "list_current_versions", new=AsyncMock(return_value=[a])
-            ),
-            patch.object(
-                sweep.agent_repo, "list_environment_versions", new=AsyncMock(return_value=[])
-            ),
-            patch.object(
-                sweep.agent_repo, "get_versions_with_agents", new=AsyncMock(side_effect=_resolve)
-            ),
-        ):
-            found = await sweep._executable_versions(MagicMock())
-        assert sorted(v.id for _, v in found) == sorted({a[1].id, b[1].id})
+        a[1].spec = _pins((b[0].id, b[1].id), max_depth=3)
+        b[1].spec = _pins((a[0].id, a[1].id), max_depth=3)
+        found = await self._run(current=[a], pairs=[a, b])
+        assert found == {a[1].id, b[1].id}
 
     @pytest.mark.anyio
     async def test_a_pin_to_an_archived_delegate_is_dropped(self):
@@ -422,29 +468,38 @@ class TestExecutableVersions:
         version can no longer load through the pin - flagging it would report a
         binding no run can reach."""
         delegate = self._pair(status=AgentStatus.ARCHIVED.value)
-        parent = self._pair(
-            {
-                "name": "Parent",
-                "subagents": [
-                    {"agent_id": str(uuid.uuid4()), "agent_version_id": str(delegate[1].id)}
-                ],
-            }
-        )
-        with (
-            patch.object(
-                sweep.agent_repo, "list_current_versions", new=AsyncMock(return_value=[parent])
-            ),
-            patch.object(
-                sweep.agent_repo, "list_environment_versions", new=AsyncMock(return_value=[])
-            ),
-            patch.object(
-                sweep.agent_repo,
-                "get_versions_with_agents",
-                new=AsyncMock(return_value=[delegate]),
-            ),
-        ):
-            found = await sweep._executable_versions(MagicMock())
-        assert delegate[1].id not in {v.id for _, v in found}
+        parent = self._pair(_pins((delegate[0].id, delegate[1].id)))
+        found = await self._run(current=[parent], pairs=[delegate])
+        assert delegate[1].id not in found
+
+    @pytest.mark.anyio
+    async def test_a_pin_to_a_version_of_a_different_agent_is_dropped(self):
+        """The pin names one agent but the version belongs to another; the runner
+        refuses it (`version.agent_id != ref.agent_id`), so the sweep must too."""
+        delegate = self._pair()
+        parent = self._pair(_pins((uuid.uuid4(), delegate[1].id)))
+        found = await self._run(current=[parent], pairs=[delegate])
+        assert delegate[1].id not in found
+
+    @pytest.mark.anyio
+    async def test_a_pin_across_organizations_is_dropped(self):
+        """The runner resolves every delegate in the run's own tenant, so a pin to
+        another organization's version resolves to nothing and never loads."""
+        delegate = self._pair(org=uuid.uuid4())
+        parent = self._pair(_pins((delegate[0].id, delegate[1].id)))
+        found = await self._run(current=[parent], pairs=[delegate])
+        assert delegate[1].id not in found
+
+    @pytest.mark.anyio
+    async def test_a_disabled_delegation_binding_follows_no_pins(self):
+        """Pins frozen in a spec whose delegation binding is switched off are not
+        followed: the runner builds the agent without the capability, so no run
+        reaches the delegate."""
+        delegate = self._pair()
+        parent = self._pair(_pins((delegate[0].id, delegate[1].id), enabled=False))
+        found = await self._run(current=[parent], pairs=[delegate])
+        assert parent[1].id in found
+        assert delegate[1].id not in found
 
 
 class TestScan:

--- a/backend/tests/test_audit_skill_bindings.py
+++ b/backend/tests/test_audit_skill_bindings.py
@@ -43,6 +43,7 @@ def _skill(*, owner_user_id: uuid.UUID | None = None, visibility: str = Visibili
         name="refund-policy",
         owner_user_id=owner_user_id,
         visibility=visibility,
+        enabled=True,
     )
 
 
@@ -225,6 +226,26 @@ class TestFindingsFor:
         assert findings == []
 
     @pytest.mark.anyio
+    async def test_a_disabled_skill_is_not_an_exposure(self):
+        """`resolve_for_agent` skips a disabled skill, so no run receives it -
+        reporting it would fail the audit over something nothing loads."""
+        skill = _skill(owner_user_id=uuid.uuid4())
+        skill.enabled = False
+        spec = AgentSpec(name="Support", skill_ids=[skill.id])
+        get_level = AsyncMock()
+        with (
+            patch.object(
+                sweep.skill_repo, "get_many", new=AsyncMock(return_value={skill.id: skill})
+            ),
+            patch.object(sweep.resource_grant_repo, "get_level", new=get_level),
+        ):
+            findings = await _findings_for(
+                MagicMock(), self._agent(), self._version(spec, publisher=uuid.uuid4())
+            )
+        assert findings == []
+        get_level.assert_not_awaited()
+
+    @pytest.mark.anyio
     async def test_an_exposed_binding_is_reported_with_the_publishers_email(self):
         publisher = uuid.uuid4()
         skill = _skill(owner_user_id=uuid.uuid4())
@@ -297,21 +318,113 @@ class TestFindingsFor:
         emails.assert_not_awaited()
 
 
-class TestScan:
+class TestExecutableVersions:
+    def _pair(self, spec: dict | None = None):
+        agent = SimpleNamespace(organization_id=uuid.uuid4(), slug=uuid.uuid4().hex[:6], name="A")
+        version = SimpleNamespace(
+            id=uuid.uuid4(),
+            version=1,
+            published_by_user_id=uuid.uuid4(),
+            spec=spec or {"name": "A"},
+        )
+        return agent, version
+
     @pytest.mark.anyio
-    async def test_it_walks_every_published_version(self):
-        agent_a = SimpleNamespace(organization_id=uuid.uuid4(), slug="a", name="A")
-        agent_b = SimpleNamespace(organization_id=uuid.uuid4(), slug="b", name="B")
-        version_a = SimpleNamespace(
-            version=1, published_by_user_id=uuid.uuid4(), spec={"name": "A"}
-        )
-        version_b = SimpleNamespace(
-            version=1, published_by_user_id=uuid.uuid4(), spec={"name": "B"}
-        )
+    async def test_it_unions_current_and_named_environment_pins_without_duplicates(self):
+        """The default environment is `current_version_id`, so it shows up in both
+        seeds - it must be counted once."""
+        current = self._pair()
+        named = self._pair()
         with (
             patch.object(
                 sweep.agent_repo,
                 "list_current_versions",
+                new=AsyncMock(return_value=[current]),
+            ),
+            patch.object(
+                sweep.agent_repo,
+                "list_environment_versions",
+                new=AsyncMock(return_value=[current, named]),
+            ),
+            patch.object(
+                sweep.agent_repo, "get_versions_with_agents", new=AsyncMock(return_value=[])
+            ),
+        ):
+            found = await sweep._executable_versions(MagicMock())
+        assert sorted(v.id for _, v in found) == sorted({current[1].id, named[1].id})
+
+    @pytest.mark.anyio
+    async def test_it_follows_a_pinned_delegate_version_a_named_environment_reaches(self):
+        """The delegate version is reachable only through the parent's pin, not
+        through any environment of its own."""
+        delegate = self._pair()
+        parent = self._pair(
+            {
+                "name": "Parent",
+                "subagents": [
+                    {"agent_id": str(uuid.uuid4()), "agent_version_id": str(delegate[1].id)}
+                ],
+            }
+        )
+        with (
+            patch.object(
+                sweep.agent_repo, "list_current_versions", new=AsyncMock(return_value=[parent])
+            ),
+            patch.object(
+                sweep.agent_repo, "list_environment_versions", new=AsyncMock(return_value=[])
+            ),
+            patch.object(
+                sweep.agent_repo,
+                "get_versions_with_agents",
+                new=AsyncMock(side_effect=[[delegate], []]),
+            ),
+        ):
+            found = await sweep._executable_versions(MagicMock())
+        assert delegate[1].id in {v.id for _, v in found}
+
+    @pytest.mark.anyio
+    async def test_a_pin_to_an_already_seen_version_does_not_loop(self):
+        """A pins B and B pins A: the closure must terminate, each seen once."""
+        a = self._pair()
+        b = self._pair()
+        a[1].spec = {
+            "name": "A",
+            "subagents": [{"agent_id": str(uuid.uuid4()), "agent_version_id": str(b[1].id)}],
+        }
+        b[1].spec = {
+            "name": "B",
+            "subagents": [{"agent_id": str(uuid.uuid4()), "agent_version_id": str(a[1].id)}],
+        }
+
+        async def _resolve(_db, ids):
+            return [b] if b[1].id in ids else [a] if a[1].id in ids else []
+
+        with (
+            patch.object(
+                sweep.agent_repo, "list_current_versions", new=AsyncMock(return_value=[a])
+            ),
+            patch.object(
+                sweep.agent_repo, "list_environment_versions", new=AsyncMock(return_value=[])
+            ),
+            patch.object(
+                sweep.agent_repo, "get_versions_with_agents", new=AsyncMock(side_effect=_resolve)
+            ),
+        ):
+            found = await sweep._executable_versions(MagicMock())
+        assert sorted(v.id for _, v in found) == sorted({a[1].id, b[1].id})
+
+
+class TestScan:
+    @pytest.mark.anyio
+    async def test_it_reports_a_finding_from_every_executable_version(self):
+        agent_a = SimpleNamespace(organization_id=uuid.uuid4(), slug="a", name="A")
+        agent_b = SimpleNamespace(organization_id=uuid.uuid4(), slug="b", name="B")
+        version_a = SimpleNamespace(id=uuid.uuid4(), version=1, published_by_user_id=uuid.uuid4())
+        version_b = SimpleNamespace(id=uuid.uuid4(), version=1, published_by_user_id=uuid.uuid4())
+        with (
+            patch.object(
+                sweep,
+                "_executable_versions",
                 new=AsyncMock(return_value=[(agent_a, version_a), (agent_b, version_b)]),
             ),
             patch.object(

--- a/backend/tests/test_audit_skill_bindings.py
+++ b/backend/tests/test_audit_skill_bindings.py
@@ -1,0 +1,402 @@
+"""Tests for the `audit-skill-bindings` sweep.
+
+The sweep is the offline half of #179: it names published agents whose frozen
+spec lends a skill the publisher could not reach, so an operator can decide what
+to do. The two things that matter and are easy to get wrong: the answer is a fact
+about the rows, not about the publisher's role today (so it must not un-flag
+itself when that role later changes), and a publisher whose user row is gone is
+reported as *unknown* rather than guessed either way. The row-based behaviour is
+proved end to end in `tests/integration/test_skill_binding_audit.py`; these cover
+the decisions and the wiring with the repositories mocked.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.agents.spec import AgentSpec, CapabilityBindingSpec
+from app.commands import audit_skill_bindings as sweep
+from app.commands.audit_skill_bindings import (
+    BindingStatus,
+    Finding,
+    _bindings,
+    _classify,
+    _findings_for,
+    _line,
+    _location,
+    _publisher,
+    _report,
+    _run,
+    _scan,
+    audit_skill_bindings,
+)
+from app.db.models.resource_grant import GrantLevel, Visibility
+
+
+def _skill(*, owner_user_id: uuid.UUID | None = None, visibility: str = Visibility.PRIVATE.value):
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        name="refund-policy",
+        owner_user_id=owner_user_id,
+        visibility=visibility,
+    )
+
+
+def _finding(**overrides) -> Finding:
+    defaults = {
+        "organization_id": uuid.uuid4(),
+        "agent_slug": "support",
+        "agent_name": "Support",
+        "version_number": 3,
+        "published_by_user_id": uuid.uuid4(),
+        "publisher_email": "a@example.com",
+        "skill_id": uuid.uuid4(),
+        "skill_name": "refund-policy",
+        "specialist": None,
+        "status": BindingStatus.EXPOSED,
+    }
+    defaults.update(overrides)
+    return Finding(**defaults)
+
+
+class TestBindings:
+    def test_the_agents_own_skill_ids_are_returned(self):
+        sid = uuid.uuid4()
+        spec = AgentSpec(name="Support", skill_ids=[sid])
+        assert _bindings(spec) == [sweep.SkillBinding(skill_id=sid, specialist=None)]
+
+    def test_an_inline_specialists_skill_ids_are_found_too(self):
+        """The half of the check easy to forget: a specialist carries its own
+        skill_ids inside the delegation capability's config."""
+        own = uuid.uuid4()
+        buried = uuid.uuid4()
+        spec = AgentSpec(
+            name="Boss",
+            skill_ids=[own],
+            capabilities=[
+                CapabilityBindingSpec(
+                    id="subagents",
+                    config={
+                        "inline": [
+                            {
+                                "name": "researcher",
+                                "description": "researches a topic",
+                                "instructions": "do research",
+                                "skill_ids": [str(buried)],
+                            }
+                        ]
+                    },
+                )
+            ],
+        )
+        bindings = _bindings(spec)
+        assert sweep.SkillBinding(skill_id=own, specialist=None) in bindings
+        assert sweep.SkillBinding(skill_id=buried, specialist="researcher") in bindings
+
+    def test_a_delegation_config_that_does_not_parse_is_skipped(self):
+        """The capability would not build from an unparsable config, so those
+        specialists never run and lend nothing - the top-level bindings are still
+        returned rather than the whole spec being abandoned."""
+        own = uuid.uuid4()
+        spec = AgentSpec(
+            name="Boss",
+            skill_ids=[own],
+            capabilities=[CapabilityBindingSpec(id="subagents", config={"inline": "not-a-list"})],
+        )
+        assert _bindings(spec) == [sweep.SkillBinding(skill_id=own, specialist=None)]
+
+    def test_a_disabled_delegation_binding_contributes_nothing(self):
+        """A switched-off capability is not built, so `delegation_binding` returns
+        nothing and its specialists are not walked."""
+        own = uuid.uuid4()
+        spec = AgentSpec(
+            name="Boss",
+            skill_ids=[own],
+            capabilities=[
+                CapabilityBindingSpec(
+                    id="subagents",
+                    enabled=False,
+                    config={
+                        "inline": [
+                            {
+                                "name": "researcher",
+                                "description": "researches a topic",
+                                "instructions": "do research",
+                                "skill_ids": [str(uuid.uuid4())],
+                            }
+                        ]
+                    },
+                )
+            ],
+        )
+        assert _bindings(spec) == [sweep.SkillBinding(skill_id=own, specialist=None)]
+
+
+class TestClassify:
+    @pytest.mark.anyio
+    async def test_an_org_visible_skill_is_fine_whoever_published_it(self):
+        """Readable by every member, so who published the spec never mattered -
+        and still does not, even with no publisher at all."""
+        skill = _skill(visibility=Visibility.ORG.value)
+        assert (
+            await _classify(
+                MagicMock(), organization_id=uuid.uuid4(), publisher_id=None, skill=skill
+            )
+            is None
+        )
+
+    @pytest.mark.anyio
+    async def test_a_private_skill_with_no_publisher_is_unknown_not_a_guess(self):
+        skill = _skill(visibility=Visibility.PRIVATE.value)
+        status = await _classify(
+            MagicMock(), organization_id=uuid.uuid4(), publisher_id=None, skill=skill
+        )
+        assert status is BindingStatus.UNKNOWN
+
+    @pytest.mark.anyio
+    async def test_a_skill_the_publisher_owns_is_reachable(self):
+        publisher = uuid.uuid4()
+        skill = _skill(owner_user_id=publisher)
+        assert (
+            await _classify(
+                MagicMock(), organization_id=uuid.uuid4(), publisher_id=publisher, skill=skill
+            )
+            is None
+        )
+
+    @pytest.mark.anyio
+    async def test_a_grant_to_the_publisher_makes_it_reachable(self):
+        skill = _skill(owner_user_id=uuid.uuid4())
+        with patch.object(
+            sweep.resource_grant_repo,
+            "get_level",
+            new=AsyncMock(return_value=GrantLevel.READ),
+        ):
+            status = await _classify(
+                MagicMock(), organization_id=uuid.uuid4(), publisher_id=uuid.uuid4(), skill=skill
+            )
+        assert status is None
+
+    @pytest.mark.anyio
+    async def test_a_private_skill_owned_by_someone_else_with_no_grant_is_exposed(self):
+        skill = _skill(owner_user_id=uuid.uuid4())
+        with patch.object(sweep.resource_grant_repo, "get_level", new=AsyncMock(return_value=None)):
+            status = await _classify(
+                MagicMock(), organization_id=uuid.uuid4(), publisher_id=uuid.uuid4(), skill=skill
+            )
+        assert status is BindingStatus.EXPOSED
+
+
+class TestFindingsFor:
+    def _version(self, spec: AgentSpec, *, publisher: uuid.UUID | None):
+        return SimpleNamespace(
+            version=2, published_by_user_id=publisher, spec=spec.model_dump(mode="json")
+        )
+
+    def _agent(self):
+        return SimpleNamespace(organization_id=uuid.uuid4(), slug="support", name="Support")
+
+    @pytest.mark.anyio
+    async def test_a_reachable_binding_produces_no_finding(self):
+        publisher = uuid.uuid4()
+        skill = _skill(owner_user_id=publisher)
+        spec = AgentSpec(name="Support", skill_ids=[skill.id])
+        with patch.object(
+            sweep.skill_repo, "get_many", new=AsyncMock(return_value={skill.id: skill})
+        ):
+            findings = await _findings_for(
+                MagicMock(), self._agent(), self._version(spec, publisher=publisher)
+            )
+        assert findings == []
+
+    @pytest.mark.anyio
+    async def test_a_skill_the_org_does_not_return_is_a_dangling_reference_not_an_exposure(self):
+        """Deleted, or another tenant's id: it loads nothing at run time, so the
+        sweep leaves it to `resolve_for_agent` rather than reporting it."""
+        spec = AgentSpec(name="Support", skill_ids=[uuid.uuid4()])
+        with patch.object(sweep.skill_repo, "get_many", new=AsyncMock(return_value={})):
+            findings = await _findings_for(
+                MagicMock(), self._agent(), self._version(spec, publisher=uuid.uuid4())
+            )
+        assert findings == []
+
+    @pytest.mark.anyio
+    async def test_an_exposed_binding_is_reported_with_the_publishers_email(self):
+        publisher = uuid.uuid4()
+        skill = _skill(owner_user_id=uuid.uuid4())
+        spec = AgentSpec(name="Support", skill_ids=[skill.id])
+        with (
+            patch.object(
+                sweep.skill_repo, "get_many", new=AsyncMock(return_value={skill.id: skill})
+            ),
+            patch.object(sweep.resource_grant_repo, "get_level", new=AsyncMock(return_value=None)),
+            patch.object(
+                sweep.member_repo,
+                "get_emails_for_users",
+                new=AsyncMock(return_value={publisher: "author@example.com"}),
+            ),
+        ):
+            findings = await _findings_for(
+                MagicMock(), self._agent(), self._version(spec, publisher=publisher)
+            )
+        assert len(findings) == 1
+        assert findings[0].status is BindingStatus.EXPOSED
+        assert findings[0].publisher_email == "author@example.com"
+
+    @pytest.mark.anyio
+    async def test_a_spec_with_no_skill_bindings_needs_no_skill_query(self):
+        spec = AgentSpec(name="Support")
+        get_many = AsyncMock()
+        with patch.object(sweep.skill_repo, "get_many", new=get_many):
+            findings = await _findings_for(
+                MagicMock(), self._agent(), self._version(spec, publisher=uuid.uuid4())
+            )
+        assert findings == []
+        get_many.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_a_publisher_who_left_the_org_resolves_to_no_email(self):
+        """User row present, membership gone: the batch is org-scoped, so it
+        returns no email and the finding shows the id instead."""
+        publisher = uuid.uuid4()
+        skill = _skill(owner_user_id=uuid.uuid4())
+        spec = AgentSpec(name="Support", skill_ids=[skill.id])
+        with (
+            patch.object(
+                sweep.skill_repo, "get_many", new=AsyncMock(return_value={skill.id: skill})
+            ),
+            patch.object(sweep.resource_grant_repo, "get_level", new=AsyncMock(return_value=None)),
+            patch.object(sweep.member_repo, "get_emails_for_users", new=AsyncMock(return_value={})),
+        ):
+            findings = await _findings_for(
+                MagicMock(), self._agent(), self._version(spec, publisher=publisher)
+            )
+        assert findings[0].publisher_email is None
+
+    @pytest.mark.anyio
+    async def test_an_unknown_finding_does_not_look_up_an_email(self):
+        """The publisher is gone, so there is nobody to resolve; the member query
+        is skipped entirely."""
+        skill = _skill(visibility=Visibility.PRIVATE.value)
+        spec = AgentSpec(name="Support", skill_ids=[skill.id])
+        emails = AsyncMock()
+        with (
+            patch.object(
+                sweep.skill_repo, "get_many", new=AsyncMock(return_value={skill.id: skill})
+            ),
+            patch.object(sweep.member_repo, "get_emails_for_users", new=emails),
+        ):
+            findings = await _findings_for(
+                MagicMock(), self._agent(), self._version(spec, publisher=None)
+            )
+        assert findings[0].status is BindingStatus.UNKNOWN
+        emails.assert_not_awaited()
+
+
+class TestScan:
+    @pytest.mark.anyio
+    async def test_it_walks_every_published_version(self):
+        agent_a = SimpleNamespace(organization_id=uuid.uuid4(), slug="a", name="A")
+        agent_b = SimpleNamespace(organization_id=uuid.uuid4(), slug="b", name="B")
+        version_a = SimpleNamespace(
+            version=1, published_by_user_id=uuid.uuid4(), spec={"name": "A"}
+        )
+        version_b = SimpleNamespace(
+            version=1, published_by_user_id=uuid.uuid4(), spec={"name": "B"}
+        )
+        with (
+            patch.object(
+                sweep.agent_repo,
+                "list_current_versions",
+                new=AsyncMock(return_value=[(agent_a, version_a), (agent_b, version_b)]),
+            ),
+            patch.object(
+                sweep, "_findings_for", new=AsyncMock(side_effect=[[_finding()], [_finding()]])
+            ),
+        ):
+            findings = await _scan(MagicMock())
+        assert len(findings) == 2
+
+
+class TestRenderHelpers:
+    def test_a_deleted_publisher_is_named_unknown(self):
+        assert "unknown" in _publisher(_finding(published_by_user_id=None))
+
+    def test_a_departed_member_is_shown_by_id(self):
+        pid = uuid.uuid4()
+        assert str(pid) in _publisher(_finding(published_by_user_id=pid, publisher_email=None))
+
+    def test_a_current_member_is_shown_by_email(self):
+        assert _publisher(_finding(publisher_email="a@b.c")) == "a@b.c"
+
+    def test_a_top_level_binding_names_the_agents_skill_ids(self):
+        assert _location(_finding(specialist=None)) == "agent skill_ids"
+
+    def test_a_specialist_binding_names_the_specialist(self):
+        assert _location(_finding(specialist="researcher")) == "specialist 'researcher'"
+
+    def test_a_line_carries_the_agent_the_skill_and_where_it_sits(self):
+        line = _line(_finding(agent_slug="support", skill_name="refund-policy"))
+        assert "support" in line
+        assert "refund-policy" in line
+
+
+class TestReport:
+    def test_a_clean_deployment_reports_nothing_and_fails_nothing(self):
+        assert _report([]) == 0
+
+    def test_the_exposure_count_is_the_exit_code(self):
+        findings = [_finding(status=BindingStatus.EXPOSED), _finding(status=BindingStatus.EXPOSED)]
+        assert _report(findings) == 2
+
+    def test_unknowns_are_reported_but_do_not_fail_the_run(self):
+        assert _report([_finding(status=BindingStatus.UNKNOWN)]) == 0
+
+    def test_both_kinds_are_reported_together(self):
+        findings = [
+            _finding(status=BindingStatus.EXPOSED),
+            _finding(status=BindingStatus.UNKNOWN),
+        ]
+        assert _report(findings) == 1
+
+
+class TestRun:
+    @staticmethod
+    def _db_context(db):
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def context():
+            yield db
+
+        return context
+
+    @pytest.mark.anyio
+    async def test_it_scans_within_a_database_session_and_returns_the_exposure_count(self):
+        with (
+            patch.object(sweep, "get_db_context", self._db_context(MagicMock())),
+            patch.object(
+                sweep, "_scan", new=AsyncMock(return_value=[_finding(status=BindingStatus.EXPOSED)])
+            ),
+        ):
+            assert await _run() == 1
+
+
+class TestEntryPoint:
+    def test_it_exits_non_zero_when_an_exposure_is_found(self):
+        from click.testing import CliRunner
+
+        with patch.object(sweep.asyncio, "run", return_value=2):
+            result = CliRunner().invoke(audit_skill_bindings, [])
+        assert result.exit_code == 1
+
+    def test_it_exits_zero_when_nothing_is_exposed(self):
+        from click.testing import CliRunner
+
+        with patch.object(sweep.asyncio, "run", return_value=0):
+            result = CliRunner().invoke(audit_skill_bindings, [])
+        assert result.exit_code == 0

--- a/backend/tests/test_audit_skill_bindings.py
+++ b/backend/tests/test_audit_skill_bindings.py
@@ -34,6 +34,7 @@ from app.commands.audit_skill_bindings import (
     _scan,
     audit_skill_bindings,
 )
+from app.db.models.agent import AgentStatus
 from app.db.models.resource_grant import GrantLevel, Visibility
 
 
@@ -319,8 +320,10 @@ class TestFindingsFor:
 
 
 class TestExecutableVersions:
-    def _pair(self, spec: dict | None = None):
-        agent = SimpleNamespace(organization_id=uuid.uuid4(), slug=uuid.uuid4().hex[:6], name="A")
+    def _pair(self, spec: dict | None = None, *, status: str = AgentStatus.PUBLISHED.value):
+        agent = SimpleNamespace(
+            organization_id=uuid.uuid4(), slug=uuid.uuid4().hex[:6], name="A", status=status
+        )
         version = SimpleNamespace(
             id=uuid.uuid4(),
             version=1,
@@ -412,6 +415,36 @@ class TestExecutableVersions:
         ):
             found = await sweep._executable_versions(MagicMock())
         assert sorted(v.id for _, v in found) == sorted({a[1].id, b[1].id})
+
+    @pytest.mark.anyio
+    async def test_a_pin_to_an_archived_delegate_is_dropped(self):
+        """The runner refuses to delegate to an archived agent, so its pinned
+        version can no longer load through the pin - flagging it would report a
+        binding no run can reach."""
+        delegate = self._pair(status=AgentStatus.ARCHIVED.value)
+        parent = self._pair(
+            {
+                "name": "Parent",
+                "subagents": [
+                    {"agent_id": str(uuid.uuid4()), "agent_version_id": str(delegate[1].id)}
+                ],
+            }
+        )
+        with (
+            patch.object(
+                sweep.agent_repo, "list_current_versions", new=AsyncMock(return_value=[parent])
+            ),
+            patch.object(
+                sweep.agent_repo, "list_environment_versions", new=AsyncMock(return_value=[])
+            ),
+            patch.object(
+                sweep.agent_repo,
+                "get_versions_with_agents",
+                new=AsyncMock(return_value=[delegate]),
+            ),
+        ):
+            found = await sweep._executable_versions(MagicMock())
+        assert delegate[1].id not in {v.id for _, v in found}
 
 
 class TestScan:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -215,9 +215,11 @@ uv run agenticos cmd doctor
 
 # Find published agents that lend a skill their publisher could not reach. The
 # publish-time check on skill_ids only guards new publishes; this is the offline
-# half, naming versions frozen before it that still hand a private skill to every
-# run. Report-only - a spec is exported into a client's own git, so unbinding is a
-# person's call. Exits non-zero when it finds one, so a cron can gate on it.
+# half, naming versions frozen before it that still hand a private skill to a run.
+# It sweeps every version a run can load, not only the current one: each named
+# environment's pinned version and each delegate a spec pins, not just the default
+# pointer. Report-only - a spec is exported into a client's own git, so unbinding
+# is a person's call. Exits non-zero when it finds one, so a cron can gate on it.
 uv run agenticos cmd audit-skill-bindings
 
 # Install the bundled skills (refund-policy, code-review, incident-report)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -213,6 +213,13 @@ uv run agenticos cmd bootstrap --org "Acme"
 # holding the wrong token.
 uv run agenticos cmd doctor
 
+# Find published agents that lend a skill their publisher could not reach. The
+# publish-time check on skill_ids only guards new publishes; this is the offline
+# half, naming versions frozen before it that still hand a private skill to every
+# run. Report-only - a spec is exported into a client's own git, so unbinding is a
+# person's call. Exits non-zero when it finds one, so a cron can gate on it.
+uv run agenticos cmd audit-skill-bindings
+
 # Install the bundled skills (refund-policy, code-review, incident-report)
 uv run agenticos cmd seed-skills
 uv run agenticos cmd seed-skills --org <org-id> --dry-run

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -217,9 +217,11 @@ uv run agenticos cmd doctor
 # publish-time check on skill_ids only guards new publishes; this is the offline
 # half, naming versions frozen before it that still hand a private skill to a run.
 # It sweeps every version a run can load, not only the current one: each named
-# environment's pinned version and each delegate a spec pins, not just the default
-# pointer. Report-only - a spec is exported into a client's own git, so unbinding
-# is a person's call. Exits non-zero when it finds one, so a cron can gate on it.
+# environment's pinned version, each version a non-terminal run (running, or parked
+# awaiting approval) still reloads, and each delegate a spec pins - the last only as
+# deep as max_depth lets a run reach, so a grandchild past the ceiling is not flagged.
+# Report-only - a spec is exported into a client's own git, so unbinding is a person's
+# call. Exits non-zero when it finds one, so a cron can gate on it.
 uv run agenticos cmd audit-skill-bindings
 
 # Install the bundled skills (refund-policy, code-review, incident-report)


### PR DESCRIPTION
## What this fixes

`Closes #186`. #179 added a publish-time check that a bound skill is one the
publisher can reach. Validation on this platform runs at publish and never at run
time, so that check protects every *future* publish and nothing already frozen: a
version published before it keeps handing another member's private skill to every
run, and the only signal is that the *next* publish of that agent is refused.

This adds the offline half — an operator sweep that names the versions frozen with
an out-of-reach binding. It is **report-only**: a spec is exported into a client's
own git repository, so unbinding a skill is a decision for a person, not something
a command does silently.

## What changed

- `app/commands/audit_skill_bindings.py` — new `agenticos cmd audit-skill-bindings`.
  Walks every published agent's *current* version (the frozen spec a run reads),
  checks its `skill_ids` and each inline specialist's `skill_ids`, and reports each
  binding the publisher could not reach. Exits non-zero on an exposure so a cron
  can gate on it.
- `app/repositories/agent.py:list_current_versions` — a deliberately unscoped
  cross-tenant read, in the mould of `list_all_published`, pairing each published
  agent with its running version.
- `pyproject.toml` — the new command joins the platform layer's 100% coverage and
  type gates (both lists, same position).
- `docs/commands.md` — documented under Setup and Diagnostics.

## The one decision this needed

The issue is explicit that **the answer must be about the row, not about the
publisher's role today** — re-deriving "can they reach it now" would move with the
publisher's role, the same time-dependence that makes a run-time re-check wrong.

So reachability is evaluated at the floor every skill-viewing role shares
(`Scope.SHARED`): a binding is fine only if the skill is org-visible, owned by the
publisher, or explicitly granted to them — all facts of the rows. For a
`Scope.SHARED` publisher (Member/Viewer) this reproduces the publish check exactly;
for a higher-privileged publisher it is deliberately stricter, and flags a private
skill they *could* see but that belongs to someone else and is now lent to every
runner via a versioned spec. That over-reporting is the safe direction for a
report-only security sweep, and it is what keeps the answer stable when the
publisher's role later changes.

A publisher whose user row is gone (`published_by_user_id` is nullable,
`ON DELETE SET NULL`) is reported as **unknown**, never guessed — a sweep that read
`NULL` as "fine" would hide the oldest specs, and one that read it as "unreachable"
would flag every agent whose author has left.

## How it failed before

Nothing detected it. A version frozen before #179 kept loading another member's
private skill on every run; `resolve_for_agent` logged nothing unusual because the
row is present, enabled and in the right organization.

## Testing

- `tests/test_audit_skill_bindings.py` — 29 unit tests; the command module is at
  100% line and branch coverage.
- `tests/integration/test_skill_binding_audit.py::...::test_it_is_still_found_after_the_publisher_is_promoted`
  — the acceptance regression, against a real database: a Member binds a
  colleague's private skill and publishes, is then promoted to Builder (whose role
  reaches every skill), and the sweep **still** reports the exposure. Plus the
  NULL-publisher → unknown case and the org-visible / owned-by-publisher clears.
- `make test` (backend + the 100% gate) and `make lint-backend` green locally;
  `make check` before this was marked ready.

## Noticed, not fixed

- The sweep checks the current running version of each agent, which is the whole of
  what any run can load — a rollback publishes a *new* current version rather than
  re-pointing at an old one, so historical versions cannot run without first
  becoming current, which a later sweep then sees. Documented in the repo query's
  docstring; called out here so the scope is explicit.
- A skill_id pointing at a deleted or another tenant's skill loads nothing at run
  time (`resolve_for_agent` skips it), so it is treated as a dangling reference
  rather than an exposure and left to that path — not the leak #186 is about.
