### PR TITLE
fix(agents): close a delegation panel when its delegate parks on an approval

### DIFF
--- a/backend/app/agents/capabilities/subagents/_journal.py
+++ b/backend/app/agents/capabilities/subagents/_journal.py
@@ -80,7 +80,12 @@ from app.agents.capabilities.budget import SpendShare, booked_to
 from app.agents.capabilities.subagents._events import FrameLabels, frame_for
 from app.agents.deps import AgentDeps
 from app.agents.spec import DelegationMode
-from app.agents.subagent_events import SubagentEventSink, SubagentFinished, SubagentStarted
+from app.agents.subagent_events import (
+    SubagentAwaitingApproval,
+    SubagentEventSink,
+    SubagentFinished,
+    SubagentStarted,
+)
 from app.agents.subagent_runtime import (
     DelegationOutcome,
     DelegationSpend,
@@ -120,7 +125,10 @@ def _terminal_status(handle: TaskHandle, mode: Literal["sync", "async"]) -> Dele
     delegate included (:meth:`DelegationJournal.park`). Recording it would write a
     run row for work that has not finished, tell whoever reads it to look for a
     defect instead of for the queue, and then count the same delegation twice,
-    because the continuation records one of its own when it answers.
+    because the continuation records one of its own when it answers. `None` here
+    refuses the *outcome*, not the *frame*: the panel a surface opened still closes,
+    with a `SubagentAwaitingApproval` that :meth:`DelegationJournal._narrate_parked`
+    sends instead of a run row.
 
     *A background delegation* cannot suspend at all: the tool call that started it
     returned a task id long ago, so there is no caller left to hand a parked call
@@ -194,7 +202,7 @@ def acting_delegate() -> ActingDelegate | None:
     if delegation is None:
         return None
     return ActingDelegate(
-        name=delegation.name, task_id=delegation.task_id, agent_id=delegation.agent_id
+        name=delegation.name, task_id=delegation.public_id, agent_id=delegation.agent_id
     )
 
 
@@ -266,7 +274,35 @@ class Delegation:
     agent_id: UUID | None = None
     agent_version_id: UUID | None = None
     task_id: str | None = None
+    """The library's id for this delegation *on this turn*, for looking the live
+    handle up. Set when the library resolves the event-stream handler, and fresh on
+    every replay - a resumed delegation is a new library task with a new one, which
+    is why it is not what a surface keys a panel on. See :attr:`public_id`."""
+
+    stable_id: str | None = None
+    """The id this delegation keeps across a park and a resume, or `None` until one.
+
+    Set only when the run is *continuing* a delegation that stopped for a person:
+    :meth:`begin` reads it from the resume stash, where it is the `task_id` the
+    delegation streamed under before it parked. Everything a surface or a run row
+    reads - frames, the recorded outcome, the parked record - carries
+    :attr:`public_id`, so the continuation reopens the panel that was left waiting
+    rather than opening a second one beside it (agenticos#173)."""
+
     started: bool = False
+
+    @property
+    def public_id(self) -> str | None:
+        """The delegation's identity for anything outside the library.
+
+        The id it keeps across every park, falling back to the library's id on a
+        delegation that has never parked - which is all of them until one does. Used
+        wherever the delegation is *named* to a reader: its frames, its recorded
+        outcome and the record a park leaves. The library's own :attr:`task_id` is
+        used only to find the live task handle, and the two diverge exactly once -
+        on the turn a parked delegation is continued.
+        """
+        return self.stable_id or self.task_id
 
     async def ensure_started(self, task_id: str, sink: SubagentEventSink) -> None:
         """Announce this delegation, at most once.
@@ -392,15 +428,19 @@ class DelegationJournal:
         delegated from, and that relationship is what nests a parked tree.
 
         A delegation the run is *continuing* opens here too - the replay presents
-        the same `task` call - which is why what it already spent, and when it first
-        began, are both read here. The ledger key allocated here is fresh, and this
-        turn's ledger has never held an entry under any other, so without `carried`
-        the continuation would be the whole of the delegation's recorded cost;
+        the same `task` call - which is why three things it carried are read here:
+        what it already spent, when it first began, and the id it streamed under
+        before the park. A continuation keeps the delegation's identity so it
+        reopens the panel it left waiting rather than opening a second one beside it
+        (`stable_id`). The ledger key allocated here is fresh, and this turn's ledger
+        has never held an entry under any other, so without `carried` the
+        continuation would be the whole of the delegation's recorded cost;
         `carried_started_at` is the same fact for the clock, so the row does not
         begin at the resume.
         """
         self._running += 1
         enclosing = _CURRENT.get()
+        resumed = None if tool_call_id is None else self.runtime.stash.resuming.get(tool_call_id)
         return Delegation(
             name=name,
             prompt=prompt,
@@ -408,9 +448,10 @@ class DelegationJournal:
             depth=self.depth,
             ledger_key=uuid4().hex,
             tool_call_id=tool_call_id,
-            parent_task_id=None if enclosing is None else enclosing.task_id,
+            parent_task_id=None if enclosing is None else enclosing.public_id,
             carried=self.runtime.stash.already_spent(tool_call_id),
             carried_started_at=self.runtime.stash.already_started(tool_call_id),
+            stable_id=None if resumed is None else resumed.task_id,
             agent_id=delegate.agent_id if delegate is not None else None,
             agent_version_id=delegate.agent_version_id if delegate is not None else None,
         )
@@ -473,7 +514,10 @@ class DelegationJournal:
         self.runtime.stash.parked.append(
             ParkedDelegation(
                 tool_call_id=delegation.tool_call_id,
-                task_id=task_id,
+                # The id the delegation streamed under, not this turn's library id:
+                # a delegation parking for the second time keeps the identity of the
+                # first, so the resume reopens one panel rather than a chain of them.
+                task_id=delegation.stable_id or task_id,
                 parent_task_id=delegation.parent_task_id,
                 subagent=delegation.name,
                 agent_id=delegation.agent_id,
@@ -516,13 +560,67 @@ class DelegationJournal:
         until its task reaches a terminal status, which `settle_background` looks
         for. *When* the settlement happens no longer decides what the delegation is
         recorded as spending - the ledger already knows which requests were its.
+
+        A sync delegation whose call returned *without* an outcome is the third
+        case, and it is not a background one: a sync delegate that stopped for a
+        person. :meth:`settle` declines to record it - the continuation records the
+        real outcome - but the panel a surface opened still has to close, and the
+        fan-out slot still has to be released rather than the delegation being
+        filed into `_background` where nothing would ever settle it (agenticos#173).
+        `_narrate_parked` does the first; the `_running` decrement above did the
+        second. Told apart from a background delegation still running by its handle:
+        a parked one is `DEFERRED`, a running one is not.
         """
         self._running -= 1
         task_id = delegation.task_id
         if task_id is None:
             return
-        if not await self.settle(task_id, delegation, sink):
+        if await self.settle(task_id, delegation, sink):
+            return
+        if self._parked(delegation, task_id):
+            await self._narrate_parked(delegation, task_id, sink)
+        else:
             self._background[task_id] = delegation
+
+    def _parked(self, delegation: Delegation, task_id: str) -> bool:
+        """Whether a sync delegation's unsettled call stopped for a person.
+
+        The one shape :meth:`settle` refuses that is not "a background task still
+        running": a sync delegate whose gated tool suspended, leaving its handle
+        `DEFERRED`. A cancelled sync delegation is *not* this - its handle is still
+        `RUNNING`, and it belongs in `_background` for :meth:`cancel_in_flight` to
+        finish - which is why the status is checked rather than the mode alone.
+        """
+        handle = self.tasks.get_handle(task_id)
+        return (
+            delegation.mode == "sync"
+            and handle is not None
+            and handle.status is TaskStatus.DEFERRED
+        )
+
+    async def _narrate_parked(
+        self, delegation: Delegation, task_id: str, sink: SubagentEventSink | None
+    ) -> None:
+        """Close the panel of a sync delegation that stopped for a person.
+
+        A frame, never an outcome: nothing is recorded here (that is the whole point
+        of `_terminal_status` answering `None` for a sync `DEFERRED`), and the
+        continuation writes the run row when the person decides. `ensure_started`
+        first, so a delegation that produced no stream events at all still opens its
+        panel before this closes it - a close for a panel nobody opened is a panel a
+        reader never learns about. Both frames carry the id the delegation is named
+        by (`stable_id` across a park, else this turn's `task_id`), so a resume
+        reopens this panel rather than the continuation opening a second one.
+        """
+        if sink is None:
+            return
+        public = delegation.stable_id or task_id
+        await delegation.ensure_started(public, sink)
+        await sink(
+            SubagentAwaitingApproval(
+                task_id=public, subagent=delegation.name, depth=delegation.depth
+            )
+        )
 
     def cancel_in_flight(self) -> None:
         """Finish every delegation still going as cancelled, and report any that ignored it.
@@ -620,11 +718,16 @@ class DelegationJournal:
         if status is None:
             return False
 
+        # The id the delegation is *named* by, which is the one it streamed under
+        # before any park - so its recorded outcome and its closing frame reach the
+        # same panel across a resume. `task_id` above is the library's handle key,
+        # which a continuation allocates fresh; see `Delegation.public_id`.
+        public = delegation.stable_id or task_id
         spent = self._spent(delegation)
         run_id = await self._record(
             DelegationOutcome(
                 subagent=delegation.name,
-                task_id=task_id,
+                task_id=public,
                 status=status,
                 cost_usd=spent.cost_usd,
                 input_tokens=spent.input_tokens,
@@ -644,10 +747,10 @@ class DelegationJournal:
             )
         )
         if sink is not None:
-            await delegation.ensure_started(task_id, sink)
+            await delegation.ensure_started(public, sink)
             await sink(
                 SubagentFinished(
-                    task_id=task_id,
+                    task_id=public,
                     subagent=delegation.name,
                     depth=delegation.depth,
                     status=status,
@@ -683,12 +786,17 @@ class DelegationJournal:
         sink = ctx.deps.subagent_events
         if sink is None:
             return None
-        labels = FrameLabels(task_id=task_id, subagent=delegation.name, depth=delegation.depth)
+        # The delegation's public id, not the library's `task_id`: on a continuation
+        # the library hands a fresh id, and streaming under it would open a second
+        # panel beside the one this delegation left waiting for a person.
+        # `delegation.task_id` above stays the library's - the live handle's key.
+        public = delegation.stable_id or task_id
+        labels = FrameLabels(task_id=public, subagent=delegation.name, depth=delegation.depth)
 
         async def stream(
             _ctx: RunContext[AgentDeps], events: AsyncIterable[AgentStreamEvent]
         ) -> None:
-            await delegation.ensure_started(task_id, sink)
+            await delegation.ensure_started(public, sink)
             async for event in events:
                 frame = frame_for(event, labels)
                 if frame is not None:

--- a/backend/app/agents/subagent_events.py
+++ b/backend/app/agents/subagent_events.py
@@ -122,6 +122,30 @@ class SubagentToolResult(_SubagentFrame):
     ok: bool = Field(description="False when the tool raised, so a surface can mark it")
 
 
+class SubagentAwaitingApproval(_SubagentFrame):
+    """A sync delegation stopped for a person, and the answer is still coming.
+
+    Not an outcome, and deliberately not a `SubagentFinished`: the delegate
+    suspended on a tool that needs approval, the signal parked the whole parent
+    run, and the continuation records the real outcome when the person decides
+    (see `DelegationJournal.settle` and `_terminal_status`). Reporting it as
+    `failed` would send a reader looking for a defect instead of for the approval
+    queue, and `completed` would claim work that has not happened.
+
+    So it carries no cost and no run id - there is nothing to record yet - and its
+    only job is to close the panel a surface opened, replacing "the researcher is
+    working" with "waiting for a person" for however long the approver takes.
+    Without it the panel spins forever, which is the bug this frame exists to fix
+    (agenticos#173).
+
+    Only a *sync* delegation reaches this: a background one has no caller left to
+    park, so a tool of its that defers is a `SubagentFinished(status="failed")`
+    instead - see `_terminal_status`.
+    """
+
+    kind: Literal["subagent_awaiting_approval"] = "subagent_awaiting_approval"
+
+
 class SubagentFinished(_SubagentFrame):
     """A delegation ended, however it ended.
 
@@ -153,6 +177,7 @@ SubagentEvent = Annotated[
     | SubagentThinkingDelta
     | SubagentToolCall
     | SubagentToolResult
+    | SubagentAwaitingApproval
     | SubagentFinished,
     Field(discriminator="kind"),
 ]

--- a/backend/app/agents/subagent_runtime.py
+++ b/backend/app/agents/subagent_runtime.py
@@ -359,6 +359,18 @@ class ResumedDelegation:
     session.
     """
 
+    task_id: str
+    """The library's id for this delegation on the turn it parked.
+
+    Carried so the continuation keeps the delegation's identity across the park:
+    the resumed run is a fresh library task with a fresh id, and a delegation that
+    adopted that id would stream under a `task_id` no earlier frame used - so a
+    surface opens a *second* panel beside the one still reading "waiting for a
+    person" rather than reopening it (agenticos#173). The journal adopts this as
+    the delegation's public id and looks the live handle up under the new one; see
+    `Delegation.public_id`.
+    """
+
     messages: list[ModelMessage]
     results: DeferredToolResults
     """The decisions for the calls *this* delegate parked, and only those.

--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -603,6 +603,7 @@ def _resume_plan(state: PausedRunState, decided_args: Mapping[str, dict[str, Any
                 # delegation runs again from the start.
                 continue
             resuming[frame.tool_call_id] = ResumedDelegation(
+                task_id=frame.task_id,
                 messages=ModelMessagesTypeAdapter.validate_python(frame.messages),
                 results=level(frame.delegations, by_delegation.get(frame.task_id, [])),
             )

--- a/backend/tests/test_subagent_nested_resume.py
+++ b/backend/tests/test_subagent_nested_resume.py
@@ -508,7 +508,12 @@ def _verdicts(
     return decided, approved_args
 
 
-async def _resume(parked: _Parked, delegate: Callable[[DelegationStash], ResolvedSubagent]) -> Any:
+async def _resume(
+    parked: _Parked,
+    delegate: Callable[[DelegationStash], ResolvedSubagent],
+    *,
+    record: DelegationRecorder | None = None,
+) -> Any:
     """Continue a parked run the way `resume` does: fresh everything, loaded stash.
 
     Nothing is reused from the first turn. The runner reassembles the whole tree
@@ -520,7 +525,10 @@ async def _resume(parked: _Parked, delegate: Callable[[DelegationStash], Resolve
     plan = _resume_plan(parked.state, approved_args)
     stash = DelegationStash(resuming=plan.delegations, spent=plan.spent, started=plan.started)
     agent, deps = _orchestrator(
-        delegate(stash), stash=stash, channel=_channel(parked.queue, decided=decided)
+        delegate(stash),
+        stash=stash,
+        channel=_channel(parked.queue, decided=decided),
+        record=record,
     )
     return await agent.run(
         None,
@@ -567,6 +575,34 @@ class TestOneLevelDown:
         # Once, on the arguments the row was written with. A second call would mean
         # the delegation had been re-run rather than continued.
         assert gated_calls == [{"city": "Krakow"}]
+
+    async def test_the_resumed_delegation_keeps_the_task_id_it_parked_under(self):
+        """One panel across the park, not a second one beside it.
+
+        The continuation is a fresh library task with a fresh id, so a delegation
+        that adopted it would stream - and record - under an id no earlier frame
+        used: a second panel beside the one the park left reading "waiting for a
+        person" (agenticos#173). The delegation keeps the id it parked under
+        instead, which every frame and the recorded outcome carry, so the resume
+        reopens that panel rather than doubling it. Asserted through the recorded
+        outcome, which carries the same `public_id` a frame does (see
+        `DelegationJournal.settle`); a streamed sink would force these test models
+        to stream, which they are not built to.
+        """
+        parked = await _park(_specialist_delegate(gated=True, calls=[]), DelegationStash())
+        (original,) = [frame.task_id for frame in parked.state.delegations]
+        parked.queue.decide(approved=True)
+
+        recorder = Recorder()
+        await _resume(
+            parked,
+            lambda _stash: _specialist_delegate(gated=True, calls=[]),
+            record=recorder,
+        )
+
+        (outcome,) = recorder.outcomes
+        assert outcome.status == "completed"
+        assert outcome.task_id == original, "the continuation kept the delegation's identity"
 
     async def test_the_queue_names_the_delegate_and_the_tool_it_is_calling(self):
         """`task` is what parked the run; `look_up` is what somebody has to decide.
@@ -710,6 +746,7 @@ async def _park_the_specialist_alone(*, gated: bool) -> tuple[Any, dict[str, Any
     queue.decide(approved=True)
     return (
         ResumedDelegation(
+            task_id="researcher-1",
             messages=result.all_messages(),
             results=DeferredToolResults(
                 approvals={call.tool_call_id: ToolApproved() for call in result.output.approvals}

--- a/backend/tests/test_subagents_capability.py
+++ b/backend/tests/test_subagents_capability.py
@@ -1654,6 +1654,54 @@ class TestApprovalInsideADelegation:
             TaskStatus.DEFERRED
         ]
 
+    async def test_a_parked_sync_delegate_closes_its_panel_and_frees_its_slot(self):
+        """The two symptoms the missing frame left behind, on the same delegation.
+
+        A sync delegate that stops for a person leaves the parent parked in the
+        approval queue for as long as the approver takes. Refusing to record the
+        outcome (the test above) refused to *narrate* it too, so two things broke
+        that recording never should have (agenticos#173):
+
+        *The panel never closed.* A surface that opened one on `subagent_start`
+        read "the researcher is working" for the whole wait and forever if nobody
+        decided. A `subagent_awaiting_approval` closes it with a state that means
+        "waiting for a person" - the frame this asserts, naming the same delegation
+        the opening one did so it is one panel and not two.
+
+        *The slot never came back.* `close` filed the delegation into `_background`,
+        where `settle_background` never settles a `DEFERRED` sync task, so
+        `in_flight` stayed at 1 after the run had ended - the number the fan-out
+        ceiling reads.
+
+        Neither is an outcome: nothing is recorded here or when the run ends, and
+        the awaiting frame is sent once rather than again by the end-of-run sweep.
+        """
+        recorder = Recorder()
+        sink = Sink()
+
+        def defer(_ctx: RunContext[AgentDeps]) -> str:
+            raise ApprovalRequired
+
+        capability = a_capability(
+            a_runtime(a_delegate(model=one_tool_call(), on_call=defer), record=recorder)
+        )
+        ctx = a_context(sink)
+
+        with pytest.raises(ApprovalRequired):
+            await delegate_to(capability, ctx)
+
+        assert sink.kinds[0] == "subagent_start"
+        assert sink.kinds[-1] == "subagent_awaiting_approval"
+        assert sink.frames[-1].task_id == sink.frames[0].task_id
+        assert recorder.outcomes == [], "a parked delegation is not an outcome"
+        assert capability.journal.in_flight() == 0
+
+        await ends_the_run(capability, ctx)
+
+        assert recorder.outcomes == [], "and still not one when the run ends"
+        assert capability.journal.in_flight() == 0
+        assert sink.kinds.count("subagent_awaiting_approval") == 1
+
 
 class TestKeepingASuspendedDelegatesPlace:
     """What is stashed when a delegate stops for a person, and what is not.

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -269,6 +269,12 @@ A child's text is never folded into the
 parent's answer: that would put words in the parent's mouth its own model never
 generated, and the conversation is persisted with them.
 
+A delegate can stop for a person too — a gated tool inside a specialist parks the
+whole turn in the approval queue. The panel then closes into a *waiting for a
+person* state rather than spinning on "working" for as long as the approver takes,
+and when the run resumes the delegation keeps the task id it parked under, so the
+same panel reopens rather than a second one appearing beside it.
+
 The assistant's answer is **not** in a bubble; only the person's message is. An answer
 is prose with headings, code and tables in it, and a rounded fill around that fights
 every one of them.

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -272,8 +272,12 @@ generated, and the conversation is persisted with them.
 A delegate can stop for a person too — a gated tool inside a specialist parks the
 whole turn in the approval queue. The panel then closes into a *waiting for a
 person* state rather than spinning on "working" for as long as the approver takes,
-and when the run resumes the delegation keeps the task id it parked under, so the
-same panel reopens rather than a second one appearing beside it.
+and the delegation keeps the task id it parked under so its identity survives the
+resume rather than a second panel appearing beside the first. The resume itself
+runs over HTTP (`POST /runs/{id}/resume`), which carries no delegation frames, so
+the waiting panel is moved to the resumed run's own outcome — completed, failed or
+cancelled — from that answer; a resume that parks again on a fresh decision leaves
+it waiting.
 
 The assistant's answer is **not** in a bubble; only the person's message is. An answer
 is prose with headings, code and tables in it, and a rounded fill around that fights

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -664,6 +664,7 @@
     "couldnAposTLoad": "Couldn't load preview",
     "defaultReturn": "; default: return",
     "delegation": {
+      "awaiting": "waiting for approval",
       "background": "Background",
       "failed": "failed",
       "finished": "finished",

--- a/frontend/src/components/chat/delegation-panel.test.tsx
+++ b/frontend/src/components/chat/delegation-panel.test.tsx
@@ -158,6 +158,16 @@ describe("DelegationPanels - how a delegation ended", () => {
     expect(screen.getByText("stopped")).toBeInTheDocument();
   });
 
+  it("shows a delegate that stopped for a person as waiting, not working", () => {
+    // The bug this state exists to fix: a parked delegate must not read "working…"
+    // for the length of the wait. The panel mounts closed, like any non-running one.
+    render(<DelegationPanels delegations={[delegation({ status: "awaiting_approval" })]} />);
+
+    expect(screen.getByText("waiting for approval")).toBeInTheDocument();
+    expect(screen.queryByText("working…")).toBeNull();
+    expect(screen.getByRole("button")).toHaveAttribute("aria-expanded", "false");
+  });
+
   it("reports the tokens behind the cost, and zero for a run that measured none", () => {
     render(
       <DelegationPanels

--- a/frontend/src/components/chat/delegation-panel.tsx
+++ b/frontend/src/components/chat/delegation-panel.tsx
@@ -54,6 +54,10 @@ const TONE: Record<DelegationStatus, string> = {
   completed: "text-muted-foreground/70",
   failed: "text-destructive",
   cancelled: "text-muted-foreground/70",
+  // The amber a parked tool call uses (`AgentStep`'s `parked` state): waiting for a
+  // person, not working and not done - and never a spinner, which is a lie that
+  // does not resolve until somebody decides.
+  awaiting_approval: "text-amber-600",
 };
 
 /**
@@ -67,6 +71,7 @@ const STATUS_KEY: Record<DelegationStatus, string> = {
   completed: "finished",
   failed: "failed",
   cancelled: "stopped",
+  awaiting_approval: "awaiting",
 };
 
 /**

--- a/frontend/src/hooks/use-chat.test.tsx
+++ b/frontend/src/hooks/use-chat.test.tsx
@@ -845,6 +845,92 @@ describe("useChat - approvals and questions", () => {
     expect(answers.at(-1)?.content).toBe("Done - 3 rows deleted.");
   });
 
+  it("closes a parked delegate's panel once the run is approved and resumes", async () => {
+    // The crux of agenticos#173. A sync delegate parks on an approval and its panel
+    // reads "waiting for approval". The resume runs over HTTP - no delegation frames
+    // reach this socket - so without reconciling the panel from its answer it would
+    // read "waiting" forever, under a transcript already showing the resumed reply.
+    post.mockImplementation((url: string) =>
+      url.endsWith("/resume")
+        ? Promise.resolve({ run_id: "r-9", output: "Sent.", status: "completed" })
+        : Promise.resolve({}),
+    );
+    const { result } = renderHook(() => useChat(), { wrapper });
+    receive("model_request_start", {});
+    receive("subagent_start", {
+      kind: "subagent_start",
+      task_id: "t1",
+      subagent: "researcher",
+      depth: 0,
+      mode: "sync",
+      prompt: "send the summary",
+      parent_task_id: null,
+    });
+    receive("subagent_text_delta", {
+      kind: "subagent_text_delta",
+      task_id: "t1",
+      subagent: "researcher",
+      depth: 0,
+      delta: "drafting",
+    });
+    receive("subagent_awaiting_approval", {
+      kind: "subagent_awaiting_approval",
+      task_id: "t1",
+      subagent: "researcher",
+      depth: 0,
+    });
+    receive("tool_approval_required", {
+      run_id: "r-9",
+      action_requests: [{ id: "ar-1", tool_call_id: "tc-1", tool_name: "send_email", args: {} }],
+      review_configs: [],
+    });
+    expect(result.current.delegations[0]?.status).toBe("awaiting_approval");
+
+    await act(async () => {
+      await result.current.sendResumeDecisions([{ type: "approve" }]);
+    });
+
+    // Terminal now - and it still holds what it streamed before it parked.
+    expect(result.current.delegations[0]).toMatchObject({ status: "completed", text: "drafting" });
+  });
+
+  it("leaves a parked delegate waiting when the resume parks again", async () => {
+    // A continuation can stop on a fresh decision. The delegate is still waiting, so
+    // its panel must not be closed to a terminal state it has not reached.
+    post.mockImplementation((url: string) =>
+      url.endsWith("/resume")
+        ? Promise.resolve({ run_id: "r-9", output: "", status: "awaiting_approval" })
+        : Promise.resolve({}),
+    );
+    const { result } = renderHook(() => useChat(), { wrapper });
+    receive("subagent_start", {
+      kind: "subagent_start",
+      task_id: "t1",
+      subagent: "researcher",
+      depth: 0,
+      mode: "sync",
+      prompt: "send the summary",
+      parent_task_id: null,
+    });
+    receive("subagent_awaiting_approval", {
+      kind: "subagent_awaiting_approval",
+      task_id: "t1",
+      subagent: "researcher",
+      depth: 0,
+    });
+    receive("tool_approval_required", {
+      run_id: "r-9",
+      action_requests: [{ id: "ar-1", tool_call_id: "tc-1", tool_name: "send_email", args: {} }],
+      review_configs: [],
+    });
+
+    await act(async () => {
+      await result.current.sendResumeDecisions([{ type: "approve" }]);
+    });
+
+    expect(result.current.delegations[0]?.status).toBe("awaiting_approval");
+  });
+
   it("adds nothing when the resumed run answered with nothing", async () => {
     // A refusal resumes into an empty output, and an empty bubble in the transcript
     // is worse than no bubble.

--- a/frontend/src/hooks/use-chat.test.tsx
+++ b/frontend/src/hooks/use-chat.test.tsx
@@ -446,6 +446,23 @@ describe("useChat - streaming a delegation", () => {
     });
   });
 
+  it("closes a delegate's panel into a waiting state when it stops for a person", () => {
+    // A sync delegate that parks on an approval sends `subagent_awaiting_approval`
+    // and no `subagent_complete` until the person decides. The panel must stop
+    // reading "working" rather than spin for the length of the wait.
+    const { result } = renderHook(() => useChat(), { wrapper });
+    startDelegation("t1");
+
+    receive("subagent_awaiting_approval", {
+      kind: "subagent_awaiting_approval",
+      task_id: "t1",
+      subagent: "researcher",
+      depth: 0,
+    });
+
+    expect(result.current.delegations[0]?.status).toBe("awaiting_approval");
+  });
+
   it("closes an unfinished delegation when the run was cancelled", () => {
     // The cancelled path sends `stopped` (`AgentSession._run_turn`) and nothing
     // more is coming, so a panel left running would spin forever. The frontend

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -21,7 +21,11 @@ import type {
   WSEvent,
 } from "@/types";
 import type { ResumedRun } from "@/types/runs";
-import { applyDelegationFrame, closeOpenDelegations } from "@/lib/delegations";
+import {
+  applyDelegationFrame,
+  closeOpenDelegations,
+  resolveAwaitingOnResume,
+} from "@/lib/delegations";
 import { WS_URL } from "@/lib/constants";
 import { toast } from "sonner";
 
@@ -657,6 +661,13 @@ export function useChat(options: UseChatOptions = {}) {
         // parked, and resuming per decision would start it while calls it has
         // not been told about are still waiting.
         const resumed = await resumeRun(parked.runId);
+        // Close whatever delegate parked here. The resume ran over HTTP and its
+        // frames went nowhere this socket can see, so a delegation panel left
+        // `awaiting_approval` never got its `subagent_complete` and would read
+        // "waiting for approval" forever - the answer above it, the panel below it
+        // frozen. The resumed run's own status is the outcome those panels take;
+        // a resume that parks again leaves them waiting. See `resolveAwaitingOnResume`.
+        setDelegations((current) => resolveAwaitingOnResume(current, resumed.status));
         // **The answer is shown, not discarded.** `resume_run` runs the agent and
         // returns what it said, but it returns it *here* - over HTTP, to the caller
         // - and not over the socket this conversation is streaming. So the reply

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -290,10 +290,11 @@ export function useChat(options: UseChatOptions = {}) {
         case "subagent_thinking_delta":
         case "subagent_tool_call":
         case "subagent_tool_result":
+        case "subagent_awaiting_approval":
         case "subagent_complete": {
-          // One branch for six frames: the envelope's `type` is the frame's own
+          // One branch for every frame: the envelope's `type` is the frame's own
           // `kind` (see `AgentSession._subagent_event`), so the payload narrows
-          // itself and the six cases share one reducer instead of six copies of
+          // itself and the cases share one reducer instead of one copy each of
           // "find the task, change one field".
           setDelegations((current) => applyDelegationFrame(current, wsEvent.data as SubagentFrame));
           break;

--- a/frontend/src/lib/delegations.test.ts
+++ b/frontend/src/lib/delegations.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { applyDelegationFrame, childrenOf, closeOpenDelegations, rootsOf } from "./delegations";
+import {
+  applyDelegationFrame,
+  childrenOf,
+  closeOpenDelegations,
+  resolveAwaitingOnResume,
+  rootsOf,
+} from "./delegations";
 import type { Delegation, SubagentFrame } from "@/types";
 
 /** A `subagent_start`, which is the only frame that can create a panel. */
@@ -389,6 +395,83 @@ describe("applyDelegationFrame - a delegate that stopped for a person", () => {
     ]);
 
     expect(named(delegations, "t1").text).toBe("so far");
+  });
+});
+
+describe("resolveAwaitingOnResume - closing a panel the HTTP resume left waiting", () => {
+  it("moves a panel waiting for approval to the resumed run's outcome", () => {
+    // The crux of agenticos#173: the resume runs over HTTP with no delegation
+    // frames, so a panel parked at `awaiting_approval` never gets its
+    // `subagent_complete` and would read "waiting" forever after the approval.
+    const parked = fold([start("t1"), awaiting("t1")]);
+    expect(named(parked, "t1").status).toBe("awaiting_approval");
+
+    const after = resolveAwaitingOnResume(parked, "completed");
+
+    expect(named(after, "t1").status).toBe("completed");
+  });
+
+  it("carries a failed resume onto the panel rather than claiming it finished", () => {
+    const after = resolveAwaitingOnResume(fold([start("t1"), awaiting("t1")]), "failed");
+
+    expect(named(after, "t1").status).toBe("failed");
+  });
+
+  it("reads a budget-exceeded resume as a delegate that stopped without finishing", () => {
+    const after = resolveAwaitingOnResume(fold([start("t1"), awaiting("t1")]), "budget_exceeded");
+
+    expect(named(after, "t1").status).toBe("failed");
+  });
+
+  it("leaves a panel waiting when the resume parks again on a fresh decision", () => {
+    // Not terminal: the delegate is waiting on a new approval, and closing the
+    // panel would claim an outcome that has not happened.
+    const parked = fold([start("t1"), awaiting("t1")]);
+
+    const after = resolveAwaitingOnResume(parked, "awaiting_approval");
+
+    expect(after).toBe(parked);
+    expect(named(after, "t1").status).toBe("awaiting_approval");
+  });
+
+  it("keeps what a resumed panel had already streamed before it parked", () => {
+    const parked = fold([
+      start("t1"),
+      {
+        kind: "subagent_text_delta",
+        task_id: "t1",
+        subagent: "researcher",
+        depth: 0,
+        delta: "so far",
+      },
+      awaiting("t1"),
+    ]);
+
+    const after = resolveAwaitingOnResume(parked, "completed");
+
+    expect(named(after, "t1").text).toBe("so far");
+  });
+
+  it("touches only panels that were waiting, leaving a finished sibling alone", () => {
+    const delegations = fold([
+      start("t1", { subagent: "researcher" }),
+      finished("t1", { status: "completed", cost_usd: 0.5 }),
+      start("t2", { subagent: "writer" }),
+      awaiting("t2"),
+    ]);
+
+    const after = resolveAwaitingOnResume(delegations, "completed");
+
+    expect(named(after, "t1")).toMatchObject({ status: "completed", costUsd: 0.5 });
+    expect(named(after, "t2").status).toBe("completed");
+  });
+
+  it("does nothing, and no render, when no panel is waiting", () => {
+    const delegations = fold([start("t1"), finished("t1", { status: "completed" })]);
+
+    const after = resolveAwaitingOnResume(delegations, "completed");
+
+    expect(after).toBe(delegations);
   });
 });
 

--- a/frontend/src/lib/delegations.test.ts
+++ b/frontend/src/lib/delegations.test.ts
@@ -340,6 +340,58 @@ describe("applyDelegationFrame - what a finished delegation reports", () => {
   });
 });
 
+/** The frame a sync delegate emits when it stops for a person. */
+function awaiting(taskId: string): SubagentFrame {
+  return { kind: "subagent_awaiting_approval", task_id: taskId, subagent: "researcher", depth: 0 };
+}
+
+describe("applyDelegationFrame - a delegate that stopped for a person", () => {
+  it("closes the panel with a waiting state rather than leaving it working", () => {
+    // The bug this frame exists to fix: without it the panel reads "working" for
+    // the length of the wait, and forever if nobody decides.
+    const delegations = fold([start("t1"), awaiting("t1")]);
+
+    expect(named(delegations, "t1").status).toBe("awaiting_approval");
+  });
+
+  it("records nothing about cost - the continuation does when the person decides", () => {
+    const delegations = fold([start("t1"), awaiting("t1")]);
+
+    expect(named(delegations, "t1")).toMatchObject({ costUsd: null, runId: null });
+  });
+
+  it("reopens the same panel on resume rather than a second appearing beside it", () => {
+    // The continuation streams under the id it parked under, so a start frame for a
+    // panel already waiting is a reopen: back to running, keeping what it had said.
+    const delegations = fold([
+      start("t1"),
+      awaiting("t1"),
+      start("t1", { subagent: "researcher" }),
+    ]);
+
+    expect(delegations).toHaveLength(1);
+    expect(named(delegations, "t1").status).toBe("running");
+  });
+
+  it("keeps what a reopened delegation had already said", () => {
+    // The panel was live before it parked; a reopen must not discard its work.
+    const delegations = fold([
+      start("t1"),
+      {
+        kind: "subagent_text_delta",
+        task_id: "t1",
+        subagent: "researcher",
+        depth: 0,
+        delta: "so far",
+      },
+      awaiting("t1"),
+      start("t1"),
+    ]);
+
+    expect(named(delegations, "t1").text).toBe("so far");
+  });
+});
+
 describe("applyDelegationFrame - nesting a specialist's own delegation", () => {
   it("hangs a deeper delegation off the parent its frame names", () => {
     const delegations = fold([

--- a/frontend/src/lib/delegations.ts
+++ b/frontend/src/lib/delegations.ts
@@ -14,6 +14,7 @@
  */
 
 import type { Delegation, DelegationStatus, SubagentFrame, SubagentStartFrame } from "@/types";
+import type { RunStatus } from "@/types/runs";
 
 /**
  * Which delegation a nested one belongs to, as its start frame names it.
@@ -179,6 +180,51 @@ export function closeOpenDelegations(current: Delegation[]): Delegation[] {
     delegation.status === "running"
       ? { ...delegation, status: "cancelled" as DelegationStatus }
       : delegation,
+  );
+}
+
+/**
+ * A resumed run's terminal status, as the disposition its parked panels take.
+ *
+ * `running` and `awaiting_approval` are absent on purpose: neither is terminal, so
+ * a panel waiting on a person stays waiting (`resolveAwaitingOnResume`). A run has
+ * no `budget_exceeded` counterpart on a delegation panel, so it reads as `failed` -
+ * the delegate stopped without finishing, which is what `failed` says.
+ */
+const TERMINAL_DELEGATION_STATUS: Partial<Record<RunStatus, DelegationStatus>> = {
+  completed: "completed",
+  failed: "failed",
+  cancelled: "cancelled",
+  budget_exceeded: "failed",
+};
+
+/**
+ * Move panels waiting on a person to the outcome of the run that has now resumed.
+ *
+ * A sync delegate that parks on an approval leaves its panel `awaiting_approval`,
+ * and in web chat the resume that follows the decision runs over HTTP
+ * (`POST /runs/{id}/resume`), not over the socket this conversation streams. So no
+ * `subagent_complete` reaches `applyDelegationFrame`, and without this the panel
+ * reads "waiting for approval" forever - the resumed answer appears above a
+ * delegation that never leaves the waiting state (agenticos#173). This supplies the
+ * closing the socket did not: the resumed run's own status is the only per-delegation
+ * outcome available over HTTP, so every panel still waiting takes it.
+ *
+ * A resume that parks *again* (`awaiting_approval`, or a run still `running`) is not
+ * terminal and changes nothing: the delegate is waiting on a fresh decision, and
+ * closing its panel would claim an outcome that has not happened. Cost, tokens and
+ * the run id stay as they were - the frame that carries them never came, and
+ * inventing them is worse than leaving them null.
+ *
+ * Returns the same array when nothing waits or the run has not settled, so a resume
+ * with no delegation in it costs no render.
+ */
+export function resolveAwaitingOnResume(current: Delegation[], runStatus: RunStatus): Delegation[] {
+  const resolved = TERMINAL_DELEGATION_STATUS[runStatus];
+  if (resolved === undefined) return current;
+  if (!current.some((delegation) => delegation.status === "awaiting_approval")) return current;
+  return current.map((delegation) =>
+    delegation.status === "awaiting_approval" ? { ...delegation, status: resolved } : delegation,
   );
 }
 

--- a/frontend/src/lib/delegations.ts
+++ b/frontend/src/lib/delegations.ts
@@ -44,8 +44,18 @@ function parentIn(current: Delegation[], named: string | null | undefined): stri
 function started(current: Delegation[], frame: SubagentStartFrame): Delegation[] {
   // A `task_id` is unique per delegation, so a second start for one is a repeat
   // rather than a second delegation - keeping the first preserves whatever has
-  // already streamed into it.
-  if (current.some((delegation) => delegation.taskId === frame.task_id)) return current;
+  // already streamed into it. The one repeat that is not a no-op is a resume: a
+  // delegation that parked for a person is continued under the same id, so its
+  // panel goes back to running rather than staying on "waiting for a person".
+  const existing = current.find((delegation) => delegation.taskId === frame.task_id);
+  if (existing) {
+    return existing.status === "awaiting_approval"
+      ? updated(current, frame.task_id, (delegation) => ({
+          ...delegation,
+          status: "running" as DelegationStatus,
+        }))
+      : current;
+  }
   return [
     ...current,
     {
@@ -128,6 +138,15 @@ export function applyDelegationFrame(current: Delegation[], frame: SubagentFrame
       return updated(current, frame.task_id, (delegation) =>
         withResult(delegation, frame.tool_call_id, frame.ok),
       );
+    case "subagent_awaiting_approval":
+      // The delegate stopped for a person. Close the panel with a state that says
+      // so, rather than leaving it reading "working" for the length of the wait -
+      // and never, if nobody decides. No cost and no run id: the continuation
+      // records the outcome when the person decides.
+      return updated(current, frame.task_id, (delegation) => ({
+        ...delegation,
+        status: "awaiting_approval" as DelegationStatus,
+      }));
     case "subagent_complete":
       return updated(current, frame.task_id, (delegation) => ({
         ...delegation,

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -169,6 +169,7 @@ export type WSEventType =
   | "subagent_thinking_delta"
   | "subagent_tool_call"
   | "subagent_tool_result"
+  | "subagent_awaiting_approval"
   | "subagent_complete";
 
 /**
@@ -348,6 +349,19 @@ export interface SubagentToolResultFrame extends SubagentFrameBase {
   ok: boolean;
 }
 
+export interface SubagentAwaitingApprovalFrame extends SubagentFrameBase {
+  /**
+   * A sync delegate stopped for a person; the answer is still coming.
+   *
+   * Not a `subagent_complete`: nothing is recorded and no cost is known yet - the
+   * continuation writes the outcome when the person decides. It closes the panel
+   * with a "waiting for a person" state so it stops reading "working", and carries
+   * no cost or run id because there is none. See `SubagentAwaitingApproval` in
+   * `backend/app/agents/subagent_events.py`.
+   */
+  kind: "subagent_awaiting_approval";
+}
+
 export interface SubagentCompleteFrame extends SubagentFrameBase {
   kind: "subagent_complete";
   status: "completed" | "failed" | "cancelled";
@@ -366,10 +380,19 @@ export type SubagentFrame =
   | SubagentThinkingDeltaFrame
   | SubagentToolCallFrame
   | SubagentToolResultFrame
+  | SubagentAwaitingApprovalFrame
   | SubagentCompleteFrame;
 
-/** `running` is this surface's own: no frame says it, the absence of a terminal one does. */
-export type DelegationStatus = "running" | "completed" | "failed" | "cancelled";
+/**
+ * `running` is this surface's own: no frame says it, the absence of a terminal one does.
+ *
+ * `awaiting_approval` is not terminal - the delegate stopped for a person and the
+ * run can still resume it - but it closes the panel all the same, because a panel
+ * reading "working" through a wait that may never end is the bug the state exists
+ * to fix (agenticos#173).
+ */
+export type DelegationStatus =
+  "running" | "completed" | "failed" | "cancelled" | "awaiting_approval";
 
 /**
  * One of the delegate's own tool calls.


### PR DESCRIPTION
## What this fixes

A sync delegation whose delegate parks on an approval left three things broken.
`Closes #173`.

A gated tool inside a `sync` delegate suspends the whole turn into the approval
queue. `DelegationJournal.settle` correctly refuses to record a `DEFERRED`
outcome for a sync delegation — the work has not finished and the continuation
records it — but the closing frame was emitted from the same place, so refusing
to record also refused to narrate.

## What changed

- `backend/app/agents/subagent_events.py` — a new `SubagentAwaitingApproval`
  frame. `SubagentFinished.status` had no honest value for "waiting for a person":
  `failed` sends a reader looking for a defect, `completed` claims work that has
  not happened. So it is its own frame, carrying no cost and no run id.
- `backend/app/agents/capabilities/subagents/_journal.py:538` — `close` now tells
  a parked sync delegation (handle `DEFERRED`) apart from a background one still
  running, sends the frame, and releases the fan-out slot instead of filing it
  into `_background` where `settle_background` would never settle it.
- `backend/app/agents/capabilities/subagents/_journal.py` — `Delegation.stable_id`
  and `public_id`: a continued delegation keeps the id it parked under, carried on
  `ResumedDelegation.task_id` and read back in `begin`. The library's own id is
  kept only to find the live handle. Frames, the recorded outcome, the parked
  record and `acting_delegate` all use the stable id, so a resume reopens the
  panel rather than a second appearing beside it.
- `frontend/src/lib/delegations.ts`, `types/chat.ts`, `hooks/use-chat.ts`,
  `components/chat/delegation-panel.tsx` — the surface: an `awaiting_approval`
  status (amber, "waiting for approval", no spinner), and a repeat `subagent_start`
  for a panel already waiting reopens it rather than being a no-op.
- `docs/channels.md` — the panel contract now describes the parked case.

## How it failed before

Observed with the suite's own harness: `in_flight: 1` and frames
`['subagent_start', 'subagent_tool_call']` — no closing frame, the slot still
held, the panel spinning on "working" for the length of the wait and forever if
nobody decided. On resume, a second panel opened beside the first.

## Testing

- `test_a_parked_sync_delegate_closes_its_panel_and_frees_its_slot` — the closing
  frame, an empty recorder (no run row), and `in_flight() == 0`, beside the
  existing `test_a_sync_delegation_that_suspends_is_not_recorded_as_an_outcome`
  which stays pinned.
- `test_the_resumed_delegation_keeps_the_task_id_it_parked_under` — the identity
  across a resume, through the recorded outcome (a streamed sink would force the
  resume test's function models to stream, which they are not built to).
- Frontend: the reducer (close, record nothing, reopen on resume), the panel
  label mounted closed, and the frame reaching the store through the socket.
- `make test` (100% platform gate), `make test-frontend-cov`, `make lint` all green
  locally.

## Noticed, not fixed

- When a parked delegate's message history could not be kept (best-effort library
  telemetry, `messages` empty), there is no `ResumedDelegation` for it, so the
  re-run-from-scratch delegation gets a fresh panel rather than reopening the old
  one. Rare and the degraded path already; carrying the original id there too
  would need a separate id map alongside the spend one. Left as-is.
