### PR TITLE
ci(review): fail the run when the reviewer produced no review

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -408,8 +408,9 @@ jobs:
         #
         #   reviewed  the reviewer read the diff and answered. Zero findings is
         #             a real answer and the most common one.
-        #   declined  a decision this workflow made - nothing to review, or a
-        #             diff over the line cap. Working as intended.
+        #   declined  no review, and nothing is wrong - nothing to review, a
+        #             diff over the line cap, or a run cancelled because a newer
+        #             one for the same pull request replaced it.
         #   broken    the reviewer could not run. Nothing was reviewed, the
         #             comment says so in those words, and the job fails.
         env:

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -475,11 +475,10 @@ jobs:
           elif codex != "success":
               status = write(
                   "broken",
-                  f"**The reviewer failed** - the Codex step ended `{codex}`. Nothing "
-                  "in this pull request was reviewed, so this comment says nothing "
-                  "about the diff. What Codex printed is below; the usual causes are "
-                  "an expired or rate-limited OpenAI key, a project spend limit, and "
-                  "a model slug the installed CLI does not carry.",
+                  f"**The reviewer failed** - the Codex step ended `{codex}`. What it "
+                  "printed is below; the usual causes are an expired or rate-limited "
+                  "OpenAI key, a project spend limit, and a model slug the installed "
+                  "CLI does not carry.",
               )
           elif not out.exists():
               status = write(
@@ -606,13 +605,18 @@ jobs:
             // timestamps and colour codes stripped, consecutive repeats
             // collapsed (Codex prints its reconnect attempts one per line), the
             // last few of them, and a cap because a comment is not a log viewer.
+            //
+            // Deliberately not `##[error]` lines: in this job all of them are
+            // the runner's, including the annotation the last step of `review`
+            // writes, and quoting our own "the reviewer produced no review"
+            // back at the reader under "what the reviewer printed" is noise.
             const complaints = [];
             for (const raw of text.split('\n')) {
               const line = raw
                 .replace(/^\S+Z /, '')
                 .replace(/\x1b\[[0-9;]*m/g, '')
                 .trimEnd();
-              if (!/^(ERROR|Error|error)\b|^##\[error\]/.test(line)) continue;
+              if (!/^(ERROR|Error|error)\b/.test(line)) continue;
               if (line !== complaints[complaints.length - 1]) complaints.push(line);
             }
             if (!complaints.length) {

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -39,6 +39,13 @@ name: AI review
 #            back, whatever the model is talked into.
 #   publish  posts the result. Never sees the key.
 #
+# `review` **fails when it did not review**, and that is the whole of the
+# lesson in #311: for eleven pull requests it concluded `success` on a reviewer
+# that had been dead since 2026-08-05, because a green job and a quiet one look
+# identical from the pull request page. What decides whether `publish` runs is
+# `review`'s `status` output rather than its result, so the job can go red and
+# the pull request still gets the comment explaining why.
+#
 # There is deliberately no `issue_comment` trigger, and it is a security
 # property rather than a simplification. `issue_comment` is privileged: it runs
 # from the default branch **with secrets**, for a comment on any pull request
@@ -173,6 +180,12 @@ jobs:
     # scope, so it is reachable from exactly one job in exactly one workflow.
     # A repository secret is reachable from any workflow anybody later adds.
     environment: ai-review
+    # `reviewed`, `declined` or `broken` - see `Normalize the result`. Empty
+    # when this job never got as far as deciding, which is also the signal
+    # `publish` reads to know whether a findings artifact exists at all. A
+    # failed job still carries the outputs its steps managed to set.
+    outputs:
+      status: ${{ steps.result.outputs.status }}
     env:
       BASE_REF: ${{ needs.context.outputs.base_ref }}
       HEAD_SHA: ${{ needs.context.outputs.head_sha }}
@@ -194,11 +207,11 @@ jobs:
         #   diff falls through to `status=ok` and the cap silently stops
         #   existing.
         #
-        # This reports rather than exits: a job that fails here skips `publish`
-        # too, and the pull request would sit with no comment at all, which is
-        # the one outcome the rest of this workflow refuses to produce. The
-        # summary says what is wrong; the `::error::` annotation makes the run
-        # loud without hiding it.
+        # This reports rather than exits, because exiting here would skip
+        # `Normalize the result` and leave the pull request with no comment at
+        # all - the one outcome the rest of this workflow refuses to produce.
+        # The job still ends red: an unconfigured reviewer normalizes to
+        # `broken` and the last step of this job fails on that.
         run: |
           set -euo pipefail
           problems=()
@@ -355,11 +368,16 @@ jobs:
           BASE_SHA: ${{ steps.diff.outputs.base_sha }}
 
       - name: Review the diff
+        id: codex
         if: steps.diff.outputs.status == 'ok'
         # A reviewer that failed says so on the pull request, where somebody is
-        # looking, rather than only as a red mark in the Actions tab. The next
-        # step turns a missing result into that message; failing the job here
-        # would skip it and leave the pull request with nothing at all.
+        # looking, and not only as a red mark in the Actions tab. Failing the job
+        # *here* would skip the two steps that produce the message and leave the
+        # pull request with nothing at all, so the failure is carried forward
+        # instead: `steps.codex.outcome` is the pre-`continue-on-error` result,
+        # the next step turns it into `broken`, and the last step of this job
+        # fails on that. Do not read `steps.codex.conclusion` - it is `success`
+        # by construction here, which is how #311 stayed invisible.
         continue-on-error: true
         uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
         with:
@@ -383,12 +401,24 @@ jobs:
         # A model that returns something other than the schema is a bug worth
         # seeing rather than a silent no-op, so its raw output is carried
         # through into the summary.
+        #
+        # It also classifies, into exactly three, because before #311 the
+        # comment rendered all of them as one sentence and a reader could not
+        # tell a clean diff from a dead reviewer:
+        #
+        #   reviewed  the reviewer read the diff and answered. Zero findings is
+        #             a real answer and the most common one.
+        #   declined  a decision this workflow made - nothing to review, or a
+        #             diff over the line cap. Working as intended.
+        #   broken    the reviewer could not run. Nothing was reviewed, the
+        #             comment says so in those words, and the job fails.
         env:
           CONFIG_STATUS: ${{ steps.config.outputs.status }}
           CONFIG_PROBLEMS: ${{ steps.config.outputs.problems }}
           STANDARD_STATUS: ${{ steps.standard.outputs.status }}
           DIFF_STATUS: ${{ steps.diff.outputs.status }}
           CHANGED_LINES: ${{ steps.diff.outputs.changed_lines }}
+          CODEX_OUTCOME: ${{ steps.codex.outcome }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -405,37 +435,58 @@ jobs:
           config = os.environ["CONFIG_STATUS"]
           standard = os.environ.get("STANDARD_STATUS", "")
           diff_status = os.environ.get("DIFF_STATUS", "")
+          codex = os.environ.get("CODEX_OUTCOME", "")
           changed = os.environ.get("CHANGED_LINES", "0")
           limit = os.environ.get("MAX_CHANGED_LINES", "")
 
-          def write(summary: str) -> None:
+          def write(status: str, summary: str) -> str:
               out.write_text(json.dumps({"summary": summary, "findings": []}))
+              return status
 
           if config == "unconfigured":
-              write(
-                  "No review: the reviewer is misconfigured - "
+              status = write(
+                  "broken",
+                  "**The reviewer did not run: it is misconfigured.** "
                   f"{os.environ['CONFIG_PROBLEMS']}. Its settings are repository "
-                  "variables, listed in `docs/code-review.md`. Nothing was read and "
-                  "nothing was charged."
+                  "variables, listed in `docs/code-review.md`. Nothing in this pull "
+                  "request was read, and nothing was charged.",
               )
           elif standard == "no-standard":
-              write(
-                  f"No review: `{base_ref}` has no `.github/codex/review-prompt.md`. "
-                  "The reviewer reads its instructions from the base branch so that a "
-                  "pull request cannot edit them, which means they have to land there "
-                  "first."
+              status = write(
+                  "broken",
+                  f"**The reviewer did not run:** `{base_ref}` has no "
+                  "`.github/codex/review-prompt.md`. The reviewer reads its "
+                  "instructions from the base branch so that a pull request cannot "
+                  "edit them, which means they have to land there first.",
               )
           elif diff_status == "empty":
-              write("No review: this pull request changes nothing outside the excluded paths.")
+              status = write(
+                  "declined",
+                  "No review: this pull request changes nothing outside the excluded paths.",
+              )
           elif diff_status == "too-large":
-              write(
+              status = write(
+                  "declined",
                   f"No review: {changed} changed lines, over the {limit} line limit. "
                   "A truncated pass costs as much as a real one and finds less. Split "
                   "the pull request, or raise `AI_REVIEW_MAX_CHANGED_LINES` if a diff "
-                  "this size is genuinely one change."
+                  "this size is genuinely one change.",
+              )
+          elif codex != "success":
+              status = write(
+                  "broken",
+                  f"**The reviewer failed** - the Codex step ended `{codex}`. Nothing "
+                  "in this pull request was reviewed, so this comment says nothing "
+                  "about the diff. What Codex printed is below; the usual causes are "
+                  "an expired or rate-limited OpenAI key, a project spend limit, and "
+                  "a model slug the installed CLI does not carry.",
               )
           elif not out.exists():
-              write("No review: the reviewer did not produce a result. See the workflow run.")
+              status = write(
+                  "broken",
+                  "**The reviewer failed:** Codex exited cleanly and wrote no result "
+                  "file. See the workflow run.",
+              )
           else:
               raw = out.read_text()
               try:
@@ -443,10 +494,16 @@ jobs:
                   if not isinstance(parsed, dict) or "findings" not in parsed:
                       raise ValueError("not the review schema")
               except (json.JSONDecodeError, ValueError) as exc:
-                  write(
-                      f"The reviewer returned output that is not the review schema ({exc}). "
-                      "Raw output:\n\n```\n" + raw[:4000] + "\n```"
+                  status = write(
+                      "broken",
+                      "**The reviewer failed:** it returned output that is not the "
+                      f"review schema ({exc}). Raw output:\n\n```\n" + raw[:4000] + "\n```",
                   )
+              else:
+                  status = "reviewed"
+
+          with pathlib.Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as handle:
+              handle.write(f"status={status}\n")
           PY
 
       - name: Upload the findings
@@ -457,14 +514,38 @@ jobs:
           path: ${{ runner.temp }}/ai-review/findings.json
           retention-days: 7
 
+      - name: Fail when the reviewer did not review
+        # Last, so that the comment is written and uploaded before this job goes
+        # red. #311 is the reason it exists: `success` on a reviewer that had
+        # produced nothing for a day is a gate reading green because the thing
+        # is not in it, which is #143 and #165 applied to the reviewer.
+        #
+        # Failing rather than `core.setNeutral` - the check is advisory and not
+        # required, so red costs nobody a merge; it only makes the outage
+        # visible on the page where somebody is already looking. A neutral
+        # conclusion renders as a grey tick, which is what we are trying to stop
+        # this from looking like.
+        if: steps.result.outputs.status == 'broken'
+        run: |
+          echo "::error::The reviewer produced no review. The summary comment on the pull request says which stage failed and what it printed."
+          exit 1
+
   publish:
     name: Publish the review
     needs: [context, review]
-    if: always() && needs.review.result == 'success'
+    # Gated on there being something to publish, not on `review` having gone
+    # green - since #311 that job deliberately fails when the reviewer did not
+    # review, and that is precisely the run whose comment matters most. The
+    # output is empty only when `review` never reached `Normalize the result`,
+    # which is also when no artifact exists to download.
+    if: always() && needs.review.outputs.status != ''
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       pull-requests: write
+      # For this run's own job log, below. It is read in the job that holds no
+      # API key, and only after `review` has finished.
+      actions: read
     steps:
       - name: Download the findings
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -472,11 +553,81 @@ jobs:
           name: ai-review-findings
           path: findings
 
+      - name: Collect what the reviewer printed
+        id: diagnosis
+        if: needs.review.outputs.status == 'broken'
+        # A diagnosis that cannot be fetched must not cost the comment: this is
+        # a nicety on top of a message that already says the reviewer failed,
+        # and the comment is the thing #311 is about.
+        continue-on-error: true
+        # The reason #311 went a day unnoticed. Codex writes its own diagnosis
+        # to stderr - for the whole outage, `Your project has reached its
+        # configured enforced spend limit` - and a `uses:` step's stderr goes
+        # nowhere but the runner log, under a Node stack trace, at the bottom of
+        # eleven hundred lines of a job that concluded green. So the log is read
+        # back through the API and its complaints travel into the comment.
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+        with:
+          github-token: ${{ github.token }}
+          # Without this the step's own return value is JSON-encoded, and the
+          # comment would carry a quoted one-line string with `\n` in it.
+          result-encoding: string
+          script: |
+            const { owner, repo } = context.repo;
+            const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRunAttempt, {
+              owner, repo,
+              run_id: context.runId,
+              attempt_number: Number(process.env.RUN_ATTEMPT),
+              per_page: 100,
+            });
+            const job = jobs.find((candidate) => candidate.name === 'Run the reviewer');
+            if (!job) {
+              core.warning('No job named "Run the reviewer" in this attempt; no output to collect.');
+              return '';
+            }
+
+            const log = await github.request('GET /repos/{owner}/{repo}/actions/jobs/{job_id}/logs', {
+              owner, repo, job_id: job.id,
+            });
+            // Octokit decodes a text content type to a string and anything else
+            // to an ArrayBuffer, and the redirect this ends at has been served
+            // as both.
+            const text = typeof log.data === 'string' ? log.data : Buffer.from(log.data).toString('utf8');
+
+            // This publishes log text into a comment, and the repository is
+            // public - but so are its Actions logs, and GitHub masks registered
+            // secrets before serving either, so nothing reaches a reader here
+            // that a link to the run did not already reach them.
+            //
+            // What is left is a thousand lines of runner bookkeeping around a
+            // handful of complaints, so only the complaints are kept -
+            // timestamps and colour codes stripped, consecutive repeats
+            // collapsed (Codex prints its reconnect attempts one per line), the
+            // last few of them, and a cap because a comment is not a log viewer.
+            const complaints = [];
+            for (const raw of text.split('\n')) {
+              const line = raw
+                .replace(/^\S+Z /, '')
+                .replace(/\x1b\[[0-9;]*m/g, '')
+                .trimEnd();
+              if (!/^(ERROR|Error|error)\b|^##\[error\]/.test(line)) continue;
+              if (line !== complaints[complaints.length - 1]) complaints.push(line);
+            }
+            if (!complaints.length) {
+              core.warning('The reviewer failed and printed nothing this step recognises as an error.');
+              return '';
+            }
+            return complaints.slice(-12).join('\n').slice(-2000);
+
       - name: Post the findings
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_NUMBER: ${{ needs.context.outputs.pr_number }}
           HEAD_SHA: ${{ needs.context.outputs.head_sha }}
+          REVIEW_STATUS: ${{ needs.review.outputs.status }}
+          REVIEWER_OUTPUT: ${{ steps.diagnosis.outputs.result }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           github-token: ${{ github.token }}
@@ -495,6 +646,10 @@ jobs:
 
             const review = JSON.parse(fs.readFileSync('findings/findings.json', 'utf8'));
             const findings = Array.isArray(review.findings) ? review.findings : [];
+            // `reviewed`, `declined` or `broken`, decided in `Normalize the
+            // result`. The heading, the deletion of the previous run's inline
+            // comments and the "no findings" line all turn on it.
+            const status = process.env.REVIEW_STATUS;
 
             // GitHub rejects a review comment whose line is not part of the
             // diff, and models get line numbers wrong regularly. Rather than
@@ -545,13 +700,19 @@ jobs:
               return parts.join('\n');
             };
 
-            // A re-run replaces its predecessor instead of stacking on it.
-            const previous = await github.paginate(github.rest.pulls.listReviewComments, {
-              owner, repo, pull_number, per_page: 100,
-            });
-            for (const comment of previous) {
-              if (comment.body?.startsWith(FINDING_MARKER)) {
-                await github.rest.pulls.deleteReviewComment({ owner, repo, comment_id: comment.id });
+            // A re-run replaces its predecessor instead of stacking on it - but
+            // only a re-run that actually reviewed. A broken or declined run
+            // has nothing to replace the previous findings *with*, and deleting
+            // them would turn a reviewer outage into the deletion of real
+            // findings somebody had not finished acting on.
+            if (status === 'reviewed') {
+              const previous = await github.paginate(github.rest.pulls.listReviewComments, {
+                owner, repo, pull_number, per_page: 100,
+              });
+              for (const comment of previous) {
+                if (comment.body?.startsWith(FINDING_MARKER)) {
+                  await github.rest.pulls.deleteReviewComment({ owner, repo, comment_id: comment.id });
+                }
               }
             }
 
@@ -587,7 +748,38 @@ jobs:
               listed.push([finding, `over the ${MAX_INLINE} inline comment limit`]);
             }
 
-            const summary = [SUMMARY_MARKER, '## AI review', '', review.summary ?? ''];
+            // The heading, not the body text, is what somebody skimming the
+            // pull request reads - so it carries the one distinction #311 was
+            // about: a reviewer that answered, and a reviewer that never ran.
+            const heading = {
+              reviewed: '## AI review',
+              declined: '## AI review — declined',
+              broken: '## AI review — the reviewer failed',
+            }[status];
+            const summary = [SUMMARY_MARKER, heading, '', review.summary ?? ''];
+            if (status === 'broken') {
+              summary.push(
+                '',
+                '**Nothing here was reviewed.** This comment is about the reviewer, ' +
+                  'not about the diff — a clean diff and a dead reviewer used to read ' +
+                  'the same, which is [#311](https://github.com/vstorm-co/agenticos/issues/311).',
+              );
+              if (process.env.REVIEWER_OUTPUT) {
+                summary.push(
+                  '',
+                  '<details><summary>What the reviewer printed</summary>',
+                  '',
+                  '```text',
+                  process.env.REVIEWER_OUTPUT,
+                  '```',
+                  '',
+                  '</details>',
+                );
+              }
+            }
+            if (status === 'reviewed' && !findings.length) {
+              summary.push('', 'No findings — the reviewer read the diff and had nothing to report.');
+            }
             if (posted.length) {
               summary.push('', `${posted.length} finding(s) posted inline.`);
             }
@@ -600,10 +792,15 @@ jobs:
                 );
               }
             }
+            // Not "add the `ai-review` label": #313 removed the `pull_request`
+            // trigger, so the label does nothing until it is restored, and a
+            // footer telling somebody to add it is a second thing on this page
+            // quietly not working.
             summary.push(
               '',
               '---',
-              `Add the \`ai-review\` label to re-run. [Run](${process.env.RUN_URL}).`,
+              `Re-run with \`gh workflow run ai-review.yml -f pr_number=${pull_number}\`. ` +
+                `[Run](${process.env.RUN_URL}).`,
               'Advisory only — this is not a required check.',
             );
 

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -472,13 +472,32 @@ jobs:
                   "the pull request, or raise `AI_REVIEW_MAX_CHANGED_LINES` if a diff "
                   "this size is genuinely one change.",
               )
-          elif codex != "success":
+          elif codex == "cancelled":
+              # Superseded by a newer dispatch for the same pull request, or the
+              # job's own timeout. Neither is a broken reviewer, and calling it
+              # one would put "the reviewer failed" on a pull request whose
+              # replacement run is already in flight.
+              status = write(
+                  "declined",
+                  "No review: the run was cancelled before Codex finished - superseded "
+                  "by a newer run for this pull request, or over the job's time limit.",
+              )
+          elif codex == "failure":
               status = write(
                   "broken",
-                  f"**The reviewer failed** - the Codex step ended `{codex}`. What it "
-                  "printed is below; the usual causes are an expired or rate-limited "
-                  "OpenAI key, a project spend limit, and a model slug the installed "
-                  "CLI does not carry.",
+                  "**The reviewer failed** - Codex exited non-zero. What it printed is "
+                  "below; the usual causes are an expired or rate-limited OpenAI key, a "
+                  "project spend limit, and a model slug the installed CLI does not "
+                  "carry.",
+              )
+          elif codex != "success":
+              # `skipped`, which at this point means a step between the diff and
+              # Codex failed. Naming Codex would send the reader to the wrong
+              # place, and none of the causes above can apply.
+              status = write(
+                  "broken",
+                  f"**The reviewer failed:** Codex never ran (`{codex}`) - a step before "
+                  "it failed. See the workflow run.",
               )
           elif not out.exists():
               status = write(
@@ -487,10 +506,17 @@ jobs:
                   "file. See the workflow run.",
               )
           else:
-              raw = out.read_text()
+              # `errors="replace"` because a decode error here would fail the
+              # step, skip the upload and leave the pull request with nothing -
+              # for the one input the branch below exists to report.
+              raw = out.read_text(errors="replace")
               try:
                   parsed = json.loads(raw)
-                  if not isinstance(parsed, dict) or "findings" not in parsed:
+                  # `findings` has to be a *list*, not merely present: `null`
+                  # passes a key check and then renders as "no findings - the
+                  # reviewer read the diff and had nothing to report", which is
+                  # the #311 sentence again with a different cause.
+                  if not isinstance(parsed, dict) or not isinstance(parsed.get("findings"), list):
                       raise ValueError("not the review schema")
               except (json.JSONDecodeError, ValueError) as exc:
                   status = write(

--- a/backend/tests/test_ai_review_outcome.py
+++ b/backend/tests/test_ai_review_outcome.py
@@ -76,17 +76,20 @@ def step(job: str, name: str) -> dict[str, Any]:
 
 
 def run_normalize(
-    tmp_path: Path, *, codex_wrote: str | None = None, **overrides: str
+    tmp_path: Path, *, codex_wrote: str | bytes | None = None, **overrides: str
 ) -> tuple[str, str]:
     """Run `Normalize the result` and return its `status` output and the summary it wrote.
 
     `codex_wrote` is the content of the result file as Codex left it, or None
-    for the run where Codex left nothing at all.
+    for the run where Codex left nothing at all. Bytes, for the run where what
+    it left is not text.
     """
     tmp_path.mkdir(parents=True, exist_ok=True)
     review_dir = tmp_path / "ai-review"
     review_dir.mkdir()
-    if codex_wrote is not None:
+    if isinstance(codex_wrote, bytes):
+        (review_dir / "findings.json").write_bytes(codex_wrote)
+    elif codex_wrote is not None:
         (review_dir / "findings.json").write_text(codex_wrote)
 
     output = tmp_path / "github_output"
@@ -135,7 +138,32 @@ def test_a_failed_codex_step_is_broken_and_says_nothing_was_reviewed(tmp_path: P
     status, summary = run_normalize(tmp_path, CODEX_OUTCOME="failure")
     assert status == "broken"
     assert "The reviewer failed" in summary
-    assert "the Codex step ended `failure`" in summary
+    assert "Codex exited non-zero" in summary
+
+
+def test_a_cancelled_run_is_declined_rather_than_broken(tmp_path: Path) -> None:
+    """A superseded dispatch must not report the reviewer as dead.
+
+    `cancel-in-progress` is on, so asking for a second review of one pull
+    request cancels the first - and `Normalize the result` runs anyway, because
+    `always()` covers cancellation. Calling that `broken` would put "the
+    reviewer failed" on a pull request whose replacement run is in flight.
+    """
+    status, summary = run_normalize(tmp_path, CODEX_OUTCOME="cancelled")
+    assert status == "declined"
+    assert "cancelled" in summary
+
+
+def test_a_step_failing_before_codex_does_not_blame_codex(tmp_path: Path) -> None:
+    """`skipped` means something earlier failed, so the causes listed differ.
+
+    Reporting "an expired key, a spend limit, a bad model slug" for a prompt
+    that was never composed sends the reader to the wrong place.
+    """
+    status, summary = run_normalize(tmp_path, CODEX_OUTCOME="skipped")
+    assert status == "broken"
+    assert "Codex never ran" in summary
+    assert "spend limit" not in summary
 
 
 def test_a_codex_failure_outranks_the_file_it_left_behind(tmp_path: Path) -> None:
@@ -161,6 +189,29 @@ def test_output_that_is_not_the_review_schema_is_broken_and_carries_the_raw_outp
     status, summary = run_normalize(tmp_path, codex_wrote='{"verdict": "looks fine"}')
     assert status == "broken"
     assert '{"verdict": "looks fine"}' in summary
+
+
+@pytest.mark.parametrize("findings", ["null", '"none"', "{}"])
+def test_findings_that_is_not_a_list_is_broken(tmp_path: Path, findings: str) -> None:
+    """Present is not enough, and the difference is the whole point of #311.
+
+    A key check passes `{"findings": null}`, `publish` then reads it through
+    `Array.isArray(…) ? … : []`, and the comment claims the reviewer read the
+    diff and had nothing to report - which it did not.
+    """
+    status, _ = run_normalize(tmp_path, codex_wrote=f'{{"summary": "x", "findings": {findings}}}')
+    assert status == "broken"
+
+
+def test_a_result_file_that_is_not_utf8_is_reported_rather_than_fatal(tmp_path: Path) -> None:
+    """Decoding it outside the guard would fail the step and skip the upload.
+
+    The pull request would then get no comment at all, for exactly the input
+    "the reviewer returned something unreadable" is there to report.
+    """
+    status, summary = run_normalize(tmp_path, codex_wrote=b"\xff\xfe not json")
+    assert status == "broken"
+    assert "not the review schema" in summary
 
 
 def test_a_misconfigured_reviewer_is_broken(tmp_path: Path) -> None:
@@ -207,11 +258,14 @@ def test_a_declined_diff_is_a_decision_rather_than_a_breakage(
     assert expected in summary
 
 
-def test_the_job_fails_on_broken_and_on_nothing_else() -> None:
+def test_a_broken_run_has_a_step_whose_only_job_is_to_fail_it() -> None:
     """A red job is the whole of the second half of #311.
 
     The condition is asserted rather than the behaviour because GitHub, not
-    bash, decides whether the step runs.
+    bash, decides whether the step runs. It is not the only way this job can go
+    red - any earlier step failing does it too, and then this one is skipped by
+    the implicit `success()` - but it is the only one that catches a reviewer
+    that produced nothing while every step reported fine.
     """
     failing = step("review", FAIL_STEP)
     assert failing["if"] == "steps.result.outputs.status == 'broken'"

--- a/backend/tests/test_ai_review_outcome.py
+++ b/backend/tests/test_ai_review_outcome.py
@@ -1,0 +1,254 @@
+"""What the AI reviewer reports when it did not review, run as the workflow runs it.
+
+#311: for eleven pull requests the reviewer died about twelve seconds into
+`Review the diff` with `codex exited with code 1`, the job concluded `success`,
+and the comment said "the reviewer did not produce a result" - a sentence that
+reads like a verdict on the diff. A clean diff and a dead reviewer rendered
+identically, so the outage was found by accident, three releases later.
+
+The fix is a three-way classification in `Normalize the result` - `reviewed`,
+`declined`, `broken` - which decides the heading on the comment and whether the
+job fails. Nothing in CI would catch a regression in it: `actionlint` checks the
+YAML and `zizmor` the permissions, and neither runs the script. So the step is
+extracted from the workflow and executed here, the same way
+`test_ai_review_config_guard.py` executes the configuration guard, rather than
+asserted about in prose.
+
+Extracting by step name rather than copying the script keeps one copy: rename
+the step and this fails loudly instead of testing a stale fork of it.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "ai-review.yml"
+NORMALIZE_STEP = "Normalize the result"
+FAIL_STEP = "Fail when the reviewer did not review"
+PUBLISH_STEP = "Post the findings"
+
+# Resolved rather than named: the runner and a developer's machine disagree
+# about whether bash is /bin or /usr/bin, and a partial path in a subprocess
+# call is a finding of its own (ruff S607).
+BASH = shutil.which("bash") or "/bin/bash"
+
+# A run where everything worked. Each test names the one thing it changes.
+HEALTHY = {
+    "REVIEW_DIR": "",  # filled in per run
+    "BASE_REF": "main",
+    "CONFIG_STATUS": "ok",
+    "CONFIG_PROBLEMS": "",
+    "STANDARD_STATUS": "ok",
+    "DIFF_STATUS": "ok",
+    "CHANGED_LINES": "24",
+    "MAX_CHANGED_LINES": "2000",
+    "CODEX_OUTCOME": "success",
+}
+
+# What Codex writes on a run that worked, and the shape `publish` knows how to
+# read. An empty findings list is the common answer on a correct pull request.
+A_REAL_REVIEW = json.dumps(
+    {"summary": "Adds a clock capability. Nothing blocks it.", "findings": []}
+)
+
+
+def workflow() -> dict[str, Any]:
+    loaded: dict[str, Any] = yaml.safe_load(WORKFLOW.read_text())
+    return loaded
+
+
+def step(job: str, name: str) -> dict[str, Any]:
+    """One step of one job, read out of the workflow itself."""
+    for candidate in workflow()["jobs"][job]["steps"]:
+        if candidate.get("name") == name:
+            found: dict[str, Any] = candidate
+            return found
+    raise AssertionError(f"No step named {name!r} in the {job!r} job of {WORKFLOW}")
+
+
+def run_normalize(
+    tmp_path: Path, *, codex_wrote: str | None = None, **overrides: str
+) -> tuple[str, str]:
+    """Run `Normalize the result` and return its `status` output and the summary it wrote.
+
+    `codex_wrote` is the content of the result file as Codex left it, or None
+    for the run where Codex left nothing at all.
+    """
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    review_dir = tmp_path / "ai-review"
+    review_dir.mkdir()
+    if codex_wrote is not None:
+        (review_dir / "findings.json").write_text(codex_wrote)
+
+    output = tmp_path / "github_output"
+    output.touch()
+    script = tmp_path / "normalize.sh"
+    script.write_text(str(step("review", NORMALIZE_STEP)["run"]))
+
+    result = subprocess.run(
+        [BASH, str(script)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **HEALTHY,
+            "REVIEW_DIR": str(review_dir),
+            **overrides,
+            "GITHUB_OUTPUT": str(output),
+            # The step shells out to `python3`; the interpreter running the
+            # suite is the one this repository pins, so use its directory
+            # rather than trusting whatever /usr/bin holds.
+            "PATH": f"{Path(sys.executable).parent}:/usr/bin:/bin",
+        },
+    )
+    assert result.returncode == 0, f"the step itself failed: {result.stderr}"
+
+    written = dict(line.split("=", 1) for line in output.read_text().splitlines() if "=" in line)
+    findings = json.loads((review_dir / "findings.json").read_text())
+    summary: str = findings["summary"]
+    return written.get("status", ""), summary
+
+
+def test_a_review_that_happened_is_reviewed_and_is_left_alone(tmp_path: Path) -> None:
+    """The normalizer must not rewrite a real review, only classify it."""
+    status, summary = run_normalize(tmp_path, codex_wrote=A_REAL_REVIEW)
+    assert status == "reviewed"
+    assert summary == "Adds a clock capability. Nothing blocks it."
+
+
+def test_a_failed_codex_step_is_broken_and_says_nothing_was_reviewed(tmp_path: Path) -> None:
+    """The #311 regression.
+
+    Before this, the only signal was a missing result file, which rendered as
+    "the reviewer did not produce a result" - indistinguishable from a clean
+    diff to anybody skimming, and the job concluded `success` besides.
+    """
+    status, summary = run_normalize(tmp_path, CODEX_OUTCOME="failure")
+    assert status == "broken"
+    assert "The reviewer failed" in summary
+    assert "Nothing in this pull request was reviewed" in summary
+
+
+def test_a_codex_failure_outranks_the_file_it_left_behind(tmp_path: Path) -> None:
+    """A crash mid-stream can leave a partial or stale result on disk.
+
+    Reading it would report a review that did not finish - so the step's own
+    outcome is checked before the file is trusted.
+    """
+    status, summary = run_normalize(tmp_path, codex_wrote=A_REAL_REVIEW, CODEX_OUTCOME="failure")
+    assert status == "broken"
+    assert "Adds a clock capability" not in summary
+
+
+def test_codex_exiting_cleanly_with_no_result_is_broken(tmp_path: Path) -> None:
+    status, summary = run_normalize(tmp_path)
+    assert status == "broken"
+    assert "wrote no result file" in summary
+
+
+def test_output_that_is_not_the_review_schema_is_broken_and_carries_the_raw_output(
+    tmp_path: Path,
+) -> None:
+    status, summary = run_normalize(tmp_path, codex_wrote='{"verdict": "looks fine"}')
+    assert status == "broken"
+    assert '{"verdict": "looks fine"}' in summary
+
+
+def test_a_misconfigured_reviewer_is_broken(tmp_path: Path) -> None:
+    status, summary = run_normalize(
+        tmp_path,
+        CONFIG_STATUS="unconfigured",
+        CONFIG_PROBLEMS="AI_REVIEW_MODEL is unset",
+        STANDARD_STATUS="",
+        DIFF_STATUS="",
+        CODEX_OUTCOME="skipped",
+    )
+    assert status == "broken"
+    assert "AI_REVIEW_MODEL is unset" in summary
+
+
+def test_a_base_branch_with_no_prompt_is_broken(tmp_path: Path) -> None:
+    status, summary = run_normalize(
+        tmp_path, STANDARD_STATUS="no-standard", DIFF_STATUS="", CODEX_OUTCOME="skipped"
+    )
+    assert status == "broken"
+    assert "review-prompt.md" in summary
+
+
+@pytest.mark.parametrize(
+    ("diff_status", "expected"),
+    [
+        ("empty", "changes nothing outside the excluded paths"),
+        ("too-large", "over the 2000 line limit"),
+    ],
+)
+def test_a_declined_diff_is_a_decision_rather_than_a_breakage(
+    tmp_path: Path, diff_status: str, expected: str
+) -> None:
+    """`declined` exists so that these do not fail the job.
+
+    Nothing to review and a diff over the cap are choices this workflow makes
+    on purpose. Reporting them the same way as a dead reviewer would train
+    everybody to ignore the red mark that matters.
+    """
+    status, summary = run_normalize(
+        tmp_path, DIFF_STATUS=diff_status, CHANGED_LINES="9000", CODEX_OUTCOME="skipped"
+    )
+    assert status == "declined"
+    assert expected in summary
+
+
+def test_the_job_fails_on_broken_and_on_nothing_else() -> None:
+    """A red job is the whole of the second half of #311.
+
+    The condition is asserted rather than the behaviour because GitHub, not
+    bash, decides whether the step runs.
+    """
+    failing = step("review", FAIL_STEP)
+    assert failing["if"] == "steps.result.outputs.status == 'broken'"
+    assert "exit 1" in failing["run"]
+
+    steps = workflow()["jobs"]["review"]["steps"]
+    assert steps[-1]["name"] == FAIL_STEP, (
+        "the failing step has to be last: an earlier one would skip the steps that "
+        "write and upload the comment explaining why"
+    )
+
+
+def test_publish_is_gated_on_the_reviewers_verdict_rather_than_its_job_result() -> None:
+    """Otherwise failing the `review` job would silence the comment as well.
+
+    That tension is exactly why `Review the diff` carries `continue-on-error`
+    and why the job's failure is deferred to its last step.
+    """
+    condition = workflow()["jobs"]["publish"]["if"]
+    assert "needs.review.outputs.status" in condition
+    assert "needs.review.result" not in condition
+
+
+def test_every_status_the_normalizer_writes_has_a_heading_in_the_comment(tmp_path: Path) -> None:
+    """The two halves live in different jobs and in different languages.
+
+    A fourth status added to the Python without a heading in the JavaScript
+    renders as `## AI review — undefined` on somebody's pull request.
+    """
+    script = str(step("publish", PUBLISH_STEP)["with"]["script"])
+    block = re.search(r"const heading = \{(.*?)\n\}", script, re.DOTALL)
+    assert block, "the heading table moved; this test is now guarding nothing"
+    headings = set(re.findall(r"^\s*(\w+):", block.group(1), re.MULTILINE))
+
+    produced = {
+        run_normalize(tmp_path / "reviewed", codex_wrote=A_REAL_REVIEW)[0],
+        run_normalize(tmp_path / "declined", DIFF_STATUS="empty", CODEX_OUTCOME="skipped")[0],
+        run_normalize(tmp_path / "broken", CODEX_OUTCOME="failure")[0],
+    }
+    assert produced == headings

--- a/backend/tests/test_ai_review_outcome.py
+++ b/backend/tests/test_ai_review_outcome.py
@@ -135,7 +135,7 @@ def test_a_failed_codex_step_is_broken_and_says_nothing_was_reviewed(tmp_path: P
     status, summary = run_normalize(tmp_path, CODEX_OUTCOME="failure")
     assert status == "broken"
     assert "The reviewer failed" in summary
-    assert "Nothing in this pull request was reviewed" in summary
+    assert "the Codex step ended `failure`" in summary
 
 
 def test_a_codex_failure_outranks_the_file_it_left_behind(tmp_path: Path) -> None:
@@ -233,6 +233,17 @@ def test_publish_is_gated_on_the_reviewers_verdict_rather_than_its_job_result() 
     condition = workflow()["jobs"]["publish"]["if"]
     assert "needs.review.outputs.status" in condition
     assert "needs.review.result" not in condition
+
+
+def test_a_broken_run_says_the_comment_is_not_about_the_diff() -> None:
+    """The sentence #311 was missing, and it is said in exactly one place.
+
+    Each `broken` path writes its own explanation of what went wrong; the claim
+    that none of it is a verdict on the code is uniform, so `publish` adds it
+    once rather than every branch of the normalizer repeating it.
+    """
+    script = str(step("publish", PUBLISH_STEP)["with"]["script"])
+    assert "Nothing here was reviewed" in script
 
 
 def test_every_status_the_normalizer_writes_has_a_heading_in_the_comment(tmp_path: Path) -> None:

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -176,9 +176,28 @@ decides both the heading on the comment and whether the job goes red.
 
 | Status | When | The job | The comment says |
 |---|---|---|---|
-| `reviewed` | Codex answered with the schema | green | `## AI review`. With no findings: "the reviewer read the diff and had nothing to report" |
-| `declined` | Nothing to review, or a diff over the line cap | green | `## AI review — declined`, and which cap |
-| `broken` | Misconfigured, no prompt on the base branch, Codex exited non-zero, or output that is not the schema | **red** | `## AI review — the reviewer failed`, then "Nothing here was reviewed" |
+| `reviewed` | Codex answered with the schema — `summary` plus a `findings` **list** | green | `## AI review`. With no findings: "the reviewer read the diff and had nothing to report" |
+| `declined` | Nothing to review, a diff over the line cap, or the run was cancelled | green | `## AI review — declined`, and which of the three |
+| `broken` | Misconfigured, no prompt on the base branch, Codex exited non-zero or never ran, or output that is not the schema | **red** | `## AI review — the reviewer failed`, then "Nothing here was reviewed" |
+
+Three edges of that table are the ones worth knowing, because each has a wrong
+answer that looks reasonable:
+
+- **A cancelled run is `declined`, not `broken`.** `cancel-in-progress` is on, so
+  a second dispatch for one pull request cancels the first — and `Normalize the
+  result` runs anyway, because `always()` covers cancellation. Reporting a dead
+  reviewer on a pull request whose replacement run is already in flight is the
+  #311 mistake pointing the other way.
+- **`findings` has to be a list, not merely present.** `{"findings": null}`
+  passes a key check, and `publish` reads it through
+  `Array.isArray(…) ? … : []` — so a malformed answer would render as "the
+  reviewer read the diff and had nothing to report", which is #311's sentence
+  again with a different cause.
+- **A `review` job that fails *before* `Normalize the result` is red with no
+  comment.** A failed checkout, a base branch missing `review-schema.json`: there
+  is no status, so `publish` is skipped. That is not new and not silent — the job
+  is red, which is the whole point — but it is the one path where the pull
+  request page carries the failure and nothing else does.
 
 The `broken` comment carries what Codex printed, in a `<details>` block. That is
 read back out of the run's own job log by `publish`, which is why that job holds

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -11,8 +11,15 @@
     describes the workflow as it will behave when the trigger is restored, and
     [When it runs](#when-it-runs) says what is live today.
 
-    Until then the review before a merge is a human one, plus the local
-    `/review` command in `.claude/commands/review.md`.
+    The **reporting** half of #311 is fixed: a run that does not review now
+    fails and says which stage broke, in the words Codex used —
+    [What a failed run looks like](#what-a-failed-run-looks-like). The cause is
+    not: the log for the whole outage reads `Your project has reached its
+    configured enforced spend limit`, which is a setting in the OpenAI project,
+    not in this repository.
+
+    Until the trigger is back the review before a merge is a human one, plus the
+    local `/review` command in `.claude/commands/review.md`.
 
 A GitHub Action reviews pull requests against **this repository's own standard**.
 It is not a linter with a language model attached: the prompt in
@@ -90,7 +97,7 @@ middle job runs a model over code the pull request controls.
 |---|---|---|
 | `context` | `pull-requests: read` | no |
 | `review` | `contents: read` | **yes** |
-| `publish` | `pull-requests: write` | no |
+| `publish` | `pull-requests: write`, `actions: read` | no |
 
 The job with `OPENAI_API_KEY` can write nothing back — no comment, no label, no
 ref — whatever the model is talked into. The job that writes has never seen the
@@ -153,17 +160,63 @@ itself in the summary comment.
   patch hunks first and demotes an unanchorable finding into the summary rather
   than losing it to a 422 — and catches the 422 as well, for the force-push
   that lands between the two jobs.
-- **A failed run.** If the reviewer produces nothing, the summary comment says
-  so and links the run. Silence would read as "no findings".
-
-    Not enough, as [#311](https://github.com/vstorm-co/agenticos/issues/311)
-    found: that comment reads like a verdict on the diff, the `review` job still
-    concludes `success`, and eleven pull requests merged before anybody noticed
-    the reviewer had stopped working. Distinguishing "the reviewer failed" from
-    "the reviewer found nothing" is the second half of #311 and is not done yet.
+- **A failed run.** The `review` job fails, and the comment says the reviewer
+  failed rather than that it had nothing to say. See below.
 
 Re-runs replace rather than pile up: the summary comment is upserted on an HTML
-marker, and the previous run's inline comments are deleted first.
+marker, and the previous run's inline comments are deleted first — but only by a
+run that reviewed. A broken run has nothing to replace them with, and deleting
+findings somebody has not finished acting on because the reviewer went down is
+the wrong half of "replace".
+
+## What a failed run looks like
+
+`Normalize the result` classifies every run into one of three, and that word
+decides both the heading on the comment and whether the job goes red.
+
+| Status | When | The job | The comment says |
+|---|---|---|---|
+| `reviewed` | Codex answered with the schema | green | `## AI review`. With no findings: "the reviewer read the diff and had nothing to report" |
+| `declined` | Nothing to review, or a diff over the line cap | green | `## AI review — declined`, and which cap |
+| `broken` | Misconfigured, no prompt on the base branch, Codex exited non-zero, or output that is not the schema | **red** | `## AI review — the reviewer failed`, then "Nothing here was reviewed" |
+
+The `broken` comment carries what Codex printed, in a `<details>` block. That is
+read back out of the run's own job log by `publish`, which is why that job holds
+`actions: read` — a `uses:` step's stderr goes nowhere else, and for the whole of
+#311 the one line that mattered was sitting at the bottom of a green job:
+
+```text
+ERROR: stream disconnected before completion: Your project has reached its
+configured enforced spend limit.
+```
+
+That block is log text in a public comment, which is worth being deliberate
+about: this repository's Actions logs are public too, and GitHub masks
+registered secrets before serving either, so a reader learns nothing there that
+the link to the run did not already give them.
+
+Three things about this worth knowing before changing it.
+
+**Red, not neutral.** The check is advisory and not required, so a red mark
+costs nobody a merge; it only makes an outage visible on the page somebody is
+already reading. A neutral conclusion renders as a grey tick, which is the thing
+#311 was about.
+
+**`Review the diff` still carries `continue-on-error`, and the job fails at its
+last step instead.** Failing at the Codex step would skip the two steps that
+write and upload the comment, and the pull request would get a red mark with no
+explanation. Read `steps.codex.outcome`, never `steps.codex.conclusion`: under
+`continue-on-error` the conclusion is `success` by construction, which is
+precisely how this stayed invisible.
+
+**`publish` is gated on `needs.review.outputs.status`, not on
+`needs.review.result`.** A job that deliberately fails is exactly the run whose
+comment matters most, so what decides whether the comment is posted is whether
+there is one to post.
+
+`backend/tests/test_ai_review_outcome.py` extracts that step from the workflow
+and runs it, because nothing else would: `actionlint` checks the YAML and
+`zizmor` the permissions, and neither executes the script.
 
 ## Setup
 


### PR DESCRIPTION
## Which half of #311 this is

The **reporting** half. `Run the reviewer` no longer concludes `success` when it
produced nothing, and the comment now says which of the two happened.

The other half — whatever makes `codex` exit 1 — is **found but not fixed here,
because it is not a code change.** The log of every failing run says so in one
line, and I only had to read it:

```text
ERROR: Reconnecting... 1/5 … 5/5
ERROR: stream disconnected before completion: Your project has reached its
configured enforced spend limit. Update your limit at
https://platform.openai.com/settings/proj_…/limits.
Error: codex exited with code 1
```

That is [run 31093280297](https://github.com/vstorm-co/agenticos/actions/runs/31093280297),
`Run the reviewer`, on #312. The twelve seconds in the issue are five reconnect
attempts and a give-up, which is the shape the issue guessed at.

**For a human, and only a human:** the enforced spend limit on the OpenAI
project. I cannot see a credential's quota or change it. Raising it — or moving
the reviewer to a project that is not capped — is what restores the reviewer;
nothing in this branch does.

Two things I checked and ruled out, so nobody re-checks them:

- **The action pin is not stale.** `52fe01ec70a42f454c9d2ebd47598f9fd6893d56`
  dereferences exactly `openai/codex-action@v1.11`, the latest tag, annotated
  2026-07-04 — a month before the outage, and unchanged across the last working
  run (#265) and the first failing one (#268).
- **Nothing changed in this repository on 2026-08-05 evening.** The spend limit
  is a state on the OpenAI side; the runs either side of it are identical.

Filed while here: **#347** — the action is pinned but the Codex CLI it installs
is not (`codex-version` is empty, so every run takes whatever npm publishes).
Out of scope, and the same failure shape as this issue.

## What changed

`Normalize the result` classifies every run into one of three, and the word
decides both the heading on the comment and whether the job goes red.

| Status | When | Job | Comment |
|---|---|---|---|
| `reviewed` | Codex answered with the schema | green | `## AI review`. With no findings, "the reviewer read the diff and had nothing to report" |
| `declined` | Nothing to review, or a diff over the cap | green | `## AI review — declined` |
| `broken` | Misconfigured, no prompt on the base branch, Codex exited non-zero, or output that is not the schema | **red** | `## AI review — the reviewer failed`, then "Nothing here was reviewed" |

Making the job red without silencing the comment is the awkward part, and it is
why the change is not one line:

- `publish` was gated on `needs.review.result == 'success'`. It is now gated on
  `needs.review.outputs.status`, set by the step that writes the comment — so
  `review` can fail at its last step and the pull request still gets the
  explanation. The run whose comment matters most is exactly the failing one.
- `Review the diff` keeps `continue-on-error` for the same reason, and gains
  `id: codex` so the normalizer can read `steps.codex.outcome`. Its
  `conclusion` is `success` by construction under `continue-on-error` — which is
  how this stayed invisible for a day.
- The failing step is **last** in the job, after the comment is written and
  uploaded. A test asserts that, because moving it up would silently restore the
  old behaviour.
- Red rather than `neutral`: the check is advisory and not required, so red
  costs nobody a merge. A neutral conclusion renders as a grey tick, which is
  the thing #311 is about.

**Codex's own output now travels into the comment**, in a `<details>` block.
`publish` reads this run's job log back through the API — it gained
`actions: read` for that, in the job that holds no key — and keeps the lines
Codex complained on. The issue is right that the output "is not surfaced beyond
the Node stack trace": a `uses:` step's stderr goes nowhere but the runner log,
under that stack trace, at the bottom of 1,100 lines of a job that concluded
green. This is a public repository, so its Actions logs are public and GitHub
masks registered secrets before serving either; the comment discloses nothing
the link to the run did not.

That step carries `continue-on-error` of its own. A diagnosis that cannot be
fetched must not cost the comment.

### Three edges the classification has to get right

Each has a wrong answer that looks reasonable, and the third commit on this
branch is me getting two of them wrong first:

- **A cancelled run is `declined`, not `broken`.** `cancel-in-progress` is on, so
  a second dispatch for one pull request cancels the first — and `Normalize the
  result` runs anyway, because `always()` covers cancellation. Scoring that as
  broken puts "the reviewer failed" on a pull request whose replacement run is
  already in flight: #311's mistake pointing the other way.
- **`skipped` is not a Codex failure.** At that point it means a step between the
  diff and Codex failed, so naming Codex — and listing a key, a spend limit and a
  model slug — sends the reader to the wrong place.
- **`findings` has to be a list, not merely present.** `{"findings": null}`
  passes a key check, `publish` reads it through `Array.isArray(…) ? … : []`, and
  the comment would claim "the reviewer read the diff and had nothing to report".
  That is #311's sentence again with a different cause and a green job behind it.

And one path this deliberately does not cover, said plainly in the docs rather
than papered over: **a `review` job that fails before the normalizer runs is red
with no comment**, because there is no status to publish. A failed checkout, or a
base branch missing `review-schema.json`. Not new, and not silent — the job is
red — but the pull request page carries only that.

### Two things fixed in passing

Both are the same defect as the one above — something on the page quietly
untrue — and both are in the lines this change already touches:

- A broken or declined re-run **deleted the previous run's inline findings** and
  replaced them with nothing, so a reviewer outage silently threw away real
  findings somebody had not finished acting on. Only a run that reviewed
  replaces its predecessor now.
- The comment footer said to add the `ai-review` label to re-run. #313 removed
  the `pull_request` trigger, so the label does nothing; it prints the
  `gh workflow run` line instead.

## How it was verified

- **Against the real failure.** `gh workflow run ai-review.yml --ref` this
  branch, at this pull request: `Run the reviewer` **fails**, and the comment
  below is headed "the reviewer failed", says nothing here was reviewed, and
  carries the spend-limit line. That is the whole change, exercised end to end
  on the live failure — see the run linked from the comment.
- `backend/tests/test_ai_review_outcome.py` — 19 cases. It extracts the
  normalize step from the workflow and executes it, the way
  `test_ai_review_config_guard.py` executes the configuration guard, because
  nothing else would: `actionlint` checks the YAML and `zizmor` the permissions,
  and neither runs the script. It covers each of the three statuses, cancelled
  and skipped separately, a `findings` that is `null` / a string / an object,
  a result file that is not text, that a Codex failure outranks a stale result
  file left on disk, that the failing step is last and conditioned on `broken`
  alone, that `publish` reads the output rather than the job result, and that
  the three statuses the Python writes match the three headings the JavaScript
  renders — those halves live in different jobs and different languages, and a
  fourth status without a heading renders as `## AI review — undefined`.
- The log filter was run over the real 84 kB and 90 kB logs of the two failing
  runs. It returns the seven lines that matter and nothing else.
- `make lint`, `make test` (3231 passed, 100% on the platform layer),
  `make db-check`, `make test-frontend-cov` (97.55% branches), `make
  build-frontend`, `make docs-build` (`--strict`), `make audit`. `pre-commit`
  over the changed files: yamlfmt, zizmor, codespell, the double-backtick guard.
  **CI green on `af76646`** — every job including `e2e`.
- `python3 scripts/docs_drift.py` — clean.

Said plainly, since it was not clean first time: a whole-suite `make check`
started before the third commit went red twice, and neither was this branch.
Once on `test_ai_review_outcome.py`, because it ran against a test file I was
editing under it — the assertion it failed on is one this branch then changed.
Once on `test-frontend-cov`, the coverage-instrumentation timeout
`.claude/rules/testing.md` warns about, on a laptop running ten worktrees'
suites at once; it passes on re-run. Every target `check` had not reached by
then was run individually afterwards, listed above, and CI ran all of them on
the head commit.

Also worth knowing when reading a red local run today: **#346** — `make check`'s
migration chain uses a constant database name, so concurrent worktrees drop each
other's schema. Not encountered here (`check` does not run `test-migrations`),
noted so the next reader does not chase it.

**Not verified, and not verifiable from here:** that a dispatched run produces a
*green* review. That needs the spend limit lifted.

**Noticed, not fixed, and deliberately not filed:** nothing bounds the summary
comment against GitHub's 65,536-character limit — every finding past
`MAX_INLINE` is appended with its full evidence, so ~160 findings on one pull
request would 422 the comment entirely. It is pre-existing, unrelated to #311,
and unreachable in practice: `MAX_INLINE` is 25 precisely because a reviewer
with 25 findings has stopped being useful. Recorded here rather than as an issue
because an unreachable branch is not a defect; happy to file it if you disagree.

## Documentation

`docs/code-review.md` gains [What a failed run looks
like](https://github.com/vstorm-co/agenticos/blob/ci/ai-review-reports-its-own-failure/docs/code-review.md):
the three statuses, the red-not-neutral reasoning, the `outcome`/`conclusion`
trap, and why `publish` is gated on an output. The note #313 honestly left under
*Caps* — that "a failed run says so" was exactly what #311 disproved — is
replaced by what a failed run now does. The top warning says the reporting half
is fixed and the cause is not, and names the cause.

## Reviewed by a human, not by the reviewer

`ai-review` is off (#313) and the label does nothing, so **this diff has not
been through an automated reviewer.** I read it as a maintainer would instead:
the failure paths through the three jobs, what happens when each step is
skipped, whether a red `review` can ever silence the comment, whether the log
scrape can throw, and whether anything published here is not already public. The
two passing fixes above came out of that pass.

Refs #311

