### PR TITLE
fix(capabilities): keep a nested delegate's specialists across a park

### DIFF
--- a/backend/app/agents/capabilities/subagents/README.md
+++ b/backend/app/agents/capabilities/subagents/README.md
@@ -144,6 +144,15 @@ So a parked run is a tree, and three pieces carry it:
   Pydantic AI refuses a resume whose results name a call the replayed response does
   not contain, so one flat set for the whole tree fails the continuation.
 
+The same tree carries a fourth thing when a level binds `allow_dynamic`: the
+specialists it kept with `create_agent`. They ride on that level's own
+`DelegationFrame`, keyed by the `task` call it was delegated from — the run's own
+agent's on the flat `PausedRunState.dynamic_specialists` — so a nested `create_agent`
+survives the park its own delegate caused, not only the run's own agent's
+(agenticos#254). `record_created_specialists` snapshots each level's registry under
+that key when its `wrap_run` ends, and `build_delegation` re-seeds each level's fresh
+registry from the same key on resume.
+
 Everything in the stash is plain data, and that is a constraint rather than a
 preference: it outlives the tool call it was made in and is written to a JSONB
 column, while `request_approval` closes over a service holding the request's
@@ -379,14 +388,21 @@ delegate does is gated by the delegate's own reviewed spec; there is no reviewed
 spec here, so the specialist itself is the thing worth a person's eye. An author
 who wants an agent to run unattended clears it with `tool_approval`.
 
-**Nothing is persisted, and a kept one lasts less long than "the run".** The
+**Nothing is persisted across turns, but a kept one survives a park.** The
 registry `create_agent` writes into belongs to the *built agent*, and a run that
-parks on an approval is built again when it is continued — so a specialist
-created before the park is unknown after it, while the transcript still carries
-the library's "created successfully". `create_agent`'s description says so and
-`task` answers "unknown subagent", which makes it recoverable rather than
-surprising; making the tool mean what its name says is agenticos#175. Keeping one
-properly means publishing an agent, which is a person's action.
+parks on an approval is built again when it is continued — so without help a
+specialist created before the park would be unknown after it, while the transcript
+still carried the library's "created successfully". The capability snapshots each
+level's registrations when the run ends and the runner carries them in
+`PausedRunState`, so a resume re-registers each one into that level's fresh registry
+through the same build path — at the run's own agent (agenticos#175) and inside a
+nested delegate (agenticos#254) alike. The carry is keyed by the `task` call each
+level was delegated from, which is how a nested delegate's ride on its own
+`DelegationFrame` the way its conversation does, rather than on the flat run-level
+list. What still does *not* survive is a conversation *turn*: each turn is its own
+build with no paused state, so a name created in one reply is unknown in the next,
+and `create_agent`'s description tells the model to create it again if `task` says
+so. Keeping one properly means publishing an agent, which is a person's action.
 
 `MAX_DYNAMIC_SPECIALISTS` bounds how many one run may **keep**, which is the
 registry's ceiling and nothing else: a `delegate` call registers nothing, so

--- a/backend/app/agents/capabilities/subagents/_capability.py
+++ b/backend/app/agents/capabilities/subagents/_capability.py
@@ -62,7 +62,7 @@ from subagents_pydantic_ai.prompts import SEND_MESSAGE_TO_SUBAGENT_DESCRIPTION
 from subagents_pydantic_ai.registry import DynamicAgentRegistry
 
 from app.agents.capabilities._registry import CapabilityToolInfo
-from app.agents.capabilities.subagents._journal import DelegationJournal
+from app.agents.capabilities.subagents._journal import DelegationJournal, enclosing_tool_call_id
 from app.agents.capabilities.subagents._toolset import DelegatingToolset
 from app.agents.deps import AgentDeps
 from app.agents.factory import DEFAULT_MAX_STEPS
@@ -699,8 +699,10 @@ class Delegation(WrapperCapability[AgentDeps]):
         approval carries them into `PausedRunState` and finds them again on the
         replay - the library's registry is per built agent and a resume builds a
         fresh one, which is what lost a specialist across a park until now
-        (agenticos#175). A no-op unless this is the run's own agent and it may
-        invent one; see `DelegationJournal.record_created_specialists`.
+        (agenticos#175, agenticos#254). This runs at every level: a nested delegate's
+        wrap_run executes inside its enclosing `delegating` block, so its snapshot is
+        keyed by that block's `task` call and rides on its own frame. A no-op unless
+        this level may invent one; see `DelegationJournal.record_created_specialists`.
         """
         try:
             return await super().wrap_run(ctx, handler=handler)
@@ -753,15 +755,18 @@ def build_delegation(
     dynamic = runtime.dynamic
     # The registry `create_agent` writes into, owned here rather than left to the
     # library so this platform can read it back when the run ends and seed it when a
-    # run resumes. A resume fills `stash.to_register`; only the run's own agent's
-    # registry is seeded from it - a nested delegate has its own registry and its
-    # own `create_agent`, and a flat list of the run's specialists is not its to
-    # replay. `None` when the agent may not invent one, and then the library needs no
-    # registry either.
+    # run resumes. A resume fills `stash.to_register`, keyed by the `task` call each
+    # level was delegated from: `None` for the run's own agent, the enclosing call for
+    # a nested delegate - which is the current delegation here, because a nested level
+    # is built from inside its enclosing `delegating` block. Each level seeds only its
+    # own key, so a nested delegate rebuilds its own specialists rather than the run's
+    # own agent's (agenticos#254). `None` when the agent may not invent one, and then
+    # the library needs no registry either.
+    key = None if depth == 0 else enclosing_tool_call_id()
     registry = (
         None
         if dynamic is None
-        else _seeded_registry(dynamic, journal, runtime.stash.to_register if depth == 0 else [])
+        else _seeded_registry(dynamic, journal, runtime.stash.specialists_to_register(key))
     )
     capability = SubAgentCapability(
         subagents=[_config_for(delegate, journal) for delegate in runtime.subagents],

--- a/backend/app/agents/capabilities/subagents/_journal.py
+++ b/backend/app/agents/capabilities/subagents/_journal.py
@@ -208,6 +208,20 @@ def acting_delegate() -> ActingDelegate | None:
     )
 
 
+def enclosing_tool_call_id() -> str | None:
+    """The `task` call the delegation now executing was made from, or `None` at the top.
+
+    This is the key a level's kept specialists ride on across a park - the same key
+    its conversation, spend and start already use. A nested delegate is built and its
+    run wrapped from *inside* the enclosing `delegating` block, so the enclosing
+    delegation is the current one at both the moment its registry is seeded
+    (`build_delegation`) and the moment it is snapshotted (`record_created_specialists`).
+    `None` is the run's own agent, delegated from nowhere and keyed as such.
+    """
+    delegation = _CURRENT.get()
+    return None if delegation is None else delegation.tool_call_id
+
+
 @dataclass
 class Delegation:
     """One delegation, from the tool call that opened it to the outcome recorded for it.
@@ -373,7 +387,8 @@ class DelegationJournal:
     creates the registry, hands it to the library capability so `create_agent`
     writes into the one this journal can read, and assigns it here. That is what
     lets :meth:`record_created_specialists` snapshot it when the run ends, so a
-    kept specialist survives an approval park (agenticos#175).
+    kept specialist survives an approval park - at the run's own agent (agenticos#175)
+    and at a nested delegate (agenticos#254) alike.
     """
 
     _running: int = field(default=0, init=False)
@@ -556,27 +571,34 @@ class DelegationJournal:
         )
 
     def record_created_specialists(self) -> None:
-        """Snapshot the kept specialists into the stash, so an approval park keeps them.
+        """Snapshot this level's kept specialists into the stash, so an approval park keeps them.
 
-        Called from `wrap_run` on the way out of the run's own agent, and a no-op
-        otherwise: a nested delegate (`depth != 0`), or an agent that may not invent
-        one at all (`registry is None`, no `create_agent` offered). The library holds
-        each `create_agent` registration in a registry it builds per *built* agent, so
-        a resume - a fresh build - starts with an empty one; writing what the registry
-        holds now into the stash is what lets the runner carry it into
-        `PausedRunState` and re-register it on the replay. See
+        Called from `wrap_run` on the way out of *every* level that may invent one,
+        and a no-op for an agent that may not (`registry is None`, no `create_agent`
+        offered). The library holds each `create_agent` registration in a registry it
+        builds per *built* agent, so a resume - a fresh build - starts with an empty
+        one; writing what the registry holds now into the stash is what lets the runner
+        carry it into `PausedRunState` and re-register it on the replay. See
         :func:`~app.agents.capabilities.subagents._capability.build_delegation`.
+
+        Keyed by the `task` call this level was delegated from - `None` for the run's
+        own agent, a nested level's enclosing call otherwise, read off the current
+        delegation, which is still the enclosing one here because a nested run is
+        wrapped from inside the enclosing `delegating` block. That is the same key the
+        level's conversation, spend and start already ride on, and it is what lets a
+        nested delegate's kept specialists hang off its own `DelegationFrame` rather
+        than being lost with the run's own agent's flat list (agenticos#254).
 
         The whole registry, not this turn's new registrations only: a resume seeds the
         registry *before* the replay, so what it holds at the end is the seeded ones
         plus any the model added this turn, which is exactly what a second park must
-        keep. Assigned rather than appended, because the stash is built fresh each turn
-        and this is its one writer - a run that ends without parking simply throws the
-        snapshot away with the stash.
+        keep. One writer per key, and the stash is built fresh each turn - a run that
+        ends without parking simply throws the snapshot away with the stash.
         """
-        if self.registry is None or self.depth != 0:
+        if self.registry is None:
             return
-        self.runtime.stash.registered[:] = [
+        key = None if self.depth == 0 else enclosing_tool_call_id()
+        self.runtime.stash.registered[key] = [
             RegisteredSpecialist(
                 name=config["name"],
                 description=config["description"],

--- a/backend/app/agents/subagent_runtime.py
+++ b/backend/app/agents/subagent_runtime.py
@@ -134,13 +134,15 @@ class DynamicSpecialists:
     in.
 
     Within that run it does now survive an approval park, which it did not before
-    (agenticos#175). The delegation library holds a `create_agent` registration in a
-    registry it creates per *built* agent, and a run that parks on an approval is
-    built again when it is continued - so the registration was lost across the park
-    while the replayed transcript still carried the library's "created successfully",
-    and `task` then answered "unknown subagent". The fix carries the registrations
-    forward in `PausedRunState` and re-registers them on resume through the same
-    build path, so a specialist created before a park is reachable after it. See
+    (agenticos#175, agenticos#254). The delegation library holds a `create_agent`
+    registration in a registry it creates per *built* agent, and a run that parks on
+    an approval is built again when it is continued - so the registration was lost
+    across the park while the replayed transcript still carried the library's "created
+    successfully", and `task` then answered "unknown subagent". The fix carries the
+    registrations forward in `PausedRunState` and re-registers them on resume through
+    the same build path, so a specialist created before a park is reachable after it -
+    at every level of the delegation tree, because the parked state is a tree and each
+    level's kept specialists ride on its own frame the way its conversation does. See
     :class:`RegisteredSpecialist` and
     `app.agents.capabilities.subagents._capability.build_delegation`.
 
@@ -182,10 +184,11 @@ class RegisteredSpecialist:
 
     Plain scalars, for the reason everything on :class:`ParkedDelegation` is: this
     is written into `agent_runs.paused_state` as JSON and read back in another
-    process. The registrations of the *run's own agent* only - a specialist a
-    nested delegate kept is out of scope here, the same way a nested delegate's
-    conversation is carried per level on :class:`ParkedDelegation` rather than
-    flat here.
+    process. One of these describes a specialist at *any* level of the tree: the
+    run's own agent's are carried flat on `PausedRunState.dynamic_specialists`, and
+    a nested delegate's hang off that delegate's `DelegationFrame` the way its
+    conversation does - so a specialist a nested delegate kept survives a park too
+    (agenticos#254), not only one the run's own agent kept (agenticos#175).
     """
 
     name: str
@@ -429,12 +432,15 @@ class DelegationStash:
     that never delegated - and in each case nothing parks and nothing resumes.
 
     `registered` and `to_register` are the same two directions for the specialists
-    a model kept with `create_agent`, and both hold the *run's own agent's* only -
-    the delegation capability writes and reads them at depth 0. A nested delegate
-    has its own registry that a nested `create_agent` writes into, and carrying one
-    of those across a park would have to hang off the delegate's own frame the way
-    its conversation does; that is not done here, so a specialist a nested delegate
-    kept is still lost across a park.
+    a model kept with `create_agent`, at *every* level of the tree. Each is keyed by
+    the `task` call the level was delegated from - `None` for the run's own agent,
+    which was delegated from nowhere - so a nested delegate's kept specialists ride
+    on the same key its conversation, spend and start already do (:attr:`resuming`,
+    :attr:`spent`, :attr:`started`). That is what lets a specialist a nested delegate
+    kept survive a park (agenticos#254), where before only the run's own agent's did
+    (agenticos#175): the capability snapshots each level's registry under its
+    enclosing `task` call when the run ends, and seeds each level's fresh registry
+    from the same key on the resume.
     """
 
     parked: list[ParkedDelegation] = field(default_factory=list)
@@ -447,23 +453,26 @@ class DelegationStash:
     """Keyed by the `task` call the delegation was made from, which is the only
     thing the toolset knows about a delegation before it starts one."""
 
-    registered: list[RegisteredSpecialist] = field(default_factory=list)
-    """The run's own agent's kept specialists, snapshotted when the run ends.
+    registered: dict[str | None, list[RegisteredSpecialist]] = field(default_factory=dict)
+    """Each level's kept specialists, snapshotted when the run ends.
 
-    Written by the delegation capability's `wrap_run` at depth 0, from the library
-    registry it owns, and read once by the runner to fill `PausedRunState` when the
-    run parks. Empty for a run that kept none, and for every nested level - a
-    snapshot at depth 0 is the whole of what a resume can put back, because that is
-    the only registry `to_register` seeds."""
+    Written by the delegation capability's `wrap_run`, one entry per level that may
+    invent one, from the library registry that level owns. Keyed by the `task` call
+    the level was delegated from - `None` for the run's own agent - so the runner can
+    put the run's own agent's on `PausedRunState.dynamic_specialists` and hang each
+    nested level's off its own `DelegationFrame`. Empty for a run that kept none at
+    any level."""
 
-    to_register: list[RegisteredSpecialist] = field(default_factory=list)
-    """The kept specialists a resume re-registers before the replay, or empty.
+    to_register: dict[str | None, list[RegisteredSpecialist]] = field(default_factory=dict)
+    """The kept specialists a resume re-registers before the replay, keyed as
+    :attr:`registered` is.
 
     The other direction of `registered`: the runner fills it from
-    `PausedRunState.dynamic_specialists`, and the depth-0 delegation capability
-    rebuilds each one into a fresh registry through the run's own build path, so a
+    `PausedRunState.dynamic_specialists` (under `None`) and from each parked
+    `DelegationFrame` (under its `task` call), and each level's delegation capability
+    rebuilds its own key into a fresh registry through the run's own build path, so a
     resumed specialist meters against the run's shared budget exactly as it did
-    before the park. Never non-empty on a fresh run, and read only at depth 0."""
+    before the park. Empty on a fresh run."""
 
     spent: dict[str, DelegationSpend] = field(default_factory=dict)
     """What each delegation being continued had already cost, on the same key.
@@ -520,6 +529,16 @@ class DelegationStash:
         if tool_call_id is None:
             return DelegationSpend()
         return self.spent.get(tool_call_id, DelegationSpend())
+
+    def specialists_to_register(self, tool_call_id: str | None) -> list[RegisteredSpecialist]:
+        """The kept specialists a resume re-registers for the level delegated from this call.
+
+        `None` is the run's own agent, which was delegated from nowhere; a `task`
+        call names a nested level. Empty for a level that kept none, and for every
+        level on a run that was never parked - which is why a fresh run seeds no
+        registry from here.
+        """
+        return self.to_register.get(tool_call_id, [])
 
 
 @dataclass

--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -257,6 +257,31 @@ def _refuse_duplicate_names(resolved: list[ResolvedSubagent]) -> None:
         )
 
 
+class DynamicSpecialistFrame(BaseModel):
+    """One specialist a level of the tree kept with `create_agent`, stored across a park.
+
+    The library holds a `create_agent` registration in a registry it builds per
+    *built* agent, and a resume is a fresh build - so without this a specialist kept
+    before an approval park was gone after it, while the replayed transcript still
+    said it had been created and `task` answered "unknown subagent" (agenticos#175).
+    The four fields are the whole of what `create_agent` was given, which is exactly
+    what a resume needs to build the specialist again on the run's shared budget.
+
+    Where one of these is stored says which level kept it: the run's own agent's sit
+    flat on `PausedRunState.dynamic_specialists`, and a nested delegate's hang off
+    that delegate's :class:`DelegationFrame` the way its conversation does - which is
+    what carries a nested delegate's specialist across a park too (agenticos#254). See
+    :class:`app.agents.subagent_runtime.RegisteredSpecialist`.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(description="How the model addresses it in `task`")
+    description: str = Field(description="What it is for, one line")
+    instructions: str = Field(description="Its system prompt - the whole of its behaviour")
+    model: str = Field(description="The organization model profile label it runs on")
+
+
 class DelegationFrame(BaseModel):
     """A delegation the run parked inside, and where its delegate stopped.
 
@@ -279,6 +304,12 @@ class DelegationFrame(BaseModel):
     delegation re-run from the start exactly as it is of one continued. Left out,
     the child run row written when the delegation ends holds only what the last
     turn spent - see :class:`app.agents.subagent_runtime.DelegationSpend`.
+
+    `dynamic_specialists` is the same shape for `create_agent`: the specialists this
+    delegate kept, so a nested `create_agent` survives the park its own delegate
+    caused. It rides on the frame rather than on the flat run-level list because a
+    nested delegate has its own registry, and a resume seeds each level's from its own
+    key (agenticos#254).
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -342,30 +373,15 @@ class DelegationFrame(BaseModel):
     delegations: list[DelegationFrame] = Field(
         default_factory=list, description="Delegations this delegate had itself parked on"
     )
-
-
-class DynamicSpecialistFrame(BaseModel):
-    """One specialist the run's own agent kept with `create_agent`, stored across a park.
-
-    The library holds a `create_agent` registration in a registry it builds per
-    *built* agent, and a resume is a fresh build - so without this a specialist kept
-    before an approval park was gone after it, while the replayed transcript still
-    said it had been created and `task` answered "unknown subagent" (agenticos#175).
-    The four fields are the whole of what `create_agent` was given, which is exactly
-    what a resume needs to build the specialist again on the run's shared budget.
-
-    The run's own agent's specialists only: a nested delegate's registry is its own,
-    and carrying one across a park would have to hang off that delegate's
-    :class:`DelegationFrame` the way its conversation does. See
-    :class:`app.agents.subagent_runtime.RegisteredSpecialist`.
-    """
-
-    model_config = ConfigDict(extra="forbid")
-
-    name: str = Field(description="How the model addresses it in `task`")
-    description: str = Field(description="What it is for, one line")
-    instructions: str = Field(description="Its system prompt - the whole of its behaviour")
-    model: str = Field(description="The organization model profile label it runs on")
+    dynamic_specialists: list[DynamicSpecialistFrame] = Field(
+        default_factory=list,
+        description=(
+            "The specialists this delegate kept with `create_agent`, re-registered "
+            "into its fresh registry on resume so a nested `create_agent` survives the "
+            "park too. Empty for a delegate that kept none, and for one parked before "
+            "this existed"
+        ),
+    )
 
 
 class PausedRunState(BaseModel):
@@ -532,7 +548,10 @@ class ApprovalChannel:
         return ApprovalPending()
 
 
-def _delegation_frames(parked: Sequence[ParkedDelegation]) -> list[DelegationFrame]:
+def _delegation_frames(
+    parked: Sequence[ParkedDelegation],
+    registered: Mapping[str | None, Sequence[RegisteredSpecialist]],
+) -> list[DelegationFrame]:
     """One run's parked delegations, nested the way they were made.
 
     Assembled from a flat list because that is what the capability can safely
@@ -544,10 +563,28 @@ def _delegation_frames(parked: Sequence[ParkedDelegation]) -> list[DelegationFra
     The recursion is bounded by `max_depth`, and by the fact that a delegation's
     children all carry its task id as their parent while its own parent is
     something else.
+
+    `registered` is what each level kept with `create_agent`, keyed by the `task`
+    call the level was delegated from - the same key the capability snapshotted it
+    under. A frame carries the specialists its own delegate kept, looked up by the
+    frame's `tool_call_id`, so a nested `create_agent` rides on the same frame its
+    conversation does and survives the park (agenticos#254). The run's own agent's
+    key (`None`) is not read here - `_parked_tree` puts it on the flat run-level list.
     """
     by_parent: dict[str | None, list[ParkedDelegation]] = {}
     for entry in parked:
         by_parent.setdefault(entry.parent_task_id, []).append(entry)
+
+    def specialists(tool_call_id: str) -> list[DynamicSpecialistFrame]:
+        return [
+            DynamicSpecialistFrame(
+                name=kept.name,
+                description=kept.description,
+                instructions=kept.instructions,
+                model=kept.model,
+            )
+            for kept in registered.get(tool_call_id, [])
+        ]
 
     def frames(entries: list[ParkedDelegation]) -> list[DelegationFrame]:
         return [
@@ -566,6 +603,7 @@ def _delegation_frames(parked: Sequence[ParkedDelegation]) -> list[DelegationFra
                 cost_is_partial=entry.spent.has_unpriced_models,
                 started_at=entry.started_at,
                 delegations=frames(by_parent.get(entry.task_id, [])),
+                dynamic_specialists=specialists(entry.tool_call_id),
             )
             for entry in entries
         ]
@@ -609,6 +647,18 @@ class _ResumePlan:
     the resume that settled it.
     """
 
+    specialists: dict[str, list[RegisteredSpecialist]]
+    """The specialists each *continued* delegate kept, on the same `task`-call key.
+
+    Only for a frame whose place was kept: a delegate re-run from the start re-runs
+    its own `create_agent` and registers them again, so seeding those would be a
+    duplicate. A continued delegate does not re-run `create_agent` - the call is a
+    completed entry in its replayed history - so its registry starts empty and has to
+    be seeded, which is exactly the nested case agenticos#254 was losing. The run's
+    own agent's are not here; they come off `PausedRunState.dynamic_specialists`
+    under the `None` key.
+    """
+
 
 def _resume_plan(state: PausedRunState, decided_args: Mapping[str, dict[str, Any]]) -> _ResumePlan:
     """Split a parked run's verdicts across the agents that were waiting on them.
@@ -629,6 +679,7 @@ def _resume_plan(state: PausedRunState, decided_args: Mapping[str, dict[str, Any
     resuming: dict[str, ResumedDelegation] = {}
     spent: dict[str, DelegationSpend] = {}
     started: dict[str, datetime | None] = {}
+    specialists: dict[str, list[RegisteredSpecialist]] = {}
 
     def level(frames: list[DelegationFrame], own: list[str]) -> DeferredToolResults:
         results = DeferredToolResults()
@@ -661,6 +712,19 @@ def _resume_plan(state: PausedRunState, decided_args: Mapping[str, dict[str, Any
                 messages=ModelMessagesTypeAdapter.validate_python(frame.messages),
                 results=level(frame.delegations, by_delegation.get(frame.task_id, [])),
             )
+            # Seeded only for a continued delegate, and keyed by the `task` call it
+            # was delegated from - which is what its own `build_delegation` reads back
+            # as `enclosing_tool_call_id()` to fill its fresh registry.
+            if frame.dynamic_specialists:
+                specialists[frame.tool_call_id] = [
+                    RegisteredSpecialist(
+                        name=kept.name,
+                        description=kept.description,
+                        instructions=kept.instructions,
+                        model=kept.model,
+                    )
+                    for kept in frame.dynamic_specialists
+                ]
         return results
 
     return _ResumePlan(
@@ -668,6 +732,7 @@ def _resume_plan(state: PausedRunState, decided_args: Mapping[str, dict[str, Any
         delegations=resuming,
         spent=spent,
         started=started,
+        specialists=specialists,
     )
 
 
@@ -1149,7 +1214,7 @@ class AgentRunnerService:
         resuming: dict[str, ResumedDelegation],
         already_spent: dict[str, DelegationSpend],
         already_started: dict[str, datetime | None],
-        specialists: Sequence[RegisteredSpecialist] = (),
+        specialists: Mapping[str | None, Sequence[RegisteredSpecialist]] | None = None,
         model_profile_id: UUID | None = None,
         version_id: UUID | None = None,
         environment_id: UUID | None = None,
@@ -1176,11 +1241,13 @@ class AgentRunnerService:
         then or the row it eventually writes holds only this turn's spend and begins
         at the resume.
 
-        `specialists` is the same kind of thing for `create_agent`: the specialists
-        the run's own agent kept, empty on a fresh run and filled from
-        `PausedRunState` on a resume, re-registered by the depth-0 delegation
-        capability before the replay so a kept specialist is reachable after the
-        park that created it (agenticos#175).
+        `specialists` is the same kind of thing for `create_agent`, keyed by the
+        `task` call each level was delegated from: `None` for the run's own agent, a
+        nested delegate's enclosing call otherwise. `None` on a fresh run and filled
+        from `PausedRunState` on a resume, re-registered by each level's delegation
+        capability before the replay so a kept specialist is reachable after the park
+        that created it - at the run's own agent (agenticos#175) and inside a nested
+        delegate (agenticos#254) alike.
         """
         # A caller's override wins over the spec's choice. Only the model is
         # replaced - instructions, tools, budgets and the approval gate are the
@@ -1305,7 +1372,7 @@ class AgentRunnerService:
             resuming=resuming,
             spent=already_spent,
             started=already_started,
-            to_register=list(specialists),
+            to_register={} if specialists is None else {k: list(v) for k, v in specialists.items()},
         )
         runtime = await self._delegation_runtime(
             ctx,
@@ -2255,9 +2322,10 @@ class AgentRunnerService:
         that delegates again from nothing and answers a question nobody asked.
 
         The kept specialists come from the same stash, snapshotted by the delegation
-        capability's `wrap_run` when the run ended - empty unless the run's own
-        agent invented one it kept, and carried forward so the resume can register
-        it again (agenticos#175).
+        capability's `wrap_run` when the run ended and keyed by the `task` call each
+        level was delegated from. The run's own agent's (`None`) go flat on
+        `dynamic_specialists`; a nested delegate's ride on its own `DelegationFrame`,
+        which is what carries them across a park too (agenticos#254, agenticos#175).
         """
         return paused_state.model_copy(
             update={
@@ -2266,7 +2334,7 @@ class AgentRunnerService:
                     for parked in prepared.approvals.requested
                     if parked.task_id is not None
                 },
-                "delegations": _delegation_frames(prepared.stash.parked),
+                "delegations": _delegation_frames(prepared.stash.parked, prepared.stash.registered),
                 "dynamic_specialists": [
                     DynamicSpecialistFrame(
                         name=specialist.name,
@@ -2274,7 +2342,7 @@ class AgentRunnerService:
                         instructions=specialist.instructions,
                         model=specialist.model,
                     )
-                    for specialist in prepared.stash.registered
+                    for specialist in prepared.stash.registered.get(None, [])
                 ],
             }
         )
@@ -2466,17 +2534,23 @@ class AgentRunnerService:
             resuming=plan.delegations,
             already_spent=plan.spent,
             already_started=plan.started,
-            # The specialists the run's own agent kept before it parked, rebuilt
-            # into a fresh registry before the replay so `task` reaches them again.
-            specialists=[
-                RegisteredSpecialist(
-                    name=frame.name,
-                    description=frame.description,
-                    instructions=frame.instructions,
-                    model=frame.model,
-                )
-                for frame in state.dynamic_specialists
-            ],
+            # The specialists each level kept before it parked, rebuilt into that
+            # level's fresh registry before the replay so `task` reaches them again.
+            # `None` is the run's own agent, off the flat state list; a nested
+            # delegate's come from its `DelegationFrame`, keyed by its `task` call
+            # (agenticos#254). One map, so `_assemble` seeds every level in one pass.
+            specialists={
+                None: [
+                    RegisteredSpecialist(
+                        name=frame.name,
+                        description=frame.description,
+                        instructions=frame.instructions,
+                        model=frame.model,
+                    )
+                    for frame in state.dynamic_specialists
+                ],
+                **plan.specialists,
+            },
         )
         prepared.built.ledger.book(_spend_already_booked(run))
 

--- a/backend/tests/test_dynamic_specialists.py
+++ b/backend/tests/test_dynamic_specialists.py
@@ -61,6 +61,7 @@ from app.agents.capabilities.subagents._capability import (
     BACKGROUND_LIFECYCLE_TOOLS,
     MAX_DYNAMIC_SPECIALISTS,
 )
+from app.agents.capabilities.subagents._journal import DelegationJournal
 from app.agents.deps import AgentDeps
 from app.agents.factory import build_agent
 from app.agents.model_resolver import ModelRequestSpec, ResolvedCredential
@@ -847,14 +848,17 @@ class TestAKeptSpecialistSurvivesTheParkThatCreatedIt:
         await call_tool(capability, ctx, "create_agent", create_args())
         await _ends_the_run(capability, ctx)
 
-        assert runtime.stash.registered == [
-            RegisteredSpecialist(
-                name="summariser",
-                description="Summarises a document in three bullets",
-                instructions="You summarise.",
-                model=PROFILE,
-            )
-        ]
+        # Under the `None` key: the run's own agent, delegated from nowhere.
+        assert runtime.stash.registered == {
+            None: [
+                RegisteredSpecialist(
+                    name="summariser",
+                    description="Summarises a document in three bullets",
+                    instructions="You summarise.",
+                    model=PROFILE,
+                )
+            ]
+        }
 
     async def test_without_the_carried_registrations_the_rebuild_loses_it(self):
         """The failure itself: a fresh build with nothing carried over answers `task`
@@ -885,7 +889,7 @@ class TestAKeptSpecialistSurvivesTheParkThatCreatedIt:
         capability = a_capability(first)
         await call_tool(capability, a_context(), "create_agent", create_args())
         await _ends_the_run(capability, a_context())
-        kept = list(first.stash.registered)
+        kept = first.stash.registered[None]
         assert [specialist.name for specialist in kept] == ["summariser"]
 
         ledger = SpendLedger()
@@ -893,7 +897,7 @@ class TestAKeptSpecialistSurvivesTheParkThatCreatedIt:
         resumed = a_runtime(
             dynamic=dynamic(specialist_builder(budget)),
             ledger=ledger,
-            stash=DelegationStash(to_register=kept),
+            stash=DelegationStash(to_register={None: kept}),
         )
         resumed_capability = a_capability(resumed)
         # The two assignments the runner makes after the build, in that order: the
@@ -923,7 +927,7 @@ class TestAKeptSpecialistSurvivesTheParkThatCreatedIt:
         )
         resumed = a_runtime(
             dynamic=dynamic(specialist_builder()),
-            stash=DelegationStash(to_register=[gone]),
+            stash=DelegationStash(to_register={None: [gone]}),
         )
 
         answer = await call_tool(
@@ -935,38 +939,36 @@ class TestAKeptSpecialistSurvivesTheParkThatCreatedIt:
 
         assert "Unknown subagent 'summariser'" in answer
 
-    async def test_a_nested_agents_registry_is_neither_seeded_nor_snapshotted(self):
-        """The scope of the fix: the run's own agent only.
+    async def test_a_nested_level_keys_its_snapshot_by_the_call_it_was_delegated_from(self):
+        """The nested half of the carry (agenticos#254): a delegate's kept specialists
+        are keyed by the `task` call it was delegated from, not lumped under the run's
+        own agent's `None`.
 
-        `PausedRunState` carries a flat list of the *run's own agent's* kept
-        specialists, so a nested delegate - which has its own registry and its own
-        `create_agent` - must not read that list as its own on a resume, nor write
-        its own registrations into it when the run ends. A delegate that carried one
-        of these across a park would have to hang it off its own `DelegationFrame`
-        the way its conversation is; that is not done, so a nested agent both
-        ignores what the run kept and keeps nothing of its own here.
+        That key is what lets a nested `create_agent` hang off its own
+        `DelegationFrame` and survive the park its delegate caused, where before a flat
+        run-level list dropped it. The key is read off the enclosing delegation, which
+        is the current one while a nested level's `wrap_run` runs - set here through a
+        parent journal's `delegating` block, exactly as the real tree sets it. The
+        full park -> resume -> re-delegate round trip is
+        `tests/test_subagent_nested_resume.py`.
         """
-        stash = DelegationStash(to_register=[a_registered("from-the-parent")])
+        stash = DelegationStash()
         nested = a_runtime(dynamic=dynamic(specialist_builder()), stash=stash, depth=1)
         capability = a_capability(nested)
         ctx = a_context()
-
-        # Seed skipped: the parent's kept specialist is not in this level's registry.
-        unknown = await call_tool(
-            capability, ctx, "task", {"description": "x", "subagent_type": "from-the-parent"}
+        # The enclosing delegation, whose `task` call is the key this level rides on.
+        parent = DelegationJournal(runtime=a_runtime(), mode="sync", max_fanout=3, depth=0)
+        enclosing = parent.begin(
+            delegate=None, name="editor", prompt="", tool_args={}, tool_call_id="editor-call"
         )
-        # Snapshot skipped: what this level keeps does not land on the shared list.
-        await call_tool(capability, ctx, "create_agent", create_args(name="nested-only"))
-        await _ends_the_run(capability, ctx)
 
-        assert "Unknown subagent 'from-the-parent'" in unknown
-        assert stash.registered == []
+        with parent.delegating(enclosing):
+            await call_tool(capability, ctx, "create_agent", create_args(name="nested-only"))
+            await _ends_the_run(capability, ctx)
 
-
-def a_registered(name: str) -> RegisteredSpecialist:
-    return RegisteredSpecialist(
-        name=name, description="Summarises.", instructions="You summarise.", model=PROFILE
-    )
+        assert [kept.name for kept in stash.registered["editor-call"]] == ["nested-only"]
+        # Not lumped under the run's own agent's key, which a resume reads flat.
+        assert None not in stash.registered
 
 
 async def _ends_the_run(capability: Delegation, ctx: RunContext[AgentDeps]) -> None:

--- a/backend/tests/test_subagent_nested_resume.py
+++ b/backend/tests/test_subagent_nested_resume.py
@@ -74,6 +74,8 @@ from app.agents.subagent_runtime import (
     DelegationRecorder,
     DelegationSpend,
     DelegationStash,
+    DynamicSpecialists,
+    RegisteredSpecialist,
     ResolvedSubagent,
     ResumedDelegation,
     SubagentRuntime,
@@ -82,6 +84,7 @@ from app.db.models.agent_run import ApprovalStatus
 from app.services.agent_runner import (
     ApprovalChannel,
     DelegationFrame,
+    DynamicSpecialistFrame,
     PausedRunState,
     _delegation_frames,
     _resume_plan,
@@ -271,6 +274,7 @@ def _capability(
     depth: int = 0,
     ledger: SpendLedger | None = None,
     record: DelegationRecorder | None = None,
+    dynamic: DynamicSpecialists | None = None,
 ) -> Delegation:
     """The delegation capability as the registry builds it, over a shared stash."""
     runtime = SubagentRuntime(
@@ -280,6 +284,7 @@ def _capability(
         stash=stash,
         ledger=ledger,
         record=record,
+        dynamic=dynamic,
     )
     built = build(
         [CapabilityBinding(capability_id="subagents", config={})],
@@ -512,8 +517,38 @@ def _parked_state(
             for parked in channel.requested
             if parked.task_id is not None
         },
-        delegations=_delegation_frames(stash.parked),
+        delegations=_delegation_frames(stash.parked, stash.registered),
+        dynamic_specialists=[
+            DynamicSpecialistFrame(
+                name=kept.name,
+                description=kept.description,
+                instructions=kept.instructions,
+                model=kept.model,
+            )
+            for kept in stash.registered.get(None, [])
+        ],
     )
+
+
+def _to_register(state: PausedRunState, plan: Any) -> dict[str | None, list[RegisteredSpecialist]]:
+    """The specialists a resume re-registers, keyed as `resume` keys them.
+
+    `None` is the run's own agent, off the flat state list; a nested delegate's come
+    from `plan.specialists`, keyed by the `task` call it was delegated from. The
+    trip `resume` makes when it builds `_assemble`'s `specialists` map.
+    """
+    return {
+        None: [
+            RegisteredSpecialist(
+                name=frame.name,
+                description=frame.description,
+                instructions=frame.instructions,
+                model=frame.model,
+            )
+            for frame in state.dynamic_specialists
+        ],
+        **plan.specialists,
+    }
 
 
 def _verdicts(
@@ -549,7 +584,12 @@ async def _resume(
     """
     decided, approved_args = _verdicts(parked.state, parked.queue)
     plan = _resume_plan(parked.state, approved_args)
-    stash = DelegationStash(resuming=plan.delegations, spent=plan.spent, started=plan.started)
+    stash = DelegationStash(
+        resuming=plan.delegations,
+        spent=plan.spent,
+        started=plan.started,
+        to_register=_to_register(parked.state, plan),
+    )
     agent, deps = _orchestrator(
         delegate(stash),
         stash=stash,
@@ -1027,7 +1067,10 @@ async def _until_it_answers(
             decided, approved_args = _verdicts(state, queue)
             plan = _resume_plan(state, approved_args)
             stash = DelegationStash(
-                resuming=plan.delegations, spent=plan.spent, started=plan.started
+                resuming=plan.delegations,
+                spent=plan.spent,
+                started=plan.started,
+                to_register=_to_register(state, plan),
             )
             history = ModelMessagesTypeAdapter.validate_python(state.messages)
             results = plan.results
@@ -1320,3 +1363,246 @@ class TestWhenADelegateFirstBegan:
         delegation.carried_started_at = began
 
         assert journal._span_start(delegation, None) == began
+
+
+MODEL = "test-model"
+"""The one model label a dynamic specialist may name here - the middle's own catalog."""
+
+HELPER = "helper"
+"""The specialist the middle delegate invents with `create_agent`."""
+
+
+def _dynamic_helper(
+    calls: list[dict[str, Any]], *, gated: bool = True, charge: Charge | None = None
+) -> DynamicSpecialists:
+    """A middle delegate's `allow_dynamic`: it invents the gated specialist itself.
+
+    The build closure ignores the name, instructions and model the model wrote and
+    returns the same `look_up` agent the pinned-specialist tests use - what is under
+    test is that the *registration* survives the park and rebuilds on the run's shared
+    ledger, not what the model wrote into it. The build path is the one a resume takes:
+    `_seeded_registry` re-registers a carried specialist with a lazy build through this
+    same closure.
+    """
+
+    def build(*, name: str, instructions: str, model: str) -> PydanticAgent[Any, Any]:
+        return _specialist_agent(gated=gated, calls=calls, charge=charge)
+
+    return DynamicSpecialists(build=build, allowed_models=(MODEL,))
+
+
+def _inventing_model(prefix: str, specialist: str) -> FunctionModel:
+    """A model that keeps a specialist with `create_agent`, then delegates to it.
+
+    Two tool calls in turn - `create_agent` then `task` - so the registration is made
+    inside the run, exactly where a nested `create_agent` lives. On the replay the
+    `create_agent` return is already in the history and is not re-run, so the specialist
+    is reachable only if its registration was carried: that is the whole of #254.
+    """
+    return _tools_then_report(
+        prefix,
+        ToolCallPart(
+            "create_agent",
+            {
+                "name": specialist,
+                "description": "looks the weather up",
+                "instructions": "You look the weather up.",
+                "model": MODEL,
+            },
+        ),
+        ToolCallPart("task", {"description": "the weather in Krakow", "subagent_type": specialist}),
+    )
+
+
+def _inventing_middle_delegate(
+    *,
+    gated: bool,
+    calls: list[dict[str, Any]],
+    stash: DelegationStash,
+    metering: _Metering | None = None,
+) -> ResolvedSubagent:
+    """A delegate that invents its own specialist with `create_agent` and delegates to it.
+
+    The two-level shape #254 is about: the specialist lives one level down, in a
+    registry the *middle* delegate owns - so a park that stops inside it loses the
+    registration unless it is carried on the middle's own frame and re-seeded into the
+    middle's fresh registry on resume. Built the way the runner builds one: its own
+    delegation capability, its own runtime with `allow_dynamic`, and the *same* stash.
+    """
+
+    def build_it() -> PydanticAgent[Any, Any]:
+        return PydanticAgent(
+            _inventing_model("edited", HELPER),
+            output_type=[str, DeferredToolRequests],
+            capabilities=[
+                _capability(
+                    stash=stash,
+                    depth=1,
+                    ledger=None if metering is None else metering.ledger,
+                    record=None if metering is None else metering.record,
+                    dynamic=_dynamic_helper(
+                        calls,
+                        gated=gated,
+                        charge=None if metering is None else metering.charge,
+                    ),
+                )
+            ],
+        )
+
+    return _resolved(MIDDLE, build_it)
+
+
+class TestANestedDynamicSpecialistSurvivesTheParkThatCreatedIt:
+    """agenticos#254: a `create_agent` specialist a nested delegate kept must be
+    reachable after the park its own delegate caused, the way #175 made one the run's
+    own agent kept reachable.
+
+    Each level of the tree that binds `allow_dynamic` owns its own registry, and a
+    resume is a fresh build of every level - so a nested `create_agent` was lost across
+    the park while the replayed transcript still said the specialist had been created,
+    and `task` answered "unknown subagent". The fix carries each level's kept
+    specialists on its own `DelegationFrame`, keyed by the `task` call it was delegated
+    from, and re-seeds that level's registry from the same key on resume.
+
+    Driven through the real capability, the real gate, and the runner's real split of
+    the verdicts and the specialists - and through `paused_state` as JSON, the trip a
+    park actually makes.
+    """
+
+    async def _park(self) -> tuple[PausedRunState, _Queue, list[dict[str, Any]]]:
+        """Run to the park a nested `create_agent` + gated `task` reaches, as a row keeps it."""
+        calls: list[dict[str, Any]] = []
+        stash = DelegationStash()
+        ledger = SpendLedger()
+        queue = _Queue()
+        channel = _channel()
+        middle = _inventing_middle_delegate(
+            gated=True,
+            calls=calls,
+            stash=stash,
+            metering=_Metering(
+                ledger=ledger, charge=_charging(ledger, Decimal("0.25")), record=Recorder()
+            ),
+        )
+        agent, deps = _orchestrator(middle, stash=stash, channel=channel, ledger=ledger)
+        result = await agent.run("what is the weather in Krakow", deps=deps)
+        assert isinstance(result.output, DeferredToolRequests), result.output
+        assert calls == [], "the gate parked before the tool body ran"
+        await _write_approvals(channel, queue)
+        state = PausedRunState.model_validate(
+            _parked_state(result, channel=channel, stash=stash).model_dump(mode="json")
+        )
+        queue.decide(approved=True)
+        return state, queue, calls
+
+    async def test_the_middle_frame_carries_the_specialist_it_kept(self):
+        """The capture half: the kept specialist hangs off the delegate's own frame,
+        not the flat run-level list the run's own agent's use."""
+        state, _queue, _calls = await self._park()
+
+        (middle_frame,) = state.delegations
+        assert middle_frame.subagent == MIDDLE
+        assert [kept.name for kept in middle_frame.dynamic_specialists] == [HELPER]
+        # The run's own agent kept nothing, so the flat list stays empty - the carry
+        # rode entirely on the frame.
+        assert state.dynamic_specialists == []
+
+    async def test_the_resumed_nested_level_reaches_the_specialist_and_meters_it(self):
+        """The whole of the fix: the specialist the middle kept before the park is
+        reachable at that level after it, and its request lands on the resume's shared
+        ledger.
+
+        The metering is asserted off the ledger rather than a recorder, because the
+        recorder reads the ledger: what proves the rebuilt specialist actually ran is
+        the entry its `look_up` turn booked.
+        """
+        state, queue, calls = await self._park()
+        decided, approved_args = _verdicts(state, queue)
+        plan = _resume_plan(state, approved_args)
+        ledger = SpendLedger()
+        stash = DelegationStash(
+            resuming=plan.delegations,
+            spent=plan.spent,
+            started=plan.started,
+            to_register=_to_register(state, plan),
+        )
+        middle = _inventing_middle_delegate(
+            gated=True,
+            calls=calls,
+            stash=stash,
+            metering=_Metering(
+                ledger=ledger, charge=_charging(ledger, Decimal("0.75")), record=Recorder()
+            ),
+        )
+        agent, deps = _orchestrator(
+            middle, stash=stash, channel=_channel(decided=decided), ledger=ledger
+        )
+
+        resumed = await agent.run(
+            None,
+            deps=deps,
+            message_history=ModelMessagesTypeAdapter.validate_python(state.messages),
+            deferred_tool_results=plan.results,
+        )
+
+        # Both levels answered, and the specialist's own report - which only a run
+        # that reached `helper` by name can produce - carries the gated tool's output.
+        # (The middle echoes every tool return, `create_agent`'s included, so this is a
+        # substring rather than the whole string.)
+        answer = _answer(resumed)
+        assert answer.startswith("answer: edited:")
+        assert "weather: Krakow: 21C and clear" in answer
+        assert calls == [{"city": "Krakow"}], "continued, so the gated call ran once"
+        # Metered on the run's shared ledger: the resumed specialist booked its request
+        # there, exactly as it did before the park.
+        assert [entry.input_tokens for entry in ledger.entries] == [INPUT_TOKENS]
+
+    async def test_a_root_only_carry_loses_the_nested_specialist(self):
+        """Proof the per-level carry is load-bearing: carrying only the root - what the
+        tree-carry did before #254 - leaves the middle's registry empty on resume, so
+        `task` answers "unknown subagent" for the specialist the transcript says exists
+        and the gated call never runs.
+        """
+        state, queue, calls = await self._park()
+        decided, approved_args = _verdicts(state, queue)
+        plan = _resume_plan(state, approved_args)
+        ledger = SpendLedger()
+        # Root only: drop `plan.specialists`, the way the pre-#254 tree-carry did. The
+        # run's own agent kept nothing, so this is an empty seed.
+        stash = DelegationStash(
+            resuming=plan.delegations,
+            spent=plan.spent,
+            started=plan.started,
+            to_register={
+                None: [
+                    RegisteredSpecialist(
+                        name=frame.name,
+                        description=frame.description,
+                        instructions=frame.instructions,
+                        model=frame.model,
+                    )
+                    for frame in state.dynamic_specialists
+                ]
+            },
+        )
+        middle = _inventing_middle_delegate(
+            gated=True,
+            calls=calls,
+            stash=stash,
+            metering=_Metering(
+                ledger=ledger, charge=_charging(ledger, Decimal("0.75")), record=Recorder()
+            ),
+        )
+        agent, deps = _orchestrator(
+            middle, stash=stash, channel=_channel(decided=decided), ledger=ledger
+        )
+
+        resumed = await agent.run(
+            None,
+            deps=deps,
+            message_history=ModelMessagesTypeAdapter.validate_python(state.messages),
+            deferred_tool_results=plan.results,
+        )
+
+        assert f"Unknown subagent '{HELPER}'" in _answer(resumed)
+        assert calls == [], "the specialist was lost, so the gated call never ran"


### PR DESCRIPTION
## What changed and why

#175 (0.0.20) made a `create_agent` specialist kept by the **run's own agent**
survive an approval park — snapshotted into `PausedRunState.dynamic_specialists`
and re-registered on resume. A specialist a **nested delegate** kept was still
lost: each level that binds `allow_dynamic` owns its own `DynamicAgentRegistry`,
and the carry was a flat run-level list read/written only at `depth == 0`. So a
nested `create_agent` was gone after the park while the replayed transcript still
said it had been created, and `task` answered `"Unknown subagent"` for it.

The parked state is a **tree**, so the specialist carry now descends it. Each
level's kept specialists are keyed by the `task` call it was delegated from —
`None` for the run's own agent (still flat on `PausedRunState.dynamic_specialists`),
a nested level's on its own `DelegationFrame` — the same key its conversation,
spend and start already ride on. `record_created_specialists` snapshots every
level's registry under that key; `build_delegation` re-seeds each level's fresh
registry from it on resume.

- `DelegationStash.registered` / `to_register`: flat lists → maps keyed by the
  enclosing `task` call (`None` = the run's own agent).
- `DelegationFrame` gains `dynamic_specialists`; `DynamicSpecialistFrame` moved
  above it so the forward ref resolves.
- `_resume_plan` fills a per-level `specialists` map for **continued** delegates
  only — a re-run delegate re-runs its own `create_agent`, so seeding those would
  duplicate.
- `enclosing_tool_call_id()` reads the current delegation, which is the enclosing
  one at both build and `wrap_run` time (a nested level is built and wrapped from
  inside the enclosing `delegating` block).

`max_agents` is unchanged: a resume re-registers only what was kept, already
bounded at creation, so a nested level cannot exceed the ceiling by rebuilding.

## Which depths now carry kept specialists

Every level of the delegation tree. The run's own agent (depth 0) as before
(#175); a nested delegate (depth ≥ 1) now too, on its own frame (#254).

## How it was verified

`make check` green (every CI job except e2e, incl. the 100% platform-layer
coverage gate).

The nested park → resume → re-delegate proof is in
`tests/test_subagent_nested_resume.py::TestANestedDynamicSpecialistSurvivesTheParkThatCreatedIt`,
driven through the real capability, the real approval gate and the runner's real
split, and through `paused_state` as JSON:

- A middle delegate (one level down) invents a specialist with `create_agent`,
  delegates to it, the specialist's gated `look_up` parks the run.
- The approval is granted; on resume the nested level reaches the specialist by
  name and answers, and its request is booked on the resume's shared ledger —
  asserted off `ledger.entries`, not a recorder.
- Proven load-bearing: reverting the per-level snapshot guard fails the positive
  tests, and `test_a_root_only_carry_loses_the_nested_specialist` shows a
  root-only carry answers `"Unknown subagent 'helper'"`.

Docstrings (which generate `docs/reference/capabilities.md`) and the subagents
`README.md` updated — the README previously described a kept specialist as lost
across a park, stale since #175 and doubly wrong now.

Closes #254
