### PR TITLE
fix(approvals): write the approval row off the shared session

### DIFF
--- a/backend/app/agents/capabilities/subagents/README.md
+++ b/backend/app/agents/capabilities/subagents/README.md
@@ -203,18 +203,18 @@ without it, and answers "No active knowledge bases selected" to every search —
 specialist that publishes cleanly, looks correctly configured, and cannot read the
 one thing it exists to read.
 
-**A background delegation gets no approval channel.** `request_approval` closes
-over `ApprovalService`, which holds the request's `AsyncSession` — shared by the
-whole run and not concurrency-safe — and a background delegation outlives the tool
-call that started it. Asking is therefore a database write from a task the parent
-is still sharing its session with, for a decision that cannot be delivered anyway:
-the tool call returned a task id long ago, so there is no caller left to hand a
-parked call back to. The channel is handed down as `None`, which is the case the
-gate is already written for — it refuses the call, tells the model a person could
-not be asked, and the delegation goes on to answer or to say it could not. A sync
-delegation keeps the channel, because there a parked call genuinely does park the
-parent run; that is the supported shape, and `mode="sync"` is what the library's
-own message tells a model to re-delegate with.
+**A background delegation gets no approval channel.** A background delegation
+outlives the tool call that started it, and a parked call it produced could not be
+delivered anyway: the tool call returned a task id long ago, so there is no caller
+left to hand the parked call back to. The channel is handed down as `None`, which
+is the case the gate is already written for — it refuses the call, tells the model
+a person could not be asked, and the delegation goes on to answer or to say it
+could not. A sync delegation keeps the channel, because there a parked call
+genuinely does park the parent run; that is the supported shape, and `mode="sync"`
+is what the library's own message tells a model to re-delegate with. (The channel
+itself no longer holds a session — a parked call is described and the row written
+from the run's terminal write, agenticos#169 — so this is about where the decision
+can be delivered, not about a write racing the shared session.)
 
 **Let a delegate ask the parent a question.** The library's `ask_parent` tool is
 injected only into agents it built itself, and every delegate here arrives

--- a/backend/app/repositories/agent.py
+++ b/backend/app/repositories/agent.py
@@ -5,7 +5,7 @@ role scope and on what was shared with them, so `list_visible` takes the
 predicate pieces the access layer resolved rather than re-deriving them here.
 """
 
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 from uuid import UUID
 
 from sqlalchemy import func, or_, select
@@ -30,6 +30,30 @@ async def get_many(
         select(Agent).where(Agent.id.in_(list(agent_ids)), Agent.organization_id == organization_id)
     )
     return {agent.id: agent for agent in result.scalars().all()}
+
+
+async def existing_ids_locked(
+    db: AsyncSession, agent_ids: Collection[UUID], *, organization_id: UUID
+) -> set[UUID]:
+    """Which of these agents still exist, locked so they cannot be deleted until commit.
+
+    For the deferred approval write. A delegate whose gated call was parked can be
+    deleted between the call and the run's terminal write - the write is deferred to
+    that point - and its id rides on the approval row as a `SET NULL` foreign key.
+    Inserting the row would then violate that key and roll the whole parked run
+    back, so the writer nulls an id whose agent is gone. `FOR KEY SHARE` - the lock
+    an insert referencing the row would itself take - holds the survivors so a
+    concurrent delete cannot slip in between this check and that insert, which is
+    the guarantee the old inline insert had and a bare existence check would lose.
+    """
+    if not agent_ids:
+        return set()
+    result = await db.execute(
+        select(Agent.id)
+        .where(Agent.id.in_(list(agent_ids)), Agent.organization_id == organization_id)
+        .with_for_update(key_share=True)
+    )
+    return set(result.scalars().all())
 
 
 async def get(db: AsyncSession, agent_id: UUID, *, organization_id: UUID) -> Agent | None:

--- a/backend/app/repositories/agent.py
+++ b/backend/app/repositories/agent.py
@@ -51,7 +51,7 @@ async def existing_ids_locked(
     result = await db.execute(
         select(Agent.id)
         .where(Agent.id.in_(list(agent_ids)), Agent.organization_id == organization_id)
-        .with_for_update(key_share=True)
+        .with_for_update(read=True, key_share=True)
     )
     return set(result.scalars().all())
 

--- a/backend/app/repositories/agent_run.py
+++ b/backend/app/repositories/agent_run.py
@@ -412,6 +412,7 @@ async def spend_by_key(
 async def create_approval(
     db: AsyncSession,
     *,
+    approval_id: UUID,
     organization_id: UUID,
     run_id: UUID,
     agent_id: UUID,
@@ -421,6 +422,7 @@ async def create_approval(
     subagent_agent_id: UUID | None = None,
 ) -> ToolApproval:
     approval = ToolApproval(
+        id=approval_id,
         organization_id=organization_id,
         run_id=run_id,
         agent_id=agent_id,

--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -379,12 +379,19 @@ class PausedRunState(BaseModel):
 
 @dataclass(frozen=True)
 class ParkedApproval:
-    """One tool call waiting for a person.
+    """One tool call waiting for a person, and everything its row will hold.
 
     Carries the `approvals` row id rather than the model's `tool_call_id`: the
     decision is recorded against that row, and it is the row the approvals queue
     and the notification email point at. A surface that invented its own
     identifier would be a second way to approve the same call.
+
+    The id is allocated when the call is parked rather than by the database,
+    because the row is not written until the run reaches its terminal write - see
+    :meth:`ApprovalChannel.__call__`. This is the same shape, and the same reason,
+    as :class:`RecordedDelegation`: a description the run collects while it runs
+    and :meth:`AgentRunnerService._write_approvals` turns into rows once, off the
+    shared session, when nothing is racing it.
     """
 
     approval_id: UUID
@@ -398,6 +405,12 @@ class ParkedApproval:
 
     subagent: str | None = None
     """Which delegate asked, or `None` for the run's own agent."""
+
+    subagent_agent_id: UUID | None = None
+    """That delegate's own agent, or `None` for the run's own agent or an inline
+    specialist, which has no agent of its own. Read from the delegation in flight
+    when the call is parked and carried here, because the row that names it is
+    written after the run ends, when the contextvar is long gone."""
 
     task_id: str | None = None
     """The delegation the ask came from, or `None` for the run's own agent.
@@ -420,9 +433,21 @@ class ApprovalChannel:
     Decisions are consumed on use. If the model calls the same tool a second
     time after being approved once, that is a second act on the world and needs
     its own approval - reusing the first would let one "yes" authorise a loop.
+
+    **Parking a call touches no database.** The row is *described* here and written
+    once by :meth:`AgentRunnerService._write_approvals` from the run's terminal
+    write. This is not tidiness - it is what makes the channel concurrency-safe.
+    Pydantic AI runs the tool calls from one model response concurrently, and
+    `parallel_tool_calls` is unset by default, so that is the provider's decision,
+    not the author's - a model that answers "email the customer and email the
+    account manager" in one step drives two gated calls into this channel at once.
+    Both would `await` a write on the request's `AsyncSession`, which the whole run
+    shares and which is not concurrency-safe; two inserts on it at once do not
+    produce a slow query, they corrupt the session and take the parent run row and
+    the conversation with it (agenticos#169). With the write deferred, `__call__`
+    never awaits, so the two calls cannot interleave inside it.
     """
 
-    approvals: ApprovalService
     organization_id: UUID
     agent_id: UUID
     run_id: UUID
@@ -430,11 +455,12 @@ class ApprovalChannel:
     parked: dict[str, str] = field(default_factory=dict)
 
     requested: list[ParkedApproval] = field(default_factory=list)
-    """What was parked, in enough detail for a surface to put it to somebody.
+    """What was parked, in enough detail for a surface to put it to somebody and
+    for :meth:`AgentRunnerService._write_approvals` to write the row.
 
-    Kept here rather than read back from the rows afterwards, because this is where
-    the row was created - re-reading it would be a query per parked call to recover
-    what this object had in hand.
+    Kept here rather than read back from the rows afterwards for two reasons: the
+    rows do not exist yet while the run is going, and re-reading them would be a
+    query per parked call to recover what this object already had in hand.
     """
 
     async def __call__(self, request: ApprovalRequest) -> ApprovalDecision:
@@ -450,28 +476,23 @@ class ApprovalChannel:
         # sent, and the parked state, which has to know which agent's replay this
         # call belongs to.
         delegate = acting_delegate()
-        approval = await self.approvals.request(
-            organization_id=self.organization_id,
-            run_id=self.run_id,
-            agent_id=self.agent_id,
-            # The tool the model called, not the capability that owns it: the
-            # approver is looking at "send_email", not at "email".
-            tool_id=request.tool_name,
-            tool_args=request.tool_args,
-            subagent_name=None if delegate is None else delegate.name,
-            # The delegate's own agent, which is *not* `self.agent_id`: that one is
-            # the agent whose run this is, and it is what the row is scoped by.
-            # Null for an inline specialist, which has no agent of its own.
-            subagent_agent_id=None if delegate is None else delegate.agent_id,
-        )
-        self.parked[str(approval.id)] = request.tool_call_id
+        # Allocated here, not by the database, because the row is written after the
+        # run ends. Everything below is synchronous - a `uuid4`, a dict set and a
+        # list append, each atomic under the GIL - so with no `await` in the body
+        # two concurrent gated calls cannot interleave and race the shared session.
+        approval_id = uuid4()
+        self.parked[str(approval_id)] = request.tool_call_id
         self.requested.append(
             ParkedApproval(
-                approval_id=approval.id,
+                approval_id=approval_id,
                 tool_call_id=request.tool_call_id,
                 tool_name=request.tool_name,
                 tool_args=request.tool_args,
                 subagent=None if delegate is None else delegate.name,
+                # The delegate's own agent, which is *not* `self.agent_id`: that one
+                # is the agent whose run this is and what the row is scoped by. Null
+                # for an inline specialist, which has no agent of its own.
+                subagent_agent_id=None if delegate is None else delegate.agent_id,
                 task_id=None if delegate is None else delegate.task_id,
             )
         )
@@ -1227,7 +1248,6 @@ class AgentRunnerService:
             started_with = await workspace_snapshot(workspace.backend)
 
         channel = ApprovalChannel(
-            approvals=self.approvals,
             organization_id=ctx.organization_id,
             agent_id=agent.id,
             run_id=run.id,
@@ -1988,6 +2008,45 @@ class AgentRunnerService:
                     extra={"run_id": str(parent.id), "delegation_id": str(delegation.id)},
                 )
 
+    async def _write_approvals(self, prepared: PreparedRun) -> None:
+        """Write the approval rows the run parked, once, off the shared session.
+
+        The rows are *described* while the run runs and written here, from the
+        run's terminal write - the one point at which the session is certainly not
+        being shared with a concurrent tool call. Parking a call on the channel
+        touches no database precisely so that two gated calls in one model step
+        cannot race two inserts on the request's `AsyncSession` (agenticos#169);
+        this is where that deferral is paid back. The loop is sequential, so the
+        writes it makes do not race each other either.
+
+        Unlike :meth:`_write_delegations`, a failure here is not swallowed. A
+        delegation row is attribution - the money is on the parent's row whether or
+        not the child row lands - but an approval row is what a resume reads to
+        learn a call is waiting and what it was asked to approve. A parked run
+        missing one of its rows cannot be continued for that call, so a write that
+        fails has to fail the run rather than strand it awaiting a decision nothing
+        recorded.
+
+        Each row is written with the id allocated when the call was parked, so it
+        matches the `paused_state` that names it and the :class:`ParkedApproval` a
+        surface already drew a card from. An unparked run leaves `requested` empty
+        and this does nothing.
+        """
+        channel = prepared.approvals
+        for parked in channel.requested:
+            await self.approvals.request(
+                approval_id=parked.approval_id,
+                organization_id=channel.organization_id,
+                run_id=channel.run_id,
+                agent_id=channel.agent_id,
+                # The tool the model called, not the capability that owns it: the
+                # approver is looking at "send_email", not at "email".
+                tool_id=parked.tool_name,
+                tool_args=parked.tool_args,
+                subagent_name=parked.subagent,
+                subagent_agent_id=parked.subagent_agent_id,
+            )
+
     @staticmethod
     async def _collect_outbound(prepared: PreparedRun) -> None:
         """Read what the turn wrote, for a surface that can deliver it.
@@ -2071,6 +2130,13 @@ class AgentRunnerService:
         # leave the run un-finished, and after the run has certainly stopped
         # using it. `close` never raises; it logs.
         await self.workspaces.close(prepared.workspace)
+
+        # The approval rows the run parked, written here rather than while it ran:
+        # parking on the channel is deferred off the shared session so two gated
+        # calls in one model step cannot race two inserts (agenticos#169), and this
+        # is where the deferral is paid back. Before the parent's terminal write,
+        # so the rows the `paused_state` names exist by the time it is stored.
+        await self._write_approvals(prepared)
 
         parked = None if paused_state is None else self._parked_tree(prepared, paused_state)
         ledger = prepared.built.ledger

--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -2027,12 +2027,27 @@ class AgentRunnerService:
         fails has to fail the run rather than strand it awaiting a decision nothing
         recorded.
 
+        The one failure that must *not* strand the run is a delegate deleted since
+        its call was parked. `subagent_agent_id` is a `SET NULL` foreign key -
+        deleting the delegate is meant to leave the record of what it was authorised
+        to do, not take it down - but that only fires for a delete that lands after
+        the row exists. Deferring the write widened the window to the whole run, so
+        a delete that lands *before* it would instead make the insert violate the
+        key and roll the parked run back. So the delegates still present are
+        resolved and locked first (:func:`agent_repo.existing_ids_locked`), and an
+        id whose agent is gone is written null - exactly what `SET NULL` would have
+        done - keeping the row, the delegate's name and the resumable run.
+
         Each row is written with the id allocated when the call was parked, so it
         matches the `paused_state` that names it and the :class:`ParkedApproval` a
         surface already drew a card from. An unparked run leaves `requested` empty
         and this does nothing.
         """
         channel = prepared.approvals
+        named = {p.subagent_agent_id for p in channel.requested if p.subagent_agent_id is not None}
+        present = await agent_repo.existing_ids_locked(
+            self.db, named, organization_id=channel.organization_id
+        )
         for parked in channel.requested:
             await self.approvals.request(
                 approval_id=parked.approval_id,
@@ -2044,7 +2059,11 @@ class AgentRunnerService:
                 tool_id=parked.tool_name,
                 tool_args=parked.tool_args,
                 subagent_name=parked.subagent,
-                subagent_agent_id=parked.subagent_agent_id,
+                # Null when the delegate's agent was deleted after the call was
+                # parked: the record of what it was authorised to do outlives it.
+                subagent_agent_id=(
+                    parked.subagent_agent_id if parked.subagent_agent_id in present else None
+                ),
             )
 
     @staticmethod

--- a/backend/app/services/approvals.py
+++ b/backend/app/services/approvals.py
@@ -38,6 +38,7 @@ class ApprovalService:
     async def request(
         self,
         *,
+        approval_id: UUID,
         organization_id: UUID,
         run_id: UUID,
         agent_id: UUID,
@@ -48,10 +49,16 @@ class ApprovalService:
     ) -> ToolApproval:
         """Park a tool call until a human decides.
 
-        Called from inside a run, so it takes ids rather than an auth context -
-        the agent, not a member, is what asks.
+        Called from the run's terminal write rather than from inside a tool call,
+        so it takes ids rather than an auth context - the agent, not a member, is
+        what asks - and one of those ids is the row's own. The id is allocated when
+        the call is parked (see :class:`~app.services.agent_runner.ParkedApproval`)
+        because parking a call must not touch the shared session, so the row it
+        names is written afterwards and cannot let the database mint the id.
 
         Args:
+            approval_id: The row's id, already handed to the surface and stored in
+                the run's `paused_state`, so the write cannot mint a second one.
             agent_id: The agent whose run this is, which is what scopes the row.
             subagent_name: Which delegate is acting, when the call came from inside
                 a delegation. A delegate's gated tool reaches the run's own approval
@@ -63,6 +70,7 @@ class ApprovalService:
         """
         approval = await agent_run_repo.create_approval(
             self.db,
+            approval_id=approval_id,
             organization_id=organization_id,
             run_id=run_id,
             agent_id=agent_id,

--- a/backend/tests/integration/test_concurrent_approvals.py
+++ b/backend/tests/integration/test_concurrent_approvals.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 from pydantic_ai.capabilities import AbstractCapability
@@ -38,18 +39,20 @@ from app.agents.capabilities import (
     load_builtins,
     register,
 )
+from app.agents.capabilities.budget import SpendLedger
 from app.agents.factory import build_agent
 from app.agents.model_resolver import ModelRequestSpec, ResolvedCredential
 from app.agents.spec import AgentSpec
 from app.core.secret_kinds import ApiKeySecret
 from app.db.models.agent import Agent, AgentVersion
-from app.db.models.agent_run import AgentRun, RunStatus, ToolApproval
+from app.db.models.agent_run import AgentRun, ApprovalStatus, RunStatus, ToolApproval
 from app.db.models.organization import Organization, OrganizationMember
 from app.db.models.user import User
 from app.repositories import agent_run_repo
 from app.services.agent_runner import (
     AgentRunnerService,
     ApprovalChannel,
+    ParkedApproval,
     PausedRunState,
     PreparedRun,
 )
@@ -255,3 +258,96 @@ async def test_two_gated_calls_in_one_step_park_once_and_write_two_rows(db, engi
     # parked, which are what the stored state names for the resume to find them.
     assert {row.id for row in rows} == {parked.approval_id for parked in channel.requested}
     assert set(finished.paused_state["tool_call_ids"]) == {str(row.id) for row in rows}
+
+
+async def test_a_delegate_deleted_before_the_write_leaves_the_approval_with_a_null_id(db, engine):
+    """A delegate gone by `finish()` must not roll the parked run back.
+
+    Found reviewing #169. Deferring the write to the run's terminal write means a
+    delegate whose gated call was parked can be deleted before the row is written.
+    `subagent_agent_id` is a `SET NULL` foreign key precisely so deleting a delegate
+    leaves the record of what it was authorised to do - but that only fires once the
+    row exists. The insert has to do the same for a delete that lands first: write
+    the id null, keep the delegate's name, and leave the run resumable rather than
+    letting the foreign key roll the whole parked run back. A surviving delegate on
+    the same run keeps its id, so the null is the deletion's doing, not a blanket drop.
+    """
+    org = await _org(db)
+    parent, parent_version = await _published(db, org)
+    gone, _ = await _published(db, org)
+    kept, _ = await _published(db, org)
+    run = await agent_run_repo.create_run(
+        db,
+        organization_id=org.id,
+        agent_id=parent.id,
+        agent_version_id=parent_version.id,
+        user_id=None,
+        conversation_id=None,
+        surface="api",
+        model_label="gpt-4.1",
+        provider="openai",
+        secret_id=None,
+        started_at=datetime.now(UTC),
+    )
+
+    channel = ApprovalChannel(organization_id=org.id, agent_id=parent.id, run_id=run.id)
+    parked_by_call: dict[str, ParkedApproval] = {}
+    for tool_call_id, delegate in (("call-gone", gone), ("call-kept", kept)):
+        approval_id = uuid.uuid4()
+        channel.parked[str(approval_id)] = tool_call_id
+        parked = ParkedApproval(
+            approval_id=approval_id,
+            tool_call_id=tool_call_id,
+            tool_name="send_email",
+            tool_args={"to": "customer"},
+            subagent="researcher",
+            subagent_agent_id=delegate.id,
+        )
+        channel.requested.append(parked)
+        parked_by_call[tool_call_id] = parked
+
+    # Somebody deletes one delegate while the run is still parked. Its id is already
+    # on the ParkedApproval the terminal write will use.
+    await db.delete(gone)
+    await db.flush()
+
+    prepared = PreparedRun(
+        run=run,
+        agent=parent,
+        spec=AgentSpec(name="Clerk"),
+        built=MagicMock(ledger=SpendLedger()),
+        approvals=channel,
+    )
+    await AgentRunnerService(db).finish(
+        prepared,
+        status=RunStatus.AWAITING_APPROVAL,
+        paused_state=PausedRunState(messages=[], tool_call_ids=channel.parked),
+    )
+    await db.commit()
+
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as fresh:
+        finished = await fresh.get(AgentRun, run.id)
+        rows = {
+            row.id: row
+            for row in (
+                await fresh.execute(select(ToolApproval).where(ToolApproval.run_id == run.id))
+            )
+            .scalars()
+            .all()
+        }
+
+    # The parked run committed rather than rolling back on the missing delegate.
+    assert finished is not None
+    assert finished.status == RunStatus.AWAITING_APPROVAL.value
+    assert len(rows) == 2
+    # The deleted delegate's row survives, its id nulled and its name kept, so a
+    # reviewer still sees what was authorised and the run can still be resumed.
+    gone_row = rows[parked_by_call["call-gone"].approval_id]
+    assert gone_row.subagent_agent_id is None
+    assert gone_row.subagent_name == "researcher"
+    assert gone_row.status == ApprovalStatus.PENDING.value
+    # The delegate that still exists keeps its id - the null above is the deletion's
+    # doing, not a blanket drop of every delegate's attribution.
+    kept_row = rows[parked_by_call["call-kept"].approval_id]
+    assert kept_row.subagent_agent_id == kept.id

--- a/backend/tests/integration/test_concurrent_approvals.py
+++ b/backend/tests/integration/test_concurrent_approvals.py
@@ -1,0 +1,257 @@
+"""Two gated tool calls in one model step, against a real session.
+
+The bug this pins (agenticos#169): a model that answers one step with two gated
+tool calls drives two calls into `ApprovalChannel` at once, because Pydantic AI
+runs the tool calls from one response concurrently. When the channel wrote the
+approval row itself, both writes landed on the request's `AsyncSession` - which
+the whole run shares and which is not concurrency-safe - and two flushes on it at
+once corrupt the session and take the parent run row and the conversation with it.
+
+A mocked session cannot show this: it flushes whatever it is told and knows
+nothing about what concurrent statements do to the transaction around it. Postgres
+does, which is why this lives here. The fix moves the write out of the concurrent
+path entirely - the channel only *describes* the parked call - so what this proves
+is the shape after the fix: the run parks once naming both calls, two rows are
+written with distinct ids at the run's terminal write, and the session is still
+usable, which the parent's committed terminal row is the evidence of.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.messages import ModelMessage, ModelMessagesTypeAdapter, ModelResponse, ToolCallPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.tools import DeferredToolRequests
+from pydantic_ai.toolsets import AbstractToolset, FunctionToolset
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.agents.capabilities import (
+    REGISTRY,
+    CapabilityBuildContext,
+    CapabilityToolInfo,
+    load_builtins,
+    register,
+)
+from app.agents.factory import build_agent
+from app.agents.model_resolver import ModelRequestSpec, ResolvedCredential
+from app.agents.spec import AgentSpec
+from app.core.secret_kinds import ApiKeySecret
+from app.db.models.agent import Agent, AgentVersion
+from app.db.models.agent_run import AgentRun, RunStatus, ToolApproval
+from app.db.models.organization import Organization, OrganizationMember
+from app.db.models.user import User
+from app.repositories import agent_run_repo
+from app.services.agent_runner import (
+    AgentRunnerService,
+    ApprovalChannel,
+    PausedRunState,
+    PreparedRun,
+)
+
+pytestmark = pytest.mark.anyio
+
+GATED_CAPABILITY = "test_concurrent_gated_action"
+GATED_TOOL = "send_email"
+
+
+@pytest.fixture(autouse=True)
+def _builtins_loaded():
+    load_builtins()
+
+
+@pytest.fixture(autouse=True)
+def gated_capability():
+    """A capability with one side-effecting tool, so every call parks on the gate."""
+
+    @register(
+        id=GATED_CAPABILITY,
+        name="Gated action",
+        category="test",
+        description="A side-effecting action that must be approved",
+        side_effecting=True,
+        tools=(CapabilityToolInfo(id=GATED_TOOL, description="Sends an email."),),
+    )
+    def _build(ctx: CapabilityBuildContext) -> _GatedAction:
+        return _GatedAction()
+
+    yield
+    REGISTRY.pop(GATED_CAPABILITY)
+
+
+class _GatedAction(AbstractCapability[Any]):
+    """One tool that runs only after a human says yes - and never does here."""
+
+    def get_toolset(self) -> AbstractToolset[Any]:
+        def send_email(to: str) -> str:
+            """Send an email to someone."""
+            return f"sent to {to}"
+
+        toolset: FunctionToolset[Any] = FunctionToolset()
+        toolset.add_function(send_email, takes_ctx=False)
+        return toolset
+
+
+def _two_gated_caller() -> FunctionModel:
+    """A model that answers one step with two calls to the gated tool.
+
+    "Email the customer and email the account manager" - the honest example from
+    the issue, and the one that drives two calls into the channel concurrently.
+    """
+
+    async def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[
+                ToolCallPart(tool_name=GATED_TOOL, args={"to": "customer"}, tool_call_id="call-a"),
+                ToolCallPart(tool_name=GATED_TOOL, args={"to": "manager"}, tool_call_id="call-b"),
+            ]
+        )
+
+    return FunctionModel(respond)
+
+
+def _model_spec() -> ModelRequestSpec:
+    return ModelRequestSpec(
+        profile_id=uuid.uuid4(),
+        label="GPT-4.1 (prod)",
+        provider="openai",
+        model="gpt-4.1",
+        params={},
+        credential=ResolvedCredential(
+            provider="openai", secret=ApiKeySecret(api_key="sk-test-key")
+        ),
+        fallbacks=[],
+    )
+
+
+async def _org(db: AsyncSession) -> Organization:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"{uuid.uuid4().hex}@example.com",
+        hashed_password="x",
+        is_active=True,
+    )
+    db.add(user)
+    await db.flush()
+    org = Organization(
+        id=uuid.uuid4(),
+        name="Acme",
+        slug=f"acme-{uuid.uuid4().hex[:8]}",
+        created_by_user_id=user.id,
+    )
+    db.add(org)
+    await db.flush()
+    db.add(
+        OrganizationMember(id=uuid.uuid4(), organization_id=org.id, user_id=user.id, role="owner")
+    )
+    await db.flush()
+    return org
+
+
+async def _published(db: AsyncSession, org: Organization) -> tuple[Agent, AgentVersion]:
+    agent = Agent(
+        id=uuid.uuid4(),
+        organization_id=org.id,
+        slug=f"clerk-{uuid.uuid4().hex[:8]}",
+        name="Clerk",
+        draft_spec={},
+    )
+    db.add(agent)
+    await db.flush()
+    version = AgentVersion(
+        id=uuid.uuid4(),
+        organization_id=org.id,
+        agent_id=agent.id,
+        version=1,
+        spec={"name": agent.name},
+    )
+    db.add(version)
+    await db.flush()
+    return agent, version
+
+
+async def test_two_gated_calls_in_one_step_park_once_and_write_two_rows(db, engine):
+    """The regression: park once, two distinct rows, session still usable.
+
+    Before the fix the two concurrent tool calls each wrote their row on the shared
+    session and corrupted it; here the writes are deferred to the run's terminal
+    write, so the parent's finished row committing beside the two approval rows is
+    what proves the session survived.
+    """
+    org = await _org(db)
+    agent, version = await _published(db, org)
+    run = await agent_run_repo.create_run(
+        db,
+        organization_id=org.id,
+        agent_id=agent.id,
+        agent_version_id=version.id,
+        user_id=None,
+        conversation_id=None,
+        surface="api",
+        model_label="gpt-4.1",
+        provider="openai",
+        secret_id=None,
+        started_at=datetime.now(UTC),
+    )
+
+    spec = AgentSpec(name="Clerk", capabilities=[{"id": GATED_CAPABILITY, "approval": "required"}])
+    channel = ApprovalChannel(organization_id=org.id, agent_id=agent.id, run_id=run.id)
+    built = build_agent(
+        spec,
+        _model_spec(),
+        organization_id=org.id,
+        agent_id=agent.id,
+        run_id=run.id,
+        request_approval=channel,
+    )
+
+    with built.agent.override(model=_two_gated_caller()):
+        result = await built.agent.run(
+            "email the customer and the account manager", deps=built.deps
+        )
+
+    # One step, both calls gated: the run parks rather than answering, and names
+    # both. Concurrent execution of the two calls is what used to race the session.
+    assert isinstance(result.output, DeferredToolRequests)
+    assert sorted(call.tool_call_id for call in result.output.approvals) == ["call-a", "call-b"]
+    assert len(channel.requested) == 2
+
+    prepared = PreparedRun(run=run, agent=agent, spec=spec, built=built, approvals=channel)
+    await AgentRunnerService(db).finish(
+        prepared,
+        status=RunStatus.AWAITING_APPROVAL,
+        paused_state=PausedRunState(
+            messages=ModelMessagesTypeAdapter.dump_python(result.all_messages(), mode="json"),
+            tool_call_ids=channel.parked,
+        ),
+    )
+    await db.commit()
+
+    # Read in another session: the question is what was committed, and this one's
+    # identity map would answer with what it holds regardless.
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as fresh:
+        finished = await fresh.get(AgentRun, run.id)
+        rows = (
+            (await fresh.execute(select(ToolApproval).where(ToolApproval.run_id == run.id)))
+            .scalars()
+            .all()
+        )
+
+    # The session survived two concurrent gated calls: its terminal write committed.
+    assert finished is not None
+    assert finished.status == RunStatus.AWAITING_APPROVAL.value
+    # Two rows, with distinct ids - not one row written twice, nor one lost to a
+    # race - and both against the gated tool.
+    assert len(rows) == 2
+    assert len({row.id for row in rows}) == 2
+    assert {row.tool_id for row in rows} == {GATED_TOOL}
+    # And the ids the row-writes used are the ones the channel allocated when it
+    # parked, which are what the stored state names for the resume to find them.
+    assert {row.id for row in rows} == {parked.approval_id for parked in channel.requested}
+    assert set(finished.paused_state["tool_call_ids"]) == {str(row.id) for row in rows}

--- a/backend/tests/integration/test_delegation_row_failures.py
+++ b/backend/tests/integration/test_delegation_row_failures.py
@@ -128,8 +128,11 @@ def _prepared(run: AgentRun, agent: Agent, delegations: list[RecordedDelegation]
         run=run,
         agent=agent,
         spec=MagicMock(),
+        # An empty channel: this run parked no approvals, so `finish` has none to
+        # write. A bare `MagicMock` would make `_write_approvals` try to iterate a
+        # mock and fail before the delegation write under test ran.
         built=MagicMock(ledger=ledger),
-        approvals=MagicMock(),
+        approvals=MagicMock(requested=[]),
         delegations=delegations,
     )
 

--- a/backend/tests/integration/test_platform_flows.py
+++ b/backend/tests/integration/test_platform_flows.py
@@ -2125,6 +2125,7 @@ class TestDecidingAnApproval:
         )
         approvals = ApprovalService(db)
         approval = await approvals.request(
+            approval_id=uuid.uuid4(),
             organization_id=tenant.organization.id,
             run_id=run.id,
             agent_id=agent.id,
@@ -2156,6 +2157,7 @@ class TestDecidingAnApproval:
         )
         approvals = ApprovalService(db)
         approval = await approvals.request(
+            approval_id=uuid.uuid4(),
             organization_id=tenant.organization.id,
             run_id=run.id,
             agent_id=agent.id,

--- a/backend/tests/test_agent_runner.py
+++ b/backend/tests/test_agent_runner.py
@@ -527,9 +527,7 @@ class TestWhatAParkedCallRecords:
 
     @pytest.mark.anyio
     async def test_a_parked_call_records_the_row_the_decision_goes_against(self):
-        approval = MagicMock(id=uuid.uuid4())
         channel = ApprovalChannel(
-            approvals=MagicMock(request=AsyncMock(return_value=approval)),
             organization_id=uuid.uuid4(),
             agent_id=uuid.uuid4(),
             run_id=uuid.uuid4(),
@@ -540,8 +538,11 @@ class TestWhatAParkedCallRecords:
 
         await channel(request)
 
+        # The id is allocated here, not by the database: parking touches no session,
+        # so the row is written afterwards against this id (agenticos#169).
         [parked] = channel.requested
-        assert parked.approval_id == approval.id
+        assert isinstance(parked.approval_id, uuid.UUID)
+        assert channel.parked == {str(parked.approval_id): "tc-1"}
         # The model's own id as well as the row's: one addresses the decision, the
         # other addresses the card already on screen.
         assert parked.tool_call_id == "tc-1"
@@ -553,7 +554,6 @@ class TestWhatAParkedCallRecords:
         """A decision is consumed on use, so an approved call runs rather than
         parking again - and nothing is put back in front of anybody."""
         channel = ApprovalChannel(
-            approvals=MagicMock(request=AsyncMock()),
             organization_id=uuid.uuid4(),
             agent_id=uuid.uuid4(),
             run_id=uuid.uuid4(),

--- a/backend/tests/test_approval_gate.py
+++ b/backend/tests/test_approval_gate.py
@@ -11,6 +11,7 @@ parked run that never continues. It drives a real agent through park and resume.
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from dataclasses import dataclass
 from typing import Any
@@ -217,10 +218,7 @@ class TestGate:
 class TestApprovalChannel:
     @pytest.mark.anyio
     async def test_a_first_ask_parks_the_call_and_remembers_which_one(self):
-        approval = MagicMock(id=uuid.uuid4())
-        approvals = MagicMock(request=AsyncMock(return_value=approval))
         channel = ApprovalChannel(
-            approvals=approvals,
             organization_id=uuid.uuid4(),
             agent_id=uuid.uuid4(),
             run_id=uuid.uuid4(),
@@ -236,17 +234,19 @@ class TestApprovalChannel:
         )
 
         assert isinstance(decision, ApprovalPending)
-        # The approver reads the tool and its arguments, not the capability id.
-        assert approvals.request.call_args.kwargs["tool_id"] == "send_email"
-        assert approvals.request.call_args.kwargs["tool_args"] == {"to": "a@example.com"}
-        assert channel.parked == {str(approval.id): "call-1"}
+        # Parking writes no row - the id is allocated here and the row follows at the
+        # run's terminal write. What the channel remembers is enough to write it:
+        # the approver reads the tool and its arguments, not the capability id.
+        [parked] = channel.requested
+        assert parked.tool_name == "send_email"
+        assert parked.tool_args == {"to": "a@example.com"}
+        # The allocated id maps to the model's call, both here and in `requested`.
+        assert channel.parked == {str(parked.approval_id): "call-1"}
 
     @pytest.mark.anyio
     async def test_a_decision_authorises_one_call_only(self):
         """One "yes" must not authorise a loop of the same side effect."""
-        approvals = MagicMock(request=AsyncMock(return_value=MagicMock(id=uuid.uuid4())))
         channel = ApprovalChannel(
-            approvals=approvals,
             organization_id=uuid.uuid4(),
             agent_id=uuid.uuid4(),
             run_id=uuid.uuid4(),
@@ -264,7 +264,41 @@ class TestApprovalChannel:
 
         assert isinstance(first, ApprovalGranted)
         assert isinstance(second, ApprovalPending)
-        approvals.request.assert_awaited_once()
+        # The decision was consumed by the first call, so only the second parked.
+        assert len(channel.requested) == 1
+
+    @pytest.mark.anyio
+    async def test_two_calls_in_one_step_park_concurrently_without_a_session(self):
+        """The property behind agenticos#169: parking touches no shared session.
+
+        Pydantic AI runs the tool calls from one model response concurrently, so two
+        gated calls reach the channel at once. When each wrote its own approval row
+        on the request's shared `AsyncSession`, the two flushes corrupted it. The
+        channel now holds no session at all and `__call__` never awaits - so this
+        drives both calls concurrently and asserts each parked with an id of its own,
+        which is exactly what a write on a shared session could not have guaranteed.
+        """
+        channel = ApprovalChannel(
+            organization_id=uuid.uuid4(),
+            agent_id=uuid.uuid4(),
+            run_id=uuid.uuid4(),
+        )
+        calls = [
+            ApprovalRequest(
+                capability_id="email",
+                tool_name="send_email",
+                tool_call_id=f"call-{n}",
+                tool_args={"to": f"{n}@example.com"},
+            )
+            for n in (1, 2)
+        ]
+
+        decisions = await asyncio.gather(*(channel(call) for call in calls))
+
+        assert all(isinstance(decision, ApprovalPending) for decision in decisions)
+        # Two rows-to-be, each with its own id, and the parked map names both calls.
+        assert len({parked.approval_id for parked in channel.requested}) == 2
+        assert set(channel.parked.values()) == {"call-1", "call-2"}
 
 
 class TestApprovalQueue:
@@ -278,8 +312,9 @@ class TestApprovalQueue:
         to travel as explicit ids - and the arguments especially: approving
         "send_email" without seeing the recipient is a rubber stamp.
         """
+        approval_id = uuid.uuid4()
         organization_id, run_id, agent_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
-        approval = MagicMock(id=uuid.uuid4())
+        approval = MagicMock(id=approval_id)
         db = MagicMock(flush=AsyncMock(), refresh=AsyncMock())
 
         with patch(
@@ -287,6 +322,7 @@ class TestApprovalQueue:
             new=AsyncMock(return_value=approval),
         ) as parked:
             requested = await ApprovalService(db).request(
+                approval_id=approval_id,
                 organization_id=organization_id,
                 run_id=run_id,
                 agent_id=agent_id,
@@ -296,6 +332,9 @@ class TestApprovalQueue:
 
         assert requested is approval
         assert parked.call_args.kwargs == {
+            # The id is allocated when the call is parked, not by the database, so
+            # the row matches the `paused_state` that already names it.
+            "approval_id": approval_id,
             "organization_id": organization_id,
             "run_id": run_id,
             "agent_id": agent_id,
@@ -421,7 +460,6 @@ class TestParkAndResume:
 
     def _channel(self, run_id: uuid.UUID, **kwargs: Any) -> ApprovalChannel:
         return ApprovalChannel(
-            approvals=MagicMock(request=AsyncMock(return_value=MagicMock(id=uuid.uuid4()))),
             organization_id=uuid.uuid4(),
             agent_id=uuid.uuid4(),
             run_id=run_id,

--- a/backend/tests/test_repositories.py
+++ b/backend/tests/test_repositories.py
@@ -80,3 +80,34 @@ class TestUserRepository:
         assert removed == 3
         statement = str(mock_session.execute.call_args.args[0])
         assert "is_app_admin" in statement
+
+
+class TestAgentRepositoryLock:
+    """The lock `existing_ids_locked` takes when the approval writer resolves delegates."""
+
+    @pytest.mark.anyio
+    async def test_it_takes_for_key_share_not_for_no_key_update(self):
+        """`FOR KEY SHARE` holds against deletion while letting ordinary updates through.
+
+        `.with_for_update(key_share=True)` alone compiles to `FOR NO KEY UPDATE`
+        in SQLAlchemy's PostgreSQL dialect, which needlessly blocks a concurrent
+        agent update until the run transaction commits. `read=True, key_share=True`
+        is what emits the intended `FOR KEY SHARE` - the lock an insert referencing
+        the row takes anyway, so a concurrent delete still cannot slip in but an
+        ordinary update is not held.
+        """
+        from uuid import uuid4
+
+        from sqlalchemy.dialects import postgresql
+
+        from app.repositories import agent as agent_repo
+
+        session = MagicMock()
+        session.execute = AsyncMock(return_value=MagicMock(scalars=lambda: MagicMock(all=list)))
+
+        await agent_repo.existing_ids_locked(session, {uuid4()}, organization_id=uuid4())
+
+        statement = session.execute.call_args.args[0]
+        sql = str(statement.compile(dialect=postgresql.dialect()))
+        assert "FOR KEY SHARE" in sql
+        assert "FOR NO KEY UPDATE" not in sql

--- a/backend/tests/test_subagent_nested_resume.py
+++ b/backend/tests/test_subagent_nested_resume.py
@@ -393,6 +393,11 @@ class _Queue:
     Stood in for rather than mocked out, because the real `ApprovalChannel` is under
     test: it is what decides which delegate a row is attributed to, and it is where
     a parked call is tied to the agent whose replay it belongs to.
+
+    Rows land here from :func:`_write_approvals`, not from the channel itself - the
+    same split production makes: the channel parks a call without touching any
+    session (agenticos#169), and the row is written once at the run's terminal
+    write, with the id the channel already allocated.
     """
 
     def __init__(self) -> None:
@@ -401,6 +406,7 @@ class _Queue:
     async def request(
         self,
         *,
+        approval_id: UUID,
         organization_id: UUID,
         run_id: UUID,
         agent_id: UUID,
@@ -410,7 +416,7 @@ class _Queue:
         subagent_agent_id: UUID | None = None,
     ) -> _Row:
         row = _Row(
-            id=uuid4(),
+            id=approval_id,
             tool_id=tool_id,
             tool_args=tool_args,
             subagent_name=subagent_name,
@@ -427,14 +433,33 @@ class _Queue:
             row.note = note
 
 
-def _channel(queue: _Queue, decided: dict[str, Any] | None = None) -> ApprovalChannel:
+def _channel(decided: dict[str, Any] | None = None) -> ApprovalChannel:
     return ApprovalChannel(
-        approvals=queue,  # ty: ignore[invalid-argument-type] - the queue above stands in
         organization_id=uuid4(),
         agent_id=uuid4(),
         run_id=uuid4(),
         decided=decided or {},
     )
+
+
+async def _write_approvals(channel: ApprovalChannel, queue: _Queue) -> None:
+    """Drain a parked channel into the queue, the way `_write_approvals` does.
+
+    The rows are written from the run's terminal write, not while it ran - so a test
+    that parks a run and then reads or decides its rows has to make this call in
+    between, exactly where a real run's `finish` makes it.
+    """
+    for parked in channel.requested:
+        await queue.request(
+            approval_id=parked.approval_id,
+            organization_id=channel.organization_id,
+            run_id=channel.run_id,
+            agent_id=channel.agent_id,
+            tool_id=parked.tool_name,
+            tool_args=parked.tool_args,
+            subagent_name=parked.subagent,
+            subagent_agent_id=parked.subagent_agent_id,
+        )
 
 
 @dataclass
@@ -456,10 +481,11 @@ async def _park(delegate: ResolvedSubagent, stash: DelegationStash) -> _Parked:
     what a real run would have written.
     """
     queue = _Queue()
-    channel = _channel(queue)
+    channel = _channel()
     agent, deps = _orchestrator(delegate, stash=stash, channel=channel)
     result = await agent.run("what is the weather in Krakow", deps=deps)
     assert isinstance(result.output, DeferredToolRequests), result.output
+    await _write_approvals(channel, queue)
     return _Parked(
         state=_parked_state(result, channel=channel, stash=stash),
         queue=queue,
@@ -527,7 +553,7 @@ async def _resume(
     agent, deps = _orchestrator(
         delegate(stash),
         stash=stash,
-        channel=_channel(parked.queue, decided=decided),
+        channel=_channel(decided=decided),
         record=record,
     )
     return await agent.run(
@@ -554,7 +580,7 @@ class TestOneLevelDown:
         ungated_agent, ungated_deps = _orchestrator(
             _specialist_delegate(gated=False, calls=ungated_calls),
             stash=DelegationStash(),
-            channel=_channel(_Queue()),
+            channel=_channel(),
         )
         expected = _answer(
             await ungated_agent.run("what is the weather in Krakow", deps=ungated_deps)
@@ -703,7 +729,7 @@ class TestEitherEntryPoint:
         resumed, decided = await _park_the_specialist_alone(gated=True)
         journal = _journal_mid_delegation(delegate, resuming={"the-task-call": resumed})
         proxy = _LazyAgent(delegate, journal)
-        deps = AgentDeps(request_approval=_channel(_Queue(), decided=decided))
+        deps = AgentDeps(request_approval=_channel(decided=decided))
 
         with journal.delegating(
             journal.begin(
@@ -738,11 +764,12 @@ async def _park_the_specialist_alone(*, gated: bool) -> tuple[Any, dict[str, Any
     gate asked, a real run ended with its parked calls as its output.
     """
     queue = _Queue()
-    channel = _channel(queue)
+    channel = _channel()
     result = await _specialist_agent(gated=gated, calls=[]).run(
         "the weather in Krakow", deps=AgentDeps(request_approval=channel)
     )
     assert isinstance(result.output, DeferredToolRequests)
+    await _write_approvals(channel, queue)
     queue.decide(approved=True)
     return (
         ResumedDelegation(
@@ -844,10 +871,11 @@ class TestAnOlderParkedRun:
         """
         calls: list[dict[str, Any]] = []
         queue = _Queue()
-        channel = _channel(queue)
+        channel = _channel()
         agent = _specialist_agent(gated=True, calls=calls)
         parked = await agent.run("the weather in Krakow", deps=AgentDeps(request_approval=channel))
         assert isinstance(parked.output, DeferredToolRequests)
+        await _write_approvals(channel, queue)
         stored: dict[str, Any] = {
             "messages": ModelMessagesTypeAdapter.dump_python(parked.all_messages(), mode="json"),
             "tool_call_ids": dict(channel.parked),
@@ -863,7 +891,6 @@ class TestAnOlderParkedRun:
             None,
             deps=AgentDeps(
                 request_approval=_channel(
-                    queue,
                     decided={
                         entry.tool_call_id: ApprovalGranted(tool_args=entry.tool_args)
                         for entry in channel.requested
@@ -893,7 +920,7 @@ class TestTwoLevelsDown:
         ungated_agent, ungated_deps = _orchestrator(
             _middle_delegate(gated=False, calls=ungated_calls, stash=ungated_stash),
             stash=ungated_stash,
-            channel=_channel(_Queue()),
+            channel=_channel(),
         )
         expected = _answer(
             await ungated_agent.run("what is the weather in Krakow", deps=ungated_deps)
@@ -1000,7 +1027,7 @@ async def _until_it_answers(
             )
             history = ModelMessagesTypeAdapter.validate_python(state.messages)
             results = plan.results
-        channel = _channel(queue, decided=decided)
+        channel = _channel(decided=decided)
         metering = _Metering(
             ledger=ledger,
             charge=_charging(ledger, cost, priced=turn not in unpriced_turns),
@@ -1022,6 +1049,7 @@ async def _until_it_answers(
         )
         if not isinstance(result.output, DeferredToolRequests):
             return parked, _answer(result)
+        await _write_approvals(channel, queue)
         queue.decide(approved=True)
         # Through the column and back, because that is the trip a park actually
         # makes: `paused_state` is JSONB, so a cost is stored as the string

--- a/backend/tests/test_tool_overrides.py
+++ b/backend/tests/test_tool_overrides.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass, field
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pydantic_ai.capabilities import AbstractCapability
@@ -293,7 +292,6 @@ class TestARenamedToolIsStillGated:
         """End to end: the model calls the new name and nothing happens without a human."""
         run_id = uuid.uuid4()
         channel = ApprovalChannel(
-            approvals=MagicMock(request=AsyncMock(return_value=MagicMock(id=uuid.uuid4()))),
             organization_id=uuid.uuid4(),
             agent_id=uuid.uuid4(),
             run_id=run_id,

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -262,7 +262,7 @@ Resolution is most-specific-first:
 The Builder states the outcome in words rather than describing the rule, because a
 rule the reader has to run in their head is a setting nobody dares touch.
 
-Three properties worth knowing:
+Four properties worth knowing:
 
 - **A parked run is resumable.** Its message history is stored, so the decision is
   applied to the conversation it belongs to rather than starting again.
@@ -270,6 +270,12 @@ Three properties worth knowing:
 - **`required` works on any capability**, not only side-effecting ones. "This only
   reads, but in my organization somebody approves it anyway" is a real decision
   and is expressible.
+- **One model step can park several calls.** A model that answers with two
+  side-effecting calls at once - "email the customer and the account manager" -
+  parks both, each its own approval row decided on its own. The rows are written
+  when the run parks rather than as each call is gated, because the calls run
+  concurrently and the run's database session is not concurrency-safe
+  ([#169](https://github.com/vstorm-co/agenticos/issues/169)).
 
 ### An approval inside a delegation
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -289,6 +289,13 @@ without saying whether the agent somebody is talking to or a specialist called
 delegation the thing being approved is often more consequential than the agent the
 reviewer thinks they are dealing with.
 
+Deleting that delegate does not erase the record of what it was authorised to do:
+the row keeps the delegate's name and drops only the link to its now-gone agent.
+This holds even when the delete lands while the run is still parked, before the
+approval row has been written - the deferred write ([#169](https://github.com/vstorm-co/agenticos/issues/169))
+resolves the delegates still present and writes a null id for one that vanished,
+exactly what deleting it after the row existed would have done.
+
 What the parent's run does is park, rather than be handed something that looks like
 a finished delegation. That is worth stating because it used to be otherwise: every
 agent built here declares an output type that lets a run end with its parked calls


### PR DESCRIPTION
## What this fixes

`ApprovalChannel.__call__` wrote the `ToolApproval` row inline — `await self.approvals.request(...)` → `db.add` + `flush` — on the request's `AsyncSession`, the one the whole run shares. Pydantic AI runs the tool calls from one model response concurrently, and `parallel_tool_calls` is unset by default, so a model that answers one step with two gated calls ("email the customer and email the account manager") drives two of these writes onto that session at once. Two concurrent flushes on one `AsyncSession` don't produce a slow query — they corrupt the session, and the session belongs to the whole request, so the damage reaches the parent run row and the conversation, not just the approval that raced.

Closes #169.

## What changed

The same shape delegation already uses for its child-run rows (`_delegation_recorder` / `_write_delegations`): describe the row while the run runs, write it once at the run's terminal write, off the shared session.

- `app/services/agent_runner.py` — `ApprovalChannel.__call__` no longer awaits or touches a session. It allocates the approval id itself (`uuid4()`), records a `ParkedApproval`, and returns `ApprovalPending()`. The body is now synchronous — a dict set and a list append, each atomic under the GIL — so two concurrent gated calls cannot interleave inside it.
- `app/services/agent_runner.py` — new `_write_approvals`, called from `finish` (the one place both surfaces converge and the session is certainly not shared with a tool call). It drains `channel.requested` and writes each row with the id already allocated. Unlike `_write_delegations` it does **not** swallow failures: a delegation row is attribution, but a missing approval row leaves a parked run that cannot be continued for that call, so the write has to fail loudly rather than strand it.
- `ParkedApproval` gains `subagent_agent_id` — the deferred write needs it, and the `acting_delegate()` contextvar is long gone by the time `finish` runs.
- `app/services/approvals.py` + `app/repositories/agent_run.py` — `request` / `create_approval` take the pre-allocated `approval_id` (the `ToolApproval.id` client-side default is otherwise minted by the model layer; here it must match the id already in `paused_state`).
- `app/agents/capabilities/subagents/README.md`, `docs/governance.md` — the "background delegation gets no approval channel" reasoning no longer rests on a write racing the shared session (there is no write during the call now); the conclusion is unchanged. Governance gains one behaviour-level property: one model step can park several calls.

## How it failed before

Two gated tool calls in one model step → two concurrent `db.add`+`flush` on the shared `AsyncSession` → corrupted session, taking the parent run row and the conversation with it. Never seen because every existing test drove one gated call at a time and `parallel_tool_calls` is unset, so whether two calls arrive in one step depends on the provider and the prompt — a live path, not a theoretical one.

## Testing

- `tests/integration/test_concurrent_approvals.py::test_two_gated_calls_in_one_step_park_once_and_write_two_rows` — a real agent whose model emits two gated calls in one response, against a real Postgres: the run parks once naming both, two rows are written with distinct ids, and the parent's terminal row commits beside them (which is what proves the session survived). This is the check #169 asked for.
- `tests/test_approval_gate.py::test_two_calls_in_one_step_park_concurrently_without_a_session` — the structural property, deterministic: two `__call__`s under `asyncio.gather`, each parking with an id of its own, on a channel that holds no session at all.
- Updated the existing park/resume harness (`test_subagent_nested_resume.py`) to write rows from a terminal-write drain rather than from the channel — mirroring the production move — plus the channel-construction and `ApprovalService.request` call sites across four test files.
- `make check` green (lint + `make test` 100 % platform gate + frontend + docs-build + audit). `_write_approvals` is covered by the unit suite via the existing `finish` test as well as the new tests.

## Note on the race itself

The corruption is a nondeterministic data race, so there is no test that flips red purely by scheduling. The fix is structural — `__call__` no longer awaits, so no write is on the concurrent path — and the tests pin that structure: rows written from the terminal write, distinct ids, and the committed parent row as evidence the session was still usable.

## Noticed, not fixed

- #17 (two approvers *deciding* one approval concurrently) is the same table and the same missing concurrency discipline on the other end of the row; out of scope here, left as its own issue.
- #152 (approval from a channel) adds a second path into `ApprovalChannel` — the deferred-write shape holds for it, since the write happens at the run's terminal write regardless of where the decision is later delivered.
