### PR TITLE
fix(approvals): build a parked run's spec before it leaves the queue

### DIFF
--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -2411,11 +2411,18 @@ class AgentRunnerService:
         handed an approval naming a tool call it never asks about, and the model
         would be free to call something else.
 
+        A continuation that cannot be built leaves the run parked. The version's
+        spec is fetched and assembled *before* the row leaves the queue, so a
+        secret deleted since the park, a removed model profile or a capability
+        dropped in a deploy refuses this attempt rather than the run: the
+        decision stands, and resuming works again once the spec does.
+
         Raises:
             NotFoundError: If the run is not in this organization.
             BadRequestError: If the run is not parked, has no stored state, or
                 still has a decision outstanding. All three mean the caller is
-                about to replay something it should not.
+                about to replay something it should not. Also if the spec it was
+                parked on can no longer be built - see above.
         """
         run = await agent_run_repo.claim_parked_run(
             self.db, run_id, organization_id=ctx.organization_id
@@ -2435,10 +2442,6 @@ class AgentRunnerService:
         state = PausedRunState.model_validate(run.paused_state)
 
         decided, plan = await self._decisions(ctx, run=run, state=state)
-        # Out of the queue before anything is replayed: the row lock above only
-        # holds until this transaction commits, and what makes a second resume
-        # refuse afterwards is the status it finds.
-        await agent_run_repo.mark_running(self.db, run=run)
 
         agent, spec = await self._parked_spec(ctx, run)
         # The continuation traces where the original did: the environment that
@@ -2476,6 +2479,29 @@ class AgentRunnerService:
             ],
         )
         prepared.built.ledger.book(_spend_already_booked(run))
+
+        # Out of the queue once the build has succeeded, and before anything is
+        # replayed. Two different things keep two different resumes out, which is
+        # why this line sits between the build and the run rather than at either
+        # end:
+        #
+        # A resume arriving *while this one is still building* waits at
+        # `claim_parked_run` - the row lock is held for the whole transaction -
+        # and then reads the status written here, so building first widens no
+        # window. A resume arriving *after this transaction commits* has no lock
+        # to wait on, and what refuses it is finding the run no longer parked; so
+        # the status has to change before the tool call is replayed, not after.
+        #
+        # It is written last because a build refuses for reasons that have
+        # nothing to do with this run: a secret a binding names deleted since the
+        # park, a model profile removed, a capability dropped in a deploy, an
+        # MCP connection unshared. Flipping the row first left every one of those
+        # with a run stuck in `running`, which `claim_parked_run` never hands out
+        # again - a decision a person made, recorded against work that cannot
+        # continue. Nothing above has touched the row, so the run is still parked
+        # and still resumable, and no failure path can commit a status that was
+        # never written.
+        await agent_run_repo.mark_running(self.db, run=run)
 
         return await self._run(
             prepared,

--- a/backend/tests/test_agent_runner.py
+++ b/backend/tests/test_agent_runner.py
@@ -20,7 +20,7 @@ from pydantic_ai.usage import RequestUsage
 
 from app.agents.capabilities.approval import ApprovalGranted, ApprovalRejected
 from app.agents.capabilities.budget import BudgetExceeded, BudgetScope, SpendLedger
-from app.agents.spec import AgentSpec, ObservabilitySpec
+from app.agents.spec import AgentSpec, CapabilityBindingSpec, ObservabilitySpec
 from app.agents.subagent_runtime import DelegationSpend, DelegationStash, ParkedDelegation
 from app.core.exceptions import BadRequestError, NotFoundError
 from app.core.permissions import AuthContext, OrgRoleName
@@ -1419,6 +1419,70 @@ class TestResume:
             await service.resume(_ctx(), run.id)
 
         assert status_when_replayed == [RunStatus.RUNNING.value]
+
+    @pytest.mark.anyio
+    async def test_a_run_whose_spec_no_longer_builds_is_still_resumable(self):
+        """A build that refuses must not spend the decision that got it there.
+
+        `claim_parked_run` only ever hands out a run that is still
+        `awaiting_approval`, so a run flipped to `running` by an attempt that then
+        failed to build is a run nobody can finish - carrying an approval a person
+        granted, and reporting nothing. The build therefore happens while the row
+        is still parked.
+
+        The failure here is the one that happens to real deployments: the secret a
+        binding names was deleted after the run parked, so the unsealed map no
+        longer holds it and the registry refuses rather than running the
+        capability without its key. What proves the run survived it is the second
+        attempt reaching the same refusal - not "this run is not waiting for
+        approval".
+        """
+        service = AgentRunnerService(_db())
+        approval = self._approval(status=ApprovalStatus.APPROVED.value, tool_args={})
+        run = _parked_run(
+            paused_state={"messages": [], "tool_call_ids": {str(approval.id): "call-1"}}
+        )
+        version = MagicMock()
+        version.spec = AgentSpec(
+            name="Researcher",
+            model_profile_id=uuid.uuid4(),
+            capabilities=[
+                CapabilityBindingSpec(
+                    id="web_research",
+                    config={"method": "tavily"},
+                    secret_id=uuid.uuid4(),
+                )
+            ],
+        ).model_dump(mode="json")
+
+        with (
+            patch(
+                "app.services.agent_runner.agent_run_repo.claim_parked_run",
+                new=AsyncMock(return_value=run),
+            ),
+            patch(
+                "app.services.agent_runner.agent_run_repo.list_approvals_for_run",
+                new=AsyncMock(return_value=[approval]),
+            ),
+            patch(
+                "app.services.agent_runner.agent_repo.get_version",
+                new=AsyncMock(return_value=version),
+            ),
+            patch.object(service.registry, "get", new=AsyncMock(return_value=MagicMock())),
+            patch.object(
+                service.models, "resolve", new=AsyncMock(return_value=MagicMock(label="gpt-4.1"))
+            ),
+            patch.object(service.skills, "resolve_for_agent", new=AsyncMock(return_value=[])),
+            # What a deleted secret looks like from here: the id resolves to
+            # nothing, which is exactly what `resolve_for_bindings` returns for a
+            # row that is gone.
+            patch.object(service.secrets, "resolve_for_bindings", new=AsyncMock(return_value={})),
+        ):
+            for _ in range(2):
+                with pytest.raises(BadRequestError, match="no longer has"):
+                    await service.resume(_ctx(), run.id)
+
+        assert run.status == RunStatus.AWAITING_APPROVAL.value
 
 
 class TestWhoTheRunSaysItIs:

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -266,6 +266,12 @@ Four properties worth knowing:
 
 - **A parked run is resumable.** Its message history is stored, so the decision is
   applied to the conversation it belongs to rather than starting again.
+- **It stays resumable if continuing it fails.** A run is continued on the version
+  it parked on, and that version's spec may have stopped building since - a secret
+  a binding names deleted, a model profile removed, a capability dropped in a
+  deploy, an MCP connection unshared. The spec is assembled before the run leaves
+  the approval queue, so a refusal there refuses the *attempt*: the decision
+  stands and resuming works again once the spec does.
 - **A decided approval cannot be decided twice.** The second decision is refused.
 - **`required` works on any capability**, not only side-effecting ones. "This only
   reads, but in my organization somebody approves it anyway" is a real decision


### PR DESCRIPTION
## What changed

`AgentRunnerService.resume` flipped the run to `RUNNING` **before** fetching the
version it parked on and assembling its spec. Every reason an assembly can refuse
then stranded the run: `claim_parked_run` only ever hands out a row still
`AWAITING_APPROVAL`, so a run left in `RUNNING` by a failed attempt is one nobody
can finish — holding an approval a person granted and reporting nothing.

The reasons are not exotic; each happens to deployments that change nothing about
the run itself: a secret a binding names deleted after the park (the registry
refuses rather than running a capability without its key, deliberately), a model
profile removed, a capability dropped from the registry in a deploy, an MCP
connection unshared. `max_depth: 0` — the field the issue was originally filed
about — is one more route into the same place, and the only one no released
version can produce.

The fix is **ordering**, not compensation: assemble first, and flip the row to
`RUNNING` only once the build has succeeded. Two different resumes must be kept
out, and neither needs the status written early:

- one arriving *while this one builds* waits at `claim_parked_run` — the row lock
  is held for the whole transaction — then reads the status written after the
  build, so building first widens no window;
- one arriving *after this transaction commits* has no lock to wait on and is
  refused by finding the run no longer parked, which is why the flip still
  happens before the replay rather than after it.

Catching the failure and writing the row back would have needed a revert committed
on a path that currently rolls everything back; a status never written cannot be
committed wrong.

## Why it matters even though the request rolls back today

On `main` the whole request rolls back on the raise, so the `RUNNING` UPDATE is
discarded and the row survives *by accident*. The row's survival depends on nothing
committing after the flip — an invariant nothing states or tests, and one #171 is
about to remove by committing a failed run's accounting the way the streaming path
already does. This removes the dependency rather than documenting it.

## How it was verified

- New unit test `test_a_run_whose_spec_no_longer_builds_is_still_resumable`
  (`tests/test_agent_runner.py::TestResume`) deletes the secret a `web_research`
  binding names, resumes twice, and asserts the second attempt reaches the same
  refusal (`...no longer has`) rather than "this run is not waiting for approval".
  **Proven to fail without the fix** — reverting the ordering locally makes it
  fail with exactly that wrong message.
- `test_a_run_leaves_the_queue_before_anything_is_replayed` still proves the status
  changes before the tool call is replayed.
- `docs/governance.md` gains the fourth property: a parked run stays resumable if
  continuing it fails.
- `POSTGRES_DB=agenticos_test_i176 make check` — green: backend 3167 passed at 100%
  platform coverage, frontend 3144 passed, db-check, build-frontend, docs-build and
  audit all pass.

Nothing is currently red.

Closes #176
