### PR TITLE
fix(rag): keep runtime vector tables out of alembic check

### DIFF
--- a/.claude/skills/alembic-migration/SKILL.md
+++ b/.claude/skills/alembic-migration/SKILL.md
@@ -22,6 +22,16 @@ in it. If autogenerate is noisy again, that is the signal something was added to
 migration by hand and never declared on the model — fix the model, do not accept
 the noise.
 
+**One family of tables alembic does not own.** The vector store creates
+`rag_<collection>` per collection at runtime, so `alembic/env.py` filters them out of
+the comparison through `include_name`; without that, `make db-check` failed on any
+database that had ever ingested a document, reporting somebody's collections as tables
+to drop. Two things follow. Do not add them to the models to quieten a diff — they are
+per-tenant runtime objects, and declaring them would have alembic dropping a
+collection. And keep the predicate in `app/db/vector_tables.py` narrow: `rag_documents`
+*is* a model table, and an exclusion that reached it would silence real drift in the one
+table ingestion writes through.
+
 ## Workflow
 
 1. **Change the model** in `backend/app/db/models/`. `Mapped[...]` + `mapped_column()`,

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -8,6 +8,7 @@ from sqlalchemy import engine_from_config, pool
 
 from app.core.config import settings
 from app.db.base import Base
+from app.db.vector_tables import is_runtime_vector_table
 
 # Import all models here to ensure they are registered with metadata
 from app.db.models.user import User  # noqa: F401
@@ -51,6 +52,24 @@ def run_migrations_offline() -> None:
         context.run_migrations()
 
 
+def include_name(name: str | None, type_: str, parent_names: dict[str, str | None]) -> bool:
+    """Keep the vector store's runtime tables out of the comparison.
+
+    `alembic check` and `--autogenerate` compare the whole database against the
+    models, so every `rag_<collection>` table the store created at runtime read as a
+    table to drop, and `check` exited non-zero on any database that had ever ingested
+    a document. What it is meant to catch is a model change with no migration; what it
+    caught was somebody having used the product (#288).
+
+    The test is narrow on purpose - `rag_documents` is a model table, and excluding it
+    would silence real drift in the one table this project ingests through.
+    `app/db/vector_tables.py` explains why both halves of that test are needed.
+    """
+    if type_ == "table" and name is not None:
+        return not is_runtime_vector_table(name, metadata=target_metadata)
+    return True
+
+
 def run_migrations_online() -> None:
     """Run migrations in 'online' mode."""
     configuration = config.get_section(config.config_ini_section) or {}
@@ -66,6 +85,7 @@ def run_migrations_online() -> None:
         context.configure(
             connection=connection,
             target_metadata=target_metadata,
+            include_name=include_name,
         )
 
         with context.begin_transaction():

--- a/backend/app/db/vector_tables.py
+++ b/backend/app/db/vector_tables.py
@@ -1,0 +1,54 @@
+"""The tables the vector store creates at runtime, and telling them from schema.
+
+`PgVectorStore` issues `CREATE TABLE IF NOT EXISTS rag_<collection>` the first time
+a collection is written to, so those tables exist in the database and in nothing
+else - no model declares them and no migration creates them. That is correct: they
+are per-collection runtime objects, and a deployment holds as many as somebody has
+made knowledge bases.
+
+It is also invisible to `alembic check`, which compares the whole database against
+the models and reads every one of them as a table the models dropped. The result is
+inverted: a gate meant to catch "edited a model, forgot the migration" failed for a
+reason that has nothing to do with models, on exactly the machines where somebody is
+editing them (#288).
+
+The prefix lives here rather than in `vectorstore.py` because two places need it and
+they answer to different layers: the store builds a name, `alembic/env.py` has to
+recognise one. Sharing a string is the easy half. The hard half is
+`is_runtime_vector_table` below, because **`rag_documents` is a real model table** -
+so "starts with `rag_`" is not a safe test, and an exclusion that got it wrong would
+silence real drift in the one table this project ingests through.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sqlalchemy import MetaData
+
+VECTOR_TABLE_PREFIX = "rag_"
+
+
+def is_runtime_vector_table(name: str, *, metadata: MetaData) -> bool:
+    """Whether this table belongs to the vector store rather than to alembic.
+
+    Both halves are load-bearing. The prefix alone would exclude `rag_documents`,
+    which the models declare and alembic owns; membership in `metadata` alone would
+    exclude every table any extension or another application put in the database.
+    Together they mean one thing only: a `rag_` table the models have never heard
+    of, which is exactly what the store creates.
+
+    Args:
+        name: A table name as reflected from the database.
+        metadata: The metadata autogenerate is comparing against - passed in rather
+            than imported, so this cannot answer differently depending on which
+            models happen to have been imported yet.
+
+    Example:
+        ```python
+        is_runtime_vector_table("rag_company_handbook", metadata=Base.metadata)  # True
+        is_runtime_vector_table("rag_documents", metadata=Base.metadata)  # False
+        ```
+    """
+    return name.startswith(VECTOR_TABLE_PREFIX) and name not in metadata.tables

--- a/backend/app/services/rag/vectorstore.py
+++ b/backend/app/services/rag/vectorstore.py
@@ -3,6 +3,7 @@ import re
 from abc import ABC, abstractmethod
 from typing import Any
 
+from app.db.vector_tables import VECTOR_TABLE_PREFIX
 from app.schemas.rag import RAGDocumentItem, RAGDocumentList
 from app.services.rag.models import (
     CollectionInfo,
@@ -216,8 +217,13 @@ class PgVectorStore(BaseVectorStore):
         await self.engine.dispose()
 
     def _table(self, name: str) -> str:
-        """Get validated table name for a collection."""
-        return f"rag_{_validate_collection_name(name)}"
+        """Get validated table name for a collection.
+
+        The prefix comes from `app/db/vector_tables.py` because `alembic/env.py` has
+        to recognise these names to keep them out of `alembic check` - a table created
+        here exists in no model and no migration, and read as a table to drop (#288).
+        """
+        return f"{VECTOR_TABLE_PREFIX}{_validate_collection_name(name)}"
 
     async def _for_collection(self, name: str) -> tuple[EmbeddingService, int]:
         """The embedder and vector width this one collection uses.
@@ -461,9 +467,11 @@ class PgVectorStore(BaseVectorStore):
         async with self.async_session() as session:
             result = await session.execute(
                 text(
-                    "SELECT table_name FROM information_schema.tables WHERE table_name LIKE 'rag_%' AND table_schema = 'public'"
-                )
+                    "SELECT table_name FROM information_schema.tables "
+                    "WHERE table_name LIKE :prefix AND table_schema = 'public'"
+                ),
+                {"prefix": f"{VECTOR_TABLE_PREFIX}%"},
             )
-            # removeprefix (Python 3.9+) strips only the leading "rag_" occurrence,
-            # unlike str.replace which would also hit inner occurrences.
-            return [row[0].removeprefix("rag_") for row in result.fetchall()]
+            # removeprefix strips the leading occurrence only, unlike str.replace,
+            # which would also hit the prefix inside a collection's own name.
+            return [row[0].removeprefix(VECTOR_TABLE_PREFIX) for row in result.fetchall()]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -335,6 +335,9 @@ include = [
     "app/core/secret_kinds.py",
     "app/core/vault.py",
     "app/core/background.py",
+    # Which tables alembic owns and which the vector store makes at runtime. It is
+    # two statements, and one of them decides whether `db-check` reports real drift.
+    "app/db/vector_tables.py",
     "app/services/access.py",
     "app/services/agent_chat.py",
     "app/services/agent_environment.py",
@@ -449,6 +452,9 @@ include = [
     "app/core/secret_kinds.py",
     "app/core/vault.py",
     "app/core/background.py",
+    # Which tables alembic owns and which the vector store makes at runtime. It is
+    # two statements, and one of them decides whether `db-check` reports real drift.
+    "app/db/vector_tables.py",
     "app/services/access.py",
     "app/services/agent_chat.py",
     "app/services/agent_environment.py",

--- a/backend/tests/test_coverage_gate.py
+++ b/backend/tests/test_coverage_gate.py
@@ -71,6 +71,7 @@ PLATFORM_MODULES = (
     "app/core/secret_kinds.py",
     "app/core/vault.py",
     "app/core/background.py",
+    "app/db/vector_tables.py",
     "app/services/access.py",
     "app/services/agent_chat.py",
     "app/services/agent_environment.py",

--- a/backend/tests/test_vector_tables.py
+++ b/backend/tests/test_vector_tables.py
@@ -1,0 +1,75 @@
+"""What `alembic check` is allowed to ignore, and what it must never ignore.
+
+`make db-check` is the gate that catches "edited a model, forgot the migration". It
+failed instead on any database that had ever ingested a document, because the vector
+store creates a `rag_<collection>` table per collection at runtime and autogenerate
+read each one as a table the models had dropped (#288). So the comparison now skips
+them - and an exclusion inside a drift gate is a way to silence drift, which is why
+the predicate is tested here rather than trusted.
+
+The test that matters most is the parametrised one: **no table the models declare may
+ever be excluded.** `rag_documents` is a real model table, so the obvious version of
+this fix - skip anything starting with `rag_` - would have turned the gate off for the
+one table this project ingests through, and nothing would have said so.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import app.db.models  # noqa: F401  - registers every table on the metadata
+from app.db.base import Base
+from app.db.vector_tables import VECTOR_TABLE_PREFIX, is_runtime_vector_table
+
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_a_collections_runtime_table_is_not_alembics() -> None:
+    """Built from the shared prefix, which is what the store builds its names with."""
+    table = f"{VECTOR_TABLE_PREFIX}company_handbook_12db7e"
+
+    assert is_runtime_vector_table(table, metadata=Base.metadata)
+
+
+def test_the_documents_table_is_alembics() -> None:
+    """It starts with the prefix and is a model table, which is the whole trap."""
+    assert "rag_documents" in Base.metadata.tables
+    assert not is_runtime_vector_table("rag_documents", metadata=Base.metadata)
+
+
+@pytest.mark.parametrize("table", sorted(Base.metadata.tables))
+def test_no_table_the_models_declare_is_ever_excluded(table: str) -> None:
+    """Parametrised over the metadata, so a table added later is covered by this code.
+
+    An exclusion that grows to cover a modelled table is a gate that stops reporting a
+    missing migration - green, and wrong in the direction nobody checks.
+    """
+    assert not is_runtime_vector_table(table, metadata=Base.metadata)
+
+
+def test_a_table_without_the_prefix_is_left_alone() -> None:
+    """Not being in the metadata is not on its own a reason to skip anything.
+
+    An extension's table, or another application sharing the database, has to keep
+    reading as unknown: that is a conversation with whoever put it there, not
+    something this predicate should quietly absorb.
+    """
+    assert not is_runtime_vector_table("spatial_ref_sys", metadata=Base.metadata)
+
+
+def test_the_store_names_its_tables_from_the_shared_prefix() -> None:
+    """Two literals would drift, and the drift is silent in the worst way.
+
+    Names built from a second literal keep working - the store creates and reads its
+    own tables - while `alembic check` stops recognising them and `db-check` starts
+    failing again on exactly the machines #288 was about.
+    """
+    source = (BACKEND_ROOT / "app" / "services" / "rag" / "vectorstore.py").read_text()
+
+    assert "VECTOR_TABLE_PREFIX" in source
+    assert '"rag_' not in source and "'rag_" not in source, (
+        "the vector store spells the prefix out again; import VECTOR_TABLE_PREFIX from "
+        "app/db/vector_tables.py instead, which is what alembic/env.py recognises"
+    )

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -64,7 +64,7 @@ first if the change is anywhere near the database.
 | `make db-init` | Start PostgreSQL + create initial migration + apply |
 | `make db-migrate` | Create new migration (prompts for message) |
 | `make db-upgrade` | Apply pending migrations |
-| `make db-check` | `alembic check` — fail if a model change has no migration. Non-destructive (it never downgrades), so unlike `test-migrations` it runs inside `make check`; needs a database at head, and skips rather than fails when none answers on 5432 |
+| `make db-check` | `alembic check` — fail if a model change has no migration. Non-destructive (it never downgrades), so unlike `test-migrations` it runs inside `make check`; needs a database at head, and skips rather than fails when none answers on 5432. The vector store's per-collection `rag_<collection>` tables are excluded from the comparison, since nothing models or migrates them — `rag_documents`, which is a model table, is not |
 | `make db-downgrade` | Rollback last migration |
 | `make db-current` | Show current migration revision |
 | `make db-history` | Show full migration history |

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -236,6 +236,17 @@ Set `EMBEDDING_MODEL` to change the model.
 Vectors are stored in **pgvector** using the existing PostgreSQL database.
 No additional services needed.
 
+**One table per collection, created at runtime.** The store issues `CREATE TABLE IF
+NOT EXISTS rag_<collection>` the first time a collection is written to, so those
+tables exist in the database and in nothing else — no model declares them and no
+migration creates them, because a deployment holds as many as somebody has made
+knowledge bases. Alembic does not own them, and `alembic/env.py` says so through
+`include_name`: without that, `make db-check` read every one as a table the models
+had dropped and failed on any database that had ever ingested a document. The
+predicate lives in `app/db/vector_tables.py`, and it is narrower than the prefix on
+purpose — `rag_documents` *is* a model table, and excluding it would have turned the
+gate off for the one table ingestion writes through.
+
 ### RAG is Global
 
 Collections are shared across **all users**:


### PR DESCRIPTION
## What this changes

`make db-check` no longer fails because somebody has used the product.

The vector store issues `CREATE TABLE IF NOT EXISTS rag_<collection>` the first time
a collection is written to. Nothing models or migrates those tables — correctly, a
deployment holds as many as somebody has made knowledge bases — but `alembic check`
compares the whole database against the metadata, so it read every one as a table the
models had dropped. A gate meant to catch "edited a model, forgot the migration"
failed for a reason with nothing to do with models, on exactly the machines where
somebody is editing them, and took `test-frontend-cov`, `build-frontend`, `docs-build`
and `audit` down with it.

`alembic/env.py` now passes `include_name`, and the prefix the store names its tables
with lives in `app/db/vector_tables.py` where both sides can read it.

## Why this way

The issue proposed excluding names matching the store's prefix. **That would have been
the wrong fix, and quietly**: `rag_documents` is a model table. Excluding everything
starting with `rag_` turns the drift gate off for the one table ingestion writes
through, and nothing anywhere would have said so — a green `db-check` over a missing
migration is the failure mode this gate exists to prevent.

So a table is the store's only if it carries the prefix **and** the models have never
heard of it. Both halves are load-bearing, and the code says why: the prefix alone
catches `rag_documents`; metadata membership alone would swallow every table an
extension or another application put in the database.

The prefix is shared rather than repeated because two literals drift in the worst
direction — names built from a second one keep working, since the store creates and
reads its own tables, while alembic silently stops recognising them and `db-check`
starts failing again on the machines this issue is about. A test asserts the store
contains no `rag_` literal at all.

## Checks

- [x] Tests cover the new behaviour, and would fail without the change
- [x] `make check` passes
- [x] Platform-layer coverage is still 100% — 3256 passed; `app/db/vector_tables.py`
      joins both `pyproject.toml` lists and `PLATFORM_MODULES`
- [ ] n/a — no capability changed
- [ ] n/a — no migration added

Proven end to end against a database created for it and migrated to head, holding a
`rag_company_handbook_12db7e` table and an index on it:

| | |
|---|---|
| with the change | `No new upgrade operations detected` |
| without it (`env.py` reverted) | the issue's exact failure — `Detected removed table 'rag_company_handbook_12db7e'`, then `FAILED: New upgrade operations detected` with a `remove_index` and a `remove_table` |
| with the change, plus an undeclared column on `RAGDocument` | still fails, on the trap table itself: `add_column … 'rag_documents' … 'drift_probe'` |

The third row is the one that matters — it is the second half of the issue's "how you
would know it was fixed", and it is checked on `rag_documents` rather than some
unrelated table on purpose.

The unit tests are parametrised over `Base.metadata`, so **a model table added later
is covered without anybody remembering to add it** — including any future table whose
name starts with `rag_`.

`make lint`, `make test`, `make test-frontend-cov` (3175 passed), `make
build-frontend`, `make docs-build`, `make audit` all green.

## Notes for the reviewer

Filed rather than fixed here — `list_collections()` has the same conflation in the
other direction: it selects `table_name LIKE 'rag_%'` and strips the prefix, so
`rag_documents` is reported as a collection called `documents`. Out of scope for a
`db-check` fix, and it wants a decision about what a collection listing is for, so it
is its own issue rather than a hitchhiker on this one.

`db-check` still fails on my machine, for a third reason that is neither this nor
#299: the shared development database sits at `0011_drop_expired_approval`, a revision
from another branch in flight, so alembic cannot locate it from a branch that does not
have that migration. Nothing here can fix a database migrated by somebody else's
branch — but it is worth noticing that all three of these would be answered by
`db-check` running against a database the branch built, the way
`tests/test_migrations.py` now does in #302.

Docs: `docs/file-processing.md` gains the paragraph about per-collection tables and
who owns them, `docs/commands.md`'s `db-check` row says what is excluded and what is
not, and the `alembic-migration` skill says plainly not to add these tables to the
models to quieten a diff — declaring them would have alembic dropping a collection.

Closes #288. Refs #299.
