### PR TITLE
ci(review): stop running ai-review on pull requests

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,5 +1,26 @@
 name: AI review
 
+# **Not running on pull requests today - #311.** Every run since 2026-08-05
+# evening has died about twelve seconds into `Review the diff` with
+# `codex exited with code 1`, which is the shape of an authentication, quota or
+# entitlement refusal at the first API call rather than a model working and
+# failing. The workflow concluded `success` each time and posted "the reviewer
+# did not produce a result", so eleven pull requests merged with no review while
+# nothing on the page said the reviewer was broken rather than quiet. A reviewer
+# that runs and says nothing is worse than one that plainly is not running, so
+# the `pull_request` trigger is gone until the Codex failure is understood.
+#
+# `workflow_dispatch` stays: whatever fixes #311 has to be testable against a
+# real pull request. Re-enabling means putting back, above `workflow_dispatch`:
+#
+#   pull_request:
+#     types: [opened, reopened, ready_for_review, labeled]
+#
+# and nothing else. The label gate, the draft gate, the fork refusal and the
+# three-job split below are deliberately untouched - their `pull_request` halves
+# are inert while only `workflow_dispatch` fires, which is the price of keeping
+# re-enabling a trigger change rather than a rewrite.
+#
 # An automated reviewer that reads this repository's own standard rather than a
 # generic checklist. `CLAUDE.md` and `.claude/rules/*` already say what correct
 # means here - `require()` on collection routes only, repositories never
@@ -23,16 +44,12 @@ name: AI review
 # from the default branch **with secrets**, for a comment on any pull request
 # including one from a fork. Checking out the pull request's own code in that
 # context, in the job that holds `OPENAI_API_KEY`, is the shape CodeQL flags as
-# `actions/untrusted-checkout` - correctly. The `ai-review` label does the same
-# job through `pull_request`, which hands a fork neither the secret nor a
-# writable token, so the exposure is gone rather than argued about.
+# `actions/untrusted-checkout` - correctly. `workflow_dispatch`, and the
+# `ai-review` label when `pull_request` is back, ask for a review on demand
+# without that privilege: neither hands a fork the secret or a writable token,
+# so the exposure is gone rather than argued about.
 
 on:
-  pull_request:
-    # Deliberately not `synchronize`. Two developers, a dozen pushes per pull
-    # request; a review on every one of them is a review nobody reads. Re-run
-    # after fixes by adding the `ai-review` label.
-    types: [opened, reopened, ready_for_review, labeled]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -63,9 +80,11 @@ jobs:
     timeout-minutes: 5
     permissions:
       pull-requests: read
-    # The gate for both triggers, evaluated before anything is checked out.
-    # `labeled` fires for every label, so it is narrowed to `ai-review` - which
-    # only somebody with write access can add, and which is what makes the
+    # The gate for every trigger, evaluated before anything is checked out.
+    # Only the `workflow_dispatch` arm can fire today (see the note at the top of
+    # this file); the rest is kept for the day `pull_request` comes back, because
+    # `labeled` fires for every label and has to be narrowed to `ai-review` -
+    # which only somebody with write access can add, and which is what makes the
     # on-demand re-run safe without an author-association check of its own.
     if: >-
       github.event_name == 'workflow_dispatch'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,30 +392,27 @@ Reverts 0f94fa4        with the reason it was reverted in the body
 `Closes` only when the change genuinely finishes it. A PR body opens with what
 changed and why, then how it was verified — and says plainly what is still red.
 
-### Ask the reviewer when you are done, not while you are working
+### Review your own diff — the automated reviewer is off (#311)
 
-The `ai-review` label runs Codex over the whole diff: minutes of wall clock and
-real money every time. It answers "is this branch finished", so **ask it when
-you believe the branch is finished** — never once per commit, and never as the
-loop for working through its own findings one at a time.
+**`ai-review` no longer runs on a pull request, and the label does nothing.**
+Every run since 2026-08-05 evening failed inside Codex, concluded `success`, and
+posted a sentence that read like a verdict on the diff — eleven pull requests
+merged that way. Until #311 is fixed, the only review before a merge is a human
+one, so the sweep that used to follow the reviewer's findings is now the whole
+job rather than the second half of it: read the surrounding files, sweep the
+siblings of anything you changed, review your own diff as a maintainer would.
+Subagents are good at this — give one the diff and a category to hunt in. The
+local `/review` command in `.claude/commands/review.md` checks the same standard.
 
-The cycle:
-
-1. The pull request opens and the reviewer runs on its own.
-2. Fix what it found, and keep going — read the surrounding files, sweep the
-   siblings of anything you changed, review your own diff as a maintainer would.
-   Subagents are good at this: give one the diff and a category to hunt in.
-3. When you are confident nothing is left, label it again.
-4. If it finds something, back to 2.
-
-Round-tripping until it comes back clean is right. Round-tripping *through* it,
-one finding per run, is not: the work between the labels is where most of the
-defects are actually found, and a reviewer that answers the same diff seven
-times has been asked the same question seven times.
-
-If the reviewer is wrong — and it is, sometimes; it does not always know what a
-file's surrounding code already does — say so in the commit body or the pull
-request, with the reason, rather than churning the code to silence it.
+When it comes back, it answers "is this branch finished", so **ask it when you
+believe the branch is finished**: label, fix everything it found plus whatever
+reviewing your own work turned up, label again, until it comes back clean. Never
+once per commit and never one finding per run — the work between the labels is
+where most of the defects are actually found, and a reviewer that answers the
+same diff seven times has been asked the same question seven times. If it is
+wrong — and it is, sometimes; it does not always know what a file's surrounding
+code already does — say so in the commit body or the pull request, with the
+reason, rather than churning the code to silence it.
 
 `github-code-quality[bot]` opens threads on the same ruleset and cannot be
 filtered. Three of its findings are **already adjudicated** in

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -1,5 +1,19 @@
 # Automated pull request review
 
+!!! warning "The reviewer is switched off on pull requests — [#311](https://github.com/vstorm-co/agenticos/issues/311)"
+
+    Since 2026-08-05 evening every run died about twelve seconds into
+    `Review the diff` (`codex exited with code 1`), concluded `success`, and
+    posted "the reviewer did not produce a result" — so eleven pull requests
+    merged with no review and nothing said the reviewer was broken rather than
+    quiet. The `pull_request` trigger has been removed until that is understood;
+    `workflow_dispatch` still works, for testing the fix. Everything below
+    describes the workflow as it will behave when the trigger is restored, and
+    [When it runs](#when-it-runs) says what is live today.
+
+    Until then the review before a merge is a human one, plus the local
+    `/review` command in `.claude/commands/review.md`.
+
 A GitHub Action reviews pull requests against **this repository's own standard**.
 It is not a linter with a language model attached: the prompt in
 `.github/codex/review-prompt.md` tells the reviewer to read `CLAUDE.md` and
@@ -32,9 +46,16 @@ is the second half of this page.
 
 | Trigger | Who | Note |
 |---|---|---|
-| A pull request is opened, reopened or marked ready | automatic | Drafts are skipped |
-| The `ai-review` label is added | anyone with write access | On demand |
-| `workflow_dispatch` with a pull request number | write access | Manual, for testing |
+| `workflow_dispatch` with a pull request number | write access | Manual, for testing. **The only live trigger today** |
+| A pull request is opened, reopened or marked ready | automatic | Drafts are skipped. Removed by [#311](https://github.com/vstorm-co/agenticos/issues/311) |
+| The `ai-review` label is added | anyone with write access | On demand. Removed by [#311](https://github.com/vstorm-co/agenticos/issues/311) |
+
+The last two rows are what the workflow does when the `pull_request` trigger is
+in it. Restoring them is putting two lines back at the top of
+`.github/workflows/ai-review.yml` — the label gate, the draft gate and the fork
+refusal were left in place, so nothing else has to be rebuilt. Adding the label
+today does nothing at all, which is the point: it is visibly not running rather
+than running and reporting nothing.
 
 Deliberately **not** on `synchronize`. Two developers, a dozen pushes per pull
 request: a review on every one of them is a review nobody reads. Ask for a
@@ -134,6 +155,12 @@ itself in the summary comment.
   that lands between the two jobs.
 - **A failed run.** If the reviewer produces nothing, the summary comment says
   so and links the run. Silence would read as "no findings".
+
+    Not enough, as [#311](https://github.com/vstorm-co/agenticos/issues/311)
+    found: that comment reads like a verdict on the diff, the `review` job still
+    concludes `success`, and eleven pull requests merged before anybody noticed
+    the reviewer had stopped working. Distinguishing "the reviewer failed" from
+    "the reviewer found nothing" is the second half of #311 and is not done yet.
 
 Re-runs replace rather than pile up: the summary comment is upserted on an HTML
 marker, and the previous run's inline comments are deleted first.


### PR DESCRIPTION
## What this fixes

`ai-review` no longer runs on a pull request. Every run since 2026-08-05 evening
died about twelve seconds into `Review the diff` with `codex exited with code 1`,
concluded `success`, and posted "No review: the reviewer did not produce a
result" — a sentence that reads like a verdict on the diff rather than a broken
reviewer. Eleven pull requests merged with no review before anybody noticed. A
reviewer that runs and says nothing is worse than one that plainly is not
running, so it is switched off until the Codex failure is understood.

Refs #311 — this is the "turn it off for now" half. The two fixes the issue asks
for (whatever makes `codex` exit 1, and making a failed run report as a failure)
are both still open, so the issue stays open.

## What changed

- `.github/workflows/ai-review.yml:47` — the `pull_request` trigger is gone;
  `workflow_dispatch` is the only trigger left, so the fix for #311 is still
  testable against a real pull request.
- `.github/workflows/ai-review.yml:3` — a header note saying why, and exactly
  which two lines restore it.
- `CLAUDE.md:395` — the review section said "the pull request opens and the
  reviewer runs on its own" and told you to label when the branch is finished.
  Both are now false, so it says review your own diff and points at the local
  `/review` command, with the label cycle kept for when the trigger is back.
- `docs/code-review.md:3` — a warning at the top, the trigger table reordered
  around what is actually live, and under *Caps* an honest note that its own "a
  failed run says so" claim is precisely what #311 disproved.

The label gate, the draft gate, the fork refusal and the three-job privilege
split are deliberately untouched. Their `pull_request` halves are inert while
only `workflow_dispatch` fires; that is the price of keeping re-enabling a
two-line trigger change rather than a rewrite, and the file says so where the
comment would otherwise read as describing live behaviour.

## How it failed before

`.github/workflows/ai-review.yml`, `Review the diff`:

```
/home/runner/work/_actions/openai/codex-action/…/dist/main.js:23546
  reject(new Error(`${program2} exited with code ${code}`));
Error: codex exited with code 1
##[error]Process completed with exit code 1.
```

Twelve seconds is too fast for a model to have worked and failed — it is the
shape of an authentication, quota or entitlement refusal at the first API call.
`continue-on-error: true` on that step then let `Normalize the result` write the
generic sentence and the job finish green, which is why the failure looked like
an outcome. Full history in #311.

## Testing

- `backend/tests/test_ai_review_config_guard.py` — 12 passed. It extracts the
  guard step from the `review` job by name, and the `review` job is untouched.
- `backend/tests/test_ci_parity.py`, `tests/test_coverage_gate.py` — 26 passed.
- `make docs-build` (`--strict`) — clean; the new admonition and the nested
  paragraph under a list item were checked in the rendered HTML, not assumed.
- `pre-commit run` over the three files — yamlfmt, zizmor, codespell, the
  double-backtick guard, conventional-commit hook: all pass.
- `python3 scripts/docs_drift.py` — no drift.
- **Not verified, and not verifiable from here:** that a dispatched run produces
  a review. The Codex failure itself is untouched by this change.

## Noticed, not fixed

- The second half of #311 — `Run the reviewer` concluding `success` when it
  produced nothing, and the comment not distinguishing "the reviewer failed"
  from "the reviewer found nothing". Left for the same issue and recorded in
  `docs/code-review.md` so the next reader does not trust the old claim.
- `.github/codex/review-prompt.md`, `review-schema.json` and the `ai-review`
  environment, secret and label are all left in place, unused. Deleting them
  would make re-enabling a rebuild.
