### PR TITLE
feat(subagents): let a sync delegate ask the person waiting on its parent

### DIFF
--- a/backend/app/agents/ask_user.py
+++ b/backend/app/agents/ask_user.py
@@ -33,13 +33,24 @@ class QuestionItem(BaseModel):
     )
 
 
+def render_answer(answer: dict[str, Any] | None) -> str:
+    """One collected answer, as the model should read it.
+
+    A missing or malformed entry is "(no answer)" rather than an error: the surface
+    returns a list parallel to the questions, and a delegate that asked one question
+    reads one answer whether or not the person typed anything.
+    """
+    if not isinstance(answer, dict):
+        return "(no answer)"
+    if answer.get("skipped"):
+        return "(skipped)"
+    return str(answer.get("answer", "")).strip() or "(no answer)"
+
+
 def format_answers(questions: list[dict[str, Any]], answers: list[dict[str, Any]]) -> str:
     """Render the collected answers as a readable Q/A transcript for the model."""
     lines: list[str] = []
     for i, q in enumerate(questions):
-        a = answers[i] if i < len(answers) else {}
-        if not isinstance(a, dict):
-            a = {}
-        ans = "(skipped)" if a.get("skipped") else str(a.get("answer", "")).strip() or "(no answer)"
-        lines.append(f"Q: {q.get('question', '')}\nA: {ans}")
+        a = answers[i] if i < len(answers) else None
+        lines.append(f"Q: {q.get('question', '')}\nA: {render_answer(a)}")
     return "\n\n".join(lines)

--- a/backend/app/agents/capabilities/subagents/README.md
+++ b/backend/app/agents/capabilities/subagents/README.md
@@ -216,27 +216,34 @@ itself no longer holds a session — a parked call is described and the row writ
 from the run's terminal write, agenticos#169 — so this is about where the decision
 can be delivered, not about a write racing the shared session.)
 
-**Let a delegate ask the parent a question.** The library's `ask_parent` tool is
-injected only into agents it built itself, and every delegate here arrives
-pre-built — so `task` passes `inject_ask_parent=False` for a pinned delegate and an
-inline specialist alike, and `_autonomously` closes the two dynamic entry points as
-well. A specialist works autonomously and says so if it could not; a specialist that
-needs a person reaches one through its own capabilities, on the parent's channels,
-which `AgentDeps.clone_for_subagent` passes down.
+**A delegate asks the parent a question only when its author allows it.** Off by
+default: a specialist works autonomously and says so if it could not. An author who
+wants the other behaviour sets `allow_questions`, and `_config_for` then grants
+`can_ask_questions` to each configured delegate whose mode is sync — a sync question
+is answered by `ctx.deps.ask_user`, the person already holding the parent's tool
+call, which `AgentDeps.clone_for_subagent` passes down. It is granted only for a
+sync delegation: a background one has handed back a task id with nobody left to
+answer, and `auto` may become one. A specialist a model *invents* never asks,
+whatever the author set — `_autonomously` holds the two dynamic entry points to
+autonomy, because a question wearing instructions a model wrote a moment ago is not
+the author's to put to a person. Reaching a pre-built delegate at all took an
+upstream change: the library injected `ask_parent` only into agents it built itself
+until subagents-pydantic-ai#76, which honours `can_ask_questions` for a
+caller-supplied agent too — every delegate here is one.
 
 So **`answer_subagent` is declared and offered to nobody** — `UNREACHABLE_TOOLS`,
-applied as a filter in `get_toolset`. It replies to a question that cannot be asked,
-and the library adds it to its toolset unconditionally, so the offered set is the
-only place the decision can be made. Declared still, because a tool absent from
-`tools=` can be neither gated by the approval policy nor renamed by a binding, and
-that half is silent; filtered, because the other half is a description in every
-turn's context inviting a call whose only answer is "that delegation is not waiting
-for an answer". Opening the path is a feature rather than a repair, and which
-channel answers depends on the mode: a `sync` question is answered by a *person*,
-through `ask_user`, and never through this tool — so it becomes reachable only for a
-background delegation, whose question the parent's own model answers while nothing
-obliges it to look. agenticos#184 is the sync half, worth doing on its own terms, and
-it would not make this tool reachable.
+applied as a filter in `get_toolset`. It answers a question a *background* delegate
+parked on, and no delegate here parks on one: a sync question goes to a person
+through `ask_user` and never this tool, and an async delegate is not granted
+`can_ask_questions` at all. The library adds the tool to its toolset
+unconditionally, so the offered set is the only place the decision can be made.
+Declared still, because a tool absent from `tools=` can be neither gated by the
+approval policy nor renamed by a binding, and that half is silent; filtered, because
+the other half is a description in every turn's context inviting a call whose only
+answer is "that delegation is not waiting for an answer". agenticos#184 opened the
+sync half — a person answering — and left this tool unreachable; the background half,
+where the parent's own model answers while nothing obliges it to look, is what would
+empty the set.
 
 ## Background delegation, and what it costs
 

--- a/backend/app/agents/capabilities/subagents/__init__.py
+++ b/backend/app/agents/capabilities/subagents/__init__.py
@@ -84,6 +84,25 @@ class SubagentsConfig(BaseModel):
             "nobody left holding the run. Keep that work on sync."
         ),
     )
+    allow_questions: bool = Field(
+        default=False,
+        description=(
+            "Whether a delegate may ask the person waiting on this agent a question "
+            "instead of guessing - 'which currency?' rather than an assumption "
+            "buried in the answer. Off by default: a specialist works autonomously "
+            "and says so when it could not, and one that stops to ask holds this "
+            "agent's turn open on a person. The author's decision, not the model's - "
+            "the question wears a name the parent published, so whether it may be "
+            "asked at all is the author's to make. It reaches the same channel this "
+            "agent's own run uses to ask, and it is not the approval gate: a "
+            "question is not an authorisation and cannot grant one. Takes effect "
+            "only for a delegation that blocks (sync) - a background one has already "
+            "handed back a task id with nobody left to answer, and auto may become "
+            "one, so both still work autonomously however this is set. It governs "
+            "the specialists this agent was given, pinned or inline; a specialist "
+            "the model invents always works autonomously, whatever this says."
+        ),
+    )
     allow_dynamic: bool = Field(
         default=False,
         description=(
@@ -201,6 +220,7 @@ def _build(ctx: CapabilityBuildContext) -> Delegation | None:
     return build_delegation(
         runtime=runtime,
         mode=config.mode,
+        allow_questions=config.allow_questions,
         max_fanout=config.max_fanout,
         max_result_chars=config.max_result_chars,
         # How far in this run's delegations already are, which is what a surface

--- a/backend/app/agents/capabilities/subagents/_capability.py
+++ b/backend/app/agents/capabilities/subagents/_capability.py
@@ -217,14 +217,15 @@ exactly - see the `descriptions` argument in `build_delegation`.
 UNREACHABLE_TOOLS: frozenset[str] = frozenset({"answer_subagent"})
 """Declared for the Builder and the approval policy, and offered to no model.
 
-`answer_subagent` replies to a question a delegate asked, and no delegate here can
-ask one. The library injects its `ask_parent` tool only into agents it built
-itself, and every delegate on this platform arrives pre-built as
-`SubAgentConfig["agent"]` from :func:`_config_for` - so the library's `task` passes
-`inject_ask_parent=False` for a pinned delegate and an inline specialist alike, and
-:func:`~app.agents.capabilities.subagents._toolset._autonomously` closes the two
-dynamic entry points as well. `TaskStatus.WAITING_FOR_ANSWER` is therefore never
-reached, and this tool has nothing it could ever answer.
+`answer_subagent` replies to a question a *background* delegate parked on, and no
+delegate here parks on one. A `sync` delegate now can ask - agenticos#184, when its
+author set `allow_questions` and its mode is sync - but a sync question is answered
+by `ctx.deps.ask_user`, a person holding the parent's tool call, and never through
+this tool: the library only routes a question here for an `async` delegation, which
+parks in `TaskStatus.WAITING_FOR_ANSWER` awaiting the parent's own model. And an
+`async` delegate cannot ask: :func:`_config_for` grants `can_ask_questions` only for
+a sync-configured one, and `TaskStatus.WAITING_FOR_ANSWER` is therefore never
+reached. So this tool still has nothing it could ever answer.
 
 *Filtered rather than left out of* :data:`DELEGATION_TOOLS`, because those are two
 different failures and only one of them is loud. A tool the model is offered and
@@ -235,18 +236,15 @@ be gated by the approval policy or renamed by a binding, and *that* half is sile
 So it stays declared and stops being offered, which is the same shape the two
 dynamic entry points had while they were declared and unwired.
 
-*Opening the path instead was the alternative, and it is a feature rather than a
-repair.* Which channel answers a question is decided by the mode: a `sync`
-delegation is answered from `ask_callback` or `ctx.deps.ask_user` - a person, and
-never through this tool - so this tool becomes reachable only for a *background*
-delegation, whose question is answered by the parent's own model through a future
-the library's task manager holds. That is the harder half: the delegate blocks for
-up to `ask_timeout_seconds` holding a fan-out slot while nothing obliges the parent
-to look, and `wrap_run` cancels every background task when the turn ends - money
-spent on a question nobody was asked. So agenticos#184 - letting a `sync` delegate
-ask the person already waiting - is worth doing and would **not** empty this set on
-its own: a sync answer never arrives through this tool. Only the background half
-does, which is why the two are one issue with two halves rather than one change.
+*Opening this tool is the background half of the same question, and it is the
+harder half.* Which channel answers is decided by the mode: agenticos#184 opened
+the sync half above, answered by a person and never here. This tool becomes
+reachable only for a *background* delegation, whose question the parent's own model
+answers through a future the library's task manager holds - and the delegate blocks
+for up to `ask_timeout_seconds` holding a fan-out slot while nothing obliges the
+parent to look, and `wrap_run` cancels every background task when the turn ends:
+money spent on a question nobody was asked. So the set is emptied only when that
+half is answered too, which is why the two were one issue with two halves.
 """
 
 
@@ -716,6 +714,7 @@ def build_delegation(
     *,
     runtime: SubagentRuntime,
     mode: DelegationMode,
+    allow_questions: bool,
     max_fanout: int,
     depth: int,
     max_result_chars: int,
@@ -734,13 +733,23 @@ def build_delegation(
             agent may invent specialists of its own.
         mode: Whether delegations block, run in the background, or are decided per
             task.
+        allow_questions: Whether a delegate whose configured mode is sync may ask
+            the person waiting on this agent a question. The author's decision; off
+            for a specialist the model invents, and inert for a background or `auto`
+            delegation.
         max_fanout: How many delegations may run at once.
         depth: How far inside the run's own agent these delegations are, which is
             what a surface needs to nest their panels.
         max_result_chars: How much of a finished delegation's answer the
             `wait_tasks` listing carries before pointing at `check_task`.
     """
-    journal = DelegationJournal(runtime=runtime, mode=mode, max_fanout=max_fanout, depth=depth)
+    journal = DelegationJournal(
+        runtime=runtime,
+        mode=mode,
+        allow_questions=allow_questions,
+        max_fanout=max_fanout,
+        depth=depth,
+    )
     dynamic = runtime.dynamic
     # The registry `create_agent` writes into, owned here rather than left to the
     # library so this platform can read it back when the run ends and seed it when a
@@ -900,11 +909,24 @@ def _config_for(delegate: ResolvedSubagent, journal: DelegationJournal) -> SubAg
     the run already parked on - are about *the delegation now executing* rather
     than about this delegate. A delegate can be delegated to twice in one run, once
     each way, and once from a stashed position.
+
+    `can_ask_questions` is set explicitly rather than left to the library's `True`
+    default, and this is where the author's `allow_questions` reaches a delegate.
+    The library injects `ask_parent` into a delegate whose agent this platform
+    supplied - every one here - only when the config asks for it, so absent this
+    line a delegate would inherit the default and every one of them would gain the
+    tool. It is granted only for a delegate whose *configured* mode is sync: the
+    library answers a sync question from `ctx.deps.ask_user`, the parent's own
+    channel and the person already holding the parent's tool call, whereas a
+    background one has handed back a task id with nobody left to answer and `auto`
+    may become one. So the mode gates it as much as the flag does.
     """
+    configured_mode = delegate.preferred_mode or journal.mode
     return SubAgentConfig(
         name=delegate.name,
         description=delegate.description,
         instructions="",
+        can_ask_questions=journal.allow_questions and configured_mode == "sync",
         agent=_LazyAgent(delegate, journal),
     )
 

--- a/backend/app/agents/capabilities/subagents/_journal.py
+++ b/backend/app/agents/capabilities/subagents/_journal.py
@@ -346,6 +346,15 @@ class DelegationJournal:
     mode: DelegationMode
     max_fanout: int
     depth: int
+    allow_questions: bool = False
+    """Whether a delegate whose configured mode is sync may ask the parent's person.
+
+    The author's decision, read by :func:`~app.agents.capabilities.subagents._capability._config_for`
+    to set `can_ask_questions` on each configured delegate. Only a delegation whose
+    configured mode is `sync` honours it - a background one has nobody left to
+    answer, and `auto` may become one - so this alone does not decide it; the mode
+    does too. Off for a specialist the model invents, always.
+    """
 
     tasks: TaskManager = field(init=False, repr=False)
     """The library's task manager, assigned once the library capability exists.

--- a/backend/app/agents/capabilities/subagents/_toolset.py
+++ b/backend/app/agents/capabilities/subagents/_toolset.py
@@ -38,12 +38,16 @@ here rather than in the library's own validation because the library validates
 what it was configured with and none of these three is expressible that way. See
 :meth:`DelegatingToolset._refuse_dynamic`.
 
-*A specialist never asks the parent a question.* Which is a decision about the
-arguments rather than about the call, so it is applied to them on the way past:
-see :func:`_autonomously`. This is the half of that decision the two dynamic entry
-points need; the library closes the configured ones itself, and
-:data:`~app.agents.capabilities.subagents._capability.UNREACHABLE_TOOLS` is what
-the two of them together mean for the tool that would have answered.
+*A specialist a model invents never asks the parent a question.* Which is a
+decision about the arguments rather than about the call, so it is applied to them
+on the way past: see :func:`_autonomously`. It closes only the two dynamic entry
+points, because they are the ones a model reaches with the licence at the library's
+`True` default. A *configured* delegate - pinned or inline - asks only when its
+author set `allow_questions` and its mode is sync, decided once when its config is
+built: see :func:`~app.agents.capabilities.subagents._capability._config_for`. A
+sync question is answered by the parent's own `ask_user` channel, never through the
+tool that :data:`~app.agents.capabilities.subagents._capability.UNREACHABLE_TOOLS`
+withholds - that one answers a *background* question, which no delegate here asks.
 
 Three entry points therefore reach a delegation - `task`, `delegate`, and `task`
 addressing something `create_agent` registered - and all three come through here.
@@ -266,10 +270,13 @@ def _autonomously(tool_args: dict[str, Any]) -> dict[str, Any]:
 
     The library injects an `ask_parent` toolset into every agent it built itself,
     which a dynamic specialist is - and `can_ask_questions` is a *model-supplied*
-    argument defaulting to `True`, so the model decides. This platform has already
-    decided, for every delegate: a specialist works autonomously and says so if it
-    could not, and one that needs a person reaches one through its own
-    capabilities, on the parent's channels.
+    argument defaulting to `True`, so the model decides. This platform decides
+    instead, and for a specialist a model invents the decision is fixed: it works
+    autonomously and says so if it could not. Whether a *configured* delegate may
+    ask is the author's `allow_questions`, applied in `_config_for`; a model
+    inventing a specialist a moment ago is not the person that decision belongs to,
+    so the two dynamic entry points are held to autonomy here whatever the author
+    set.
 
     Left at the model's discretion the tool would not merely be useless, it would
     work: `ask_parent` falls back to `ctx.deps.ask_user`, which

--- a/backend/app/agents/deps.py
+++ b/backend/app/agents/deps.py
@@ -20,7 +20,17 @@ from uuid import UUID
 from app.agents.approval import ApprovalDecision, ApprovalRequest
 from app.agents.subagent_events import SubagentEventSink
 
-AskUserCallback = Callable[[list[dict[str, Any]]], Awaitable[list[dict[str, Any]]]]
+AskUserCallback = Callable[[str, list[str]], Awaitable[str]]
+"""How a delegate reaches the person waiting on its parent, and back.
+
+One question in, one answer out, which is the shape `subagents_pydantic_ai`'s
+`ask_parent` tool calls `ctx.deps.ask_user` with - this field exists to feed that
+tool and nothing here calls it otherwise. A surface that batches its elicitation
+(the WebSocket asks a whole list at once) adapts that to this one-question shape at
+its edge; a surface that cannot hold a question open leaves it `None`, and a
+delegate that would ask is told a person could not be reached.
+"""
+
 ApprovalCallback = Callable[[ApprovalRequest], Awaitable[ApprovalDecision]]
 
 

--- a/backend/app/services/agent_session.py
+++ b/backend/app/services/agent_session.py
@@ -69,6 +69,14 @@ class AgentSession:
         self.current_conversation_id: str | None = None
         self._turn_task: asyncio.Task[None] | None = None
         self._ask_user_future: asyncio.Future[list[dict[str, Any]]] | None = None
+        # One question round on the wire at a time. The client renders a single
+        # `ask_user` form and its `ask_user_response` carries no correlation, and
+        # `_ask_user_future` is one slot - so two delegates asking at once (a
+        # fan-out of sync delegates, each reaching `ask_parent`) would otherwise
+        # have the second overwrite the first's future and strand it. The lock
+        # holds each round until its answer arrives, so questions queue rather
+        # than collide.
+        self._ask_lock = asyncio.Lock()
 
     async def handle_frame(self, data: dict[str, Any]) -> None:
         """Dispatch one incoming WebSocket frame.
@@ -318,15 +326,19 @@ class AgentSession:
         Emits an `ask_user` event with the whole batch, then awaits a future the
         frame dispatcher completes when the matching `ask_user_response` arrives.
         The client returns a list of answers parallel to the questions.
+
+        Held under `_ask_lock` so a second round - another delegate's question -
+        waits for this one's answer rather than overwriting its future.
         """
-        loop = asyncio.get_running_loop()
-        fut: asyncio.Future[list[dict[str, Any]]] = loop.create_future()
-        self._ask_user_future = fut
-        try:
-            await send_event(self.websocket, "ask_user", {"questions": questions})
-            return await fut
-        finally:
-            self._ask_user_future = None
+        async with self._ask_lock:
+            loop = asyncio.get_running_loop()
+            fut: asyncio.Future[list[dict[str, Any]]] = loop.create_future()
+            self._ask_user_future = fut
+            try:
+                await send_event(self.websocket, "ask_user", {"questions": questions})
+                return await fut
+            finally:
+                self._ask_user_future = None
 
     async def _subagent_event(self, event: SubagentEvent) -> None:
         """Forward one frame from inside a delegation, under the frame's own name.

--- a/backend/app/services/agent_session.py
+++ b/backend/app/services/agent_session.py
@@ -21,6 +21,7 @@ from pydantic_ai.messages import (
     ThinkingPartDelta,
 )
 
+from app.agents.ask_user import QuestionItem, render_answer
 from app.agents.capabilities.budget import BudgetExceeded
 from app.agents.subagent_events import SubagentEvent
 from app.core.exceptions import AppException, AuthorizationError
@@ -206,7 +207,7 @@ class AgentSession:
                     conversation_id=(
                         UUID(self.current_conversation_id) if self.current_conversation_id else None
                     ),
-                    ask_user=self._ask_user,
+                    ask_user=self._ask_one,
                     stream=stream,
                     subagent_events=self._subagent_event,
                     # The chat may run a published agent on another of the
@@ -298,6 +299,18 @@ class AgentSession:
         except Exception as e:
             logger.exception("Error processing agent request")
             await send_event(self.websocket, "error", {"message": str(e)})
+
+    async def _ask_one(self, question: str, options: list[str]) -> str:
+        """Put one question to the client and return the answer as a string.
+
+        The shape `AgentDeps.ask_user` promises, and what a delegate's `ask_parent`
+        calls. It adapts the one-question protocol to this surface's batch channel -
+        a list of one - so the WebSocket keeps a single wire format for one question
+        and several, and the delegate reads back the rendered answer.
+        """
+        item = QuestionItem(question=question, options=options)
+        answers = await self._ask_user([item.model_dump()])
+        return render_answer(answers[0] if answers else None)
 
     async def _ask_user(self, questions: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Pause the run: ask the client questions and block until they answer.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -70,6 +70,10 @@ dependencies = [
     # labelled per delegation (#65), and a bounded wait in `cancel_all`'s
     # `finally` so a child that swallows cancellation cannot hang our teardown
     # (#66).
+    # 0.2.17 first carried the caller-supplied-subagent ask_parent fix a sync
+    # delegate needs to reach the person waiting on its parent
+    # (subagents-pydantic-ai#76); 0.2.18 also fixes the general-purpose delegate
+    # (#78), so the floor is 0.2.18.
     "subagents-pydantic-ai>=0.2.18",
     "cryptography>=50.0.0",
     "aiogram>=3.17,<4.0",

--- a/backend/tests/test_agent_session.py
+++ b/backend/tests/test_agent_session.py
@@ -770,6 +770,36 @@ class TestAskingTheUser:
 
         assert await asking == "(no answer)"
 
+    async def test_two_delegates_asking_at_once_are_served_one_at_a_time(self):
+        """A fan-out of sync delegates can reach `ask_parent` concurrently.
+
+        The channel holds one question on the wire at a time — a single
+        `_ask_user_future` and a response frame with no correlation — so without
+        serialisation the second question would overwrite the first's future and
+        strand that delegate for the whole ask timeout, hanging the turn. Under the
+        lock the second waits for the first's answer, and each delegate gets its own.
+        """
+        session = _session()
+
+        first_out = _next_frame(session)
+        ask1 = asyncio.create_task(session._ask_one("Region?", []))
+        ask2 = asyncio.create_task(session._ask_one("Currency?", []))
+        await _wait(first_out)
+
+        # Only the first round is on the wire; the second is queued behind the lock.
+        assert _frame_types(session) == ["ask_user"]
+        assert _sent_events(session)[0][1]["questions"][0]["question"] == "Region?"
+
+        second_out = _next_frame(session)
+        await session.handle_frame({"type": "ask_user_response", "answers": [{"answer": "eu"}]})
+        assert await ask1 == "eu"
+
+        # Answering the first releases the lock and lets the second question out.
+        await _wait(second_out)
+        assert _sent_events(session)[-1][1]["questions"][0]["question"] == "Currency?"
+        await session.handle_frame({"type": "ask_user_response", "answers": [{"answer": "usd"}]})
+        assert await ask2 == "usd"
+
 
 class TestAttachedFiles:
     async def test_a_frame_carrying_only_a_file_is_not_an_empty_message(self):

--- a/backend/tests/test_agent_session.py
+++ b/backend/tests/test_agent_session.py
@@ -731,6 +731,45 @@ class TestAskingTheUser:
 
         assert await asking == [{"answer": "eu"}]
 
+    async def test_a_delegates_single_question_is_put_to_the_client_and_answered(self):
+        """`_ask_one` is what a delegate's `ask_parent` reaches - one question in, one
+        answer string out, over the same batch channel a whole form uses."""
+        session = _session()
+        asked = _next_frame(session)
+
+        asking = asyncio.create_task(session._ask_one("Which region?", ["eu", "us"]))
+        await _wait(asked)
+
+        assert _sent_events(session) == [
+            (
+                "ask_user",
+                {
+                    "questions": [
+                        {"question": "Which region?", "options": ["eu", "us"], "allow_custom": True}
+                    ]
+                },
+            )
+        ]
+
+        await session.handle_frame(
+            {"type": "ask_user_response", "answers": [{"answer": "eu", "skipped": False}]}
+        )
+
+        assert await asking == "eu"
+
+    async def test_a_delegates_question_left_unanswered_reads_as_no_answer(self):
+        """An empty answers payload releases the delegate with "(no answer)" rather
+        than hanging it: the delegate goes on with what it already had."""
+        session = _session()
+        asked = _next_frame(session)
+
+        asking = asyncio.create_task(session._ask_one("Which region?", []))
+        await _wait(asked)
+
+        await session.handle_frame({"type": "ask_user_response", "answers": None})
+
+        assert await asking == "(no answer)"
+
 
 class TestAttachedFiles:
     async def test_a_frame_carrying_only_a_file_is_not_an_empty_message(self):

--- a/backend/tests/test_dynamic_specialists.py
+++ b/backend/tests/test_dynamic_specialists.py
@@ -566,6 +566,32 @@ class TestASpecialistCannotWidenWhatItWasGranted:
 
         assert seen == [[], []]
 
+    async def test_a_specialist_the_model_invents_cannot_ask_even_when_questions_are_allowed(self):
+        """`allow_questions` opens the door for a delegate an author reviewed, and
+        never for one a model wrote a moment ago.
+
+        The author's flag reaches only the configured delegates, through
+        `_config_for`; `_autonomously` forces `can_ask_questions` off on both dynamic
+        entry points regardless, so a specialist the model invents is handed no
+        `ask_parent` tool even with questions turned on for the agent. This is the
+        refusal half of agenticos#184 - the sync feature does not leak to the shape
+        of delegate whose instructions nobody read.
+        """
+        seen: list[list[str]] = []
+        runtime = a_runtime(
+            dynamic=dynamic(specialist_builder(runs_on=specialist_model(tools_seen=seen)))
+        )
+        capability = a_capability(runtime, {"allow_questions": True})
+        ctx = a_context()
+
+        await call_tool(capability, ctx, "delegate", delegate_args(name="one-shot"))
+        await call_tool(capability, ctx, "create_agent", create_args(name="kept"))
+        await call_tool(
+            capability, ctx, "task", {"description": "summarise it", "subagent_type": "kept"}
+        )
+
+        assert seen == [[], []]
+
     async def test_a_specialist_cannot_take_a_published_delegates_handle(self):
         """Two delegates answering to one name leave the model no way to say which.
 

--- a/backend/tests/test_subagents_capability.py
+++ b/backend/tests/test_subagents_capability.py
@@ -78,6 +78,7 @@ from app.agents.capabilities.subagents import Delegation, SubagentsConfig
 from app.agents.capabilities.subagents._capability import (
     BACKGROUND_LIFECYCLE_TOOLS,
     UNREACHABLE_TOOLS,
+    _config_for,
     _LazyAgent,
 )
 from app.agents.capabilities.subagents._events import UNNAMED_TOOL, FrameLabels, frame_for
@@ -85,7 +86,7 @@ from app.agents.capabilities.subagents._journal import DelegationJournal
 from app.agents.capabilities.subagents._toolset import DelegatingToolset
 from app.agents.deps import AgentDeps
 from app.agents.factory import DEFAULT_MAX_STEPS
-from app.agents.spec import AgentSpec, CapabilityBindingSpec
+from app.agents.spec import AgentSpec, CapabilityBindingSpec, DelegationMode
 from app.agents.subagent_events import SubagentEvent
 from app.agents.subagent_runtime import (
     SUBAGENT_RUNTIME_RESOURCE,
@@ -166,6 +167,24 @@ def handing_on(to: str, *, ledger: SpendLedger) -> FunctionModel:
         return ModelResponse(
             parts=[ToolCallPart("task", {"description": "check the claim", "subagent_type": to})]
         )
+
+    return FunctionModel(respond)
+
+
+def asking(question: str, *, prefix: str = "answer: ") -> FunctionModel:
+    """A delegate that asks the parent one question, then answers with what came back.
+
+    Two requests, like `handing_on`: an `ask_parent` call first, then - once the
+    person's answer is a tool result - the final text built from it. No
+    `stream_function`, so nothing narrates and the library drives the delegate
+    through `run`; a streamed half would be a branch these ask tests never reach.
+    """
+
+    def respond(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        returned = _tool_results(messages)
+        if returned:
+            return ModelResponse(parts=[TextPart(f"{prefix}{' '.join(returned)}")])
+        return ModelResponse(parts=[ToolCallPart("ask_parent", {"question": question})])
 
     return FunctionModel(respond)
 
@@ -497,11 +516,30 @@ class Approvals:
         return ApprovalPending()
 
 
+class Asker:
+    """Stands in for the person waiting on the parent, reached through `ask_user`.
+
+    The one-question shape `subagents_pydantic_ai`'s `ask_parent` calls
+    `ctx.deps.ask_user` with - a question and options in, one answer string out.
+    Records the questions so a test can assert the delegate reached a person rather
+    than guessing.
+    """
+
+    def __init__(self, answer: str = "euros") -> None:
+        self.answer = answer
+        self.asked: list[str] = []
+
+    async def __call__(self, question: str, _options: list[str]) -> str:
+        self.asked.append(question)
+        return self.answer
+
+
 def a_context(
     sink: Sink | None = None,
     approvals: Approvals | None = None,
     *,
     run: str = "run-1",
+    asker: Asker | None = None,
 ) -> RunContext[AgentDeps]:
     """A parent run, with an organization, a run id and collections of its own.
 
@@ -524,6 +562,7 @@ def a_context(
             kb_collection_names=["kb_only_the_parent_may_read"],
             subagent_events=sink,
             request_approval=approvals,
+            ask_user=asker,
         ),
         model=TestModel(),
         usage=RunUsage(),
@@ -624,9 +663,10 @@ class TestAttaching:
     async def test_a_delegating_agent_is_offered_no_way_to_answer_a_question(self):
         """The exact set a delegating agent's model reads, and why one is missing.
 
-        `answer_subagent` replies to a question a delegate asked, and no delegate
-        here can ask one: the library injects its `ask_parent` tool only into agents
-        it built itself, and every delegate arrives pre-built. So the tool could only
+        `answer_subagent` answers a question a *background* delegate parked on, and
+        no delegate here parks on one: a sync delegate that may ask (agenticos#184)
+        is answered by a person through `ask_user`, never this tool, and an async
+        delegate is not granted `can_ask_questions` at all. So the tool could only
         ever answer "that delegation is not waiting for an answer" - from a
         description in every turn's context, which is the strongest prompt surface in
         this product.
@@ -634,7 +674,7 @@ class TestAttaching:
         It stays *declared*, which is the second assertion. A tool absent from
         `tools=` can be neither gated by the approval policy nor renamed by a
         binding, and that half of the same failure is silent. `UNREACHABLE_TOOLS`
-        says what making it reachable would take, and why agenticos#184 is only
+        says what making it reachable would take, and why agenticos#184 was only
         half of that.
 
         `async`, so that this stays a statement about `answer_subagent` alone: it is
@@ -781,6 +821,70 @@ class TestOfferedSet:
         capability = a_capability(a_runtime(a_delegate(preferred_mode="sync")), {"mode": "sync"})
 
         assert not (await self._offered(capability) & BACKGROUND_LIFECYCLE_TOOLS)
+
+
+class TestAskingTheParent:
+    """A sync delegate may ask the person waiting on the parent, when its author allows.
+
+    Off by default, gated on the mode, and never open to a specialist a model
+    invented - the three things agenticos#184 turns on, without turning on more.
+    `TestADynamicSpecialist` in `test_dynamic_specialists.py` holds the last of those.
+    """
+
+    async def test_a_sync_delegate_reaches_the_person_and_finishes_on_the_answer(self):
+        """The whole feature, end to end and through the real library.
+
+        The delegate asks, a person answers through the run's `ask_user` channel,
+        and the delegation finishes using the answer - which the library injects
+        `ask_parent` for a caller-supplied delegate to do only since
+        subagents-pydantic-ai#76.
+        """
+        asker = Asker("euros")
+        capability = a_capability(
+            a_runtime(a_delegate(model=asking("which currency should I use?"))),
+            {"allow_questions": True},
+        )
+
+        answer = await delegate_to(capability, a_context(asker=asker))
+
+        assert asker.asked == ["which currency should I use?"]
+        assert "euros" in answer
+
+    def test_the_author_flag_and_the_mode_together_gate_asking(self):
+        """`can_ask_questions` is granted only for a sync delegation whose author
+        set `allow_questions` - the one combination with a person there to answer.
+
+        A background delegation has handed back a task id with nobody waiting, and
+        `auto` may become one, so neither is granted it however the flag is set. A
+        delegate's own `preferred_mode` decides which it is, in both directions.
+        """
+
+        def may_ask(*, allow: bool, mode: DelegationMode, preferred: DelegationMode | None = None):
+            journal = DelegationJournal(
+                runtime=a_runtime(), mode=mode, allow_questions=allow, max_fanout=3, depth=0
+            )
+            return _config_for(a_delegate(preferred_mode=preferred), journal).get(
+                "can_ask_questions"
+            )
+
+        assert may_ask(allow=True, mode="sync") is True
+        assert may_ask(allow=False, mode="sync") is False
+        assert may_ask(allow=True, mode="async") is False
+        assert may_ask(allow=True, mode="auto") is False
+        assert may_ask(allow=True, mode="async", preferred="sync") is True
+        assert may_ask(allow=True, mode="sync", preferred="async") is False
+
+    async def test_answer_subagent_stays_unoffered_even_when_questions_are_allowed(self):
+        """The sync half never routes through `answer_subagent`: a person answers it.
+
+        So opening questions must not start offering the tool - only the background
+        half, which no delegate here reaches, ever would. See `UNREACHABLE_TOOLS`.
+        """
+        capability = a_capability(a_runtime(a_delegate()), {"allow_questions": True})
+        toolset = capability.get_toolset()
+        assert toolset is not None
+
+        assert "answer_subagent" not in await toolset.get_tools(a_context())
 
 
 class TestRecording:

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -274,6 +274,7 @@ the YAML export and the permission model can all see it.
 |---|---|---|
 | `inline` | none | specialists defined inside this agent |
 | `mode` | `sync` | `sync`, `async`, `auto` |
+| `allow_questions` | `false` | a sync delegate may ask the parent's person |
 | `allow_dynamic` | `false` | |
 | `max_depth` | 1 | 1–3 |
 | `max_fanout` | 3 | 1–10 |
@@ -338,25 +339,34 @@ suspends anyway — a shape the library documents as undeliverable — is record
 "still running" for as long as the process lives: its spend attributed to nothing,
 its fan-out slot never released, and the panel a surface opened never closed.
 
-**And no delegate can ask a question of its own, so `answer_subagent` is offered to no
-model.** Parking for an approval is a gated tool being reviewed, not a specialist asking
-anything. This tool replies to a question a delegate asked, and the delegation library
-injects its `ask_parent` tool only into agents it built itself — every delegate here
-arrives pre-built, published delegate and inline specialist alike, and a specialist the
-model invents has the same door closed on purpose. So the tool's only possible answer is
-"that delegation is not waiting for an answer". It stays *declared*, because a tool
-absent from the declaration cannot be gated by the approval policy or renamed by a
-binding and that half of the failure is silent; it is filtered out of the offered set,
-because the other half is a description in every turn's context describing an action
-that cannot happen, and tool descriptions are the strongest prompt in this product.
+**A sync delegate may ask the parent's person, when `allow_questions` is set.** Off
+by default: a specialist works autonomously and says so if it could not. Set on, a
+delegate whose mode is sync is given the library's `ask_parent` tool, and a question
+it asks is answered by the run's own `ask_user` channel — the person already holding
+the parent's tool call — never by the model. It is the author's decision because the
+question wears a name the author published; a specialist the model *invents* never
+asks, whatever this says, because instructions a model wrote a moment ago are not the
+author's to put to a person. Only sync: a background delegation has handed back a
+task id with nobody left to answer, and `auto` may become one. Reaching a pre-built
+delegate needed an upstream change —
+[subagents-pydantic-ai#76](https://github.com/vstorm-co/subagents-pydantic-ai/pull/76)
+honours `can_ask_questions` for a caller-supplied agent, which every delegate here
+is — landing the sync half of
+[#184](https://github.com/vstorm-co/agenticos/issues/184).
 
-Opening the path is a feature rather than a repair, and the mode decides who could
-answer: a `sync` delegation's question goes to a **person**, through the run's own
-`ask_user` channel and never through this tool, while only a *background* delegation's
-question is answered by the parent's own model — which is the harder half, since the
-delegate then blocks holding a fan-out slot while nothing obliges the parent to look
-and the turn's end cancels it. Letting a sync delegate ask the person already waiting
-is [#184](https://github.com/vstorm-co/agenticos/issues/184).
+**`answer_subagent` is offered to no model.** It answers a question a *background*
+delegate parked on, and no delegate here parks on one: a sync question goes to a
+person through `ask_user` and never this tool, and an async delegate is not given
+`ask_parent` at all. So the tool's only possible answer is "that delegation is not
+waiting for an answer". It stays *declared*, because a tool absent from the
+declaration cannot be gated by the approval policy or renamed by a binding and that
+half of the failure is silent; it is filtered out of the offered set, because the
+other half is a description in every turn's context describing an action that cannot
+happen, and tool descriptions are the strongest prompt in this product. The tool
+becomes reachable only when the background half of
+[#184](https://github.com/vstorm-co/agenticos/issues/184) is answered — where the
+parent's own model answers while nothing obliges it to look, the delegate blocking
+on a fan-out slot the turn's end cancels.
 
 **`wait_tasks` truncates, and says so.** A completed task's result is cut at
 `max_result_chars` with an explicit marker pointing at `check_task`, which always


### PR DESCRIPTION
Closes #184.

Lets an author turn on questions for a delegation, so a **sync** delegate can ask
the person already waiting on the parent — "which currency?" instead of an
assumption buried in the answer — answered on the run's own `ask_user` channel.
Off by default: a specialist works autonomously and says so when it could not.

## Why this was more than a flag

The issue named the sync half as worth doing on its own. Three things had to line
up, and each had kept it closed:

1. **A configured delegate could not reach `ask_parent` at all.** Every delegate
   here is handed to the library pre-built as `SubAgentConfig["agent"]`, and the
   library injected `ask_parent` only into agents it built itself (`task`
   hardcoded `inject_ask_parent=False` for the configured path). Fixed upstream in
   **subagents-pydantic-ai#76**, shipped as **0.2.17** — this PR depends on `>=0.2.17`.
2. **`ask_user` was the wrong shape.** `AgentDeps.ask_user` was a batch protocol
   (`list[dict] → list[dict]`) with *no live caller*, while the library's
   `ask_parent` calls `ctx.deps.ask_user(question, []) → str`. A real sync delegate
   would have `TypeError`-ed against the production channel — the `_autonomously`
   docstring's "falls back to `ctx.deps.ask_user`" was never exercised. `ask_user`
   is now the one-question shape its only consumer needs; the WebSocket session
   adapts its batch elicitation to it at the edge (`_ask_one`).
3. **The decision is the author's, and only for sync.** `_config_for` sets
   `can_ask_questions` from `allow_questions` and the delegate's configured mode,
   granting it only when that mode is `sync`. `_autonomously` still forces it off
   on both dynamic entry points, so a model-invented specialist never asks.

## What changed

- `capabilities/subagents/__init__.py` — new `allow_questions` config field.
- `.../_capability.py:_config_for` — sets `can_ask_questions = allow_questions and configured_mode == "sync"`; threaded through `build_delegation` and the journal.
- `agents/deps.py` — `AskUserCallback` retyped to `(question, options) → str`.
- `agents/ask_user.py` — `render_answer` helper (reused by `format_answers`).
- `services/agent_session.py` — `_ask_one` adapts the batch channel to one question.
- `pyproject.toml` / `uv.lock` — `subagents-pydantic-ai >= 0.2.17`.
- Docs + the capability README + three docstrings that described "no delegate can ask" updated to the new reality.

## How it failed before

A configured sync delegate that called `ask_parent` got nothing — the tool was
never injected — and even if it had been, the call would have hit the batch
`ask_user` with the wrong signature and raised.

## Testing

- `test_subagents_capability.py::TestAskingTheParent` — end-to-end through the real library: a sync delegate asks, a person answers via `ask_user`, the delegation finishes on the answer; plus `_config_for` gating (sync/async/auto/off, per-delegate override) and `answer_subagent` still unoffered with `allow_questions` on.
- `test_dynamic_specialists.py` — a model-invented specialist is handed no `ask_parent` even with `allow_questions` on.
- `test_agent_session.py` — `_ask_one` puts one question and returns the answer / "(no answer)".
- `make check` locally: backend 100% coverage (3065 passed), lint, ty, docs-build all green — against the released 0.2.17.

## Noticed, not fixed

The **background** half of #184 (a delegate that parks in `WAITING_FOR_ANSWER`
for the parent's model to answer via `answer_subagent`) stays closed on purpose —
`answer_subagent` is still offered to no model. That is the harder half the issue
describes, and its own change.
