### PR TITLE
fix(api): encode error details so a 404 stops arriving as a 500

### DIFF
--- a/.claude/rules/exceptions-security.md
+++ b/.claude/rules/exceptions-security.md
@@ -10,16 +10,24 @@ globs: ["backend/app/core/**/*.py", "backend/app/services/**/*.py"]
 All extend `AppException`. Always pass `message` and `details`:
 
 ```python
-raise NotFoundError(message="User not found", details={"user_id": str(user_id)})
+raise NotFoundError(message="User not found", details={"user_id": user_id})
 raise AlreadyExistsError(message="Email already registered", details={"email": email})
 raise AuthenticationError(message="Invalid or expired token")
 raise AuthorizationError(message="Role 'admin' required for this action")
 ```
 
+**Put the value in `details`, not a string of it.** The handler encodes with
+`jsonable_encoder`, the same one `response_model` uses, so a `UUID`, `datetime`,
+`Enum` or nested structure reaches the wire the way it does everywhere else. This
+example used to say `str(user_id)` while the code said `user_id`, and the code was
+right: stringifying is a rule only review can enforce, and the call site that forgets
+turns a clean 404 into a bodiless 500 (#307). Money is the one exception - a `Decimal`
+encodes to a float, so a cost or a cap is stringified deliberately by the raiser.
+
 Exception handlers in `api/exception_handlers.py` automatically:
 - Map to HTTP status codes
 - Log with structured context (path, method, error code)
-- Return consistent JSON error format
+- Return consistent JSON error format, `details` included
 - Add `WWW-Authenticate: Bearer` header on 401
 
 ## Security Patterns

--- a/.claude/rules/exceptions-security.md
+++ b/.claude/rules/exceptions-security.md
@@ -24,6 +24,15 @@ right: stringifying is a rule only review can enforce, and the call site that fo
 turns a clean 404 into a bodiless 500 (#307). Money is the one exception - a `Decimal`
 encodes to a float, so a cost or a cap is stringified deliberately by the raiser.
 
+**A value, not a row.** `details` is serialized into the response body, and
+`jsonable_encoder` reaches an object it does not recognise through `vars()` - so
+`details={"user": user}` puts `hashed_password` on the wire, where `details={"user_id":
+user.id}` puts an id. Name the field that explains the refusal; never hand it a
+SQLAlchemy row, a settings object, an upstream client or an exception instance. The
+same applies to the caller's own input: `exc.errors(include_url=False,
+include_input=False)` - a form needs to know which field is wrong, not to be sent a
+copy of what it posted.
+
 Exception handlers in `api/exception_handlers.py` automatically:
 - Map to HTTP status codes
 - Log with structured context (path, method, error code)

--- a/backend/app/agents/capabilities/_registry.py
+++ b/backend/app/agents/capabilities/_registry.py
@@ -305,7 +305,14 @@ class CapabilityDef:
         except ValidationError as exc:
             raise BadRequestError(
                 message=f"Invalid configuration for capability '{self.id}'",
-                details={"capability_id": self.id, "errors": exc.errors(include_url=False)},
+                # `include_input=False` for the same reason `ingestion_config`
+                # sets it: the rejected value is the caller's own submission and
+                # echoing it back adds nothing a form can act on, while putting
+                # whatever was posted into a response body and an error log.
+                details={
+                    "capability_id": self.id,
+                    "errors": exc.errors(include_url=False, include_input=False),
+                },
             ) from exc
 
     def config_json_schema(self) -> dict[str, Any] | None:

--- a/backend/app/api/exception_handlers.py
+++ b/backend/app/api/exception_handlers.py
@@ -13,6 +13,11 @@ including schema validation, which FastAPI would otherwise answer in its own
 `{"detail": [...]}` format. Two shapes on the wire means every caller either
 handles both or silently mishandles one, and the one it mishandles is the one
 that carries the field names a form needs.
+
+Every response is built by `_envelope`, which encodes `details` the way
+`response_model` encodes a body. `JSONResponse` on its own serializes with
+plain `json.dumps`, and a domain exception carries whatever the service that
+raised it had to hand - most often the `UUID` it could not find.
 """
 
 import logging
@@ -20,6 +25,7 @@ from collections.abc import Sequence
 from typing import Any
 
 from fastapi import FastAPI
+from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from starlette.requests import HTTPConnection
@@ -32,6 +38,49 @@ logger = logging.getLogger(__name__)
 # Where a validation error came from, as Pydantic reports it in the first
 # element of `loc`. Nothing a form can act on, so it is dropped from the path.
 _LOCATIONS = frozenset({"body", "query", "path", "header", "cookie"})
+
+
+def _envelope(
+    *,
+    status_code: int,
+    code: str,
+    message: str,
+    details: Any,
+    headers: dict[str, str] | None = None,
+) -> JSONResponse:
+    """The one response shape, with `details` encoded rather than dumped.
+
+    `JSONResponse` serializes with `json.dumps`, which raises `TypeError` on a
+    `UUID` - and `details` is where a service puts the id it could not find, the
+    timestamp a token expired at, the money a budget was short by. Around twenty
+    call sites pass a raw `UUID` today. When the handler raises, the refusal it
+    was reporting never reaches the caller: the log says `NOT_FOUND` and the wire
+    says 500 with no body, so a stale session is indistinguishable from a broken
+    server (agenticos#307).
+
+    Stringifying at each call site would be twenty edits enforceable only by
+    review, and the twenty-first is written next month. `jsonable_encoder` is
+    what `response_model` already uses, so `details` reaches the wire the same
+    way every other field of every other response does - a `UUID` as its string,
+    a `datetime` in ISO 8601, an `Enum` as its value - and a call site is free to
+    pass what it actually has.
+
+    Encoding is deliberately not wrapped in a `try`: a value `jsonable_encoder`
+    cannot reach - a live client, an open file - is a bug in the raising code and
+    has no business in an error payload. It should fail loudly here rather than
+    reach a caller as a plausible-looking refusal with a field quietly missing.
+    """
+    return JSONResponse(
+        status_code=status_code,
+        content={
+            "error": {
+                "code": code,
+                "message": message,
+                "details": jsonable_encoder(details),
+            }
+        },
+        headers=headers,
+    )
 
 
 def _connection_meta(conn: HTTPConnection) -> dict[str, Any]:
@@ -76,15 +125,11 @@ async def app_exception_handler(request: HTTPConnection, exc: AppException) -> J
     if exc.status_code == 401:
         headers["WWW-Authenticate"] = "Bearer"
 
-    return JSONResponse(
+    return _envelope(
         status_code=exc.status_code,
-        content={
-            "error": {
-                "code": exc.code,
-                "message": exc.message,
-                "details": exc.details,
-            }
-        },
+        code=exc.code,
+        message=exc.message,
+        details=exc.details,
         headers=headers,
     )
 
@@ -148,18 +193,16 @@ async def budget_exceeded_handler(
         logger.warning("BUDGET_EXCEEDED: %s", exc, extra=_connection_meta(request))
         return None
 
-    return JSONResponse(
+    return _envelope(
         status_code=402,
-        content={
-            "error": {
-                "code": "BUDGET_EXCEEDED",
-                "message": str(exc),
-                "details": {
-                    "scope": exc.scope,
-                    "limit_usd": str(exc.limit_usd),
-                    "spent_usd": str(exc.spent_usd),
-                },
-            }
+        code="BUDGET_EXCEEDED",
+        message=str(exc),
+        details={
+            "scope": exc.scope,
+            # Money stays a string: `jsonable_encoder` would answer a `Decimal`
+            # with a float, and a cap is not a thing to round on the way out.
+            "limit_usd": str(exc.limit_usd),
+            "spent_usd": str(exc.spent_usd),
         },
     )
 
@@ -177,15 +220,11 @@ async def unhandled_exception_handler(
     if _is_websocket(request):
         return None
 
-    return JSONResponse(
+    return _envelope(
         status_code=500,
-        content={
-            "error": {
-                "code": "INTERNAL_ERROR",
-                "message": "An unexpected error occurred",
-                "details": None,
-            }
-        },
+        code="INTERNAL_ERROR",
+        message="An unexpected error occurred",
+        details=None,
     )
 
 

--- a/backend/app/api/exception_handlers.py
+++ b/backend/app/api/exception_handlers.py
@@ -52,18 +52,22 @@ def _envelope(
 
     `JSONResponse` serializes with `json.dumps`, which raises `TypeError` on a
     `UUID` - and `details` is where a service puts the id it could not find, the
-    timestamp a token expired at, the money a budget was short by. Around twenty
-    call sites pass a raw `UUID` today. When the handler raises, the refusal it
-    was reporting never reaches the caller: the log says `NOT_FOUND` and the wire
-    says 500 with no body, so a stale session is indistinguishable from a broken
-    server (agenticos#307).
+    timestamp a token expired at, the money a budget was short by. When the
+    handler raises, the refusal it was reporting never reaches the caller: the
+    log says `NOT_FOUND` and the wire says 500 with no body, so a stale session
+    is indistinguishable from a broken server (agenticos#307). `UserService`
+    passes the `UUID` it was given, which is why a JWT for a user that no longer
+    exists - a browser session kept across a database reset - answered every
+    request with an empty 500.
 
-    Stringifying at each call site would be twenty edits enforceable only by
-    review, and the twenty-first is written next month. `jsonable_encoder` is
-    what `response_model` already uses, so `details` reaches the wire the same
-    way every other field of every other response does - a `UUID` as its string,
-    a `datetime` in ISO 8601, an `Enum` as its value - and a call site is free to
-    pass what it actually has.
+    Stringifying at each call site is a rule only review can enforce, and the
+    call site that forgets is the one that takes an endpoint down. Most of this
+    codebase does stringify, out of habit rather than obligation, so the cost of
+    the convention is paid everywhere and the benefit held hostage to the two
+    places that did not. `jsonable_encoder` is what `response_model` already
+    uses, so `details` reaches the wire the same way every other field of every
+    other response does - a `UUID` as its string, a `datetime` in ISO 8601, an
+    `Enum` as its value - and a call site is free to pass what it holds.
 
     Encoding is deliberately not wrapped in a `try`: a value `jsonable_encoder`
     cannot reach - a live client, an open file - is a bug in the raising code and

--- a/backend/app/api/exception_handlers.py
+++ b/backend/app/api/exception_handlers.py
@@ -73,6 +73,16 @@ def _envelope(
     cannot reach - a live client, an open file - is a bug in the raising code and
     has no business in an error payload. It should fail loudly here rather than
     reach a caller as a plausible-looking refusal with a field quietly missing.
+
+    What this asks of a call site, and what the rule in
+    `.claude/rules/exceptions-security.md` now says: a value, not a row.
+    `jsonable_encoder` reaches an unrecognised object through `vars()`, so
+    `details={"user": user}` would serialize `hashed_password` where
+    `details={"user_id": user.id}` serializes an id. No call site does that today
+    and there is no guard against one that starts - a runtime type check here
+    would be a branch guarding a caller that does not exist, and the review that
+    would catch it is the same review that catches a plaintext secret anywhere
+    else.
     """
     return JSONResponse(
         status_code=status_code,
@@ -203,8 +213,10 @@ async def budget_exceeded_handler(
         message=str(exc),
         details={
             "scope": exc.scope,
-            # Money stays a string: `jsonable_encoder` would answer a `Decimal`
-            # with a float, and a cap is not a thing to round on the way out.
+            # Money stays a string: `jsonable_encoder` answers a `Decimal` with
+            # a float (an int when the exponent is not negative), so `40.10`
+            # would leave as `40.1` and a cap is not a thing to reshape on the
+            # way out.
             "limit_usd": str(exc.limit_usd),
             "spent_usd": str(exc.spent_usd),
         },

--- a/backend/app/api/exception_handlers.py
+++ b/backend/app/api/exception_handlers.py
@@ -45,7 +45,7 @@ def _envelope(
     status_code: int,
     code: str,
     message: str,
-    details: Any,
+    details: dict[str, Any] | None,
     headers: dict[str, str] | None = None,
 ) -> JSONResponse:
     """The one response shape, with `details` encoded rather than dumped.

--- a/backend/tests/api/test_error_envelope.py
+++ b/backend/tests/api/test_error_envelope.py
@@ -8,7 +8,10 @@ name reached the browser as "Request failed" and a 422 reached it as the string
 form of a list of dicts.
 
 The tests here pin the envelope itself rather than any one endpoint, because the
-value of a single shape is entirely in it being the only one.
+value of a single shape is entirely in it being the only one. The last class pins
+the other half of that claim: a shape the caller never receives is not a shape.
+Its vehicle is `GET /users/avatar/{user_id}`, the one route that reaches a
+service without authenticating first - the handler it exercises is global.
 """
 
 from __future__ import annotations

--- a/backend/tests/api/test_error_envelope.py
+++ b/backend/tests/api/test_error_envelope.py
@@ -13,13 +13,20 @@ value of a single shape is entirely in it being the only one.
 
 from __future__ import annotations
 
+import json
+from datetime import UTC, datetime
 from decimal import Decimal
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
 
 import pytest
 from fastapi.exceptions import RequestValidationError
 from httpx import AsyncClient
 
 from app.agents.capabilities.budget import BudgetExceeded, BudgetScope
+from app.api import deps
 from app.api.exception_handlers import (
     _field_path,
     _summarize,
@@ -27,6 +34,10 @@ from app.api.exception_handlers import (
     validation_exception_handler,
 )
 from app.core.config import settings
+from app.core.exceptions import NotFoundError
+from app.main import app
+from app.repositories import user_repo
+from app.schemas.message_rating import RatingValue
 
 
 class TestFieldPath:
@@ -174,3 +185,142 @@ class TestValidationEnvelope:
 
         exc = RequestValidationError([{"type": "missing", "loc": ("body", "x"), "msg": "Required"}])
         assert await validation_exception_handler(_Connection(), exc) is None  # ty: ignore[invalid-argument-type]
+
+
+class TestDetailsSurviveSerialization:
+    """A refusal that cannot be serialized is a refusal nobody is told about.
+
+    `details` is where a service puts the thing it is refusing over - the id it
+    could not find, the moment a token expired, the cap that was spent. The
+    handler used to hand that dictionary to `json.dumps`, which raises on a
+    `UUID`, so the handler died on the way out and the caller got a bodiless 500
+    for what the log had already recorded as a clean 404 (#307).
+    """
+
+    @pytest.mark.anyio
+    async def test_a_missing_user_is_a_404_carrying_the_id_it_could_not_find(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The everyday reproduction: a session kept across a database reset.
+
+        Whole-stack on purpose - route, service and handler - because the defect
+        was not in what the service raised but in what happened to it afterwards.
+        """
+        monkeypatch.setattr(user_repo, "get_by_id", AsyncMock(return_value=None))
+        user_id = uuid4()
+
+        response = await client.get(f"{settings.API_V1_STR}/users/avatar/{user_id}")
+
+        assert response.status_code == 404
+        assert response.json() == {
+            "error": {
+                "code": "NOT_FOUND",
+                "message": "User not found",
+                "details": {"user_id": str(user_id)},
+            }
+        }
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            pytest.param(
+                UUID("0e2e0f04-2a99-4c5b-8b3f-96f1a2a1b0d1"),
+                "0e2e0f04-2a99-4c5b-8b3f-96f1a2a1b0d1",
+                id="uuid",
+            ),
+            pytest.param(
+                datetime(2026, 8, 6, 12, 30, tzinfo=UTC), "2026-08-06T12:30:00+00:00", id="datetime"
+            ),
+            # Lossy, and the reason the budget handler stringifies money itself
+            # before it ever reaches here.
+            pytest.param(Decimal("41.50"), 41.5, id="decimal"),
+            pytest.param(RatingValue.DISLIKE, -1, id="enum"),
+            pytest.param(Path("/workspace/report.pdf"), "/workspace/report.pdf", id="path"),
+            pytest.param(
+                {"rows": [{"id": UUID("11111111-1111-1111-1111-111111111111")}]},
+                {"rows": [{"id": "11111111-1111-1111-1111-111111111111"}]},
+                id="nested",
+            ),
+        ],
+    )
+    @pytest.mark.anyio
+    async def test_details_carry_what_a_service_naturally_holds(
+        self, client: AsyncClient, value: Any, expected: Any
+    ):
+        """Not only `UUID`: the encoder's reach is the whole point of fixing it once."""
+        service = MagicMock()
+        service.get_by_id = AsyncMock(
+            side_effect=NotFoundError(message="User not found", details={"value": value})
+        )
+        app.dependency_overrides[deps.get_user_service] = lambda: service
+
+        response = await client.get(f"{settings.API_V1_STR}/users/avatar/{uuid4()}")
+
+        assert response.status_code == 404
+        assert response.json()["error"]["details"] == {"value": expected}
+
+    @pytest.mark.anyio
+    async def test_a_set_of_scopes_arrives_as_a_list(self, client: AsyncClient):
+        """`json.dumps` refuses a set as flatly as it refuses a `UUID`."""
+        service = MagicMock()
+        service.get_by_id = AsyncMock(
+            side_effect=NotFoundError(
+                message="User not found", details={"scopes": {"agents:edit", "agents:read"}}
+            )
+        )
+        app.dependency_overrides[deps.get_user_service] = lambda: service
+
+        response = await client.get(f"{settings.API_V1_STR}/users/avatar/{uuid4()}")
+
+        assert response.status_code == 404
+        assert sorted(response.json()["error"]["details"]["scopes"]) == [
+            "agents:edit",
+            "agents:read",
+        ]
+
+    @pytest.mark.anyio
+    async def test_an_unencodable_value_fails_here_rather_than_on_the_wire(
+        self, client: AsyncClient
+    ):
+        """No silent fallback: a payload nothing can encode is a bug in the raiser.
+
+        Answering with the field quietly dropped would hide it in exactly the
+        place a person goes looking for the reason something was refused.
+        """
+        service = MagicMock()
+        service.get_by_id = AsyncMock(
+            side_effect=NotFoundError(message="User not found", details={"open": object()})
+        )
+        app.dependency_overrides[deps.get_user_service] = lambda: service
+
+        with pytest.raises(ValueError):
+            await client.get(f"{settings.API_V1_STR}/users/avatar/{uuid4()}")
+
+    @pytest.mark.anyio
+    async def test_a_budget_refusal_keeps_its_money_exact(self):
+        """`jsonable_encoder` answers a `Decimal` with a float; a cap is not a
+        thing to round on the way out, so the handler stringifies it first."""
+
+        class _Connection:
+            scope = {"type": "http"}
+            method = "POST"
+
+            class url:
+                path = "/api/v1/rag/documents"
+
+        response = await budget_exceeded_handler(
+            _Connection(),  # ty: ignore[invalid-argument-type]
+            BudgetExceeded(
+                limit_usd=Decimal("40.10"),
+                spent_usd=Decimal("40.15"),
+                scope=BudgetScope.ORGANIZATION,
+            ),
+        )
+
+        assert response is not None
+        details = json.loads(response.body)["error"]["details"]
+        assert details == {
+            "scope": "organization",
+            "limit_usd": "40.10",
+            "spent_usd": "40.15",
+        }

--- a/backend/tests/test_capability_registry.py
+++ b/backend/tests/test_capability_registry.py
@@ -404,6 +404,14 @@ class TestConfigValidation:
         assert exc.value.details is not None
         assert exc.value.details["errors"]
 
+    def test_the_rejected_value_is_not_echoed_back(self):
+        """`details` reaches the caller verbatim, so it carries the diagnosis
+        rather than a copy of what was posted (agenticos#307)."""
+        with pytest.raises(BadRequestError) as exc:
+            get("knowledge").validate_config({"default_top_k": 999})
+        assert exc.value.details is not None
+        assert all("input" not in error for error in exc.value.details["errors"])
+
     def test_capabilities_without_a_schema_accept_nothing(self):
         assert get("charts").validate_config({}) is None
 

--- a/docs/adding_features.md
+++ b/docs/adding_features.md
@@ -117,7 +117,7 @@ which delegates to a repository.
            if not notification:
                raise NotFoundError(
                    message="Notification not found",
-                   details={"id": str(notification_id)},
+                   details={"id": notification_id},
                )
            return notification
 

--- a/docs/howto/add-api-endpoint.md
+++ b/docs/howto/add-api-endpoint.md
@@ -120,7 +120,7 @@ class NotificationService:
         if not notification:
             raise NotFoundError(
                 message="Notification not found",
-                details={"id": str(notification_id)},
+                details={"id": notification_id},
             )
         return notification
 

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -44,7 +44,7 @@ class ConversationService:
     async def get_or_raise(self, id: UUID) -> Conversation:
         conv = await self.repo.get_by_id(self.db, id)
         if not conv:
-            raise NotFoundError(message="Conversation not found", details={"id": str(id)})
+            raise NotFoundError(message="Conversation not found", details={"id": id})
         return conv
 ```
 
@@ -90,7 +90,7 @@ from app.core.exceptions import NotFoundError, AlreadyExistsError, ValidationErr
 if not conversation:
     raise NotFoundError(
         message="Conversation not found",
-        details={"id": str(id)}
+        details={"id": id}
     )
 
 if await self.repo.exists_by_email(self.db, email):
@@ -99,7 +99,12 @@ if await self.repo.exists_by_email(self.db, email):
     )
 ```
 
-Exception handlers convert to HTTP responses automatically.
+Exception handlers convert to HTTP responses automatically, and `details` is
+encoded with `jsonable_encoder` - the same encoder `response_model` uses - so the
+raiser passes the value it has rather than a string of it. A `UUID` arrives as its
+string form, a `datetime` in ISO 8601, an `Enum` as its value. Money is the
+exception worth knowing: a `Decimal` encodes to a float, so a cost or a cap is
+stringified by the code that raises.
 
 ## Schema Patterns
 


### PR DESCRIPTION
## What changed

`app_exception_handler` built its response with `JSONResponse`, which serializes with plain `json.dumps`. `json.dumps` raises `TypeError` on a `UUID`, and `details` is where a service puts the id it could not find — so the handler died on the way out and the refusal it was reporting never reached the caller. The log recorded `NOT_FOUND: User not found` at WARNING; the wire carried a 500 with no body at all. A JWT for a user that no longer exists — a browser session kept across a database reset — is the everyday way in, and it takes `GET /api/v1/auth/me` down for that session for good.

Fixed once, in the handler. All three handlers that build a response now go through a single `_envelope`, which encodes `details` with `jsonable_encoder` — the same encoder `response_model` uses — so `details` reaches the wire the way every other field of every other response does, and a service may pass what it holds rather than a string of it.

Three decisions worth naming, because each is a thing a reader would otherwise wonder about:

- **Not `str(uuid)` at the call sites.** That is a rule only review can enforce, and the call site that forgets is the one that takes an endpoint down.
- **Not wrapped in a `try`.** A value `jsonable_encoder` cannot reach is a bug in the raising code; a refusal delivered with a field quietly dropped hides it exactly where somebody would go looking for the reason something was refused. It fails loudly, and a test pins that.
- **The budget handler keeps stringifying its money**, now with the reason written down: `jsonable_encoder` answers a `Decimal` with a float, and a cap is not a thing to round on the way out.

The sibling handlers were checked rather than assumed. `validation_exception_handler` delegates to `app_exception_handler`, so the same fix covers it; `unhandled_exception_handler` passes a constant `None`. Both now share `_envelope`, so the envelope has one definition instead of three.

## The issue's call-site count did not hold up

#307 says "~20 call sites pass a raw `UUID`" and names five files. An AST pass over `backend/app/` — every `details={...}` whose value is a name annotated `UUID` in the enclosing signature — finds **two**, both in `UserService`; four of the five files named take their ids as `str` (`rag_document`, `sync_source`, `sandbox_connection`, `collection_access`). The third commit here corrects the first one's message, which had repeated the claim.

It does not change the fix, and the audit shows the shape of the problem better than the number did: nearly every call site stringifies out of habit, so the cost of the convention is paid everywhere while two omissions were enough to answer a live endpoint with an empty 500.

## The rule and the code disagreed

`.claude/rules/exceptions-security.md` showed `details={"user_id": str(user_id)}` while `.claude/rules/architecture.md` showed the raw value, and the code followed the second. The rule now says to pass the value, says why, and names the one exception (money). `docs/patterns.md`, `docs/adding_features.md` and `docs/howto/add-api-endpoint.md` carried the same `str(...)` example and now match. `python3 scripts/docs_drift.py` is clean.

## How it was verified

Ten tests in `backend/tests/api/test_error_envelope.py`; **eight fail without the fix** (the two that do not are contract pins — an `IntEnum`, and the budget handler's already-stringified money).

- The first is whole-stack — route, service and handler through the ASGI transport — because the defect was not in what the service raised but in what happened to it afterwards. Without the fix it does not merely assert a wrong status: the `TypeError` propagates out of the transport, which is what a bodiless 500 looks like from the inside.
- The rest pin the encoder's reach: `datetime` (ISO 8601), `Decimal` (a float — asserted as such, so the lossiness is documented rather than discovered), `Enum`, `Path`, a `set`, and a nested dict/list holding a `UUID`.
- One pins the deliberate absence of a fallback.

`make lint` and `make test` green, coverage still 100% on the platform layer, `make docs-build` clean, `make check` run over the branch. The frontend half of `check` needed `bun install` in this worktree first; the diff does not touch `frontend/`. Every CI job is green, `e2e` included and not flaking.

## What the self-review changed

**The automated reviewer has not seen this diff — it cannot.** #313 removed the `pull_request` trigger from `ai-review` this morning, because since 2026-08-05 it had been dying inside Codex, concluding `success` and posting a sentence that read like a verdict (#311). The label does nothing now, so this branch has had a maintainer-eye pass by hand and by subagent against `.claude/commands/review.md` instead, and a human reader should treat it as unreviewed by anything automatic.

That pass audited all **226** `details=` call sites reaching a domain exception and produced three changes beyond the fix itself:

- **`_registry.py:308` stopped echoing the rejected value.** `CapabilityDef.validate_config` called `exc.errors(include_url=False)` and left `include_input` at its default, so a 400 came back carrying whatever config had been posted — while `ingestion_config.py:390` sets `include_input=False` on the identical call. Fixed here rather than filed, because it is the one call site putting caller input into a payload this branch makes reliably reachable. A test now pins its absence.
- **The rule gained "a value, not a row."** `jsonable_encoder` reaches an unrecognised object through `vars()`, so a future `details={"user": user}` would serialize `hashed_password`. No call site does that today — of the 226, every value is a scalar, a `UUID` or a `list[str]` — and a runtime type check in the handler would be a branch guarding a caller that does not exist, which this repo's own standard refuses. So `.claude/rules/exceptions-security.md` and the `_envelope` docstring carry it, and the trade-off is written down rather than assumed.
- **A comment that was slightly wrong.** `jsonable_encoder` answers a `Decimal` with a float *or an int*, when the exponent is not negative. Verified against the installed FastAPI 0.141.1 rather than from memory, along with every other encoding claim in the docstring.

Also checked and clean: no frontend consumer breaks (all six readers of `error.details` in `frontend/src` narrow the type before using it — `lib/api-error.ts:129`, `:151`, `lib/delegations.ts:256`, `hooks/use-active-organization.ts:33`); no other path re-wraps an `AppException` into a body (`agent_session.py:162`, `channels/router.py:150,207` and `embed_session.py:128` all send `exc.message`, a string).

## Found and deliberately not fixed

- **#342** (filed, triaged): two pre-existing sites whose `details` describes the server rather than the refusal — an upstream client's exception text on a 503 (`knowledge/_search.py:105`) and absolute container paths on a 500 (`email/templates.py:38,47`). Out of scope for this branch, and worth recording now precisely because this branch makes `details` reliably reach the wire.
- A second, entirely separate rate limiter — `backend/app/services/rate_limit/` — that nothing outside its own directory imports, and whose `_raise_429` would answer `{"detail": {"error": {...}}}`, the second envelope shape this module exists to prevent. That is #7 ("Actually apply the rate limiter") seen from another direction rather than a new bug, so it is [recorded as a comment there](https://github.com/vstorm-co/agenticos/issues/7#issuecomment-5204612210) rather than filed as a duplicate.
- `docs/reference/capabilities.md` is named by `scripts/docs_drift.py` because `_registry.py` changed. Nothing is owed: the page is a catalog of what ships, generated from docstrings, and a keyword argument on a validation error changes nothing it describes.

Nothing is known-red.

Closes #307
