### PR TITLE
test(migrations): create the database the chain is tested on

### DIFF
--- a/.claude/skills/alembic-migration/SKILL.md
+++ b/.claude/skills/alembic-migration/SKILL.md
@@ -46,9 +46,13 @@ the noise.
    ```bash
    uv run alembic upgrade head && uv run alembic current
    uv run alembic downgrade -1 && uv run alembic upgrade head
-   make test-migrations   # the whole chain, forwards and back, against Postgres
+   uv run pytest tests/test_migrations.py   # the whole chain, forwards and back
    ```
-   `make test-migrations` is the only thing that proves `downgrade()` is real.
+   That module is what proves `downgrade()` is real. It runs in `make test`, against
+   a database it creates and drops itself (`agenticos_migrations_test_p<pid>`), so it
+   is also safe to run while your own database is populated. `make test-migrations`
+   asks the same question by hand — but against whatever `backend/.env` names, which
+   on a laptop is the database with your work in it.
 
 ## Tightening a rule is a data migration
 

--- a/.claude/skills/backend-tests/references/patterns.md
+++ b/.claude/skills/backend-tests/references/patterns.md
@@ -73,6 +73,14 @@ nothing.
 
 ## Migrations
 
-`make test-migrations` applies and rolls back the whole chain against Postgres. It is
-the only thing that proves `downgrade()` is real. Run it when you touch
-`alembic/versions/` — see the `alembic-migration` skill.
+`tests/test_migrations.py` applies and rolls back the whole chain against Postgres,
+and it is what proves `downgrade()` is real. It runs in `make test` — on a database
+it creates and drops itself (`agenticos_migrations_test_p<pid>`), because
+`downgrade base` empties whatever it is pointed at. Run it when you touch
+`alembic/versions/`; see the `alembic-migration` skill.
+
+It skips when no Postgres answers, and **only** then: under `CI` an unreachable
+server raises instead, because a declared service container that did not start is
+not a laptop without Docker. The module spent its whole life skipping in CI for want
+of a database nothing created, and a skip is not a failure
+([#234](https://github.com/vstorm-co/agenticos/issues/234)).

--- a/backend/tests/test_migration_suite_database.py
+++ b/backend/tests/test_migration_suite_database.py
@@ -1,0 +1,77 @@
+"""What decides whether the migration suite runs, skips, or refuses to skip.
+
+`tests/test_migrations.py` is the only thing in this repository that applies the
+whole chain to an empty database and rolls it back again, and for the whole of its
+life it did none of that: it skipped unless a database called
+`agenticos_migrations_test` already existed, and nothing ever created one, so on a
+runner it skipped every time and the build was green anyway (#234).
+
+The module now creates its own database, which leaves one decision worth asserting
+directly: which absence of a server is a skip and which is a failure. These are
+unit tests for the same reason `test_integration_database_isolation.py` is - the
+decision has to be made before anything is created, and it is the part a machine
+with no Postgres can still check.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tests import test_migrations
+from tests.integration.conftest import _refuse_a_real_database
+
+
+def test_the_database_this_module_uses_is_named_after_this_process() -> None:
+    """The module drops the database it names, so no two runs may share a name.
+
+    A constant name is #189 again: two runs on one machine - two worktrees, or a
+    `make test` beside this one - dropping and recreating each other's database
+    mid-upgrade, and reporting failures belonging to neither.
+    """
+    assert test_migrations.MIGRATION_DATABASE.endswith(f"_p{os.getpid()}")
+
+
+def test_the_name_this_module_uses_would_survive_the_integration_guard() -> None:
+    """Held to the same bar, from the module that already states it.
+
+    Nothing derives this name from the environment, which is why it is a literal
+    rather than a guarded value - but "obviously a test database, and a plain
+    identifier" is the property that makes an unconditional drop safe either way.
+    """
+    _refuse_a_real_database(test_migrations.MIGRATION_DATABASE)
+
+
+def test_the_alembic_subprocesses_are_pointed_at_that_database() -> None:
+    """`downgrade base` empties whatever it reaches, so this is the whole guard."""
+    assert test_migrations._env()["POSTGRES_DB"] == test_migrations.MIGRATION_DATABASE
+
+
+def test_a_server_that_answers_is_neither_skipped_nor_refused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(test_migrations, "_server_answers", lambda url: True)
+    test_migrations._demand_a_server("postgresql://nowhere/postgres")
+
+
+def test_no_server_on_a_laptop_skips(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`make test` on a machine without Docker still runs everything else."""
+    monkeypatch.setattr(test_migrations, "_server_answers", lambda url: False)
+    monkeypatch.delenv("CI", raising=False)
+    with pytest.raises(pytest.skip.Exception, match="make docker-db"):
+        test_migrations._demand_a_server("postgresql://nowhere/postgres")
+
+
+def test_no_server_in_ci_fails_rather_than_skipping(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The skip that hid #234 for this module's entire life.
+
+    CI declares a Postgres service container, so an unreachable server there is a
+    service that did not start - not an environment that cannot answer. Skipping
+    then reports a green build over a chain nobody applied, and looks identical in
+    the log to the laptop case above.
+    """
+    monkeypatch.setattr(test_migrations, "_server_answers", lambda url: False)
+    monkeypatch.setenv("CI", "true")
+    with pytest.raises(RuntimeError, match="refusing to skip the migration suite"):
+        test_migrations._demand_a_server("postgresql://nowhere/postgres")

--- a/backend/tests/test_migration_suite_database.py
+++ b/backend/tests/test_migration_suite_database.py
@@ -51,16 +51,19 @@ def test_the_alembic_subprocesses_are_pointed_at_that_database() -> None:
 def test_a_server_that_answers_is_neither_skipped_nor_refused(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(test_migrations, "_server_answers", lambda url: True)
+    monkeypatch.setattr(test_migrations, "_why_the_server_did_not_answer", lambda url: None)
     test_migrations._demand_a_server("postgresql://nowhere/postgres")
 
 
 def test_no_server_on_a_laptop_skips(monkeypatch: pytest.MonkeyPatch) -> None:
     """`make test` on a machine without Docker still runs everything else."""
-    monkeypatch.setattr(test_migrations, "_server_answers", lambda url: False)
+    monkeypatch.setattr(
+        test_migrations, "_why_the_server_did_not_answer", lambda url: "connection refused"
+    )
     monkeypatch.delenv("CI", raising=False)
-    with pytest.raises(pytest.skip.Exception, match="make docker-db"):
+    with pytest.raises(pytest.skip.Exception, match="make docker-db") as raised:
         test_migrations._demand_a_server("postgresql://nowhere/postgres")
+    assert "connection refused" in str(raised.value)
 
 
 def test_no_server_in_ci_fails_rather_than_skipping(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -71,7 +74,13 @@ def test_no_server_in_ci_fails_rather_than_skipping(monkeypatch: pytest.MonkeyPa
     then reports a green build over a chain nobody applied, and looks identical in
     the log to the laptop case above.
     """
-    monkeypatch.setattr(test_migrations, "_server_answers", lambda url: False)
+    monkeypatch.setattr(
+        test_migrations, "_why_the_server_did_not_answer", lambda url: "connection refused"
+    )
     monkeypatch.setenv("CI", "true")
-    with pytest.raises(RuntimeError, match="refusing to skip the migration suite"):
+    with pytest.raises(RuntimeError, match="Refusing to skip the migration suite") as raised:
         test_migrations._demand_a_server("postgresql://nowhere/postgres")
+    # The reason travels with it: a server that is up and refusing us is a third
+    # case, and reporting it as a container that never started sends the reader
+    # to the wrong file.
+    assert "connection refused" in str(raised.value)

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -84,13 +84,20 @@ def _alembic(*args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def _server_answers(url: str) -> bool:
+def _why_the_server_did_not_answer(url: str) -> str | None:
+    """`None` when the server answers, otherwise the reason it did not.
+
+    The reason is carried out rather than flattened to a bool because a server
+    that is up and refusing - a wrong password, a database still in recovery -
+    is a third case, and reporting it as the two below sends the reader to the
+    wrong place. Telling those apart is the whole job of `_demand_a_server`.
+    """
     engine = create_engine(url)
     try:
         with engine.connect():
-            return True
-    except Exception:
-        return False
+            return None
+    except Exception as exc:  # noqa: BLE001 - any failure to connect is the answer
+        return str(exc).strip()
     finally:
         engine.dispose()
 
@@ -118,15 +125,16 @@ def _demand_a_server(url: str) -> None:
     over a migration chain nobody applied, which is exactly the failure this
     module was already reporting silently.
     """
-    if _server_answers(url):
+    reason = _why_the_server_did_not_answer(url)
+    if reason is None:
         return
     if os.getenv("CI"):
         raise RuntimeError(
-            f"No database reachable at {url} but CI is set. The Postgres service "
-            "container did not come up; refusing to skip the migration suite and "
-            "report a green build."
+            f"No database reachable at {url} but CI is set, so the Postgres "
+            f"service container did not come up or is refusing us: {reason}. "
+            "Refusing to skip the migration suite and report a green build."
         )
-    pytest.skip("No database reachable - start one with `make docker-db`")
+    pytest.skip(f"No database reachable ({reason}) - start one with `make docker-db`")
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -12,18 +12,55 @@ developer's working database. An ordinary `pytest` run emptied it: model tables
 gone, `alembic_version` recreated by the upgrade that followed, and nothing in
 the output to say so. The name below is the fix, and it is passed explicitly to
 each subprocess rather than left to the environment to get right.
+
+**That database is created here, and dropped again when the module is done.** It
+used to have to exist already: `alembic current` was run for its side effect of
+failing, and a missing database became a module-level skip. Nothing in the
+repository ever created it - the docstring saying so named `make test-migrations`,
+which cycles the chain against whatever `POSTGRES_DB` says and never touches this
+name - so every test here skipped on every CI run this project has ever had, and a
+build stayed green over four assertions nobody was making (#234). A skip meaning
+"no Postgres on this laptop" and a skip meaning "nobody has ever answered this"
+read identically in pytest's output, and only one of them is acceptable on a
+runner; `_demand_a_server` below is where they are told apart.
 """
+
+from __future__ import annotations
 
 import os
 import subprocess
 import sys
+from collections.abc import Iterator
 
 import pytest
+from sqlalchemy import create_engine
 
-# Owned by this module alone. Not the integration suite's database either: that
-# one builds its schema from the models with `create_all`, and alembic finds
-# those tables already present and fails on the first `CREATE TABLE`.
-MIGRATION_DATABASE = "agenticos_migrations_test"
+from app.core.config import settings
+
+# Owned by this module alone, and by this run of it. Not the integration suite's
+# database either: that one builds its schema from the models with `create_all`,
+# and alembic finds those tables already present and fails on the first `CREATE
+# TABLE`. The process id carries the same weight it does in `tests/conftest.py` -
+# this module drops the database it names, so a constant name would mean two runs
+# on one machine (two worktrees, or a `make test` beside this one) dropping each
+# other's mid-upgrade (#189).
+MIGRATION_DATABASE = f"agenticos_migrations_test_p{os.getpid()}"
+
+# Where `CREATE DATABASE` and `DROP DATABASE` are issued from, neither of which
+# can run from inside the database it names. Every Postgres image this project
+# uses ships it.
+_MAINTENANCE_DATABASE = "postgres"
+
+
+def _url(database: str) -> str:
+    """The DSN alembic builds, pointed at a different database on that server.
+
+    Derived from `settings` rather than from `os.environ` so this module and the
+    subprocesses it starts cannot disagree about the host, the user or the
+    password: `alembic/env.py` builds its URL from the same place, and a laptop
+    keeps those three in `backend/.env` rather than in the environment.
+    """
+    return f"{settings.DATABASE_URL_SYNC.rsplit('/', 1)[0]}/{database}"
 
 
 def _env() -> dict[str, str]:
@@ -47,20 +84,80 @@ def _alembic(*args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def _db_available() -> bool:
-    """Whether this module's own database exists and answers.
+def _server_answers(url: str) -> bool:
+    engine = create_engine(url)
+    try:
+        with engine.connect():
+            return True
+    except Exception:
+        return False
+    finally:
+        engine.dispose()
 
-    Created by hand or by `make test-migrations`; skipped rather than created
-    here, because creating a database is a privileged act and a test module is
-    the wrong place to perform one silently.
+
+def _outside_a_transaction(url: str, statement: str) -> None:
+    """Run one statement with no transaction around it.
+
+    `CREATE DATABASE` and `DROP DATABASE` are refused inside one, and SQLAlchemy
+    opens a transaction for anything else.
     """
-    return _alembic("current").returncode == 0
+    engine = create_engine(url, isolation_level="AUTOCOMMIT")
+    try:
+        with engine.connect() as connection:
+            connection.exec_driver_sql(statement)
+    finally:
+        engine.dispose()
 
 
-pytestmark = pytest.mark.skipif(
-    not _db_available(),
-    reason="No live database available - skipping migration tests",
-)
+def _demand_a_server(url: str) -> None:
+    """Skip where no database can answer, and refuse to skip where one must.
+
+    On a laptop without Docker, skipping is the whole point: `make test` still
+    runs everything else. In CI the Postgres service container is declared, so an
+    unreachable server means it failed to start - and a skip is then a green build
+    over a migration chain nobody applied, which is exactly the failure this
+    module was already reporting silently.
+    """
+    if _server_answers(url):
+        return
+    if os.getenv("CI"):
+        raise RuntimeError(
+            f"No database reachable at {url} but CI is set. The Postgres service "
+            "container did not come up; refusing to skip the migration suite and "
+            "report a green build."
+        )
+    pytest.skip("No database reachable - start one with `make docker-db`")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def migration_database() -> Iterator[None]:
+    """The database these tests run against, for as long as they need it.
+
+    Creating one is a privileged act, and this module used to refuse to perform
+    one on that ground. The refusal cost more than it bought: nothing else created
+    the database either, so the suite skipped everywhere rather than running
+    somewhere. `CREATE DATABASE` needs no privilege the migrations do not already
+    have, `tests/integration/conftest.py` owns its database's lifecycle the same
+    way, and the name is a literal with this process's id on it - not something an
+    environment variable can steer at a real database, which is what the guard in
+    that conftest exists to catch.
+
+    The drop before the create reclaims a leftover from a run that was killed
+    outright. That is the only way one survives, since the teardown below runs
+    even when the suite fails.
+    """
+    maintenance = _url(_MAINTENANCE_DATABASE)
+    _demand_a_server(maintenance)
+
+    drop = f'DROP DATABASE IF EXISTS "{MIGRATION_DATABASE}" WITH (FORCE)'
+    _outside_a_transaction(maintenance, drop)
+    _outside_a_transaction(maintenance, f'CREATE DATABASE "{MIGRATION_DATABASE}"')
+    try:
+        yield
+    finally:
+        # FORCE because a connection outliving its subprocess would otherwise
+        # leave the database behind. Nobody else ever connects to it.
+        _outside_a_transaction(maintenance, drop)
 
 
 class TestMigrations:
@@ -101,29 +198,9 @@ class TestMigrations:
 
     def test_current_matches_head(self):
         """Test that current migration revision matches head after upgrade."""
-        # Upgrade to head first
-        up = subprocess.run(
-            [sys.executable, "-m", "alembic", "upgrade", "head"],
-            capture_output=True,
-            text=True,
-            cwd=".",
-            env=_env(),
-        )
+        up = _alembic("upgrade", "head")
         assert up.returncode == 0, f"Migration upgrade failed:\n{up.stderr}"
 
-        # Check if there are any migration revisions
-        heads = subprocess.run(
-            [sys.executable, "-m", "alembic", "heads"],
-            capture_output=True,
-            text=True,
-            cwd=".",
-        )
-        assert heads.returncode == 0
-
-        if not heads.stdout.strip():
-            pytest.skip("No migration revisions found - nothing to verify")
-
-        # Check current
         result = _alembic("current")
         assert result.returncode == 0
         assert "(head)" in result.stdout, (

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -48,7 +48,7 @@ About five minutes, serial, on a warm cache. What it deliberately leaves out:
 |---|---|
 | `e2e` | Needs a migrated database, a seeded organization and a running backend: `make dev && make platform-bootstrap && make test-e2e` |
 | The image build and Trivy scan | CI runs those only on a push to `main` |
-| `make test-migrations` | CI cycles the chain against a throwaway `test_db`. On a laptop `alembic downgrade base` points at whatever `backend/.env` says, which is usually the database with your own work in it |
+| `make test-migrations` | CI cycles the chain against a throwaway `test_db`. On a laptop `alembic downgrade base` points at whatever `backend/.env` says, which is usually the database with your own work in it — `uv run pytest tests/test_migrations.py` asks the same question against a database of its own, and `make test` already runs it |
 
 One gap no command can close: CI's `test` job has a Postgres beside it, so
 `tests/integration/` runs there, and locally it skips itself when nothing answers

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -216,3 +216,27 @@ dropping each other's tables and reporting failures that belonged to neither bra
 The suite still refuses any database whose name does not contain `test` or `ci`: it
 drops tables unconditionally, so the guard is the only thing between it and a
 development database.
+
+### The migration suite has a third one
+
+`tests/test_migrations.py` applies the whole chain to an empty database and rolls it
+back to base, so it can use neither of the above: the integration database already
+has the schema in it (built from the models, which is a different question), and
+`downgrade base` against the unit suite's would empty it mid-run. It gets
+`agenticos_migrations_test_p<pid>`, created before its first test and dropped after
+its last, and every alembic subprocess is passed that name explicitly rather than
+inheriting `POSTGRES_DB`.
+
+That database used to have to exist already, and nothing ever created it, so every
+test in the module skipped on every CI run this project had — a green build over the
+only assertions that `downgrade()` works at all
+([#234](https://github.com/vstorm-co/agenticos/issues/234)). It now creates its own,
+and the surviving skip means only what it says: **no Postgres answered.** In CI,
+where a service container is declared, that is a failure instead — a container that
+did not start is not an environment that cannot answer, and the two are
+indistinguishable in pytest's output.
+
+`make test-migrations` still exists and is still the one to run by hand after
+touching `alembic/versions/`, but it points at whatever `backend/.env` says, which
+on a laptop is the database with your own work in it. Prefer
+`uv run pytest tests/test_migrations.py`, which cannot reach it.


### PR DESCRIPTION
## What this changes

`tests/test_migrations.py` runs. It has never run on a runner: it needed a database
called `agenticos_migrations_test`, a missing one became a module-level skip, and
nothing in the repository ever created it — so the only assertions in this project
that `downgrade()` works at all have always reported "5 skipped" into a green build.

The module now creates that database before its first test and drops it after its
last, the way `tests/integration/conftest.py` already does, with the process id in
the name. The remaining skip means one thing only — no Postgres answered — and under
`CI` it is not a skip at all but a `RuntimeError`, because a declared service
container that did not come up is not a laptop without Docker.

## Why this way

#234 offered two fixes: let the module create its own database, or have CI create it
in a step before `make test`. The first, for two reasons. It fixes the module
everywhere rather than on one runner — a laptop with `make docker-db` up now runs
these tests too, where before it needed somebody to have typed `CREATE DATABASE` by
hand at some point. And the "privileged act" argument the old docstring refused on
does not survive contact with the outcome: the alternative to creating it carefully
was not somebody else creating it carefully, it was nobody creating it, and
`tests/integration/conftest.py` had already settled the precedent.

The pid in the name is not decoration. This module drops the database it names,
twice, so a constant name is #189 again — two worktrees, or a `make test` beside
this one, dropping each other's mid-upgrade. The name is a literal rather than an
environment-derived value, so it needs no `_refuse_a_real_database` guard of its own;
the new test asserts it would pass that guard anyway, since "obviously a test
database, and a plain identifier" is what makes an unconditional drop safe.

Two notes on the issue text, which is slightly stale: the module has four tests, not
five — `test_the_chain_builds_the_schema_the_models_declare` is not in `main`, #183
landed its drift assertion through `make db-check` instead. And I removed
`test_current_matches_head`'s `alembic heads` round-trip: a `pytest.skip("No
migration revisions found")` that cannot fire with nine migrations, in the one module
whose defect was a skip that could not be told apart from a real one. It was also the
only subprocess in the file that ran without the forced `POSTGRES_DB`.

## Checks

- [x] Tests cover the new behaviour, and would fail without the change —
      `tests/test_migration_suite_database.py` covers both halves of the skip
      decision and the naming; the same `pytest tests/test_migrations.py` reports
      **4 passed** on this branch and **4 skipped** on `origin/main`
- [x] `make check` passes — with the exception below
- [x] Platform-layer coverage is still 100% (3195 passed, 6 skipped)
- [ ] n/a — no capability changed
- [ ] n/a — no migration added

Verified against a real Postgres 16:

- `pytest tests/test_migrations.py tests/test_migration_suite_database.py` → 10
  passed in 9s, and `agenticos_migrations_test_p*` is gone from `pg_database`
  afterwards.
- Breaking `0009_align_index_names.py`'s `downgrade()` with a bad index name turns
  `test_downgrade_base` and `test_upgrade_downgrade_cycle` red — the issue's "a
  deliberately broken `downgrade()` turns that job red".
- `make lint`, `make test`, `make test-frontend-cov`, `make build-frontend`,
  `make docs-build`, `make audit` all green.

## Notes for the reviewer

**`make check` fails at `db-check` on this machine and it is not this branch.**
`alembic check` runs against the development database `backend/.env` names, which is
currently at `0010_message_run_id` — a revision from another branch in flight. Same
target and same blast radius as #288 and #299. The four targets after it were run
individually.

Worth a thought, not done here: CI's `test` job still runs `make test-migrations`
against `test_db` in the step before `make test`, which now asks the same question
less safely and less specifically. It stays for now — it is in
`CI_ONLY_TARGETS` in `tests/test_ci_parity.py` and removing a CI step belongs in its
own change.

Docs: `docs/testing.md` gains the third test database beside the other two,
`docs/commands.md` points at the module from the `test-migrations` row, and both the
`alembic-migration` and `backend-tests` skills said `make test-migrations` was "the
only thing that proves `downgrade()` is real", which was true only because this
module never ran.

Closes #234, #346. Refs #183, #189, #288, #299.