### PR TITLE
fix(compose): supervise the local reloader so a killed worker comes back

### DIFF
--- a/backend/cli/commands.py
+++ b/backend/cli/commands.py
@@ -12,11 +12,11 @@ from tabulate import tabulate
 from app import __version__
 from app.commands import register_commands
 from app.main import app
-from cli.reload_supervisor import APP, WS_PROTOCOL, run_reload_server
 from app.core.exceptions import AlreadyExistsError
 from app.db.session import async_session_maker
 from app.schemas.user import UserCreate
 from app.services.user import UserService
+from cli.reload_supervisor import APP, WS_PROTOCOL, run_reload_server
 
 
 @click.group()
@@ -34,7 +34,7 @@ def server_cli():
 @click.option("--host", default="0.0.0.0", help="Host to bind to")
 @click.option("--port", default=8000, type=int, help="Port to bind to")
 @click.option("--reload", is_flag=True, help="Enable auto-reload")
-def server_run(host: str, port: int, reload: bool):
+def server_run(host: str, port: int, reload: bool) -> None:
     """Run the server.
 
     `--reload` runs under `SupervisedReload` rather than uvicorn's own reloader,

--- a/backend/cli/commands.py
+++ b/backend/cli/commands.py
@@ -12,6 +12,7 @@ from tabulate import tabulate
 from app import __version__
 from app.commands import register_commands
 from app.main import app
+from cli.reload_supervisor import APP, WS_PROTOCOL, run_reload_server
 from app.core.exceptions import AlreadyExistsError
 from app.db.session import async_session_maker
 from app.schemas.user import UserCreate
@@ -34,13 +35,16 @@ def server_cli():
 @click.option("--port", default=8000, type=int, help="Port to bind to")
 @click.option("--reload", is_flag=True, help="Enable auto-reload")
 def server_run(host: str, port: int, reload: bool):
-    """Run the development server."""
-    uvicorn.run(
-        "app.main:app",
-        host=host,
-        port=port,
-        reload=reload,
-    )
+    """Run the server.
+
+    `--reload` runs under `SupervisedReload` rather than uvicorn's own reloader,
+    which never notices a worker the kernel kills - it keeps watching files
+    while nothing is listening. `cli/reload_supervisor.py` has the whole story.
+    """
+    if reload:
+        run_reload_server(host=host, port=port)
+        return
+    uvicorn.run(APP, host=host, port=port, ws=WS_PROTOCOL)
 
 
 @server_cli.command("routes")

--- a/backend/cli/reload_supervisor.py
+++ b/backend/cli/reload_supervisor.py
@@ -1,0 +1,114 @@
+"""The development server, and the supervision `uvicorn --reload` does not do.
+
+`--reload` starts a *file watcher*, not a process supervisor. Its loop reacts to
+a file changing and to a signal arriving, and to nothing else:
+`uvicorn.supervisors.basereload.BaseReload.run` never reads
+`self.process.exitcode`. So a worker the kernel kills is never noticed. The
+reloader keeps watching, the dead worker stays a zombie because nobody waited on
+it, and in a container PID 1 is therefore still alive - `docker ps` says `Up`,
+the restart policy has nothing to act on, and no port is listening. The health
+check does go `unhealthy`, but a column is not a mechanism.
+
+An out-of-memory kill is the realistic way in.
+
+Only the reload path has this hole. `--workers`, which is what production runs,
+gets uvicorn's `Multiprocess` supervisor, and its `keep_subprocess_alive` already
+polls, reaps and replaces a dead worker twice a second. This module gives the
+reload path the same treatment, with one distinction the workers path does not
+need:
+
+- **Killed by a signal** (`exitcode < 0`, so `-9` for the OOM killer). The code
+  is fine and nobody is coming to edit it. Reap and start a replacement.
+- **Exited on its own** (`exitcode >= 0`). The application raised on import or
+  called `sys.exit`; respawning would loop on the same traceback forever. Reap,
+  say so once, and wait for the file change that fixes it - which is the whole
+  reason `--reload` exists.
+
+Either way the process is reaped, so the zombies are gone in both cases.
+"""
+
+import logging
+from pathlib import Path
+from socket import socket
+from typing import Final
+
+from uvicorn import Config, Server
+from uvicorn.supervisors import ChangeReload
+
+# uvicorn's `auto` picks the legacy websockets implementation, which fails the
+# handshake against websockets >=14 with an HTTP 500. The dashboard chat is a
+# WebSocket, so `auto` means no chat at all. Every compose file passes this for
+# the same reason; the development server reads it from here.
+WS_PROTOCOL: Final = "websockets-sansio"
+
+APP: Final = "app.main:app"
+
+logger = logging.getLogger("uvicorn.error")
+
+
+class SupervisedReload(ChangeReload):
+    """A `--reload` reloader that also notices a worker the kernel killed.
+
+    `ChangeReload` polls for changes with a timeout rather than blocking
+    forever, so overriding `should_restart` is enough to get a periodic tick:
+    `WatchFilesReload` passes `yield_on_timeout=True` with watchfiles' 5s
+    `rust_timeout`, and the fallback `StatReload` polls at `reload_delay`.
+    Detection therefore costs at most about five seconds, against the three
+    failed health checks - ninety seconds - that a container restart would take.
+    """
+
+    def __init__(self, config: Config, target: object, sockets: list[socket]) -> None:
+        super().__init__(config, target, sockets)
+        # The pid whose ordinary exit has already been reported, so the "waiting
+        # for a change" line is written once rather than on every poll.
+        self._reported_pid: int | None = None
+
+    def should_restart(self) -> list[Path] | None:
+        changes = super().should_restart()
+        if changes is not None:
+            return changes
+        self._replace_a_killed_worker()
+        return None
+
+    def _replace_a_killed_worker(self) -> None:
+        """Reap a worker that is gone, and replace it if it was killed.
+
+        Reading `exitcode` is what clears the zombie: the property calls
+        `Popen.poll()`, which is a `waitpid` with `WNOHANG`. It answers `None`
+        while the worker is running.
+        """
+        exitcode = self.process.exitcode
+        if exitcode is None:
+            return
+
+        pid = self.process.pid
+        if exitcode < 0:
+            logger.error(
+                "Server process [%s] was killed by signal %s. Starting a replacement.",
+                pid,
+                -exitcode,
+            )
+            # `restart` terminates, joins and respawns. Terminating a process
+            # that has already exited is a no-op, so this is the whole job.
+            self.restart()
+            return
+
+        if pid != self._reported_pid:
+            self._reported_pid = pid
+            logger.error(
+                "Server process [%s] exited with code %s. Waiting for a file change.",
+                pid,
+                exitcode,
+            )
+
+
+def run_reload_server(*, host: str, port: int) -> None:
+    """Run the development server under `SupervisedReload`.
+
+    The wiring is `uvicorn.main.run`'s own reload branch, with the supervisor
+    swapped: bind the socket in the parent so a replacement worker inherits a
+    port that never stopped being bound.
+    """
+    config = Config(APP, host=host, port=port, reload=True, ws=WS_PROTOCOL)
+    server = Server(config=config)
+    SupervisedReload(config, target=server.run, sockets=[config.bind_socket()]).run()

--- a/backend/cli/reload_supervisor.py
+++ b/backend/cli/reload_supervisor.py
@@ -17,22 +17,27 @@ polls, reaps and replaces a dead worker twice a second. This module gives the
 reload path the same treatment, with one distinction the workers path does not
 need:
 
-- **Killed by a signal** (`exitcode < 0`, so `-9` for the OOM killer). The code
-  is fine and nobody is coming to edit it. Reap and start a replacement.
+- **Died from a signal** (`exitcode < 0`). `-9` is the OOM killer; `-15` is a
+  `kill` from outside, and a *graceful* shutdown lands here too, because
+  `Server.capture_signals` re-raises the signal it just handled cleanly. The
+  distinction does not matter: the process is gone, nothing is listening, and no
+  edit is coming. Reap and start a replacement.
 - **Exited on its own** (`exitcode >= 0`). The application raised on import or
   called `sys.exit`; respawning would loop on the same traceback forever. Reap,
   say so once, and wait for the file change that fixes it - which is the whole
   reason `--reload` exists.
 
-Either way the process is reaped, so the zombies are gone in both cases.
+Either way the process is reaped, so the zombies are gone in both cases. Neither
+happens once `should_exit` is set: a replacement started while the reloader is
+shutting down is a process nothing will ever stop.
 
 **This module is its own entrypoint** - `python -m cli.reload_supervisor` - and
-imports nothing but uvicorn on purpose. Reaching it through `cli.commands`
-instead would pull `app.main` into the reloader, and the reloader never serves a
-request: measured in `agenticos_backend:dev`, importing `cli.commands` peaks at
-464 MB against 28 MB for uvicorn alone. Handing the process that exists to
-survive an out-of-memory kill another 436 MB to be killed for would be an odd
-way to fix this.
+imports nothing beyond uvicorn and click on purpose. Reaching it through
+`cli.commands` instead would pull `app.main` into the reloader, and the reloader
+never serves a request: measured in `agenticos_backend:dev`, importing
+`cli.commands` peaks at 464 MB against 28 MB for uvicorn alone. Handing the
+process that exists to survive an out-of-memory kill another 436 MB to be killed
+for would be an odd way to fix this.
 """
 
 import logging
@@ -50,8 +55,9 @@ from uvicorn.supervisors import ChangeReload
 
 # uvicorn's `auto` picks the legacy websockets implementation, which fails the
 # handshake against websockets >=14 with an HTTP 500. The dashboard chat is a
-# WebSocket, so `auto` means no chat at all. Every compose file passes this for
-# the same reason; the development server reads it from here.
+# WebSocket, so `auto` means no chat at all. The other two compose files pass
+# `--ws websockets-sansio` on their own command lines for the same reason;
+# `docker-compose.yml` and `agenticos server run` read it from here instead.
 WS_PROTOCOL: Final = "websockets-sansio"
 
 APP: Final = "app.main:app"
@@ -60,7 +66,7 @@ logger = logging.getLogger("uvicorn.error")
 
 
 class SupervisedReload(ChangeReload):
-    """A `--reload` reloader that also notices a worker the kernel killed.
+    """A `--reload` reloader that also notices a worker that died.
 
     `ChangeReload` polls for changes with a timeout rather than blocking
     forever, so overriding `should_restart` is enough to get a periodic tick:
@@ -82,27 +88,35 @@ class SupervisedReload(ChangeReload):
         self._reported_pid: int | None = None
 
     def should_restart(self) -> list[Path] | None:
+        # `if changes`, not `is not None`: a change to a file the reload filter
+        # rejects yields `[]`, which `BaseReload.run` treats as no change at
+        # all. Reading it as one would skip supervision for that tick - and the
+        # local stack mounts `media_data` inside the watched directory, so
+        # ingestion writing a file is enough to produce a steady drip of them.
         changes = super().should_restart()
-        if changes is not None:
+        if changes:
             return changes
-        self._replace_a_killed_worker()
+        self._replace_a_dead_worker()
         return None
 
-    def _replace_a_killed_worker(self) -> None:
-        """Reap a worker that is gone, and replace it if it was killed.
+    def _replace_a_dead_worker(self) -> None:
+        """Reap a worker that is gone, and replace it if a signal took it.
 
         Reading `exitcode` is what clears the zombie: the property calls
         `Popen.poll()`, which is a `waitpid` with `WNOHANG`. It answers `None`
         while the worker is running.
         """
         exitcode = self.process.exitcode
-        if exitcode is None:
+        if exitcode is None or self.should_exit.is_set():
+            # Nothing to do, or the reloader is on its way out and a fresh
+            # worker would outlive the supervisor meant to stop it. This is the
+            # same guard `Multiprocess.keep_subprocess_alive` opens with.
             return
 
         pid = self.process.pid
         if exitcode < 0:
             logger.error(
-                "Server process [%s] was killed by signal %s. Starting a replacement.",
+                "Server process [%s] died from signal %s. Starting a replacement.",
                 pid,
                 -exitcode,
             )

--- a/backend/cli/reload_supervisor.py
+++ b/backend/cli/reload_supervisor.py
@@ -25,14 +25,27 @@ need:
   reason `--reload` exists.
 
 Either way the process is reaped, so the zombies are gone in both cases.
+
+**This module is its own entrypoint** - `python -m cli.reload_supervisor` - and
+imports nothing but uvicorn on purpose. Reaching it through `cli.commands`
+instead would pull `app.main` into the reloader, and the reloader never serves a
+request: measured in `agenticos_backend:dev`, importing `cli.commands` peaks at
+464 MB against 28 MB for uvicorn alone. Handing the process that exists to
+survive an out-of-memory kill another 436 MB to be killed for would be an odd
+way to fix this.
 """
 
 import logging
+from collections.abc import Callable
 from pathlib import Path
 from socket import socket
 from typing import Final
 
+import click
 from uvicorn import Config, Server
+
+# The reload supervisor uvicorn's own `main.run` uses: `WatchFilesReload`, or
+# `StatReload` where watchfiles is missing. `uvicorn[standard]` ships watchfiles.
 from uvicorn.supervisors import ChangeReload
 
 # uvicorn's `auto` picks the legacy websockets implementation, which fails the
@@ -57,7 +70,12 @@ class SupervisedReload(ChangeReload):
     failed health checks - ninety seconds - that a container restart would take.
     """
 
-    def __init__(self, config: Config, target: object, sockets: list[socket]) -> None:
+    def __init__(
+        self,
+        config: Config,
+        target: Callable[[list[socket] | None], None],
+        sockets: list[socket],
+    ) -> None:
         super().__init__(config, target, sockets)
         # The pid whose ordinary exit has already been reported, so the "waiting
         # for a change" line is written once rather than on every poll.
@@ -112,3 +130,15 @@ def run_reload_server(*, host: str, port: int) -> None:
     config = Config(APP, host=host, port=port, reload=True, ws=WS_PROTOCOL)
     server = Server(config=config)
     SupervisedReload(config, target=server.run, sockets=[config.bind_socket()]).run()
+
+
+@click.command()
+@click.option("--host", default="0.0.0.0", help="Host to bind to")
+@click.option("--port", default=8000, type=int, help="Port to bind to")
+def main(host: str, port: int) -> None:
+    """Run the development server with a supervised reloader."""
+    run_reload_server(host=host, port=port)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_reload_supervisor.py
+++ b/backend/tests/test_reload_supervisor.py
@@ -8,6 +8,8 @@ edit that fixes it - and that the local stack actually runs the supervisor.
 """
 
 import logging
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -127,20 +129,43 @@ def test_the_development_server_keeps_the_sansio_websocket_implementation(
     assert captured[0].should_reload
 
 
-def test_the_local_stack_does_not_run_uvicorns_unsupervised_reloader() -> None:
-    """The whole of #308 is that `uvicorn --reload` is PID 1 of this container."""
+def test_the_entrypoint_does_not_drag_the_application_into_the_reloader() -> None:
+    """The reloader serves no request, so it should hold no application.
+
+    Importing `cli.commands` peaks at 464 MB in `agenticos_backend:dev` against
+    28 MB for uvicorn alone, and this process exists to survive an
+    out-of-memory kill. A convenience import of anything under `app.` in
+    `cli/reload_supervisor.py` would quietly undo that.
+    """
+    probe = "import cli.reload_supervisor, sys; print(any(m == 'app' or m.startswith('app.') for m in sys.modules))"
+    loaded = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=REPO_ROOT / "backend",
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert loaded.stdout.strip() == "False"
+
+
+def test_the_local_stack_runs_the_supervisor_and_not_uvicorns_own_reloader() -> None:
+    """The whole of #308 is that `uvicorn --reload` was PID 1 of this container.
+
+    `cli.reload_supervisor` and not `cli.commands server run --reload`: the
+    latter imports `app.main`, which would carry the entire application inside
+    a reloader that never serves a request - on a fix about surviving an
+    out-of-memory kill.
+    """
     compose: dict[str, Any] = yaml.safe_load(LOCAL_COMPOSE.read_text())
     command = compose["services"]["app"]["command"]
 
     assert command.split() == [
         "python",
         "-m",
-        "cli.commands",
-        "server",
-        "run",
+        "cli.reload_supervisor",
         "--host",
         "0.0.0.0",
         "--port",
         "8000",
-        "--reload",
     ]

--- a/backend/tests/test_reload_supervisor.py
+++ b/backend/tests/test_reload_supervisor.py
@@ -80,11 +80,23 @@ def test_a_worker_that_exited_on_its_own_is_not_replaced(supervisor: RecordingRe
     assert supervisor.replacements == 0
 
 
-def test_a_running_worker_is_left_alone(supervisor: RecordingReload) -> None:
-    supervisor.process = FakeWorker(None)
+def test_a_running_worker_is_left_alone(
+    supervisor: RecordingReload, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The expensive way to get this wrong is to restart a worker that is fine.
+
+    `exitcode` answers `None` while the process runs, and a supervisor that
+    treated that as death would replace the server on every poll - every five
+    seconds, for ever. Worth a test even though it asserts that nothing
+    happened.
+    """
+    worker = FakeWorker(None)
+    supervisor.process = worker
 
     assert supervisor.should_restart() is None
     assert supervisor.replacements == 0
+    assert supervisor.process is worker
+    assert caplog.records == []
 
 
 def test_an_ordinary_exit_is_reported_once_rather_than_every_poll(
@@ -100,6 +112,18 @@ def test_an_ordinary_exit_is_reported_once_rather_than_every_poll(
     ) == 1
 
 
+def test_a_second_worker_dying_is_reported_again(
+    supervisor: RecordingReload, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Reporting once is per worker, not once for the life of the reloader."""
+    supervisor.process = FakeWorker(1, pid=1)
+    supervisor.should_restart()
+    supervisor.process = FakeWorker(1, pid=2)
+    supervisor.should_restart()
+
+    assert len(caplog.records) == 2
+
+
 def test_a_file_change_still_reloads(
     supervisor: RecordingReload, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -109,6 +133,41 @@ def test_a_file_change_still_reloads(
     supervisor.process = FakeWorker(None)
 
     assert supervisor.should_restart() == changed
+    assert supervisor.replacements == 0
+
+
+def test_a_change_the_reload_filter_rejects_does_not_skip_supervision(
+    supervisor: RecordingReload, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`[]` is not a change, and reading it as one would strand a dead worker.
+
+    `WatchFilesReload.should_restart` filters after watchfiles yields, so a
+    write to a non-Python file inside a watched directory answers `[]` rather
+    than `None`. The local stack mounts `media_data` under the watched `/app`,
+    so ingestion alone produces these - and a supervisor that took each one for
+    a reload would postpone noticing a dead worker for as long as they kept
+    arriving.
+    """
+    monkeypatch.setattr(ChangeReload, "should_restart", lambda self: [])
+    supervisor.process = FakeWorker(-9)
+
+    assert supervisor.should_restart() is None
+    assert supervisor.replacements == 1
+
+
+def test_a_worker_dying_during_shutdown_is_not_replaced(
+    supervisor: RecordingReload,
+) -> None:
+    """A replacement started while the reloader is leaving is an orphan.
+
+    Uvicorn re-raises a signal it handled gracefully, so a worker that shut
+    down cleanly on SIGTERM reports `-15` and is otherwise indistinguishable
+    from one the kernel killed. `should_exit` is what tells them apart.
+    """
+    supervisor.should_exit.set()
+    supervisor.process = FakeWorker(-15)
+
+    assert supervisor.should_restart() is None
     assert supervisor.replacements == 0
 
 
@@ -123,19 +182,19 @@ def test_the_development_server_keeps_the_sansio_websocket_implementation(
     )
     monkeypatch.setattr(SupervisedReload, "run", lambda self: None)
 
-    run_reload_server(host="0.0.0.0", port=8000)
+    run_reload_server(host="127.0.0.1", port=9999)
 
     assert captured[0].ws == "websockets-sansio"
     assert captured[0].should_reload
+    assert (captured[0].host, captured[0].port) == ("127.0.0.1", 9999)
 
 
 def test_the_entrypoint_does_not_drag_the_application_into_the_reloader() -> None:
     """The reloader serves no request, so it should hold no application.
 
-    Importing `cli.commands` peaks at 464 MB in `agenticos_backend:dev` against
-    28 MB for uvicorn alone, and this process exists to survive an
-    out-of-memory kill. A convenience import of anything under `app.` in
-    `cli/reload_supervisor.py` would quietly undo that.
+    `cli/reload_supervisor.py` explains what going through `cli.commands`
+    instead would cost. A convenience import of anything under `app.` would
+    quietly undo it.
     """
     probe = "import cli.reload_supervisor, sys; print(any(m == 'app' or m.startswith('app.') for m in sys.modules))"
     loaded = subprocess.run(

--- a/backend/tests/test_reload_supervisor.py
+++ b/backend/tests/test_reload_supervisor.py
@@ -1,0 +1,146 @@
+"""The development server survives a worker the kernel kills.
+
+`uvicorn --reload` does not: its reloader watches files and nothing else, so an
+OOM-killed worker leaves a zombie, a reloader still politely watching, and a
+container reporting `Up` with nothing listening (#308). These pin the decision
+the supervisor makes about a worker that is gone - replace it, or wait for the
+edit that fixes it - and that the local stack actually runs the supervisor.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from uvicorn import Config
+from uvicorn.supervisors import ChangeReload
+
+from cli import reload_supervisor
+from cli.reload_supervisor import APP, WS_PROTOCOL, SupervisedReload, run_reload_server
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LOCAL_COMPOSE = REPO_ROOT / "docker-compose.yml"
+
+
+class FakeWorker:
+    """Enough of `multiprocessing.Process` for the supervisor's decision."""
+
+    def __init__(self, exitcode: int | None, pid: int = 4242) -> None:
+        self.exitcode = exitcode
+        self.pid = pid
+
+
+class RecordingReload(SupervisedReload):
+    """Records the replacement rather than spawning a real worker."""
+
+    def __init__(self, config: Config) -> None:
+        super().__init__(config, target=lambda sockets: None, sockets=[])
+        self.replacements = 0
+
+    def restart(self) -> None:
+        self.replacements += 1
+        self.process = FakeWorker(None, pid=self.process.pid + 1)
+
+
+@pytest.fixture
+def supervisor(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> RecordingReload:
+    """A supervisor whose file watcher reports no changes, with its log captured.
+
+    Constructing a `Config` applies uvicorn's own logging configuration, under
+    which `uvicorn.error` reaches uvicorn's handler rather than the root logger
+    `caplog` listens on. The module's logger is swapped for an ordinary one so
+    the assertions can be about what was written rather than about handlers.
+    """
+    monkeypatch.setattr(ChangeReload, "should_restart", lambda self: None)
+    reloader = RecordingReload(Config(APP, reload=True, ws=WS_PROTOCOL))
+    monkeypatch.setattr(reload_supervisor, "logger", logging.getLogger("tests.reload_supervisor"))
+    caplog.set_level(logging.ERROR, logger="tests.reload_supervisor")
+    return reloader
+
+
+def test_a_worker_killed_by_a_signal_is_replaced(supervisor: RecordingReload) -> None:
+    """`-9` is what the OOM killer leaves behind, and no edit is coming to fix it."""
+    supervisor.process = FakeWorker(-9)
+
+    assert supervisor.should_restart() is None
+    assert supervisor.replacements == 1
+    assert supervisor.process.exitcode is None
+
+
+def test_a_worker_that_exited_on_its_own_is_not_replaced(supervisor: RecordingReload) -> None:
+    """An import error would otherwise respawn forever on the same traceback."""
+    supervisor.process = FakeWorker(1)
+
+    assert supervisor.should_restart() is None
+    assert supervisor.replacements == 0
+
+
+def test_a_running_worker_is_left_alone(supervisor: RecordingReload) -> None:
+    supervisor.process = FakeWorker(None)
+
+    assert supervisor.should_restart() is None
+    assert supervisor.replacements == 0
+
+
+def test_an_ordinary_exit_is_reported_once_rather_than_every_poll(
+    supervisor: RecordingReload, caplog: pytest.LogCaptureFixture
+) -> None:
+    supervisor.process = FakeWorker(1)
+
+    for _ in range(3):
+        supervisor.should_restart()
+
+    assert [r.getMessage() for r in caplog.records].count(
+        "Server process [4242] exited with code 1. Waiting for a file change."
+    ) == 1
+
+
+def test_a_file_change_still_reloads(
+    supervisor: RecordingReload, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The reload loop is unchanged; supervision only runs on a quiet poll."""
+    changed = [Path("app/main.py")]
+    monkeypatch.setattr(ChangeReload, "should_restart", lambda self: changed)
+    supervisor.process = FakeWorker(None)
+
+    assert supervisor.should_restart() == changed
+    assert supervisor.replacements == 0
+
+
+def test_the_development_server_keeps_the_sansio_websocket_implementation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """uvicorn's `auto` fails the chat handshake against websockets >=14."""
+    captured: list[Config] = []
+    monkeypatch.setattr(Config, "bind_socket", lambda self: None)
+    monkeypatch.setattr(
+        SupervisedReload, "__init__", lambda self, config, **kw: captured.append(config)
+    )
+    monkeypatch.setattr(SupervisedReload, "run", lambda self: None)
+
+    run_reload_server(host="0.0.0.0", port=8000)
+
+    assert captured[0].ws == "websockets-sansio"
+    assert captured[0].should_reload
+
+
+def test_the_local_stack_does_not_run_uvicorns_unsupervised_reloader() -> None:
+    """The whole of #308 is that `uvicorn --reload` is PID 1 of this container."""
+    compose: dict[str, Any] = yaml.safe_load(LOCAL_COMPOSE.read_text())
+    command = compose["services"]["app"]["command"]
+
+    assert command.split() == [
+        "python",
+        "-m",
+        "cli.commands",
+        "server",
+        "run",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "8000",
+        "--reload",
+    ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,11 +53,15 @@ services:
     # nothing is listening. `cli/reload_supervisor.py` is the same reloader with
     # a worker the kernel killed replaced within about five seconds.
     #
+    # It, and not `cli.commands server run --reload`, because that entrypoint
+    # imports `app.main` and would put the whole application - 464 MB against
+    # 28 MB - inside a reloader that never serves a request.
+    #
     # The websockets implementation moved in there too: uvicorn's `auto` picks
     # the legacy one, broken with websockets >=14 (handshake → HTTP 500), and
     # the chat WS needs the sansio one. The other two compose files still pass
     # `--ws websockets-sansio` explicitly, because neither runs with `--reload`.
-    command: python -m cli.commands server run --host 0.0.0.0 --port 8000 --reload
+    command: python -m cli.reload_supervisor --host 0.0.0.0 --port 8000
     networks:
       - backend
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,10 +46,18 @@ services:
       # Empty outside compose, so a bare `uvicorn` run degrades to "no container
       # workspace available" rather than erroring. Note what is absent here:
       # no docker.sock, which is the whole point of the service below.
-    # --ws websockets-sansio: uvicorn's `auto` picks the legacy websockets impl,
-    # which is broken with websockets >=14 (handshake → HTTP 500). The sansio
-    # implementation is the modern, compatible one. Required for the chat WS.
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload --ws websockets-sansio
+    # Not `uvicorn --reload` directly. Its reloader is a file watcher, not a
+    # process supervisor: when the kernel kills the worker - an OOM kill is the
+    # realistic way - it neither reaps it nor replaces it, so PID 1 stays alive,
+    # this container stays `Up`, `restart:` below has nothing to act on, and
+    # nothing is listening. `cli/reload_supervisor.py` is the same reloader with
+    # a worker the kernel killed replaced within about five seconds.
+    #
+    # The websockets implementation moved in there too: uvicorn's `auto` picks
+    # the legacy one, broken with websockets >=14 (handshake → HTTP 500), and
+    # the chat WS needs the sansio one. The other two compose files still pass
+    # `--ws websockets-sansio` explicitly, because neither runs with `--reload`.
+    command: python -m cli.commands server run --host 0.0.0.0 --port 8000 --reload
     networks:
       - backend
     depends_on:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -141,6 +141,18 @@ uv run agenticos server run --port 9000  # Custom port
 uv run agenticos server routes           # Show all registered routes
 ```
 
+`--reload` runs uvicorn's reloader under a supervisor of our own
+(`backend/cli/reload_supervisor.py`), because uvicorn's is a file watcher and
+nothing more: when the kernel kills the worker — an out-of-memory kill is the
+realistic way — it neither reaps it nor replaces it, so the reloader carries on
+watching while no port is listening. Under the supervisor a worker killed by a
+signal is replaced within about five seconds, and one that exited on its own
+still waits for the edit that fixes it, which is what `--reload` is for.
+
+`server run` also selects the `websockets-sansio` implementation in both modes.
+uvicorn's `auto` picks the legacy one, which fails the handshake against
+websockets >=14 with an HTTP 500 — and the dashboard chat is a WebSocket.
+
 
 ### Database Commands
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -168,8 +168,24 @@ does not.
 make install                                    # uv sync + pre-commit
 docker compose -f docker-compose.yml up -d db redis
 make db-upgrade                                 # apply migrations
-make run                                        # uvicorn --reload
+make run                                        # uvicorn --reload, supervised
 ```
+
+!!! note "The reloader is supervised"
+
+    `--reload` runs under `backend/cli/reload_supervisor.py` rather than
+    uvicorn's reloader alone. Uvicorn's watches files and nothing else, so a
+    worker the kernel kills — an out-of-memory kill being the realistic way — is
+    neither reaped nor replaced: the reloader keeps watching while no port is
+    listening, and inside a container that means PID 1 is still alive, `docker
+    ps` still says `Up`, and the restart policy has nothing to act on. A worker
+    killed by a signal is now replaced within about five seconds. One that
+    exited on its own still waits for the edit that fixes it.
+
+    This is the reload path only. `make dev-server` runs a single unsupervised
+    uvicorn, so a kill takes PID 1 with it and `restart: unless-stopped`
+    restarts the container; `make prod` runs `--workers 4`, where uvicorn's own
+    `Multiprocess` supervisor already replaces a dead worker twice a second.
 
 !!! note "Python is pinned to 3.12"
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -177,10 +177,10 @@ make run                                        # uvicorn --reload, supervised
     uvicorn's reloader alone. Uvicorn's watches files and nothing else, so a
     worker the kernel kills — an out-of-memory kill being the realistic way — is
     neither reaped nor replaced: the reloader keeps watching while no port is
-    listening, and inside a container that means PID 1 is still alive, `docker
-    ps` still says `Up`, and the restart policy has nothing to act on. A worker
-    killed by a signal is now replaced within about five seconds. One that
-    exited on its own still waits for the edit that fixes it.
+    listening, and inside a container that means PID 1 is still alive,
+    `docker ps` still says `Up`, and the restart policy has nothing to act on.
+    A worker killed by a signal is now replaced within about five seconds. One
+    that exited on its own still waits for the edit that fixes it.
 
     This is the reload path only. `make dev-server` runs a single unsupervised
     uvicorn, so a kill takes PID 1 with it and `restart: unless-stopped`


### PR DESCRIPTION
## What changed

The local stack no longer runs `uvicorn --reload` as PID 1. It runs
`python -m cli.reload_supervisor`, which is uvicorn's own reloader with the
missing half added: on every quiet poll it reads the worker's exit code, and

- **killed by a signal** (`exitcode < 0`, `-9` for the OOM killer) — reap and
  start a replacement, within about five seconds;
- **exited on its own** (`exitcode >= 0` — an import error, `sys.exit`) — reap,
  say so once, and wait for the file change that fixes it, which is what
  `--reload` exists for. Respawning here would loop on the same traceback.

Reading `exitcode` is what clears the zombie: the property is a `waitpid` with
`WNOHANG`, so both branches reap.

`docker-compose.yml` is the only compose file touched. **The issue names
`docker-compose-dev.yml`, which has no `--reload`** — the reloader is in
`docker-compose.yml`, the laptop file.

`server run` also moved to `websockets-sansio` in both modes. It had to: the
compose command it replaces passed `--ws websockets-sansio`, and uvicorn's
`auto` picks the implementation that answers the chat handshake with a 500.
`make run` gained that fix on the way past.

## Which option, and why not the other two

The issue's diagnosis under option 2 is right — the supervisor is the broken
part — so its open question is the one to answer first.

**Can uvicorn be made to exit when its child dies?** No, not by any flag.
`BaseReload.run` iterates `should_restart()` and reacts to a file changing and
to a signal arriving; it never reads `self.process.exitcode`, in 0.52.0 or in
any version. Only a wrapper can do it.

Exiting is the wrong remedy even so, and this takes a better one: the supervisor
**replaces** the worker instead. Two seconds against three failed health checks
plus a container restart plus a cold boot — and no exponential restart backoff
to sit through, which on a laptop is the difference between not noticing and
waiting a minute after fixing a typo. It is also not a novel invention: it is
what uvicorn already does on the `--workers` path, where
`Multiprocess.keep_subprocess_alive` polls, reaps and replaces twice a second.
The reload path never got it.

**Option 1, `restart: unless-stopped`** — already set on the service, and the
container never exits. That is the whole defect.

**Option 3, wiring the health check to something that acts** — rejected on two
counts. `autoheal` needs the Docker socket, which is root-equivalent on the
host; `docker-compose.yml` says exactly that in a comment a few services below
the one being edited, and keeps `sandboxd` behind a profile for that reason.
Adding a socket-holding container to the default local stack in order to recover
from a dead process is a large trade for a small benefit. And the other half of
the option, `depends_on: condition: service_healthy`, only orders startup — it
restarts nothing, so it was never a fix at all.

**What option 3 would have covered and this does not: a wedged worker** — alive
but not answering. Filed as #336 rather than folded in here.

## Production, confirmed

The issue asks for this before closing. The answer is right in its outcome and
wrong in its mechanism, which is worth recording for whoever reads it next.

| Stack | PID 1 | `kill -9` the worker | Result |
|---|---|---|---|
| `docker-compose.yml` (before) | `uvicorn --reload` | zombie, PID 1 alive | `status=running restarts=0 health=unhealthy`, **not serving after 150s** |
| `docker-compose.yml` (after) | `cli.reload_supervisor` | worker replaced | **serving again after 2s**, 0 zombies, `restarts=0` |
| `docker-compose-dev.yml` | `uvicorn`, single, no reload | PID 1 *is* the server | container exits, `restarts=1`, **serving after 12s** |
| `docker-compose-prod.yml` | `uvicorn --workers 4` | `Multiprocess` replaces it | **never stopped serving**, four workers again, 0 zombies, `restarts=0` |

So production recovers — but **not** by the container exiting and the restart
policy applying, which is what the issue supposes. Uvicorn's `Multiprocess`
supervisor replaces the dead worker in place and the container never exits at
all; the restart policy only comes into it if PID 1 itself is killed. Same
outcome, different mechanism, and the dev-only framing holds either way.

## How it was verified

**Docker was available, so all four rows above are real runs rather than
reasoning.** Method: the already-built `agenticos_backend:dev` image on the
running compose network, this branch's source bind-mounted exactly as
`docker-compose.yml` does, in a throwaway container on a spare port so nothing
touched the working stack. `kill -9` on the worker pid inside the container,
which is what the issue's "how you would know it was fixed" asks for.

The before case reproduced the issue's `ps` verbatim:

```
  PID  PPID STAT COMMAND
    1     0 Ssl  uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload --ws websockets-sansio
    7     1 S    ... resource_tracker ...
    8     1 Z    [python] <defunct>
```

The after case:

```
ERROR:    Server process [54] was killed by signal 9. Starting a replacement.
INFO:     Started server process [113]
  serving again after 2s
  zombie count: 0
```

One correction worth recording: **`kill -9 1` from inside a container does
nothing.** The kernel drops signals sent to a PID namespace's init from within
that namespace, so the `docker-compose-dev.yml` row had to be killed from
outside the namespace — which is what the OOM killer does anyway. The first
attempt read as "the container survived" when nothing had been signalled at all.

Also measured, and it changed the design: routing PID 1 through
`cli.commands server run --reload` imports `app.main`, which peaks at **464 MB
against 28 MB** for uvicorn alone — the whole application inside a process that
never serves a request, on a fix about surviving an out-of-memory kill. Hence
the dedicated entrypoint. In the running container PID 1 is 31 MB against the
worker's 476 MB, and a test asserts nothing under `app.` is importable from it.

`docker stop` still exits 0 in about five seconds; the shutdown path is
untouched, since only `should_restart` is overridden.

### What is green, and what is not

CI is green on every check. Locally, `make check` is green apart from
`tests/test_migrations.py` — `test_upgrade_head` on one run, that plus
`test_upgrade_downgrade_cycle` on the next. **Not this branch**: it touches no
model and no migration, the four tests pass in isolation, and CI's `test` job
passes them on the same commits. Five other agents were running `make check`
against the same Postgres at the time, and `test_migrations` is the one suite
that cycles a real schema. Coverage reported 100% on both runs.
`python3 scripts/docs_drift.py` is clean.

## Not fixed, deliberately

- **A wedged worker** — alive, not answering. Nothing here notices it, and
  nothing in the other two stacks does either. Out of scope for this branch,
  seen and carried by **#336**, which is queued behind this one because it
  edits the file this one creates.
- **No backoff on repeated signal deaths.** A worker segfaulting during import
  would respawn about every five seconds. Uvicorn's `Multiprocess` has no
  backoff either, and an OOM kill takes real work to reach so it does not
  hot-loop; adding one speculatively is machinery nobody has needed.
- **`cli/` sits outside `ty`** (`[tool.ty.src] exclude`), so the new module is
  linted by ruff and tested but not type-checked. Bringing it into the checker
  means bringing it into the coverage gate's `include` as well — the two lists
  are asserted equal — and dev tooling is not the platform layer. Left as it is;
  the module is fully annotated regardless.

## Where this meets #333

#333 owns the image-level `HEALTHCHECK` and both replacement probes; nothing
here touches `backend/Dockerfile`, `app/worker/prefect_app.py` or any
`prefect-runner` service. The two diffs do both edit the `app` service in
`docker-compose.yml`, in adjacent but distinct hunks:

- this branch replaces the `command:` line and the comment above it, between
  `environment:` and `networks:`;
- #333 inserts a `healthcheck:` block after `depends_on:`, immediately before
  `restart: unless-stopped`.

About ten lines apart with `networks:` and `depends_on:` between them, so git
should merge them without a conflict — but whichever lands second is worth a
glance at that block, because both changes are about the same service's
lifecycle. They compose rather than collide: #333 gives the local `app` a probe
that fails on a 500 instead of passing, and this makes the process behind it
come back on its own. The evidence above was gathered against the image-level
probe #333 removes; `restarts=0` and the zombie are properties of the process
tree, so removing it changes none of it.

## Review

**The automated reviewer is off** — #313 removed the `pull_request` trigger from
`.github/workflows/ai-review.yml` this morning, because since 2026-08-05 every
run died about twelve seconds in, concluded `success`, and posted a line that
read like a verdict (#311). The `ai-review` label now does nothing, silently, so
it has deliberately not been applied and its silence is not a clean review.

What was done instead: the local `/review` standard, a maintainer-eye pass over
the whole diff, and a subagent given the diff and a category to hunt in
(supervisor correctness against the installed uvicorn source, every factual
claim in a comment or docs page, `multiprocessing` spawn semantics under
`python -m`, repo conventions, and test quality). It found two real defects, both now
fixed with tests, in `fix(compose): stop a filtered change and a shutdown
fooling the supervisor`:

- **a change the reload filter rejects yielded `[]`, not `None`**, and the
  supervisor read that as a reload and skipped the reap for that tick. Reachable
  here: `reload_dirs` is `/app` and `media_data` is mounted under it, shared with
  the Prefect runner, so ingestion alone produces a drip of them;
- **`exitcode < 0` is not "the kernel killed it"** — `Server.capture_signals`
  re-raises a signal it handled *gracefully*, so a clean shutdown also reports
  `-15`. The log line said "was killed by", and a replacement could in principle
  be started while the reloader was already leaving. Guarded on `should_exit`,
  the same guard `Multiprocess.keep_subprocess_alive` opens with, and the wording
  corrected.

The cosmetic half of the pass is `style(compose): tidy the reload supervisor's
edges`, kept as its own commit rather than squashed in silently.

Closes #308
