### PR TITLE
chore: cut 0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,27 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.11] - 2026-08-05
+
+### Fixed
+
+- **Run history can tell a delegated run from one a person started**
+  ([#181](https://github.com/vstorm-co/agenticos/issues/181)). The columns
+  (`parent_run_id`, `subagent_task_id`) had existed since delegation landed and nothing
+  read them, so a fan-out turn listed as several independent runs and a page that summed a
+  column double-counted every delegation — a parent's cost already contains its children's.
+  `AgentRunRead` now carries both, and withholds the delegation handle whenever the parent
+  is gone (a foreign key can only null its own column, so `subagent_task_id` outlives the
+  delete that nulls `parent_run_id`); `list_runs` filters `parent_run_id IS NULL` for the
+  history list, and answers the run-detail query — "what did this run delegate" — by
+  `parent_run_id`, which is the lookup the migration's index was speculative weight for
+  until it had one.
+
+  A delegated run is **badged** in the table and reachable from its chat panel, so the
+  fan-out reads as one tree rather than a list of strangers. The monthly sums keep the
+  existing `(organization_id, started_at)` index, with the null test applied to rows it
+  already found.
+
 ## [0.0.10] - 2026-08-05
 
 ### Fixed
@@ -702,7 +723,8 @@ installed hook did nothing.
   codebase has diverged from the generator past the point where a 3-way merge
   helps.
 
-[Unreleased]: https://github.com/vstorm-co/agenticos/compare/v0.0.10...HEAD
+[Unreleased]: https://github.com/vstorm-co/agenticos/compare/v0.0.11...HEAD
+[0.0.11]: https://github.com/vstorm-co/agenticos/compare/v0.0.10...v0.0.11
 [0.0.10]: https://github.com/vstorm-co/agenticos/compare/v0.0.9...v0.0.10
 [0.0.9]: https://github.com/vstorm-co/agenticos/compare/v0.0.8...v0.0.9
 [0.0.8]: https://github.com/vstorm-co/agenticos/compare/v0.0.7...v0.0.8

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.10"
+version = "0.0.11"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.10"
+version = "0.0.11"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for **#181** — run history can now tell a delegated run from one a person started. `parent_run_id`/`subagent_task_id` had existed since delegation and nothing read them, so a fan-out listed as several independent runs and a summed column double-counted every delegation. `AgentRunRead` carries both (withholding the handle when the parent is gone), `list_runs` filters `parent_run_id IS NULL` for the list and answers the run-detail query by parent id, and a delegated run is badged and reachable from its chat panel.

Code landed as #200; `make check` green at 3065 passed / 100%.

No schema change, `SPEC_VERSION` unchanged at 7.