### PR TITLE
Pre-validate a model-chosen specialist name before promoting from chat

### DIFF
--- a/frontend/src/components/chat/delegation-panel.integration.test.tsx
+++ b/frontend/src/components/chat/delegation-panel.integration.test.tsx
@@ -205,6 +205,27 @@ describe("promoting a specialist the model invented", () => {
     expect(screen.queryByRole("button", { name: "Promote to a draft agent" })).toBeNull();
   });
 
+  it("refuses to promote a model-chosen name the backend would reject, and says why", async () => {
+    // The model names a dynamic specialist itself; the library allows names the
+    // backend `SpecialistSpec` rejects (pattern, length), and a person cannot edit
+    // it in chat. So the control disables with the reason - matching the Builder's
+    // own promote button - rather than letting the promote fail into a 422 toast.
+    render(
+      <DelegationPanels
+        delegations={[finished({ subagent: "research topics", specialist: invented, runId: null })]}
+      />,
+      { wrapper: wrapperGranting("agents:edit") },
+    );
+    (await screen.findByRole("button", { name: /research topics/ })).click();
+
+    expect(await screen.findByRole("button", { name: "Promote to a draft agent" })).toBeDisabled();
+    expect(
+      screen.getByText(
+        "Letters, digits, underscores and dashes only. The model emits this verbatim.",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("offers nothing to keep for a delegate that is already keepable", async () => {
     // No definition on the frame - a configured delegate or an inline specialist,
     // both of which are kept already. Nothing to promote even with the permission.

--- a/frontend/src/components/chat/delegation-panel.tsx
+++ b/frontend/src/components/chat/delegation-panel.tsx
@@ -8,7 +8,7 @@ import { toast } from "sonner";
 
 import { useAgents, useModelProviders, usePermissions } from "@/hooks";
 import { ROUTES } from "@/lib/constants";
-import { newSpecialist } from "@/lib/agent-spec";
+import { newSpecialist, specialistNameError } from "@/lib/agent-spec";
 import { cn, getErrorMessage } from "@/lib/utils";
 import { childrenOf, rootsOf } from "@/lib/delegations";
 import { toolStep } from "@/lib/tool-steps";
@@ -253,6 +253,12 @@ function DelegationPanel({ delegation, all }: { delegation: Delegation; all: Del
  * keyed by the profile's id, so it is resolved here - and a label that no longer
  * resolves (a profile deleted since) promotes with no model, leaving the draft to
  * ask for one before it can publish rather than failing the promote.
+ *
+ * The name is the model's own - whatever it chose when it invented the specialist,
+ * which the library allows but the backend `SpecialistSpec` may reject (its pattern
+ * and length). A person cannot edit it in chat, so the control refuses up front
+ * with the reason - the same disable the Builder's `SpecialistEditor` does on a
+ * name it would fail to publish - rather than letting the promote 422 into a toast.
  */
 function PromoteDynamicSpecialist({
   name,
@@ -262,8 +268,12 @@ function PromoteDynamicSpecialist({
   definition: SpecialistDefinition;
 }) {
   const t = useTranslations("chat.delegation");
+  // The name-error copy lives with the Builder's, keyed off the same helper; a
+  // second translator reaches it without duplicating the strings into `chat`.
+  const tAgents = useTranslations("agents");
   const { profiles } = useModelProviders();
   const { promote } = useAgents();
+  const nameError = specialistNameError(name);
   const modelProfileId = profiles.find((profile) => profile.label === definition.model)?.id ?? null;
 
   const onPromote = () =>
@@ -288,13 +298,25 @@ function PromoteDynamicSpecialist({
 
   return (
     <div>
-      <Button variant="outline" size="sm" disabled={promote.isPending} onClick={onPromote}>
+      <Button
+        variant="outline"
+        size="sm"
+        // A promoted specialist keeps its name as the new agent's handle, so a name
+        // the backend would refuse cannot be promoted - the same guard the Builder
+        // puts on its own promote button.
+        disabled={promote.isPending || nameError !== null}
+        onClick={onPromote}
+      >
         <CopyPlus className="h-3.5 w-3.5" />
         {t("promoteSpecialist")}
       </Button>
-      <p className="text-muted-foreground mt-1 text-[12px] leading-relaxed">
-        {t("promoteSpecialistDetail")}
-      </p>
+      {nameError !== null ? (
+        <p className="text-destructive mt-1 text-[12px] leading-relaxed">{tAgents(nameError)}</p>
+      ) : (
+        <p className="text-muted-foreground mt-1 text-[12px] leading-relaxed">
+          {t("promoteSpecialistDetail")}
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What this fixes

The chat "Promote to a draft agent" control passed a dynamic specialist's
model-chosen name straight to the promote request. The library allows names the
backend `SpecialistSpec` rejects (pattern `^[a-zA-Z0-9_-]+$`, max length 64), so
an over-long or oddly-punctuated name promoted with a raw 422 that surfaced as an
error toast — for a name a person cannot even edit in chat. The Builder's
`SpecialistEditor` already does the polished thing; the chat sibling did not.

`Closes #293`

## What changed

- `frontend/src/components/chat/delegation-panel.tsx` — `PromoteDynamicSpecialist`
  now computes `specialistNameError(name)`, disables the button when it returns a
  reason, and shows that reason in place of the usual detail line. Same guard the
  Builder puts on its own promote button.
- The reason copy already lives in the `agents` namespace keyed off that helper, so
  a second `useTranslations("agents")` reaches it without duplicating strings into
  `chat`.

## How it failed before

A model-chosen name like `research topics` (a space) or a 65-character name left the
button enabled; pressing it hit the backend, which answered 422, caught by the
mutation's `onError` and shown as a toast. Graceful, but less polished than the
Builder, and the name is not editable in chat.

## Testing

- `delegation-panel.integration.test.tsx` — new case: a specialist named
  `research topics` renders the promote button disabled with the reason, alongside
  the existing cases where a valid name promotes. 9 tests in the file pass.
- `make test-frontend-cov` equivalent (`bun run test:coverage`): 184 files, 3175
  tests pass; the platform-layer gate holds (100% statements/lines/functions,
  97.55% branches).
- `eslint`, `prettier`, `tsc`, `check_i18n.py`, `docs_drift.py` all clean.

## Noticed, not fixed

Nothing — the change is scoped to the chat promote control.
