### PR TITLE
fix(agents): keep a create_agent specialist across an approval park

### DIFF
--- a/backend/app/agents/capabilities/subagents/_capability.py
+++ b/backend/app/agents/capabilities/subagents/_capability.py
@@ -34,7 +34,8 @@ which has a handle and no task - and it says what the sweep does not guarantee.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import logging
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field, replace
 from typing import Any, cast
 
@@ -58,6 +59,7 @@ from subagents_pydantic_ai import (
 )
 from subagents_pydantic_ai.dynamic_agent import AgentFactory
 from subagents_pydantic_ai.prompts import SEND_MESSAGE_TO_SUBAGENT_DESCRIPTION
+from subagents_pydantic_ai.registry import DynamicAgentRegistry
 
 from app.agents.capabilities._registry import CapabilityToolInfo
 from app.agents.capabilities.subagents._journal import DelegationJournal
@@ -67,10 +69,13 @@ from app.agents.factory import DEFAULT_MAX_STEPS
 from app.agents.spec import DelegationMode
 from app.agents.subagent_runtime import (
     DynamicSpecialists,
+    RegisteredSpecialist,
     ResolvedSubagent,
     ResumedDelegation,
     SubagentRuntime,
 )
+
+logger = logging.getLogger(__name__)
 
 MAX_DYNAMIC_SPECIALISTS = 5
 """How many specialists one run may **keep** before `create_agent` is refused.
@@ -691,12 +696,20 @@ class Delegation(WrapperCapability[AgentDeps]):
         nothing will check again. Nothing here can stop it, so
         `cancel_in_flight` names it in a warning instead, and this docstring says
         so rather than claiming the terminal status is a certainty.
+
+        *And the kept specialists are snapshotted*, so a run that parks on an
+        approval carries them into `PausedRunState` and finds them again on the
+        replay - the library's registry is per built agent and a resume builds a
+        fresh one, which is what lost a specialist across a park until now
+        (agenticos#175). A no-op unless this is the run's own agent and it may
+        invent one; see `DelegationJournal.record_created_specialists`.
         """
         try:
             return await super().wrap_run(ctx, handler=handler)
         finally:
             self.journal.cancel_in_flight()
             await self.journal.settle_background(ctx.deps.subagent_events)
+            self.journal.record_created_specialists()
 
 
 def build_delegation(
@@ -729,6 +742,18 @@ def build_delegation(
     """
     journal = DelegationJournal(runtime=runtime, mode=mode, max_fanout=max_fanout, depth=depth)
     dynamic = runtime.dynamic
+    # The registry `create_agent` writes into, owned here rather than left to the
+    # library so this platform can read it back when the run ends and seed it when a
+    # run resumes. A resume fills `stash.to_register`; only the run's own agent's
+    # registry is seeded from it - a nested delegate has its own registry and its
+    # own `create_agent`, and a flat list of the run's specialists is not its to
+    # replay. `None` when the agent may not invent one, and then the library needs no
+    # registry either.
+    registry = (
+        None
+        if dynamic is None
+        else _seeded_registry(dynamic, journal, runtime.stash.to_register if depth == 0 else [])
+    )
     capability = SubAgentCapability(
         subagents=[_config_for(delegate, journal) for delegate in runtime.subagents],
         # Passed because the library's own default is `True`, not because anything
@@ -755,8 +780,12 @@ def build_delegation(
         # `0` rejects every registration, which is the honest ceiling for an agent
         # that may not create one at all - `is not None`, not truthiness, is how the
         # library reads it, so this is not "unlimited". It bounds `create_agent`
-        # only; a `delegate` call registers nothing.
+        # only; a `delegate` call registers nothing. Read only when no `registry` is
+        # passed: the one above carries its own ceiling, set to the same constant.
         max_agents=0 if dynamic is None else MAX_DYNAMIC_SPECIALISTS,
+        # Owned here rather than created inside the library, so its registrations
+        # can be snapshotted when the run parks and re-seeded when it resumes.
+        registry=registry,
         # `default_model` is left at the library's own, and this platform has no
         # default model anywhere: a specialist that names none is refused in
         # `DelegatingToolset._refuse_dynamic`, before either entry point reaches
@@ -789,7 +818,71 @@ def build_delegation(
     # inside the capability the journal was passed into, so this is the first
     # moment both exist.
     journal.tasks = capability.task_manager
+    # The registry `create_agent` writes into, so `record_created_specialists` can
+    # snapshot it when the run ends. `None` for an agent that may not invent one.
+    journal.registry = registry
     return Delegation(wrapped=capability, journal=journal)
+
+
+def _seeded_registry(
+    dynamic: DynamicSpecialists,
+    journal: DelegationJournal,
+    specialists: Sequence[RegisteredSpecialist],
+) -> DynamicAgentRegistry:
+    """The library registry `create_agent` writes into, with a resume's kept ones in it.
+
+    Empty on a fresh run - `specialists` is empty unless a resume filled the stash -
+    and re-populated on a resume, so a specialist kept before an approval park is
+    reachable through `task` after it (agenticos#175). Each one is registered the way
+    `create_agent` would have: a `_LazyAgent` whose build goes through
+    `DynamicSpecialists.build`, the same door an inline specialist and a pinned
+    delegate come through, so it reaches `build_agent` with the run's shared budget
+    guard and meters against the run's ledger like every other delegation.
+
+    Built *lazily*, which is the one place a re-registration departs from
+    :func:`_specialist_factory`: the factory builds at once, and the run's budget
+    guard is a product of `build_agent` that the runner assigns *after* this
+    capability is built - so a seeded specialist built here would be handed no guard
+    and meter nothing, the one property agenticos#175 was careful not to break. The
+    build is deferred to the first `task`, by when the guard is in place, exactly as
+    a resolved delegate's is.
+
+    A model this deployment no longer holds is skipped rather than raised: a profile
+    can be deleted between the park and the resume, and one gone specialist must not
+    fail the whole continuation - the model reads "unknown subagent" for that one
+    name and can create it again, which is the pre-fix behaviour for it alone.
+    """
+    registry = DynamicAgentRegistry(max_agents=MAX_DYNAMIC_SPECIALISTS)
+    for specialist in specialists:
+        if specialist.model not in dynamic.allowed_models:
+            logger.warning(
+                "dynamic_specialist_not_re_registered_model_gone",
+                extra={"subagent": specialist.name, "model": specialist.model},
+            )
+            continue
+        config = SubAgentConfig(
+            name=specialist.name,
+            description=specialist.description,
+            instructions=specialist.instructions,
+            model=specialist.model,
+            # As `_autonomously` set it at creation: a specialist here never asks the
+            # parent a question. See `_toolset._autonomously` and `UNREACHABLE_TOOLS`.
+            can_ask_questions=False,
+        )
+        # `s=specialist` binds the loop variable into the closure, so every lazy
+        # build resolves its own specialist rather than the last of the loop.
+        agent = _LazyAgent(
+            ResolvedSubagent(
+                name=specialist.name,
+                description=specialist.description,
+                build=lambda s=specialist: dynamic.build(
+                    name=s.name, instructions=s.instructions, model=s.model
+                ),
+            ),
+            journal,
+        )
+        registry.register(config, agent)
+    return registry
 
 
 def _config_for(delegate: ResolvedSubagent, journal: DelegationJournal) -> SubAgentConfig:

--- a/backend/app/agents/capabilities/subagents/_journal.py
+++ b/backend/app/agents/capabilities/subagents/_journal.py
@@ -75,6 +75,7 @@ from subagents_pydantic_ai import (
     TaskStatus,
     decide_execution_mode,
 )
+from subagents_pydantic_ai.registry import DynamicAgentRegistry
 
 from app.agents.capabilities.budget import SpendShare, booked_to
 from app.agents.capabilities.subagents._events import FrameLabels, frame_for
@@ -91,6 +92,7 @@ from app.agents.subagent_runtime import (
     DelegationSpend,
     DelegationStatus,
     ParkedDelegation,
+    RegisteredSpecialist,
     ResolvedSubagent,
     ResumedDelegation,
     SubagentRuntime,
@@ -354,6 +356,17 @@ class DelegationJournal:
     next line.
     """
 
+    registry: DynamicAgentRegistry | None = field(default=None, init=False, repr=False)
+    """The library registry `create_agent` writes into, when this agent may invent one.
+
+    `None` when the agent's author did not switch `allow_dynamic` on - then neither
+    entry point is offered and nothing registers. Otherwise `build_delegation`
+    creates the registry, hands it to the library capability so `create_agent`
+    writes into the one this journal can read, and assigns it here. That is what
+    lets :meth:`record_created_specialists` snapshot it when the run ends, so a
+    kept specialist survives an approval park (agenticos#175).
+    """
+
     _running: int = field(default=0, init=False)
     _background: dict[str, Delegation] = field(default_factory=dict, init=False)
 
@@ -532,6 +545,37 @@ class DelegationJournal:
                 started_at=self._span_start(delegation, handle),
             )
         )
+
+    def record_created_specialists(self) -> None:
+        """Snapshot the kept specialists into the stash, so an approval park keeps them.
+
+        Called from `wrap_run` on the way out of the run's own agent, and a no-op
+        otherwise: a nested delegate (`depth != 0`), or an agent that may not invent
+        one at all (`registry is None`, no `create_agent` offered). The library holds
+        each `create_agent` registration in a registry it builds per *built* agent, so
+        a resume - a fresh build - starts with an empty one; writing what the registry
+        holds now into the stash is what lets the runner carry it into
+        `PausedRunState` and re-register it on the replay. See
+        :func:`~app.agents.capabilities.subagents._capability.build_delegation`.
+
+        The whole registry, not this turn's new registrations only: a resume seeds the
+        registry *before* the replay, so what it holds at the end is the seeded ones
+        plus any the model added this turn, which is exactly what a second park must
+        keep. Assigned rather than appended, because the stash is built fresh each turn
+        and this is its one writer - a run that ends without parking simply throws the
+        snapshot away with the stash.
+        """
+        if self.registry is None or self.depth != 0:
+            return
+        self.runtime.stash.registered[:] = [
+            RegisteredSpecialist(
+                name=config["name"],
+                description=config["description"],
+                instructions=config["instructions"],
+                model=str(config.get("model", "")),
+            )
+            for config in self.registry.list_configs()
+        ]
 
     def resuming(self) -> ResumedDelegation | None:
         """The place this delegation is being continued from, if it is being continued.

--- a/backend/app/agents/subagent_runtime.py
+++ b/backend/app/agents/subagent_runtime.py
@@ -128,17 +128,26 @@ class DynamicSpecialists:
     may hold no key for, priced by nothing and metered by nothing, which is an
     unmetered model request and the one thing this platform exists to refuse.
 
-    Nothing here is persisted, and that is deliberate rather than unfinished.
-    Keeping a specialist means publishing an agent, which is a person's action; one
-    invented at run time is held in a registry the delegation library creates per
-    built agent, so it lasts as long as that agent does and no longer.
+    Nothing here is persisted *across runs*, and that is deliberate rather than
+    unfinished. Keeping a specialist means publishing an agent, which is a person's
+    action; one invented at run time lives no longer than the run it was invented
+    in.
 
-    Which is *not* the same as "for the run", and the difference is worth stating
-    because it is visible to a model: a run that parks on an approval is built again
-    when it is continued, so a specialist created before the park is gone after it,
-    and the transcript still carries the library's "created successfully". The model
-    is told so in `create_agent`'s description, and `task` answers "unknown
-    subagent" rather than doing something surprising - see agenticos#175.
+    Within that run it does now survive an approval park, which it did not before
+    (agenticos#175). The delegation library holds a `create_agent` registration in a
+    registry it creates per *built* agent, and a run that parks on an approval is
+    built again when it is continued - so the registration was lost across the park
+    while the replayed transcript still carried the library's "created successfully",
+    and `task` then answered "unknown subagent". The fix carries the registrations
+    forward in `PausedRunState` and re-registers them on resume through the same
+    build path, so a specialist created before a park is reachable after it. See
+    :class:`RegisteredSpecialist` and
+    `app.agents.capabilities.subagents._capability.build_delegation`.
+
+    A specialist is still not carried across conversation *turns*: each turn is its
+    own build with no paused state, so a name created in one reply is unknown in the
+    next, and `create_agent`'s description tells the model to create it again if
+    `task` says so.
     """
 
     build: DynamicSpecialistBuilder
@@ -159,6 +168,30 @@ class DynamicSpecialists:
     profile is gone, so "an organization with no usable model" is not a state a
     run reaches.
     """
+
+
+@dataclass(frozen=True)
+class RegisteredSpecialist:
+    """One specialist a run's model kept with `create_agent`, as it survives a park.
+
+    Enough to rebuild the specialist and no more: the four things the model wrote
+    when it invented one, which is exactly what `create_agent` handed the library
+    to compile. It carries no built agent and no budget guard - those are products
+    of the run, and a resume builds a fresh one of each, which is the whole point
+    of re-registering rather than storing the agent itself.
+
+    Plain scalars, for the reason everything on :class:`ParkedDelegation` is: this
+    is written into `agent_runs.paused_state` as JSON and read back in another
+    process. The registrations of the *run's own agent* only - a specialist a
+    nested delegate kept is out of scope here, the same way a nested delegate's
+    conversation is carried per level on :class:`ParkedDelegation` rather than
+    flat here.
+    """
+
+    name: str
+    description: str
+    instructions: str
+    model: str
 
 
 @dataclass(frozen=True)
@@ -394,6 +427,14 @@ class DelegationStash:
 
     The default is empty on both sides, which is a preview, a unit test, or a run
     that never delegated - and in each case nothing parks and nothing resumes.
+
+    `registered` and `to_register` are the same two directions for the specialists
+    a model kept with `create_agent`, and both hold the *run's own agent's* only -
+    the delegation capability writes and reads them at depth 0. A nested delegate
+    has its own registry that a nested `create_agent` writes into, and carrying one
+    of those across a park would have to hang off the delegate's own frame the way
+    its conversation does; that is not done here, so a specialist a nested delegate
+    kept is still lost across a park.
     """
 
     parked: list[ParkedDelegation] = field(default_factory=list)
@@ -405,6 +446,24 @@ class DelegationStash:
     resuming: dict[str, ResumedDelegation] = field(default_factory=dict)
     """Keyed by the `task` call the delegation was made from, which is the only
     thing the toolset knows about a delegation before it starts one."""
+
+    registered: list[RegisteredSpecialist] = field(default_factory=list)
+    """The run's own agent's kept specialists, snapshotted when the run ends.
+
+    Written by the delegation capability's `wrap_run` at depth 0, from the library
+    registry it owns, and read once by the runner to fill `PausedRunState` when the
+    run parks. Empty for a run that kept none, and for every nested level - a
+    snapshot at depth 0 is the whole of what a resume can put back, because that is
+    the only registry `to_register` seeds."""
+
+    to_register: list[RegisteredSpecialist] = field(default_factory=list)
+    """The kept specialists a resume re-registers before the replay, or empty.
+
+    The other direction of `registered`: the runner fills it from
+    `PausedRunState.dynamic_specialists`, and the depth-0 delegation capability
+    rebuilds each one into a fresh registry through the run's own build path, so a
+    resumed specialist meters against the run's shared budget exactly as it did
+    before the park. Never non-empty on a fresh run, and read only at depth 0."""
 
     spent: dict[str, DelegationSpend] = field(default_factory=dict)
     """What each delegation being continued had already cost, on the same key.

--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -105,6 +105,7 @@ from app.agents.subagent_runtime import (
     DynamicSpecialistBuilder,
     DynamicSpecialists,
     ParkedDelegation,
+    RegisteredSpecialist,
     ResolvedSubagent,
     ResumedDelegation,
     SubagentRuntime,
@@ -343,6 +344,30 @@ class DelegationFrame(BaseModel):
     )
 
 
+class DynamicSpecialistFrame(BaseModel):
+    """One specialist the run's own agent kept with `create_agent`, stored across a park.
+
+    The library holds a `create_agent` registration in a registry it builds per
+    *built* agent, and a resume is a fresh build - so without this a specialist kept
+    before an approval park was gone after it, while the replayed transcript still
+    said it had been created and `task` answered "unknown subagent" (agenticos#175).
+    The four fields are the whole of what `create_agent` was given, which is exactly
+    what a resume needs to build the specialist again on the run's shared budget.
+
+    The run's own agent's specialists only: a nested delegate's registry is its own,
+    and carrying one across a park would have to hang off that delegate's
+    :class:`DelegationFrame` the way its conversation does. See
+    :class:`app.agents.subagent_runtime.RegisteredSpecialist`.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(description="How the model addresses it in `task`")
+    description: str = Field(description="What it is for, one line")
+    instructions: str = Field(description="Its system prompt - the whole of its behaviour")
+    model: str = Field(description="The organization model profile label it runs on")
+
+
 class PausedRunState(BaseModel):
     """What a parked run needs to pick up where it stopped.
 
@@ -374,6 +399,14 @@ class PausedRunState(BaseModel):
     )
     delegations: list[DelegationFrame] = Field(
         default_factory=list, description="The delegations this run parked inside"
+    )
+    dynamic_specialists: list[DynamicSpecialistFrame] = Field(
+        default_factory=list,
+        description=(
+            "The specialists the run's own agent kept with `create_agent`, so a "
+            "park does not lose them. Empty for a run that kept none, and for one "
+            "parked before this existed"
+        ),
     )
 
 
@@ -1116,6 +1149,7 @@ class AgentRunnerService:
         resuming: dict[str, ResumedDelegation],
         already_spent: dict[str, DelegationSpend],
         already_started: dict[str, datetime | None],
+        specialists: Sequence[RegisteredSpecialist] = (),
         model_profile_id: UUID | None = None,
         version_id: UUID | None = None,
         environment_id: UUID | None = None,
@@ -1141,6 +1175,12 @@ class AgentRunnerService:
         cost before the park - and when it first began - have to be in the stash by
         then or the row it eventually writes holds only this turn's spend and begins
         at the resume.
+
+        `specialists` is the same kind of thing for `create_agent`: the specialists
+        the run's own agent kept, empty on a fresh run and filled from
+        `PausedRunState` on a resume, re-registered by the depth-0 delegation
+        capability before the replay so a kept specialist is reachable after the
+        park that created it (agenticos#175).
         """
         # A caller's override wins over the spec's choice. Only the model is
         # replaced - instructions, tools, budgets and the approval gate are the
@@ -1261,7 +1301,12 @@ class AgentRunnerService:
         run_budget = _RunBudget()
         runtimes: list[SubagentRuntime] = []
         delegations: list[RecordedDelegation] = []
-        stash = DelegationStash(resuming=resuming, spent=already_spent, started=already_started)
+        stash = DelegationStash(
+            resuming=resuming,
+            spent=already_spent,
+            started=already_started,
+            to_register=list(specialists),
+        )
         runtime = await self._delegation_runtime(
             ctx,
             spec=spec,
@@ -2208,6 +2253,11 @@ class AgentRunnerService:
         surfaces that park a run are the two that would have to agree about it
         forever. One of them would eventually not, and the failure is a resumed run
         that delegates again from nothing and answers a question nobody asked.
+
+        The kept specialists come from the same stash, snapshotted by the delegation
+        capability's `wrap_run` when the run ended - empty unless the run's own
+        agent invented one it kept, and carried forward so the resume can register
+        it again (agenticos#175).
         """
         return paused_state.model_copy(
             update={
@@ -2217,6 +2267,15 @@ class AgentRunnerService:
                     if parked.task_id is not None
                 },
                 "delegations": _delegation_frames(prepared.stash.parked),
+                "dynamic_specialists": [
+                    DynamicSpecialistFrame(
+                        name=specialist.name,
+                        description=specialist.description,
+                        instructions=specialist.instructions,
+                        model=specialist.model,
+                    )
+                    for specialist in prepared.stash.registered
+                ],
             }
         )
 
@@ -2404,6 +2463,17 @@ class AgentRunnerService:
             resuming=plan.delegations,
             already_spent=plan.spent,
             already_started=plan.started,
+            # The specialists the run's own agent kept before it parked, rebuilt
+            # into a fresh registry before the replay so `task` reaches them again.
+            specialists=[
+                RegisteredSpecialist(
+                    name=frame.name,
+                    description=frame.description,
+                    instructions=frame.instructions,
+                    model=frame.model,
+                )
+                for frame in state.dynamic_specialists
+            ],
         )
         prepared.built.ledger.book(_spend_already_booked(run))
 

--- a/backend/tests/test_agent_runner.py
+++ b/backend/tests/test_agent_runner.py
@@ -1046,6 +1046,9 @@ class TestParking:
             # added for delegation reads as "this run delegated nothing".
             "delegated_approvals": {},
             "delegations": [],
+            # And no kept specialists, which is a run that invented none - or, as
+            # here, one whose agent binds no delegation at all (agenticos#175).
+            "dynamic_specialists": [],
         }
 
     @pytest.mark.anyio

--- a/backend/tests/test_dynamic_specialists.py
+++ b/backend/tests/test_dynamic_specialists.py
@@ -69,8 +69,10 @@ from app.agents.subagent_events import SubagentEvent
 from app.agents.subagent_runtime import (
     SUBAGENT_RUNTIME_RESOURCE,
     DelegationOutcome,
+    DelegationStash,
     DynamicSpecialistBuilder,
     DynamicSpecialists,
+    RegisteredSpecialist,
     ResolvedSubagent,
     SubagentRuntime,
 )
@@ -235,8 +237,17 @@ def a_runtime(
     dynamic: DynamicSpecialists | None = None,
     ledger: SpendLedger | None = None,
     record: Recorder | None = None,
+    stash: DelegationStash | None = None,
+    depth: int = 0,
 ) -> SubagentRuntime:
-    return SubagentRuntime(subagents=delegates, record=record, dynamic=dynamic, ledger=ledger)
+    runtime = SubagentRuntime(
+        subagents=delegates, record=record, dynamic=dynamic, ledger=ledger, depth=depth
+    )
+    if stash is not None:
+        # A resume hands over a stash carrying what an earlier turn kept; a fresh
+        # run gets the default empty one.
+        runtime.stash = stash
+    return runtime
 
 
 def dynamic(
@@ -781,6 +792,155 @@ class TestADynamicDelegationIsAccountedForLikeAnyOther:
         assert "the specialist answered" in answer
         assert [outcome.subagent for outcome in recorder.outcomes] == ["summariser"]
         assert ledger.entries != []
+
+
+class TestAKeptSpecialistSurvivesTheParkThatCreatedIt:
+    """agenticos#175: a `create_agent` specialist kept before an approval park must
+    be reachable after it.
+
+    The library holds each registration in a registry it builds per *built* agent,
+    and a resume is a fresh build - so a specialist kept before the park was gone
+    after it while the replayed transcript still said it had been created, and
+    `task` answered "unknown subagent". The fix snapshots the registrations when the
+    run ends, the runner carries them in `PausedRunState`, and the resume rebuilds
+    each one into a fresh registry.
+
+    Two runtimes stand in for the park and its resume, one `build_delegation` each -
+    which is exactly what a park and a resume are, two builds of the same run. The
+    first keeps a specialist and snapshots it as the run ends; the second is handed
+    what the first kept, the way the runner hands it back through the stash.
+    """
+
+    async def test_the_run_snapshots_what_create_agent_kept(self):
+        """The capture half: when the run ends, the kept specialist is on the stash,
+        in the four fields a resume needs to build it again."""
+        runtime = a_runtime(dynamic=dynamic(specialist_builder()))
+        capability = a_capability(runtime)
+        ctx = a_context()
+
+        await call_tool(capability, ctx, "create_agent", create_args())
+        await _ends_the_run(capability, ctx)
+
+        assert runtime.stash.registered == [
+            RegisteredSpecialist(
+                name="summariser",
+                description="Summarises a document in three bullets",
+                instructions="You summarise.",
+                model=PROFILE,
+            )
+        ]
+
+    async def test_without_the_carried_registrations_the_rebuild_loses_it(self):
+        """The failure itself: a fresh build with nothing carried over answers `task`
+        with "unknown subagent", which is what every resume did before the fix."""
+        resumed = a_runtime(dynamic=dynamic(specialist_builder()))
+
+        answer = await call_tool(
+            a_capability(resumed),
+            a_context(),
+            "task",
+            {"description": "summarise it", "subagent_type": "summariser"},
+        )
+
+        assert "Unknown subagent 'summariser'" in answer
+
+    async def test_task_reaches_a_resumed_specialist_and_still_meters_it(self):
+        """The whole of the fix: the specialist the first turn kept is reachable in
+        the second, and its spend still lands on the run's shared ledger.
+
+        The metering is the half the naive fix breaks. A resume re-registers before
+        the run's budget guard exists - it is a product of `build_agent`, assigned
+        after this build - so a specialist built eagerly at re-registration would be
+        handed no guard and meter nothing. The guard is set here *after* the
+        capability is built, as the runner sets it, and the ledger entry is what
+        proves the rebuilt specialist waited for it.
+        """
+        first = a_runtime(dynamic=dynamic(specialist_builder()))
+        capability = a_capability(first)
+        await call_tool(capability, a_context(), "create_agent", create_args())
+        await _ends_the_run(capability, a_context())
+        kept = list(first.stash.registered)
+        assert [specialist.name for specialist in kept] == ["summariser"]
+
+        ledger = SpendLedger()
+        budget = _RunBudget()
+        resumed = a_runtime(
+            dynamic=dynamic(specialist_builder(budget)),
+            ledger=ledger,
+            stash=DelegationStash(to_register=kept),
+        )
+        resumed_capability = a_capability(resumed)
+        # The two assignments the runner makes after the build, in that order: the
+        # guard is a product of the build, and a lazily rebuilt specialist reads it
+        # only when `task` runs it below.
+        budget.guard = BudgetGuard(ledger=ledger, provider="openai")
+
+        answer = await call_tool(
+            resumed_capability,
+            a_context(),
+            "task",
+            {"description": "summarise it", "subagent_type": "summariser"},
+        )
+
+        assert "the specialist answered" in answer
+        assert [entry.input_tokens for entry in ledger.entries] == [SPECIALIST_TOKENS]
+
+    async def test_a_specialist_whose_model_is_gone_is_skipped_not_raised(self):
+        """A profile can be deleted between the park and the resume. That one
+        specialist reads as unknown again - the model can recreate it - rather than
+        failing the whole continuation, and any others carried over still resume."""
+        gone = RegisteredSpecialist(
+            name="summariser",
+            description="Summarises a document in three bullets",
+            instructions="You summarise.",
+            model="A model the organization no longer holds",
+        )
+        resumed = a_runtime(
+            dynamic=dynamic(specialist_builder()),
+            stash=DelegationStash(to_register=[gone]),
+        )
+
+        answer = await call_tool(
+            a_capability(resumed),
+            a_context(),
+            "task",
+            {"description": "summarise it", "subagent_type": "summariser"},
+        )
+
+        assert "Unknown subagent 'summariser'" in answer
+
+    async def test_a_nested_agents_registry_is_neither_seeded_nor_snapshotted(self):
+        """The scope of the fix: the run's own agent only.
+
+        `PausedRunState` carries a flat list of the *run's own agent's* kept
+        specialists, so a nested delegate - which has its own registry and its own
+        `create_agent` - must not read that list as its own on a resume, nor write
+        its own registrations into it when the run ends. A delegate that carried one
+        of these across a park would have to hang it off its own `DelegationFrame`
+        the way its conversation is; that is not done, so a nested agent both
+        ignores what the run kept and keeps nothing of its own here.
+        """
+        stash = DelegationStash(to_register=[a_registered("from-the-parent")])
+        nested = a_runtime(dynamic=dynamic(specialist_builder()), stash=stash, depth=1)
+        capability = a_capability(nested)
+        ctx = a_context()
+
+        # Seed skipped: the parent's kept specialist is not in this level's registry.
+        unknown = await call_tool(
+            capability, ctx, "task", {"description": "x", "subagent_type": "from-the-parent"}
+        )
+        # Snapshot skipped: what this level keeps does not land on the shared list.
+        await call_tool(capability, ctx, "create_agent", create_args(name="nested-only"))
+        await _ends_the_run(capability, ctx)
+
+        assert "Unknown subagent 'from-the-parent'" in unknown
+        assert stash.registered == []
+
+
+def a_registered(name: str) -> RegisteredSpecialist:
+    return RegisteredSpecialist(
+        name=name, description="Summarises.", instructions="You summarise.", model=PROFILE
+    )
 
 
 async def _ends_the_run(capability: Delegation, ctx: RunContext[AgentDeps]) -> None:

--- a/backend/tests/test_subagent_nested_resume.py
+++ b/backend/tests/test_subagent_nested_resume.py
@@ -883,7 +883,11 @@ class TestAnOlderParkedRun:
         queue.decide(approved=True)
 
         state = PausedRunState.model_validate(stored)
-        assert (state.delegations, state.delegated_approvals) == ([], {})
+        assert (state.delegations, state.delegated_approvals, state.dynamic_specialists) == (
+            [],
+            {},
+            [],
+        )
         plan = _resume_plan(
             state, {parked.tool_call_id: parked.tool_args for parked in channel.requested}
         )

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -426,10 +426,18 @@ key for.
 The model may name only a model the organization has a profile for, and the refusal
 names the list. It may not attach capabilities: letting a model grant its own child
 a capability is the ungranted-scope failure wearing a new hat. It gets no knowledge,
-no delegates of its own, and nothing is persisted — keeping a specialist means
-publishing an agent, which is a person's action. `MAX_DYNAMIC_SPECIALISTS` bounds how
-many one run may keep, and a kept one lasts for the reply rather than the run
-([#175](https://github.com/vstorm-co/agenticos/issues/175)).
+no delegates of its own, and nothing is persisted across runs — keeping a specialist
+means publishing an agent, which is a person's action. `MAX_DYNAMIC_SPECIALISTS`
+bounds how many one run may keep.
+
+A kept one lasts the whole run it was invented in, an approval park included: the
+registration lives in a registry the delegation library builds per *built* agent,
+and a run that parks is built again when it is continued, so it was lost across the
+park until the registrations were carried in `PausedRunState` and re-registered on
+the replay ([#175](https://github.com/vstorm-co/agenticos/issues/175)). It does not
+survive into the *next conversation turn*, which is a fresh build with no paused
+state — a name created in one reply is unknown in the next, and `create_agent`'s
+description tells the model to create it again if `task` says so.
 
 **The delegation library's own unspecialised delegate is not offered at all**, and
 there is no setting for it. It would run on a model this deployment did not


### PR DESCRIPTION
## What this fixes

`Closes #175.` A specialist kept with `create_agent` did not survive the approval
park that created it. The registration lived in the delegation library's
`DynamicAgentRegistry`, which `SubAgentToolset` builds once per `build_agent` — so
once per turn, not once per run. A run that parks for an approval is built again
when it is continued, so every registration made before the park was gone after it,
while the replayed transcript still carried the library's `Agent 'x' created
successfully`. The model then called `task(..., 'x')` and read `Unknown subagent
'x'` — recoverable, but it had been told otherwise.

## What changed

- `backend/app/agents/subagent_runtime.py` — new `RegisteredSpecialist` plain-data
  type; `DelegationStash` gains `registered` (capture) and `to_register` (seed);
  `DynamicSpecialists` docstring corrected — the "gone after a park" note it carried
  is no longer true.
- `backend/app/agents/capabilities/subagents/_capability.py:build_delegation` — the
  capability now **owns** the library registry (rather than letting the library
  create it), seeds it from `stash.to_register` at depth 0, and hands it to
  `SubAgentCapability(registry=...)`. `Delegation.wrap_run` snapshots it on the way
  out. `_seeded_registry` rebuilds each kept specialist through `DynamicSpecialists.build`.
- `backend/app/agents/capabilities/subagents/_journal.py` — `DelegationJournal` holds
  the `registry` and `record_created_specialists()` snapshots it into the stash at
  depth 0.
- `backend/app/services/agent_runner.py` — `PausedRunState.dynamic_specialists`
  (optional, defaulted); `resume` re-registers them; `_parked_tree` folds them in
  from the stash.
- `docs/reference/capabilities.md` — the lifetime prose now describes the fixed
  behaviour.

## How it failed before

An agent with `allow_dynamic`: the model calls `create_agent('summariser')` (approved,
registers), then anything parks the run again — a second `create_agent`, a `delegate`,
a gated tool inside a delegate. On resume `task(..., 'summariser')` answered "Unknown
subagent", because the resumed run's registry was freshly empty while the transcript
still claimed the specialist existed.

## The metering subtlety

The one property #175 was careful not to break: a resumed specialist must still meter
against the run's shared budget. A re-registration is built **lazily**, unlike
`_specialist_factory`'s eager build — the run's budget guard is a product of
`build_agent` that the runner assigns *after* the capability is built, so an eager
seed would hand the specialist no guard and meter nothing. Deferred to the first
`task`, the guard is in place. `test_task_reaches_a_resumed_specialist_and_still_meters_it`
sets the guard after the build, as the runner does, and asserts the ledger entry —
so it fails if the seed is ever made eager.

## Testing

Backend gates green locally: `make lint-backend`, `make test` (100% platform-layer
coverage), `make docs-build --strict`. Frontend gates (`lint-frontend`,
`test-frontend-cov`, `build-frontend`) green as well — the diff touches no frontend
files, so they run exactly as on `main`. `audit` clean.

- `tests/test_dynamic_specialists.py::TestAKeptSpecialistSurvivesTheParkThatCreatedIt`
  — capture (`test_the_run_snapshots_what_create_agent_kept`), the pre-fix failure
  (`test_without_the_carried_registrations_the_rebuild_loses_it`), the seed round-trip
  **with metering**, the deleted-model edge, and the nested-scope guarantee.
- `tests/test_subagent_nested_resume.py::TestAnOlderParkedRun` and
  `tests/test_agent_runner.py::TestParking` — extended to lock the new field's default,
  proving a run parked before this deploy still validates and resumes.
- `make test` → 100% platform-layer coverage (7014 stmts, 0 miss, 1500 branch, 0 partial).

## Noticed, not fixed

- **A specialist kept by a *nested* delegate still does not survive a park.** Its
  registry is the delegate's own, and carrying it would have to hang off that
  delegate's `DelegationFrame` the way its conversation does — a flat run-level list
  cannot represent it. The stash reads/writes are guarded to depth 0 and a test pins
  that a nested level neither seeds from nor snapshots into the run's list. Filed as
  #254 (delegation cluster in #168) — its fix is a per-`DelegationFrame` list, so it is
  independent of this PR rather than a widening of it.
- **Persistence across conversation turns is unchanged** and out of scope: each turn
  is a fresh build with no paused state, so a name created in one reply is unknown in
  the next. `create_agent`'s description already tells the model to recreate it —
  keeping one across runs is what publishing an agent is for (as #40 ruled).
