### PR TITLE
fix(worker): cap how many flow runs the Prefect runner starts at once

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -115,6 +115,10 @@ S3_RAG_REGION=us-east-1
 # Prefect Cloud: set to your workspace URL and add PREFECT_API_KEY.
 PREFECT_API_URL=http://localhost:4200/api
 # PREFECT_API_KEY=pnu_xxxxxxxxxxxxxxxxxxxx   # required for Cloud only
+# Flow runs executed at once; the rest queue. A memory ceiling, not a throughput
+# dial - each run is a process importing the whole application, and the moment it
+# matters is the restart after downtime, when a backlog is waiting.
+PREFECT_RUNNER_LIMIT=5
 
 # === Web search ===
 # No key here on purpose: an agent chooses its own search method in the

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -133,6 +133,12 @@ class Settings(BaseSettings):
 
     PREFECT_API_URL: str = "http://localhost:4200/api"
     PREFECT_API_KEY: str | None = None
+    # How many flow runs the runner may execute at once. Each one is a separate
+    # Python process that imports the whole application, so the ceiling is memory
+    # rather than CPU: five of them is about 600 MB. It matters most after
+    # downtime, when the runner picks up a backlog of scheduled runs and would
+    # otherwise start all of them - see app/worker/prefect_app.py.
+    PREFECT_RUNNER_LIMIT: int = 5
 
     # The embeddings credential. Every collection in the deployment is embedded
     # on this key (via OpenRouter); model *profiles* in the vault cover chat

--- a/backend/app/worker/prefect_app.py
+++ b/backend/app/worker/prefect_app.py
@@ -6,6 +6,10 @@ Run with:
 The process registers scheduled deployments with the Prefect server and polls for
 work.  Set PREFECT_API_URL to http://prefect-server:4200/api (self-hosted Docker)
 or to your Prefect Cloud workspace URL + PREFECT_API_KEY for Cloud mode.
+
+At most PREFECT_RUNNER_LIMIT runs execute at once; the rest queue.  Each run is a
+separate process that imports the whole application, so an uncapped runner meeting
+a backlog is an out-of-memory kill rather than a slow afternoon.
 """
 
 import asyncio
@@ -15,6 +19,7 @@ from datetime import timedelta
 from prefect import aserve
 from prefect.client.schemas.schedules import IntervalSchedule
 
+from app.core.config import settings
 from app.worker.tasks.mcp_tasks import mcp_connection_sweep_flow
 from app.worker.tasks.rag_tasks import (
     check_scheduled_syncs_flow,
@@ -70,8 +75,19 @@ async def main() -> None:
             schedules=[IntervalSchedule(interval=timedelta(days=30))],
         )
     )
-    logger.info("Starting Prefect runner with %d deployments", len(deployments))
-    await aserve(*deployments)
+    logger.info(
+        "Starting Prefect runner with %d deployments, at most %d run(s) at once",
+        len(deployments),
+        settings.PREFECT_RUNNER_LIMIT,
+    )
+    # `limit` is not optional in practice. `aserve` declares it `Optional[int] = None`
+    # and hands that straight to `Runner(limit=...)`, where `None` means *no cap* -
+    # whereas constructing a `Runner` without the argument would fall back to
+    # Prefect's own default of five. So calling `aserve` and saying nothing is how
+    # this runner ended up with no ceiling at all: after three days of downtime it
+    # picked up the backlog of `rag-sync-check` runs and started 71 processes at
+    # once, 6 GiB on a 7.75 GiB host, and the kernel OOM-killed the API container.
+    await aserve(*deployments, limit=settings.PREFECT_RUNNER_LIMIT)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_prefect_app.py
+++ b/backend/tests/test_prefect_app.py
@@ -1,0 +1,67 @@
+"""The Prefect runner registers its deployments with a ceiling on concurrency."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.core.config import settings
+from app.worker import prefect_app
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def captured_runner(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Stand in for the Prefect `Runner` that `aserve` builds, and record its arguments.
+
+    `aserve` imports `Runner` from `prefect.runner` inside its own body, so that
+    is where the patch has to land.
+    """
+    runner = MagicMock()
+    runner.add_deployment = AsyncMock()
+    runner.start = AsyncMock()
+    factory = MagicMock(return_value=runner)
+    monkeypatch.setattr("prefect.runner.Runner", factory)
+    runner.factory = factory
+    return runner
+
+
+async def test_the_runner_refuses_to_start_more_runs_than_the_host_can_hold(
+    captured_runner: MagicMock,
+) -> None:
+    """A backlog must queue, not fan out.
+
+    Every flow run is a separate process importing the whole application, so the
+    ceiling is memory. `aserve` declares `limit: Optional[int] = None` and passes
+    it straight to `Runner`, where `None` means *no cap* - while constructing a
+    `Runner` without the argument would have fallen back to Prefect's own default
+    of five. Calling `aserve` and saying nothing is therefore how this runner came
+    to have no ceiling: after three days of downtime it picked up the backlog of
+    once-a-minute `rag-sync-check` runs, started 71 processes at once and took
+    6 GiB of a 7.75 GiB host, and the kernel resolved it by OOM-killing the API.
+    """
+    await prefect_app.main()
+
+    limit = captured_runner.factory.call_args.kwargs["limit"]
+    assert limit == settings.PREFECT_RUNNER_LIMIT
+    assert isinstance(limit, int) and limit > 0
+
+
+async def test_every_deployment_is_registered_before_the_runner_starts(
+    captured_runner: MagicMock,
+) -> None:
+    """A deployment added after `start()` is one the runner never polls for."""
+    await prefect_app.main()
+
+    registered: list[Any] = [call.args[0] for call in captured_runner.add_deployment.call_args_list]
+    assert {deployment.name for deployment in registered} == {
+        "ingest-document",
+        "sync-single-source",
+        "sync-collection",
+        "rag-sync-check",
+        "mcp-connection-sweep",
+        "weekly-usage-report",
+        "monthly-usage-report",
+    }
+    assert captured_runner.start.await_count == 1

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,6 +121,22 @@ Computed properties:
 | `REDIS_PASSWORD` | (none) | Redis password (optional) |
 | `REDIS_DB` | `0` | Redis database number |
 
+## Background work (Prefect)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PREFECT_API_URL` | `http://localhost:4200/api` | The self-hosted server, or a Prefect Cloud workspace URL |
+| `PREFECT_API_KEY` | (none) | Prefect Cloud only |
+| `PREFECT_RUNNER_LIMIT` | `5` | How many flow runs execute at once; the rest queue |
+
+`PREFECT_RUNNER_LIMIT` is a memory ceiling, not a throughput dial. Each run is a
+separate process that imports the whole application — roughly 120 MB — and the
+number that matters is not the steady state but the restart: the runner comes up,
+finds every run that was scheduled while it was down, and starts as many as the
+limit allows. Uncapped, three days of downtime was 71 processes and 6 GiB. Raise
+it if ingestion queues behind syncs on a machine with memory to spare; lower it on
+a small host.
+
 ## AI Models — configured in the app, not here
 
 Chat models are not environment variables. Each organization stores its own

--- a/docs/howto/add-background-task.md
+++ b/docs/howto/add-background-task.md
@@ -54,3 +54,8 @@ deployments.append(await send_notification_flow.ato_deployment(
 uv run --directory backend python -m app.worker.prefect_app
 # Prefect UI: http://localhost:4200
 ```
+
+At most `PREFECT_RUNNER_LIMIT` runs execute at once (default 5) and the rest queue,
+so a short schedule is cheap to add but not free: the interval decides how much
+work is waiting after downtime, and every run is a process that imports the whole
+application. Prefer the longest interval that still answers the question.


### PR DESCRIPTION
## What changed

The Prefect runner now starts at most `PREFECT_RUNNER_LIMIT` flow runs at once
(default 5, Prefect's own); the rest queue.

One line does the work:

```diff
-await aserve(*deployments)
+await aserve(*deployments, limit=settings.PREFECT_RUNNER_LIMIT)
```

## Why

`aserve` declares `limit: Optional[int] = None` and hands it straight to
`Runner(limit=...)`, where `None` means **no cap** — while constructing a `Runner`
without the argument falls back to Prefect's default of five. Calling `aserve` and
saying nothing is therefore the one spelling that removes the ceiling entirely,
and that is what `prefect_app.py` did.

Found by starting the stack after three days of downtime. The runner came up,
found the backlog of `rag-sync-check` runs (a 60-second interval, so ~100 were
waiting) and started **71 `prefect.engine` processes at once** — each a fresh
interpreter importing the whole application, roughly 120 MB apiece.

```
agenticos_prefect_runner   1040.27%   6.02GiB / 7.75GiB
```

The kernel resolved it with a global OOM kill that took the API container's
worker (`OOMKilled: true`), and uvicorn's reloader left the reaped child as a
zombie rather than restarting it — so the container reported `Up` while nothing
served and every request timed out.

The limit is a setting rather than a constant because the right number is a
property of the host, not of the code. It is a memory ceiling, not a throughput
dial, and the moment it matters is the restart rather than the steady state.

## How it was verified

- `backend/tests/test_prefect_app.py` drives `main()` against a patched
  `prefect.runner.Runner` and asserts the limit that arrives. **It fails without
  the fix** — `limit` comes through as `None`. Confirmed by reverting the one line
  and re-running.
- A second test pins that all seven deployments are registered before `start()`,
  since one added afterwards is one the runner never polls for.
- `make check` green: 3191 passed, 100% on the gated platform layer, lint, ty,
  frontend, docs build, audit.
- Manually: the runner came back up capped, and the stack has been steady at
  ~950 MiB total since.

## What this does not fix

Two defects were found on the way and are filed rather than folded in:

- **#307** — the exception handler serializes `details` with plain `json.dumps`,
  so a `NotFoundError` carrying a raw `UUID` turns a 404 into a bodiless 500.
  That is what made the outage look like an auth problem.
- **#308** — uvicorn `--reload` leaves a zombie instead of restarting a killed
  worker, so the container reports `Up` with nothing listening. This PR removes
  the trigger that was seen; it does not remove that failure mode.
- **#310** — `prefect-runner` inherits the API image's HTTP health check and is
  therefore permanently `unhealthy`, in production as well as dev. That is why a
  runner in trouble looks identical to a runner that is fine, and it is the
  reason the memory spike was noticed by `docker stats` rather than by the
  status column.

Also seen: `make db-check` fails locally on leftover `rag_test_*` tables. That is
the already-open **#288**, not this branch.

## Still open, deliberately

`rag-sync-check` runs every 60 seconds, which is 1440 flow-run rows a day
forever and is what made the backlog large enough to matter. Whether that
interval is right is a separate question from whether the runner should have a
ceiling — it should, regardless of the interval.

Refs #168

