### PR TITLE
chore: cut 0.0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.24] - 2026-08-05
+
+### Fixed
+
+- **A parked run whose spec no longer builds stays resumable**
+  ([#176](https://github.com/vstorm-co/agenticos/issues/176)). `resume` flipped the run to
+  `RUNNING` before fetching and building its spec, and `claim_parked_run` only claims a run
+  in `AWAITING_APPROVAL` — so if the build then failed (a secret a binding named was
+  deleted, a model profile removed, a capability dropped in a deploy, an MCP connection
+  unshared), the row was stranded in `RUNNING` and could never be resumed again, with a
+  person's approval recorded against work that would not continue and nothing reporting it.
+  The spec is built first now, and the run is marked `RUNNING` only once the build has
+  succeeded; a build that raises leaves the run `AWAITING_APPROVAL`, so the same approval
+  can be resumed once whatever the spec named is restored.
+
 ## [0.0.23] - 2026-08-05
 
 ### Fixed
@@ -956,7 +971,8 @@ installed hook did nothing.
   codebase has diverged from the generator past the point where a 3-way merge
   helps.
 
-[Unreleased]: https://github.com/vstorm-co/agenticos/compare/v0.0.23...HEAD
+[Unreleased]: https://github.com/vstorm-co/agenticos/compare/v0.0.24...HEAD
+[0.0.24]: https://github.com/vstorm-co/agenticos/compare/v0.0.23...v0.0.24
 [0.0.23]: https://github.com/vstorm-co/agenticos/compare/v0.0.22...v0.0.23
 [0.0.22]: https://github.com/vstorm-co/agenticos/compare/v0.0.21...v0.0.22
 [0.0.21]: https://github.com/vstorm-co/agenticos/compare/v0.0.20...v0.0.21

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.23"
+version = "0.0.24"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.23"
+version = "0.0.24"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for **#176** — a parked run whose spec no longer builds stays resumable. `resume` marked the run `RUNNING` before building its spec, and `claim_parked_run` only claims `AWAITING_APPROVAL`, so a build that failed (a deleted secret/model-profile/capability/MCP connection) stranded the row in `RUNNING` forever. The spec is built first now; a failed build leaves the run `AWAITING_APPROVAL`, resumable once what it named is restored. Code landed as #270.

No schema change, `SPEC_VERSION` unchanged at 7.