### PR TITLE
build(deps): adopt subagents-pydantic-ai 0.2.18, closing #174

### DIFF
--- a/backend/app/agents/capabilities/subagents/README.md
+++ b/backend/app/agents/capabilities/subagents/README.md
@@ -412,14 +412,15 @@ filter as drift.
 the library's own default of `True`. That is a fact about somebody else's default,
 stated in one place — not a setting, and never one an author could reach.
 
-The library compiles this delegate at construction from `default_model`, a model
-string of its own choosing: no profile of this organization's resolves it, no
-credential of this organization's is unsealed for it, and the run's `BudgetGuard`
-never wraps it. So a deployment holding no such key fails the build outright, and
-one with that key in its process environment runs a tenant's work on a
-deployment-wide credential — unpriced, unmetered, and against the one rule
-`model_resolver.py` states outright. A switch whose two outcomes are a crash and a
-credential leak is a trap, and a warning beside it is not a guard.
+Before subagents-pydantic-ai 0.2.18 the library compiled this delegate at
+construction from `default_model`, a model string of its own choosing: no profile
+of this organization's resolved it, no credential of this organization's was
+unsealed for it, and the run's `BudgetGuard` never wrapped it. A deployment holding
+no such key failed the build outright, and one with that key in its process
+environment ran a tenant's work on a deployment-wide credential — unpriced,
+unmetered, and against the one rule `model_resolver.py` states outright. A switch
+whose two outcomes are a crash and a credential leak is a trap, and a warning beside
+it is not a guard.
 
 There was briefly an `include_general_purpose` field on `SubagentsConfig`,
 defaulting off with that warning written next to it. It was removed rather than
@@ -430,9 +431,11 @@ round trip to learn it does nothing.
 
 An author who wants a catch-all writes an inline specialist, which runs on one of
 this organization's model profiles through `build_agent` like every other delegate,
-and whose instructions somebody can read. Making the library's own work means
-resolving it here the same way: agenticos#174, still open, and an upstream defect
-regardless of what this deployment configures.
+and whose instructions somebody can read. The library's own is fixed as of 0.2.18
+(agenticos#174): with no `default_model` and no `default_agent_factory` it now
+refuses to build the delegate rather than compiling it from a model of its own, so
+leaving the switch on would raise here, not leak. This platform still does not offer
+it, for the reason above.
 
 ## Reading the code
 

--- a/backend/app/agents/capabilities/subagents/_capability.py
+++ b/backend/app/agents/capabilities/subagents/_capability.py
@@ -758,16 +758,18 @@ def build_delegation(
         subagents=[_config_for(delegate, journal) for delegate in runtime.subagents],
         # Passed because the library's own default is `True`, not because anything
         # here can ask for it: this is a fact about somebody else's default, and
-        # the one place it is stated. The delegate it would add is compiled at
-        # construction from `default_model` - a model string of the library's
-        # choosing, resolved from no profile of this organization's, unsealed from
-        # no credential in its vault and wrapped by no budget guard - so on a
-        # deployment holding no such key the build raises, and on one that has that
-        # key in its environment a tenant's work runs on a deployment-wide
-        # credential. Neither is a delegate this platform can account for, so there
-        # is no setting for it and never was one an author could reach
-        # (agenticos#174 tracks fixing it upstream). An author who wants a
-        # catch-all writes an inline specialist, whose instructions somebody read.
+        # the one place it is stated. The delegate it would add is the library's
+        # unspecialised one - resolved from no profile of this organization's,
+        # unsealed from no credential in its vault, wrapped by no budget guard -
+        # not one this platform can account for, so there is no setting for it and
+        # never was one an author could reach. subagents-pydantic-ai 0.2.18 fixed
+        # the upstream half of this (agenticos#174): with no `default_model` and no
+        # `default_agent_factory` the library now refuses to build the delegate
+        # rather than compiling it from a model of its own choosing, so leaving
+        # this `True` would raise here instead of quietly running a tenant's work
+        # on a deployment-wide credential. Either way it is not offered; an author
+        # who wants a catch-all writes an inline specialist, whose instructions
+        # somebody read.
         include_general_purpose=False,
         max_result_chars=max_result_chars,
         # Which entry points exist at all. `default` is `task` alone;
@@ -786,14 +788,13 @@ def build_delegation(
         # Owned here rather than created inside the library, so its registrations
         # can be snapshotted when the run parks and re-seeded when it resumes.
         registry=registry,
-        # `default_model` is left at the library's own, and this platform has no
-        # default model anywhere: a specialist that names none is refused in
-        # `DelegatingToolset._refuse_dynamic`, before either entry point reaches
-        # the fallback, and the general-purpose delegate that would otherwise be
-        # compiled from it at construction is switched off above. So the field is
-        # unread here, and an unusable sentinel in its place would buy a second
-        # spelling of a refusal that already has one - as an exception rather than
-        # a tool result the model can act on.
+        # `default_model` is left unset - which since 0.2.18 is the library's own
+        # default too - because this platform has no default model anywhere: a
+        # specialist that names none is refused in `DelegatingToolset._refuse_dynamic`
+        # before it reaches the library, and the general-purpose delegate that would
+        # otherwise be built from a default is switched off above. The field is
+        # unread here; unset, the library now refuses a modelless dynamic call of its
+        # own accord too, only later and less specifically than the refusal above.
         # The nesting budget the runner had left after resolving this level. The
         # library subtracts one per delegation and passes it to
         # `AgentDeps.clone_for_subagent`, which is where a delegate learns whether
@@ -913,12 +914,14 @@ def _specialist_factory(dynamic: DynamicSpecialists, journal: DelegationJournal)
 
     The whole point of the phase, and it is one line of substance: the library is
     given a factory, so it never builds a dynamic specialist itself. Left to its
-    own devices it constructs `Agent(default_model, system_prompt=...)` - an agent
-    on a model string of the library's choosing, with no credential from this
+    own devices it would build `Agent(default_model, system_prompt=...)` - an agent
+    on a model string of its own choosing, with no credential from this
     organization's vault, no price attached to its requests and **no budget
-    guard**. That is an unmetered model request on a provider the organization may
-    hold no key for, and it is the reason both entry points were declared and not
-    offered for two phases.
+    guard**; that was an unmetered model request on a provider the organization may
+    hold no key for. Since 0.2.18, with `default_model` unset, it refuses to build
+    one at all rather than pick a model - but a refusal is not a specialist either,
+    and giving it the factory is why both entry points could move from declared and
+    not offered to offered.
 
     What the factory produces instead goes through `build_agent` with the run's
     `shared_budget`, which is the same door an inline specialist and a pinned

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
     # labelled per delegation (#65), and a bounded wait in `cancel_all`'s
     # `finally` so a child that swallows cancellation cannot hang our teardown
     # (#66).
-    "subagents-pydantic-ai>=0.2.16",
+    "subagents-pydantic-ai>=0.2.18",
     "cryptography>=50.0.0",
     "aiogram>=3.17,<4.0",
     "slack-sdk>=3.35.0",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -120,7 +120,7 @@ requires-dist = [
     { name = "slack-sdk", specifier = ">=3.35.0" },
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.51" },
-    { name = "subagents-pydantic-ai", specifier = ">=0.2.16" },
+    { name = "subagents-pydantic-ai", specifier = ">=0.2.18" },
     { name = "tabulate", specifier = ">=0.9.0" },
     { name = "tavily-python", specifier = ">=0.7.27" },
     { name = "tqdm", specifier = ">=4.70.0" },
@@ -4937,16 +4937,16 @@ wheels = [
 
 [[package]]
 name = "subagents-pydantic-ai"
-version = "0.2.16"
+version = "0.2.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "pydantic-ai-slim" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/4d/9eefe5dddd4cb9764e2d50b8d795c0872e777c30618e02d4258489f76ff9/subagents_pydantic_ai-0.2.16.tar.gz", hash = "sha256:11620cf319c770ebc35026e044d0db8c533c7be7bfc8aa756943eb6a7791b4fe", size = 637956, upload-time = "2026-08-02T22:09:11.21Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/1d/776ff26ca85ca659092a5cf47452577abefd22a794f49d5abcd04a3d9c28/subagents_pydantic_ai-0.2.18.tar.gz", hash = "sha256:5153bc2372f994d0f2b0ceec09b6b88fe08b8aa7990c3546f084b82a2157b1ac", size = 644494, upload-time = "2026-08-05T16:02:47.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/a4/350ad0b908f0eefa0bb7de1737e421c980bdb2dc15ff6a7a974d66c22c2e/subagents_pydantic_ai-0.2.16-py3-none-any.whl", hash = "sha256:d3e6ff87b1caeada799fb6db63ad9394d2f182848a2fa753c4c1b08b99abe8c0", size = 79000, upload-time = "2026-08-02T22:09:09.712Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/37/98e6305c56116f297f2c82ed175c06a5ad86b2805b300733e15da24405d0/subagents_pydantic_ai-0.2.18-py3-none-any.whl", hash = "sha256:82d1933b4f8aacc63a65f098768a39170882a675afe40450ca962d34141c480a", size = 82053, upload-time = "2026-08-05T16:02:46.343Z" },
 ]
 
 [[package]]

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -440,13 +440,15 @@ state — a name created in one reply is unknown in the next, and `create_agent`
 description tells the model to create it again if `task` says so.
 
 **The delegation library's own unspecialised delegate is not offered at all**, and
-there is no setting for it. It would run on a model this deployment did not
-configure — compiled from the library's own default model string, so outside the
-organization's profiles, its vault and the run's budget guard, exactly like the
-run-time specialist above before it took a factory. A catch-all is a legitimate
-thing to want; write it as an inline specialist, where you can read what it does
-and it is priced like everything else. Fixing the library's own is
-[#174](https://github.com/vstorm-co/agenticos/issues/174).
+there is no setting for it. Before subagents-pydantic-ai 0.2.18 it would have run on
+a model this deployment did not configure — compiled from the library's own default
+model string, outside the organization's profiles, its vault and the run's budget
+guard, exactly like the run-time specialist above before it took a factory. A
+catch-all is a legitimate thing to want; write it as an inline specialist, where you
+can read what it does and it is priced like everything else. The library's own is
+fixed as of 0.2.18 ([#174](https://github.com/vstorm-co/agenticos/issues/174)): with
+no default model or factory it now refuses to build the delegate rather than picking
+a model.
 
 What the model is told about all of this is written here rather than by the
 library: the delegates by name and description, the mode this run will actually

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -417,11 +417,14 @@ What the switch buys is a specialist the model writes itself: instructions and a
 model, and nothing else. It is built through the same `build_agent` an inline
 specialist comes through, on the run's shared budget guard and its approval
 channel, so its requests are priced and counted against the cap somebody set. That
-is the entire reason this took a factory rather than a flag — left to itself the
-library compiles a run-time specialist from its own default model string, which is
-an agent outside this deployment's model catalog, outside its vault and outside its
-budget guard: an unmetered request, possibly to a provider the organization holds no
-key for.
+is the entire reason this took a factory rather than a flag: a specialist the
+library built for itself would sit outside this deployment's model catalog, its
+vault and its budget guard — an unmetered request, possibly to a provider the
+organization holds no key for. The factory is what routes it back through this
+platform instead. (Before `subagents-pydantic-ai` 0.2.18 the library also carried a
+default model string a modelless specialist was compiled from; 0.2.18 removed that
+fallback, so a specialist naming no model is now refused rather than built — this
+platform refuses it earlier still, in `DelegatingToolset._refuse_dynamic`.)
 
 The model may name only a model the organization has a profile for, and the refusal
 names the list. It may not attach capabilities: letting a model grant its own child


### PR DESCRIPTION
## What this does

Adopts **subagents-pydantic-ai 0.2.18**, which lands the upstream half of #174 — the last thing that issue was tracking.

Before 0.2.18 the delegation library defaulted `default_model` to `openai:gpt-4.1`: leaving the general-purpose delegate on with no model either crashed the build or, on a deployment with that key in its environment, ran a tenant's work on a deployment-wide credential — outside every profile, vault and budget guard. 0.2.18 removes that implicit default; with no `default_model` and no `default_agent_factory` the library now **refuses to build** rather than picking a model.

## What changed

- `backend/pyproject.toml` / `backend/uv.lock` — floor `>=0.2.16` → `>=0.2.18`, relocked.
- **No functional change.** `build_delegation` already passes `include_general_purpose=False`, prebuilt agents, and a `default_agent_factory` for dynamic specialists, so it never reached the fallback.
- The explanatory text around those calls was stale — it described the defect as a live *crash-or-credential-leak* and #174 as open. Updated to reflect 0.2.18's refusal behaviour, in `_capability.py` (two comments + the `_specialist_factory` docstring), the subagents `README.md`, and `docs/reference/capabilities.md`.

## Testing

- `tests/test_subagents_library_contract.py` + `tests/test_subagents_capability.py`: 102 passing against 0.2.18.
- `ruff check` / `ruff format` clean; `ty` 0 errors (baseline-compared); `scripts/docs_drift.py` reports no drift.

Closes #174