### PR TITLE
chore: cut 0.0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,23 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.21] - 2026-08-05
+
+### Changed
+
+- **Adopt `subagents-pydantic-ai` 0.2.18, which fixes the general-purpose delegate at the
+  source** ([#174](https://github.com/vstorm-co/agenticos/issues/174)). The delegation
+  library used to default its `default_model` to a hardcoded string, so a consumer with no
+  usable default — which AgenticOS is, on purpose: there is no deployment-wide model — got a
+  general-purpose delegate that either failed or, worse, ran one tenant's work on whatever
+  provider key happened to sit in the process environment. AgenticOS had already removed the
+  switch from its own surface (0.0.7) and refuses a modelless dynamic specialist in
+  `DelegatingToolset._refuse_dynamic`; 0.2.18 removes the fallback upstream too, so the
+  library now refuses a modelless dynamic call of its own accord rather than compiling an
+  unmetered one. The pin moves to `>=0.2.18` and the local comments and the capability
+  reference are corrected to describe the removed fallback in the past tense. `#174` closes
+  now that AgenticOS is on the fixed version.
+
 ## [0.0.20] - 2026-08-05
 
 ### Fixed
@@ -902,7 +919,8 @@ installed hook did nothing.
   codebase has diverged from the generator past the point where a 3-way merge
   helps.
 
-[Unreleased]: https://github.com/vstorm-co/agenticos/compare/v0.0.20...HEAD
+[Unreleased]: https://github.com/vstorm-co/agenticos/compare/v0.0.21...HEAD
+[0.0.21]: https://github.com/vstorm-co/agenticos/compare/v0.0.20...v0.0.21
 [0.0.20]: https://github.com/vstorm-co/agenticos/compare/v0.0.19...v0.0.20
 [0.0.19]: https://github.com/vstorm-co/agenticos/compare/v0.0.18...v0.0.19
 [0.0.18]: https://github.com/vstorm-co/agenticos/compare/v0.0.17...v0.0.18

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.20"
+version = "0.0.21"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.20"
+version = "0.0.21"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for **#174** — adopts `subagents-pydantic-ai` 0.2.18, which removes upstream the `default_model` fallback that would run a run-time general-purpose delegate on whatever provider key sat in the process environment. AgenticOS had already removed the switch from its own surface (0.0.7); 0.2.18 fixes it at the source, so the library now refuses a modelless dynamic call rather than compiling an unmetered one. Pin moves to `>=0.2.18`. Code landed as #264, closing #174.

No schema change, `SPEC_VERSION` unchanged at 7.