### PR TITLE
fix(rag): embed with the collection's key, not the deployment's

### DIFF
--- a/backend/app/services/embedding_resolution.py
+++ b/backend/app/services/embedding_resolution.py
@@ -14,12 +14,22 @@ nothing breaks the day this lands; an organization that wants its own billing
 picks a vault key at creation. A *missing or unopenable* chosen key also falls
 back - with a log line - because "the org deleted a secret" must degrade to
 the deployment's key, not take document search down.
+
+What the fallback must not do is stay quiet about itself. Three of the five
+:class:`EmbeddingKeySource` values are a collection asking for its
+organization's key and not getting it, and a `logger.warning` in this module
+reaches neither the flow log a worker's operator reads nor the error the
+upload leaves on the document row. So the source travels *with* the
+resolution, and both surfaces name it.
 """
 
 from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from enum import StrEnum
+
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.secret_kinds import ApiKeySecret, SecretKind, unseal_secret
@@ -35,6 +45,65 @@ logger = logging.getLogger(__name__)
 EMBEDDING_KEY_PURPOSES = ("openrouter",)
 
 
+class EmbeddingKeySource(StrEnum):
+    """Which credential a collection's embeddings actually went out on.
+
+    Four of these five mean the deployment key paid, and only one of those
+    four is the collection never having chosen otherwise. Telling them apart
+    is the difference between "configure a key" and "the key you configured is
+    gone", which is the whole of what an operator needs from the message.
+    """
+
+    ORGANIZATION = "organization"
+    DEPLOYMENT = "deployment"
+    SECRET_MISSING = "secret_missing"
+    SECRET_UNUSABLE = "secret_unusable"
+    SECRET_WRONG_KIND = "secret_wrong_kind"
+
+    @property
+    def explanation(self) -> str:
+        """The clause a log line or an error message says out loud."""
+        return _EXPLANATIONS[self]
+
+    @property
+    def is_degraded(self) -> bool:
+        """True when the collection asked for a key and did not get it.
+
+        `DEPLOYMENT` is not degraded: a collection that chose no key is
+        supposed to embed on the deployment's, and saying so on every document
+        would bury the three that matter.
+        """
+        return self in _DEGRADED
+
+
+_EXPLANATIONS = {
+    EmbeddingKeySource.ORGANIZATION: "the vault key the collection chose",
+    EmbeddingKeySource.DEPLOYMENT: (
+        "the deployment's OPENROUTER_API_KEY, because the collection chose no key of its own"
+    ),
+    EmbeddingKeySource.SECRET_MISSING: (
+        "the deployment's OPENROUTER_API_KEY, because the vault key the collection chose "
+        "is no longer in this organization's vault"
+    ),
+    EmbeddingKeySource.SECRET_UNUSABLE: (
+        "the deployment's OPENROUTER_API_KEY, because the vault key the collection chose "
+        "could not be unsealed"
+    ),
+    EmbeddingKeySource.SECRET_WRONG_KIND: (
+        "the deployment's OPENROUTER_API_KEY, because the vault entry the collection chose "
+        "does not hold an API key"
+    ),
+}
+
+_DEGRADED = frozenset(
+    {
+        EmbeddingKeySource.SECRET_MISSING,
+        EmbeddingKeySource.SECRET_UNUSABLE,
+        EmbeddingKeySource.SECRET_WRONG_KIND,
+    }
+)
+
+
 @dataclass(frozen=True, repr=False)
 class ResolvedEmbeddings:
     """Everything one collection's embedding call needs.
@@ -46,9 +115,21 @@ class ResolvedEmbeddings:
     model: str
     dim: int
     api_key: str
+    key_source: EmbeddingKeySource
 
     def __repr__(self) -> str:
-        return f"ResolvedEmbeddings(model={self.model!r}, dim={self.dim}, api_key='***')"
+        return (
+            f"ResolvedEmbeddings(model={self.model!r}, dim={self.dim}, "
+            f"api_key='***', key_source={self.key_source.value!r})"
+        )
+
+    def describe(self, collection_name: str) -> str:
+        """One sentence-fragment naming the collection and the key it embeds on.
+
+        Written once here rather than at each surface so the flow log and the
+        failure on the document row cannot drift apart.
+        """
+        return f"collection {collection_name!r}, which embeds on {self.key_source.explanation}"
 
 
 async def embeddings_for_collection(collection_name: str) -> ResolvedEmbeddings | None:
@@ -63,31 +144,34 @@ async def embeddings_for_collection(collection_name: str) -> ResolvedEmbeddings 
         kb = await knowledge_base_repo.get_by_collection_name(db, collection_name)
         if kb is None:
             return None
+        api_key, key_source = await _api_key_for(db, kb)
         return ResolvedEmbeddings(
             model=kb.embedding_model,
             # The recorded width, not a fresh lookup: the table was created at
             # this number, and a later catalog change must not disagree with it.
             dim=kb.embedding_dim,
-            api_key=await _api_key_for(db, kb),
+            api_key=api_key,
+            key_source=key_source,
         )
 
 
-async def _api_key_for(db, kb: KnowledgeBase) -> str:
-    """The organization's chosen key, or the deployment's.
+async def _api_key_for(db: AsyncSession, kb: KnowledgeBase) -> tuple[str, EmbeddingKeySource]:
+    """The organization's chosen key, or the deployment's, and which of the two.
 
     Every failure path lands on the deployment key with a log line rather than
     an exception: the choice of *whose key pays* must never decide *whether
-    documents can be found*.
+    documents can be found*. The second element is what stops that policy from
+    being invisible - it is carried out to the flow log and the error message.
     """
     if kb.embedding_secret_id is None or kb.organization_id is None:
-        return settings.OPENROUTER_API_KEY
+        return settings.OPENROUTER_API_KEY, EmbeddingKeySource.DEPLOYMENT
 
     row = await organization_secret_repo.get(
         db, kb.embedding_secret_id, organization_id=kb.organization_id
     )
     if row is None:
         logger.warning("embedding_secret_missing", extra={"collection": kb.collection_name})
-        return settings.OPENROUTER_API_KEY
+        return settings.OPENROUTER_API_KEY, EmbeddingKeySource.SECRET_MISSING
     try:
         secret = unseal_secret(
             row.sealed_secret,
@@ -97,8 +181,8 @@ async def _api_key_for(db, kb: KnowledgeBase) -> str:
         )
     except Exception:
         logger.warning("embedding_secret_unusable", extra={"collection": kb.collection_name})
-        return settings.OPENROUTER_API_KEY
+        return settings.OPENROUTER_API_KEY, EmbeddingKeySource.SECRET_UNUSABLE
     if not isinstance(secret, ApiKeySecret):
         logger.warning("embedding_secret_wrong_kind", extra={"collection": kb.collection_name})
-        return settings.OPENROUTER_API_KEY
-    return secret.api_key.get_secret_value()
+        return settings.OPENROUTER_API_KEY, EmbeddingKeySource.SECRET_WRONG_KIND
+    return secret.api_key.get_secret_value(), EmbeddingKeySource.ORGANIZATION

--- a/backend/app/services/rag/embeddings.py
+++ b/backend/app/services/rag/embeddings.py
@@ -36,17 +36,28 @@ class OpenAIEmbeddingProvider(BaseEmbeddingProvider):
     Uses OpenAI's embedding models to generate text embeddings.
     """
 
-    def __init__(self, model: str, api_key: str = "", base_url: str | None = None) -> None:
+    def __init__(
+        self,
+        model: str,
+        api_key: str = "",
+        base_url: str | None = None,
+        key_origin: str | None = None,
+    ) -> None:
         """Initialize the OpenAI embedding provider.
 
         Args:
             model: The OpenAI embedding model name (e.g., 'text-embedding-3-small').
             api_key: API key for `base_url`. Absent, embedding is unavailable.
             base_url: Override base URL (e.g. OpenRouter-compatible endpoint).
+            key_origin: Where `api_key` came from, said in words, for the
+                refusal below. A per-collection caller passes what
+                `ResolvedEmbeddings.describe` built; the deployment-wide
+                provider has nothing to add and passes nothing.
         """
         self.model = model
         self._api_key = api_key
         self._base_url = base_url
+        self._key_origin = key_origin
         self._client: OpenAI | None = None
 
     @property
@@ -64,16 +75,29 @@ class OpenAIEmbeddingProvider(BaseEmbeddingProvider):
         OpenRouter, so an OpenAI key would have been accepted at construction
         and rejected on the first request - and silently sending one vendor's
         credential to another is not a fallback worth keeping.
+
+        The refusal names `key_origin` when it has one. Advising "set
+        OPENROUTER_API_KEY" to somebody who picked an organization key in the
+        UI is advice for a deployment they are not running; which key was
+        tried, and why that one, is the part that tells them what to do.
         """
         if self._client is None:
             if not self._api_key:
+                origin = f" for {self._key_origin}" if self._key_origin else ""
+                details: dict[str, str] = {
+                    "setting": "OPENROUTER_API_KEY",
+                    "model": self.model,
+                }
+                if self._key_origin is not None:
+                    details["key_origin"] = self._key_origin
                 raise ConfigurationError(
                     message=(
-                        "No embedding credential is configured, so documents cannot be "
-                        "indexed or searched. Set OPENROUTER_API_KEY in the backend "
-                        "environment and restart."
+                        f"No embedding credential is configured{origin}, so documents "
+                        "cannot be indexed or searched. Set OPENROUTER_API_KEY in the "
+                        "backend environment and restart, or give the collection a "
+                        "usable key from its organization's vault."
                     ),
-                    details={"setting": "OPENROUTER_API_KEY", "model": self.model},
+                    details=details,
                 )
             self._client = OpenAI(api_key=self._api_key, base_url=self._base_url)
         return self._client
@@ -108,6 +132,7 @@ class EmbeddingService:
         settings: RAGSettings,
         api_key: str | None = None,
         expected_dim: int | None = None,
+        key_origin: str | None = None,
     ) -> None:
         """One model, one credential, one expected width.
 
@@ -115,7 +140,8 @@ class EmbeddingService:
         passes the organization's own (see `embedding_resolution`).
         `expected_dim` defaults to the config's derived width; a collection
         passes the width its table was actually created at, which a later
-        catalog change must not overrule.
+        catalog change must not overrule. `key_origin` says in words where
+        `api_key` came from, so a refusal for an empty one is actionable.
         """
         config = settings.embeddings_config
         self.expected_dim = expected_dim if expected_dim is not None else config.dim
@@ -123,6 +149,7 @@ class EmbeddingService:
             model=config.model,
             api_key=api_key if api_key is not None else app_settings.OPENROUTER_API_KEY,
             base_url="https://openrouter.ai/api/v1",
+            key_origin=key_origin,
         )
 
     def embed_query(self, query: str) -> list[float]:

--- a/backend/app/services/rag/embeddings.py
+++ b/backend/app/services/rag/embeddings.py
@@ -83,12 +83,13 @@ class OpenAIEmbeddingProvider(BaseEmbeddingProvider):
         """
         if self._client is None:
             if not self._api_key:
-                origin = f" for {self._key_origin}" if self._key_origin else ""
                 details: dict[str, str] = {
                     "setting": "OPENROUTER_API_KEY",
                     "model": self.model,
                 }
+                origin = ""
                 if self._key_origin is not None:
+                    origin = f" for {self._key_origin}"
                     details["key_origin"] = self._key_origin
                 raise ConfigurationError(
                     message=(

--- a/backend/app/services/rag/vectorstore.py
+++ b/backend/app/services/rag/vectorstore.py
@@ -198,16 +198,20 @@ class PgVectorStore(BaseVectorStore):
         self,
         settings: RAGSettings,
         embedding_service: EmbeddingService,
-        resolver: "EmbeddingResolver | None" = None,
+        resolver: "EmbeddingResolver",
     ):
         self.settings = settings
         self.embedder = embedding_service
         self.dim = settings.embeddings_config.dim
-        # Which model - and whose key - one collection embeds with. None keeps
-        # the deployment defaults for everything, which is the pre-resolver
-        # behaviour and still what a collection outside the KB table gets.
+        # Which model - and whose key - one collection embeds with. Required,
+        # and deliberately not defaulted: it used to default to None, and the
+        # one construction that forgot it - the worker that ingests every
+        # uploaded document - silently ignored every collection's chosen key
+        # and model for as long as nobody read the bill (#306). A collection
+        # outside the KB table still gets the deployment defaults, but that is
+        # now the resolver answering None rather than nobody asking.
         self._resolver = resolver
-        self._services: dict[tuple[str, str], EmbeddingService] = {}
+        self._services: dict[tuple[str, str, str], EmbeddingService] = {}
         self.engine = create_async_engine(app_settings.DATABASE_URL, echo=False)
         self.async_session = sessionmaker(self.engine, class_=AsyncSession, expire_on_commit=False)
 
@@ -222,23 +226,28 @@ class PgVectorStore(BaseVectorStore):
     async def _for_collection(self, name: str) -> tuple[EmbeddingService, int]:
         """The embedder and vector width this one collection uses.
 
-        Cached per (model, key): an `EmbeddingService` holds an HTTP client,
-        and rebuilding one per chunk would open a connection pool per page of a
-        PDF. The recorded width wins over the catalog's - the table was created
-        at that number.
+        Cached per (collection, model, key): an `EmbeddingService` holds an
+        HTTP client, and rebuilding one per chunk would open a connection pool
+        per page of a PDF. The collection is in the key because the service
+        carries a `key_origin` naming it - two collections on the same key
+        would otherwise share a client whose refusal names whichever of them
+        embedded first. The recorded width wins over the catalog's: the table
+        was created at that number.
         """
-        if self._resolver is None:
-            return self.embedder, self.dim
         resolved = await self._resolver(name)
         if resolved is None:
             return self.embedder, self.dim
-        cache_key = (resolved.model, resolved.api_key)
+        cache_key = (name, resolved.model, resolved.api_key)
         service = self._services.get(cache_key)
         if service is None:
             service = EmbeddingService(
                 settings=RAGSettings(embeddings_config=EmbeddingsConfig(model=resolved.model)),
                 api_key=resolved.api_key,
                 expected_dim=resolved.dim,
+                # So a resolution that ended on an empty key says which key it
+                # tried, for which collection, instead of advising an operator
+                # to set a variable they may already have set.
+                key_origin=resolved.describe(name),
             )
             self._services[cache_key] = service
         return service, resolved.dim

--- a/backend/app/services/rag/vectorstore.py
+++ b/backend/app/services/rag/vectorstore.py
@@ -231,8 +231,13 @@ class PgVectorStore(BaseVectorStore):
         per page of a PDF. The collection is in the key because the service
         carries a `key_origin` naming it - two collections on the same key
         would otherwise share a client whose refusal names whichever of them
-        embedded first. The recorded width wins over the catalog's: the table
-        was created at that number.
+        embedded first. That bounds a long-lived store's cache by the number
+        of collections it has embedded for rather than by the number of
+        distinct credentials; each entry builds its `OpenAI` client lazily, so
+        a collection only ever read costs an object and no socket.
+
+        The recorded width wins over the catalog's: the table was created at
+        that number.
         """
         resolved = await self._resolver(name)
         if resolved is None:

--- a/backend/app/worker/tasks/rag_tasks.py
+++ b/backend/app/worker/tasks/rag_tasks.py
@@ -10,7 +10,8 @@ from pathlib import Path
 from typing import Any
 from uuid import UUID
 
-from prefect import flow
+from prefect import flow, get_run_logger
+from prefect.exceptions import MissingContextError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agents.capabilities.budget import BudgetExceeded, SpendLedger, metered_by
@@ -18,6 +19,10 @@ from app.core.config import settings
 from app.db.session import get_worker_db_context
 from app.repositories import ingestion_spend_repo, knowledge_base_repo
 from app.repositories import sync_source as sync_source_repo
+from app.services.embedding_resolution import (
+    ResolvedEmbeddings,
+    embeddings_for_collection,
+)
 from app.services.ingestion_config import (
     IngestionConfig,
     IngestionConfigService,
@@ -35,6 +40,41 @@ from app.services.sync_source import SyncSourceService
 logger = logging.getLogger(__name__)
 
 
+def _say_in_flow_log(message: str) -> None:
+    """Put one line where the operator of a failing ingestion is looking.
+
+    Prefect ships a run's log to the UI through the logger `get_run_logger`
+    hands out; a `logging` call from a library module goes to the worker's
+    stdout and no further. Outside a run there is no such logger, and this is
+    still a plain module function - a direct CLI ingest, or a test - so the
+    module logger is the fallback rather than a crash on a log line.
+    """
+    try:
+        get_run_logger().warning(message)
+    except MissingContextError:
+        logger.warning(message)
+
+
+async def _resolve_embeddings_in_flow(collection_name: str) -> ResolvedEmbeddings | None:
+    """`embeddings_for_collection`, with a degraded credential said out loud.
+
+    The resolver falls back to the deployment key on three paths - the chosen
+    secret deleted, unsealable, or not an API key - each a `logger.warning` in
+    `app.services.embedding_resolution` that reaches nothing an operator reads.
+    So a collection that *had* been given a vault key either failed with advice
+    about a deployment variable, or succeeded while billing the deployment's
+    account, and in both cases nothing said which of the three had happened.
+
+    A collection that simply chose no key is not reported: that is the
+    documented normal path, and a line per document about it would bury the
+    three that matter.
+    """
+    resolved = await embeddings_for_collection(collection_name)
+    if resolved is not None and resolved.key_source.is_degraded:
+        _say_in_flow_log(f"Embedding {resolved.describe(collection_name)}.")
+    return resolved
+
+
 async def _ingestion_service_for(
     db: AsyncSession,
     *,
@@ -43,14 +83,35 @@ async def _ingestion_service_for(
 ) -> IngestionService:
     """An ingester that reads documents the way the collection asked to be read.
 
-    The vector store and the embedder are still built from deployment settings:
-    the embedding model is fixed per deployment and recorded per collection, and
-    the check that the two still agree happens before an upload is accepted.
-    What varies here is the parser, the chunker and the image model.
+    Both halves come off the collection. The parser, the chunker and the image
+    model come from its `IngestionConfig`; the embedding model, its recorded
+    vector width and the vault key that pays for it come from the resolver,
+    which the store consults per collection.
+
+    That resolver used to be omitted here, and only here - the deployment's
+    model and `OPENROUTER_API_KEY` were used for every collection, whatever it
+    had chosen. On a deployment with no key set that was a crash advising the
+    operator to set one; with both set it was worse, because the embeddings
+    were billed to the deployment while the product said the organization's
+    key paid (#306).
+
+    An earlier version of this docstring said the model was fixed per
+    deployment and that "the check that the two still agree happens before an
+    upload is accepted". No such check exists, and none should: since
+    per-collection resolution landed, a collection keeps embedding with the
+    model it was built with whatever the deployment default became, which is
+    the point of recording it. What *is* checked before an upload is accepted
+    is `IngestionConfigService.check_embedding_model` - that this build knows a
+    width for the collection's model at all, because vectors it cannot produce
+    would fail in a worker with nothing on screen.
     """
     rag_settings = settings.rag
     embed_service = EmbeddingService(settings=rag_settings)
-    vector_store = VectorStore(settings=rag_settings, embedding_service=embed_service)
+    vector_store = VectorStore(
+        settings=rag_settings,
+        embedding_service=embed_service,
+        resolver=_resolve_embeddings_in_flow,
+    )
     processor = await IngestionConfigService(db).build_processor(organization_id, config)
     return IngestionService(processor=processor, vector_store=vector_store)
 

--- a/backend/app/worker/tasks/rag_tasks.py
+++ b/backend/app/worker/tasks/rag_tasks.py
@@ -33,6 +33,7 @@ from app.services.rag.connectors import CONNECTOR_REGISTRY
 from app.services.rag.embeddings import EmbeddingService
 from app.services.rag.ingestion import IngestionService
 from app.services.rag.models import IngestionStatus
+from app.services.rag.vectorstore import EmbeddingResolver
 from app.services.rag.vectorstore import PgVectorStore as VectorStore
 from app.services.spend import assert_organization_within_budget
 from app.services.sync_source import SyncSourceService
@@ -55,8 +56,8 @@ def _say_in_flow_log(message: str) -> None:
         logger.warning(message)
 
 
-async def _resolve_embeddings_in_flow(collection_name: str) -> ResolvedEmbeddings | None:
-    """`embeddings_for_collection`, with a degraded credential said out loud.
+def _announcing_resolver() -> EmbeddingResolver:
+    """`embeddings_for_collection`, saying a degraded credential out loud once.
 
     The resolver falls back to the deployment key on three paths - the chosen
     secret deleted, unsealable, or not an API key - each a `logger.warning` in
@@ -65,14 +66,29 @@ async def _resolve_embeddings_in_flow(collection_name: str) -> ResolvedEmbedding
     about a deployment variable, or succeeded while billing the deployment's
     account, and in both cases nothing said which of the three had happened.
 
-    A collection that simply chose no key is not reported: that is the
-    documented normal path, and a line per document about it would bury the
-    three that matter.
+    Two things it does not say. A collection that simply chose no key: that is
+    the documented normal path. And the same collection twice - the store
+    resolves per operation rather than per cache miss, so indexing one document
+    asks twice (once to create the table, once to embed), and a sync of two
+    hundred files would otherwise print four hundred copies of the line it
+    exists to make noticeable. The set is per ingestion service, so it is per
+    flow run rather than per process; a credential fixed between runs is
+    reported again on the next one.
     """
-    resolved = await embeddings_for_collection(collection_name)
-    if resolved is not None and resolved.key_source.is_degraded:
-        _say_in_flow_log(f"Embedding {resolved.describe(collection_name)}.")
-    return resolved
+    announced: set[str] = set()
+
+    async def resolve(collection_name: str) -> ResolvedEmbeddings | None:
+        resolved = await embeddings_for_collection(collection_name)
+        if (
+            resolved is not None
+            and resolved.key_source.is_degraded
+            and collection_name not in announced
+        ):
+            announced.add(collection_name)
+            _say_in_flow_log(f"Embedding {resolved.describe(collection_name)}.")
+        return resolved
+
+    return resolve
 
 
 async def _ingestion_service_for(
@@ -110,7 +126,7 @@ async def _ingestion_service_for(
     vector_store = VectorStore(
         settings=rag_settings,
         embedding_service=embed_service,
-        resolver=_resolve_embeddings_in_flow,
+        resolver=_announcing_resolver(),
     )
     processor = await IngestionConfigService(db).build_processor(organization_id, config)
     return IngestionService(processor=processor, vector_store=vector_store)

--- a/backend/tests/test_capability_edges.py
+++ b/backend/tests/test_capability_edges.py
@@ -154,7 +154,9 @@ class TestEmbeddingCredential:
         """
         store = PgVectorStore.__new__(PgVectorStore)
         store.dim = 1536
-        store._resolver = None
+        # No knowledge base claims this name, which is the resolver's `None`
+        # and the store's deployment defaults.
+        store._resolver = AsyncMock(return_value=None)
         store.embedder = MagicMock()
         store._collection_exists = AsyncMock(return_value=False)
         # A session that would raise if it were opened at all: reporting the

--- a/backend/tests/test_embedding_resolution.py
+++ b/backend/tests/test_embedding_resolution.py
@@ -17,7 +17,11 @@ from pydantic import SecretStr
 
 from app.core.secret_kinds import ApiKeySecret, SecretKind, seal_secret
 from app.core.vault import VaultScope
-from app.services.embedding_resolution import ResolvedEmbeddings, embeddings_for_collection
+from app.services.embedding_resolution import (
+    EmbeddingKeySource,
+    ResolvedEmbeddings,
+    embeddings_for_collection,
+)
 
 pytestmark = pytest.mark.anyio
 
@@ -79,7 +83,10 @@ class TestResolution:
             resolved, _ = await _resolve(_kb())
 
         assert resolved == ResolvedEmbeddings(
-            model="text-embedding-3-small", dim=1536, api_key="sk-deployment"
+            model="text-embedding-3-small",
+            dim=1536,
+            api_key="sk-deployment",
+            key_source=EmbeddingKeySource.DEPLOYMENT,
         )
 
     async def test_the_organizations_own_key_is_unsealed_and_used(self):
@@ -88,16 +95,26 @@ class TestResolution:
 
         assert resolved is not None
         assert resolved.api_key == "sk-org-own-key"
+        assert resolved.key_source is EmbeddingKeySource.ORGANIZATION
 
     async def test_a_repr_never_carries_the_key(self):
         """A dataclass repr in a log line is the way a key usually escapes."""
-        resolved = ResolvedEmbeddings(model="m", dim=8, api_key="sk-secret")
+        resolved = ResolvedEmbeddings(
+            model="m", dim=8, api_key="sk-secret", key_source=EmbeddingKeySource.ORGANIZATION
+        )
 
         assert "sk-secret" not in repr(resolved)
+        assert "organization" in repr(resolved)
 
 
 class TestCredentialDegradation:
-    """Every failure lands on the deployment key, with a log line."""
+    """Every failure lands on the deployment key, saying which failure it was.
+
+    The key itself is the same on all four fallback paths, so `api_key` alone
+    cannot tell an operator whether they never chose a key or chose one that is
+    now gone. `key_source` is what carries that out to the flow log and the
+    error left on the document row.
+    """
 
     async def test_a_deleted_secret_falls_back_to_the_deployment_key(self):
         with patch(f"{_MODULE}.settings") as env:
@@ -106,6 +123,7 @@ class TestCredentialDegradation:
 
         assert resolved is not None
         assert resolved.api_key == "sk-deployment"
+        assert resolved.key_source is EmbeddingKeySource.SECRET_MISSING
 
     async def test_an_unopenable_ciphertext_falls_back(self):
         """A rotated master key must not take search down."""
@@ -120,6 +138,7 @@ class TestCredentialDegradation:
 
         assert resolved is not None
         assert resolved.api_key == "sk-deployment"
+        assert resolved.key_source is EmbeddingKeySource.SECRET_UNUSABLE
 
     async def test_a_secret_of_the_wrong_kind_falls_back(self):
         """The vault can hold shapes an embedding client cannot use."""
@@ -133,6 +152,7 @@ class TestCredentialDegradation:
 
         assert resolved is not None
         assert resolved.api_key == "sk-deployment"
+        assert resolved.key_source is EmbeddingKeySource.SECRET_WRONG_KIND
 
     async def test_a_personal_collection_never_looks_in_a_vault(self):
         """No organization, no vault scope to open an envelope with."""
@@ -142,4 +162,50 @@ class TestCredentialDegradation:
 
         assert resolved is not None
         assert resolved.api_key == "sk-deployment"
+        assert resolved.key_source is EmbeddingKeySource.DEPLOYMENT
         secrets.get.assert_not_called()
+
+
+class TestSayingWhichKeyPaid:
+    """A fallback nobody can see is a fallback nobody can fix.
+
+    Until #306 the three degradations were a `logger.warning` in this module
+    and nothing else: not in the Prefect flow log, not in the error on the
+    document row, not in the product. An organization that had chosen a key
+    could be billed to the deployment's account with nothing anywhere saying
+    so.
+    """
+
+    @pytest.mark.parametrize("source", list(EmbeddingKeySource))
+    def test_every_source_says_which_key_paid_and_why(self, source: EmbeddingKeySource):
+        explanation = source.explanation
+
+        assert explanation
+        if source is EmbeddingKeySource.ORGANIZATION:
+            assert "OPENROUTER_API_KEY" not in explanation
+        else:
+            assert "OPENROUTER_API_KEY" in explanation
+
+    def test_only_a_key_that_was_asked_for_and_not_given_counts_as_degraded(self):
+        """A collection that chose no key embedding on the deployment's is the
+        documented normal path, not an incident to log per document."""
+        degraded = {source for source in EmbeddingKeySource if source.is_degraded}
+
+        assert degraded == {
+            EmbeddingKeySource.SECRET_MISSING,
+            EmbeddingKeySource.SECRET_UNUSABLE,
+            EmbeddingKeySource.SECRET_WRONG_KIND,
+        }
+
+    def test_the_description_names_the_collection_and_the_key(self):
+        resolved = ResolvedEmbeddings(
+            model="text-embedding-3-small",
+            dim=1536,
+            api_key="",
+            key_source=EmbeddingKeySource.SECRET_MISSING,
+        )
+
+        described = resolved.describe("handbook")
+
+        assert "'handbook'" in described
+        assert "no longer in this organization's vault" in described

--- a/backend/tests/test_ingestion_embedding_key.py
+++ b/backend/tests/test_ingestion_embedding_key.py
@@ -1,9 +1,9 @@
 """The worker embeds with the collection's key, not the deployment's (#306).
 
 `app/worker/tasks/rag_tasks.py` built its vector store with no `resolver=`,
-which is the one construction of five that did. `PgVectorStore._for_collection`
-short-circuits to the deployment embedder when it has no resolver, so a
-collection's `embedding_secret_id` and `embedding_model` were read by every
+the one construction of six that did not. `PgVectorStore._for_collection`
+short-circuited to the deployment embedder whenever the resolver was None, so
+a collection's `embedding_secret_id` and `embedding_model` were read by every
 path except the one every uploaded document actually takes.
 
 Two failures, and the quiet one is the worse:
@@ -38,8 +38,8 @@ from app.services.rag.config import RAGSettings
 from app.services.rag.embeddings import EmbeddingService
 from app.services.rag.vectorstore import PgVectorStore
 from app.worker.tasks.rag_tasks import (
+    _announcing_resolver,
     _ingestion_service_for,
-    _resolve_embeddings_in_flow,
     _say_in_flow_log,
 )
 
@@ -319,7 +319,7 @@ class TestWhatTheFlowLogSays:
             ),
             patch("app.worker.tasks.rag_tasks._say_in_flow_log") as said,
         ):
-            answer = await _resolve_embeddings_in_flow("handbook")
+            answer = await _announcing_resolver()("handbook")
         return answer, said
 
     async def test_a_degraded_credential_is_announced_with_the_reason(self):
@@ -348,9 +348,55 @@ class TestWhatTheFlowLogSays:
             ),
             patch("app.worker.tasks.rag_tasks._say_in_flow_log") as said,
         ):
-            assert await _resolve_embeddings_in_flow("unclaimed") is None
+            assert await _announcing_resolver()("unclaimed") is None
 
         said.assert_not_called()
+
+    async def test_one_collection_is_announced_once_however_often_it_resolves(self):
+        """Indexing one document resolves twice - once to create the table,
+        once to embed - and a sync of two hundred files would otherwise print
+        four hundred copies of the line that exists to be noticed. Each
+        collection still gets its own."""
+        resolutions = {
+            name: ResolvedEmbeddings(
+                model=_MODEL, dim=_DIM, api_key="", key_source=EmbeddingKeySource.SECRET_MISSING
+            )
+            for name in ("handbook", "policies")
+        }
+        with (
+            patch(
+                "app.worker.tasks.rag_tasks.embeddings_for_collection",
+                new=AsyncMock(side_effect=lambda name: resolutions[name]),
+            ),
+            patch("app.worker.tasks.rag_tasks._say_in_flow_log") as said,
+        ):
+            resolve = _announcing_resolver()
+            for name in ("handbook", "handbook", "policies", "handbook"):
+                await resolve(name)
+
+        assert [call.args[0].split("'")[1] for call in said.call_args_list] == [
+            "handbook",
+            "policies",
+        ]
+
+    async def test_a_second_flow_run_reports_a_credential_that_is_still_broken(self):
+        """The set lives on the resolver, which lives on the ingestion service,
+        which is built per flow run - so silence never outlasts the run that
+        earned it."""
+        resolved = ResolvedEmbeddings(
+            model=_MODEL, dim=_DIM, api_key="", key_source=EmbeddingKeySource.SECRET_UNUSABLE
+        )
+        with (
+            patch(
+                "app.worker.tasks.rag_tasks.embeddings_for_collection",
+                new=AsyncMock(return_value=resolved),
+            ),
+            patch("app.worker.tasks.rag_tasks._say_in_flow_log") as said,
+        ):
+            await _announcing_resolver()("handbook")
+            await _announcing_resolver()("handbook")
+
+        assert said.call_count == 2
 
     def test_the_line_goes_to_the_prefect_run_when_there_is_one(self):
         with patch("app.worker.tasks.rag_tasks.get_run_logger") as run_logger:
@@ -359,7 +405,7 @@ class TestWhatTheFlowLogSays:
         run_logger.return_value.warning.assert_called_once_with("the collection's key is gone")
 
     def test_outside_a_run_it_still_logs_rather_than_raising(self, caplog):
-        """`_resolve_embeddings_in_flow` is a plain function: a CLI ingest and
+        """The resolver is a plain callable: a CLI ingest and
         a test both reach it with no Prefect context, and a log line must never
         be what takes an ingestion down."""
         with caplog.at_level("WARNING"):

--- a/backend/tests/test_ingestion_embedding_key.py
+++ b/backend/tests/test_ingestion_embedding_key.py
@@ -1,0 +1,364 @@
+"""The worker embeds with the collection's key, not the deployment's (#306).
+
+`app/worker/tasks/rag_tasks.py` built its vector store with no `resolver=`,
+which is the one construction of five that did. `PgVectorStore._for_collection`
+short-circuits to the deployment embedder when it has no resolver, so a
+collection's `embedding_secret_id` and `embedding_model` were read by every
+path except the one every uploaded document actually takes.
+
+Two failures, and the quiet one is the worse:
+
+- with no `OPENROUTER_API_KEY` set - the normal case when an organization pays
+  for its own embeddings - every upload died in the worker advising the
+  operator to set a variable, about a collection they had already given a key;
+- with both set, embeddings were billed to the deployment's account while the
+  product said the organization's key paid, and nothing said otherwise.
+
+So these tests run the real resolver against a knowledge-base row and assert
+what the outgoing client was actually built with, rather than that a resolver
+was passed.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from app.core.exceptions import ConfigurationError
+from app.core.secret_kinds import ApiKeySecret, SecretKind, seal_secret
+from app.core.vault import VaultScope
+from app.services.embedding_resolution import EmbeddingKeySource, ResolvedEmbeddings
+from app.services.ingestion_config import IngestionConfig
+from app.services.rag.config import RAGSettings
+from app.services.rag.embeddings import EmbeddingService
+from app.services.rag.vectorstore import PgVectorStore
+from app.worker.tasks.rag_tasks import (
+    _ingestion_service_for,
+    _resolve_embeddings_in_flow,
+    _say_in_flow_log,
+)
+
+pytestmark = pytest.mark.anyio
+
+_RESOLUTION = "app.services.embedding_resolution"
+_EMBEDDINGS = "app.services.rag.embeddings"
+_ORG = uuid.uuid4()
+_MODEL = "text-embedding-3-small"
+_DIM = 1536
+
+
+def _knowledge_base(*, secret_id: uuid.UUID | None):
+    return MagicMock(
+        collection_name="handbook",
+        embedding_model=_MODEL,
+        embedding_dim=_DIM,
+        embedding_secret_id=secret_id,
+        organization_id=_ORG,
+    )
+
+
+def _vault_row(plaintext: str, *, organization_id: uuid.UUID = _ORG):
+    sealed = seal_secret(
+        ApiKeySecret(api_key=SecretStr(plaintext)),
+        scope=VaultScope.organization(organization_id),
+    )
+    return MagicMock(
+        sealed_secret=sealed.ciphertext,
+        kind=SecretKind.API_KEY.value,
+        key_version=sealed.key_version,
+        purpose="openrouter",
+    )
+
+
+async def _store() -> PgVectorStore:
+    """The store the ingestion flow actually builds.
+
+    Built through `_ingestion_service_for` rather than constructed here: what
+    #306 was is that function passing no `resolver=`, so a test that wires one
+    itself would pass against the bug it exists to catch. Only the processor -
+    parsers, chunker, image model, all of which need a session - is stubbed.
+    """
+    with patch("app.worker.tasks.rag_tasks.IngestionConfigService") as config_service:
+        config_service.return_value.build_processor = AsyncMock(return_value=MagicMock())
+        service = await _ingestion_service_for(
+            MagicMock(), config=IngestionConfig(), organization_id=_ORG
+        )
+    store = service.store
+    assert isinstance(store, PgVectorStore)
+    return store
+
+
+class _CapturedOpenAI:
+    """Stands in for the OpenAI SDK, recording what key it was built with."""
+
+    def __init__(self) -> None:
+        self.api_keys: list[str] = []
+        self.embedded: list[list[str]] = []
+
+    def __call__(self, *, api_key: str, base_url: str | None = None) -> MagicMock:
+        self.api_keys.append(api_key)
+
+        def create(*, model: str, input: list[str]) -> MagicMock:
+            self.embedded.append(input)
+            return MagicMock(
+                data=[MagicMock(embedding=[0.0] * _DIM) for _ in input],
+                usage=None,
+            )
+
+        return MagicMock(embeddings=MagicMock(create=create))
+
+
+async def _embed_through_the_flows_store(*, secret_id: uuid.UUID | None, vault_row, deployment_key):
+    """Embed one query through the flow's store, capturing the client.
+
+    Patches the two repositories the resolver reads and the SDK it ends up
+    calling; everything between is the production path.
+    """
+    openai = _CapturedOpenAI()
+    with (
+        patch(f"{_RESOLUTION}.get_db_context") as db_ctx,
+        patch(f"{_RESOLUTION}.knowledge_base_repo") as bases,
+        patch(f"{_RESOLUTION}.organization_secret_repo") as secrets,
+        patch(f"{_RESOLUTION}.settings") as resolution_env,
+        patch(f"{_EMBEDDINGS}.app_settings") as embedding_env,
+        patch(f"{_EMBEDDINGS}.OpenAI", openai),
+    ):
+        db_ctx.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+        db_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+        bases.get_by_collection_name = AsyncMock(return_value=_knowledge_base(secret_id=secret_id))
+        secrets.get = AsyncMock(return_value=vault_row)
+        resolution_env.OPENROUTER_API_KEY = deployment_key
+        embedding_env.OPENROUTER_API_KEY = deployment_key
+
+        embedder, dim = await (await _store())._for_collection("handbook")
+        vector = embedder.embed_query("what is the refund policy")
+
+    return openai, dim, vector
+
+
+class TestTheCollectionsKeyPays:
+    async def test_a_collection_with_a_vault_key_indexes_with_no_deployment_key(self):
+        """The reported crash, and the assertion that fixes it.
+
+        `OPENROUTER_API_KEY` empty is the deployment the issue was filed from:
+        the organization pays for its own embeddings. Before the resolver was
+        wired here, this raised `ConfigurationError` telling the operator to
+        set the variable.
+        """
+        openai, dim, vector = await _embed_through_the_flows_store(
+            secret_id=uuid.uuid4(),
+            vault_row=_vault_row("sk-org-own-key"),
+            deployment_key="",
+        )
+
+        assert openai.api_keys == ["sk-org-own-key"]
+        assert openai.embedded == [["what is the refund policy"]]
+        assert (dim, len(vector)) == (_DIM, _DIM)
+
+    async def test_the_deployment_is_not_billed_when_the_collection_chose_a_key(self):
+        """The quiet half. With both keys set nothing failed - the deployment's
+        account simply paid for work the product attributed to the
+        organization's key."""
+        openai, _, _ = await _embed_through_the_flows_store(
+            secret_id=uuid.uuid4(),
+            vault_row=_vault_row("sk-org-own-key"),
+            deployment_key="sk-deployment",
+        )
+
+        assert openai.api_keys == ["sk-org-own-key"]
+
+    async def test_a_collection_that_chose_no_key_still_embeds_on_the_deployments(self):
+        """The fallback is deliberate, and wiring the resolver must not end it."""
+        openai, _, _ = await _embed_through_the_flows_store(
+            secret_id=None,
+            vault_row=None,
+            deployment_key="sk-deployment",
+        )
+
+        assert openai.api_keys == ["sk-deployment"]
+
+    def test_a_store_cannot_be_built_without_a_resolver(self):
+        """The default is what made forgetting silent for five call sites.
+
+        Five constructions passed a resolver and one did not, and nothing -
+        not a type error, not a test, not a log line - distinguished the sixth
+        from a deliberate deployment-wide store.
+        """
+        with pytest.raises(TypeError):
+            PgVectorStore(  # ty: ignore[missing-argument]  - that is the assertion
+                settings=RAGSettings(), embedding_service=EmbeddingService(settings=RAGSettings())
+            )
+
+    async def test_two_collections_on_one_key_do_not_share_each_others_name(self):
+        """The embedder cache is keyed by collection as well as by credential.
+
+        It was keyed by (model, key) alone, which is fine while a service is
+        only an HTTP client - but it now carries the sentence a refusal prints,
+        so the second collection to embed on a shared key would have been
+        refused in the first one's name.
+        """
+        store = await _store()
+        resolutions = {
+            "handbook": ResolvedEmbeddings(
+                model=_MODEL, dim=_DIM, api_key="", key_source=EmbeddingKeySource.SECRET_MISSING
+            ),
+            "policies": ResolvedEmbeddings(
+                model=_MODEL, dim=_DIM, api_key="", key_source=EmbeddingKeySource.DEPLOYMENT
+            ),
+        }
+        store._resolver = AsyncMock(side_effect=lambda name: resolutions[name])
+
+        origins = []
+        for collection in resolutions:
+            embedder, _ = await store._for_collection(collection)
+            with pytest.raises(ConfigurationError) as refusal:
+                embedder.embed_query("anything")
+            origins.append(refusal.value.details["key_origin"])
+
+        assert "'handbook'" in origins[0] and "no longer in this organization's vault" in origins[0]
+        assert "'policies'" in origins[1] and "chose no key of its own" in origins[1]
+
+
+class TestWhenTheChosenKeyCannotBeUsed:
+    """Three refusals that must degrade, and say that they did.
+
+    The resolver deliberately falls back rather than raising - whose key pays
+    must not decide whether documents can be found - so the only thing that
+    can carry the failure to an operator is the message.
+    """
+
+    async def test_a_secret_from_another_organization_is_not_readable(self):
+        """The repository scopes every read by `organization_id`, so a secret
+        id belonging to another tenant simply is not found - the same answer as
+        a deleted one, and never that tenant's key."""
+        openai, _, _ = await _embed_through_the_flows_store(
+            secret_id=uuid.uuid4(),
+            vault_row=None,
+            deployment_key="sk-deployment",
+        )
+
+        assert openai.api_keys == ["sk-deployment"]
+
+    async def test_an_unsealable_key_says_so_instead_of_naming_a_variable(self):
+        openai = _CapturedOpenAI()
+        broken = MagicMock(
+            sealed_secret="not-a-ciphertext", kind=SecretKind.API_KEY.value, key_version=1
+        )
+
+        with (
+            patch(f"{_RESOLUTION}.get_db_context") as db_ctx,
+            patch(f"{_RESOLUTION}.knowledge_base_repo") as bases,
+            patch(f"{_RESOLUTION}.organization_secret_repo") as secrets,
+            patch(f"{_RESOLUTION}.settings") as resolution_env,
+            patch(f"{_EMBEDDINGS}.OpenAI", openai),
+        ):
+            db_ctx.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+            db_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+            bases.get_by_collection_name = AsyncMock(
+                return_value=_knowledge_base(secret_id=uuid.uuid4())
+            )
+            secrets.get = AsyncMock(return_value=broken)
+            resolution_env.OPENROUTER_API_KEY = ""
+
+            embedder, _ = await (await _store())._for_collection("handbook")
+            with pytest.raises(ConfigurationError) as refusal:
+                embedder.embed_query("anything")
+
+        assert "'handbook'" in refusal.value.message
+        assert "could not be unsealed" in refusal.value.message
+        assert refusal.value.details["key_origin"]
+        assert openai.api_keys == []
+
+    async def test_a_secret_of_the_wrong_kind_says_which_collection_chose_it(self):
+        openai = _CapturedOpenAI()
+
+        with (
+            patch(f"{_RESOLUTION}.get_db_context") as db_ctx,
+            patch(f"{_RESOLUTION}.knowledge_base_repo") as bases,
+            patch(f"{_RESOLUTION}.organization_secret_repo") as secrets,
+            patch(f"{_RESOLUTION}.settings") as resolution_env,
+            patch(f"{_RESOLUTION}.unseal_secret", return_value=MagicMock(spec=[])),
+            patch(f"{_EMBEDDINGS}.OpenAI", openai),
+        ):
+            db_ctx.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+            db_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+            bases.get_by_collection_name = AsyncMock(
+                return_value=_knowledge_base(secret_id=uuid.uuid4())
+            )
+            secrets.get = AsyncMock(return_value=_vault_row("sk-org"))
+            resolution_env.OPENROUTER_API_KEY = ""
+
+            embedder, _ = await (await _store())._for_collection("handbook")
+            with pytest.raises(ConfigurationError) as refusal:
+                embedder.embed_query("anything")
+
+        assert "'handbook'" in refusal.value.message
+        assert "does not hold an API key" in refusal.value.message
+
+
+class TestWhatTheFlowLogSays:
+    """The `logger.warning` in the resolver reaches the worker's stdout and
+    stops there, so a degraded credential was invisible to the run an operator
+    opens. These pin that a fallback is announced and a normal one is not."""
+
+    async def _resolution(self, key_source: EmbeddingKeySource):
+        resolved = ResolvedEmbeddings(
+            model=_MODEL, dim=_DIM, api_key="sk-deployment", key_source=key_source
+        )
+        with (
+            patch(
+                "app.worker.tasks.rag_tasks.embeddings_for_collection",
+                new=AsyncMock(return_value=resolved),
+            ),
+            patch("app.worker.tasks.rag_tasks._say_in_flow_log") as said,
+        ):
+            answer = await _resolve_embeddings_in_flow("handbook")
+        return answer, said
+
+    async def test_a_degraded_credential_is_announced_with_the_reason(self):
+        answer, said = await self._resolution(EmbeddingKeySource.SECRET_MISSING)
+
+        assert answer is not None
+        said.assert_called_once()
+        assert "no longer in this organization's vault" in said.call_args.args[0]
+        assert "'handbook'" in said.call_args.args[0]
+
+    async def test_a_collection_embedding_on_the_key_it_chose_says_nothing(self):
+        _, said = await self._resolution(EmbeddingKeySource.ORGANIZATION)
+
+        said.assert_not_called()
+
+    async def test_a_collection_that_chose_no_key_says_nothing_either(self):
+        _, said = await self._resolution(EmbeddingKeySource.DEPLOYMENT)
+
+        said.assert_not_called()
+
+    async def test_a_collection_no_knowledge_base_claims_says_nothing(self):
+        with (
+            patch(
+                "app.worker.tasks.rag_tasks.embeddings_for_collection",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("app.worker.tasks.rag_tasks._say_in_flow_log") as said,
+        ):
+            assert await _resolve_embeddings_in_flow("unclaimed") is None
+
+        said.assert_not_called()
+
+    def test_the_line_goes_to_the_prefect_run_when_there_is_one(self):
+        with patch("app.worker.tasks.rag_tasks.get_run_logger") as run_logger:
+            _say_in_flow_log("the collection's key is gone")
+
+        run_logger.return_value.warning.assert_called_once_with("the collection's key is gone")
+
+    def test_outside_a_run_it_still_logs_rather_than_raising(self, caplog):
+        """`_resolve_embeddings_in_flow` is a plain function: a CLI ingest and
+        a test both reach it with no Prefect context, and a log line must never
+        be what takes an ingestion down."""
+        with caplog.at_level("WARNING"):
+            _say_in_flow_log("the collection's key is gone")
+
+        assert "the collection's key is gone" in caplog.text

--- a/backend/tests/test_ingestion_embedding_key.py
+++ b/backend/tests/test_ingestion_embedding_key.py
@@ -22,6 +22,8 @@ was passed.
 from __future__ import annotations
 
 import uuid
+from collections.abc import AsyncIterator
+from contextlib import ExitStack, asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -111,21 +113,35 @@ class _CapturedOpenAI:
         return MagicMock(embeddings=MagicMock(create=create))
 
 
-async def _embed_through_the_flows_store(*, secret_id: uuid.UUID | None, vault_row, deployment_key):
-    """Embed one query through the flow's store, capturing the client.
+@asynccontextmanager
+async def _the_flows_embedder(
+    *,
+    secret_id: uuid.UUID | None,
+    vault_row: object,
+    deployment_key: str,
+    unseals_to_something_else: bool = False,
+) -> AsyncIterator[tuple[EmbeddingService, int, _CapturedOpenAI]]:
+    """The embedder the flow's store hands out for `handbook`, and the SDK it uses.
 
-    Patches the two repositories the resolver reads and the SDK it ends up
-    calling; everything between is the production path.
+    Patched at two edges only - the repositories the resolver reads and the
+    OpenAI client it ends up constructing. Everything between is the production
+    path, which is the point: the bug was one argument missing in the middle
+    of it. Stays open for the caller's assertions because the SDK stub has to
+    still be in place when the embedding is actually requested.
     """
     openai = _CapturedOpenAI()
-    with (
-        patch(f"{_RESOLUTION}.get_db_context") as db_ctx,
-        patch(f"{_RESOLUTION}.knowledge_base_repo") as bases,
-        patch(f"{_RESOLUTION}.organization_secret_repo") as secrets,
-        patch(f"{_RESOLUTION}.settings") as resolution_env,
-        patch(f"{_EMBEDDINGS}.app_settings") as embedding_env,
-        patch(f"{_EMBEDDINGS}.OpenAI", openai),
-    ):
+    with ExitStack() as patches:
+        db_ctx = patches.enter_context(patch(f"{_RESOLUTION}.get_db_context"))
+        bases = patches.enter_context(patch(f"{_RESOLUTION}.knowledge_base_repo"))
+        secrets = patches.enter_context(patch(f"{_RESOLUTION}.organization_secret_repo"))
+        resolution_env = patches.enter_context(patch(f"{_RESOLUTION}.settings"))
+        embedding_env = patches.enter_context(patch(f"{_EMBEDDINGS}.app_settings"))
+        patches.enter_context(patch(f"{_EMBEDDINGS}.OpenAI", openai))
+        if unseals_to_something_else:
+            patches.enter_context(
+                patch(f"{_RESOLUTION}.unseal_secret", return_value=MagicMock(spec=[]))
+            )
+
         db_ctx.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
         db_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
         bases.get_by_collection_name = AsyncMock(return_value=_knowledge_base(secret_id=secret_id))
@@ -134,9 +150,7 @@ async def _embed_through_the_flows_store(*, secret_id: uuid.UUID | None, vault_r
         embedding_env.OPENROUTER_API_KEY = deployment_key
 
         embedder, dim = await (await _store())._for_collection("handbook")
-        vector = embedder.embed_query("what is the refund policy")
-
-    return openai, dim, vector
+        yield embedder, dim, openai
 
 
 class TestTheCollectionsKeyPays:
@@ -148,11 +162,12 @@ class TestTheCollectionsKeyPays:
         wired here, this raised `ConfigurationError` telling the operator to
         set the variable.
         """
-        openai, dim, vector = await _embed_through_the_flows_store(
+        async with _the_flows_embedder(
             secret_id=uuid.uuid4(),
             vault_row=_vault_row("sk-org-own-key"),
             deployment_key="",
-        )
+        ) as (embedder, dim, openai):
+            vector = embedder.embed_query("what is the refund policy")
 
         assert openai.api_keys == ["sk-org-own-key"]
         assert openai.embedded == [["what is the refund policy"]]
@@ -162,21 +177,21 @@ class TestTheCollectionsKeyPays:
         """The quiet half. With both keys set nothing failed - the deployment's
         account simply paid for work the product attributed to the
         organization's key."""
-        openai, _, _ = await _embed_through_the_flows_store(
+        async with _the_flows_embedder(
             secret_id=uuid.uuid4(),
             vault_row=_vault_row("sk-org-own-key"),
             deployment_key="sk-deployment",
-        )
+        ) as (embedder, _, openai):
+            embedder.embed_query("anything")
 
         assert openai.api_keys == ["sk-org-own-key"]
 
     async def test_a_collection_that_chose_no_key_still_embeds_on_the_deployments(self):
         """The fallback is deliberate, and wiring the resolver must not end it."""
-        openai, _, _ = await _embed_through_the_flows_store(
-            secret_id=None,
-            vault_row=None,
-            deployment_key="sk-deployment",
-        )
+        async with _the_flows_embedder(
+            secret_id=None, vault_row=None, deployment_key="sk-deployment"
+        ) as (embedder, _, openai):
+            embedder.embed_query("anything")
 
         assert openai.api_keys == ["sk-deployment"]
 
@@ -234,36 +249,38 @@ class TestWhenTheChosenKeyCannotBeUsed:
         """The repository scopes every read by `organization_id`, so a secret
         id belonging to another tenant simply is not found - the same answer as
         a deleted one, and never that tenant's key."""
-        openai, _, _ = await _embed_through_the_flows_store(
-            secret_id=uuid.uuid4(),
-            vault_row=None,
-            deployment_key="sk-deployment",
-        )
+        async with _the_flows_embedder(
+            secret_id=uuid.uuid4(), vault_row=None, deployment_key="sk-deployment"
+        ) as (embedder, _, openai):
+            embedder.embed_query("anything")
 
         assert openai.api_keys == ["sk-deployment"]
 
+    async def test_a_deleted_key_on_a_deployment_with_none_says_which_key_is_gone(self):
+        """The reported error, on the collection that most deserves a better one.
+
+        It used to read "Set OPENROUTER_API_KEY in the backend environment and
+        restart" - true of the deployment, useless to the person who had
+        already chosen a key that has since been removed from the vault.
+        """
+        async with _the_flows_embedder(
+            secret_id=uuid.uuid4(), vault_row=None, deployment_key=""
+        ) as (embedder, _, openai):
+            with pytest.raises(ConfigurationError) as refusal:
+                embedder.embed_query("anything")
+
+        assert "'handbook'" in refusal.value.message
+        assert "no longer in this organization's vault" in refusal.value.message
+        assert openai.api_keys == []
+
     async def test_an_unsealable_key_says_so_instead_of_naming_a_variable(self):
-        openai = _CapturedOpenAI()
         broken = MagicMock(
             sealed_secret="not-a-ciphertext", kind=SecretKind.API_KEY.value, key_version=1
         )
 
-        with (
-            patch(f"{_RESOLUTION}.get_db_context") as db_ctx,
-            patch(f"{_RESOLUTION}.knowledge_base_repo") as bases,
-            patch(f"{_RESOLUTION}.organization_secret_repo") as secrets,
-            patch(f"{_RESOLUTION}.settings") as resolution_env,
-            patch(f"{_EMBEDDINGS}.OpenAI", openai),
-        ):
-            db_ctx.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
-            db_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
-            bases.get_by_collection_name = AsyncMock(
-                return_value=_knowledge_base(secret_id=uuid.uuid4())
-            )
-            secrets.get = AsyncMock(return_value=broken)
-            resolution_env.OPENROUTER_API_KEY = ""
-
-            embedder, _ = await (await _store())._for_collection("handbook")
+        async with _the_flows_embedder(
+            secret_id=uuid.uuid4(), vault_row=broken, deployment_key=""
+        ) as (embedder, _, openai):
             with pytest.raises(ConfigurationError) as refusal:
                 embedder.embed_query("anything")
 
@@ -273,25 +290,12 @@ class TestWhenTheChosenKeyCannotBeUsed:
         assert openai.api_keys == []
 
     async def test_a_secret_of_the_wrong_kind_says_which_collection_chose_it(self):
-        openai = _CapturedOpenAI()
-
-        with (
-            patch(f"{_RESOLUTION}.get_db_context") as db_ctx,
-            patch(f"{_RESOLUTION}.knowledge_base_repo") as bases,
-            patch(f"{_RESOLUTION}.organization_secret_repo") as secrets,
-            patch(f"{_RESOLUTION}.settings") as resolution_env,
-            patch(f"{_RESOLUTION}.unseal_secret", return_value=MagicMock(spec=[])),
-            patch(f"{_EMBEDDINGS}.OpenAI", openai),
-        ):
-            db_ctx.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
-            db_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
-            bases.get_by_collection_name = AsyncMock(
-                return_value=_knowledge_base(secret_id=uuid.uuid4())
-            )
-            secrets.get = AsyncMock(return_value=_vault_row("sk-org"))
-            resolution_env.OPENROUTER_API_KEY = ""
-
-            embedder, _ = await (await _store())._for_collection("handbook")
+        async with _the_flows_embedder(
+            secret_id=uuid.uuid4(),
+            vault_row=_vault_row("sk-org"),
+            deployment_key="",
+            unseals_to_something_else=True,
+        ) as (embedder, _, _openai):
             with pytest.raises(ConfigurationError) as refusal:
                 embedder.embed_query("anything")
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -173,8 +173,8 @@ is needed.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `OPENROUTER_API_KEY` | (empty) | The embeddings credential — every collection embeds on it |
-| `EMBEDDING_MODEL` | `text-embedding-3-large` | Deployment-level on purpose: pgvector columns are created at this model's width, so changing it mid-life invalidates existing collections |
+| `OPENROUTER_API_KEY` | (empty) | The fallback embeddings credential, for collections that chose no vault key of their own — and the one a degraded choice falls back to. Not "every collection embeds on it": see [File processing](file-processing.md#embeddings-the-model-and-whose-key-pays) |
+| `EMBEDDING_MODEL` | `text-embedding-3-large` | What a **new** collection is built with. The width is recorded on the row and never changes afterwards, so changing this does not invalidate existing collections — they keep embedding with the model they were created with |
 
 ### Document Parsing — configured per collection, not here
 

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -228,9 +228,31 @@ Per collection, alongside the parser:
 | `markdown` | Markdown/structured docs; splits at heading boundaries |
 | `fixed` | Uniform chunk sizes; simplest but may split mid-sentence |
 
-### Embedding Providers
-Embeddings are generated using **OpenAI** (`text-embedding-3-small` by default).
-Set `EMBEDDING_MODEL` to change the model.
+### Embeddings — the model, and whose key pays
+
+Embeddings go out through OpenRouter to an OpenAI embedding model. Both halves
+of that call are decided **per collection**, not per deployment, by
+`app/services/embedding_resolution.py`:
+
+| | |
+|---|---|
+| **Model and width** | Recorded on the knowledge base at creation (`embedding_model`, `embedding_dim`) and never changed afterwards — `PgVectorStore` writes `embedding vector(N)` once, so a second model either cannot be written or is silently compared against vectors from another space. `EMBEDDING_MODEL` decides only what a *new* collection is built with. |
+| **Credential** | The vault key chosen on the collection (`embedding_secret_id`), which is what the organization is billed for. A collection that chose none embeds on the deployment's `OPENROUTER_API_KEY`. |
+
+The key is validated at creation — a key another organization holds, or one of
+the wrong purpose, is refused there, where the person choosing can fix it. At
+embed time nothing is refused: a chosen key that has since been deleted, cannot
+be unsealed, or does not hold an API key falls back to the deployment's, because
+*whose key pays* must never decide *whether documents can be found*.
+
+That fallback is announced rather than assumed. The resolution carries which of
+the five sources it landed on, ingestion writes the degraded ones into the
+Prefect run's log, and a deployment with no key of its own fails with a message
+naming the collection and which key it tried — not with advice to set a variable
+about a collection that already had a key. Before #306 the ingestion worker was
+the one caller that never asked the resolver at all, so every uploaded document
+was embedded with the deployment's model and key whatever its collection had
+chosen.
 
 ### Vector Storage
 Vectors are stored in **pgvector** using the existing PostgreSQL database.


### PR DESCRIPTION
## What changed, and why

`_ingestion_service_for` in `app/worker/tasks/rag_tasks.py` built its
`PgVectorStore` with no `resolver=` — the one construction of six that did not.
`PgVectorStore._for_collection` short-circuited to the deployment embedder
whenever the resolver was `None`, so a collection's `embedding_secret_id` and
`embedding_model` were read by every path except the one every uploaded document
actually takes.

Two failures, and the quiet one is worse:

- With no `OPENROUTER_API_KEY` set — the normal case when an organization pays
  for its own embeddings — every upload died in the worker with
  `RuntimeError: … Set OPENROUTER_API_KEY in the backend environment and
  restart`, about a collection that had already been given a vault key.
- With both set, nothing failed: embeddings were billed to the deployment's
  account while the product said the organization's key paid.

The model went the same way. A collection built on a non-default
`embedding_model` was indexed with `EMBEDDING_MODEL` and searched with its own —
an insert failure if the widths differ, and silently poor retrieval if they
happen to match.

### The fix

- **`resolver` is required on `PgVectorStore`** rather than `None`-defaulted,
  and the `if self._resolver is None` short-circuit is deleted. All six call
  sites were checked (`app/main.py`, `app/api/deps.py`,
  `app/services/rag/ingestion.py`, `app/commands/rag.py`,
  `app/agents/capabilities/knowledge/_search.py`, and the worker); every one
  passes `embeddings_for_collection`, and **nothing legitimately needs the
  deployment-only path**, so the default is gone rather than made explicit. A
  collection no knowledge base claims still gets the deployment defaults — that
  is now the resolver answering `None` rather than nobody asking. The one test
  construction that set `_resolver = None` by hand
  (`tests/test_capability_edges.py`) now stubs a resolver that answers `None`,
  which is the state it was modelling.
- **The resolution carries which of five sources the key came from.**
  `_api_key_for` degrades to the deployment key on three paths (secret row
  missing, unseal failure, wrong kind) and that policy is deliberate — whose key
  pays must not decide whether documents can be found — but the `logger.warning`
  explaining which one fired reached nothing an operator reads. So
  `EmbeddingKeySource` travels with `ResolvedEmbeddings`, the worker writes the
  degraded ones into the Prefect run's log through `get_run_logger`, and the
  `ConfigurationError` for an empty key now names the collection and which key it
  tried instead of advising a variable the reader may already have set.
- **The embedder cache is keyed by collection as well as by credential.** It was
  `(model, key)`, which was fine while the service was only an HTTP client; it
  now carries the sentence a refusal prints, so two collections sharing a key
  would have been refused in each other's name. The cache is therefore bounded by
  collections embedded for rather than by distinct credentials, and each entry
  builds its `OpenAI` client lazily — a collection only ever read costs an object
  and no socket.
- **The degradation is announced once per flow run, not once per resolve.** The
  store resolves per operation rather than per cache miss (`insert_document` asks
  once through `_ensure_collection` and once for the embedder), so a
  two-hundred-file sync would otherwise have printed four hundred copies of the
  line that exists to be noticed. `_announcing_resolver()` holds the set of
  collections it has reported; the set lives on the ingestion service, which is
  built per flow run, so a credential still broken on the next run is reported
  again.

### The docstring claim at `rag_tasks.py:46-48`

**Corrected, not implemented.** It said the embedding model is fixed per
deployment and that "the check that the two still agree happens before an upload
is accepted". No such check exists and none should: since per-collection
resolution landed, a collection keeps embedding with the model it was built with
whatever the deployment default became — that is the point of recording it, and
`tests/integration/test_platform_flows.py::test_a_changed_deployment_default_no_longer_strands_a_collection`
pins it. What `RAGDocumentService.upload` does check before accepting an upload
is `IngestionConfigService.check_embedding_model`: that this build knows a width
for the collection's model at all. The new docstring says both, and says plainly
that the old one was wrong.

## How it was verified, and how far that reaches

`backend/tests/test_ingestion_embedding_key.py` (17 tests) builds the store
through `_ingestion_service_for` — not by wiring a resolver itself, which would
pass against the bug — runs the real resolver against a knowledge-base row, and
asserts what the OpenAI client was actually constructed with. Reverting the two
halves of the fix locally turns 6 of the 17 red.

Covered: a vault key indexing with `OPENROUTER_API_KEY` empty; the deployment not
being billed when a key was chosen; a collection that chose none still falling
back; a secret belonging to another organization (the repository scopes every
read by `organization_id`, so it is simply not found — never that tenant's key);
a deleted one; an unsealable one; a wrong-purpose one; and what the flow log says
for each. `tests/test_embedding_resolution.py` gains the `key_source` assertions.

It reaches as far as the outgoing client and no further — no test here embeds
against a real endpoint, so "the request goes out with the organization's key" is
asserted at the SDK boundary.

- `make lint` — green. `make test` — green, with
  `app/services/embedding_resolution.py` still at 100% in the gated layer.
- `pytest tests/integration` against a real `pgvector/pgvector:pg16` — 255
  passed. It did **not** skip for want of a database.
- `make check` — green. One earlier local run failed
  `tests/test_migrations.py::test_upgrade_head`; that is
  [#346](https://github.com/vstorm-co/agenticos/issues/346), not this branch.
  `MIGRATION_DATABASE` is a constant name rather than pid-scoped, so concurrent
  worktrees on one Postgres drop each other's chain mid-run. It passes in
  isolation here, CI's `test` job passes it on this exact commit, and this branch
  adds no migration — `db-check` is green as its own step.

## About the red `e2e` on the first push of this commit

It was **not** this change, and it was **not** a product spec.
[Run 31102852185](https://github.com/vstorm-co/agenticos/actions/runs/31102852185/job/92620704058)
failed in `[seed]` at `seed.setup.ts:244 › a colleague is a member of the
organization`, so `fixture-reporter.ts` printed its banner and **87 specs never
ran**. Re-running the identical commit passed. That is
[#335](https://github.com/vstorm-co/agenticos/issues/335), already open from the
same failure on `main` an hour earlier — I added a third sighting and the
archaeology to it: PR #222 introduced `nowThere` and converted four seed call
sites, and this one, which predates it, was the one it missed.

## Deliberately not fixed

- The `asyncpg.exceptions.TooManyConnectionsError` further down the issue's log
  is the uncapped Prefect runner, already fixed on `main` in 92e6da5
  (`PREFECT_RUNNER_LIMIT`).
- #335 above — a fixture defect in a file this branch does not touch.
- [#339](https://github.com/vstorm-co/agenticos/issues/339) — `list_collections()`
  reporting a phantom `documents` collection, in the same file. A separate branch
  has it. **No collision:** this branch's two hunks in
  `app/services/rag/vectorstore.py` are `__init__` (lines ~198) and
  `_for_collection` (~226); #339's fix is `list_collections()` at ~460 plus a
  prefix constant near `_HNSW_MAX_VECTOR_DIM` at ~173. Different methods,
  twenty-five lines clear of the nearest edit here.
- `docs/file-processing.md`'s "RAG is Global" section, two headings below the one
  rewritten here, is stale about per-user isolation. Out of scope; not filed
  because it is already inside the frontend/docs cluster in #168 territory rather
  than a defect this branch found.

## Also updated

`docs/file-processing.md` — the "Embedding Providers" section said the model
comes from `EMBEDDING_MODEL` and said nothing about per-collection keys; it now
describes both halves, the validation at creation and the fallback at embed time.
`docs/configuration.md` — `OPENROUTER_API_KEY` was described as the key "every
collection embeds on", and `EMBEDDING_MODEL` as invalidating existing collections
if changed. Both stopped being true when per-collection resolution landed; this
branch is what made the two pages contradict each other outright, so it fixes
them here.

## Note on review

The `ai-review` label was **not** applied: `.github/workflows/ai-review.yml` has
had its `pull_request` trigger removed by #313 while
[#311](https://github.com/vstorm-co/agenticos/issues/311) is open, so labelling
would post a "no result" comment that reads like a verdict and change nothing. In
its place the diff was swept by a maintainer-style review pass, which found and
fixed three things: the double announcement per document, the shared-cache name
collision, and the `docs/configuration.md` contradiction.

Closes #306
