### PR TITLE
ci: stop paying for superseded runs and suites a change cannot affect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,21 @@ on:
   pull_request:
     branches: [main, master]
 
+# One run per branch. `CLAUDE.md` asks for a commit and a push per finished piece,
+# which is right - but with nothing cancelling, each push started a fresh 24-minute
+# matrix and left the previous one running to completion, answering a question
+# about a commit nobody was waiting on. 75 of the 369 runs in the first six days of
+# August were superseded while still in flight, about 1,800 billed minutes, and
+# only 2 runs in that window were ever `cancelled`. See #317.
+#
+# `main` is deliberately excluded: the push run is what makes the merge history and
+# the badge mean anything, and cancelling it would leave commits whose CI never
+# finished. `github.ref` separates them without a second condition - a pull request
+# is `refs/pull/N/merge`, a merge is `refs/heads/main`.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # Least privilege for every job. Nothing in this workflow writes anything back:
 # the docker job builds with `push: false`, and Codecov uses its own token. A
 # job that later needs more should declare it on itself, not here.
@@ -17,7 +32,55 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    # Which of the three expensive suites this pull request can provably not
+    # affect. `scripts/ci_changed_scope.py` decides, timidly - a path it does not
+    # recognise runs everything - and its docstring says why that direction is the
+    # only safe one. A skipped job satisfies a required status check (GitHub counts
+    # `success`, `skipped` and `neutral`), which is what makes this legal against
+    # the six contexts `main`'s ruleset requires; a workflow-level `paths:` filter
+    # would instead leave those checks never reporting and block every merge
+    # forever, which is the trap named in #317.
+    #
+    # A job of its own rather than a step inside `lint`, at the cost of the one
+    # billed minute GitHub rounds it up to: folding it into `lint` would be free,
+    # but it would put `test`, `test-frontend` and `e2e` behind `needs: lint`, so a
+    # ruff error would skip all three and hide whatever else was broken until the
+    # next push.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: read
+    outputs:
+      backend: ${{ steps.scope.outputs.backend }}
+      frontend: ${{ steps.scope.outputs.frontend }}
+      e2e: ${{ steps.scope.outputs.e2e }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Work out which suites the changed paths require
+        id: scope
+        # Nothing is emitted on a push, so every downstream `if:` compares against
+        # an empty string and runs. A merge to `main` runs the whole matrix, and
+        # so does a re-run of this job that fails - `!= 'false'` is the safe
+        # direction in both cases.
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          gh api --paginate \
+            "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" \
+            --jq '.[].filename' > "$RUNNER_TEMP/changed.txt"
+          python3 scripts/ci_changed_scope.py "$RUNNER_TEMP/changed.txt" >> "$GITHUB_OUTPUT"
+
   lint:
+    # Never gated. It is one billed minute, `make lint-spelling` reads every
+    # tracked file rather than a subtree, and a suite that skips is only defensible
+    # while something still looks at the whole tree.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -28,6 +91,10 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "latest"
+          # Caches `~/.cache/uv`, keyed on `**/uv.lock`. Without it every job
+          # re-resolved and re-downloaded all 278 locked packages, five times per
+          # run across this workflow. See #317.
+          enable-cache: true
 
       - name: Set up Python
         run: uv python install 3.12
@@ -65,6 +132,10 @@ jobs:
     # runs in the `test` job, where a database exists.
 
   test:
+    needs: changes
+    # `!= 'false'` rather than `== 'true'`: on a push the `changes` step does not
+    # run and the output is empty, which has to mean *run*.
+    if: needs.changes.outputs.backend != 'false'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -115,6 +186,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "latest"
+          enable-cache: true
 
       - name: Set up Python
         run: uv python install 3.12
@@ -164,6 +236,8 @@ jobs:
           fail_ci_if_error: false
 
   test-frontend:
+    needs: changes
+    if: needs.changes.outputs.frontend != 'false'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -172,6 +246,18 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      # `setup-bun` caches the bun binary, not the packages, so
+      # `bun install --frozen-lockfile` re-downloaded every dependency on every
+      # run. Bun's global install cache is what makes the second run cheap; the
+      # key is the lockfile, so a dependency change invalidates it and nothing
+      # else does.
+      - name: Cache the bun install cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('frontend/bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -200,6 +286,10 @@ jobs:
     # uv, a migrated database, a seeded organization and a running backend;
     # linting needs none of that, and making a formatting error wait on a
     # database pull — or hiding it behind a browser timeout — helps nobody.
+    needs: changes
+    # Exempted from neither half: this job drives the frontend against the
+    # backend, so it is only skippable for a change that touches neither.
+    if: needs.changes.outputs.e2e != 'false'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -253,6 +343,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "latest"
+          enable-cache: true
 
       - name: Set up Python
         run: uv python install 3.12
@@ -313,6 +404,13 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
+      - name: Cache the bun install cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('frontend/bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
       - name: Install frontend dependencies
         run: bun install --frozen-lockfile
         working-directory: frontend
@@ -324,7 +422,19 @@ jobs:
         run: bun run build
         working-directory: frontend
 
+      # Chromium is ~170 MB downloaded on every run otherwise. Keyed on the
+      # lockfile, because that is what pins the Playwright version the browser
+      # has to match - a browser cached against a different version is the kind
+      # of failure that reads as a flaky spec.
+      - name: Cache the Playwright browsers
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('frontend/bun.lock') }}
+
       - name: Install Playwright browsers
+        # `--with-deps` still runs: the apt packages Chromium links against live
+        # outside the cached directory, and installing them on a hit is seconds.
         run: bunx playwright install --with-deps chromium
         working-directory: frontend
 
@@ -367,6 +477,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "latest"
+          enable-cache: true
 
       - name: Set up Python
         run: uv python install 3.12
@@ -398,6 +509,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "latest"
+          enable-cache: true
 
       - name: Set up Python
         run: uv python install 3.12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,21 @@ on:
 # only 2 runs in that window were ever `cancelled`. See #317.
 #
 # `main` is deliberately excluded: the push run is what makes the merge history and
-# the badge mean anything, and cancelling it would leave commits whose CI never
-# finished. `github.ref` separates them without a second condition - a pull request
-# is `refs/pull/N/merge`, a merge is `refs/heads/main`.
+# the badge mean anything, and a commit whose CI never finished is worse than a
+# minute overspent. `cancel-in-progress: false` is **not** how you exclude it, which
+# is the trap this originally fell into: false means *queue*, and GitHub's rule is
+# that "any existing pending job or workflow in the same concurrency group will be
+# canceled and the new queued job or workflow will take its place". So with one
+# group for `main`, merge A running and B pending, C landing cancels B outright and
+# B's commit gets no CI at all - at fourteen releases in six days plus feature
+# merges, against a ~10 minute `main` run, two merges inside one window is not rare.
+#
+# So `main` is kept out of the group entirely rather than out of the cancelling:
+# `github.run_id` is unique per run, so every push gets a group of its own and
+# neither queues nor cancels. Pull requests all resolve to `-pr` and cancel each
+# other per `github.ref`, which is the whole point.
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.ref }}-${{ github.event_name == 'push' && github.run_id || 'pr' }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Least privilege for every job. Nothing in this workflow writes anything back:
@@ -49,7 +59,13 @@ jobs:
     # next push.
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # A job-level block *replaces* the workflow-level one rather than adding to it,
+    # so `contents: read` has to be repeated here - this job checks out. Omitting it
+    # works on a public repository, where any token can read public content, and
+    # breaks on the day #317's premise changes and this repository goes private:
+    # a checkout failure that reads like a credentials problem.
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       backend: ${{ steps.scope.outputs.backend }}
@@ -63,9 +79,15 @@ jobs:
       - name: Work out which suites the changed paths require
         id: scope
         # Nothing is emitted on a push, so every downstream `if:` compares against
-        # an empty string and runs. A merge to `main` runs the whole matrix, and
-        # so does a re-run of this job that fails - `!= 'false'` is the safe
-        # direction in both cases.
+        # an empty string and runs: a merge to `main` gets the whole matrix.
+        #
+        # That covers a *skipped step*. It does not cover this *job* failing - a 502
+        # from the API, a rate limit, `set -euo pipefail` catching anything - because
+        # a failed `needs` skips its dependents without evaluating their `if:` at
+        # all, and a skipped required check is a pass. `changes` is not itself one of
+        # the six required contexts, so nothing would have blocked: the merge button
+        # would go green on a branch where no suite ran. Hence `!cancelled()` on each
+        # gated job, which is what makes them run when this one fails.
         if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -74,7 +96,8 @@ jobs:
           set -euo pipefail
           gh api --paginate \
             "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" \
-            --jq '.[].filename' > "$RUNNER_TEMP/changed.txt"
+            --jq '.[] | .filename, (.previous_filename // empty)' \
+            > "$RUNNER_TEMP/changed.txt"
           python3 scripts/ci_changed_scope.py "$RUNNER_TEMP/changed.txt" >> "$GITHUB_OUTPUT"
 
   lint:
@@ -133,9 +156,12 @@ jobs:
 
   test:
     needs: changes
-    # `!= 'false'` rather than `== 'true'`: on a push the `changes` step does not
-    # run and the output is empty, which has to mean *run*.
-    if: needs.changes.outputs.backend != 'false'
+    # Two mechanisms, deliberately both. `!= 'false'` rather than `== 'true'` because
+    # on a push the `changes` step does not run and the empty output has to mean
+    # *run*; `!cancelled()` because a `changes` job that *failed* would otherwise
+    # skip this one without the `if:` being read at all - and a skipped required
+    # check is a pass, so that is a green merge button over a suite that never ran.
+    if: ${{ !cancelled() && needs.changes.outputs.backend != 'false' }}
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -237,7 +263,7 @@ jobs:
 
   test-frontend:
     needs: changes
-    if: needs.changes.outputs.frontend != 'false'
+    if: ${{ !cancelled() && needs.changes.outputs.frontend != 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -289,7 +315,7 @@ jobs:
     needs: changes
     # Exempted from neither half: this job drives the frontend against the
     # backend, so it is only skippable for a change that touches neither.
-    if: needs.changes.outputs.e2e != 'false'
+    if: ${{ !cancelled() && needs.changes.outputs.e2e != 'false' }}
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,15 @@ frontend spec answers in about two seconds against seventy for the suite, one ba
 file in under one against ninety-five for `make test`. CI's jobs run in parallel and
 answer in about seven minutes — from a pushed branch, while you carry on working.
 
+Two things about that answer, both since #317. **Pushing again cancels the run in
+flight**, so the answer you were waiting on disappears rather than arriving about a
+commit you have already replaced — which is the point, but it means a push is also a
+decision to stop caring about the previous one. And **CI runs fewer jobs than
+`make check` does**: `test`, `test-frontend` and `e2e` skip when the changed paths
+cannot affect them, so a backend-only branch gets no frontend answer at all, and a
+`skipped` required check is a pass rather than a problem.
+`docs/branching.md` has the rule.
+
 ```bash
 cd frontend && bunx vitest run src/components/chat/usage-strip.test.tsx
 cd backend  && uv run pytest tests/test_sandbox_workspace.py -q

--- a/backend/tests/test_ci_changed_scope.py
+++ b/backend/tests/test_ci_changed_scope.py
@@ -11,7 +11,13 @@ quietly rather than loudly:
   - **The concurrency group.** Nothing checks that it exists, so deleting it costs
     ~1,800 billed minutes per six days and produces no signal at all. Its `main`
     exemption is load-bearing in the other direction: cancel a merge's run and the
-    commit's CI never finishes.
+    commit's CI never finishes - and `cancel-in-progress: false` does not deliver
+    that exemption, which is the mistake the first version of this made.
+
+Three of the assertions here are about the *shape* of `ci.yml` rather than about the
+classifier, and they are the ones that matter most: a perfect classifier wired to a
+gate that skips on failure, or fed only half of a rename, saves minutes by not
+testing things.
 
 The same shape as `test_ci_parity.py` and `test_coverage_gate.py` - a gate whose
 failure mode is a green build needs something checking the checker.
@@ -76,6 +82,18 @@ class TestNothingUnrecognisedIsEverSkipped:
         """`tests/test_ci_parity.py` reads `ci.yml`, so the backend suite cares."""
         assert ci_changed_scope.scope([".github/workflows/ci.yml"])["backend"] is True
 
+    def test_a_rename_across_the_halves_requires_both_suites(self) -> None:
+        """Given both ends of a rename, neither half is skipped.
+
+        The other end of `test_a_rename_is_fed_in_from_both_ends`: this is what the
+        answer looks like once the caller supplies `previous_filename`, and the
+        reason supplying it matters.
+        """
+        decided = ci_changed_scope.scope(
+            ["frontend/src/lib/moved.ts", "backend/app/services/moved.py"]
+        )
+        assert decided == {"backend": True, "frontend": True, "e2e": True}
+
 
 class TestWhatMayBeSkipped:
     def test_a_documentation_only_change_skips_all_three(self) -> None:
@@ -135,16 +153,33 @@ class TestTheWorkflowActuallyUsesIt:
             "and every gated job runs - expensive, but at least not silent"
         )
 
+    def test_a_rename_is_fed_in_from_both_ends(self, workflow: dict[str, Any]) -> None:
+        """`filename` is the new path, so a rename hides the path it left.
+
+        Renaming `backend/app/services/foo.py` to `frontend/src/foo.ts` reports one
+        path under `frontend/`, and the classifier - correctly, on what it was given -
+        skips the backend suite for a change that deleted a backend module. The
+        classifier cannot detect the omission, so the assertion has to live on the jq.
+        """
+        commands = " ".join(step.get("run", "") for step in workflow["jobs"]["changes"]["steps"])
+        assert "previous_filename" in commands, (
+            "the `changes` job must pass `previous_filename` through as well, or a "
+            "rename out of a directory is invisible to the suite that owned it"
+        )
+
     @pytest.mark.parametrize(("job", "output"), sorted(GATED_JOBS.items()))
     def test_each_gated_job_reads_its_own_output(
         self, workflow: dict[str, Any], job: str, output: str
     ) -> None:
         definition = workflow["jobs"][job]
         assert "changes" in definition["needs"], f"`{job}` does not depend on `changes`"
-        assert definition["if"] == f"needs.changes.outputs.{output} != 'false'", (
-            f"`{job}` must gate on `needs.changes.outputs.{output} != 'false'`. "
+        expected = f"${{{{ !cancelled() && needs.changes.outputs.{output} != 'false' }}}}"
+        assert definition["if"] == expected, (
+            f"`{job}` must gate on `{expected}`, and both halves earn their place. "
             "`== 'true'` would skip it on a push to `main`, where the classifier does "
-            "not run and the output is empty."
+            "not run and the output is empty; and without `!cancelled()` a *failed* "
+            "`changes` job skips this suite without reading the condition at all, "
+            "which a required status check accepts as a pass."
         )
 
     def test_every_output_the_script_emits_is_declared(self, workflow: dict[str, Any]) -> None:
@@ -171,6 +206,17 @@ class TestTheConcurrencyGroup:
     def test_it_is_keyed_per_ref(self, workflow: dict[str, Any]) -> None:
         """A shared group would have one branch cancelling another's run."""
         assert "github.ref" in workflow["concurrency"]["group"]
+
+    def test_a_push_gets_a_group_of_its_own(self, workflow: dict[str, Any]) -> None:
+        """`cancel-in-progress: false` is not how `main` is protected.
+
+        `false` means *queue*, and GitHub cancels any previously **pending** run in
+        the group when a newer one is queued - so with one group for `main`, a third
+        merge arriving cancels the second outright and that commit gets no CI at all.
+        `github.run_id` is unique per run, which keeps every push out of every other
+        push's group rather than merely out of the cancelling.
+        """
+        assert "github.run_id" in workflow["concurrency"]["group"]
 
     def test_a_push_to_main_is_never_cancelled(self, workflow: dict[str, Any]) -> None:
         """The merge's own run is what makes the history and the badge mean anything."""

--- a/backend/tests/test_ci_changed_scope.py
+++ b/backend/tests/test_ci_changed_scope.py
@@ -1,0 +1,180 @@
+"""The two things about `ci.yml` whose failure mode is a build that reads green.
+
+Both were added by #317, both to spend fewer Actions minutes, and both fail
+quietly rather than loudly:
+
+  - **The path gate.** `scripts/ci_changed_scope.py` decides which of `test`,
+    `test-frontend` and `e2e` a pull request can skip. Get it wrong in the
+    permissive direction and a suite stops running - which is not a red build, it
+    is a green one with a gate missing from it. That is #143 and #165 exactly, and
+    the reason the script is written to skip only what it can prove irrelevant.
+  - **The concurrency group.** Nothing checks that it exists, so deleting it costs
+    ~1,800 billed minutes per six days and produces no signal at all. Its `main`
+    exemption is load-bearing in the other direction: cancel a merge's run and the
+    commit's CI never finishes.
+
+The same shape as `test_ci_parity.py` and `test_coverage_gate.py` - a gate whose
+failure mode is a green build needs something checking the checker.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+_SCRIPT = REPO_ROOT / "scripts" / "ci_changed_scope.py"
+
+_spec = importlib.util.spec_from_file_location("ci_changed_scope_under_test", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+ci_changed_scope = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ci_changed_scope)
+
+# Job name in the workflow -> the `changes` output that gates it.
+GATED_JOBS = {"test": "backend", "test-frontend": "frontend", "e2e": "e2e"}
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict[str, Any]:
+    with WORKFLOW.open() as handle:
+        loaded: dict[str, Any] = yaml.safe_load(handle)
+    return loaded
+
+
+class TestNothingUnrecognisedIsEverSkipped:
+    """The direction that matters. A path nobody classified must run everything."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            ".github/workflows/ci.yml",
+            "Makefile",
+            "scripts/ci_changed_scope.py",
+            ".pre-commit-config.yaml",
+            "compose.yml",
+            "a-directory-nobody-has-invented-yet/thing.py",
+        ],
+    )
+    def test_an_unclassified_path_requires_every_suite(self, path: str) -> None:
+        assert ci_changed_scope.scope([path]) == {"backend": True, "frontend": True, "e2e": True}
+
+    def test_one_unclassified_path_among_documentation_is_enough(self) -> None:
+        """All of them have to be irrelevant, not most of them."""
+        decided = ci_changed_scope.scope(["docs/testing.md", "README.md", "Makefile"])
+        assert decided == {"backend": True, "frontend": True, "e2e": True}
+
+    def test_an_empty_change_set_requires_every_suite(self) -> None:
+        """`all()` over nothing is `True`, which would have skipped all three."""
+        assert ci_changed_scope.scope([]) == {"backend": True, "frontend": True, "e2e": True}
+
+    def test_a_workflow_edit_is_not_documentation(self) -> None:
+        """`tests/test_ci_parity.py` reads `ci.yml`, so the backend suite cares."""
+        assert ci_changed_scope.scope([".github/workflows/ci.yml"])["backend"] is True
+
+
+class TestWhatMayBeSkipped:
+    def test_a_documentation_only_change_skips_all_three(self) -> None:
+        decided = ci_changed_scope.scope(
+            ["docs/testing.md", "docs/reference/spec.md", "mkdocs.yml", "CHANGELOG.md"]
+        )
+        assert decided == {"backend": False, "frontend": False, "e2e": False}
+
+    def test_a_backend_only_change_skips_the_frontend_suite_and_nothing_else(self) -> None:
+        decided = ci_changed_scope.scope(["backend/app/services/access.py"])
+        assert decided == {"backend": True, "frontend": False, "e2e": True}
+
+    def test_a_frontend_only_change_skips_the_backend_suite_and_nothing_else(self) -> None:
+        decided = ci_changed_scope.scope(["frontend/src/lib/api-client.ts"])
+        assert decided == {"backend": False, "frontend": True, "e2e": True}
+
+    def test_a_change_to_both_halves_skips_nothing(self) -> None:
+        decided = ci_changed_scope.scope(
+            ["backend/app/api/routes/v1/agents.py", "frontend/src/hooks/use-agents.ts"]
+        )
+        assert decided == {"backend": True, "frontend": True, "e2e": True}
+
+    def test_e2e_is_exempted_from_neither_half(self) -> None:
+        """It drives the frontend against the backend, so either half affects it."""
+        assert ci_changed_scope.scope(["backend/app/main.py"])["e2e"] is True
+        assert ci_changed_scope.scope(["frontend/src/app/page.tsx"])["e2e"] is True
+
+    def test_a_release_bump_runs_everything(self) -> None:
+        """Worth stating: `chore: cut 0.0.x` touches both halves, so it skips nothing.
+
+        #317 originally claimed a release pull request would stop paying for the
+        whole matrix. It does not - the version lives in `backend/pyproject.toml`,
+        `backend/uv.lock` and `frontend/package.json`, so every filter matches.
+        """
+        decided = ci_changed_scope.scope(
+            [
+                "CHANGELOG.md",
+                "backend/pyproject.toml",
+                "backend/uv.lock",
+                "frontend/package.json",
+            ]
+        )
+        assert decided == {"backend": True, "frontend": True, "e2e": True}
+
+    def test_a_nested_markdown_file_is_not_documentation(self) -> None:
+        """Only a *top-level* `*.md` is exempt; `backend/app/README.md` is not."""
+        assert ci_changed_scope.scope(["backend/app/agents/NOTES.md"])["backend"] is True
+
+
+class TestTheWorkflowActuallyUsesIt:
+    """A perfect classifier wired to nothing skips nothing, and saves nothing."""
+
+    def test_the_changes_job_runs_the_script(self, workflow: dict[str, Any]) -> None:
+        commands = [step.get("run", "") for step in workflow["jobs"]["changes"]["steps"]]
+        assert any("scripts/ci_changed_scope.py" in command for command in commands), (
+            "the `changes` job no longer runs the classifier, so its outputs are empty "
+            "and every gated job runs - expensive, but at least not silent"
+        )
+
+    @pytest.mark.parametrize(("job", "output"), sorted(GATED_JOBS.items()))
+    def test_each_gated_job_reads_its_own_output(
+        self, workflow: dict[str, Any], job: str, output: str
+    ) -> None:
+        definition = workflow["jobs"][job]
+        assert "changes" in definition["needs"], f"`{job}` does not depend on `changes`"
+        assert definition["if"] == f"needs.changes.outputs.{output} != 'false'", (
+            f"`{job}` must gate on `needs.changes.outputs.{output} != 'false'`. "
+            "`== 'true'` would skip it on a push to `main`, where the classifier does "
+            "not run and the output is empty."
+        )
+
+    def test_every_output_the_script_emits_is_declared(self, workflow: dict[str, Any]) -> None:
+        """A job gating on an output nothing sets is a job that always runs."""
+        declared = set(workflow["jobs"]["changes"]["outputs"])
+        assert declared == set(ci_changed_scope.JOBS)
+
+    def test_lint_is_never_gated(self, workflow: dict[str, Any]) -> None:
+        """`make lint-spelling` reads every tracked file, so something must always.
+
+        It is also one billed minute, so gating it would buy nothing worth the
+        argument.
+        """
+        assert "if" not in workflow["jobs"]["lint"]
+
+
+class TestTheConcurrencyGroup:
+    def test_the_workflow_declares_one(self, workflow: dict[str, Any]) -> None:
+        assert "concurrency" in workflow, (
+            "without a concurrency group nothing cancels a superseded run: 75 of 369 "
+            "runs in six days, about 1,800 billed minutes (#317)"
+        )
+
+    def test_it_is_keyed_per_ref(self, workflow: dict[str, Any]) -> None:
+        """A shared group would have one branch cancelling another's run."""
+        assert "github.ref" in workflow["concurrency"]["group"]
+
+    def test_a_push_to_main_is_never_cancelled(self, workflow: dict[str, Any]) -> None:
+        """The merge's own run is what makes the history and the badge mean anything."""
+        assert (
+            workflow["concurrency"]["cancel-in-progress"]
+            == "${{ github.event_name == 'pull_request' }}"
+        )

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -38,6 +38,46 @@ single aggregating `All Checks Passed` job, so that adding a CI job stops meanin
 "remember to edit a ruleset" — a required-check list that drifts from the
 workflow is how a build ends up passing on nothing.
 
+### A required check may legitimately report `skipped`
+
+Three of those six do not run on every pull request. `test`, `test-frontend` and
+`e2e` are 8.2, 5.3 and 5.1 billed minutes each, and a `changes` job decides which
+of them a change set can provably not affect — `scripts/ci_changed_scope.py`, so
+the rule is testable rather than a glob in a YAML file
+([#317](https://github.com/vstorm-co/agenticos/issues/317)).
+
+This is legal because GitHub satisfies a required status check with **`success`,
+`skipped` or `neutral`**. It is why the gate is a job-level `if:` and **not** a
+`paths:` filter on the workflow: a filtered-out workflow never posts its checks at
+all, so the ruleset waits for six contexts that will never arrive and the merge
+button stays grey forever.
+
+The classifier is written the timid way round — **a job is skipped only when every
+changed path is provably irrelevant to it**, so an unrecognised path runs
+everything. The permissive spelling of the same idea would let a new directory
+silently stop a suite from running, which is not a red build but a green one with a
+gate missing from it, and this repository has already paid for that twice (#143,
+#165). Only two exemptions exist, both checked rather than assumed: `docs/**`,
+`mkdocs.yml` and a top-level `*.md` (no test reads any of them), and the opposite
+half of the tree for each of the two unit suites. `e2e` is exempted from neither
+half. `lint` is never gated at all, because `make lint-spelling` is the only thing
+that reads every tracked file.
+
+What a change set skips is printed in the `changes` job's log. Locally nothing is
+skipped: `make check` runs the whole set.
+
+### One run per branch
+
+`ci.yml` carries a concurrency group keyed on `github.ref`, so pushing again to a
+branch cancels its previous run. That matters because `CLAUDE.md` asks for a commit
+and a push per finished piece: with nothing cancelling, 75 of the 369 runs in the
+first six days of August were superseded while still in flight — about 1,800 billed
+minutes answering questions about commits nobody was waiting on.
+
+A push to `main` is deliberately exempt. The merge's own run is what makes the
+history and the badge mean anything, and a cancelled one leaves a commit whose CI
+never finished.
+
 ## Squash, and why the pull request title matters
 
 `main` keeps one commit per pull request, built from the **pull request title and

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -63,6 +63,19 @@ half of the tree for each of the two unit suites. `e2e` is exempted from neither
 half. `lint` is never gated at all, because `make lint-spelling` is the only thing
 that reads every tracked file.
 
+Two details the timid direction needs in order to actually hold, both of which the
+first version of this got wrong:
+
+- Each gated job carries `!cancelled()` alongside the output check. Without it, a
+  `changes` job that **failed** — a 502 from the API, a rate limit — would skip all
+  three suites without their conditions ever being read, and since `changes` is not
+  itself a required context, the merge button would go green over a branch where no
+  suite ran.
+- The job feeds `previous_filename` in as well as `filename`. A rename reports only
+  the path it arrived at, so a module moved out of `backend/` would otherwise be one
+  frontend path and skip the backend suite for a change that deleted a backend
+  module.
+
 What a change set skips is printed in the `changes` job's log. Locally nothing is
 skipped: `make check` runs the whole set.
 
@@ -74,9 +87,18 @@ and a push per finished piece: with nothing cancelling, 75 of the 369 runs in th
 first six days of August were superseded while still in flight — about 1,800 billed
 minutes answering questions about commits nobody was waiting on.
 
-A push to `main` is deliberately exempt. The merge's own run is what makes the
-history and the badge mean anything, and a cancelled one leaves a commit whose CI
-never finished.
+**A push to `main` is exempt, and the way it is exempted is the interesting part.**
+The merge's own run is what makes the history and the badge mean anything, so a
+`main` run must neither be cancelled nor queued. `cancel-in-progress: false` gives
+only the first of those: `false` means *queue*, and GitHub cancels any previously
+**pending** run in a group when a newer one is queued. With a single group for
+`main`, merge A running and B pending, C landing would cancel B outright and B's
+commit would get no CI at all — at fourteen releases in six days against a ~10
+minute `main` run, two merges inside one window is not a rare shape.
+
+So the group carries `github.run_id` on a push, which is unique per run: every
+merge gets a group of its own and collides with nothing. Pull requests all resolve
+to the same suffix and go on cancelling each other per `github.ref`.
 
 ## Squash, and why the pull request title matters
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -32,6 +32,14 @@ repeating their commands, and `tests/test_ci_parity.py` fails if a gating job
 grows a step `make check` does not run. It has drifted four times — see
 [Commands](commands.md#before-a-pull-request) for what `check` leaves out and why.
 
+**CI may run fewer jobs than `check` does, and that is not drift.** `test`,
+`test-frontend` and `e2e` are skipped on a pull request whose changed paths cannot
+affect them — a docs-only change runs none of the three, a backend-only change runs
+no frontend suite. What decides is `scripts/ci_changed_scope.py`, it errs towards
+running, and [Branches](branching.md#a-required-check-may-legitimately-report-skipped)
+has the rule and why a `skipped` required check still lets a merge through. Locally
+there is no equivalent: `check` runs everything.
+
 `make test-fast` skips coverage, which makes it the wrong last word before a push:
 the gate is most of what these commands are for. `pytest` without `uv run` picks up
 whatever interpreter is on the path rather than the pinned 3.12.

--- a/scripts/ci_changed_scope.py
+++ b/scripts/ci_changed_scope.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Which expensive CI jobs a pull request's changed paths cannot possibly affect.
+
+`test`, `test-frontend` and `e2e` are 8.2, 5.3 and 5.1 billed minutes of every CI
+run, and a backend-only pull request pays all three. This decides which of them
+may be skipped - and it is deliberately written the timid way round.
+
+**A job is skipped only when every changed path is provably irrelevant to it.**
+Not "run it when a path I recognise as relevant changed", which is the same
+sentence with the failure mode reversed: an unclassified path - a new top-level
+directory, a config file nobody thought about - would silently stop a suite from
+running, and a suite that does not run is a gate that reads green because the
+thing is not in it. That is #143 and #165, and it is the mistake this file exists
+to not make. So anything unrecognised runs everything.
+
+Which is why the exemptions are only these, each true because it was checked:
+
+`docs/**`, `mkdocs.yml` and a top-level `*.md`
+:   No test under `backend/tests/` reads any of them - the one mention is a
+    docstring naming `docs/channels.md` in prose. The `docs` job builds the site
+    on every run and is not gated here, so a dead link still fails the build.
+
+`frontend/**` for the backend suite, `backend/**` for the frontend suite
+:   The two halves share no source. They do share the *pull request*, which is
+    why `e2e` is exempted from neither.
+
+Everything else runs everything, `.github/**` and `Makefile` emphatically
+included: `tests/test_ci_parity.py` reads both, so a workflow edit is a change
+the backend suite has an opinion about - this very file's arrival among them.
+
+Usage, from the `changes` job:
+
+    python3 scripts/ci_changed_scope.py changed-files.txt >> "$GITHUB_OUTPUT"
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+# The jobs this decides for, in the order the workflow declares them.
+JOBS = ("backend", "frontend", "e2e")
+
+
+def _is_documentation(path: str) -> bool:
+    """A path that no test reads and only the `docs` job builds."""
+    if path.startswith("docs/") or path == "mkdocs.yml":
+        return True
+    return "/" not in path and path.endswith(".md")
+
+
+def _irrelevant_to(job: str, path: str) -> bool:
+    if _is_documentation(path):
+        return True
+    if job == "backend":
+        return path.startswith("frontend/")
+    if job == "frontend":
+        return path.startswith("backend/")
+    # `e2e` drives the frontend against the backend, so either half affects it.
+    return False
+
+
+def scope(paths: Iterable[str]) -> dict[str, bool]:
+    """Map each job to whether this change set requires it to run.
+
+    An empty change set runs everything. That is not a case worth optimising -
+    a pull request with no files is a pull request with nothing to skip for -
+    and `all()` over nothing answering `True` would skip all three.
+    """
+    changed = [path for path in paths if path]
+    if not changed:
+        return dict.fromkeys(JOBS, True)
+    return {job: not all(_irrelevant_to(job, path) for path in changed) for job in JOBS}
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(f"usage: {argv[0]} <file-of-changed-paths>", file=sys.stderr)
+        return 2
+
+    paths = Path(argv[1]).read_text().splitlines()
+    decided = scope(paths)
+    for job, required in decided.items():
+        print(f"{job}={'true' if required else 'false'}")
+
+    skipped = sorted(job for job, required in decided.items() if not required)
+    print(
+        f"{len(paths)} changed path(s); skipping {', '.join(skipped) if skipped else 'nothing'}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/ci_changed_scope.py
+++ b/scripts/ci_changed_scope.py
@@ -28,6 +28,14 @@ Everything else runs everything, `.github/**` and `Makefile` emphatically
 included: `tests/test_ci_parity.py` reads both, so a workflow edit is a change
 the backend suite has an opinion about - this very file's arrival among them.
 
+**A rename is two paths, and the caller owes both.** The proof this makes is over
+every path a change touched, and GitHub's `pulls/{n}/files` reports only the *new*
+one in `filename` - so a module renamed out of `backend/` into `frontend/` would
+arrive as a single frontend path and skip the backend suite for a change that
+deleted a backend module. The `changes` job therefore feeds `previous_filename`
+through as well; `tests/test_ci_changed_scope.py` asserts that it still does,
+because nothing here can detect its absence.
+
 Usage, from the `changes` job:
 
     python3 scripts/ci_changed_scope.py changed-files.txt >> "$GITHUB_OUTPUT"
@@ -85,8 +93,11 @@ def main(argv: list[str]) -> int:
         print(f"{job}={'true' if required else 'false'}")
 
     skipped = sorted(job for job, required in decided.items() if not required)
+    # Counted the way `scope` counts, so the number names what was decided on rather
+    # than how many lines the file happened to have.
+    counted = sum(1 for path in paths if path)
     print(
-        f"{len(paths)} changed path(s); skipping {', '.join(skipped) if skipped else 'nothing'}",
+        f"{counted} changed path(s); skipping {', '.join(skipped) if skipped else 'nothing'}",
         file=sys.stderr,
     )
     return 0


### PR DESCRIPTION
## What this fixes

CI spent about **8,900 billed Actions minutes** in the first six days of August —
369 `ci.yml` runs at 24.1 minutes each. Three of the four things #317 asked for.

Refs #317 — the issue stays open for the fourth (see *Deliberately not done*).

## What changed

### 1. A concurrency group, which the workflow simply did not have

`.github/workflows/ci.yml:20` — `ai-review.yml` and `docs.yml` both carry one;
`ci.yml` did not. Every push started a fresh matrix and left the previous one
running to completion. **75 of those 369 runs were superseded while still in
flight — about 1,800 billed minutes**, a fifth of the total, and only 2 runs in
the window were ever `cancelled`, which is what nothing-cancels looks like from
the outside.

Keyed on `github.ref`, exempting `main`: cancelling a merge's run leaves a commit
whose CI never finished and a badge that means nothing.

### 2. Caching, absent at all seven install sites

- `setup-uv` × 5 → `enable-cache: true`. It was called with only
  `version: "latest"`, so every job re-resolved and re-downloaded all **278**
  locked packages.
- `~/.bun/install/cache` × 2 → `setup-bun` caches the binary, not the packages,
  so `bun install --frozen-lockfile` refetched everything twice per run.
- `~/.cache/ms-playwright` → `e2e` downloaded ~170 MB of Chromium every run.

All three keyed on the lockfile that pins them, so a dependency change
invalidates them and nothing else does.

### 3. Skipping the suites a change set cannot affect

`test`, `test-frontend` and `e2e` are 8.2, 5.3 and 5.1 billed minutes, and a
backend-only pull request paid for all three. A `changes` job now decides, and
the decision lives in `scripts/ci_changed_scope.py` rather than in a glob, so it
is testable.

**It is a job-level `if:`, deliberately not a `paths:` filter.** GitHub satisfies
a required status check with `success`, `skipped` **or** `neutral`, so a skipped
job is a pass. A filtered-out workflow never posts its checks at all, and `main`'s
ruleset would wait forever on six contexts that never arrive — the trap named in
#317.

**The classifier is written the timid way round.** A job is skipped only when
*every* changed path is provably irrelevant to it, so anything unrecognised runs
everything. The permissive spelling — *run when a path I recognise as relevant
changed* — would let a new directory silently stop a suite, which is not a red
build but a green one with a gate missing from it. That is #143 and #165. Two
exemptions only, both checked rather than assumed:

- `docs/**`, `mkdocs.yml`, a top-level `*.md` — no test under `backend/tests/`
  reads any of them; the one mention is a docstring naming `docs/channels.md`.
- the opposite half of the tree, for each unit suite.

`e2e` is exempted from neither half. `lint` is not gated at all, because
`make lint-spelling` is the only thing that reads every tracked file.

`changes` is its own job and costs the billed minute GitHub rounds it up to.
Folding it into `lint` would be free but would put all three suites behind
`needs: lint`, so a ruff error would skip them and hide whatever else was broken
until the next push.

## The guard

`backend/tests/test_ci_changed_scope.py` — 25 tests, same shape as
`test_ci_parity.py` and `test_coverage_gate.py`, because both halves of this
change fail *quietly*. It asserts the timid direction explicitly, that each gated
job reads its own output with `!= 'false'` and not `== 'true'` (which would skip
it on a push, where the classifier does not run), that `lint` is never gated, and
that `main` is never cancelled.

## One correction to #317

**It overstated the saving, and the arithmetic is worth having straight.** #317
claimed a release pull request would stop paying for the whole matrix. It will
not: the version lives in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`, so every filter matches — now asserted in
`test_a_release_bump_runs_everything`.

Measured over the 97 pull requests merged since 2026-07-25, the available skips
are 27 `test-frontend`, 15 `test`, 4 `e2e` — about 286 minutes over first runs,
~850 across re-runs. Minus the `changes` job's own minute per run, **the path gate
nets around 5%** of the total. The concurrency group is 20% for four lines. These
were not three equal wins and the issue read as though they were.

## Deliberately not done

Folding `lint`, `docs` and `Security Scan` into one job. They bill a whole minute
each for 22–28 seconds of work — 372 minutes for about 150 minutes of work — and
merging them recovers most of it. But **all three are required status checks by
name**, so it needs `main`'s ruleset edited in the same breath or every pull
request is blocked; it costs three independent failure signals; and it means
editing `test_ci_parity.py`'s `GATING_JOBS`, which is the one thing keeping
`make check` honest (#143). That is a merge-gate change, so it wants a decision
rather than a commit. Left on #317 with the trade written down.

CodeQL's 625 `Analyze` jobs (1,118 minutes) are also untouched: default setup
generates those workflows and gives us no surface to tune, as `docs/code-review.md`
already records.

## Testing

- `make test` — 3216 passed, 6 skipped, **100%** on the platform layer
- `make lint-backend`, `make lint-spelling` — clean
- `make docs-build` under `--strict` — clean; `scripts/docs_drift.py` — no drift
- yamlfmt + zizmor over the workflow, and the full pre-commit set over the diff
- `scripts/ci_changed_scope.py` run as the workflow runs it, against a docs-only
  list, a backend-only list and this change's own file list

**Not verified, and not verifiable from this branch:** that a skipped required
check satisfies the ruleset. This pull request touches `.github/`, `scripts/` and
`backend/`, so by its own rule it runs everything — there is no skip to observe.
The behaviour is documented by GitHub, a failure would show immediately as a merge
button that never goes green, and the revert is the three `if:` lines. **The first
docs-only pull request after this merges is the real proof, and is worth watching.**

## Docs

`docs/branching.md` gains *A required check may legitimately report `skipped`* and
*One run per branch*; `docs/testing.md` says CI may run fewer jobs than
`make check` and that this is not drift; `CLAUDE.md`'s **The loop** says a push now
cancels the run in flight, so the answer you were waiting on disappears rather
than arriving about a commit you already replaced.
