### PR TITLE
fix(agents): own each dynamic specialist's definition per delegation

### DIFF
--- a/backend/app/agents/capabilities/subagents/_capability.py
+++ b/backend/app/agents/capabilities/subagents/_capability.py
@@ -875,11 +875,11 @@ def _seeded_registry(
                 extra={"subagent": specialist.name, "model": specialist.model},
             )
             continue
-        # Recorded here as well as in `_specialist_factory`, because a specialist
-        # kept across an approval park is re-registered through this path rather
-        # than the factory - and a `task` to it *after* the resume would otherwise
-        # open a panel carrying no definition, hiding the promote offer on the one
-        # kind of specialist the offer exists for, while it is visibly working.
+        # A specialist kept across an approval park is re-registered through this
+        # path rather than through `create_agent`, so its definition is recorded here
+        # too - a `task` to it *after* the resume would otherwise open a panel
+        # carrying no definition, hiding the promote offer on the one kind of
+        # specialist the offer exists for, while it is visibly working.
         journal.record_dynamic_definition(
             name=specialist.name,
             description=specialist.description,
@@ -978,6 +978,14 @@ def _specialist_factory(dynamic: DynamicSpecialists, journal: DelegationJournal)
     lands in the model's context and in no log line. That is the library's choice
     and it is the right one for a tool call - the model can try something else -
     but it means a misconfiguration here is visible only in a transcript.
+
+    It only builds; it records no definition. A specialist's definition is kept where
+    the delegation to it can read it, and that is two different places for the two
+    kinds this factory serves: a one-shot `delegate` owns its copy on the delegation
+    (`DelegatingToolset._delegate`), while a `create_agent` specialist is recorded by
+    name once it is registered (`DelegatingToolset.call_tool`). Recording here keyed
+    by name instead let two same-named `delegate` calls overwrite each other, so the
+    frame carried the wrong specialist's instructions (agenticos#292).
     """
 
     def factory(config: SubAgentConfig) -> _LazyAgent:
@@ -988,17 +996,6 @@ def _specialist_factory(dynamic: DynamicSpecialists, journal: DelegationJournal)
             # that named no model, and one of `dynamic.allowed_models` because
             # `subagents_pydantic_ai.dynamic_agent.validate_model` checked it
             # against exactly that list before this factory was reached.
-            model=str(config["model"]),
-        )
-        # Both entry points that invent a specialist - `create_agent` and
-        # `delegate` - build through this factory, so this is the one place that
-        # sees every dynamic specialist's definition. Recorded here so the opening
-        # frame of the delegation to it carries it, the only window a surface has to
-        # offer promoting a specialist nothing else keeps.
-        journal.record_dynamic_definition(
-            name=config["name"],
-            description=config["description"],
-            instructions=config["instructions"],
             model=str(config["model"]),
         )
         return _LazyAgent(

--- a/backend/app/agents/capabilities/subagents/_journal.py
+++ b/backend/app/agents/capabilities/subagents/_journal.py
@@ -306,6 +306,25 @@ class Delegation:
     :attr:`public_id`, so the continuation reopens the panel that was left waiting
     rather than opening a second one beside it (agenticos#173)."""
 
+    specialist: SpecialistDefinition | None = None
+    """The definition of the specialist a one-shot `delegate` invented for *this* one.
+
+    A `delegate` call carries the whole specialist - instructions, model, the
+    description the model wrote - in its own arguments, so the definition is known
+    the moment the delegation opens and belongs to the delegation itself. Owned here
+    rather than looked up by name because two `delegate` calls in one turn may share
+    a name with different instructions, and pydantic-ai may run them concurrently: a
+    shared name-keyed store lets the second overwrite the first, so whichever settles
+    later stamps the wrong specialist onto its opening frame and the promote offer
+    carries someone else's instructions (agenticos#292).
+
+    `None` for every other delegation - a configured delegate, an inline specialist,
+    and a `task` to a `create_agent` specialist. The last is genuinely addressed by
+    name and registered one-per-name, so it is resolved through
+    :attr:`DelegationJournal._dynamic_definitions`; see
+    :meth:`DelegationJournal._definition_for`.
+    """
+
     started: bool = False
 
     @property
@@ -337,8 +356,9 @@ class Delegation:
 
         `specialist` is the definition of a specialist the model invented at run
         time, and `None` for every configured delegate and inline specialist - the
-        journal resolves it by name, so the announcement of a dynamic delegation
-        carries the only legible copy of what nothing else keeps.
+        journal resolves it through :meth:`DelegationJournal._definition_for`, so the
+        announcement of a dynamic delegation carries the only legible copy of what
+        nothing else keeps.
         """
         if self.started:
             return
@@ -408,15 +428,24 @@ class DelegationJournal:
     _dynamic_definitions: dict[str, SpecialistDefinition] = field(
         default_factory=dict, init=False, repr=False
     )
-    """What each specialist the model invented was built from, keyed by its name.
+    """What each *kept* specialist the model invented was built from, keyed by name.
 
-    Filled by `_specialist_factory` the moment `create_agent` or `delegate` builds
-    one - both go through the factory - and read by :meth:`dynamic_definition` when
-    the delegation to it opens, so the opening frame can carry the definition. This
-    is the streamed half of what :meth:`record_created_specialists` snapshots for a
-    park: the registry keeps the kept ones across an approval, this keeps every
-    invented one legible to the surface for the length of the turn. Thrown away with
-    the journal when the turn ends, because a dynamic specialist is not persisted.
+    Only the specialists a `task` reaches by name: one a `create_agent` registered
+    this turn, and one re-registered from the stash on a resume. Both are addressed
+    by name and the registry holds one per name, so a name key is exactly right - the
+    `task` that delegates to one carries no definition of its own, so this is the only
+    place its opening frame can read one from.
+
+    A one-shot `delegate` is deliberately *not* here: it owns its definition on the
+    delegation itself (:attr:`Delegation.specialist`), because two `delegate` calls in
+    one turn may share a name and a name-keyed store would let one overwrite the
+    other's (agenticos#292). :meth:`_definition_for` reads the delegation's own copy
+    first and falls back to this.
+
+    This is the streamed half of what :meth:`record_created_specialists` snapshots for
+    a park: the registry keeps the kept ones across an approval, this keeps them
+    legible to the surface for the length of the turn. Thrown away with the journal
+    when the turn ends, because a dynamic specialist is not persisted.
     """
 
     def in_background(self) -> bool:
@@ -476,6 +505,7 @@ class DelegationJournal:
         prompt: str,
         tool_args: dict[str, Any],
         tool_call_id: str | None,
+        specialist: SpecialistDefinition | None = None,
     ) -> Delegation:
         """Open a delegation, deciding the one thing the model does not get to.
 
@@ -499,6 +529,11 @@ class DelegationJournal:
         continuation would be the whole of the delegation's recorded cost;
         `carried_started_at` is the same fact for the clock, so the row does not
         begin at the resume.
+
+        `specialist` is set only by the one-shot `delegate` entry point, which reads
+        the whole definition off the call's own arguments and hands it here so the
+        delegation owns its copy rather than sharing a name-keyed store with any
+        same-named sibling (agenticos#292); see :attr:`Delegation.specialist`.
         """
         self._running += 1
         enclosing = _CURRENT.get()
@@ -514,6 +549,7 @@ class DelegationJournal:
             carried=self.runtime.stash.already_spent(tool_call_id),
             carried_started_at=self.runtime.stash.already_started(tool_call_id),
             stable_id=None if resumed is None else resumed.task_id,
+            specialist=specialist,
             agent_id=delegate.agent_id if delegate is not None else None,
             agent_version_id=delegate.agent_version_id if delegate is not None else None,
         )
@@ -660,29 +696,38 @@ class DelegationJournal:
     def record_dynamic_definition(
         self, *, name: str, description: str, instructions: str, model: str
     ) -> None:
-        """Remember what a model just invented, so the delegation to it can carry it.
+        """Remember a *kept* specialist, so a `task` that reaches it by name can carry it.
 
-        Called from `_specialist_factory` the moment the library builds a specialist
-        the model wrote - `create_agent` and `delegate` both build through that
-        factory, so both are captured. The definition then rides the opening
-        `SubagentStarted` frame (see :meth:`dynamic_definition` and
-        :meth:`Delegation.ensure_started`), which is the only moment a surface can
-        read it: nothing persists a dynamic specialist past the turn.
+        Called for the two specialists a `task` addresses by name: one a
+        `create_agent` just registered (`DelegatingToolset.call_tool`), and one
+        re-registered from the stash on a resume (`_seeded_registry`). A one-shot
+        `delegate` records nothing here - it owns its definition on the delegation
+        (:attr:`Delegation.specialist`), for the collision agenticos#292 describes.
+
+        The definition then rides the opening `SubagentStarted` frame (see
+        :meth:`_definition_for` and :meth:`Delegation.ensure_started`), which is the
+        only moment a surface can read it: nothing persists a dynamic specialist past
+        the turn.
         """
         self._dynamic_definitions[name] = SpecialistDefinition(
             description=description, instructions=instructions, model=model
         )
 
-    def dynamic_definition(self, name: str) -> SpecialistDefinition | None:
-        """The definition of the named specialist, if the model invented it this run.
+    def _definition_for(self, delegation: Delegation) -> SpecialistDefinition | None:
+        """The definition to announce with this delegation, wherever it is kept.
 
-        `None` for a configured delegate or an inline specialist, which the factory
-        never built and so never recorded - and that `None` is exactly what tells a
+        A one-shot `delegate` owns its copy on the delegation itself, so a same-name
+        sibling in the same turn cannot overwrite it (agenticos#292); a `task` to a
+        `create_agent` specialist, and one re-registered on a resume, carry none of
+        their own and are resolved by name from :attr:`_dynamic_definitions`. Prefer
+        the delegation's own, fall back to the name.
+
+        `None` for a configured delegate or an inline specialist, which own no
+        definition and were never recorded - and that `None` is exactly what tells a
         surface the delegation is to something already keepable, needing no promote
-        offer. Read when a delegation opens, where the name is the one handle both
-        this and the streamed frame share.
+        offer.
         """
-        return self._dynamic_definitions.get(name)
+        return delegation.specialist or self._dynamic_definitions.get(delegation.name)
 
     def resuming(self) -> ResumedDelegation | None:
         """The place this delegation is being continued from, if it is being continued.
@@ -766,7 +811,7 @@ class DelegationJournal:
         if sink is None:
             return
         public = delegation.stable_id or task_id
-        await delegation.ensure_started(public, sink, self.dynamic_definition(delegation.name))
+        await delegation.ensure_started(public, sink, self._definition_for(delegation))
         await sink(
             SubagentAwaitingApproval(
                 task_id=public, subagent=delegation.name, depth=delegation.depth
@@ -904,7 +949,7 @@ class DelegationJournal:
             )
         )
         if sink is not None:
-            await delegation.ensure_started(public, sink, self.dynamic_definition(delegation.name))
+            await delegation.ensure_started(public, sink, self._definition_for(delegation))
             await sink(
                 SubagentFinished(
                     task_id=public,
@@ -953,7 +998,7 @@ class DelegationJournal:
         async def stream(
             _ctx: RunContext[AgentDeps], events: AsyncIterable[AgentStreamEvent]
         ) -> None:
-            await delegation.ensure_started(public, sink, self.dynamic_definition(delegation.name))
+            await delegation.ensure_started(public, sink, self._definition_for(delegation))
             async for event in events:
                 frame = frame_for(event, labels)
                 if frame is not None:

--- a/backend/app/agents/capabilities/subagents/_toolset.py
+++ b/backend/app/agents/capabilities/subagents/_toolset.py
@@ -67,6 +67,7 @@ from pydantic_ai.toolsets import ToolsetTool, WrapperToolset
 
 from app.agents.capabilities.subagents._journal import DelegationJournal
 from app.agents.deps import AgentDeps
+from app.agents.subagent_events import SpecialistDefinition
 
 TASK_TOOL = "task"
 """The library's delegation entry point, under the id this repository declares it.
@@ -137,7 +138,22 @@ class DelegatingToolset(WrapperToolset[AgentDeps]):
             refusal = self._refuse_dynamic(tool_args, named=str(tool_args.get("name", "")))
             if refusal is not None:
                 return refusal
-            return await self.wrapped.call_tool(name, _autonomously(tool_args), ctx, tool)
+            result = await self.wrapped.call_tool(name, _autonomously(tool_args), ctx, tool)
+            # Recorded only on success, so a `task` that reaches this specialist by
+            # name later can carry its definition to the surface - the only place a
+            # kept dynamic specialist's promote offer can read it (agenticos#292 moved
+            # this off the build factory, so a one-shot `delegate` no longer writes a
+            # name-keyed store it would collide in). The library answers a refused
+            # build with an error string rather than raising, so "created" is read off
+            # the answer it hands back, the same phrase it reports success with.
+            if "created successfully" in result:
+                self.journal.record_dynamic_definition(
+                    name=str(tool_args.get("name", "")),
+                    description=str(tool_args.get("description", "")),
+                    instructions=str(tool_args.get("instructions", "")),
+                    model=str(tool_args.get("model", "")),
+                )
+            return result
 
         entry = _ENTRY_POINTS.get(name)
         if entry is None:
@@ -154,11 +170,22 @@ class DelegatingToolset(WrapperToolset[AgentDeps]):
     ) -> Any:
         """One delegation, whichever entry point the model reached it through."""
         name_asked = str(tool_args.get(entry.delegate, ""))
+        specialist: SpecialistDefinition | None = None
         if entry.dynamic:
             refusal = self._refuse_dynamic(tool_args, named=name_asked)
             if refusal is not None:
                 return refusal
             tool_args = _autonomously(tool_args)
+            # A one-shot `delegate` carries its whole specialist in its own arguments,
+            # so the definition is built here and owned by the delegation rather than
+            # kept in a name-keyed store two same-named siblings would collide in
+            # (agenticos#292). `entry.prompt` is the specialist's description for this
+            # entry point, the same text the frame's `prompt` carries.
+            specialist = SpecialistDefinition(
+                description=str(tool_args.get(entry.prompt, "")),
+                instructions=str(tool_args.get("instructions", "")),
+                model=str(tool_args.get("model", "")),
+            )
 
         sink = ctx.deps.subagent_events
         # Before the ceiling is checked, so a background delegation that has
@@ -180,6 +207,9 @@ class DelegatingToolset(WrapperToolset[AgentDeps]):
             # replayed run presents the same call, which is how the stand-in agent
             # knows to continue the delegate rather than start it again.
             tool_call_id=ctx.tool_call_id,
+            # `None` for `task`; the specialist a one-shot `delegate` invented, so the
+            # delegation owns its own copy of it (agenticos#292).
+            specialist=specialist,
         )
         try:
             with self.journal.delegating(delegation):

--- a/backend/tests/test_dynamic_specialists.py
+++ b/backend/tests/test_dynamic_specialists.py
@@ -826,6 +826,38 @@ class TestADynamicDelegationIsAccountedForLikeAnyOther:
         assert started.specialist.instructions == args["instructions"]
         assert started.specialist.model == PROFILE
 
+    async def test_a_delegate_announces_its_own_definition_not_a_same_named_siblings(self):
+        """agenticos#292: two `delegate` calls in one turn may share a name with
+        different instructions, and pydantic-ai may run them concurrently. Keying the
+        definition by name let the second overwrite the first before the first opened
+        its panel, so its `SubagentStarted` frame stamped the wrong specialist - and
+        the chat's promote-to-draft control (agenticos#177) then carried someone else's
+        instructions. Each delegation must announce the specialist from its *own* call.
+
+        The name-keyed store is seeded with a same-named specialist first, standing in
+        for the concurrent sibling that has already won it - the deterministic form of
+        the race, so no scheduling is relied on. The delegation the model actually made
+        must ignore it and announce its own; keyed by name, the frame carried the
+        planted one instead."""
+        sink = Sink()
+        ledger = SpendLedger()
+        budget = _RunBudget(guard=BudgetGuard(ledger=ledger, provider="openai"))
+        runtime = a_runtime(dynamic=dynamic(specialist_builder(budget)), ledger=ledger)
+        capability = a_capability(runtime)
+        # What a concurrent same-named `delegate` left in the shared store before this
+        # one opened its panel - the second writer used to win it outright.
+        capability.journal.record_dynamic_definition(
+            name="summariser", description="theirs", instructions="A different one.", model=PROFILE
+        )
+
+        await call_tool(
+            capability, a_context(sink), "delegate", delegate_args(instructions="Only this one.")
+        )
+
+        (started,) = [frame for frame in sink.frames if frame.kind == "subagent_start"]
+        assert started.specialist is not None
+        assert started.specialist.instructions == "Only this one."
+
     async def test_a_specialist_kept_for_the_run_is_addressed_through_task(self):
         """`create_agent` registers it and `task` reaches it,
         which is what puts it back under the mode, the ceiling and the recording


### PR DESCRIPTION
## What this fixes

A dynamic specialist's definition was recorded in one per-run dict keyed by name
(`DelegationJournal._dynamic_definitions`), and `_specialist_factory` overwrote on a
repeated name. Two `delegate` calls in one turn with the **same `name`** but
different `instructions` — which pydantic-ai may run concurrently — both wrote that
one entry; the second won, so whichever delegation opened its panel later stamped the
*other* specialist's definition onto its `SubagentStarted` frame. The chat's "Promote
to a draft agent" control (#177) then carried someone else's instructions and model.

Narrow and self-inflicted — it needs a model to invent two same-named specialists in
one turn — and the only effect was a wrong promote payload; no cross-tenant or
permission impact, as #292 notes.

Closes #292.

## What changed

- `_journal.py` — `Delegation` gains a `specialist` field. A one-shot `delegate` owns
  its own definition, so a same-named sibling in the same turn cannot overwrite it.
  New `_definition_for(delegation)` reads the delegation's own copy first, falling back
  to the name-keyed store; the three `ensure_started` call sites use it.
  `_dynamic_definitions` is now only the *kept* specialists a `task` reaches by name
  (`create_agent` this turn, or one re-registered on a resume) — one-per-name, no
  collision.
- `_toolset.py` — `_delegate` builds the `SpecialistDefinition` from the call's own
  arguments and hands it to `journal.begin(...)`. `create_agent` records its definition
  once the library reports the agent registered, taking over the recording the factory
  used to do.
- `_capability.py` — `_specialist_factory` no longer records; it only builds. The
  seeded-resume path (`_seeded_registry`) still records, unchanged.

Moving the delegate path off the shared dict also closes a sibling of the same bug,
where a `delegate` could clobber a `create_agent` entry of the same name.

## How it failed before

Two `delegate(name="helper", …)` calls with different instructions, run in one step:
both built through the factory, the second overwrote `_dynamic_definitions["helper"]`,
and both opening frames read that one entry — so both promote panels offered the same
(second) specialist.

## Testing

- `tests/test_dynamic_specialists.py::…::test_a_delegate_announces_its_own_definition_not_a_same_named_siblings`
  — seeds the shared name-keyed store with a same-named specialist (the deterministic
  stand-in for the concurrent sibling that has already won it), runs one real
  `delegate`, and asserts its `SubagentStarted` frame carries **its own** definition.
  Fails when `_definition_for` is reverted to the name lookup; passes with the fix.
  Deterministic — no scheduling relied on. (An earlier concurrent, task-group form
  reproduced the race faithfully but disrupted coverage instrumentation of
  `_journal.py` under the full suite; the seeded form exercises the same real emission
  path without that fragility.)
- Full `tests/test_dynamic_specialists.py` (34) and the subagent suite pass.
- `make lint`, `make test` (100% platform-layer gate), `make db-check`, `make
  docs-build` all pass locally. Frontend gates were not run in this worktree (no
  `bun install`); this change is backend-only and touches no frontend — CI runs them.

## Behaviour note, deliberately not "fixed"

For a one-shot `delegate`, `specialist.description` now carries the full task text the
model wrote, where the old factory path recorded the library's 120-char truncation of
it. The frame's `prompt` already carries the same text, and the promote payload is
better with the untruncated version; flagging it because it is a (tiny) change beyond
the collision itself.

## Docs

No page owes an update. `docs/reference/capabilities.md` describes the behaviour at
concept level — "its definition rides the opening `SubagentStarted` frame" — which the
fix makes *more* true, not less; it does not describe the name-keyed internal. The
`subagents/` README does not cover the promote/definition mechanism at all.
