### PR TITLE
fix(chat): close a delegate panel when an approved resume raises

### DIFF
--- a/backend/app/core/exceptions.py
+++ b/backend/app/core/exceptions.py
@@ -124,6 +124,28 @@ class ConfigurationError(AppException):
     status_code = 503
 
 
+class RunExecutionError(AppException):
+    """A run failed while executing, its terminal status already recorded (500).
+
+    Raised by :meth:`~app.services.agent_runner.AgentRunnerService.resume` when the
+    continuation of a parked run *itself* raises. `AgentRunnerService._run` has by
+    then recorded the run `failed` (or `cancelled`) and committed it, so the failure
+    is durable and this does not swallow it - the caller still gets a 5xx. What it
+    adds is the recorded status in `details`: the resume answer is the only place a
+    web-chat surface learns a delegate's outcome (the continuation ran over HTTP, not
+    the socket the conversation streams), and the raising path used to discard that
+    answer - leaving a panel waiting on a decision already spent and a run that can no
+    longer be resumed (agenticos#262). The original exception is chained, and `_run`
+    has already logged it; the message here stays generic for the same reason the
+    unhandled-exception handler's does - a raw run error is not a thing to put on the
+    wire.
+    """
+
+    message = "The run failed while continuing after approval"
+    code = "RUN_EXECUTION_FAILED"
+    status_code = 500
+
+
 class DatabaseError(AppException):
     """Database error (500)."""
 

--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -110,7 +110,7 @@ from app.agents.subagent_runtime import (
     ResumedDelegation,
     SubagentRuntime,
 )
-from app.core.exceptions import BadRequestError, NotFoundError
+from app.core.exceptions import BadRequestError, NotFoundError, RunExecutionError
 from app.core.permissions import AuthContext, Perm
 from app.core.secret_kinds import StorableSecret
 from app.db.models.agent import Agent, AgentStatus
@@ -2503,14 +2503,31 @@ class AgentRunnerService:
         # never written.
         await agent_run_repo.mark_running(self.db, run=run)
 
-        return await self._run(
-            prepared,
-            # No new prompt: the conversation resumes at the tool call it stopped
-            # on, and inventing a user turn here would put words in their mouth.
-            user_prompt=None,
-            message_history=ModelMessagesTypeAdapter.validate_python(state.messages),
-            deferred_tool_results=plan.results,
-        )
+        try:
+            return await self._run(
+                prepared,
+                # No new prompt: the conversation resumes at the tool call it stopped
+                # on, and inventing a user turn here would put words in their mouth.
+                user_prompt=None,
+                message_history=ModelMessagesTypeAdapter.validate_python(state.messages),
+                deferred_tool_results=plan.results,
+            )
+        except Exception as exc:
+            # The continuation raised. `_run` has recorded the run terminal and
+            # committed before re-raising, so this re-raise carries the failure to
+            # the caller rather than swallowing it - but it also carries the
+            # recorded status, which the raising path used to throw away. The resume
+            # answer is where a web-chat surface learns a delegate's outcome (the
+            # continuation ran over HTTP, not the socket the conversation streams);
+            # without the status the surface leaves an `awaiting_approval` panel
+            # waiting on a decision already spent, and the run cannot be resumed
+            # again because it is now terminal (agenticos#262). A build refusal
+            # raised *before* `_run` leaves the run parked and is retryable, so it
+            # is deliberately outside this `try` - it must keep surfacing as itself.
+            # `CancelledError` is a `BaseException` and not caught: over HTTP it
+            # means the request itself went away, so there is nobody to hand a
+            # status to, and catching it would break the cancellation it signals.
+            raise RunExecutionError(details={"run_id": str(run.id), "status": run.status}) from exc
 
     async def _decisions(
         self, ctx: AuthContext, *, run: AgentRun, state: PausedRunState

--- a/backend/tests/api/test_platform_routes.py
+++ b/backend/tests/api/test_platform_routes.py
@@ -33,7 +33,7 @@ from httpx import ASGITransport, AsyncClient
 
 from app.api import deps
 from app.core.config import settings
-from app.core.exceptions import NotFoundError
+from app.core.exceptions import NotFoundError, RunExecutionError
 from app.core.permissions import ROLE_PERMS, AuthContext, OrgRoleName, Perm, Scope
 from app.db.models.resource_grant import Visibility
 from app.main import app
@@ -734,6 +734,37 @@ class TestSharingRoutesRefuseWithoutAGrant:
         # Reading reports the row as missing rather than forbidden, so ids
         # cannot be probed; changing it is an outright refusal.
         assert response.status_code == (404 if method == "GET" else 403)
+
+
+class TestResumeConveysAFailedContinuation:
+    """A resume whose continuation raised is a 5xx that still names the run's status.
+
+    The service records the run terminal and re-raises `RunExecutionError` carrying
+    that status (agenticos#262). This proves the HTTP layer does not discard it: the
+    failure is a 500 - not swallowed into a success - and the recorded status rides
+    in the error envelope's `details`, which is the only place a web-chat surface can
+    read a delegate's outcome when the resume did not return.
+    """
+
+    async def test_a_failed_resume_answers_5xx_with_the_status_in_the_body(
+        self, as_role: ClientFactory, synthetic_roles: None
+    ) -> None:
+        run_id = uuid4()
+
+        class _Failing:
+            async def resume(self, *args: Any, **kwargs: Any) -> Any:
+                raise RunExecutionError(
+                    details={"run_id": str(run_id), "status": "failed"}
+                ) from RuntimeError("the tool the approval unblocked then failed")
+
+        overrides = {deps.get_agent_runner_service: lambda: _Failing()}
+        async with as_role(only(Perm.APPROVALS_DECIDE), overrides) as client:
+            response = await client.post(_url(f"/runs/{run_id}/resume"))
+
+        assert response.status_code == 500
+        body = response.json()
+        assert body["error"]["code"] == "RUN_EXECUTION_FAILED"
+        assert body["error"]["details"] == {"run_id": str(run_id), "status": "failed"}
 
 
 # -- the inverse guard, for routes that are deliberately open -----------------

--- a/backend/tests/test_agent_runner.py
+++ b/backend/tests/test_agent_runner.py
@@ -22,7 +22,7 @@ from app.agents.capabilities.approval import ApprovalGranted, ApprovalRejected
 from app.agents.capabilities.budget import BudgetExceeded, BudgetScope, SpendLedger
 from app.agents.spec import AgentSpec, CapabilityBindingSpec, ObservabilitySpec
 from app.agents.subagent_runtime import DelegationSpend, DelegationStash, ParkedDelegation
-from app.core.exceptions import BadRequestError, NotFoundError
+from app.core.exceptions import BadRequestError, NotFoundError, RunExecutionError
 from app.core.permissions import AuthContext, OrgRoleName
 from app.db.models.agent_run import ApprovalStatus, RunStatus, RunSurface
 from app.services.agent_runner import (
@@ -1483,6 +1483,68 @@ class TestResume:
                     await service.resume(_ctx(), run.id)
 
         assert run.status == RunStatus.AWAITING_APPROVAL.value
+
+    @pytest.mark.anyio
+    async def test_a_resume_whose_continuation_fails_records_the_status_and_conveys_it(self):
+        """The failure reaches the caller, and the recorded status travels with it.
+
+        The gap #262 fixes: when the continuation raises, `_run` records the run
+        `failed` and commits it, then re-raises - and the resume route used to let
+        that raw exception through with no status, so a web-chat surface (which
+        learns a delegate's outcome only from this HTTP answer) left an
+        `awaiting_approval` panel waiting on a decision already spent, on a run that
+        can no longer be resumed. `resume` now re-raises `RunExecutionError` carrying
+        the recorded status, while still surfacing the failure - the original
+        exception is chained, not swallowed.
+        """
+        service = AgentRunnerService(_db())
+        approval = self._approval(status=ApprovalStatus.APPROVED.value, tool_args={})
+        run = _parked_run(
+            paused_state={"messages": [], "tool_call_ids": {str(approval.id): "call-1"}}
+        )
+        built = self._built()
+        blew_up = RuntimeError("the tool the approval unblocked then failed")
+        built.agent.run = AsyncMock(side_effect=blew_up)
+
+        # The real `finish` runs; `finish_run` is the one call stubbed, and it stamps
+        # the terminal status onto the row the way the repository does - which is what
+        # makes `run.status` the recorded truth by the time `resume` reads it.
+        async def record_terminal_status(*args: Any, **kwargs: Any) -> Any:
+            run.status = kwargs["status"]
+            return run
+
+        with (
+            patch(
+                "app.services.agent_runner.agent_run_repo.claim_parked_run",
+                new=AsyncMock(return_value=run),
+            ),
+            patch(
+                "app.services.agent_runner.agent_run_repo.list_approvals_for_run",
+                new=AsyncMock(return_value=[approval]),
+            ),
+            patch(
+                "app.services.agent_runner.agent_repo.get_version",
+                new=AsyncMock(return_value=self._version()),
+            ),
+            patch("app.services.agent_runner.build_agent", return_value=built),
+            patch(
+                "app.services.agent_runner.agent_run_repo.finish_run",
+                new=AsyncMock(side_effect=record_terminal_status),
+            ),
+            patch.object(service.registry, "get", new=AsyncMock(return_value=MagicMock())),
+            patch.object(
+                service.models, "resolve", new=AsyncMock(return_value=MagicMock(label="gpt-4.1"))
+            ),
+            patch.object(service.skills, "resolve_for_agent", new=AsyncMock(return_value=[])),
+            pytest.raises(RunExecutionError) as raised,
+        ):
+            await service.resume(_ctx(), run.id)
+
+        # The run was recorded terminal, and the caller is told which status.
+        assert run.status == RunStatus.FAILED.value
+        assert raised.value.details == {"run_id": str(run.id), "status": RunStatus.FAILED.value}
+        # The failure is conveyed, not hidden: the original exception is chained.
+        assert raised.value.__cause__ is blew_up
 
 
 class TestWhoTheRunSaysItIs:

--- a/frontend/src/hooks/use-chat.test.tsx
+++ b/frontend/src/hooks/use-chat.test.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useChat } from "./use-chat";
+import { ApiError } from "@/lib/api-error";
 import { qk } from "@/lib/query-keys";
 import {
   useAgentSelectionStore,
@@ -929,6 +930,59 @@ describe("useChat - approvals and questions", () => {
     });
 
     expect(result.current.delegations[0]?.status).toBe("awaiting_approval");
+  });
+
+  it("closes a parked delegate's panel when the resume's continuation fails", async () => {
+    // agenticos#262. The approval is granted and the continuation *raises*: the
+    // resume does not return, so there is no `status` to reconcile from - but the
+    // backend recorded the run `failed` and sent it in the error body. Without
+    // reading it, the panel reads "waiting for approval" forever, on a run that can
+    // no longer be resumed. It must close to `failed`, and the decided approval must
+    // not come back for a retry that would only 400.
+    post.mockImplementation((url: string) =>
+      url.endsWith("/resume")
+        ? Promise.reject(
+            new ApiError(500, "The run failed while continuing after approval", {
+              error: {
+                code: "RUN_EXECUTION_FAILED",
+                message: "The run failed while continuing after approval",
+                details: { run_id: "r-9", status: "failed" },
+              },
+            }),
+          )
+        : Promise.resolve({}),
+    );
+    const { result } = renderHook(() => useChat(), { wrapper });
+    receive("model_request_start", {});
+    receive("subagent_start", {
+      kind: "subagent_start",
+      task_id: "t1",
+      subagent: "researcher",
+      depth: 0,
+      mode: "sync",
+      prompt: "send the summary",
+      parent_task_id: null,
+    });
+    receive("subagent_awaiting_approval", {
+      kind: "subagent_awaiting_approval",
+      task_id: "t1",
+      subagent: "researcher",
+      depth: 0,
+    });
+    receive("tool_approval_required", {
+      run_id: "r-9",
+      action_requests: [{ id: "ar-1", tool_call_id: "tc-1", tool_name: "send_email", args: {} }],
+      review_configs: [],
+    });
+    expect(result.current.delegations[0]?.status).toBe("awaiting_approval");
+
+    await act(async () => {
+      await result.current.sendResumeDecisions([{ type: "approve" }]);
+    });
+
+    expect(result.current.delegations[0]?.status).toBe("failed");
+    // Not restored: the run is terminal, so a retry cannot succeed.
+    expect(result.current.pendingApproval).toBeNull();
   });
 
   it("adds nothing when the resumed run answered with nothing", async () => {

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -25,6 +25,7 @@ import {
   applyDelegationFrame,
   closeOpenDelegations,
   resolveAwaitingOnResume,
+  resumeFailureStatus,
 } from "@/lib/delegations";
 import { WS_URL } from "@/lib/constants";
 import { toast } from "sonner";
@@ -691,9 +692,22 @@ export function useChat(options: UseChatOptions = {}) {
           });
         }
       } catch (error) {
-        // Put it back rather than swallowing it. A decision that failed to
-        // record is a run still parked, and a panel that vanished is a person
-        // believing they unblocked it.
+        const terminalStatus = resumeFailureStatus(error);
+        if (terminalStatus !== null) {
+          // The continuation itself failed. The backend recorded the run terminal
+          // and committed it before re-raising, so the run is no longer parked and
+          // this resume cannot be retried - restoring the approval would only offer
+          // a button that 400s. Close the delegate panels to that outcome instead,
+          // the closing the resume answer would have carried had it returned, and
+          // still surface the failure (agenticos#262).
+          setDelegations((current) => resolveAwaitingOnResume(current, terminalStatus));
+          toast.error(getErrorMessage(error));
+          return;
+        }
+        // The decision failed to record, or the resume could not be built (a secret
+        // deleted since the park): the run is still parked, so put the approval back
+        // rather than swallowing it - a panel that vanished is a person believing
+        // they unblocked it, and the retry can now succeed.
         setPendingApproval(parked);
         toast.error(getErrorMessage(error));
       }

--- a/frontend/src/lib/delegations.test.ts
+++ b/frontend/src/lib/delegations.test.ts
@@ -5,8 +5,10 @@ import {
   childrenOf,
   closeOpenDelegations,
   resolveAwaitingOnResume,
+  resumeFailureStatus,
   rootsOf,
 } from "./delegations";
+import { ApiError } from "@/lib/api-error";
 import type { Delegation, SubagentFrame } from "@/types";
 
 /** A `subagent_start`, which is the only frame that can create a panel. */
@@ -472,6 +474,37 @@ describe("resolveAwaitingOnResume - closing a panel the HTTP resume left waiting
     const after = resolveAwaitingOnResume(delegations, "completed");
 
     expect(after).toBe(delegations);
+  });
+});
+
+describe("resumeFailureStatus - reading a terminal status off a failed resume", () => {
+  /** The refusal envelope a raising continuation produces (`RUN_EXECUTION_FAILED`). */
+  function resumeError(details: Record<string, unknown> | null): ApiError {
+    return new ApiError(500, "The run failed while continuing after approval", {
+      error: { code: "RUN_EXECUTION_FAILED", message: "failed", details },
+    });
+  }
+
+  it("reads the recorded status when the continuation raised", () => {
+    // The crux of agenticos#262: the resume did not return, so this status - carried
+    // in the error body - is the only per-delegation outcome the surface can get.
+    expect(resumeFailureStatus(resumeError({ run_id: "r1", status: "failed" }))).toBe("failed");
+  });
+
+  it("returns null when the run is still parked, so the decision is kept for retry", () => {
+    // A build refusal (a secret deleted since the park) leaves the run parked and
+    // carries no status: the caller must restore the approval, not close the panel.
+    expect(resumeFailureStatus(resumeError({ run_id: "r1" }))).toBeNull();
+    expect(resumeFailureStatus(resumeError(null))).toBeNull();
+  });
+
+  it("returns null for a non-terminal status, which is no outcome to close a panel to", () => {
+    expect(resumeFailureStatus(resumeError({ status: "running" }))).toBeNull();
+    expect(resumeFailureStatus(resumeError({ status: "awaiting_approval" }))).toBeNull();
+  });
+
+  it("returns null for anything that is not an ApiError", () => {
+    expect(resumeFailureStatus(new Error("network down"))).toBeNull();
   });
 });
 

--- a/frontend/src/lib/delegations.ts
+++ b/frontend/src/lib/delegations.ts
@@ -13,6 +13,7 @@
  * in the order the parent asked, not in whichever order a hash lands.
  */
 
+import { ApiError } from "@/lib/api-error";
 import type { Delegation, DelegationStatus, SubagentFrame, SubagentStartFrame } from "@/types";
 import type { RunStatus } from "@/types/runs";
 
@@ -226,6 +227,31 @@ export function resolveAwaitingOnResume(current: Delegation[], runStatus: RunSta
   return current.map((delegation) =>
     delegation.status === "awaiting_approval" ? { ...delegation, status: resolved } : delegation,
   );
+}
+
+/**
+ * The terminal run status a *failed* resume reports, or null when it reports none.
+ *
+ * `POST /runs/{id}/resume` answers with the run's status when it returns - and the
+ * caller reconciles its panels from that (`resolveAwaitingOnResume`). When the
+ * continuation *raises*, there is no answer: the backend records the run terminal,
+ * commits it, and re-raises carrying that status in the error envelope's
+ * `details.status` (code `RUN_EXECUTION_FAILED`). This reads it back so the same
+ * reconciliation runs on the error path, closing a panel the raising resume would
+ * otherwise leave waiting forever (agenticos#262).
+ *
+ * Only a genuinely terminal status counts. A resume that could not be *built* - a
+ * secret deleted since the park, a model profile removed - leaves the run still
+ * parked and carries no status here; that returns null, and the caller restores the
+ * decision for a retry that can now succeed. `running` and `awaiting_approval`
+ * likewise return null: neither is an outcome to close a panel to.
+ */
+export function resumeFailureStatus(error: unknown): RunStatus | null {
+  if (!(error instanceof ApiError)) return null;
+  const status = error.details?.status;
+  return typeof status === "string" && status in TERMINAL_DELEGATION_STATUS
+    ? (status as RunStatus)
+    : null;
 }
 
 /** The delegations started from this one, in the order they started. */


### PR DESCRIPTION
## What changed and why

A sync delegate that parks on an approval leaves its panel `awaiting_approval`. In web chat the resume that follows the decision runs over HTTP (`POST /runs/{id}/resume`), not the socket the conversation streams, so #250 reconciled that panel from the resume's answer. That works when the resume **returns** — but not when the continuation **raises**: `AgentRunnerService._run` records the run `failed`/`cancelled`, commits, and re-raises, so the route returned nothing. The frontend saw no result, skipped `resolveAwaitingOnResume`, restored the already-decided approval, and left the panel waiting forever on a decision already spent — un-retryable, because the run is now terminal.

The gap was the **HTTP layer discarding the recorded status**, not `_run` re-raising (which is correct and stays). Chosen shape: **the backend conveys the recorded terminal status on the raising path while keeping the failure visible as a 5xx.**

- `resume` catches the continuation's exception, reads the status `_run` already recorded and committed, and re-raises `RunExecutionError` (500) carrying `{run_id, status}` in `details`. The failure still surfaces as a 5xx (original exception chained, already logged), but the status travels with it. A build refusal raised *before* `_run` stays outside the `try` — the run is still parked and retryable, so it keeps surfacing as itself. `CancelledError` is deliberately not caught: over HTTP it means the request went away, so there is nobody to hand a status to.
- The frontend reads that status via `resumeFailureStatus`: on a terminal one it reconciles the panels (`resolveAwaitingOnResume`) and does **not** restore the approval; on none (a run still parked) it restores it for a retry that can now succeed.

## Tests

Both fail without the fix:

- **Backend service** (`test_agent_runner.py`): a resume whose continuation raises records the terminal status and re-raises `RunExecutionError` carrying it, with the original exception chained (asserts `RunExecutionError`, where the raw `RuntimeError` would otherwise propagate).
- **Backend API** (`test_platform_routes.py`): the route answers 500 with `error.details.status` in the body — the status is conveyed, the error not swallowed.
- **Frontend** (`delegations.test.ts`, `use-chat.test.tsx`): `resumeFailureStatus` reads a terminal status off the error body and returns null for a still-parked run; the hook closes the panel to `failed` and does **not** restore the approval on a resume-that-fails.

## Verification

`make check` green locally against a migrated `agenticos_test_i262`: backend 100% platform-coverage gate (3169 passed), frontend gate (3149 passed), build-frontend, docs-build (no drift owed), audit. e2e not run locally.

Closes #262
