### PR TITLE
fix(rag): stop listing the documents tracking table as a collection

### DIFF
--- a/backend/app/db/vector_tables.py
+++ b/backend/app/db/vector_tables.py
@@ -18,6 +18,11 @@ recognise one. Sharing a string is the easy half. The hard half is
 `is_runtime_vector_table` below, because **`rag_documents` is a real model table** -
 so "starts with `rag_`" is not a safe test, and an exclusion that got it wrong would
 silence real drift in the one table this project ingests through.
+
+Both sides of that ask it now. `alembic/env.py` asks which tables it must not
+compare; `PgVectorStore.list_collections` asks which are collections, and until it
+did, the prefix alone had it reporting `rag_documents` as a collection called
+`documents` (#339). One question, one answer, whichever direction it is read from.
 """
 
 from __future__ import annotations
@@ -41,9 +46,11 @@ def is_runtime_vector_table(name: str, *, metadata: MetaData) -> bool:
 
     Args:
         name: A table name as reflected from the database.
-        metadata: The metadata autogenerate is comparing against - passed in rather
-            than imported, so this cannot answer differently depending on which
-            models happen to have been imported yet.
+        metadata: The metadata to judge against - what autogenerate is comparing to,
+            or `Base.metadata` for a caller outside alembic. Passed in rather than
+            imported, so this cannot answer differently depending on which models
+            happen to have been imported yet; a caller that imports it is
+            responsible for having imported the models too.
 
     Example:
         ```python

--- a/backend/app/db/vector_tables.py
+++ b/backend/app/db/vector_tables.py
@@ -47,10 +47,13 @@ def is_runtime_vector_table(name: str, *, metadata: MetaData) -> bool:
     Args:
         name: A table name as reflected from the database.
         metadata: The metadata to judge against - what autogenerate is comparing to,
-            or `Base.metadata` for a caller outside alembic. Passed in rather than
-            imported, so this cannot answer differently depending on which models
-            happen to have been imported yet; a caller that imports it is
-            responsible for having imported the models too.
+            or `Base.metadata` for a caller outside alembic. A parameter rather
+            than an import because this function must not choose: whichever
+            metadata the caller is reasoning about is the one the answer has to
+            be true of. It does not make the answer independent of what has been
+            imported - a caller passing `Base.metadata` is asserting that the
+            models are registered on it, and one that has not imported them gets
+            "every `rag_` table is the store's" with no error to say so.
 
     Example:
         ```python

--- a/backend/app/services/rag/vectorstore.py
+++ b/backend/app/services/rag/vectorstore.py
@@ -3,7 +3,11 @@ import re
 from abc import ABC, abstractmethod
 from typing import Any
 
-import app.db.models  # noqa: F401  - registers every model table on `Base.metadata`
+# Registers every model table on `Base.metadata`, which `list_collections` judges a
+# `rag_` table against. Another import already reaches the models today; this one
+# says the listing depends on it, rather than leaving that to a chain belonging to
+# a different concern.
+import app.db.models  # noqa: F401
 from app.db.base import Base
 from app.db.vector_tables import VECTOR_TABLE_PREFIX, is_runtime_vector_table
 from app.schemas.rag import RAGDocumentItem, RAGDocumentList

--- a/backend/app/services/rag/vectorstore.py
+++ b/backend/app/services/rag/vectorstore.py
@@ -3,7 +3,9 @@ import re
 from abc import ABC, abstractmethod
 from typing import Any
 
-from app.db.vector_tables import VECTOR_TABLE_PREFIX
+import app.db.models  # noqa: F401  - registers every model table on `Base.metadata`
+from app.db.base import Base
+from app.db.vector_tables import VECTOR_TABLE_PREFIX, is_runtime_vector_table
 from app.schemas.rag import RAGDocumentItem, RAGDocumentList
 from app.services.rag.models import (
     CollectionInfo,
@@ -478,6 +480,19 @@ class PgVectorStore(BaseVectorStore):
         return sorted(chunks, key=lambda chunk: (chunk.page_num, chunk.chunk_num))
 
     async def list_collections(self) -> list[str]:
+        """Every collection this store holds, and nothing that only looks like one.
+
+        Carrying the prefix is not enough to be a collection: `rag_documents`
+        is a model table, so the prefix alone reported a collection called
+        `documents` on every deployment since that table existed, and a caller
+        that believed it would read chunks out of a schema with none of the
+        columns it expects (#339).
+
+        The question is the same one `alembic/env.py` asks from the other side,
+        so it is the same predicate rather than a second one - a `rag_` table
+        the models have never heard of. `app/db/vector_tables.py` says why both
+        halves are load-bearing.
+        """
         async with self.async_session() as session:
             result = await session.execute(
                 text(
@@ -488,4 +503,8 @@ class PgVectorStore(BaseVectorStore):
             )
             # removeprefix strips the leading occurrence only, unlike str.replace,
             # which would also hit the prefix inside a collection's own name.
-            return [row[0].removeprefix(VECTOR_TABLE_PREFIX) for row in result.fetchall()]
+            return [
+                row[0].removeprefix(VECTOR_TABLE_PREFIX)
+                for row in result.fetchall()
+                if is_runtime_vector_table(row[0], metadata=Base.metadata)
+            ]

--- a/backend/tests/integration/test_vector_store_listing.py
+++ b/backend/tests/integration/test_vector_store_listing.py
@@ -14,6 +14,8 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
 
+from app.db.base import Base
+from app.db.vector_tables import VECTOR_TABLE_PREFIX
 from app.services.rag.vectorstore import PgVectorStore
 
 pytestmark = pytest.mark.anyio
@@ -38,8 +40,12 @@ async def test_the_listing_holds_the_collection_and_not_the_documents_table(
             )
         )
         # The premise, asserted rather than assumed: the tracking table is in
-        # this database and does carry the prefix the store matches on.
-        assert {row[0] for row in present} == {"rag_documents", "rag_company_handbook"}
+        # this database and does carry the prefix the store matches on. Derived
+        # from the metadata, so a second prefixed model table added later is part
+        # of the premise instead of failing this line.
+        modelled = {name for name in Base.metadata.tables if name.startswith(VECTOR_TABLE_PREFIX)}
+        assert "rag_documents" in modelled
+        assert {row[0] for row in present} == modelled | {"rag_company_handbook"}
 
     store = PgVectorStore.__new__(PgVectorStore)
     store.async_session = async_sessionmaker(engine, expire_on_commit=False)

--- a/backend/tests/integration/test_vector_store_listing.py
+++ b/backend/tests/integration/test_vector_store_listing.py
@@ -1,0 +1,47 @@
+"""What the vector store lists, asked of a real database.
+
+The unit version of this (`tests/test_collection_listing.py`) hands the store a
+fixed list of table names, which proves the predicate is applied but takes on
+trust the two facts the bug actually rested on: that `rag_documents` is really
+there, and that the store's own query really returns it. Both come from the
+database or not at all - the first from `Base.metadata.create_all`, the second
+from `information_schema` - so they are asked here (#339).
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
+
+from app.services.rag.vectorstore import PgVectorStore
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_the_listing_holds_the_collection_and_not_the_documents_table(
+    engine: AsyncEngine,
+) -> None:
+    """A database with both in it answers with the collection alone.
+
+    The collection's table is created with raw DDL rather than through
+    `create_collection`: that path needs the `vector` extension, an embedding
+    width and a resolver, none of which this is about. What `list_collections`
+    reads is a name in `information_schema`, and this is one.
+    """
+    async with engine.begin() as connection:
+        await connection.execute(text("CREATE TABLE rag_company_handbook (id VARCHAR(100))"))
+        present = await connection.execute(
+            text(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_name LIKE 'rag_%' AND table_schema = 'public'"
+            )
+        )
+        # The premise, asserted rather than assumed: the tracking table is in
+        # this database and does carry the prefix the store matches on.
+        assert {row[0] for row in present} == {"rag_documents", "rag_company_handbook"}
+
+    store = PgVectorStore.__new__(PgVectorStore)
+    store.async_session = async_sessionmaker(engine, expire_on_commit=False)
+
+    assert await store.list_collections() == ["company_handbook"]

--- a/backend/tests/test_collection_listing.py
+++ b/backend/tests/test_collection_listing.py
@@ -1,0 +1,92 @@
+"""What the vector store says it holds.
+
+`list_collections` is the store's own answer to "which collections exist" - what a
+`rag-collections` command prints, and what an existence check reads. It selected
+every table carrying the store's prefix, and `rag_documents` carries it without
+being a collection: it is the model table tracking ingested documents. So the
+listing held a phantom called `documents` on every deployment since that table
+existed, and a caller that believed it would read chunks out of a table with none
+of the columns it expects (#339).
+
+The fix is the predicate `alembic/env.py` already asks from the other side, not a
+name this file could spell out - which is why the second test below exists. A
+collection genuinely called `documents_archive` has to keep listing.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+import app.db.models  # noqa: F401  - registers every table on the metadata
+from app.db.base import Base
+from app.db.vector_tables import VECTOR_TABLE_PREFIX
+from app.services.rag.vectorstore import PgVectorStore
+
+pytestmark = pytest.mark.anyio
+
+
+class _Result:
+    def __init__(self, rows: list[tuple[str]]) -> None:
+        self._rows = rows
+
+    def fetchall(self) -> list[tuple[str]]:
+        return self._rows
+
+
+class _Session:
+    """The one query `list_collections` makes, answered from a fixed table list."""
+
+    def __init__(self, table_names: list[str]) -> None:
+        self._rows = [(name,) for name in table_names]
+
+    async def __aenter__(self) -> _Session:
+        return self
+
+    async def __aexit__(self, *exc_info: Any) -> None:
+        return None
+
+    async def execute(self, statement: Any, parameters: Any = None) -> _Result:
+        return _Result(self._rows)
+
+
+def _store_over(table_names: list[str]) -> PgVectorStore:
+    """A store whose database holds exactly these tables and no engine at all."""
+    store = PgVectorStore.__new__(PgVectorStore)
+    store.async_session = MagicMock(return_value=_Session(table_names))
+    return store
+
+
+def _modelled_prefixed_tables() -> list[str]:
+    return sorted(name for name in Base.metadata.tables if name.startswith(VECTOR_TABLE_PREFIX))
+
+
+async def test_a_table_the_models_own_is_not_reported_as_a_collection() -> None:
+    """The regression. Built from the metadata, so a later one is covered too.
+
+    `rag_documents` is the one that made this a bug, and the assertion below keeps
+    the case from quietly emptying if the model is ever renamed - but the row list
+    is every prefixed table the models declare, so a second one added tomorrow is
+    tested by this code rather than by somebody remembering.
+    """
+    modelled = _modelled_prefixed_tables()
+    assert "rag_documents" in modelled
+
+    store = _store_over([*modelled, f"{VECTOR_TABLE_PREFIX}company_handbook"])
+
+    assert await store.list_collections() == ["company_handbook"]
+
+
+async def test_a_collection_whose_name_starts_like_a_model_table_still_lists() -> None:
+    """`documents_archive` is a collection somebody may reasonably create.
+
+    Excluding the literal `documents`, or anything beginning with it, would answer
+    #339 for the phantom and hide a real collection alongside it. The store asks
+    whether the models declare *that table*, which is a question about the database
+    rather than about how a name reads.
+    """
+    store = _store_over([f"{VECTOR_TABLE_PREFIX}documents_archive"])
+
+    assert await store.list_collections() == ["documents_archive"]

--- a/backend/tests/test_collection_listing.py
+++ b/backend/tests/test_collection_listing.py
@@ -9,7 +9,7 @@ existed, and a caller that believed it would read chunks out of a table with non
 of the columns it expects (#339).
 
 The fix is the predicate `alembic/env.py` already asks from the other side, not a
-name this file could spell out - which is why the second test below exists. A
+name this file could spell out - which is what the last test below is for. A
 collection genuinely called `documents_archive` has to keep listing.
 """
 

--- a/backend/tests/test_collection_listing.py
+++ b/backend/tests/test_collection_listing.py
@@ -15,6 +15,7 @@ collection genuinely called `documents_archive` has to keep listing.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -26,6 +27,8 @@ from app.db.vector_tables import VECTOR_TABLE_PREFIX
 from app.services.rag.vectorstore import PgVectorStore
 
 pytestmark = pytest.mark.anyio
+
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
 
 
 class _Result:
@@ -77,6 +80,36 @@ async def test_a_table_the_models_own_is_not_reported_as_a_collection() -> None:
     store = _store_over([*modelled, f"{VECTOR_TABLE_PREFIX}company_handbook"])
 
     assert await store.list_collections() == ["company_handbook"]
+
+
+def test_the_store_registers_the_models_it_judges_a_table_against() -> None:
+    """The one line holding the fix up, and the only way left to guard it.
+
+    `is_runtime_vector_table` is only as good as the metadata handed to it: on an
+    empty `Base.metadata` every prefixed table reads as a collection, which is
+    #339 again with no error to announce it. So `vectorstore.py` imports
+    `app.db.models` for the side effect.
+
+    That import is *currently* redundant - `app.services.embedding_resolution`
+    reaches the models through `app.repositories` - and redundant is exactly the
+    problem. It makes the line read as unused (it carries a `noqa`, so nothing
+    else objects), and it puts the correctness of this listing on an import chain
+    belonging to a different concern, which a refactor may cut without ever
+    looking here.
+
+    Asserted on the source because no run of this suite can assert it on
+    behaviour: `tests/conftest.py` imports `app.main`, so the metadata is
+    populated before any test module loads, and even a subprocess would still be
+    saved by the accidental route - a test that cannot fail on the edit worth
+    catching is not a guard.
+    """
+    source = (BACKEND_ROOT / "app" / "services" / "rag" / "vectorstore.py").read_text()
+
+    assert "import app.db.models" in source, (
+        "the vector store no longer registers the models on Base.metadata, so "
+        "list_collections judges tables against whatever happens to have been imported; "
+        "on an empty metadata it reports rag_documents as a collection again (#339)"
+    )
 
 
 async def test_a_collection_whose_name_starts_like_a_model_table_still_lists() -> None:

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -269,6 +269,12 @@ predicate lives in `app/db/vector_tables.py`, and it is narrower than the prefix
 purpose — `rag_documents` *is* a model table, and excluding it would have turned the
 gate off for the one table ingestion writes through.
 
+The store answers the same question with the same predicate: `list_collections`,
+which is what `rag-collections` prints, reports a `rag_` table only when no model
+declares it. Matching the prefix alone had it reporting `rag_documents` as a
+collection called `documents` — one nobody created, whose "vector count" was the
+number of ingested documents, and which any caller could then ask to search.
+
 ### RAG is Global
 
 Collections are shared across **all users**:


### PR DESCRIPTION
## What this changes

`PgVectorStore.list_collections()` no longer reports a collection called
`documents` that nobody created.

It selected every table carrying the store's prefix and stripped the prefix off.
`rag_documents` carries it and is not a collection — it is the model table tracking
ingested documents — so the listing has held one phantom entry on every deployment
since that table existed. The knowledge-base page lists from `knowledge_bases`, so
the phantom never reached it; what read it is the store's own view of what exists.
`rag-collections` printed the phantom and then asked `get_collection_info` for it,
so its "vector count" was the number of ingested documents in the whole deployment,
and a caller that believed the listing could go on to search a table with none of
the columns it expects.

## Why this shape

The distinction was already written and tested on the other side of the same
conflation: `is_runtime_vector_table(name, metadata=...)`, which #288 added for
`alembic/env.py` to decide which tables it must *not* compare. This is the same
question read from the other direction, so the store asks that predicate rather
than a second one — a `rag_` table the models have never heard of. There is now
one answer to "is this a collection table", and no second place to keep in step.

**Not a name test, deliberately.** Excluding the literal `documents` — or anything
beginning with it — would answer the phantom and hide a collection somebody
genuinely called `documents_archive`. The second unit test pins that case.

The predicate takes its metadata as an argument, so the store supplies one:
`Base.metadata`, with `import app.db.models` at the top of `vectorstore.py`. That
import is redundant *today* — `app.services.embedding_resolution` reaches the models
through `app.repositories` — and redundant is the reason it is there rather than a
reason to drop it: it makes the listing's dependency its own rather than an
accident of somebody else's import chain, and the third commit adds a test so the
line cannot be tidied away as unused.

Two things it fixes incidentally, both worth knowing:

- `LIKE 'rag_%'` treats `_` as a single-character wildcard, so `ragXfoo` was listed
  as a collection called `Xfoo`. `startswith` inside the predicate excludes it. The
  SQL still over-selects; the filter is what makes the answer right.
- `rag-stats` called `get_collection_info("documents")`, which returned
  `COUNT(*) FROM rag_documents` as `total_vectors` — a plausible, non-erroring,
  wrong number. That path is closed.

The tradeoff, stated because nothing else states it: the answer is now
name-vs-`Base.metadata`, so a future `rag_`-prefixed *model* table would un-list a
same-named collection whose data still exists. That is the correct reading — such a
collection is already broken, see #345 — but it is a silent un-listing.

## How it was verified

| | |
|---|---|
| `tests/test_collection_listing.py` | The store over a fixed table list. Fails without the change |
| `tests/integration/test_vector_store_listing.py` | The same claim against a real Postgres: `create_all` puts `rag_documents` there, the store's own `information_schema` query returns it, the listing answers `["company_handbook"]` alone |

Both derive their table list from `Base.metadata` rather than hardcoding it, so a
second `rag_`-prefixed model table added later is covered without anybody
remembering, and both assert `rag_documents` is in that list so the case cannot
quietly empty. The integration test asserts its premise — both tables present, both
matching the prefix — before asserting the answer, because that premise is the whole
bug and a mock cannot hold it. Confirmed it catches the pre-fix behaviour: with the
predicate stubbed to accept every prefixed name it fails with
`['company_handbook', 'documents'] == ['company_handbook']`.

`make test` green (exit 0), `make check` green, and **integration tests ran rather
than skipping** — a `pgvector/pgvector:pg16` on 5432.

## Where it touches other branches

- **#338 (`ci/db-check-runtime-tables`, closes #288)** — this branch is stacked on
  it, because `app/db/vector_tables.py` and `is_runtime_vector_table` are its work
  and are not on `main` yet. **So the diff below contains #338's commit as well as
  this branch's four, and #338 must merge first.** Reviewing only this branch:
  `git diff origin/ci/db-check-runtime-tables` — five files, all listed under
  "How it was verified" plus two docstring paragraphs in `vector_tables.py`.

  The base was briefly set to `ci/db-check-runtime-tables` so the diff would be
  only its own; that is worth knowing not to repeat, because **CI does not run on
  a pull request whose base is not `main`** — `.github/workflows/ci.yml` filters
  `pull_request: branches: [main, master]`, so the checks simply never report. A
  stacked pull request in this repository is a pull request with no CI.
- **#323 (`fix/ingestion-uses-collection-embedding-key`, #306)** — same file,
  different methods: it changes `__init__` (making `resolver` required) and
  `_for_collection`; this changes `list_collections`. Not assumed to be fine —
  **merged all three on a scratch branch and ran the tests: clean textual merge, 127
  passed**, including `test_ingestion_embedding_key.py` and
  `test_capability_edges.py`. Nothing here constructs a `PgVectorStore`, so the
  required-`resolver` constructor is not a surface this branch has.
- **#346** — `tests/test_migrations.py` uses a constant database name, so concurrent
  `make check` runs on one Postgres drop each other's schema. Not hit on this branch,
  noted so a red `test-migrations` elsewhere is not read as this.

## Found and not fixed here

- [#345](https://github.com/vstorm-co/agenticos/issues/345) — nothing refuses a
  collection *named* `documents`, and `DELETE /rag/collections/documents` then runs
  `DROP TABLE IF EXISTS rag_documents`, taking every organization's document
  tracking with it. Same missing distinction in a third direction, but it needs a
  refusal at create time rather than a filter at read time. Worse than it first
  looked: `documents` is the **default** collection name in `services/rag/config.py`,
  `schemas/rag.py` and four `rag-*` commands, so the collision sits on the documented
  first-run path — corrected in a comment there rather than silently.
- [#354](https://github.com/vstorm-co/agenticos/issues/354) — the page this PR
  edits still says "only admins can manage collections", a role model dropped in
  migration `0066`. Rewriting an access-control section is not a hitchhiker on a
  listing fix.

## Review

The automated reviewer does not run on pull requests (#311/#313), so **this diff
has not been through one.** Swept it myself and with a subagent: both callers of
`list_collections` in `app/commands/rag.py` (neither compensated for the phantom),
the route at `api/routes/v1/rag.py:130` (lists from `knowledge_bases`, unaffected),
and the sibling methods on `PgVectorStore` — which is where #345 and the correction
to it came from. The third commit is that pass: it found the import above holding
the fix up with nothing watching it, and a docstring on `is_runtime_vector_table`
that had come out self-contradictory.

## Checks

- [x] Tests cover the new behaviour, and would fail without the change
- [x] `make check` passes
- [x] Coverage: `app/services/rag/*` is template-inherited and outside the gate;
      `app/db/vector_tables.py` is inside it and gained no code, only docstrings
- [ ] n/a — no capability changed
- [ ] n/a — no migration added

Docs: `docs/file-processing.md` gains a paragraph next to #338's, since
`rag-collections` visibly stops printing a collection it used to.

Closes #339
