### PR TITLE
chore: cut 0.0.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,26 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.33] - 2026-08-06
+
+### Fixed
+
+- **The Prefect runner no longer starts every queued flow run at once.** `aserve` declares
+  `limit: Optional[int] = None` and hands that straight to `Runner(limit=...)`, where `None` means
+  *no cap* — while constructing a `Runner` without the argument falls back to Prefect's own default
+  of five. Calling `aserve(*deployments)` and saying nothing was therefore the one spelling that
+  removed the ceiling entirely. Starting the stack after three days of downtime, the runner found
+  the backlog of once-a-minute `rag-sync-check` runs and started 71 `prefect.engine` processes at
+  once — each a fresh interpreter importing the whole application, about 120 MB apiece. 6.02 GiB of
+  a 7.75 GiB host, and the kernel resolved it by OOM-killing the API container's worker.
+
+### Added
+
+- **`PREFECT_RUNNER_LIMIT`** (default `5`) — how many flow runs execute at once; the rest queue. A
+  memory ceiling rather than a throughput dial, and the moment it matters is the restart after
+  downtime rather than the steady state. Documented in
+  [configuration](docs/configuration.md#background-work-prefect).
+
 ## [0.0.32] - 2026-08-06
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.32"
+version = "0.0.33"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.32"
+version = "0.0.33"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
## What changed

Release for the uncapped Prefect runner, which landed as #309.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.33]` section.

## What is in it

**Fixed** — the Prefect runner no longer starts every queued flow run at once.
`aserve` declares `limit: Optional[int] = None` and passes it straight to
`Runner(limit=...)`, where `None` means *no cap*, while constructing a `Runner`
without the argument falls back to Prefect's own default of five. After three
days of downtime the runner met the backlog of once-a-minute `rag-sync-check`
runs and started 71 `prefect.engine` processes at once — 6.02 GiB of a 7.75 GiB
host — and the kernel OOM-killed the API container's worker.

**Added** — `PREFECT_RUNNER_LIMIT` (default `5`). A memory ceiling, not a
throughput dial; the moment it matters is the restart, not the steady state.

No schema change. `SPEC_VERSION` unchanged at 7.

## How it was verified

`make check` green — 3191 backend tests, 100% on the gated platform layer, lint,
`db-check`, frontend coverage, frontend build, docs build, audit. #309 itself
also passed `e2e`.

## Filed, not folded in

Four defects found on the way, none of them caused by this work:

- **#307** — a `UUID` in a domain exception's `details` turns a 404 into a
  bodiless 500, on ~20 call sites.
- **#308** — a killed uvicorn worker leaves a zombie and a container that still
  reports `Up`.
- **#310** — `prefect-runner` inherits the API image's HTTP health check and is
  therefore permanently `unhealthy`, in production as well as dev.
- **#311** — the `ai-review` reviewer has produced nothing since 2026-08-05 and
  concludes `success` while doing so. **The last eleven pull requests merged with
  no automated review**, including three releases. #309 is the twelfth: its
  reviewer run was triggered twice and failed both times.

#311 is the one to read first. It is not about this release, but it is the reason
this release has not been reviewed by anything but a person.

Refs #307, #308, #310, #311