### PR TITLE
chore: cut 0.0.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,24 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.34] - 2026-08-06
+
+### Changed
+
+- **The automated reviewer no longer runs on a pull request**
+  ([#311](https://github.com/vstorm-co/agenticos/issues/311)). Every `ai-review` run since
+  2026-08-05 evening died about twelve seconds into its Codex step with `codex exited with code 1` —
+  the shape of an authentication, quota or entitlement refusal at the first API call rather than a
+  model working and failing — and then concluded `success` and posted "No review: the reviewer did
+  not produce a result", a sentence that reads like a verdict on the diff. Eleven pull requests
+  merged with no automated review before anybody noticed, three of them releases. A reviewer that
+  runs and says nothing is worse than one that plainly is not running, so the `pull_request` trigger
+  is removed until the Codex failure is understood; `workflow_dispatch` stays, because the fix has
+  to be testable against a real pull request. Adding the `ai-review` label now does nothing at all.
+  `CLAUDE.md` and [code review](docs/code-review.md) say so, and the latter records that its own
+  "a failed run says so" claim is what #311 disproved — making a failed run *report* as a failure is
+  the second half of that issue and is not done.
+
 ## [0.0.33] - 2026-08-06
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.33"
+version = "0.0.34"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.33"
+version = "0.0.34"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for the switched-off automated reviewer — the code landed as #313.

## What changed

`ai-review` no longer runs on a pull request. Every run since 2026-08-05 evening
died about twelve seconds into its Codex step with `codex exited with code 1`,
concluded `success`, and posted "No review: the reviewer did not produce a
result" — a sentence that reads like a verdict on the diff. Eleven pull requests
merged with no automated review before anybody noticed, three of them releases.

The `pull_request` trigger is removed until the Codex failure is understood;
`workflow_dispatch` stays so the fix is testable against a real pull request.
Adding the `ai-review` label now does nothing at all.

## The bump

- `backend/pyproject.toml`, `backend/uv.lock`, `frontend/package.json` → `0.0.34`
- `CHANGELOG.md` gets the `[0.0.34]` section
- No schema change, `SPEC_VERSION` unchanged at 7

## Verified

- `pre-commit run` over the four files — check-toml, check-json, codespell and
  the double-backtick guard all pass
- `uv lock --check` — the lockfile matches the bumped `pyproject.toml`
- `backend/app/__init__.py` reads the version from installed distribution
  metadata rather than a constant, so nothing else needed editing
- #313's own CI was green before it merged

## Still open

#311 — neither half is fixed. The Codex failure itself is untouched, and
`Run the reviewer` still concludes `success` when it produced nothing.
`docs/code-review.md` now records that its own "a failed run says so" claim is
what the issue disproved.

Refs #311
