### PR TITLE
fix(rag): resolve a sync source before reading its logs

### DIFF
--- a/backend/app/api/routes/v1/knowledge_bases.py
+++ b/backend/app/api/routes/v1/knowledge_bases.py
@@ -406,14 +406,30 @@ async def list_kb_sync_source_logs(
     kb_id: UUID,
     source_id: UUID,
     service: KnowledgeBaseSvc,
+    sync_source_svc: SyncSourceSvc,
     db: DBSession,
     ctx: Auth,
     limit: int = Query(20, ge=1, le=100),
 ) -> Any:
-    """List sync run history for a specific KB sync source."""
+    """List sync run history for a specific KB sync source.
+
+    The source is resolved against this KB before its logs are read, rather than
+    the rows being filtered afterwards. Filtering afterwards leaked nothing, but
+    `limit` was applied in SQL to logs of *every* source with that id and then
+    thinned in Python - so a page came back short whenever another collection's
+    history interleaved with this one's, `total` described the survivors rather
+    than the source, and there was no way to page past the gap. A source that is
+    not this KB's is now missing rather than empty, which is what every other
+    per-resource read on this surface answers.
+    """
     kb = await service.get(kb_id, ctx=ctx)
-    logs = await sync_log_repo.get_all(db, sync_source_id=source_id, limit=limit)
-    # Verify source belongs to this KB's collection (security: don't leak other KBs' logs).
+    source = await sync_source_svc.get_source(str(source_id))
+    if source.collection_name != kb.collection_name:
+        raise NotFoundError(
+            message="Sync source not found in this knowledge base",
+            details={"kb_id": str(kb_id), "source_id": str(source_id)},
+        )
+    logs = await sync_log_repo.get_all(db, sync_source_id=source.id, limit=limit)
     items = [
         RAGSyncLogItem(
             id=str(log.id),
@@ -431,7 +447,6 @@ async def list_kb_sync_source_logs(
             completed_at=log.completed_at,
         )
         for log in logs
-        if log.collection_name == kb.collection_name
     ]
     return RAGSyncLogList(items=items, total=len(items))
 

--- a/backend/tests/integration/test_platform_flows.py
+++ b/backend/tests/integration/test_platform_flows.py
@@ -538,13 +538,16 @@ async def _sync_source_row(db, *, tenant: Tenant, collection_name: str) -> SyncS
     return source
 
 
-async def _sync_log_row(db, *, collection_name: str) -> SyncLog:
+async def _sync_log_row(
+    db, *, collection_name: str, sync_source_id: uuid.UUID | None = None
+) -> SyncLog:
     log = SyncLog(
         id=uuid.uuid4(),
         source="gdrive",
         collection_name=collection_name,
         mode="full",
         status="running",
+        sync_source_id=sync_source_id,
     )
     db.add(log)
     await db.flush()
@@ -1158,6 +1161,73 @@ class TestWritingToAKnowledgeBaseTakesMoreThanReading:
 
         resolved = await service.get_for_write(rag_estate.home_collection.id, ctx=viewer)
         assert resolved.id == rag_estate.home_collection.id
+
+
+class TestReadingOneSyncSourcesHistory:
+    """The log listing resolves the source first, rather than thinning its rows.
+
+    It used to read every log carrying that source id, apply `limit` in SQL, and
+    then drop the rows whose `collection_name` was not this base's. Nothing leaked
+    - but a source can be repointed at another base, since `SyncSourceUpdate`
+    carries `collection_name`, and its earlier runs keep the name they ran
+    against. So the thinning happened after the page had been cut, and there was
+    no way to page past the gap (#233).
+    """
+
+    async def test_a_source_from_another_base_is_missing_rather_than_empty(
+        self, db, kb_api: KbClient, rag_estate: RagEstate
+    ) -> None:
+        """`200 []` says "this source has never run" for a source that is not ours.
+
+        Both are a page rendering "no syncs yet", and one of them is a request that
+        should have failed. Every other per-resource read on this surface reports a
+        row it may not have as missing.
+        """
+        elsewhere = await _sync_source_row(
+            db, tenant=rag_estate.home, collection_name=rag_estate.home_private.collection_name
+        )
+        await _sync_log_row(
+            db,
+            collection_name=rag_estate.home_private.collection_name,
+            sync_source_id=elsewhere.id,
+        )
+
+        response = await kb_api(rag_estate.home).get(
+            f"{settings.API_V1_STR}/kb/{rag_estate.home_collection.id}"
+            f"/sync-sources/{elsewhere.id}/logs",
+        )
+
+        assert response.status_code == 404
+
+    async def test_a_full_page_of_one_sources_history_comes_back_full(
+        self, db, kb_api: KbClient, rag_estate: RagEstate
+    ) -> None:
+        """`limit` and `total` have to describe the same set of rows.
+
+        This source ran twice against this base and once, before it was moved,
+        against another. Asking for three runs used to answer with two and call it
+        the whole history.
+        """
+        for collection_name in (
+            rag_estate.home_collection.collection_name,
+            rag_estate.home_private.collection_name,
+            rag_estate.home_collection.collection_name,
+        ):
+            await _sync_log_row(
+                db,
+                collection_name=collection_name,
+                sync_source_id=rag_estate.home_source.id,
+            )
+
+        response = await kb_api(rag_estate.home).get(
+            f"{settings.API_V1_STR}/kb/{rag_estate.home_collection.id}"
+            f"/sync-sources/{rag_estate.home_source.id}/logs?limit=3",
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body["items"]) == 3
+        assert body["total"] == 3
 
 
 # -- how a collection reads its documents -------------------------------------

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -274,6 +274,15 @@ Sync operations are tracked via the `SyncLog` model, recording source, mode,
 total files, ingested/updated/skipped/failed counts, and timing. View sync
 history via `GET /rag/sync/logs`.
 
+One source's own history is `GET /kb/{kb_id}/sync-sources/{source_id}/logs`. The
+source is resolved against that knowledge base first, so a source belonging to
+another base answers **404** rather than an empty list — the two render the same
+screen otherwise, and one of them is a request that should have failed. Its runs
+are then read by source id, which is what keeps `limit` and `total` describing the
+same set of rows: a source repointed at another base keeps its earlier runs under
+the collection name it had then, and those used to be dropped from the page after
+`limit` had already cut it.
+
 ### Image Description
 
 When processing documents that contain images, the system can optionally


### PR DESCRIPTION
## What this changes

`GET /kb/{kb_id}/sync-sources/{source_id}/logs` now resolves the sync source
against the knowledge base before reading anything, instead of reading every log
row with that source id, cutting the page in SQL, and thinning the survivors in
Python.

Two answers change:

- **A source that is not this base's is `404`, not `200 []`.** "This source has
  never run" and "this source is not yours" used to render the same page, and one
  of them is a request that should have failed.
- **A full page comes back full.** `SyncSourceUpdate` carries `collection_name`,
  so a source can be repointed at another base and its earlier runs keep the name
  they ran against. Those rows were dropped *after* `limit` had already cut the
  page: asking for three runs answered with two, `total` described the survivors
  rather than the source, and nothing let a caller page past the gap.

Nothing leaked either way — the comparison did catch a foreign source — so this
was a wrong answer rather than an exposure.

## Why this way

The issue names the shape and it is already in the tree twice:
`GET /org/integrations/{source_id}/logs` resolves the source and then reads its
logs, and `trigger_kb_sync_source` — directly above this handler — does the
resolve-or-404 against `kb.collection_name`. Copying the neighbour keeps the two
sibling routes reading the same way, and it puts the scope in the query rather than
in a list comprehension, which is what makes `limit` and `total` describe one set
of rows.

The `if source.collection_name != kb.collection_name: raise NotFoundError` block is
now the sixth copy in this module (three for documents, three for sources). That is
deliberate rather than lazy: **#232 moves these route bodies into services**, and
extracting a helper here would be a second, conflicting refactor of the same lines.
`total` is still the page size, matching `list_org_integration_logs`; a real count
query is not what this issue asks for and would change the response's meaning on
both routes at once.

## Checks

- [x] Tests cover the new behaviour, and would fail without the change — both fail
      on the previous code with `assert 200 == 404` and `assert 2 == 3`
- [x] `make check` passes — except `db-check`, below
- [x] Platform-layer coverage is still 100% (3189 passed)
- [ ] n/a — no capability changed
- [ ] n/a — no migration

The tests are integration rather than unit on purpose: the defect was the order of
a query and a filter, and a mocked session cannot show that. They live in
`tests/integration/test_platform_flows.py` beside the other `/kb` sync-source
tests, and use the `rag_estate` fixture; `_sync_log_row` gained an optional
`sync_source_id`, because the seeded rows deliberately have none.

Verified: `make lint`, `make test`, `make test-frontend-cov` (3175 passed),
`make build-frontend`, `make docs-build`, `make audit` — all green. `db-check`
fails on this machine for want of a `backend/.env`, which is
[#299](https://github.com/vstorm-co/agenticos/issues/299), the twin of #288.

## Notes for the reviewer

**Heads-up for #232**, which touches these same lines: the two behaviours above
have to survive the move into a service, and the two tests here should keep passing
untouched. If they need editing, the refactor changed behaviour.

One thing the issue claims that the code does not: it describes the short page as
two sources' histories interleaving. They cannot interleave — the SQL already
filters by `sync_source_id`. The reachable version is the repointed source above,
which is what the test builds.

Docs: `docs/file-processing.md`'s "Sync Operations" section described only the
collection-wide `GET /rag/sync/logs`; it now also describes the per-source endpoint
and what it answers for a source that is not that base's.

Closes #233. Refs #232, #299.
