### PR TITLE
fix(kb): give Describe images the whole model picker, minus the bin

### DIFF
--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -279,8 +279,13 @@ history via `GET /rag/sync/logs`.
 When processing documents that contain images, the system can optionally
 describe images using LLM vision capabilities. Image description is a
 per-collection setting: turn it on in the knowledge base's ingestion
-configuration and pick a vision-capable model profile there. The generated
-descriptions are included in the document text for better semantic search.
+configuration and pick a vision-capable model profile there. The picker is the
+one the agent builder uses, so a provider, a model and its key can be defined
+without leaving the dialog — a deployment with no model profiles yet is not a
+dead end. What it does not offer is deleting a profile: that belongs where an
+organization's models are managed, because every agent pointed at one loses it.
+The generated descriptions are included in the document text for better semantic
+search.
 
 ## From a channel
 

--- a/frontend/src/app/[locale]/(dashboard)/agents/[id]/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/agents/[id]/page.tsx
@@ -644,6 +644,9 @@ export default function AgentBuilderPage({ params }: PageProps) {
                 <Label>{t("model")}</Label>
                 <ModelProfilePicker
                   allowAdd
+                  // The Builder is where an organization's models are managed,
+                  // so it is the one panel that also takes one away.
+                  allowRemove
                   profiles={profiles}
                   value={spec.model_profile_id ?? null}
                   onChange={(model_profile_id) => update({ model_profile_id })}

--- a/frontend/src/components/agents/add-model.tsx
+++ b/frontend/src/components/agents/add-model.tsx
@@ -274,6 +274,11 @@ export function AddModel({ onCreated, onCancel, disabled }: AddModelProps) {
                 suggestedName={provider.label}
                 helpUrl={provider.help_url ?? undefined}
                 onCreated={setSecretId}
+                // Passed on rather than left to the submit button. This writes
+                // an organization-wide secret, and a caller that disabled the
+                // form - a dialog mid-save, a panel somebody may only read -
+                // did not mean "except the vault".
+                disabled={disabled}
               />
             </div>
           )}

--- a/frontend/src/components/agents/model-profile-picker.test.tsx
+++ b/frontend/src/components/agents/model-profile-picker.test.tsx
@@ -146,17 +146,44 @@ describe("ModelProfilePicker", () => {
   });
 
   it("deletes a saved model only where models are managed", async () => {
-    mount({ allowAdd: true });
+    mount({ allowAdd: true, allowRemove: true });
 
     await userEvent.click(screen.getByRole("button", { name: "Remove openai default" }));
 
     expect(deleteProfile.mutate).toHaveBeenCalledWith("p1");
   });
 
-  it("offers the chat no way to delete a model every agent may be pointed at", () => {
+  it("offers a panel that only chooses no way to delete a model every agent may use", () => {
     mount();
 
     expect(screen.queryByRole("button", { name: /^Remove/ })).toBeNull();
+  });
+
+  it("lets a panel create a model without letting it destroy one", async () => {
+    // The reason the two are separate flags. The knowledge-base dialog has to be
+    // able to define the model that reads its images and store the key for it,
+    // or a fresh deployment cannot finish the form at all; deleting an
+    // organization-wide profile that agents are pointed at is a bigger claim
+    // than a collection form makes.
+    const onChange = vi.fn();
+    mount({ allowAdd: true, onChange });
+
+    expect(screen.queryByRole("button", { name: /^Remove/ })).toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: "Add model" }));
+
+    expect(onChange).toHaveBeenCalledWith("p-new");
+  });
+
+  it("states which model is in use even where the panel only chooses", () => {
+    // The line moved out of the add-capable branch: whether the chosen profile
+    // has a key is what decides whether anything runs, and in a list of a dozen
+    // saved models the chosen one's badge is a badge among twelve.
+    mount({ value: "p1" });
+
+    const current = screen.getByRole("group", { name: "Current model" });
+    expect(within(current).getByText("openai default")).toBeInTheDocument();
+    expect(within(current).getByText("no key")).toBeInTheDocument();
   });
 
   it("accepts nothing from somebody who cannot edit the spec", async () => {

--- a/frontend/src/components/agents/model-profile-picker.tsx
+++ b/frontend/src/components/agents/model-profile-picker.tsx
@@ -19,14 +19,25 @@ interface ModelProfilePickerProps {
   /**
    * Whether this panel can create a model, which also decides its shape.
    *
-   * Off in the chat on purpose, and the reason is the same one that makes the
-   * two layouts different. The chat popover answers one question - which model
-   * should *this conversation* run on - so it is a list of what exists. Adding a
-   * model is a different act: it creates something every agent in the
-   * organization can be pointed at, which is a Builder decision, and in the
-   * Builder the form is the panel rather than a state of it.
+   * Off where the panel only chooses between models somebody else defined - the
+   * specialist row answers one question, which model should *this* delegate run
+   * on, so it is a list of what exists. Adding a model is a different act: it
+   * creates something every agent in the organization can be pointed at, and
+   * where that is allowed the form is the panel rather than a state of it.
    */
   allowAdd?: boolean;
+  /**
+   * Whether a saved model can be deleted from here.
+   *
+   * Its own flag rather than a second meaning of `allowAdd`, because the two are
+   * different claims. Creating a model adds something agents may be pointed at;
+   * deleting one takes away something they already are, from under every agent
+   * in the organization at once. The Builder is where an organization's models
+   * are managed, so it offers both. The knowledge-base dialog needs to name a
+   * model and store a key for it and nothing more, so it gets the first and not
+   * the second - which is the whole reason this split exists.
+   */
+  allowRemove?: boolean;
   disabled?: boolean;
 }
 
@@ -50,12 +61,23 @@ interface ModelProfilePickerProps {
  * `provider · model`, and the `no key` badge. That badge decides whether the
  * agent can run at all, and it was once visible on the vault page and invisible
  * here.
+ *
+ * Two flags, not one. `allowAdd` decides the shape - the form and its inline
+ * key field, or a list of what exists; `allowRemove` decides whether a saved
+ * model can be deleted from here. They were the same flag until the
+ * knowledge-base dialog needed one without the other.
+ *
+ * The current-model line renders in both shapes. It says whether the profile
+ * that will actually be used has a key, which is the fact that decides whether
+ * the run - or the ingestion - can happen at all, and it is not something one
+ * caller should get and another should have to infer from a list.
  */
 export function ModelProfilePicker({
   profiles,
   value,
   onChange,
   allowAdd = false,
+  allowRemove = false,
   disabled,
 }: ModelProfilePickerProps) {
   const t = useTranslations("agents");
@@ -80,14 +102,41 @@ export function ModelProfilePicker({
           // no key.
           noKey={!profile.secret_id}
           disabled={disabled}
-          onRemove={allowAdd ? () => deleteProfile.mutate(profile.id) : undefined}
+          onRemove={allowRemove ? () => deleteProfile.mutate(profile.id) : undefined}
         />
       ))}
     </div>
   );
 
-  // The chat popover chooses between what exists and adds nothing, so it is the
-  // list and only the list.
+  // What this runs on today, stated above whatever would change it: the form
+  // where there is one, the list where there is not. It is the fact somebody
+  // opens this panel to check, and in a list of a dozen saved models the chosen
+  // one's `no key` badge is a badge among twelve - which of them is chosen is
+  // what decides whether anything runs at all.
+  const current = selected ? (
+    <div
+      // Named, because the same label also appears in the saved-model list
+      // below: without it there are two identical strings on this panel and
+      // nothing distinguishes "what this agent runs on" from "one of the
+      // options".
+      role="group"
+      aria-label={t("currentModel")}
+      className="border-border bg-muted/20 flex flex-wrap items-center gap-2 rounded-lg border px-3 py-2"
+    >
+      <ProviderIcon provider={selected.provider} />
+      <span className="min-w-0 flex-1 truncate text-sm">
+        <span className="font-medium">{selected.label}</span>
+        <span className="text-muted-foreground font-mono text-xs">
+          {" "}
+          {selected.provider} · {selected.model}
+        </span>
+      </span>
+      {!selected.secret_id && <Badge variant="destructive">{t("noKey")}</Badge>}
+    </div>
+  ) : null;
+
+  // A panel that only chooses between what exists is the list, and the line
+  // saying which of them is in use.
   if (!allowAdd) {
     if (profiles.length === 0) {
       return (
@@ -97,36 +146,17 @@ export function ModelProfilePicker({
         </div>
       );
     }
-    return list;
+    return (
+      <div className="space-y-3">
+        {current}
+        {list}
+      </div>
+    );
   }
 
   return (
     <div className="space-y-3">
-      {/* What the agent runs on today, stated before the form that changes it.
-          The form is the default view now, and without this line the one fact
-          somebody opens this panel to check - which model is this agent on -
-          would be the one thing behind a disclosure. */}
-      {selected && (
-        <div
-          // Named, because the same label also appears in the saved-model list
-          // below: without it there are two identical strings on this panel and
-          // nothing distinguishes "what this agent runs on" from "one of the
-          // options".
-          role="group"
-          aria-label={t("currentModel")}
-          className="border-border bg-muted/20 flex flex-wrap items-center gap-2 rounded-lg border px-3 py-2"
-        >
-          <ProviderIcon provider={selected.provider} />
-          <span className="min-w-0 flex-1 truncate text-sm">
-            <span className="font-medium">{selected.label}</span>
-            <span className="text-muted-foreground font-mono text-xs">
-              {" "}
-              {selected.provider} · {selected.model}
-            </span>
-          </span>
-          {!selected.secret_id && <Badge variant="destructive">{t("noKey")}</Badge>}
-        </div>
-      )}
+      {current}
 
       {/* Provider, model and key, always. Choosing a model is picking those three
           things; the named profile is a consequence of the choice rather than the

--- a/frontend/src/components/kb/ingestion-settings.integration.test.tsx
+++ b/frontend/src/components/kb/ingestion-settings.integration.test.tsx
@@ -1,0 +1,175 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { IngestionSettings } from "./ingestion-settings";
+import { apiClient } from "@/lib/api-client";
+import { DEFAULT_INGESTION_CONFIG } from "@/lib/ingestion-config";
+import type { ModelProfile, ProviderInfo } from "@/types/providers";
+import type { Secret, SecretPurpose } from "@/types/secrets";
+
+/**
+ * The model that reads the pictures, in the dialog where a collection is made.
+ *
+ * `ingestion-settings.test.tsx` covers the form's own decisions with the API
+ * answering nothing. This asserts the one part of it that is somebody else's
+ * component: the control that picks the describing model is the same one the
+ * Builder uses - provider, model and a key stored inline - and not the bare
+ * list of saved profiles it used to be, which on a fresh deployment was a
+ * dashed box saying the organization has no models and offering no way to make
+ * one.
+ *
+ * What it must *not* be is the Builder's panel entire. Deleting a model profile
+ * from here would take it out from under every agent pointed at it, from a form
+ * about one collection.
+ */
+
+vi.mock("@/lib/api-client", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api-client")>("@/lib/api-client");
+  return {
+    ...actual,
+    apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+  };
+});
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+const OPENAI: ProviderInfo = {
+  id: "openai",
+  name: "OpenAI",
+  secret_kind: "api_key",
+  supports_base_url: true,
+  keyless: true,
+};
+
+const PURPOSE: SecretPurpose = {
+  id: "openai",
+  label: "OpenAI",
+  category: "model_provider",
+  kind: "api_key",
+  help_url: null,
+  description: "OpenAI keys",
+};
+
+function profile(overrides: Partial<ModelProfile> = {}): ModelProfile {
+  return {
+    id: "p1",
+    label: "vision",
+    provider: "openai",
+    model: "gpt-4.1",
+    secret_id: null,
+    params: {},
+    allow_byo: false,
+    fallback_profile_ids: [],
+    ...overrides,
+  };
+}
+
+const state = { profiles: [] as ModelProfile[], secrets: [] as Secret[] };
+
+/** The vault and the provider catalog, as everything under this control reads them. */
+function serve() {
+  vi.mocked(apiClient.get).mockImplementation(async (path: string) => {
+    if (path === "/providers/model-profiles")
+      return { items: state.profiles, total: state.profiles.length };
+    if (path === "/providers/catalog") return { items: [OPENAI], total: 1 };
+    if (path === "/secrets") return { items: state.secrets, total: state.secrets.length };
+    if (path === "/secrets/purposes") return { items: [PURPOSE], total: 1 };
+    if (path === "/secrets/kinds") return { items: [], total: 0 };
+    if (path === "/providers/openai/models")
+      return { items: [{ id: "gpt-5", name: "GPT-5" }], total: 1, source: "live" };
+    throw new Error(`unexpected GET ${path}`);
+  });
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+/** The form with image description switched on, which is what renders the picker. */
+function show(modelProfileId: string | null = null) {
+  render(
+    <IngestionSettings
+      idPrefix="test"
+      value={{
+        ...DEFAULT_INGESTION_CONFIG,
+        describe_images: true,
+        image_description: {
+          ...DEFAULT_INGESTION_CONFIG.image_description,
+          model_profile_id: modelProfileId,
+        },
+      }}
+      onChange={vi.fn()}
+    />,
+    { wrapper },
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.profiles = [profile()];
+  state.secrets = [];
+  serve();
+});
+
+describe("the model that describes the images", () => {
+  it("asks for a provider, a model and a key rather than listing what exists", async () => {
+    show();
+
+    expect(await screen.findByLabelText("Provider")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add model" })).toBeInTheDocument();
+  });
+
+  it("is not a dead end on a deployment with no models at all", async () => {
+    // What the bare list rendered here: a dashed box saying the organization has
+    // no models, in a dialog whose only remaining action was Cancel.
+    state.profiles = [];
+    show();
+
+    expect(await screen.findByLabelText("Provider")).toBeInTheDocument();
+    expect(screen.queryByText(/no models yet/)).toBeNull();
+  });
+
+  it("offers to store the missing key here instead of naming the page that holds it", async () => {
+    // The provider has no key in the vault, and the answer to that is a form.
+    // Sending somebody to the Vault and back is the flow this control replaced
+    // everywhere else, and this dialog was the one place still describing it.
+    show();
+
+    await userEvent.click(await screen.findByLabelText("Provider"));
+    await userEvent.click(screen.getByRole("option", { name: /OpenAI/ }));
+
+    expect(screen.getByText(/No OpenAI key in the vault yet/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add a key" })).toBeInTheDocument();
+  });
+
+  it("says the chosen model has no key, which is what decides whether ingestion runs", async () => {
+    show("p1");
+
+    const current = await screen.findByRole("group", { name: "Current model" });
+    expect(within(current).getByText("vision")).toBeInTheDocument();
+    expect(within(current).getByText("no key")).toBeInTheDocument();
+  });
+
+  it("drops the badge once the model is keyed", async () => {
+    state.profiles = [profile({ secret_id: "s-1" })];
+    show("p1");
+
+    const current = await screen.findByRole("group", { name: "Current model" });
+    expect(within(current).queryByText("no key")).toBeNull();
+  });
+
+  it("cannot delete a model every agent in the organization may be pointed at", async () => {
+    // The reason this passes `allowAdd` and not `allowRemove`. A collection form
+    // may create a model and a key; destroying an organization-wide profile is a
+    // bigger claim than it makes, and the Builder is where that lives.
+    show();
+
+    await waitFor(() => expect(screen.getByText("Use a saved model (1)")).toBeInTheDocument());
+    expect(screen.queryByRole("button", { name: /^Remove/ })).toBeNull();
+  });
+});

--- a/frontend/src/components/kb/ingestion-settings.integration.test.tsx
+++ b/frontend/src/components/kb/ingestion-settings.integration.test.tsx
@@ -7,6 +7,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { IngestionSettings } from "./ingestion-settings";
 import { apiClient } from "@/lib/api-client";
 import { DEFAULT_INGESTION_CONFIG } from "@/lib/ingestion-config";
+import { Perm } from "@/types/permissions";
+import type { Permission } from "@/types/permissions";
 import type { ModelProfile, ProviderInfo } from "@/types/providers";
 import type { Secret, SecretPurpose } from "@/types/secrets";
 
@@ -66,11 +68,22 @@ function profile(overrides: Partial<ModelProfile> = {}): ModelProfile {
   };
 }
 
-const state = { profiles: [] as ModelProfile[], secrets: [] as Secret[] };
+const state = {
+  profiles: [] as ModelProfile[],
+  secrets: [] as Secret[],
+  permissions: [] as Permission[],
+};
 
-/** The vault and the provider catalog, as everything under this control reads them. */
+/** The vault, the provider catalog and the caller, as this control reads them. */
 function serve() {
   vi.mocked(apiClient.get).mockImplementation(async (path: string) => {
+    if (path === "/me/permissions")
+      return {
+        organization_id: "org-1",
+        role: "member",
+        is_app_admin: false,
+        permissions: state.permissions.map((permission) => ({ permission, scope: "all" })),
+      };
     if (path === "/providers/model-profiles")
       return { items: state.profiles, total: state.profiles.length };
     if (path === "/providers/catalog") return { items: [OPENAI], total: 1 };
@@ -91,7 +104,7 @@ function wrapper({ children }: { children: ReactNode }) {
 }
 
 /** The form with image description switched on, which is what renders the picker. */
-function show(modelProfileId: string | null = null) {
+function show(modelProfileId: string | null = null, disabled = false) {
   render(
     <IngestionSettings
       idPrefix="test"
@@ -104,6 +117,7 @@ function show(modelProfileId: string | null = null) {
         },
       }}
       onChange={vi.fn()}
+      disabled={disabled}
     />,
     { wrapper },
   );
@@ -113,6 +127,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   state.profiles = [profile()];
   state.secrets = [];
+  state.permissions = [Perm.collectionsEdit, Perm.connectionsManage];
   serve();
 });
 
@@ -147,6 +162,19 @@ describe("the model that describes the images", () => {
     expect(screen.getByRole("button", { name: "Add a key" })).toBeInTheDocument();
   });
 
+  it("stores no key while the dialog that holds it is frozen", async () => {
+    // The form disables its submit on `disabled` and used to stop there, which
+    // was harmless while this panel was a list of radios. It is not now: the
+    // key field writes an organization-wide vault secret, and a dialog mid-save
+    // did not mean "except the vault".
+    show(null, true);
+
+    await userEvent.click(await screen.findByLabelText("Provider"));
+    await userEvent.click(screen.getByRole("option", { name: /OpenAI/ }));
+
+    expect(screen.getByRole("button", { name: "Add a key" })).toBeDisabled();
+  });
+
   it("says the chosen model has no key, which is what decides whether ingestion runs", async () => {
     show("p1");
 
@@ -161,6 +189,19 @@ describe("the model that describes the images", () => {
 
     const current = await screen.findByRole("group", { name: "Current model" });
     expect(within(current).queryByText("no key")).toBeNull();
+  });
+
+  it("offers no form to somebody who may edit the collection but not add a model", async () => {
+    // `POST /providers/model-profiles` is `connections:manage`, which a
+    // collection editor need not hold. Rendering the form for them would be a
+    // 403 dressed as a control; the list of what already exists is the honest
+    // answer, and it is what this panel showed everybody before.
+    state.permissions = [Perm.collectionsEdit];
+    show();
+
+    await waitFor(() => expect(screen.getByRole("radio", { name: "vision" })).toBeInTheDocument());
+    expect(screen.queryByLabelText("Provider")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Add model" })).toBeNull();
   });
 
   it("cannot delete a model every agent in the organization may be pointed at", async () => {

--- a/frontend/src/components/kb/ingestion-settings.test.tsx
+++ b/frontend/src/components/kb/ingestion-settings.test.tsx
@@ -24,10 +24,12 @@ function wrapper({ children }: { children: ReactNode }) {
 /**
  * Render the form over a configuration, and hand back what it tried to change.
  *
- * jsdom cannot open a Radix select, so nothing here drives one - the selects are
- * exercised end to end. What is asserted is everything the form decides on its
- * own: which controls exist for a given parser, how an unset value reads, and
- * what leaves through `onChange`.
+ * Nothing here drives a select; they are exercised end to end. This used to say
+ * jsdom cannot open a Radix one, which is not true - `vitest.setup.ts` shims the
+ * pointer-capture methods Radix needs, and `ingestion-settings.integration.test.
+ * tsx` next door opens the provider select. What is asserted here is everything
+ * the form decides on its own: which controls exist for a given parser, how an
+ * unset value reads, and what leaves through `onChange`.
  */
 function show(value: Partial<IngestionConfig> = {}) {
   const onChange = vi.fn<(next: IngestionConfig) => void>();

--- a/frontend/src/components/kb/ingestion-settings.test.tsx
+++ b/frontend/src/components/kb/ingestion-settings.test.tsx
@@ -45,7 +45,15 @@ function show(value: Partial<IngestionConfig> = {}) {
 describe("IngestionSettings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(apiClient.get).mockResolvedValue({ items: [], total: 0 });
+    // Everything this form reads is a list, except the caller's own permissions
+    // - which the model field asks for, because whether it may offer to create
+    // a model profile is `connections:manage`. A list-shaped answer there is not
+    // "no permissions", it is a `TypeError` in `usePermissions`.
+    vi.mocked(apiClient.get).mockImplementation(async (path: string) =>
+      path === "/me/permissions"
+        ? { organization_id: "org-1", role: "member", is_app_admin: false, permissions: [] }
+        : { items: [], total: 0 },
+    );
   });
 
   it("names every control it renders", () => {

--- a/frontend/src/components/kb/ingestion-settings.tsx
+++ b/frontend/src/components/kb/ingestion-settings.tsx
@@ -17,7 +17,7 @@ import {
   Textarea,
 } from "@/components/ui";
 import { InlineSecret } from "@/components/vault/inline-secret";
-import { useModelProviders, useSecrets } from "@/hooks";
+import { useModelProviders, usePermissions, useSecrets } from "@/hooks";
 import {
   CHUNKING_STRATEGIES,
   DEFAULT_IMAGE_PROMPT,
@@ -37,6 +37,7 @@ import type {
   PdfParser,
   ThinkingEffort,
 } from "@/types";
+import { Perm } from "@/types/permissions";
 import { useTranslations } from "next-intl";
 
 export interface IngestionSettingsProps {
@@ -542,6 +543,7 @@ function ImageModelField({
 }) {
   const t = useTranslations("kb");
   const { profiles } = useModelProviders();
+  const { can } = usePermissions();
 
   return (
     <div className="space-y-2">
@@ -553,9 +555,14 @@ function ImageModelField({
             created is a fine place to define the model that will read its
             images and to store the key that pays for it. It is not a place to
             delete a model every agent in the organization may be pointed at,
-            which is why `allowRemove` is not passed with it. */}
+            which is why `allowRemove` is not passed with it.
+
+            And only for somebody who may create one: a model profile is
+            `connections:manage`, which a collection editor need not hold. The
+            form would otherwise be a 403 dressed as a control - the list of
+            what already exists is what is left, and it is the honest answer. */}
         <ModelProfilePicker
-          allowAdd
+          allowAdd={can(Perm.connectionsManage)}
           profiles={profiles}
           value={value}
           onChange={onChange}

--- a/frontend/src/components/kb/ingestion-settings.tsx
+++ b/frontend/src/components/kb/ingestion-settings.tsx
@@ -519,11 +519,17 @@ export function IngestionSettings({
 const NOT_REQUESTED = "not-requested";
 
 /**
- * Which of the organization's models reads the images.
+ * Which model reads the images: provider, model id and the key that pays for it.
  *
  * Its own component so the vault is only read where something on screen can use
  * it - the same reason the Builder's secret picker reads it itself. `/providers/
- * model-profiles` is not a request every collection form should be making.
+ * model-profiles` is not a request every collection form should be making, and
+ * this one is rendered only once image description is switched on.
+ *
+ * The full picker, not the list. Choosing a model here is the same act it is in
+ * the Builder, and a list of profiles somebody else created answers it only on a
+ * deployment that already has one - on a fresh one it was a dashed box saying
+ * the organization has no models, in a dialog offering no way to make one.
  */
 function ImageModelField({
   value,
@@ -540,10 +546,16 @@ function ImageModelField({
   return (
     <div className="space-y-2">
       <Label htmlFor="image-description-model">{t("model2")}</Label>
-      {/* The picker is a radiogroup rather than a labelled control, so the label
-          above names the group and this id exists for it to point at. */}
+      {/* Several controls rather than one labelled field, so the label above
+          names the group and this id exists for it to point at. */}
       <div id="image-description-model">
+        {/* The same control the Builder uses, minus the bin. A collection being
+            created is a fine place to define the model that will read its
+            images and to store the key that pays for it. It is not a place to
+            delete a model every agent in the organization may be pointed at,
+            which is why `allowRemove` is not passed with it. */}
         <ModelProfilePicker
+          allowAdd
           profiles={profiles}
           value={value}
           onChange={onChange}


### PR DESCRIPTION
Turning on **Describe images** in Create knowledge base rendered
`ModelProfilePicker` in its lesser shape — no `allowAdd`, so a bare radio list of
saved profiles and nothing else. It lost the provider/model/key form, the
`InlineSecret` field that answers "there is no key for this provider", and the
current-model line carrying the `no key` badge, which is the one fact deciding
whether ingestion can call the model at all. On a deployment with no saved
profiles the branch rendered a dashed box saying the organization has no models,
in a dialog offering no way to make one — the setting could be switched on and
never configured.

## The decision: option 2, the flag is split

`allowAdd` meant two things at once — show the form, and offer the bin on every
saved row. Passing it here (option 1) would let a collection form delete an
organization-wide model profile that agents are pointed at, which is a bigger
claim than this dialog makes. So:

| | |
|---|---|
| `allowAdd` | the shape: the form and its inline vault field, instead of a list |
| `allowRemove` | whether a saved model can be deleted from this panel |

The Builder (`agents/[id]/page.tsx`) passes both, which is exactly what it had
under one name — nothing about it changes. The knowledge-base dialog passes only
the first. Reading the code did not turn up a reason to diverge from the issue's
stated preference: the two flags are genuinely different claims, and the Builder
is the only caller that should make the second.

The **current-model line now renders in both shapes** rather than only the
add-capable one, as the issue asks. In a list of a dozen saved models the chosen
one's `no key` badge is a badge among twelve, and which of them is chosen is what
somebody opens the panel to check. Two consequences worth naming rather than
burying: the specialist picker in `specialist-list.tsx` — the third caller,
list-only — gains that line too, and in its narrow two-column cell the label,
`provider · model` and the badge now appear twice, once in the line and once on
the selected radio. It is the same fact about the same choice and the issue asks
for it in both branches, so it stays; if a reviewer would rather the line were
suppressed when the whole list is already visible, that is a one-line change and
worth saying now.

## What reviewing the diff added

`allowAdd` put a form that POSTs `/providers/model-profiles` into a dialog gated
on `collections:edit`. Creating a model profile is `connections:manage`, so a
member holding one and not the other would be shown "Add model" and refused on
submit — which `.claude/rules/frontend.md` rules out outright. The second commit
makes it `allowAdd={can(Perm.connectionsManage)}`; somebody without it gets the
list of what already exists, which is what this panel showed everybody before.
`AddModel` also now passes `disabled` down to `InlineSecret`, which it never did:
it disabled its submit button alone, so a dialog mid-save still let somebody
store an organization-wide vault secret.

Three things found and deliberately **not** fixed here, each filed triaged:

- **#329** — the Builder's copy of this picker has never been permission-gated,
  and `AddModel` offers `InlineSecret` without checking `secrets:edit`. The same
  defect, pre-existing, on a surface this branch is not about.
- **#331** — the create-collection dialog can now show two buttons called "Add a
  key" (the embedding key and the model key). Caused by this change; the fix is
  in `InlineSecret`'s label and reaches every caller.
- **#332** — `scripts/check_i18n.py` reads green over two hardcoded English
  sentences in `model-profile-picker.tsx` and `add-model.tsx`, which this change
  renders on a second surface. A hole in the guard, not a rule somebody skipped.

#168 has been updated with all three.

## How it was verified

- `frontend/src/components/agents/model-profile-picker.test.tsx` — the split
  itself: the form offered without the bin (`allowAdd` alone), the bin only with
  `allowRemove`, the current-model line and its badge in the list-only shape. The
  pre-existing delete test now passes both flags, which is the Builder's
  configuration.
- `frontend/src/components/kb/ingestion-settings.integration.test.tsx` (new) —
  the real control inside the real dialog, against a mocked vault, provider
  catalog and permission set: the form is offered, a provider with no stored key
  offers to store one, a profile with no key is badged on the current-model line,
  zero profiles is not a dead end, no row offers a delete, a caller with
  `collections:edit` alone gets no form, and a frozen dialog stores no key.
- `ingestion-settings.test.tsx` grew a path-aware mock. It answered every GET
  with `{items, total}`, and `usePermissions` reads `data.permissions` — a
  list-shaped answer there is a `TypeError`, not "no permissions".
- The Builder keeping the bin is already covered end to end: `e2e/models.spec.ts`
  deletes a profile through that panel, so a regression fails the `e2e` job.
- `make lint-frontend`, `scripts/check_i18n.py`, `make test-frontend-cov`
  (3186 tests, 185 files; statements/lines/functions 100%, branches 97.55%) and
  `make check` all green locally. No new user-facing copy, so no message keys
  moved. `docs/file-processing.md` updated — it said "pick a vision-capable model
  profile there", which was true of a picker that could only pick.

Nothing is known-red. CI is green on `d205821` — `lint`, `docs`, `e2e`,
`test-frontend`, CodeQL and the security scan; `test` and `docker` skipped
because no path they cover changed.

## This diff has not been through the automated reviewer

**Deliberately, and it cannot be.** #313 removed the `pull_request` trigger from
`.github/workflows/ai-review.yml` this morning, leaving only
`workflow_dispatch` — the reviewer had been dying twelve seconds into every run
since 2026-08-05 while concluding `success` (#311). Adding the `ai-review` label
now does nothing at all, silently, so it was not added and its absence is not a
clean bill of health. What this had instead is a subagent over the whole diff
with a maintainer's brief: everything under "what reviewing the diff added" and
all three filed issues came out of that pass. A human read is still owed.

## Two adjacent issues on the same dialog

- **#331** is caused by this branch and is filed rather than folded in — see
  above. It is the honest cost of putting the full picker here, and the fix
  belongs in `InlineSecret`, which every surface renders.
- **#328** (the embedding Model select showing `""`) is in
  `create-kb-dialog.tsx`'s own select, not in this control. This diff neither
  helps nor worsens it; the two touch no common code.

Closes #305
