### PR TITLE
chore: cut 0.0.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.28] - 2026-08-06
+
+### Fixed
+
+- **A `create_agent` specialist created by a nested delegate survives an approval park**
+  ([#254](https://github.com/vstorm-co/agenticos/issues/254)). 0.0.20 (#175) carried a
+  top-level dynamic specialist across a park — its definition serialised into `paused_state`
+  and re-seeded on resume through the same factory — but only at the root. A specialist a
+  delegate *one level down* created was still lost when a nested delegation parked and
+  resumed: the nested level's registry was rebuilt empty, so `task` answered "unknown
+  subagent" for it. The specialist carry now descends the parked tree, so a kept specialist
+  at any depth is re-seeded on resume and reachable by name, metered on the run's shared
+  ledger exactly as it was the first time. `max_agents` still bounds each level, so a resume
+  cannot exceed it by rebuilding.
+
 ## [0.0.27] - 2026-08-05
 
 ### Fixed
@@ -1025,7 +1040,8 @@ installed hook did nothing.
   codebase has diverged from the generator past the point where a 3-way merge
   helps.
 
-[Unreleased]: https://github.com/vstorm-co/agenticos/compare/v0.0.27...HEAD
+[Unreleased]: https://github.com/vstorm-co/agenticos/compare/v0.0.28...HEAD
+[0.0.28]: https://github.com/vstorm-co/agenticos/compare/v0.0.27...v0.0.28
 [0.0.27]: https://github.com/vstorm-co/agenticos/compare/v0.0.26...v0.0.27
 [0.0.26]: https://github.com/vstorm-co/agenticos/compare/v0.0.25...v0.0.26
 [0.0.25]: https://github.com/vstorm-co/agenticos/compare/v0.0.24...v0.0.25

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.27"
+version = "0.0.28"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.27"
+version = "0.0.28"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for **#254** — the nested sibling of #175 (0.0.20). A `create_agent` specialist created by a delegate *one level down* was lost when a nested delegation parked and resumed (the nested registry rebuilt empty → `task` answered "unknown subagent"). The specialist carry now descends the parked tree, so a kept specialist at any depth is re-seeded on resume and reachable by name, metered on the run's shared ledger. `max_agents` still bounds each level. Code landed as #286.

No schema change, `SPEC_VERSION` unchanged at 7.