### PR TITLE
chore: cut 0.0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,25 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.16] - 2026-08-05
+
+### Fixed
+
+- **A delegation panel reaches a terminal state when its delegate parked on an approval**
+  ([#173](https://github.com/vstorm-co/agenticos/issues/173)). When a sync delegation
+  parked for a human approval in web chat, its panel showed the delegate as still working
+  and stayed there — because `POST /runs/{id}/resume` runs over HTTP with no
+  `subagent_events` sink, so no `subagent_complete` frame ever reached the WebSocket
+  reducer, and the panel sat on `awaiting_approval` forever after the approval was granted.
+  Web-chat resume doesn't stream, so the panel is now reconciled from the HTTP answer: the
+  resumed run's own status is applied to every panel still awaiting — `completed`,
+  `failed`/`budget_exceeded`→failed, `cancelled` — while a resume that parks *again* is
+  left waiting, preserving the continuation case. Streamed text is kept; cost and tokens
+  stay null rather than invented, since the frame that carries them never arrived. This
+  covers a resume that **returns** a status; a resume whose continuation itself raises
+  returns no result and still leaves the panel waiting, tracked as
+  [#262](https://github.com/vstorm-co/agenticos/issues/262).
+
 ## [0.0.15] - 2026-08-05
 
 ### Fixed
@@ -801,7 +820,8 @@ installed hook did nothing.
   codebase has diverged from the generator past the point where a 3-way merge
   helps.
 
-[Unreleased]: https://github.com/vstorm-co/agenticos/compare/v0.0.15...HEAD
+[Unreleased]: https://github.com/vstorm-co/agenticos/compare/v0.0.16...HEAD
+[0.0.16]: https://github.com/vstorm-co/agenticos/compare/v0.0.15...v0.0.16
 [0.0.15]: https://github.com/vstorm-co/agenticos/compare/v0.0.14...v0.0.15
 [0.0.14]: https://github.com/vstorm-co/agenticos/compare/v0.0.13...v0.0.14
 [0.0.13]: https://github.com/vstorm-co/agenticos/compare/v0.0.12...v0.0.13

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.15"
+version = "0.0.16"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.15"
+version = "0.0.16"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for **#173** — a delegation panel reaches a terminal state when its delegate parked on an approval. Web-chat resume runs over HTTP with no `subagent_events` sink, so no `subagent_complete` frame reached the WebSocket reducer and the panel sat on `awaiting_approval` forever after approval. Reconciled from the HTTP answer now: the resumed run's status is applied to every still-waiting panel; a resume that parks again is left waiting. Code landed as #250.

No schema change, `SPEC_VERSION` unchanged at 7.