### PR TITLE
ci(lint): skip a nested checkout rather than a directory name

### DIFF
--- a/backend/tests/test_check_backticks.py
+++ b/backend/tests/test_check_backticks.py
@@ -1,0 +1,111 @@
+"""Where the backtick guard looks, and the two ways that has been wrong.
+
+`scripts/check_backticks.py` gates every commit and every `make lint`, and it walks
+the tree rather than a file list. Both failures so far were about *where* it walked.
+
+It used to descend into `.claude/worktrees/`, which holds a full checkout per branch.
+So `make lint` reported three findings on line 170 of a file nobody had edited - the
+copy of this very script living in each worktree, whose error message has to spell the
+pattern out - and no commit could be made with a worktree open (#225).
+
+Skipping every directory named `worktrees` stopped that and traded it for the quieter
+mistake: a `docs/worktrees/` that is only a directory with a name would be dropped
+from the scan, and a worktree placed anywhere else would still be walked. So the rule
+is now what it always meant - **do not descend into another checkout** - and both
+halves are asserted here, because a guard that silently reads less than it claims is
+the failure mode this file exists to catch.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = REPO_ROOT / "scripts" / "check_backticks.py"
+_spec = importlib.util.spec_from_file_location("check_backticks_under_test", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+check_backticks = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(check_backticks)
+
+# Built rather than quoted. This file is scanned by the guard it tests, so a literal
+# span here would be a finding in `make lint` - the same reason the script exempts
+# itself and every copy of itself.
+TICKS = "`" * 2
+OFFENDING_LINE = f"See {TICKS}--fix{TICKS} for the flag.\n"
+
+
+def _tree(root: Path) -> None:
+    """A checkout with a worktree under it, both holding an offending line."""
+    (root / "docs").mkdir(parents=True)
+    (root / "docs" / "guide.md").write_text(OFFENDING_LINE)
+
+    worktree = root / ".claude" / "worktrees" / "other-branch"
+    (worktree / "docs").mkdir(parents=True)
+    # What `git worktree add` leaves behind: a file, not a directory.
+    (worktree / ".git").write_text("gitdir: /somewhere/.git/worktrees/other-branch\n")
+    (worktree / "docs" / "guide.md").write_text(OFFENDING_LINE)
+    (worktree / "scripts").mkdir()
+    (worktree / "scripts" / "check_backticks.py").write_text(_SCRIPT.read_text())
+
+
+def _walked(root: Path) -> set[str]:
+    return {str(path.relative_to(root)) for path in check_backticks.walk([root])}
+
+
+def test_a_double_backtick_span_in_prose_is_reported(tmp_path: Path) -> None:
+    """The half that has to keep working, or the rest of this is a green no-op."""
+    sample = tmp_path / "guide.md"
+    sample.write_text(OFFENDING_LINE)
+
+    assert check_backticks.scan(sample) == [(1, OFFENDING_LINE.rstrip("\n"))]
+
+
+def test_a_fenced_block_is_not_prose(tmp_path: Path) -> None:
+    """A code fence renders literally on purpose; rewriting one would corrupt it."""
+    sample = tmp_path / "guide.md"
+    sample.write_text(f"```\nrun with {TICKS}--fix{TICKS}\n```\n")
+
+    assert check_backticks.scan(sample) == []
+
+
+def test_this_branch_is_walked(tmp_path: Path) -> None:
+    _tree(tmp_path)
+
+    assert "docs/guide.md" in _walked(tmp_path)
+
+
+def test_a_worktree_is_not_walked(tmp_path: Path) -> None:
+    """Another branch's files, and a copy of this script that names the pattern.
+
+    Neither belongs in this branch's report: the findings are not on this branch, and
+    the copy's own error message is not a defect in anything.
+    """
+    _tree(tmp_path)
+
+    assert not [path for path in _walked(tmp_path) if "other-branch" in path]
+
+
+def test_a_directory_merely_called_worktrees_is_still_walked(tmp_path: Path) -> None:
+    """The other half. An exclusion by name reads less of the tree than it says.
+
+    `docs/worktrees/notes.md` is prose in this checkout, on this branch, and a guard
+    that skips it because of the directory's name is one that reports "no double
+    backticks" about a file it never opened.
+    """
+    (tmp_path / "docs" / "worktrees").mkdir(parents=True)
+    (tmp_path / "docs" / "worktrees" / "notes.md").write_text(OFFENDING_LINE)
+
+    assert "docs/worktrees/notes.md" in _walked(tmp_path)
+
+
+def test_a_copy_of_this_script_is_exempt_even_when_named_directly(tmp_path: Path) -> None:
+    """`--fix` on a copy would rewrite the pattern it exists to detect.
+
+    The exemption used to be one absolute path, so every copy was a finding; it is
+    the file's name now.
+    """
+    copy = tmp_path / "check_backticks.py"
+    copy.write_text(_SCRIPT.read_text())
+
+    assert check_backticks.scan(copy) == []

--- a/scripts/check_backticks.py
+++ b/scripts/check_backticks.py
@@ -14,7 +14,9 @@ untouched either way. Whole lines are scanned, string literals included: a
 runtime string holding a double-backtick span ends up in a chat message or a
 tool description, which is Markdown territory again.
 
-This file exempts itself — it has to be able to name the pattern it detects.
+This file exempts itself — it has to be able to name the pattern it detects — and
+skips any nested checkout, because a git worktree holds another branch's files plus
+a copy of this script, whose error message spells the pattern out.
 
 Usage::
 
@@ -27,6 +29,7 @@ Exits 1 when anything is found (so it can gate CI), 0 when clean.
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import sys
 from collections.abc import Iterator
@@ -41,20 +44,15 @@ TYPESCRIPT_SUFFIXES = {".ts", ".tsx", ".js", ".jsx"}
 PYTHON_SUFFIXES = {".py"}
 
 # This script's own docstring, regex and messages must be able to spell the
-# pattern out.
-SELF = Path(__file__).resolve()
+# pattern out - and so must every copy of it. Matched by name rather than by
+# absolute path: a copy under a worktree is a different path and was reported as
+# three findings on line 170 of a file nobody had edited.
+SELF = Path(__file__).name
 
 SKIP_DIRS = {
     ".git",
     ".next",
     ".venv",
-    # A git worktree is another checkout of this repository, so scanning one
-    # reports every finding twice - and `SELF` only excludes *this* copy of this
-    # script, not the copies of it living under each worktree, each of which
-    # contains the literal double backticks in its own error message. So with any
-    # worktree checked out the hook fails on itself and nothing else can be
-    # committed. Found the hard way, with six worktrees open at once.
-    "worktrees",
     "__pycache__",
     "node_modules",
     "htmlcov",
@@ -102,7 +100,7 @@ def typescript_comments(text: str) -> Iterator[tuple[int, str]]:
 
 def scan(path: Path) -> list[tuple[int, str]]:
     """Every offending line in one file, as (line number, line)."""
-    if path.resolve() == SELF:
+    if path.name == SELF:
         return []
     if path.suffix in MARKDOWN_SUFFIXES:
         lines = markdown_prose(path.read_text(encoding="utf-8"))
@@ -130,18 +128,41 @@ def fix(path: Path) -> int:
     return len(offenders)
 
 
+def is_nested_checkout(directory: Path) -> bool:
+    """Whether this directory is a checkout of its own rather than part of this one.
+
+    A git worktree holds a `.git` file, a clone holds a `.git` directory, and either
+    way the files under it belong to some other branch. Scanning one reports findings
+    twice, reports them against paths that are not on this branch, and - since a copy
+    of this script lives there too - fails on the error message it is about to print.
+
+    Detected rather than named: `.claude/worktrees/` is where this repository puts
+    them, but skipping every directory called `worktrees` both misses one placed
+    anywhere else and silently stops reading a `docs/worktrees/` that is only a
+    directory with a name.
+    """
+    return (directory / ".git").exists()
+
+
 def walk(roots: list[Path]) -> Iterator[Path]:
     for root in roots:
         if root.is_file():
             yield root
             continue
-        for path in root.rglob("*"):
-            if not path.is_file():
-                continue
-            if any(part in SKIP_DIRS for part in path.parts):
-                continue
-            if path.suffix in MARKDOWN_SUFFIXES | TYPESCRIPT_SUFFIXES | PYTHON_SUFFIXES:
-                yield path
+        for directory, subdirectories, filenames in os.walk(root):
+            here = Path(directory)
+            # Pruned in place, which is what `os.walk` reads to decide where to go
+            # next - the reason this is not `rglob`. Skipping a nested checkout means
+            # not descending into it, not filtering its files out one at a time.
+            subdirectories[:] = [
+                name
+                for name in subdirectories
+                if name not in SKIP_DIRS and not is_nested_checkout(here / name)
+            ]
+            for name in sorted(filenames):
+                path = here / name
+                if path.suffix in MARKDOWN_SUFFIXES | TYPESCRIPT_SUFFIXES | PYTHON_SUFFIXES:
+                    yield path
 
 
 def main() -> int:


### PR DESCRIPTION
## What this changes

`scripts/check_backticks.py` no longer decides where to walk by directory name. It
skips a directory that is **another checkout** — a git worktree carries a `.git` file,
a clone a `.git` directory — and walks everything else.

Read the issue's symptom first, because it is already gone: `worktrees` was added to
`SKIP_DIRS` at some point after #225 was filed, so `make lint` is green in a checkout
with worktrees today. What is left is the trade that made:

- a `docs/worktrees/` that is only a directory with a name is **dropped from the
  scan**, and nothing says so — a guard reporting "no double backticks" about files it
  never opened is the failure mode this script exists to prevent;
- a worktree placed anywhere else is still walked, which is the original bug;
- and none of it was pinned by a test, so the fix was a string in a set with a comment
  as its only protection.

## Why this way

**Detected, not named.** `.claude/worktrees/` is where this repository happens to put
them; `git worktree add scratch` puts one at the root. The property that matters is
"these files belong to another branch", and the `.git` entry is exactly that property.

**`os.walk` with in-place pruning of `dirnames`, not `rglob`.** Skipping a checkout
means not descending into it, rather than filtering its files out one at a time —
which is also why pointing the script at a tree holding thirteen worktrees takes 0.4s.

**The self-exemption is the file's name now, not one absolute path.** Every copy of
this script contains the pattern it detects, in the error message it prints; the issue
names this as the reason each copy was a finding. Pointing the script directly at a
copy used to report it, and `--fix` would have rewritten the regex it exists to run.

## Checks

- [x] Tests cover the new behaviour, and would fail without the change — reverting
      only the script fails `test_a_directory_merely_called_worktrees_is_still_walked`
      and the exemption test
- [x] `make check` passes
- [x] Platform-layer coverage is still 100% (3221 passed)
- [ ] n/a — no capability changed
- [ ] n/a — no migration

`backend/tests/test_check_backticks.py` asserts **both** halves, because either alone
looks like success: a worktree's copy is not walked, and a directory merely called
`worktrees` still is. The first passes on `main` too — it is there to say what must not
regress, since that is the behaviour somebody tidying `SKIP_DIRS` would take out.

Verified against the checkout #225 was filed from — thirteen worktrees present:
`python3 scripts/check_backticks.py` is green, walks 1365 files, and none of them is
under a worktree. `make lint`, `make test`, `make test-frontend-cov` (3175 passed),
`make build-frontend`, `make docs-build` and `make audit` all green.

## Notes for the reviewer

One thing the test file has to do, and it looks odd until you see why: it builds its
offending line from `"`" * 2` instead of quoting a span. A literal one there is a
finding in `make lint`, for exactly the reason the script exempts itself — the test
that proves the guard works cannot be written in prose the guard rejects.

No docs page describes the guard's traversal (it appears as "the two guards" in
`make lint`'s description and as a pre-commit hook), so nothing under `docs/` is owed;
`scripts/docs_drift.py` agrees.

Closes #225.
