### PR TITLE
chore: cut 0.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.13] - 2026-08-05
+
+### Fixed
+
+- **`bootstrap` ensures the model profile it names, rather than adopting any it finds**
+  ([#172](https://github.com/vstorm-co/agenticos/issues/172)). On a database that had
+  been used before, `make platform-bootstrap` adopted whatever model profile already
+  existed instead of ensuring the one it was told to create — so the agent it published
+  ran on a profile nobody asked for, and several E2E specs that assume the named profile
+  failed on any database not freshly created. It now ensures the profile it names,
+  creating it when absent and matching by name when present, so a second bootstrap is
+  idempotent rather than dependent on what the database happened to hold.
+
 ## [0.0.12] - 2026-08-05
 
 ### Fixed
@@ -751,7 +764,8 @@ installed hook did nothing.
   codebase has diverged from the generator past the point where a 3-way merge
   helps.
 
-[Unreleased]: https://github.com/vstorm-co/agenticos/compare/v0.0.12...HEAD
+[Unreleased]: https://github.com/vstorm-co/agenticos/compare/v0.0.13...HEAD
+[0.0.13]: https://github.com/vstorm-co/agenticos/compare/v0.0.12...v0.0.13
 [0.0.12]: https://github.com/vstorm-co/agenticos/compare/v0.0.11...v0.0.12
 [0.0.11]: https://github.com/vstorm-co/agenticos/compare/v0.0.10...v0.0.11
 [0.0.10]: https://github.com/vstorm-co/agenticos/compare/v0.0.9...v0.0.10

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.12"
+version = "0.0.13"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for **#172** — `make platform-bootstrap` now ensures the model profile it names instead of adopting whatever profile a reused database happened to hold, which had made the published agent run on the wrong profile and several E2E specs fail on any non-fresh database. Idempotent now. Code landed as #241.

No schema change, `SPEC_VERSION` unchanged at 7.