### PR TITLE
fix(budgets): bill an inline specialist to its published ancestor

### DIFF
--- a/backend/app/agents/capabilities/budget/README.md
+++ b/backend/app/agents/capabilities/budget/README.md
@@ -36,11 +36,16 @@ incomplete.
 
 One ledger per run, and a run can contain several agents: a delegation runs a
 second agent's whole conversation inside a turn of the first, against this ledger,
-which is what makes the parent's cap bind on it. So each entry is stamped with the
-delegation that booked it (`booked_to`, `SpendLedger.share_of`) and `book` is the
-only way in. That is not bookkeeping for its own sake - a delegate's own run row is
-what answers "what did the researcher cost this month", and the alternative
-(subtracting the shared total across the delegation) put the parent's later spend
-on the child and a delegate's delegates inside its own share. Attribution keeps one
-set of prices for both questions; the second lookup that pricing a task handle's
-usage would need is the thing `BudgetGuard.for_delegate` exists to prevent.
+which is what makes the parent's cap bind on it. So each entry is stamped with two
+things and `book` is the only way in: the delegation that booked it (`booked_to`,
+`SpendLedger.share_of`), for the delegation panel, and the nearest agent-row it
+bills to (`billed_to`, `SpendLedger.billed_share_of`), for the month. The two are
+equal for a published delegate's own requests and differ only under an inline
+specialist, which has no row of its own - its spend bills to its nearest published
+ancestor's month while its panel keeps its own share (agenticos#228). That is not
+bookkeeping for its own sake - a delegate's own run row is what answers "what did
+the researcher cost this month", and the alternative (subtracting the shared total
+across the delegation) put the parent's later spend on the child and a delegate's
+delegates inside its own share. Attribution keeps one set of prices for every
+question; the second lookup that pricing a task handle's usage would need is the
+thing `BudgetGuard.for_delegate` exists to prevent.

--- a/backend/app/agents/capabilities/budget/_capability.py
+++ b/backend/app/agents/capabilities/budget/_capability.py
@@ -159,6 +159,32 @@ class SpendEntry:
     grandchild. That is what keeps a mid-tree delegate's share from containing its
     own delegates' spend, which is the same money its delegates' rows already
     record (agenticos#180).
+
+    This is the *panel* attribution: :meth:`SpendLedger.share_of` reads it, and a
+    delegation panel shows an agent only what its own requests cost. It is not what
+    a monthly total is summed off - see :attr:`billed_to`.
+    """
+
+    billed_to: str | None = None
+    """Which agent-row this request bills to, or `None` for the run's own agent.
+
+    A *second* attribution beside :attr:`delegation`, because the two answer
+    different questions and diverge for exactly one shape. `delegation` is the
+    innermost delegation - what the panel shows. `billed_to` is the nearest
+    delegation with an `agent_runs` row of its own, which is the nearest *published*
+    delegate: an inline specialist has no row, so its spend has to land in some
+    row's month, and the honest one is its published ancestor's (agenticos#228).
+
+    They are equal for every request a published delegate makes on its own account,
+    and they differ only under an inline specialist: its entry is stamped
+    `delegation=<the specialist>` so its panel keeps its own share, and
+    `billed_to=<the published ancestor>` so its spend still reaches a month. Stamped
+    from :func:`booked_to`, which advances `billed_to` only across a delegation that
+    has its own row and leaves an inline one inheriting its ancestor's.
+
+    `None` - the run's own agent - is what the top-level run row already sums as the
+    whole ledger, so an inline specialist directly under the run's own agent needs
+    no delegated row: :meth:`SpendLedger.billed_share_of` never reads `None`.
     """
 
 
@@ -236,8 +262,39 @@ class SpendLedger:
         looked at. Zero for a delegation that made no request of its own - a
         delegate the library refused, or one whose whole job was to delegate
         further.
+
+        Filtered on :attr:`SpendEntry.delegation`, the innermost stamp - so this is
+        the *panel* number, an agent's own requests and not its inline specialists'.
+        What a monthly total is summed off is :meth:`billed_share_of`.
         """
-        mine = [entry for entry in self.entries if entry.delegation == delegation]
+        return self._share_where(lambda entry: entry.delegation == delegation)
+
+    def billed_share_of(self, billed_to: str) -> SpendShare:
+        """What bills to one published delegate's row: its own spend and its inline
+        specialists'.
+
+        Filtered on :attr:`SpendEntry.billed_to` rather than
+        :attr:`SpendEntry.delegation`, which is the whole of the difference. An
+        inline specialist's entry is stamped to the specialist for the panel and to
+        its nearest published ancestor for the row, so this share is the one that
+        makes the ancestor's month whole again without inventing a row for the
+        specialist (agenticos#228). For a published delegate with no inline
+        specialist below it the two shares are identical.
+
+        Only ever asked of a delegation that has a row - a published delegate - so
+        `None` (the run's own agent) is not a key here: its spend is the whole
+        ledger the top-level run row already carries.
+        """
+        return self._share_where(lambda entry: entry.billed_to == billed_to)
+
+    def _share_where(self, matches: Callable[[SpendEntry], bool]) -> SpendShare:
+        """The share of the ledger the matching entries make up.
+
+        One summation for both attributions, so the panel number and the row number
+        are the same arithmetic over a different filter and cannot drift in how they
+        add tokens or decide `has_unpriced_models`.
+        """
+        mine = [entry for entry in self.entries if matches(entry)]
         return SpendShare(
             cost_usd=sum((entry.cost_usd for entry in mine), Decimal(0)),
             input_tokens=sum(entry.input_tokens for entry in mine),
@@ -256,8 +313,13 @@ class SpendLedger:
         A copy rather than the caller's object: `record` builds a fresh entry, but a
         caller with an entry of its own - a resumed run's opening balance - would
         otherwise have that object mutated by being booked.
+
+        Both attributions are stamped here, from the two context variables
+        :func:`booked_to` sets together: `delegation` for the panel and `billed_to`
+        for the row. Stamping them anywhere but the one way in is how a delegate's
+        spend came to be counted as the parent's, and how it would be again.
         """
-        booked = replace(entry, delegation=_booked_to.get())
+        booked = replace(entry, delegation=_booked_to.get(), billed_to=_billed_to.get())
         self.entries.append(booked)
         return booked
 
@@ -285,11 +347,23 @@ Read by :meth:`SpendLedger.record` rather than passed to it, for the reason
 :func:`metered_by` is a context variable too: the guard that records a request is
 built per agent, while the delegation that is running is per *task* - a fan-out of
 three runs three delegations in three asyncio tasks against one guard.
+
+The *innermost* delegation, and what the panel is read off (:meth:`share_of`).
+"""
+
+_billed_to: ContextVar[str | None] = ContextVar("spend_billed_to", default=None)
+"""Which agent-row the spend in this task bills to, if it bills to a delegate's.
+
+The companion to :data:`_booked_to`, and it advances only across a delegation with
+a row of its own - a published delegate. An inline specialist leaves it pointing at
+whatever it was, which is its nearest published ancestor, so the specialist's spend
+lands in that ancestor's month while `_booked_to` still names the specialist for its
+panel (agenticos#228). `None` is the run's own agent, whose row is the whole ledger.
 """
 
 
 @contextmanager
-def booked_to(delegation: str) -> Iterator[None]:
+def booked_to(delegation: str, *, has_own_row: bool) -> Iterator[None]:
     """Attribute what is metered inside this block to one delegation.
 
     Opened around the tool call that starts a delegation, which is what makes it
@@ -301,12 +375,24 @@ def booked_to(delegation: str) -> Iterator[None]:
 
     Nested rather than exclusive: a delegate's own delegation sets this again, so
     the innermost one wins and each level is attributed only what it spent itself.
+
+    Two attributions are set together, because a request has to answer two
+    questions at once - which panel, and which month. `delegation` is always the
+    innermost, for the panel. `has_own_row` says whether this delegation is a
+    published delegate (one with its own `agent_runs` row): if it is, its spend
+    bills to itself; if it is an inline specialist, it has no row, so what is
+    metered here bills to its nearest published ancestor - whatever was billed here
+    already. Setting them together is the point - any window in which only one held
+    would attribute a request to a panel and a month that disagree.
     """
-    token = _booked_to.set(delegation)
+    billed = delegation if has_own_row else _billed_to.get()
+    booked_token = _booked_to.set(delegation)
+    billed_token = _billed_to.set(billed)
     try:
         yield
     finally:
-        _booked_to.reset(token)
+        _billed_to.reset(billed_token)
+        _booked_to.reset(booked_token)
 
 
 _active_ledger: ContextVar[SpendLedger | None] = ContextVar("active_spend_ledger", default=None)

--- a/backend/app/agents/capabilities/subagents/_journal.py
+++ b/backend/app/agents/capabilities/subagents/_journal.py
@@ -565,9 +565,33 @@ class DelegationJournal:
                 # resume so that a history the runner cannot serialise fails while
                 # there is still a run to attribute the failure to.
                 messages=[] if history is None else list(json.loads(history)),
-                spent=self._spent(delegation),
+                spent=self._carried_for_park(delegation),
                 started_at=self._span_start(delegation, handle),
             )
+        )
+
+    def _carried_for_park(self, delegation: Delegation) -> DelegationSpend:
+        """Everything this delegation has spent so far, both attributions, for the resume.
+
+        One :class:`DelegationSpend` carrying both numbers the two ends of a park
+        read: the panel spend (:meth:`_spent`) the streamed frame keeps, and the
+        billed spend (:meth:`_billed`) the row is owed. Kept together because a
+        published delegate that parks with an inline specialist below it has to
+        resume with both intact - the panel short by the specialist's own pre-park
+        spend was agenticos#245, the row short by it is agenticos#228, and a park
+        that carried only one would reintroduce whichever it dropped.
+        """
+        spent = self._spent(delegation)
+        billed = self._billed(delegation)
+        return DelegationSpend(
+            cost_usd=spent.cost_usd,
+            input_tokens=spent.input_tokens,
+            output_tokens=spent.output_tokens,
+            has_unpriced_models=spent.has_unpriced_models,
+            billed_cost_usd=billed.cost_usd,
+            billed_input_tokens=billed.input_tokens,
+            billed_output_tokens=billed.output_tokens,
+            billed_has_unpriced_models=billed.has_unpriced_models,
         )
 
     def record_created_specialists(self) -> None:
@@ -799,15 +823,21 @@ class DelegationJournal:
         # which a continuation allocates fresh; see `Delegation.public_id`.
         public = delegation.stable_id or task_id
         spent = self._spent(delegation)
+        # The row carries the *billed* share - a published delegate's own spend plus
+        # its inline specialists', which the panel below keeps separate (agenticos#228).
+        # The two are equal for a delegation with no inline specialist under it, and
+        # for an inline specialist the recorder writes no row at all, so its billed
+        # number (zero, since it bills to its ancestor) never reaches one.
+        billed = self._billed(delegation)
         run_id = await self._record(
             DelegationOutcome(
                 subagent=delegation.name,
                 task_id=public,
                 status=status,
-                cost_usd=spent.cost_usd,
-                input_tokens=spent.input_tokens,
-                output_tokens=spent.output_tokens,
-                cost_is_partial=spent.has_unpriced_models,
+                cost_usd=billed.cost_usd,
+                input_tokens=billed.input_tokens,
+                output_tokens=billed.output_tokens,
+                cost_is_partial=billed.has_unpriced_models,
                 agent_id=delegation.agent_id,
                 agent_version_id=delegation.agent_version_id,
                 error=handle.error,
@@ -895,7 +925,11 @@ class DelegationJournal:
         """
         token = _CURRENT.set(delegation)
         try:
-            with booked_to(delegation.ledger_key):
+            # A published delegate has an `agent_runs` row and bills to itself; an
+            # inline specialist (`agent_id is None`) has none, so its spend bills to
+            # its nearest published ancestor - which is what `has_own_row=False`
+            # tells `booked_to` to keep pointing at (agenticos#228).
+            with booked_to(delegation.ledger_key, has_own_row=delegation.agent_id is not None):
                 yield
         finally:
             _CURRENT.reset(token)
@@ -980,6 +1014,31 @@ class DelegationJournal:
             return carried
         return min(carried, this_segment)
 
+    def _billed(self, delegation: Delegation) -> SpendShare:
+        """What this delegation's row is owed: its own spend and its inline specialists'.
+
+        The counterpart to :meth:`_spent`, and read at the one place a *row* is
+        written rather than a panel: :meth:`settle` hands this to the recorder as
+        :class:`DelegationOutcome`, while :meth:`_spent` still fills the streamed
+        frame. For a published delegate with no inline specialist below it the two
+        are identical; they diverge only where an inline specialist's spend, stamped
+        to the specialist for its panel, has to reach a month through its published
+        ancestor (agenticos#228).
+
+        The carried half is the ancestor's, kept across a park the way the panel
+        spend is - a published delegate that parked with an inline specialist
+        mid-flight resumes with its row's pre-park spend intact rather than short by
+        what the specialist had already cost.
+        """
+        share = self._billed_share(delegation)
+        carried = delegation.carried
+        return SpendShare(
+            cost_usd=carried.billed_cost_usd + share.cost_usd,
+            input_tokens=carried.billed_input_tokens + share.input_tokens,
+            output_tokens=carried.billed_output_tokens + share.output_tokens,
+            has_unpriced_models=carried.billed_has_unpriced_models or share.has_unpriced_models,
+        )
+
     def _share(self, delegation: Delegation) -> SpendShare:
         """What this delegation booked into the run's ledger, or zeros if nothing meters.
 
@@ -991,6 +1050,19 @@ class DelegationJournal:
         if ledger is None:
             return SpendShare()
         return ledger.share_of(delegation.ledger_key)
+
+    def _billed_share(self, delegation: Delegation) -> SpendShare:
+        """What bills to this delegation's row this turn, or zeros if nothing meters.
+
+        The billed counterpart to :meth:`_share`: the same `None`-ledger fallback,
+        read off :meth:`~app.agents.capabilities.budget.SpendLedger.billed_share_of`
+        so an inline specialist's spend is inside its published ancestor's number
+        rather than lost between the two (agenticos#228).
+        """
+        ledger = self.runtime.ledger
+        if ledger is None:
+            return SpendShare()
+        return ledger.billed_share_of(delegation.ledger_key)
 
 
 def _characteristics(tool_args: dict[str, Any]) -> TaskCharacteristics:

--- a/backend/app/agents/subagent_runtime.py
+++ b/backend/app/agents/subagent_runtime.py
@@ -202,13 +202,23 @@ class DelegationOutcome:
     """What one delegation cost and how it ended.
 
     Reported to the runner so it can write the child's run row. The numbers are
-    this delegation's **share of the run's one shared ledger**: the requests its
-    own agent made, and only those. There is still one ledger per run - a delegate
-    records into the parent's by construction, which is what makes the parent's
-    budget see a delegate's spend before the next request - but every entry in it
-    carries the delegation that booked it, so the share is filtered out of the
-    ledger rather than inferred from it. See
+    this delegation's **billed share of the run's one shared ledger**: the requests
+    its own agent made, plus any its inline specialists made below it. There is
+    still one ledger per run - a delegate records into the parent's by construction,
+    which is what makes the parent's budget see a delegate's spend before the next
+    request - but every entry in it carries two attributions, so a share is filtered
+    out of the ledger rather than inferred from it. See
     :func:`app.agents.capabilities.budget.booked_to`.
+
+    Why the *billed* share and not the delegation's own: an inline specialist has no
+    row of its own, so the money it spends has to land in some agent's month, and
+    the honest one is its nearest published ancestor's - which is this row when the
+    delegation is that ancestor. The specialist's *panel* still shows only its own
+    share; that is the other attribution, on the streamed
+    :class:`~app.agents.subagent_events.SubagentFinished` rather than here, so the
+    two answer "what did this specialist cost" and "what does this agent owe"
+    without one distorting the other (agenticos#228). For a published delegate with
+    no inline specialist under it the two shares are identical.
 
     Exact in both modes and at every depth, which the arithmetic that came before
     it was not (agenticos#180). It measured the *growth* of the shared total across
@@ -316,6 +326,28 @@ class DelegationSpend:
     approval and resumed onto a priced model would otherwise have its row claim an
     exact cost for money nobody priced - the one number on a delegated row nothing
     downstream can re-derive.
+    """
+
+    billed_cost_usd: Decimal = Decimal(0)
+    billed_input_tokens: int = 0
+    billed_output_tokens: int = 0
+    billed_has_unpriced_models: bool = False
+    """The same four numbers again, but for what this delegation's *row* is owed
+    rather than what its *panel* shows (agenticos#228).
+
+    The fields above are a delegation's own spend - its panel, and what a delegate
+    with no inline specialists also bills to its row. These are what bills to the
+    row: a published delegate's own spend plus every inline specialist below it,
+    since an inline specialist has no row and its spend has to reach some month. The
+    two are equal for a delegation with no inline specialist under it, and the
+    journal keeps them apart only where they diverge (`_spent` reads the first four,
+    `_billed` these).
+
+    Carried across a park exactly as the panel spend is - a published delegate that
+    parked with an inline specialist mid-flight would otherwise resume with a row
+    short by the specialist's pre-park spend, the same silent under-report the panel
+    spend was (agenticos#245). Zero on an inline specialist's own carry: it bills to
+    nobody's row but its ancestor's, and that ancestor carries it here instead.
     """
 
 

--- a/backend/app/repositories/agent_run.py
+++ b/backend/app/repositories/agent_run.py
@@ -265,22 +265,20 @@ async def sum_cost_since(
     does not double-count.
 
     Included when the question is one agent's month, because a delegate's rows
-    are the only place its own spend is recorded. **Its own**, which is what makes
-    summing them meaningful for a delegate that delegates further: a *delegated* row
-    holds the requests that agent issued, not the ones its own delegates issued,
-    because the ledger those rows are read off stamps every entry with the delegation
-    that made it. A row that carried its grandchildren's spend counted the same money
-    twice under one agent's month, and did it silently (agenticos#180). A top-level
-    row is still the whole run, descendants included - that is what the first
-    question needs. That cap does not stop a run mid-delegation - inside a delegation
-    the parent's caps bind, see `app/agents/factory.py` - but it is what makes "the
-    researcher agent cost $40 this month" answerable and what a budget alert on that
-    agent fires on.
-
-    One known gap, agenticos#228: a delegate's *inline* specialist gets no row of its
-    own and is no longer inside its delegator's share either, so a delegate that uses
-    one under-reports its month by what the specialist spent. The organization's total
-    is unaffected - the top-level row is the whole ledger.
+    are the only place its own spend is recorded. **Its own**, which for a delegate
+    that delegates further means the requests that agent issued and its inline
+    specialists' - but not its *published* delegates', because those have rows of
+    their own. Every ledger entry carries two attributions: the delegation that made
+    it, for the delegation panel, and the nearest agent-row it bills to, for this
+    sum. A delegated row is the billed share, so a published delegate's inline
+    specialist lands in the delegate's month (agenticos#228) while a published
+    grandchild does not (agenticos#180) - the same money is never under one agent's
+    month twice, and an inline specialist's spend is never left out of every month.
+    A top-level row is still the whole run, descendants included - that is what the
+    first question needs. That cap does not stop a run mid-delegation - inside a
+    delegation the parent's caps bind, see `app/agents/factory.py` - but it is what
+    makes "the researcher agent cost $40 this month" answerable and what a budget
+    alert on that agent fires on.
     """
     query = select(func.coalesce(func.sum(AgentRun.cost_usd), 0)).where(
         AgentRun.organization_id == organization_id,

--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -362,6 +362,23 @@ class DelegationFrame(BaseModel):
             "per delegation now, so the turn that resumes cannot re-derive it"
         ),
     )
+    billed_cost_usd: Decimal = Field(
+        default=Decimal(0),
+        description=(
+            "What this delegation's row is owed by the stop - its own spend plus its "
+            "inline specialists', which `cost_usd` above leaves out because that is "
+            "the panel number. Equal to `cost_usd` for a delegate with no inline "
+            "specialist below it; carried so a published delegate that parked with "
+            "one resumes with its month intact (agenticos#228). Zero on an inline "
+            "specialist's own frame - it bills to its ancestor's row, not its own"
+        ),
+    )
+    billed_input_tokens: int = Field(default=0, description="The billed share, in input tokens")
+    billed_output_tokens: int = Field(default=0, description="The billed share, in output tokens")
+    billed_cost_is_partial: bool = Field(
+        default=False,
+        description="Whether the billed share went unpriced, making `billed_cost_usd` a floor",
+    )
     started_at: datetime | None = Field(
         default=None,
         description=(
@@ -601,6 +618,10 @@ def _delegation_frames(
                 input_tokens=entry.spent.input_tokens,
                 output_tokens=entry.spent.output_tokens,
                 cost_is_partial=entry.spent.has_unpriced_models,
+                billed_cost_usd=entry.spent.billed_cost_usd,
+                billed_input_tokens=entry.spent.billed_input_tokens,
+                billed_output_tokens=entry.spent.billed_output_tokens,
+                billed_cost_is_partial=entry.spent.billed_has_unpriced_models,
                 started_at=entry.started_at,
                 delegations=frames(by_parent.get(entry.task_id, [])),
                 dynamic_specialists=specialists(entry.tool_call_id),
@@ -699,6 +720,14 @@ def _resume_plan(state: PausedRunState, decided_args: Mapping[str, dict[str, Any
                 input_tokens=frame.input_tokens,
                 output_tokens=frame.output_tokens,
                 has_unpriced_models=frame.cost_is_partial,
+                # The row's share, carried alongside the panel's so a published
+                # delegate that parked with an inline specialist below it resumes
+                # with its month whole (agenticos#228). Zero on an inline
+                # specialist's frame, which bills to its ancestor, not itself.
+                billed_cost_usd=frame.billed_cost_usd,
+                billed_input_tokens=frame.billed_input_tokens,
+                billed_output_tokens=frame.billed_output_tokens,
+                billed_has_unpriced_models=frame.billed_cost_is_partial,
             )
             started[frame.tool_call_id] = frame.started_at
             if not frame.messages:

--- a/backend/tests/test_delegation_seams.py
+++ b/backend/tests/test_delegation_seams.py
@@ -256,7 +256,7 @@ def test_one_ledger_still_says_which_delegation_spent_what() -> None:
     ledger = SpendLedger()
 
     ledger.book(_priced("0.20"))
-    with booked_to("delegation-a"):
+    with booked_to("delegation-a", has_own_row=True):
         ledger.book(_priced("0.01"))
     ledger.book(_priced("0.30"))
 
@@ -273,9 +273,9 @@ def test_a_nested_delegation_takes_the_spend_from_the_one_it_is_inside() -> None
     """
     ledger = SpendLedger()
 
-    with booked_to("child"):
+    with booked_to("child", has_own_row=True):
         ledger.book(_priced("0.02"))
-        with booked_to("grandchild"):
+        with booked_to("grandchild", has_own_row=True):
             ledger.book(_priced("0.04"))
         ledger.book(_priced("0.02"))
 
@@ -283,6 +283,71 @@ def test_a_nested_delegation_takes_the_spend_from_the_one_it_is_inside() -> None
     assert ledger.share_of("grandchild").cost_usd == Decimal("0.04")
     # The whole, once: the shares partition the ledger rather than overlapping it.
     assert ledger.total_usd == Decimal("0.08")
+
+
+def test_an_inline_specialist_bills_its_spend_to_its_published_ancestor() -> None:
+    """The panel keeps the specialist's own share; the row gets the ancestor's whole.
+
+    A published delegate (`has_own_row=True`) delegates to an inline specialist
+    (`has_own_row=False`). The specialist's request is stamped to the specialist for
+    its panel and to the delegate for its month, so `share_of` and `billed_share_of`
+    answer the two questions that used to be one - and the money no longer falls
+    between them (agenticos#228).
+    """
+    ledger = SpendLedger()
+
+    with booked_to("researcher", has_own_row=True):
+        ledger.book(_priced("0.50"))
+        with booked_to("fact-checker", has_own_row=False):
+            ledger.book(_priced("0.25"))
+
+    # The panel: each shows only its own requests, exactly as before.
+    assert ledger.share_of("researcher").cost_usd == Decimal("0.50")
+    assert ledger.share_of("fact-checker").cost_usd == Decimal("0.25")
+    # The row: the delegate's month is its own plus the specialist it used, and the
+    # specialist bills nothing to a row of its own - it has none.
+    assert ledger.billed_share_of("researcher").cost_usd == Decimal("0.75")
+    assert ledger.billed_share_of("fact-checker").cost_usd == Decimal("0")
+    # Nothing counted twice: the whole ledger is the researcher's billed share here.
+    assert ledger.total_usd == Decimal("0.75")
+
+
+def test_inline_specialists_nest_to_the_nearest_published_ancestor() -> None:
+    """Two levels of inline still bill to the one published delegate above them.
+
+    `billed_to` advances only across a delegation with its own row, so an inline
+    specialist under an inline specialist under a published delegate leaves both of
+    them pointing at the delegate - which is the only agent with a month to land in.
+    """
+    ledger = SpendLedger()
+
+    with booked_to("researcher", has_own_row=True):
+        ledger.book(_priced("0.10"))
+        with booked_to("summariser", has_own_row=False):
+            ledger.book(_priced("0.20"))
+            with booked_to("fact-checker", has_own_row=False):
+                ledger.book(_priced("0.30"))
+
+    assert ledger.billed_share_of("researcher").cost_usd == Decimal("0.60")
+    assert ledger.billed_share_of("summariser").cost_usd == Decimal("0")
+    assert ledger.billed_share_of("fact-checker").cost_usd == Decimal("0")
+
+
+def test_an_inline_specialist_under_the_runs_own_agent_bills_to_no_delegated_row() -> None:
+    """Its spend is in the top-level row, which is the whole ledger, so it needs none.
+
+    `has_own_row=False` with nothing published above it leaves `billed_to` at its
+    default - the run's own agent - which no delegated row is ever keyed by. The
+    money is not lost: the top-level run row is the whole ledger regardless.
+    """
+    ledger = SpendLedger()
+
+    with booked_to("fact-checker", has_own_row=False):
+        ledger.book(_priced("0.25"))
+
+    assert ledger.share_of("fact-checker").cost_usd == Decimal("0.25")
+    assert [entry.billed_to for entry in ledger.entries] == [None]
+    assert ledger.total_usd == Decimal("0.25")
 
 
 def test_a_share_carries_the_tokens_and_whether_it_was_priced() -> None:
@@ -296,10 +361,10 @@ def test_a_share_carries_the_tokens_and_whether_it_was_priced() -> None:
     ledger = SpendLedger()
 
     ledger.book(SpendEntry("mystery-1", 5, 5, Decimal(0), priced=False))
-    with booked_to("delegation-a"):
+    with booked_to("delegation-a", has_own_row=True):
         ledger.book(_priced("0.01", tokens=7))
 
-    with booked_to("delegation-b"):
+    with booked_to("delegation-b", has_own_row=True):
         ledger.book(SpendEntry("mystery-2", 5, 5, Decimal(0), priced=False))
 
     priced = ledger.share_of("delegation-a")
@@ -327,7 +392,7 @@ def test_spend_outside_a_delegation_belongs_to_the_run_itself() -> None:
     """
     ledger = SpendLedger()
 
-    with booked_to("delegation-a"):
+    with booked_to("delegation-a", has_own_row=True):
         ledger.book(_priced("0.01"))
     ledger.book(_priced("0.30"))
 

--- a/backend/tests/test_dynamic_specialists.py
+++ b/backend/tests/test_dynamic_specialists.py
@@ -754,7 +754,14 @@ class TestADynamicDelegationIsAccountedForLikeAnyOther:
     async def test_it_is_recorded_with_no_agent_of_its_own(self):
         """An invented specialist has no agent row to attribute a run to, exactly
         as an inline specialist has none: its cost is the parent's, and the tool
-        call in the transcript is the record."""
+        call in the transcript is the record.
+
+        So the money it spends is real and on the run's ledger, but the row it would
+        write bills nothing to itself - it has no row, and directly under the run's
+        own agent its spend bills to the top-level row, which is the whole ledger
+        anyway (agenticos#228). The runner drops this outcome for want of an
+        `agent_id`; what it carries is the billed share, which is zero here.
+        """
         ledger = SpendLedger()
         recorder = Recorder()
         budget = _RunBudget(guard=BudgetGuard(ledger=ledger, provider="openai"))
@@ -767,7 +774,10 @@ class TestADynamicDelegationIsAccountedForLikeAnyOther:
         (outcome,) = recorder.outcomes
         assert (outcome.subagent, outcome.status) == ("summariser", "completed")
         assert (outcome.agent_id, outcome.agent_version_id) == (None, None)
-        assert outcome.cost_usd > 0
+        # The specialist did spend - it is the parent's ledger that holds it - and it
+        # bills to no row of its own.
+        assert ledger.total_usd > 0
+        assert outcome.cost_usd == Decimal(0)
 
     async def test_the_authors_mode_is_forced_on_it_too(self):
         """`delegate` takes a `mode` argument whose default is `sync`, so the

--- a/backend/tests/test_subagent_nested_resume.py
+++ b/backend/tests/test_subagent_nested_resume.py
@@ -75,6 +75,7 @@ from app.agents.subagent_runtime import (
     DelegationSpend,
     DelegationStash,
     DynamicSpecialists,
+    ParkedDelegation,
     RegisteredSpecialist,
     ResolvedSubagent,
     ResumedDelegation,
@@ -324,6 +325,7 @@ def _middle_delegate(
     calls: list[dict[str, Any]],
     stash: DelegationStash,
     metering: _Metering | None = None,
+    specialist_agent_id: UUID | None = None,
 ) -> ResolvedSubagent:
     """A delegate that delegates on, so the gated tool sits two levels down.
 
@@ -336,6 +338,10 @@ def _middle_delegate(
     is being followed across a park, and a middle that charged as well would put its
     own requests inside its subtree's total, which is a different defect
     (agenticos#180) and not this one.
+
+    `specialist_agent_id` publishes the specialist - gives it a row of its own - so a
+    test can assert the row it writes. Left `None`, the specialist is inline and its
+    spend bills to its nearest published ancestor instead (agenticos#228).
     """
 
     def build_it() -> PydanticAgent[Any, Any]:
@@ -348,6 +354,7 @@ def _middle_delegate(
                         gated=gated,
                         calls=calls,
                         charge=None if metering is None else metering.charge,
+                        agent_id=specialist_agent_id,
                     ),
                     stash=stash,
                     depth=1,
@@ -890,6 +897,86 @@ class TestWhenAPlaceCannotBeKept:
         assert plan.started == {"the-task-call": began}
 
 
+class TestABilledShareSurvivesAPark:
+    """A published delegate's row keeps its inline specialist's spend across a park.
+
+    The intersection of agenticos#228 and agenticos#245: the row a published delegate
+    writes is its own spend plus its inline specialists', and that whole has to be
+    carried across a park the way its panel spend is - the paused state is JSONB and
+    the resuming turn's ledger starts empty, so a billed share not written down is a
+    row that resumes short by exactly what the specialist spent before the approval.
+    """
+
+    def test_the_billed_share_is_written_carried_and_read_back(self):
+        """Through `_delegation_frames`, the column, and `_resume_plan`, in one trip.
+
+        A published researcher parked with $0.75 billed to its row - its own $0.50
+        and its inline fact-checker's $0.25 - and the fact-checker parked with $0.25
+        of its own but nothing billed to a row it does not have. The whole trip is
+        exercised because that is the trip a real park makes: the frame is built from
+        the stash, dumped as JSON, validated back, and split by `_resume_plan`.
+        """
+        parked = [
+            ParkedDelegation(
+                tool_call_id="researcher-call",
+                task_id="researcher-task",
+                parent_task_id=None,
+                subagent="researcher",
+                agent_id=uuid4(),
+                agent_version_id=uuid4(),
+                child_run_id=None,
+                messages=[],
+                spent=DelegationSpend(
+                    cost_usd=Decimal("0.50"),
+                    input_tokens=INPUT_TOKENS * 2,
+                    output_tokens=OUTPUT_TOKENS * 2,
+                    billed_cost_usd=Decimal("0.75"),
+                    billed_input_tokens=INPUT_TOKENS * 3,
+                    billed_output_tokens=OUTPUT_TOKENS * 3,
+                ),
+                started_at=None,
+            ),
+            ParkedDelegation(
+                tool_call_id="fact-checker-call",
+                task_id="fact-checker-task",
+                parent_task_id="researcher-task",
+                subagent="fact-checker",
+                agent_id=None,
+                agent_version_id=None,
+                child_run_id=None,
+                messages=[],
+                spent=DelegationSpend(
+                    cost_usd=Decimal("0.25"),
+                    input_tokens=INPUT_TOKENS,
+                    output_tokens=OUTPUT_TOKENS,
+                ),
+                started_at=None,
+            ),
+        ]
+
+        (researcher_frame,) = _delegation_frames(parked, {})
+        (fact_checker_frame,) = researcher_frame.delegations
+        # Written from the stash: the published delegate's row keeps the whole, the
+        # inline specialist's frame bills nothing to a row of its own.
+        assert researcher_frame.billed_cost_usd == Decimal("0.75")
+        assert fact_checker_frame.billed_cost_usd == Decimal("0")
+
+        state = PausedRunState.model_validate(
+            PausedRunState(
+                messages=[], tool_call_ids={}, delegations=[researcher_frame]
+            ).model_dump(mode="json")
+        )
+        plan = _resume_plan(state, {})
+
+        # Read back onto the key the resuming turn opens the delegation under, so
+        # `_billed` adds the specialist's pre-park spend to the researcher's row.
+        # (Its place was not kept - `messages=[]` - so the fact-checker is re-run
+        # rather than continued, which is why only the researcher's key is here; its
+        # own $0.25 is already inside the researcher's $0.75 either way.)
+        assert plan.spent["researcher-call"].billed_cost_usd == Decimal("0.75")
+        assert plan.spent["researcher-call"].billed_input_tokens == INPUT_TOKENS * 3
+
+
 class TestAnOlderParkedRun:
     """A run parked before any of this existed has to stay resumable.
 
@@ -1201,7 +1288,11 @@ class TestWhatADelegateSpentBeforeItParked:
 
         parked, answer = await _until_it_answers(
             lambda _stash, metering: _specialist_delegate(
-                gated=True, calls=calls, cities=("Krakow", "Warsaw"), charge=metering.charge
+                gated=True,
+                calls=calls,
+                cities=("Krakow", "Warsaw"),
+                charge=metering.charge,
+                agent_id=uuid4(),
             ),
             turn_costs=(Decimal("0.25"), Decimal("0.75"), Decimal("0.50")),
             parent_cost=Decimal("0.10"),
@@ -1237,7 +1328,11 @@ class TestWhatADelegateSpentBeforeItParked:
 
         parked, answer = await _until_it_answers(
             lambda stash, metering: _middle_delegate(
-                gated=True, calls=calls, stash=stash, metering=metering
+                gated=True,
+                calls=calls,
+                stash=stash,
+                metering=metering,
+                specialist_agent_id=uuid4(),
             ),
             turn_costs=(Decimal("0.25"), Decimal("0.75")),
             parent_cost=Decimal("0.10"),
@@ -1247,8 +1342,9 @@ class TestWhatADelegateSpentBeforeItParked:
         assert answer == "answer: edited: weather: Krakow: 21C and clear"
         assert calls == [{"city": "Krakow"}]
         # The specialist's own row holds what the specialist spent across both turns.
-        # The editor's holds its subtree, which is the separate defect agenticos#180
-        # is about and is deliberately not asserted here.
+        # Published (it has an `agent_id`), so it has a row at all; the editor's holds
+        # its subtree, which is the separate defect agenticos#180 is about and is
+        # deliberately not asserted here.
         specialist = [outcome for outcome in recorder.outcomes if outcome.subagent == SPECIALIST]
         assert [outcome.cost_usd for outcome in specialist] == [Decimal("1.00")]
         # Nested where it was made, which is what keeps one level's carry off another.

--- a/backend/tests/test_subagents_capability.py
+++ b/backend/tests/test_subagents_capability.py
@@ -87,7 +87,7 @@ from app.agents.capabilities.subagents._toolset import DelegatingToolset
 from app.agents.deps import AgentDeps
 from app.agents.factory import DEFAULT_MAX_STEPS
 from app.agents.spec import AgentSpec, CapabilityBindingSpec, DelegationMode
-from app.agents.subagent_events import SubagentEvent
+from app.agents.subagent_events import SubagentEvent, SubagentFinished
 from app.agents.subagent_runtime import (
     SUBAGENT_RUNTIME_RESOURCE,
     DelegationOutcome,
@@ -169,6 +169,37 @@ def handing_on(to: str, *, ledger: SpendLedger) -> FunctionModel:
         )
 
     return FunctionModel(respond)
+
+
+def streaming_handing_on(to: str, *, ledger: SpendLedger) -> FunctionModel:
+    """A `handing_on` that also narrates, for a tree observed through a surface.
+
+    Same two requests booked to whichever delegation is running - a delegate's own
+    two, then its own delegate's third - but with a `stream_function`, because a run
+    with a sink is driven through `iter` and a `FunctionModel` with no stream raises
+    there. Needed where the assertion is on the *panel* a surface shows, which only
+    exists when the delegation is streamed.
+    """
+    args = {"description": "check the claim", "subagent_type": to}
+
+    def respond(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        ledger.book(ENTRY)
+        returned = _tool_results(messages)
+        if returned:
+            return ModelResponse(parts=[TextPart(" ".join(returned))])
+        return ModelResponse(parts=[ToolCallPart("task", args)])
+
+    async def stream(
+        messages: list[ModelMessage], _info: AgentInfo
+    ) -> AsyncIterator[str | DeltaToolCalls]:
+        ledger.book(ENTRY)
+        returned = _tool_results(messages)
+        if returned:
+            yield " ".join(returned)
+        else:
+            yield {0: DeltaToolCall(name="task", json_args=json.dumps(args))}
+
+    return FunctionModel(respond, stream_function=stream)
 
 
 def asking(question: str, *, prefix: str = "answer: ") -> FunctionModel:
@@ -924,12 +955,23 @@ class TestRecording:
         assert outcome.error is None
 
     async def test_what_the_parent_spent_before_delegating_is_not_the_delegates(self):
-        """The share, not the total: the parent has already spent before it delegates."""
+        """The share, not the total: the parent has already spent before it delegates.
+
+        A published delegate, so the number under test is the row it writes: the
+        billed share reads the same as the delegate's own here, because it has no
+        inline specialist below it (agenticos#228).
+        """
         ledger = SpendLedger()
         ledger.book(ENTRY)
         recorder = Recorder()
         capability = a_capability(
-            a_runtime(a_delegate(model=answering(ledger=ledger)), ledger=ledger, record=recorder)
+            a_runtime(
+                a_delegate(
+                    model=answering(ledger=ledger), agent_id=uuid4(), agent_version_id=uuid4()
+                ),
+                ledger=ledger,
+                record=recorder,
+            )
         )
 
         await delegate_to(capability, a_context())
@@ -1152,7 +1194,13 @@ class TestBackgroundDelegations:
         ledger = SpendLedger()
         recorder = Recorder()
         capability = a_capability(
-            a_runtime(a_delegate(model=answering(ledger=ledger)), ledger=ledger, record=recorder),
+            a_runtime(
+                a_delegate(
+                    model=answering(ledger=ledger), agent_id=uuid4(), agent_version_id=uuid4()
+                ),
+                ledger=ledger,
+                record=recorder,
+            ),
             {"mode": "async"},
         )
         ctx = a_context()
@@ -1222,7 +1270,13 @@ class TestBackgroundDelegations:
         ledger = SpendLedger()
         recorder = Recorder()
         capability = a_capability(
-            a_runtime(a_delegate(model=answering(ledger=ledger)), ledger=ledger, record=recorder),
+            a_runtime(
+                a_delegate(
+                    model=answering(ledger=ledger), agent_id=uuid4(), agent_version_id=uuid4()
+                ),
+                ledger=ledger,
+                record=recorder,
+            ),
             {"mode": "async"},
         )
         ctx = a_context()
@@ -1463,6 +1517,82 @@ class TestADelegateThatDelegates:
         # relies on to answer one agent's month.
         assert ledger.total_usd == ENTRY.cost_usd * 3
         assert sum(outcome.cost_usd for outcome in recorder.outcomes) == ledger.total_usd
+
+    @staticmethod
+    def _tree_with_inline_specialist(
+        ledger: SpendLedger, recorder: Recorder
+    ) -> tuple[Delegation, UUID]:
+        """A published researcher that delegates to an *inline* fact-checker.
+
+        The one shape agenticos#228 was filed for: the fact-checker has no
+        `agent_id`, so it gets no run row of its own, and before the fix its spend
+        was stamped to itself - a key nothing per-agent reads - and so was in no
+        row at all. The researcher is published and streams (`streaming_handing_on`)
+        so the panel a surface shows can be asserted beside the row a month sums.
+        """
+        checker = ResolvedSubagent(
+            name="fact-checker",
+            description="Checks one claim.",
+            build=delegate_agent(answering("checked", ledger=ledger)),
+        )
+        inner = a_capability(
+            a_runtime(checker, ledger=ledger, record=recorder, depth_remaining=0, depth=1)
+        )
+        researcher_id, researcher_version = uuid4(), uuid4()
+        researcher = ResolvedSubagent(
+            name="researcher",
+            description="Researches a topic and cites its sources.",
+            build=lambda: PydanticAgent(
+                streaming_handing_on("fact-checker", ledger=ledger),
+                output_type=[str, DeferredToolRequests],
+                capabilities=[inner],
+            ),
+            agent_id=researcher_id,
+            agent_version_id=researcher_version,
+        )
+        outer = a_capability(a_runtime(researcher, ledger=ledger, record=recorder))
+        return outer, researcher_id
+
+    async def test_a_published_delegates_row_takes_in_its_inline_specialists_spend(self):
+        """The row is whole again and the panel is untouched - the shape of agenticos#228.
+
+        Three requests at $0.25: two the researcher's, one the inline fact-checker's.
+        Before the fix the researcher's row read $0.50 and the fact-checker's $0.25
+        went to no month at all. Now the researcher's row is the full $0.75 while its
+        fact-checker's *panel* still shows only its own $0.25 - what did this
+        specialist cost, and what does this agent owe, kept apart.
+        """
+        ledger = SpendLedger()
+        recorder = Recorder()
+        sink = Sink()
+        capability, researcher_id = self._tree_with_inline_specialist(ledger, recorder)
+
+        assert "checked" in await delegate_to(capability, a_context(sink))
+
+        outcomes = {outcome.subagent: outcome for outcome in recorder.outcomes}
+        # The row: the published researcher's month is its own two requests plus the
+        # one its inline specialist made - the whole run, not two-thirds of it.
+        assert outcomes["researcher"].cost_usd == ENTRY.cost_usd * 3
+        assert outcomes["researcher"].agent_id == researcher_id
+        # The inline specialist bills nothing to a row of its own: it has none, and
+        # its spend is already inside the researcher's. The runner drops this outcome
+        # for want of an `agent_id`; the number it would carry is zero regardless.
+        assert outcomes["fact-checker"].cost_usd == Decimal(0)
+        assert outcomes["fact-checker"].agent_id is None
+
+        # The panel: each still shows only what its own requests cost, so a surface
+        # nests the fact-checker's $0.25 inside the researcher's own $0.50.
+        finished = {
+            frame.subagent: frame for frame in sink.frames if isinstance(frame, SubagentFinished)
+        }
+        assert finished["researcher"].cost_usd == ENTRY.cost_usd * 2
+        assert finished["fact-checker"].cost_usd == ENTRY.cost_usd
+
+        # The organization's bill is the whole ledger, once, and no dollar is under a
+        # delegated row twice: the only row with a month here is the researcher's.
+        assert ledger.total_usd == ENTRY.cost_usd * 3
+        billed = sum(o.cost_usd for o in recorder.outcomes if o.agent_id is not None)
+        assert billed == ledger.total_usd
 
 
 class TestTaskLifecycle:

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -84,14 +84,16 @@ A delegation to a **published** agent gets an `agent_runs` row of its own, carry
 has no agent to attribute one to, so its cost is the *run's* and the tool call in
 the transcript is the record.
 
-!!! warning "A delegate's own inline specialist — [#228](https://github.com/vstorm-co/agenticos/issues/228)"
-
-    The run's, not the delegating agent's, and below the top level that is a gap
-    rather than a decision. A specialist's requests are stamped to the specialist,
-    which gets no row, and the innermost stamp wins - so they are not in its
-    delegator's share either. A published delegate that uses an inline specialist
-    therefore under-reports its own month by what the specialist spent. The
-    organization's total is unaffected: the top-level row is the whole ledger.
+Which run's, though, is the question [#228](https://github.com/vstorm-co/agenticos/issues/228)
+answered. A specialist directly under the run's own agent bills to the top-level
+row, which is the whole ledger anyway. A specialist under a **published delegate**
+bills to *that delegate's* row, not the top-level one - so the delegate's month
+includes what its specialist spent, which is the only place it could honestly land.
+Each ledger entry therefore carries two attributions: the delegation that made it,
+for the panel, and the nearest agent-row it bills to, for the month. The two are
+equal for every request a published delegate makes on its own account and diverge
+only under an inline specialist - whose panel keeps its own share while its spend
+reaches its ancestor's row.
 
 !!! important "The parent's row is the authority; a child's row is its share of it"
 
@@ -112,8 +114,8 @@ the transcript is the record.
     Splitting it with a ledger *per agent* is still the design to avoid - that is
     what stops the parent's cap binding at all. One ledger, attributed, keeps both
     properties: the parent's cap sees every request before the next one, and each
-    delegated row says what that one agent spent - with the inline-specialist gap
-    above.
+    delegated row says what that one agent spent, its own inline specialists
+    included and its published delegates excluded.
 
     The parent's row remains the authority for the run. Its `cost_usd` is the whole
     ledger, delegates included, which is what the organization is billed; the child
@@ -161,7 +163,7 @@ opposite arithmetic:
 | The question | Child rows |
 |---|---|
 | **What does the organization owe?** | **excluded** - the parent's row already contains these tokens, so counting both bills the organization twice for one request |
-| **What did *this agent* cost this month?** | **included** - a delegate's rows are the only place its own spend is recorded, and each one holds that agent's own requests rather than its delegates' as well ([#228](https://github.com/vstorm-co/agenticos/issues/228) for what it currently leaves out) |
+| **What did *this agent* cost this month?** | **included** - a delegate's rows are the only place its own spend is recorded, and each one holds that agent's own requests and its inline specialists' ([#228](https://github.com/vstorm-co/agenticos/issues/228)) but not its published delegates', which have rows of their own |
 
 The second is what makes "the researcher cost $40 this month" answerable, and it is
 what a per-agent usage report or a budget alert on that agent fires on. The


### PR DESCRIPTION
## What and why

An **inline specialist under a published delegate** spent money that reached no
agent's month (#228, found while fixing #192).

Since #192 every `SpendEntry` is stamped with the delegation that booked it, and a
delegation's cost is its share of that stamp, innermost winning. An inline
specialist gets no `agent_runs` row - only published delegates do - so its share
was in no row, and because the innermost stamp won it was no longer in its
delegator's share either. On a $0.75 run a published `researcher` delegating to an
inline `fact-checker` rowed **$0.50**. The organisation total was unaffected (the
top-level row is the whole ledger), which is why nothing failed and the suite
stayed green.

## The design: a second attribution

An entry now answers two questions, because they diverge for exactly one shape:

- `SpendEntry.delegation` — the innermost delegation, for the **panel**
  (`share_of`, `SubagentFinished.cost_usd`). Unchanged.
- `SpendEntry.billed_to` — the nearest delegation with a **row** of its own (the
  nearest *published* delegate), for the **month** (`billed_share_of`, the child
  `agent_runs` row).

`booked_to` sets both together and advances `billed_to` only across a delegation
that has its own row. A published delegate bills to itself; an inline specialist
(one level or several) inherits its published ancestor's; the run's own agent stays
`None`, which the top-level whole-ledger row already covers. `settle` hands the
billed share to the child-row recorder while the streamed frame keeps `_spent`, so
"what did this specialist cost" and "what does this agent owe" stop distorting each
other. The two shares are identical for a published delegate with no inline
specialist below it.

I considered deriving the billed share from the frame tree at resume rather than a
second stamp; the stamp is cleaner (no per-node published/inline branch in the
runner) and mirrors the existing `delegation` stamp exactly.

### Parks

Carried across a park too, or a published delegate that parked with an inline
specialist mid-flight would resume with its row short by the specialist's pre-park
spend — the same silent under-report #245 was for the panel. `DelegationSpend`,
`DelegationFrame` and the paused-state round trip carry the billed share beside the
panel share; an older payload defaults it to zero ("parked before this existed").

## Tests

- **New capability test** — a published researcher delegating to an inline
  fact-checker: the researcher's row is the full **$0.75**, the fact-checker's panel
  keeps **$0.25**, the org total is unchanged, nothing double-counted. Proven to
  **fail at $0.50 without the fix**.
- **Seam tests** — the two-attribution split, and the nearest-published-ancestor
  inheritance at one and two levels of inline, plus an inline specialist directly
  under the run's own agent billing to no delegated row.
- **Paused-state round-trip test** — the billed share survives
  `_delegation_frames` → JSONB → `_resume_plan`.
- Existing park tests (`test_two_parks…`, `test_a_specialist_two_levels_down…`,
  the dynamic-specialist accounting test) now route the child row through `billed`;
  updated to publish the delegate whose row they assert, since an inline delegate's
  outcome is billed-zero and dropped by the runner. They are what prove the carry.

Docs: `docs/governance.md` and the `sum_cost_since` / `DelegationOutcome` docstrings
now describe billed-share attribution instead of naming #228 as an open gap.

## Verification

`PGPASSWORD=… POSTGRES_DB=agenticos_test_i228 make check` — **green**. Backend
platform layer at **100%** statements and branches (`app/agents/**`,
`agent_runner.py`, `spend.py` included); frontend 3164 tests; build, docs, audit all
pass. `e2e` not run locally (needs a seeded backend); nothing here touches a journey.

Closes #228
