### PR TITLE
fix(compose): give the Prefect runner a health probe it can pass

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -69,8 +69,12 @@ USER appuser
 
 EXPOSE 8000
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD python -c "import httpx; httpx.get('http://localhost:8000/api/v1/health')" || exit 1
-
+# No HEALTHCHECK here, deliberately. This image has two consumers with different
+# commands: the API (`uvicorn app.main:app`) and the Prefect runner
+# (`python -m app.worker.prefect_app`). The probe that used to live here asked
+# localhost:8000 for `/api/v1/health`, which the runner serves nothing on - so the
+# runner was `unhealthy` from the second it started and stayed that way, hiding
+# the one thing a health status exists to show. An image cannot know which of the
+# two it was started as; a service definition does. Both probes are in the compose
+# files, one per service.
 CMD ["python", "-m", "cli.commands", "server", "run", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/worker/prefect_app.py
+++ b/backend/app/worker/prefect_app.py
@@ -10,6 +10,10 @@ or to your Prefect Cloud workspace URL + PREFECT_API_KEY for Cloud mode.
 At most PREFECT_RUNNER_LIMIT runs execute at once; the rest queue.  Each run is a
 separate process that imports the whole application, so an uncapped runner meeting
 a backlog is an out-of-memory kill rather than a slow afternoon.
+
+The runner also serves its own health endpoint, on 127.0.0.1:8080 inside its
+container, so that a container orchestrator can tell a runner that is polling from
+one that has stopped.  See `main` for why it is not optional.
 """
 
 import asyncio
@@ -87,7 +91,19 @@ async def main() -> None:
     # this runner ended up with no ceiling at all: after three days of downtime it
     # picked up the backlog of `rag-sync-check` runs and started 71 processes at
     # once, 6 GiB on a 7.75 GiB host, and the kernel OOM-killed the API container.
-    await aserve(*deployments, limit=settings.PREFECT_RUNNER_LIMIT)
+    #
+    # `webserver` is what makes this container's health status mean something.
+    # It starts Prefect's runner webserver on a daemon thread, serving `/health`
+    # on PREFECT_RUNNER_SERVER_HOST:PREFECT_RUNNER_SERVER_PORT - the compose files
+    # pin those to 127.0.0.1:8080, reachable by a probe inside the container and by
+    # nothing else, which matters because the same server also exposes `/shutdown`.
+    # The endpoint answers 503 once `last_polled` is older than
+    # PREFECT_RUNNER_SERVER_MISSED_POLLS_TOLERANCE * PREFECT_RUNNER_POLL_FREQUENCY
+    # (20s by default), so a process that is alive but no longer polling reads as
+    # unhealthy rather than as fine. Before this, the runner inherited the API's
+    # HTTP probe from the shared image and was unhealthy from the second it
+    # started, which is a status nobody can act on.
+    await aserve(*deployments, limit=settings.PREFECT_RUNNER_LIMIT, webserver=True)
 
 
 if __name__ == "__main__":

--- a/backend/app/worker/prefect_app.py
+++ b/backend/app/worker/prefect_app.py
@@ -11,9 +11,11 @@ At most PREFECT_RUNNER_LIMIT runs execute at once; the rest queue.  Each run is 
 separate process that imports the whole application, so an uncapped runner meeting
 a backlog is an out-of-memory kill rather than a slow afternoon.
 
-The runner also serves its own health endpoint, on 127.0.0.1:8080 inside its
-container, so that a container orchestrator can tell a runner that is polling from
-one that has stopped.  See `main` for why it is not optional.
+The runner also serves its own health endpoint, so that a container orchestrator
+can tell a runner that is polling from one that has stopped.  Where it listens is
+Prefect's decision, not this module's - PREFECT_RUNNER_SERVER_HOST and
+PREFECT_RUNNER_SERVER_PORT, `localhost:8080` unless something sets them, which
+every compose file here does.  See `main` for why it is not optional.
 """
 
 import asyncio

--- a/backend/tests/test_prefect_app.py
+++ b/backend/tests/test_prefect_app.py
@@ -48,6 +48,24 @@ async def test_the_runner_refuses_to_start_more_runs_than_the_host_can_hold(
     assert isinstance(limit, int) and limit > 0
 
 
+async def test_the_runner_serves_a_health_endpoint_of_its_own(
+    captured_runner: MagicMock,
+) -> None:
+    """Without it this container's health status is a constant, and a constant is not a status.
+
+    The runner shares `agenticos_backend` with the API, whose image-level
+    `HEALTHCHECK` asked localhost:8000 for `/api/v1/health` - nothing the runner
+    serves, so it was `unhealthy` from the second it started and a runner that had
+    actually died looked exactly like one that was fine. `webserver=True` starts
+    Prefect's own runner server, whose `/health` answers 503 once `last_polled`
+    goes stale; the compose files probe it and the image no longer carries a
+    `HEALTHCHECK` at all.
+    """
+    await prefect_app.main()
+
+    assert captured_runner.factory.call_args.kwargs["webserver"] is True
+
+
 async def test_every_deployment_is_registered_before_the_runner_starts(
     captured_runner: MagicMock,
 ) -> None:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -52,6 +52,15 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    # Moved out of backend/Dockerfile, which the Prefect runner shares and could
+    # never answer; see docker-compose.yml for the whole reasoning, including why
+    # `raise_for_status` and a 30s start_period are not what the image had.
+    healthcheck:
+      test: ["CMD", "python", "-c", "import httpx; httpx.get('http://localhost:8000/api/v1/health').raise_for_status()"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 
   db:
@@ -132,6 +141,11 @@ services:
       - POSTGRES_HOST=db
       - REDIS_HOST=redis
       - PREFECT_API_URL=http://prefect-server:4200/api
+      # The runner's own health endpoint, started by app/worker/prefect_app.py.
+      # Bound to the loopback because the same webserver serves `/shutdown`; see
+      # docker-compose.yml.
+      - PREFECT_RUNNER_SERVER_HOST=127.0.0.1
+      - PREFECT_RUNNER_SERVER_PORT=8080
       # Empty unless the sandbox profile is up. Note what is absent from
       # this service: the Docker socket.
     networks:
@@ -143,6 +157,14 @@ services:
         condition: service_healthy
       app:
         condition: service_started
+    # 503 once the runner has missed two polls; the start_period covers the
+    # application import and the first poll. See docker-compose.yml.
+    healthcheck:
+      test: ["CMD", "python", "-c", "import httpx; httpx.get('http://127.0.0.1:8080/health').raise_for_status()"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
     restart: unless-stopped
 
   # The only service holding the Docker socket. See docker-compose.yml for the

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -63,6 +63,16 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    # Moved out of backend/Dockerfile, which the Prefect runner shares and could
+    # never answer; see docker-compose.yml for the whole reasoning, including why
+    # `raise_for_status` and a 30s start_period are not what the image had. Four
+    # workers import the application four times, so the grace matters more here.
+    healthcheck:
+      test: ["CMD", "python", "-c", "import httpx; httpx.get('http://localhost:8000/api/v1/health').raise_for_status()"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
     deploy:
       resources:
@@ -164,6 +174,11 @@ services:
       - POSTGRES_HOST=db
       - REDIS_HOST=redis
       - PREFECT_API_URL=http://prefect-server:4200/api
+      # The runner's own health endpoint, started by app/worker/prefect_app.py.
+      # Bound to the loopback because the same webserver serves `/shutdown`; see
+      # docker-compose.yml.
+      - PREFECT_RUNNER_SERVER_HOST=127.0.0.1
+      - PREFECT_RUNNER_SERVER_PORT=8080
       # Empty unless the sandbox profile is up. Note what is absent from
       # this service: the Docker socket.
     # Egress too: ingestion calls an embedding provider.
@@ -177,6 +192,14 @@ services:
         condition: service_healthy
       app:
         condition: service_started
+    # 503 once the runner has missed two polls; the start_period covers the
+    # application import and the first poll. See docker-compose.yml.
+    healthcheck:
+      test: ["CMD", "python", "-c", "import httpx; httpx.get('http://127.0.0.1:8080/health').raise_for_status()"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
     restart: unless-stopped
     deploy:
       resources:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,20 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    # This probe used to be a HEALTHCHECK in backend/Dockerfile, which the Prefect
+    # runner inherited along with the image and could never answer. It lives with
+    # the service that serves it now; see prefect-runner for the other half.
+    # Two things are not carried over verbatim. `raise_for_status`: `httpx.get` on
+    # its own returns a response object whatever the status, so the old probe
+    # passed on a 500 as happily as on a 200. And `start_period`, which was 5s -
+    # shorter than this application takes to import on any machine measured, so
+    # every start went through a spell of `unhealthy` before settling.
+    healthcheck:
+      test: ["CMD", "python", "-c", "import httpx; httpx.get('http://localhost:8000/api/v1/health').raise_for_status()"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 
   db:
@@ -138,6 +152,13 @@ services:
       - DEBUG=true
       - POSTGRES_HOST=db
       - PREFECT_API_URL=http://prefect-server:4200/api
+      # The runner's own health endpoint, started by app/worker/prefect_app.py.
+      # 127.0.0.1 rather than 0.0.0.0 because the same webserver also serves
+      # `/shutdown`, and the only caller that should reach it is the probe below,
+      # inside this container. Pinned here rather than left to Prefect's defaults
+      # so a value in backend/.env cannot move the port out from under the probe.
+      - PREFECT_RUNNER_SERVER_HOST=127.0.0.1
+      - PREFECT_RUNNER_SERVER_PORT=8080
     networks:
       - backend
     depends_on:
@@ -145,6 +166,17 @@ services:
         condition: service_healthy
       db:
         condition: service_healthy
+    # Answers 503 once the runner has missed two polls, so a process that is alive
+    # but no longer polling reads as unhealthy - which is the failure this status
+    # exists to show. The long start_period covers importing the whole application
+    # and registering the deployments: until the first poll `/health` has no
+    # `last_polled` to compare against and errors.
+    healthcheck:
+      test: ["CMD", "python", "-c", "import httpx; httpx.get('http://127.0.0.1:8080/health').raise_for_status()"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
     restart: unless-stopped
 
   # The only service that holds the Docker socket, and the reason an agent can

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,6 +128,8 @@ Computed properties:
 | `PREFECT_API_URL` | `http://localhost:4200/api` | The self-hosted server, or a Prefect Cloud workspace URL |
 | `PREFECT_API_KEY` | (none) | Prefect Cloud only |
 | `PREFECT_RUNNER_LIMIT` | `5` | How many flow runs execute at once; the rest queue |
+| `PREFECT_RUNNER_SERVER_HOST` | `127.0.0.1` in compose | Interface the runner serves its own health endpoint on |
+| `PREFECT_RUNNER_SERVER_PORT` | `8080` | Port for the same |
 
 `PREFECT_RUNNER_LIMIT` is a memory ceiling, not a throughput dial. Each run is a
 separate process that imports the whole application — roughly 120 MB — and the
@@ -136,6 +138,19 @@ finds every run that was scheduled while it was down, and starts as many as the
 limit allows. Uncapped, three days of downtime was 71 processes and 6 GiB. Raise
 it if ingestion queues behind syncs on a machine with memory to spare; lower it on
 a small host.
+
+The two `PREFECT_RUNNER_SERVER_*` variables are Prefect's, and the compose files
+pin them so the runner's container has a health status that means something. The
+runner starts Prefect's runner webserver, whose `GET /health` answers 503 once it
+has missed two polls of the Prefect API — so a process that is alive but no longer
+picking up work reads `unhealthy` rather than fine. It is bound to the loopback
+because the same webserver also exposes `POST /shutdown`; the probe runs inside
+the container, and nothing outside it can reach either. Moving the port means
+moving the probe in the compose files with it.
+
+There is no `HEALTHCHECK` in `backend/Dockerfile`. The image is started as two
+different processes — the API and this runner — and a probe for one is a
+permanent false alarm on the other, so each service definition carries its own.
 
 ## AI Models — configured in the app, not here
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -122,6 +122,24 @@ part is missing rather than that something failed.
 | A port is already taken (3000, 5432, 6379, 8000, 4200) | Something else is on it. `make dev-down`, stop the other process, start again |
 | Anything stranger | `make docker-clean` wipes containers, networks **and volumes** - all local data - then `make dev` from scratch |
 
+### The health column is worth reading
+
+Every service in every compose file carries its own healthcheck, so
+`docker compose ps` is a first diagnosis rather than decoration:
+
+| Service | `healthy` means |
+|---|---|
+| `app` | `GET /api/v1/health` answered 200 — uvicorn is serving |
+| `prefect-runner` | it polled the Prefect API within the last 20 seconds |
+| `db` · `redis` · `prefect-server` | `pg_isready` · `PING` · `GET /api/health` |
+
+The runner's probe is Prefect's own runner webserver, bound to `127.0.0.1:8080`
+inside the container and reachable from nowhere else. A runner whose process is
+alive but no longer polling turns `unhealthy` in about 45 seconds; it used to be
+`unhealthy` from the second it started, because it inherited the API's HTTP probe
+from the image the two services share. `backend/Dockerfile` now carries no
+`HEALTHCHECK` at all — see [Configuration](configuration.md#background-work-prefect).
+
 ## The database must be pgvector
 
 Not stock Postgres. The retrieval store issues

--- a/docs/install.md
+++ b/docs/install.md
@@ -124,20 +124,23 @@ part is missing rather than that something failed.
 
 ### The health column is worth reading
 
-Every service in every compose file carries its own healthcheck, so
-`docker compose ps` is a first diagnosis rather than decoration:
+Every backend service has a probe, so `docker compose ps` is a first diagnosis
+rather than decoration:
 
 | Service | `healthy` means |
 |---|---|
 | `app` | `GET /api/v1/health` answered 200 — uvicorn is serving |
 | `prefect-runner` | it polled the Prefect API within the last 20 seconds |
 | `db` · `redis` · `prefect-server` | `pg_isready` · `PING` · `GET /api/health` |
+| `sandboxd` | `GET /healthz` — its own image's probe, not one of ours |
 
 The runner's probe is Prefect's own runner webserver, bound to `127.0.0.1:8080`
 inside the container and reachable from nowhere else. A runner whose process is
-alive but no longer polling turns `unhealthy` in about 45 seconds; it used to be
-`unhealthy` from the second it started, because it inherited the API's HTTP probe
-from the image the two services share. `backend/Dockerfile` now carries no
+alive but no longer polling turns `unhealthy` inside a minute — up to 20 seconds
+before `/health` starts answering 503, then three failed probes 15 seconds apart;
+42 seconds when it was measured. It used to be `unhealthy` from the second it
+started, because it inherited the API's HTTP probe from the image the two
+services share. `backend/Dockerfile` now carries no
 `HEALTHCHECK` at all — see [Configuration](configuration.md#background-work-prefect).
 
 ## The database must be pgvector


### PR DESCRIPTION
`prefect-runner` runs the `agenticos_backend` image and inherited the
`HEALTHCHECK` written for the API, which asks localhost:8000 for
`/api/v1/health`. The runner is `python -m app.worker.prefect_app` and serves no
HTTP, so the probe had never once succeeded and never could: `unhealthy` was the
container's resting state, a runner that had actually died looked exactly like
one that was fine, and `depends_on: condition: service_healthy` against it was
off the table. No compose file overrode it, so production was in the same state
as a laptop.

## Which options, and why

The issue's recommended pair, **(2) + (3)**, unchanged.

**(2) A probe the runner can pass.** `aserve(*deployments, limit=…, webserver=True)`
in `backend/app/worker/prefect_app.py`. Checked against the installed Prefect
(3.8.1) rather than taken on trust: `aserve` forwards `**kwargs` to `Runner`,
which takes `webserver: bool = False`; `Runner.start` puts the webserver on a
daemon thread; `build_server` routes `/health`, `/run_count` and `/shutdown`; and
`perform_health_check` answers **503** once `last_polled` is older than
`PREFECT_RUNNER_SERVER_MISSED_POLLS_TOLERANCE * PREFECT_RUNNER_POLL_FREQUENCY`
(2 × 10s). So the status tracks polling rather than the process merely existing —
which is the shape #308 is about, one service over.

**(3) The probe leaves the image.** An image started as two different processes
cannot know which one it is; a service definition does.

Two departures from the issue, both small:

- **The host and port are pinned in `environment:`** (`PREFECT_RUNNER_SERVER_HOST=127.0.0.1`,
  `PREFECT_RUNNER_SERVER_PORT=8080`) rather than left to Prefect's defaults
  (`localhost`, `8080`). The same webserver serves `POST /shutdown`, so it should
  be reachable by the in-container probe and by nothing else, and a value in
  `backend/.env` must not be able to move the port out from under the probe.
- **The API probe is not moved verbatim.** It gains `.raise_for_status()` —
  `httpx.get` on its own returns a response object whatever the status, so the
  probe as written passed on a 500 as happily as on a 200 — and its
  `start_period` goes 5s → 30s, because 5s is shorter than this application takes
  to import anywhere it was measured, so every start went through a spell of
  `unhealthy` before settling. That is the same "learn to ignore the column"
  habit the issue is about.

## Exactly which lines moved, for #308's merge

Removed — `backend/Dockerfile:72-74`, replaced by a comment saying why the image
has no probe:

```dockerfile
# Health check
HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
    CMD python -c "import httpx; httpx.get('http://localhost:8000/api/v1/health')" || exit 1
```

Added, in `docker-compose.yml`, `docker-compose-dev.yml` and
`docker-compose-prod.yml`:

| Service | What was added |
|---|---|
| `app` | a `healthcheck:` block, between `depends_on:` and `restart:` |
| `prefect-runner` | two `PREFECT_RUNNER_SERVER_*` entries in `environment:`, and a `healthcheck:` block between `depends_on:` and `restart:` |

**Nothing else in the compose files is touched** — no `command:`, no `restart:`,
no `depends_on:`. #308 owns the `app` service's command and supervision strategy;
this branch owns the `HEALTHCHECK` line and the two probes that replace it.

Checked against #334 (#308's branch), which is finished and green: it leaves
`backend/Dockerfile` and every `prefect-runner` service alone. Both diffs do edit
the `app` service in `docker-compose.yml`, in separate hunks about ten lines
apart — its `command:` between `environment:` and `networks:` (lines 46-55), this
one's `healthcheck:` after `depends_on:` (from 57). The `docs/install.md` hunks
are at its line 168 against this one's 122. Both should merge clean; whichever
lands second is worth a glance at that block.

## How it was verified

Docker **was** available. The whole local stack was brought up from this branch
under its own project name (`agenticos310`), image tag
(`agenticos310_backend:dev`), container names and bridge network, so it could not
collide with the stack already running on the host:

| Check | Result |
|---|---|
| `prefect-runner` after start | `starting` → **`healthy` at t+15s** |
| `prefect-server` stopped — runner alive, cannot poll | **`unhealthy` 42s later** (up to 20s of staleness, then three probes 15s apart) |
| `prefect-server` started again | back to **`healthy` within 21s** |
| `docker inspect` on the built image | `Config.Healthcheck: null` |
| `httpx.get('http://prefect-runner:8080/health')` from the `app` container | `ConnectError: Connection refused` — neither `/health` nor `/shutdown` is on the network |
| `app` after `alembic upgrade head` | `healthy` |

Both halves of the issue's "how you would know it was fixed", then, with one
substitution worth stating plainly: **the failure was induced by taking the
Prefect API away, not by stopping the runner process.** `SIGSTOP` on the runner
was tried first and is not a usable test — the kernel ignores it for PID 1 of a
namespace, so the container stayed healthy with the signal discarded rather than
the process frozen (`/proc/1/stat` still `S`). Removing the API exercises the
same path the probe exists for: a process that is up and no longer working.

Also run: `make check` (every CI job but e2e), and
`docker compose config -q` against each of the three files.

## Two false reds this branch found and did not cause

- **`e2e` was red on the first run — [#335](https://github.com/vstorm-co/agenticos/issues/335).**
  The `[seed]` project's membership step (`e2e/seed.setup.ts:244`) reads the
  member list once after the acceptance rather than polling like every other
  step in that file; being a project dependency, it reports the suite red having
  run **no product spec at all** (87 did not run). The identical failure hit
  `main` at 11:58 UTC, an hour before this branch existed. Re-run: green.
- **`make check` was red twice locally — [#344](https://github.com/vstorm-co/agenticos/issues/344)**
  (filed again as #346, closed as a duplicate). `tests/test_migrations.py` drives
  one fixed database name, `agenticos_migrations_test`, so the several
  `make check` runs on this machine broke each other's chain — a different test
  each time. All four pass in isolation
  (`uv run pytest tests/test_migrations.py -q` → 4 passed) and CI, which gets a
  database per job, passed them. #189, one module over.

Neither is fixed here — both are out of scope and filed triaged.

## Docs

- `docs/configuration.md` — the two `PREFECT_RUNNER_SERVER_*` variables, what the
  runner's `healthy` means, and why `backend/Dockerfile` carries no `HEALTHCHECK`.
- `docs/install.md` — a short "the health column is worth reading" table under
  *When it does not come up*, which is where somebody reads a red row.

## Tests

`backend/tests/test_prefect_app.py` gains
`test_the_runner_serves_a_health_endpoint_of_its_own`, asserting `webserver=True`
reaches the `Runner`. It fails without the one-line change.

## Review

`ai-review` is off: PR #313 removed the `pull_request` trigger this morning, so
the label does nothing and its silence is not a verdict (#311 — it had been
dying twelve seconds into every run while concluding `success`). The maintainer
pass was done by hand and by a subagent over the whole diff, hunting for other
consumers of the image, drift between the three compose files, `.claude/` and
`docs/` gone stale, and comments claiming more than is true. Three things it
found, all in the second commit:

- `docs/install.md` claimed every service in every compose file carries its own
  healthcheck. `sandboxd`'s comes from its own image; the table says so now.
- "turns unhealthy in about 45 seconds" was Docker's confirmation window alone
  and omitted the up-to-20s before `/health` answers 503 at all — somebody
  timing an incident off it would call a stale runner healthy.
- The module docstring gave `127.0.0.1:8080` as though `webserver=True` chose it.
  Prefect chooses `localhost:8080`; the compose files pin the rest.

Nothing about the code itself came back, and the compose blocks are byte
identical across the three files.

## Not in this branch

[#336](https://github.com/vstorm-co/agenticos/issues/336) cites this PR for
making the probes honest without making anything *act* on them: Docker does not
restart a container for being `unhealthy`. That is true and deliberate — a
restart policy is #334's half of the pair, and this branch does not touch any
service's `restart:`.

Everything on this PR is green, e2e included, after the re-run described above.

Closes #310
