### PR TITLE
chore: cut 0.0.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,25 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.26] - 2026-08-05
+
+### Added
+
+- **The agent map is interactive, and shows delegates as their own nodes**
+  ([#126](https://github.com/vstorm-co/agenticos/issues/126)). The map — the read-only
+  picture of "what is this agent, in total?" — now draws delegation. A published delegate
+  (pinned, navigable), an inline specialist (no page of its own), and a pin the
+  organization no longer has or the caller cannot see (named as unreachable rather than
+  dropped) each render as a distinct kind of node — an agent, not a tool — grouped under a
+  Delegation heading and edged to the hub by the same measured layout the capabilities use.
+
+  And it is a control now, not a picture: every node is a focusable button, click or
+  Enter/Space lights its edge and dims the rest and opens a detail panel, Escape or a click
+  away clears it, and a published delegate's panel links through to *that* agent's page — so
+  the delegation tree is walkable one hop at a time. It stays read-only (the forms own the
+  fields) and keeps pan/zoom. Rendering the tree recursively inline is a deliberate
+  follow-up, [#276](https://github.com/vstorm-co/agenticos/issues/276).
+
 ## [0.0.25] - 2026-08-05
 
 ### Changed
@@ -991,7 +1010,8 @@ installed hook did nothing.
   codebase has diverged from the generator past the point where a 3-way merge
   helps.
 
-[Unreleased]: https://github.com/vstorm-co/agenticos/compare/v0.0.25...HEAD
+[Unreleased]: https://github.com/vstorm-co/agenticos/compare/v0.0.26...HEAD
+[0.0.26]: https://github.com/vstorm-co/agenticos/compare/v0.0.25...v0.0.26
 [0.0.25]: https://github.com/vstorm-co/agenticos/compare/v0.0.24...v0.0.25
 [0.0.24]: https://github.com/vstorm-co/agenticos/compare/v0.0.23...v0.0.24
 [0.0.23]: https://github.com/vstorm-co/agenticos/compare/v0.0.22...v0.0.23

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.25"
+version = "0.0.26"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.25"
+version = "0.0.26"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for **#126** — the agent map is interactive and draws delegation. A published delegate (navigable), an inline specialist, and an unreachable pin each render as a distinct kind of node — an agent, not a tool — under a Delegation heading. Every node is a focusable button: click or Enter lights its edge and opens a detail panel, and a published delegate's panel links through to that agent's page, so the tree is walkable one hop at a time. Read-only and pan/zoom kept. Recursive-inline tree is follow-up #276. Code landed as #275.

No schema change, `SPEC_VERSION` unchanged at 7.