### PR TITLE
refactor(vault): draw the brand mark in every provider and key picker

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1036,6 +1036,7 @@
     "create": "Create",
     "createKnowledgeBase": "Create knowledge base",
     "creating": "Creating...",
+    "customized": "customized",
     "defaultIngestionConfigConst": "(DEFAULT_INGESTION_CONFIG); const [embeddingModel, setEmbeddingModel] = useState",
     "deploymentDefault": "deployment default",
     "deploymentDefaults": "deployment defaults",

--- a/frontend/src/components/agents/add-model.integration.test.tsx
+++ b/frontend/src/components/agents/add-model.integration.test.tsx
@@ -126,6 +126,11 @@ function mount(props: Partial<Parameters<typeof AddModel>[0]> = {}) {
   return { onCreated };
 }
 
+/** The brand mark actually drawn, by the name lobehub titles its SVG with. */
+function markIn(element: HTMLElement): string | null {
+  return element.querySelector("svg > title")?.textContent ?? null;
+}
+
 async function pickProvider(label: string) {
   await userEvent.click(screen.getByLabelText("Provider"));
   await userEvent.click(screen.getByRole("option", { name: new RegExp(label) }));
@@ -166,6 +171,46 @@ describe("the add-model form", () => {
     // The tick is decorative; what matters is that both are offered and the
     // keyed one is distinguishable at all.
     expect(screen.getByRole("option", { name: /OpenAI/ })).toBeInTheDocument();
+  });
+
+  it("draws each provider's own brand mark", async () => {
+    mount();
+
+    await userEvent.click(screen.getByLabelText("Provider"));
+
+    expect(markIn(screen.getByRole("option", { name: /OpenAI/ }))).toBe("OpenAI");
+    expect(markIn(screen.getByRole("option", { name: /OpenRouter/ }))).toBe("OpenRouter");
+  });
+
+  it("carries the chosen provider's mark on the closed trigger", async () => {
+    // For nothing: Radix draws the selected item's own text in the trigger.
+    mount();
+    await pickProvider("OpenRouter");
+
+    expect(markIn(screen.getByLabelText("Provider"))).toBe("OpenRouter");
+  });
+
+  it("leaves the has-a-key tick in the list rather than repeating it in the trigger", async () => {
+    // In the trigger there is nothing to compare it against, so a tick there
+    // reads as "selected" - which is a different claim, and a wrong one for a
+    // provider whose key was deleted.
+    state.secrets = [secret()];
+    mount();
+    await pickProvider("OpenAI");
+
+    expect(screen.getByLabelText("Provider").querySelector(".lucide-check")).toBeNull();
+  });
+
+  it("draws the mark and the masked tail of every key it offers", async () => {
+    state.secrets = [secret(), secret({ id: "s-2", name: "OpenAI staging", hint: "9999" })];
+    mount();
+    await pickProvider("OpenAI");
+
+    await userEvent.click(screen.getByLabelText("Key"));
+
+    const staging = screen.getByRole("option", { name: /OpenAI staging/ });
+    expect(markIn(staging)).toBe("OpenAI");
+    expect(staging).toHaveTextContent("····9999");
   });
 
   it("cannot be submitted before a provider is chosen", () => {

--- a/frontend/src/components/agents/add-model.integration.test.tsx
+++ b/frontend/src/components/agents/add-model.integration.test.tsx
@@ -162,15 +162,20 @@ describe("the add-model form", () => {
     });
   });
 
-  it("marks the providers a key is already stored for", async () => {
+  it("marks the providers a key is already stored for, and only those", async () => {
+    // Which providers can answer today is the question this list is scanned
+    // for, and the tick is the whole of the answer.
     state.secrets = [secret()];
     mount();
 
     await userEvent.click(screen.getByLabelText("Provider"));
 
-    // The tick is decorative; what matters is that both are offered and the
-    // keyed one is distinguishable at all.
-    expect(screen.getByRole("option", { name: /OpenAI/ })).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: /OpenAI/ }).querySelector(".lucide-check"),
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("option", { name: /OpenRouter/ }).querySelector(".lucide-check"),
+    ).toBeNull();
   });
 
   it("draws each provider's own brand mark", async () => {

--- a/frontend/src/components/agents/add-model.tsx
+++ b/frontend/src/components/agents/add-model.tsx
@@ -192,6 +192,10 @@ export function AddModel({ onCreated, onCancel, disabled }: AddModelProps) {
                   <SelectItem
                     key={entry.id}
                     value={entry.id}
+                    // The row draws a mark and a mark has a `<title>`, which
+                    // counts as the item's text: without this, type-to-search
+                    // matches the brand rather than the provider's name.
+                    textValue={entry.label}
                     // Outside the row on purpose: the trigger mirrors an item's
                     // text, and a tick there would read as "selected" rather
                     // than "this provider already has a key".
@@ -259,7 +263,7 @@ export function AddModel({ onCreated, onCancel, disabled }: AddModelProps) {
                 </SelectTrigger>
                 <SelectContent>
                   {keys.map((secret) => (
-                    <SelectItem key={secret.id} value={secret.id}>
+                    <SelectItem key={secret.id} value={secret.id} textValue={secret.name}>
                       {/* The provider is the filter this list was built with, so
                           it is also every row's mark - no `purpose` lookup. */}
                       <ProviderRow provider={provider.id} name={secret.name} hint={secret.hint} />

--- a/frontend/src/components/agents/add-model.tsx
+++ b/frontend/src/components/agents/add-model.tsx
@@ -5,7 +5,7 @@ import { Check, KeyRound, Plus } from "lucide-react";
 
 import { ModelCombobox } from "@/components/agents/model-combobox";
 import { InlineSecret } from "@/components/vault/inline-secret";
-import { ProviderIcon } from "@/components/vault/provider-icon";
+import { ProviderRow } from "@/components/vault/provider-row";
 import {
   Button,
   Input,
@@ -189,12 +189,19 @@ export function AddModel({ onCreated, onCancel, disabled }: AddModelProps) {
               {providers.map((entry) => {
                 const keyed = secrets.some((secret) => secret.purpose === entry.id);
                 return (
-                  <SelectItem key={entry.id} value={entry.id}>
-                    <span className="flex w-full items-center gap-2">
-                      <ProviderIcon provider={entry.id} />
-                      <span>{entry.label}</span>
-                      {keyed && <Check className="text-muted-foreground ml-auto h-3.5 w-3.5" />}
-                    </span>
+                  <SelectItem
+                    key={entry.id}
+                    value={entry.id}
+                    // Outside the row on purpose: the trigger mirrors an item's
+                    // text, and a tick there would read as "selected" rather
+                    // than "this provider already has a key".
+                    trailing={
+                      keyed && (
+                        <Check className="text-muted-foreground ml-auto h-3.5 w-3.5 shrink-0" />
+                      )
+                    }
+                  >
+                    <ProviderRow provider={entry.id} name={entry.label} />
                   </SelectItem>
                 );
               })}
@@ -253,8 +260,9 @@ export function AddModel({ onCreated, onCancel, disabled }: AddModelProps) {
                 <SelectContent>
                   {keys.map((secret) => (
                     <SelectItem key={secret.id} value={secret.id}>
-                      {secret.name}
-                      <span className="text-muted-foreground font-mono"> ····{secret.hint}</span>
+                      {/* The provider is the filter this list was built with, so
+                          it is also every row's mark - no `purpose` lookup. */}
+                      <ProviderRow provider={provider.id} name={secret.name} hint={secret.hint} />
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/frontend/src/components/agents/capability-settings.integration.test.tsx
+++ b/frontend/src/components/agents/capability-settings.integration.test.tsx
@@ -410,6 +410,27 @@ describe("SecretField · narrowing by what a key is for", () => {
     await waitFor(() => expect(screen.getByLabelText("Secret")).toHaveTextContent("OpenAI"));
   });
 
+  it("draws each key's mark and masked tail, so eleven api_key rows are eleven rows", async () => {
+    // The reason narrowing was added at all: a real vault holds a dozen keys of
+    // this kind. The purpose that filters the list is also what draws the row.
+    serve([
+      { ...API_KEY_SECRET, id: "sec-openai", name: "Prod", purpose: "openai" },
+      // No purpose at all - stored before purposes existed. It is still offered,
+      // and a monogram is what keeps it from being a blank gap.
+      { ...API_KEY_SECRET, id: "sec-old", name: "Search key" },
+    ]);
+    mount(binding());
+
+    await userEvent.click(await screen.findByLabelText("Secret"));
+
+    const marked = screen.getByRole("option", { name: /Prod/ });
+    expect(marked.querySelector("svg > title")?.textContent).toBe("OpenAI");
+    expect(marked).toHaveTextContent("····P7KD");
+    expect(
+      screen.getByRole("option", { name: /Search key/ }).querySelector("svg > title"),
+    ).toBeNull();
+  });
+
   it("offers every key of the right kind when nothing names a service", async () => {
     // An unconditional requirement - the weather capability - has no field to
     // read a service from, so narrowing would be guessing.

--- a/frontend/src/components/agents/capability-settings.tsx
+++ b/frontend/src/components/agents/capability-settings.tsx
@@ -20,6 +20,7 @@ import {
   Textarea,
 } from "@/components/ui";
 import { InlineSecret } from "@/components/vault/inline-secret";
+import { ProviderRow } from "@/components/vault/provider-row";
 import { useSecrets } from "@/hooks";
 import { ROUTES } from "@/lib/constants";
 import { cn, getErrorMessage } from "@/lib/utils";
@@ -452,8 +453,15 @@ function SecretField({ binding, requirement, onChange, disabled }: SecretFieldPr
         </SelectTrigger>
         <SelectContent>
           {usable.map((secret) => (
-            <SelectItem key={secret.id} value={secret.id}>
-              {secret.name} <span className="font-mono">····{secret.hint}</span>
+            <SelectItem key={secret.id} value={secret.id} textValue={secret.name}>
+              {/* What the key is for is what `fitsPurpose` filtered on, and it
+                  is also its mark - including the `custom` a key stored before
+                  purposes existed reads as. */}
+              <ProviderRow
+                provider={secret.purpose ?? "custom"}
+                name={secret.name}
+                hint={secret.hint}
+              />
             </SelectItem>
           ))}
         </SelectContent>

--- a/frontend/src/components/agents/observability-card.test.tsx
+++ b/frontend/src/components/agents/observability-card.test.tsx
@@ -65,6 +65,20 @@ describe("the tracing card", () => {
     });
   });
 
+  it("draws each token the way every other key picker draws one", async () => {
+    // Logfire has no brand mark compiled in, so what the row carries is the
+    // monogram - the same square, in the same place, as the logo an OpenAI key
+    // gets three panels away. The masked tail is what tells two apart, since an
+    // organization names both after the client.
+    state.secrets = [secret(), secret({ id: "s-two", name: "Client Logfire", hint: "9999" })];
+    mount();
+
+    await userEvent.click(screen.getByLabelText("Write token"));
+
+    expect(screen.getByRole("option", { name: /····3123/ }).textContent).toMatch(/^lClient/);
+    expect(screen.getByRole("option", { name: /····9999/ })).toBeInTheDocument();
+  });
+
   it("lets a token be added here when the vault has none", () => {
     // Rather than an empty picker and a sentence pointing somewhere else: the
     // answer to "no tokens stored yet" is a form, and a picker with nothing in it

--- a/frontend/src/components/agents/observability-card.tsx
+++ b/frontend/src/components/agents/observability-card.tsx
@@ -15,6 +15,7 @@ import {
   SelectValue,
 } from "@/components/ui";
 import { InlineSecret } from "@/components/vault/inline-secret";
+import { ProviderRow } from "@/components/vault/provider-row";
 import { useSecrets } from "@/hooks";
 import type { ObservabilitySpec } from "@/types/agents";
 import { useTranslations } from "next-intl";
@@ -90,8 +91,12 @@ export function ObservabilityCard({
             <SelectContent>
               <SelectItem value={NONE}>{t("deploymentSProject")}</SelectItem>
               {tokens.map((secret) => (
-                <SelectItem key={secret.id} value={secret.id}>
-                  {secret.name} <span className="font-mono">····{secret.hint}</span>
+                <SelectItem key={secret.id} value={secret.id} textValue={secret.name}>
+                  {/* Every token here is a Logfire token by construction - that
+                      is the filter above - so the mark is the constant, not a
+                      lookup. Logfire has no mark compiled in; the monogram is
+                      the floor, and the row still reads like the others. */}
+                  <ProviderRow provider={TOKEN_PURPOSE} name={secret.name} hint={secret.hint} />
                 </SelectItem>
               ))}
             </SelectContent>

--- a/frontend/src/components/chat/chat-model-picker.test.tsx
+++ b/frontend/src/components/chat/chat-model-picker.test.tsx
@@ -75,6 +75,21 @@ describe("the chat's two-step model picker", () => {
     expect(screen.queryByRole("option", { name: /Tavily/ })).not.toBeInTheDocument();
   });
 
+  it("draws every provider's brand mark, and carries the chosen one's into the trigger", async () => {
+    // The same row the Builder draws. Radix mirrors the selected item's text
+    // into the trigger, which is what makes the second half free.
+    listedSecrets.mockReturnValue([{ id: "s1", purpose: "openai" }]);
+    render(<ChatModelPicker value={null} onChange={vi.fn()} />);
+
+    await pickProvider("OpenRouter");
+
+    const trigger = screen.getByRole("combobox", { name: "Provider" });
+    expect(trigger.querySelector("svg > title")?.textContent).toBe("OpenRouter");
+    // The tick means "this provider already has a key". Mirrored into the
+    // trigger it would read as "selected", so it is not part of the row.
+    expect(trigger.querySelector(".lucide-check")).toBeNull();
+  });
+
   it("keeps the model field closed until a provider is chosen", () => {
     // Step two depends on step one: a model id means nothing without knowing
     // whose catalog it names.

--- a/frontend/src/components/chat/chat-model-picker.tsx
+++ b/frontend/src/components/chat/chat-model-picker.tsx
@@ -136,6 +136,9 @@ export function ChatModelPicker({ value, onChange }: ChatModelPickerProps) {
                 <SelectItem
                   key={entry.id}
                   value={entry.id}
+                  // Type-to-search keys off this rather than off the mark's own
+                  // title, which is otherwise part of the item's text.
+                  textValue={entry.label}
                   // Outside the row: the trigger mirrors an item's text, and a
                   // tick there reads as "selected" rather than "has a key".
                   trailing={

--- a/frontend/src/components/chat/chat-model-picker.tsx
+++ b/frontend/src/components/chat/chat-model-picker.tsx
@@ -9,6 +9,7 @@ import {
   placeholderWords,
 } from "@/components/agents/add-model";
 import { ProviderIcon } from "@/components/vault/provider-icon";
+import { ProviderRow } from "@/components/vault/provider-row";
 import {
   Button,
   Input,
@@ -132,12 +133,18 @@ export function ChatModelPicker({ value, onChange }: ChatModelPickerProps) {
             {providers.map((entry) => {
               const keyed = secrets.some((secret) => secret.purpose === entry.id);
               return (
-                <SelectItem key={entry.id} value={entry.id}>
-                  <span className="flex w-full items-center gap-2">
-                    <ProviderIcon provider={entry.id} />
-                    <span>{entry.label}</span>
-                    {keyed && <Check className="text-muted-foreground ml-auto h-3.5 w-3.5" />}
-                  </span>
+                <SelectItem
+                  key={entry.id}
+                  value={entry.id}
+                  // Outside the row: the trigger mirrors an item's text, and a
+                  // tick there reads as "selected" rather than "has a key".
+                  trailing={
+                    keyed && (
+                      <Check className="text-muted-foreground ml-auto h-3.5 w-3.5 shrink-0" />
+                    )
+                  }
+                >
+                  <ProviderRow provider={entry.id} name={entry.label} />
                 </SelectItem>
               );
             })}

--- a/frontend/src/components/kb/create-kb-dialog.integration.test.tsx
+++ b/frontend/src/components/kb/create-kb-dialog.integration.test.tsx
@@ -1,0 +1,123 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CreateKBDialog } from "./create-kb-dialog";
+import { apiClient } from "@/lib/api-client";
+
+/**
+ * The Embeddings section of Create knowledge base, as somebody reading it sees it.
+ *
+ * Both selects here choose something billed to an OpenRouter key, and both used
+ * to say so in bare text: "Deployment key", "OpenRouter", `text-embedding-3-large`.
+ * The rest of the product draws that choice with the service's own mark, three
+ * clicks away in the Builder. `create-kb-dialog.test.tsx` covers what the form
+ * posts; this covers what it shows.
+ */
+
+vi.mock("@/lib/api-client", () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+const SECRETS = {
+  items: [
+    { id: "s-1", name: "OpenRouter prod", hint: "3123", purpose: "openrouter", kind: "api_key" },
+    // A key for something else entirely: it must not be offered as one that can
+    // pay for embeddings, and its mark must not appear in this select either.
+    { id: "s-2", name: "Tavily", hint: "9999", purpose: "tavily", kind: "api_key" },
+  ],
+  total: 2,
+};
+
+const EMBEDDING_MODELS = {
+  default: "text-embedding-3-large",
+  models: [
+    { model: "text-embedding-3-large", dim: 3072 },
+    { model: "text-embedding-3-small", dim: 1536 },
+  ],
+};
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+/** The brand mark actually drawn, by the name lobehub titles its SVG with. */
+function markIn(element: HTMLElement): string | null {
+  return element.querySelector("svg > title")?.textContent ?? null;
+}
+
+/** Open the disclosure the embedding model and its key live behind. */
+async function openEmbeddings() {
+  await userEvent.click(screen.getByText("Embeddings"));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(apiClient.get).mockImplementation(async (path: string) => {
+    if (path === "/secrets") return SECRETS;
+    if (path === "/rag/embedding-models") return EMBEDDING_MODELS;
+    return { items: [], total: 0 };
+  });
+  render(<CreateKBDialog open onOpenChange={vi.fn()} />, { wrapper });
+});
+
+describe("the embedding key picker", () => {
+  it("draws the mark for every key it offers, and its masked tail", async () => {
+    await openEmbeddings();
+    await userEvent.click(screen.getByLabelText("Key"));
+
+    const key = await screen.findByRole("option", { name: /OpenRouter prod/ });
+    expect(markIn(key)).toBe("OpenRouter");
+    expect(key).toHaveTextContent("····3123");
+  });
+
+  it("marks the deployment's own key too, which is an OpenRouter key as well", async () => {
+    // `EmbeddingService` sends every embedding request to openrouter.ai, on the
+    // deployment's key when a collection names none - so the two rows are the
+    // same service and reading as two different things was the bug.
+    await openEmbeddings();
+    await userEvent.click(screen.getByLabelText("Key"));
+
+    expect(markIn(await screen.findByRole("option", { name: "Deployment key" }))).toBe(
+      "OpenRouter",
+    );
+  });
+
+  it("offers no key that cannot pay for embeddings", async () => {
+    await openEmbeddings();
+    await userEvent.click(screen.getByLabelText("Key"));
+
+    expect(screen.queryByRole("option", { name: /Tavily/ })).toBeNull();
+  });
+
+  it("shows the selected key's mark on the closed trigger", async () => {
+    await openEmbeddings();
+
+    expect(markIn(screen.getByLabelText("Key"))).toBe("OpenRouter");
+  });
+});
+
+describe("the embedding model picker", () => {
+  it("draws the mark of the key that pays, beside every model id", async () => {
+    await openEmbeddings();
+    await userEvent.click(screen.getByLabelText("Model"));
+
+    expect(markIn(await screen.findByRole("option", { name: /text-embedding-3-small/ }))).toBe(
+      "OpenRouter",
+    );
+  });
+
+  it("says which model an untouched deployment would use, in the list", async () => {
+    await openEmbeddings();
+    await userEvent.click(screen.getByLabelText("Model"));
+
+    const preselected = await screen.findByRole("option", { name: /text-embedding-3-large/ });
+    expect(preselected).toHaveTextContent("deployment default");
+  });
+});

--- a/frontend/src/components/kb/create-kb-dialog.tsx
+++ b/frontend/src/components/kb/create-kb-dialog.tsx
@@ -25,6 +25,7 @@ import {
 import { useQuery } from "@tanstack/react-query";
 import { IngestionSettings } from "@/components/kb/ingestion-settings";
 import { InlineSecret } from "@/components/vault/inline-secret";
+import { ProviderRow } from "@/components/vault/provider-row";
 import { useKnowledgeBases, useSecrets } from "@/hooks";
 import { apiClient } from "@/lib/api-client";
 import { submitFailure } from "@/lib/api-error";
@@ -193,7 +194,7 @@ export function CreateKBDialog({ open, onOpenChange, onCreated }: CreateKBDialog
             <details className="group border-border rounded-lg border">
               <summary className="text-foreground flex cursor-pointer list-none items-center gap-1.5 p-3 text-sm">
                 <ChevronRight className="h-3.5 w-3.5 transition-transform group-open:rotate-90" />
-                Embeddings
+                {t("embeddings")}
                 <span className="text-muted-foreground ml-auto text-xs">
                   {embeddingModel && embeddingModel !== embeddingModels?.default
                     ? embeddingModel
@@ -214,9 +215,25 @@ export function CreateKBDialog({ open, onOpenChange, onCreated }: CreateKBDialog
                     </SelectTrigger>
                     <SelectContent>
                       {(embeddingModels?.models ?? []).map((entry) => (
-                        <SelectItem key={entry.model} value={entry.model}>
-                          {entry.model}
-                          {entry.model === embeddingModels?.default ? " (default)" : ""}
+                        <SelectItem
+                          key={entry.model}
+                          value={entry.model}
+                          // In the list rather than in the row: the trigger
+                          // draws whatever the row draws, and "deployment
+                          // default" is a comparison against the other options.
+                          trailing={
+                            entry.model === embeddingModels?.default && (
+                              <span className="text-muted-foreground ml-auto shrink-0 pl-2 text-xs">
+                                {t("deploymentDefault")}
+                              </span>
+                            )
+                          }
+                        >
+                          {/* Whichever model is chosen, the request goes to
+                              OpenRouter and an OpenRouter key pays for it - so
+                              the mark says which key that is, which a bare
+                              model id never did. */}
+                          <ProviderRow provider={EMBEDDING_KEY_PURPOSE} name={entry.model} />
                         </SelectItem>
                       ))}
                     </SelectContent>
@@ -232,10 +249,20 @@ export function CreateKBDialog({ open, onOpenChange, onCreated }: CreateKBDialog
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value={DEPLOYMENT_KEY}>{t("deploymentKey")}</SelectItem>
+                      {/* The deployment's own key is an OpenRouter key too -
+                          `EmbeddingService` sends every request to
+                          openrouter.ai - so it carries the same mark as the
+                          organization's, and the row says which of them pays. */}
+                      <SelectItem value={DEPLOYMENT_KEY}>
+                        <ProviderRow provider={EMBEDDING_KEY_PURPOSE} name={t("deploymentKey")} />
+                      </SelectItem>
                       {embeddingKeys.map((secret) => (
                         <SelectItem key={secret.id} value={secret.id}>
-                          {secret.name}
+                          <ProviderRow
+                            provider={EMBEDDING_KEY_PURPOSE}
+                            name={secret.name}
+                            hint={secret.hint}
+                          />
                         </SelectItem>
                       ))}
                     </SelectContent>
@@ -264,9 +291,9 @@ export function CreateKBDialog({ open, onOpenChange, onCreated }: CreateKBDialog
             <details className="group border-border rounded-lg border">
               <summary className="text-foreground flex cursor-pointer list-none items-center gap-1.5 p-3 text-sm">
                 <ChevronRight className="h-3.5 w-3.5 transition-transform group-open:rotate-90" />
-                How documents are parsed
+                {t("howDocumentsAreParsed")}
                 <span className="text-muted-foreground ml-auto text-xs">
-                  {chosen ? "customized" : t("deploymentDefaults")}
+                  {chosen ? t("customized") : t("deploymentDefaults")}
                 </span>
               </summary>
               <div className="space-y-4 border-t p-4">

--- a/frontend/src/components/kb/create-kb-dialog.tsx
+++ b/frontend/src/components/kb/create-kb-dialog.tsx
@@ -218,6 +218,10 @@ export function CreateKBDialog({ open, onOpenChange, onCreated }: CreateKBDialog
                         <SelectItem
                           key={entry.model}
                           value={entry.model}
+                          // Without this every row answers to "openrouter…" -
+                          // the mark's title is part of the item's text - and
+                          // typing a model id finds nothing.
+                          textValue={entry.model}
                           // In the list rather than in the row: the trigger
                           // draws whatever the row draws, and "deployment
                           // default" is a comparison against the other options.
@@ -253,11 +257,11 @@ export function CreateKBDialog({ open, onOpenChange, onCreated }: CreateKBDialog
                           `EmbeddingService` sends every request to
                           openrouter.ai - so it carries the same mark as the
                           organization's, and the row says which of them pays. */}
-                      <SelectItem value={DEPLOYMENT_KEY}>
+                      <SelectItem value={DEPLOYMENT_KEY} textValue={t("deploymentKey")}>
                         <ProviderRow provider={EMBEDDING_KEY_PURPOSE} name={t("deploymentKey")} />
                       </SelectItem>
                       {embeddingKeys.map((secret) => (
-                        <SelectItem key={secret.id} value={secret.id}>
+                        <SelectItem key={secret.id} value={secret.id} textValue={secret.name}>
                           <ProviderRow
                             provider={EMBEDDING_KEY_PURPOSE}
                             name={secret.name}

--- a/frontend/src/components/kb/ingestion-settings.test.tsx
+++ b/frontend/src/components/kb/ingestion-settings.test.tsx
@@ -89,6 +89,25 @@ describe("IngestionSettings", () => {
     expect(screen.getByLabelText("LlamaParse tier")).toBeInTheDocument();
   });
 
+  it("tells two LlamaParse keys apart by their masked tails", async () => {
+    // Both are called after the service they are for, because that is what the
+    // inline form suggests - so with only a name in the row, "whose account is
+    // billed" was a choice between two identical options.
+    vi.mocked(apiClient.get).mockResolvedValue({
+      items: [
+        { id: "s-1", name: "LlamaParse", hint: "3123", purpose: "llamaparse", kind: "api_key" },
+        { id: "s-2", name: "LlamaParse", hint: "9999", purpose: "llamaparse", kind: "api_key" },
+      ],
+      total: 2,
+    });
+    show({ pdf_parser: "llamaparse" });
+
+    await userEvent.click(screen.getByLabelText("LlamaParse key"));
+
+    expect(await screen.findByRole("option", { name: /····3123/ })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /····9999/ })).toBeInTheDocument();
+  });
+
   it("offers OCR language and a timeout to the parser that reads them", () => {
     show({ pdf_parser: "liteparse" });
 

--- a/frontend/src/components/kb/ingestion-settings.tsx
+++ b/frontend/src/components/kb/ingestion-settings.tsx
@@ -17,6 +17,7 @@ import {
   Textarea,
 } from "@/components/ui";
 import { InlineSecret } from "@/components/vault/inline-secret";
+import { ProviderRow } from "@/components/vault/provider-row";
 import { useModelProviders, usePermissions, useSecrets } from "@/hooks";
 import {
   CHUNKING_STRATEGIES,
@@ -75,6 +76,9 @@ export interface IngestionSettingsProps {
 /** Sentinel for "the deployment's key" - a Select item may not be empty. */
 const DEPLOYMENT_KEY = "__deployment__";
 
+/** What a key here is for, which is also the id its mark is drawn from. */
+const LLAMAPARSE = "llamaparse";
+
 export function IngestionSettings({
   value,
   onChange,
@@ -84,7 +88,7 @@ export function IngestionSettings({
 }: IngestionSettingsProps) {
   const t = useTranslations("kb");
   const { secrets } = useSecrets();
-  const llamaparseKeys = secrets.filter((secret) => secret.purpose === "llamaparse");
+  const llamaparseKeys = secrets.filter((secret) => secret.purpose === LLAMAPARSE);
   const id = (suffix: string) => `${idPrefix}-${suffix}`;
   const set = <K extends keyof IngestionConfig>(key: K, next: IngestionConfig[K]) =>
     onChange({ ...value, [key]: next });
@@ -178,10 +182,16 @@ export function IngestionSettings({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value={DEPLOYMENT_KEY}>{t("deploymentKey2")}</SelectItem>
+                  <SelectItem value={DEPLOYMENT_KEY} textValue={t("deploymentKey2")}>
+                    <ProviderRow provider={LLAMAPARSE} name={t("deploymentKey2")} />
+                  </SelectItem>
                   {llamaparseKeys.map((secret) => (
-                    <SelectItem key={secret.id} value={secret.id}>
-                      {secret.name}
+                    <SelectItem key={secret.id} value={secret.id} textValue={secret.name}>
+                      {/* Every key in this list is a LlamaParse key - that is
+                          the filter - so the mark is the constant. The masked
+                          tail is what tells two of them apart, and without it
+                          two keys both called "LlamaParse" were one row twice. */}
+                      <ProviderRow provider={LLAMAPARSE} name={secret.name} hint={secret.hint} />
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -192,7 +202,7 @@ export function IngestionSettings({
                   picker had. */}
               <InlineSecret
                 kind="api_key"
-                purpose="llamaparse"
+                purpose={LLAMAPARSE}
                 suggestedName="LlamaParse"
                 helpUrl="https://cloud.llamaindex.ai/api-key"
                 disabled={disabled}

--- a/frontend/src/components/sandboxes/connection-dialog.test.tsx
+++ b/frontend/src/components/sandboxes/connection-dialog.test.tsx
@@ -193,9 +193,10 @@ describe("ConnectionDialog", () => {
     expect(markIn(marked)).toBe("OpenAI");
     expect(marked).toHaveTextContent("····1111");
     // `daytona` is a service with no compiled-in mark, and so is a key with no
-    // purpose at all: both fall back rather than drawing nothing.
-    expect(markIn(screen.getByRole("option", { name: /Daytona prod/ }))).toBeNull();
-    expect(markIn(screen.getByRole("option", { name: /Sandbox token/ }))).toBeNull();
+    // purpose at all. Both draw the monogram of what they are for - the initial
+    // in front of the name - rather than leaving the square empty.
+    expect(screen.getByRole("option", { name: /Daytona prod/ }).textContent).toMatch(/^dDaytona/);
+    expect(screen.getByRole("option", { name: /Sandbox token/ }).textContent).toMatch(/^cSandbox/);
   });
 
   it("carries the chosen key's mark on the closed trigger", async () => {

--- a/frontend/src/components/sandboxes/connection-dialog.test.tsx
+++ b/frontend/src/components/sandboxes/connection-dialog.test.tsx
@@ -5,8 +5,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ConnectionDialog } from "./connection-dialog";
 import type { SandboxConnectionRecord } from "@/lib/sandbox-connections-api";
 
+interface VaultKey {
+  id: string;
+  name: string;
+  kind: string;
+  hint: string;
+  /** What the key is for. Absent for one stored against no service at all. */
+  purpose?: string;
+}
+
 const state = vi.hoisted(() => ({
-  secrets: [{ id: "s-1", name: "Sandbox token", kind: "api_key", hint: "4242" }],
+  secrets: [{ id: "s-1", name: "Sandbox token", kind: "api_key", hint: "4242" }] as VaultKey[],
   local: null as {
     url: string | null;
     token_available: boolean;
@@ -45,6 +54,11 @@ vi.mock("@/components/vault/inline-secret", () => ({
     </button>
   ),
 }));
+
+/** The brand mark actually drawn, by the name lobehub titles its SVG with. */
+function markIn(element: HTMLElement): string | null {
+  return element.querySelector("svg > title")?.textContent ?? null;
+}
 
 function connection(overrides: Partial<SandboxConnectionRecord> = {}): SandboxConnectionRecord {
   return {
@@ -159,6 +173,38 @@ describe("ConnectionDialog", () => {
     await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
     expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ secret_id: "s-1" }));
+  });
+
+  it("draws each key's own mark and masked tail, and a monogram for a custom one", async () => {
+    // Any API key in the vault can be offered here, so the mark is the one
+    // thing that says which service a row's token actually belongs to. A key
+    // stored for no particular service has no logo anywhere - that is the
+    // normal case, and a monogram is what keeps it from being a blank gap.
+    state.secrets = [
+      { id: "s-1", name: "Sandbox token", kind: "api_key", hint: "4242" },
+      { id: "s-2", name: "Daytona prod", kind: "api_key", hint: "7777", purpose: "daytona" },
+      { id: "s-3", name: "Acme webhook", kind: "api_key", hint: "1111", purpose: "openai" },
+    ];
+    mount(connection({ secret_id: null }));
+
+    await userEvent.click(screen.getByLabelText("Credential"));
+
+    const marked = screen.getByRole("option", { name: /Acme webhook/ });
+    expect(markIn(marked)).toBe("OpenAI");
+    expect(marked).toHaveTextContent("····1111");
+    // `daytona` is a service with no compiled-in mark, and so is a key with no
+    // purpose at all: both fall back rather than drawing nothing.
+    expect(markIn(screen.getByRole("option", { name: /Daytona prod/ }))).toBeNull();
+    expect(markIn(screen.getByRole("option", { name: /Sandbox token/ }))).toBeNull();
+  });
+
+  it("carries the chosen key's mark on the closed trigger", async () => {
+    state.secrets = [
+      { id: "s-1", name: "OpenAI prod", kind: "api_key", hint: "4242", purpose: "openai" },
+    ];
+    mount(connection());
+
+    expect(markIn(screen.getByLabelText("Credential"))).toBe("OpenAI");
   });
 
   it("takes one added inline as well", async () => {

--- a/frontend/src/components/sandboxes/connection-dialog.tsx
+++ b/frontend/src/components/sandboxes/connection-dialog.tsx
@@ -20,6 +20,7 @@ import {
   Switch,
 } from "@/components/ui";
 import { InlineSecret } from "@/components/vault/inline-secret";
+import { ProviderRow } from "@/components/vault/provider-row";
 import { useLocalSandboxService, useSecrets } from "@/hooks";
 import { getErrorMessage } from "@/lib/utils";
 import type {
@@ -228,7 +229,15 @@ export function ConnectionDialog({ editing, onOpenChange, onSubmit }: Connection
               <SelectContent>
                 {usable.map((secret) => (
                   <SelectItem key={secret.id} value={secret.id}>
-                    {secret.name} <span className="font-mono">····{secret.hint}</span>
+                    {/* Any API key in the vault can be offered here, so the mark
+                        comes from what each one is for - a Daytona key looks
+                        like a Daytona key, and `custom` falls back to a
+                        monogram. */}
+                    <ProviderRow
+                      provider={secret.purpose ?? "custom"}
+                      name={secret.name}
+                      hint={secret.hint}
+                    />
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/frontend/src/components/sandboxes/connection-dialog.tsx
+++ b/frontend/src/components/sandboxes/connection-dialog.tsx
@@ -228,11 +228,12 @@ export function ConnectionDialog({ editing, onOpenChange, onSubmit }: Connection
               </SelectTrigger>
               <SelectContent>
                 {usable.map((secret) => (
-                  <SelectItem key={secret.id} value={secret.id}>
-                    {/* Any API key in the vault can be offered here, so the mark
-                        comes from what each one is for - a Daytona key looks
-                        like a Daytona key, and `custom` falls back to a
-                        monogram. */}
+                  <SelectItem key={secret.id} value={secret.id} textValue={secret.name}>
+                    {/* Every API key in the vault is offered here, whatever it
+                        is for, so its purpose is the only thing that says which
+                        service a row's token belongs to. Most of them have no
+                        brand mark - `sandboxd` and `daytona` included - and the
+                        monogram is what keeps those from being a blank gap. */}
                     <ProviderRow
                       provider={secret.purpose ?? "custom"}
                       name={secret.name}

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -110,8 +110,13 @@ SelectLabel.displayName = SelectPrimitive.Label.displayName;
  * against the other options - a tick meaning "this one already has a key" - must
  * not go in `children`, where the trigger would repeat it as if it meant
  * "selected". `trailing` renders outside `ItemText`, so it stays in the list;
- * give it `ml-auto` to sit at the right, inside the padding the selected-item
- * indicator occupies.
+ * give it `ml-auto` to put it at the right-hand edge of the content box, which
+ * `pr-8` keeps clear of the selected-item indicator.
+ *
+ * One thing `children` costs: an item with no `textValue` takes its
+ * type-to-search key from its own `textContent`, so children carrying anything
+ * but the label - a brand mark's `<title>`, a monogram's initial - need
+ * `textValue` as well. See `ProviderRow`.
  */
 const SelectItem = React.forwardRef<
   React.ComponentRef<typeof SelectPrimitive.Item>,

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -101,10 +101,22 @@ const SelectLabel = React.forwardRef<
 ));
 SelectLabel.displayName = SelectPrimitive.Label.displayName;
 
+/**
+ * One option.
+ *
+ * `children` is the option's text, and Radix mirrors it into `SelectValue`: the
+ * closed trigger draws whatever an item drew, which is how a brand mark reaches
+ * the trigger for free. The same mechanism is why a badge that only makes sense
+ * against the other options - a tick meaning "this one already has a key" - must
+ * not go in `children`, where the trigger would repeat it as if it meant
+ * "selected". `trailing` renders outside `ItemText`, so it stays in the list;
+ * give it `ml-auto` to sit at the right, inside the padding the selected-item
+ * indicator occupies.
+ */
 const SelectItem = React.forwardRef<
   React.ComponentRef<typeof SelectPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item> & { trailing?: React.ReactNode }
+>(({ className, children, trailing, ...props }, ref) => (
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
@@ -119,6 +131,7 @@ const SelectItem = React.forwardRef<
       </SelectPrimitive.ItemIndicator>
     </span>
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    {trailing}
   </SelectPrimitive.Item>
 ));
 SelectItem.displayName = SelectPrimitive.Item.displayName;

--- a/frontend/src/components/vault/provider-row.test.tsx
+++ b/frontend/src/components/vault/provider-row.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Check } from "lucide-react";
+import { describe, expect, it } from "vitest";
+
+import { ProviderRow } from "./provider-row";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui";
+
+/** The brand mark actually drawn, by the name lobehub titles its SVG with. */
+function markIn(element: HTMLElement): string | null {
+  return element.querySelector("svg > title")?.textContent ?? null;
+}
+
+describe("ProviderRow", () => {
+  it("draws the brand mark for the id it is given", () => {
+    const { container } = render(<ProviderRow provider="openrouter" name="Embeddings key" />);
+
+    expect(markIn(container)).toBe("OpenRouter");
+    expect(screen.getByText("Embeddings key")).toBeInTheDocument();
+  });
+
+  it("falls back to a monogram rather than a gap for an id with no mark", () => {
+    // A deployment gains a provider whenever Pydantic AI does, and a key can be
+    // for a service nobody has a logo for - so this is the normal case.
+    const { container } = render(<ProviderRow provider="custom" name="Acme webhook" />);
+
+    expect(container.querySelector("svg")).toBeNull();
+    expect(screen.getByText("c")).toBeInTheDocument();
+  });
+
+  it("masks a key's hint the way the vault listing does", () => {
+    render(<ProviderRow provider="openai" name="OpenAI prod" hint="3123" />);
+
+    expect(screen.getByText("····3123")).toBeInTheDocument();
+  });
+
+  it("draws no hint at all where there is no key to identify", () => {
+    // A provider row is a provider, not a credential; four dots with nothing
+    // after them would read as a key whose tail failed to load.
+    render(<ProviderRow provider="openai" name="OpenAI" />);
+
+    expect(screen.queryByText(/····/)).toBeNull();
+  });
+});
+
+/**
+ * Why the tick is `SelectItem`'s to draw and not this row's.
+ *
+ * Radix mirrors an item's `ItemText` children into `SelectValue`: the closed
+ * trigger renders whatever the selected item rendered. That is the whole reason
+ * a mark in the row reaches the trigger for nothing - and the reason anything
+ * meaningful only *against the other options* must stay out of it.
+ */
+describe("what a select trigger inherits from the row", () => {
+  function pickerWith(trailing: React.ReactNode) {
+    return render(
+      <Select defaultValue="openrouter">
+        <SelectTrigger aria-label="Provider">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="openrouter" trailing={trailing}>
+            <ProviderRow provider="openrouter" name="OpenRouter" />
+          </SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+  }
+
+  it("draws the selected row's mark in the closed trigger", () => {
+    pickerWith(null);
+
+    expect(markIn(screen.getByLabelText("Provider"))).toBe("OpenRouter");
+  });
+
+  it("leaves a trailing badge in the list instead of repeating it in the trigger", async () => {
+    pickerWith(<Check data-testid="keyed" className="ml-auto h-3.5 w-3.5" />);
+
+    expect(screen.queryByTestId("keyed")).toBeNull();
+
+    await userEvent.click(screen.getByLabelText("Provider"));
+    expect(screen.getByRole("option", { name: "OpenRouter" })).toContainElement(
+      screen.getByTestId("keyed"),
+    );
+  });
+});

--- a/frontend/src/components/vault/provider-row.test.tsx
+++ b/frontend/src/components/vault/provider-row.test.tsx
@@ -73,6 +73,37 @@ describe("what a select trigger inherits from the row", () => {
     expect(markIn(screen.getByLabelText("Provider"))).toBe("OpenRouter");
   });
 
+  it("needs `textValue`, because the mark's own title is part of the item's text", async () => {
+    // Radix takes an item's type-to-search key from its `textContent` unless
+    // `textValue` says otherwise, and lobehub titles its SVGs - so a row for
+    // `text-embedding-3-large` answered to `openroutertext-embedding-3-large`
+    // and typing `t` found nothing. Every picker that draws a mark passes it.
+    render(
+      <Select>
+        <SelectTrigger aria-label="Model">
+          <SelectValue placeholder="Pick one" />
+        </SelectTrigger>
+        <SelectContent>
+          {/* First, so that "the search did nothing" and "the search found the
+              second one" are two different outcomes rather than one. */}
+          <SelectItem value="ada" textValue="ada-002">
+            <ProviderRow provider="openrouter" name="ada-002" />
+          </SelectItem>
+          <SelectItem value="large" textValue="text-embedding-3-large">
+            <ProviderRow provider="openrouter" name="text-embedding-3-large" />
+          </SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+
+    await userEvent.click(screen.getByLabelText("Model"));
+    await userEvent.keyboard("t");
+
+    expect(screen.getByRole("option", { name: /text-embedding-3-large/ })).toHaveAttribute(
+      "data-highlighted",
+    );
+  });
+
   it("leaves a trailing badge in the list instead of repeating it in the trigger", async () => {
     pickerWith(<Check data-testid="keyed" className="ml-auto h-3.5 w-3.5" />);
 

--- a/frontend/src/components/vault/provider-row.tsx
+++ b/frontend/src/components/vault/provider-row.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { ProviderIcon } from "@/components/vault/provider-icon";
-import { cn } from "@/lib/utils";
 
 interface ProviderRowProps {
   /**
@@ -23,7 +22,6 @@ interface ProviderRowProps {
    * vault shows one.
    */
   hint?: string;
-  className?: string;
 }
 
 /**
@@ -41,15 +39,19 @@ interface ProviderRowProps {
  * meaning "this provider already has a key": in a trigger, next to nothing to
  * compare it with, it reads as "selected". `SelectItem` takes it as `trailing`
  * instead, where it stays in the list.
+ *
+ * **Inside a `SelectItem`, pass `textValue={name}`.** A `SelectItem` with no
+ * `textValue` takes its type-to-search key from the item's `textContent`, and a
+ * mark contributes to that: lobehub titles its SVGs, so a row for
+ * `text-embedding-3-large` answers to `openroutertext-embedding-3-large` and
+ * typing `t` finds nothing. `provider-row.test.tsx` holds the case.
  */
-export function ProviderRow({ provider, name, hint, className }: ProviderRowProps) {
+export function ProviderRow({ provider, name, hint }: ProviderRowProps) {
   return (
-    <span className={cn("flex min-w-0 items-center gap-2", className)}>
+    <span className="flex min-w-0 items-center gap-2">
       <ProviderIcon provider={provider} />
       <span className="truncate">{name}</span>
-      {hint !== undefined && (
-        <span className="text-muted-foreground shrink-0 font-mono">····{hint}</span>
-      )}
+      {hint && <span className="text-muted-foreground shrink-0 font-mono">····{hint}</span>}
     </span>
   );
 }

--- a/frontend/src/components/vault/provider-row.tsx
+++ b/frontend/src/components/vault/provider-row.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { ProviderIcon } from "@/components/vault/provider-icon";
+import { cn } from "@/lib/utils";
+
+interface ProviderRowProps {
+  /**
+   * The catalog id whose mark is drawn.
+   *
+   * A provider id where a provider is being chosen (`openrouter`), and a
+   * secret's `purpose` where a key is - the two are the same namespace, which
+   * is what makes a key's brand mark a lookup rather than a second table
+   * somebody has to keep in step.
+   */
+  provider: string;
+  /** What the thing is called, in the words its own catalog uses. */
+  name: string;
+  /**
+   * The four characters that identify a stored key, drawn masked: `····3123`.
+   *
+   * The mask belongs here rather than at each caller, because it is the
+   * convention that makes a hint read as a redacted credential everywhere the
+   * vault shows one.
+   */
+  hint?: string;
+  className?: string;
+}
+
+/**
+ * One row of a provider or key picker: the brand mark, the name, and the masked
+ * tail of a key where there is one.
+ *
+ * Choosing a provider and choosing a key for a provider are the same act, and
+ * they were drawn six different ways - a marked row in the Builder, bare strings
+ * in Create knowledge base, name-plus-hint in the sandbox connection dialog.
+ * Three clicks apart in one product, and not recognisably the same product.
+ *
+ * **A tick does not belong in here.** Radix mirrors a `SelectItem`'s
+ * `ItemText` children into `SelectValue`, so anything in this row is also drawn
+ * in the closed trigger - which is right for the mark and wrong for a tick
+ * meaning "this provider already has a key": in a trigger, next to nothing to
+ * compare it with, it reads as "selected". `SelectItem` takes it as `trailing`
+ * instead, where it stays in the list.
+ */
+export function ProviderRow({ provider, name, hint, className }: ProviderRowProps) {
+  return (
+    <span className={cn("flex min-w-0 items-center gap-2", className)}>
+      <ProviderIcon provider={provider} />
+      <span className="truncate">{name}</span>
+      {hint !== undefined && (
+        <span className="text-muted-foreground shrink-0 font-mono">····{hint}</span>
+      )}
+    </span>
+  );
+}

--- a/frontend/src/components/vault/secret-dialog.tsx
+++ b/frontend/src/components/vault/secret-dialog.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { toast } from "sonner";
 
-import { ProviderIcon } from "@/components/vault/provider-icon";
+import { ProviderRow } from "@/components/vault/provider-row";
 import { useSecretPurposes } from "@/hooks";
 import { cn } from "@/lib/utils";
 
@@ -245,13 +245,10 @@ export function AddSecretDialog({
                 </SelectTrigger>
                 <SelectContent className="max-h-80">
                   {inCategory.map((entry) => (
-                    <SelectItem key={entry.id} value={entry.id}>
+                    <SelectItem key={entry.id} value={entry.id} textValue={entry.label}>
                       {/* The mark, where there is one. A vault is scanned rather
                           than read, and a logo is what the eye lands on. */}
-                      <span className="flex items-center gap-2">
-                        <ProviderIcon provider={entry.id} className="h-4 w-4" />
-                        <span>{entry.label}</span>
-                      </span>
+                      <ProviderRow provider={entry.id} name={entry.label} />
                     </SelectItem>
                   ))}
                 </SelectContent>


### PR DESCRIPTION
Choosing a provider and choosing the key that pays for it are the same act, and this
console drew them several ways: a marked row in the Builder, bare strings in Create
knowledge base ("Deployment key", "OpenRouter", a raw model id), name-plus-hint in the
sandbox connection dialog and in three more pickers #304 did not name. Three clicks
apart in one product, and not recognisably the same product.

## What changed

**`components/vault/provider-row.tsx`** — one row: the brand mark, the name, and the
masked `····hint` of a key where there is one. Next to `ProviderIcon`, because a key's
mark is its `purpose` and that is the same namespace a provider id lives in — which is
what `secrets-table.tsx:118` already relies on. No new data anywhere.

Used in the four places #304 lists:

| | |
|---|---|
| `kb/create-kb-dialog.tsx` | the Key select, and the Model select above it |
| `agents/add-model.tsx` | its own Key select |
| `sandboxes/connection-dialog.tsx` | the secret select |

…in the two provider selects that were already right (`add-model`,
`chat-model-picker`), which now draw the component rather than a third and fourth copy
of its JSX…

…and in **four more the issue's table missed**, found by sweeping the siblings
(third commit): `agents/capability-settings.tsx` (the Builder's secret picker, the most
used key picker in the product), `agents/observability-card.tsx` (the Logfire token
picker — gene for gene the KB embedding-key select), `kb/ingestion-settings.tsx` (the
LlamaParse key picker, which had **no mark and no hint**, so two keys both called
"LlamaParse" were one row printed twice), and `vault/secret-dialog.tsx` (the vault's own
service picker, which drew the mark inline at `h-4 w-4` — it converges on the row's
`h-5 w-5`).

Every embedding request in this deployment goes to `openrouter.ai` on an OpenRouter key
— the deployment's own when a collection names none (`services/rag/embeddings.py:122-126`)
— so both selects in the Embeddings section carry that mark. Logfire, LlamaParse,
`sandboxd` and `daytona` have no brand mark anywhere, so those rows draw the monogram:
the same square in the same place, which is the argument for having it.

## What I found about `<SelectValue />`, and what it cost

Verified rather than assumed, and it cuts three ways.

1. Radix mirrors the selected item's `ItemText` children into the trigger, so **the mark
   arrives there for free** — the closed trigger holds the whole row.
2. It also means the **`<Check />` was being drawn in the closed trigger**, where there
   is nothing to compare it against and it reads as "selected" rather than "this
   provider already has a key". That was live on `main` in both provider selects.
   `SelectItem` grew a `trailing` slot rendered *outside* `ItemText`; the tick and the
   "deployment default" badge go there.
3. **And the mark's `<title>` becomes the item's type-to-search key.** A `SelectItem`
   with no `textValue` takes it from its own `textContent`, so every model in Create
   knowledge base answered to `openroutertext-embedding-3-large`: typing `t` found
   nothing and `o` collided on every row. Caught reviewing the first commit and fixed in
   the second — every item drawing a row now passes `textValue`, with a regression test
   that fails without it.

## Also, four hardcoded strings

`create-kb-dialog.tsx` had "Embeddings" and "How documents are parsed" as English in the
source (both named in #304), plus `"customized"` and `" (default)"` in the same two
elements. All four now read from `messages/en.json`; `customized` is the one new key.
`check_i18n.py` walks past all four — a text node alone on its line, and a lower-case
word inside a ternary — which is #249 / #314 / #325, not something this branch changes.

## How it was verified

- `make lint-frontend`, `make test-frontend-cov` (186 files, 3198 tests; 100%
  statements/functions/lines, 97.66% branches — up from 97.51), `make build-frontend`,
  `make check`.
- New: `provider-row.test.tsx` (the primitive, plus the three Radix trigger/typeahead
  contracts above), `create-kb-dialog.integration.test.tsx`. Extended:
  `add-model.integration.test.tsx`, `connection-dialog.test.tsx`,
  `chat-model-picker.test.tsx`, `capability-settings.integration.test.tsx`,
  `observability-card.test.tsx`, `ingestion-settings.test.tsx`.
- Three of those assertions were rewritten after checking they passed with the
  implementation reverted — the tick had only ever been asserted *absent from the
  trigger*, and two monogram cases were `expect(mark).toBeNull()`, which is equally true
  of a row that drew nothing at all.

**The automated reviewer did not see this diff.** `ai-review`'s `pull_request` trigger
was removed this morning in #313 (it had been failing inside Codex and reporting
success — #311), so the label does nothing. The review above is mine plus two subagent
sweeps: one for every other place a provider or key is picked, one reading the diff
against `CLAUDE.md`. It found the typeahead defect and the three weak tests.

If `make check` fails for you in `tests/test_migrations.py`, that is #346 — a constant
database name shared by concurrent worktrees — not this branch, which is frontend only.

## What is deliberately not fixed here

- **#328** — the embedding **Model** select's trigger is stuck on "Loading models…" and
  `embeddingModel` is clobbered to `""`. Radix's bubble input dispatches a `change` on
  the hidden native select before the items have registered their native options, so the
  controlled value bounces back empty. Verified in jsdom against `main`'s own markup
  before this branch touched the file; the mechanism is not jsdom-specific but it has not
  been watched in a browser, which the issue says. Its options draw the mark correctly;
  only the trigger cannot.
- **#341** — seven other selects put a comparative badge inside `children`, so their
  triggers repeat it: `runtime-field.tsx` mirrors an amber "NOT ON THIS HOST" into a
  trigger whose own comment records having to be truncated to cope. `trailing` is the
  remedy; each fix is two lines and none of them is this branch's file.
- The two-line summary rows (`secrets-table.tsx`, `model-profile-picker.tsx`, the active
  strip in `chat-model-picker.tsx`, the one-key line in `add-model.tsx`) keep their own
  layout. The primitive is a single-line row; widening it with a subtitle slot for four
  callers that each want a different one is the abstraction #139 is warning about, and
  the `add-model` line also carries an English sentence that belongs to the i18n sweep.

Closes #304
