### PR TITLE
fix(e2e): make the frontend and stub ports configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,7 +342,16 @@ audit:
 # Playwright starts the frontend itself; the backend and its seed are on you.
 # Checked rather than assumed: against a backend that is not there the suite
 # fails in fifty places at once, none of which say what is actually wrong.
+#
+# All three addresses are overridable so the suite can run beside another
+# checkout holding the defaults: E2E_PORT moves the frontend, E2E_STUB_MODEL_PORT
+# the stub model server, E2E_BACKEND the API the health check dials. They are
+# passed into the recipe's environment so Playwright and its specs read the same
+# values, and printed first because a suite that fails on a busy port should say
+# which one it wanted.
 E2E_BACKEND ?= http://localhost:8000
+E2E_PORT ?= 3000
+E2E_STUB_MODEL_PORT ?= 4010
 
 test-e2e:
 	@if ! curl -sf $(E2E_BACKEND)/api/v1/health > /dev/null; then \
@@ -350,7 +359,8 @@ test-e2e:
 		echo "  make dev && make platform-bootstrap"; \
 		exit 1; \
 	fi
-	cd frontend && bun run test:e2e
+	@echo "▶ frontend :$(E2E_PORT)  ·  stub model :$(E2E_STUB_MODEL_PORT)  ·  backend $(E2E_BACKEND)"
+	cd frontend && E2E_PORT=$(E2E_PORT) E2E_STUB_MODEL_PORT=$(E2E_STUB_MODEL_PORT) bun run test:e2e
 
 # Every CI job, in the order the workflow declares them, with the exceptions
 # named below. This is the one claim in this file that has to be exactly true:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -119,9 +119,21 @@ bun run test:e2e --headed                                  # ...with a browser t
 97.5% branches over `src/{app/api,lib,stores,hooks}` and most of `src/components`.
 
 Playwright starts what the suite needs: the frontend, and an OpenAI-compatible
-**stub model server** (`frontend/e2e/stub-model-server.ts`) on `127.0.0.1:4010`.
-The backend and its database have to be up already — the seeded owner, model
-profile and published agent come from `agenticos cmd bootstrap`.
+**stub model server** (`frontend/e2e/stub-model-server.ts`) on `127.0.0.1:4010`
+by default. The backend and its database have to be up already — the seeded
+owner, model profile and published agent come from `agenticos cmd bootstrap`.
+
+Both ports are configurable, so the suite runs beside another checkout that
+already holds the defaults — a `bun run dev` left up on 3000, or a second
+worktree. `E2E_PORT` moves the frontend, `E2E_STUB_MODEL_PORT` the stub, and
+`playwright.config.ts` derives `baseURL`, both `webServer.url`s and the servers'
+`PORT`/`E2E_STUB_MODEL_PORT` from them — so nothing is told a port twice.
+`make test-e2e` reads all three (with `E2E_BACKEND`) and prints them before it
+starts:
+
+```bash
+E2E_PORT=3100 make test-e2e          # frontend on 3100, stub on its default
+```
 
 The stub is what lets `journey.spec.ts` run an agent end to end without a
 provider key: it serves the Chat Completions API, streaming included, and a model
@@ -130,6 +142,11 @@ agent's instructions tell it to say — which is the assertion, since nothing el
 could put that token in the reply — and returns usage, so the run is priced and
 the journey's last assertion has a cost to find. It authenticates nothing and
 calls no tools; what it does not prove is that a real provider answers.
+
+The stub binds loopback, and the backend dials it at `127.0.0.1:<port>` through
+that stored profile — so the backend has to share the host's loopback. That is
+the host-uvicorn path CI runs; a backend in a container cannot reach the host's
+`127.0.0.1`, and moving the port does not change that.
 
 ### A red `e2e` is often the fixture, not the product
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
-    "dev": "next dev -p 3000",
+    "dev": "next dev",
     "build": "next build",
     "analyze": "ANALYZE=true next build",
-    "start": "next start -p 3000",
+    "start": "next start",
     "start:standalone": "cp -r public .next/standalone/public 2>/dev/null; cp -r .next/static .next/standalone/.next/static 2>/dev/null; node .next/standalone/server.js",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,6 +1,36 @@
 import { defineConfig, devices } from "@playwright/test";
 
 /**
+ * The two ports the suite occupies, each derived from the environment so the
+ * suite can run beside another checkout that already holds the defaults.
+ *
+ * Derived rather than `setdefault`: `Number(process.env.X ?? default)` reads
+ * whatever is set and falls back only when nothing is — so `E2E_PORT=3100`
+ * moves the whole suite while an unset environment (CI, and `make test-e2e`
+ * with nothing exported) stays on the historical 3000/4010. A default that
+ * ignored an already-set value would leave CI on the fixed port with the new
+ * code never exercised there, which is the trap #189 named for the test
+ * database name.
+ *
+ * `E2E_STUB_MODEL_PORT` is read here *and* in `journey.spec.ts` and
+ * `delegation.spec.ts`, both with the same `?? 4010` default: the specs dial
+ * the stub through a model profile whose Endpoint is
+ * `http://127.0.0.1:${E2E_STUB_MODEL_PORT}/v1`, so the number the backend
+ * learns and the number the stub binds have to be the one value. Passing it
+ * into the stub's `webServer.env` below is what forbids them to disagree even
+ * if the config later chose the port itself.
+ *
+ * The stub binds loopback (`127.0.0.1`), and the backend reaches it by that
+ * address — so the backend has to share the host's loopback. That is the
+ * host-uvicorn path CI runs and `journey.spec.ts` needs; a backend in a
+ * container cannot reach `127.0.0.1:${E2E_STUB_MODEL_PORT}` and this file does
+ * not pretend otherwise. Moving the port does not change that.
+ */
+const FRONTEND_PORT = Number(process.env.E2E_PORT ?? 3000);
+const STUB_MODEL_PORT = Number(process.env.E2E_STUB_MODEL_PORT ?? 4010);
+const BASE_URL = `http://localhost:${FRONTEND_PORT}`;
+
+/**
  * Playwright E2E test configuration.
  *
  * See https://playwright.dev/docs/test-configuration.
@@ -59,7 +89,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000",
+    baseURL: BASE_URL,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
@@ -135,7 +165,13 @@ export default defineConfig({
        * older checkout thought a model should say.
        */
       command: "bun run e2e/stub-model-server.ts",
-      url: "http://127.0.0.1:4010/health",
+      url: `http://127.0.0.1:${STUB_MODEL_PORT}/health`,
+      // Handed the port explicitly rather than left to inherit it: the server
+      // and the two specs that dial it read the same variable, so binding one
+      // port while the profile names another becomes impossible instead of a
+      // pair of silent `element(s) not found` failures in journey and
+      // delegation.
+      env: { E2E_STUB_MODEL_PORT: String(STUB_MODEL_PORT) },
       reuseExistingServer: false,
       timeout: 30 * 1000,
     },
@@ -155,7 +191,12 @@ export default defineConfig({
       // proxies to the backend, so a broken data layer would look like a frontend
       // that never started, and Playwright would report nothing at all instead of
       // the specs that failed.
-      url: "http://localhost:3000",
+      url: BASE_URL,
+      // Both commands read `PORT` - `next dev` when it is not given `-p`, and the
+      // standalone `server.js` always - so this one variable moves whichever one
+      // runs. The `dev` and `start` scripts dropped their hardcoded `-p 3000` for
+      // exactly this: the port lives here now, not in package.json.
+      env: { PORT: String(FRONTEND_PORT) },
       reuseExistingServer: !process.env.CI,
       timeout: 120 * 1000,
     },


### PR DESCRIPTION
## What and why

`playwright.config.ts` hardcoded both ports the E2E suite needs — `3000`
(frontend) and `127.0.0.1:4010` (stub model server) — so
`CI=1 bunx playwright test` refused to start whenever either was held: a
`bun run dev` left up in another worktree, or two checkouts running at
once. Under CI the frontend `webServer` sets `reuseExistingServer:false`
(right — a stale process must never be mistaken for the build under
test), which is also the only configuration that exercises what ships,
so the only way to run the suite the way CI does was to kill somebody
else's server.

Both ports are now derived from the environment the way #189 derived the
test-database name — `Number(process.env.X ?? default)`, not
`setdefault` — so an unset environment (CI, `make test-e2e` with nothing
exported) stays on the historical 3000/4010, while `E2E_PORT` and
`E2E_STUB_MODEL_PORT` move the whole suite together.

## How the pieces agree

- `playwright.config.ts` derives `baseURL`, both `webServer.url` values
  and each server's `PORT` / `E2E_STUB_MODEL_PORT` from the two
  variables.
- The stub's port is passed into its `webServer.env`, so the server and
  the two specs that dial it (`journey`, `delegation`) cannot disagree —
  they read the same `E2E_STUB_MODEL_PORT` with the same `?? 4010`
  default.
- **Where the backend learns the stub's port:** the specs build
  `http://127.0.0.1:${E2E_STUB_MODEL_PORT}/v1` and fill it into a model
  profile's **Endpoint** field (`journey.spec.ts:148`); the backend
  dials that stored URL when it runs the agent. So one variable reaches
  the stub (bind), the specs (assert) and the backend (via the profile).
- The stub still binds loopback. The backend must therefore share the
  host's loopback — the host-uvicorn path CI runs and `journey.spec.ts`
  needs. **A containerised backend cannot reach `127.0.0.1:<port>`, and
  neither the config nor `docs/testing.md` pretends otherwise.** Moving
  the port does not change that.
- `dev` and `start` dropped their hardcoded `-p 3000` so `PORT` drives
  the port from one place; both still default to 3000 unset, leaving
  `make dev-frontend`, the Dockerfile (`bun server.js`) and a bare
  `bun run dev` unchanged.
- `make test-e2e` reads all three addresses (`E2E_PORT`,
  `E2E_STUB_MODEL_PORT`, `E2E_BACKEND`) and prints them before starting.

## Verification — the occupied-ports proof

With **3000 and 4010 both occupied** (3000 by another checkout's dev
server, 4010 by a trivial listener):

- **Without this change** (`origin/main`), `CI=1 bunx playwright test`
  refused before a single test ran:
  ```
  Error: http://127.0.0.1:4010/health is already used, make sure that
  nothing is running on the port/url or set reuseExistingServer:true ...
  ```
- **With this change**,
  `E2E_PORT=3100 E2E_STUB_MODEL_PORT=4110 bunx playwright test` brought
  the frontend up on `:3100` and the stub on `:4110` and reached the
  `setup` project — no "already used" error. (Setup then failed at login
  because the live backend here is not the e2e-bootstrapped one; that is
  backend state, not a port matter.)

Also run green locally: `bunx tsc --noEmit`, `prettier --check` and
`eslint` on the changed frontend files, and `mkdocs build --strict`.

No automated regression test is added: the change is test-harness
configuration, and the guard is the occupied-ports run above rather than
a unit test that would only re-assert the wiring.

## Where this sits

Tests/CI/dependencies cluster in #168 — the local-environment friction
pair with #172 (bootstrap adopting an existing profile). Nearest
neighbour, not a duplicate: #172 is about the database's state, this is
about the ports. Pre-existing; surfaced while working #132.

Closes #223
