### PR TITLE
fix(e2e): poll for the colleague's membership, and say what was seen

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -71,7 +71,10 @@ Traps, each of which has cost a red job here:
   `element(s) not found` for a refusal it never looked at (#132). And a **fixture** step
   asserts through the API, never on the row appearing - the refetch after a write is
   sometimes answered with the pre-write list (#230), which is a product bug and must not
-  be reported as a broken fixture.
+  be reported as a broken fixture. It asserts by **polling** that API, because a 2xx
+  from this backend says the request was answered and not that the write is readable:
+  the commit runs after the response goes out (#353). One step read once instead and
+  took all 87 specs down three times in a day (#335).
 - **Coverage instrumentation slows tests enough to trip a 5s `testTimeout`.** A
   heavy spec that passes under `test:run` can time out under `test:coverage`; re-run
   before believing it.

--- a/.claude/skills/e2e-tests/SKILL.md
+++ b/.claude/skills/e2e-tests/SKILL.md
@@ -63,10 +63,17 @@ It does **not** promise the row is rendered, and that is not a shortcut — the 
 refetch is sometimes answered with the pre-write list even though the row is committed
 and both server layers return it (**#230**, about one run in eight). Two consequences:
 
-- **A fixture step asks the API.** Every step of `seed.setup.ts` asserts through
-  `/api/…` now, because its job is that the fixture exists. Whether it renders is a
-  product claim, and `vault.spec.ts` / `skills.spec.ts` make it against the rows the
-  seed left, on pages they loaded themselves.
+- **A fixture step asks the API, and asks more than once.** Every step of
+  `seed.setup.ts` asserts through `/api/…` now, because its job is that the fixture
+  exists. Whether it renders is a product claim, and `vault.spec.ts` /
+  `skills.spec.ts` make it against the rows the seed left, on pages they loaded
+  themselves. Asking the API is not enough on its own: **a 2xx from this backend
+  means the request was answered, not that the write is readable.** The commit sits
+  in a `Depends`-with-`yield` exit code, which FastAPI unwinds after the response
+  has gone out (**#353**) — measured at 21.7ms on one acceptance. So a fixture check
+  is `nowThere`, a poll, never a single read. The membership step was the one site
+  #222 missed when it converted the file, and it cost 87 skipped specs three times
+  in a day (**#335**).
 - **A product spec about the rendering reloads first**, marked `#230`, until that
   issue closes.
 

--- a/.claude/skills/e2e-tests/SKILL.md
+++ b/.claude/skills/e2e-tests/SKILL.md
@@ -70,10 +70,13 @@ and both server layers return it (**#230**, about one run in eight). Two consequ
   themselves. Asking the API is not enough on its own: **a 2xx from this backend
   means the request was answered, not that the write is readable.** The commit sits
   in a `Depends`-with-`yield` exit code, which FastAPI unwinds after the response
-  has gone out (**#353**) — measured at 21.7ms on one acceptance. So a fixture check
-  is `nowThere`, a poll, never a single read. The membership step was the one site
-  #222 missed when it converted the file, and it cost 87 skipped specs three times
-  in a day (**#335**).
+  has gone out (**#353**) — measured at 21.7ms on one acceptance. So a check that
+  *follows a write* is `nowThere`, a poll, never a single read; the `alreadyThere`
+  guard at the head of each step stays one read, because it runs before the write.
+  The membership step was the one site #222 missed when it converted the file, and
+  it cost 87 skipped specs three times in a day (**#335**). One step is still the
+  exception in either direction: `a draft agent exists` waits on the Builder's
+  heading.
 - **A product spec about the rendering reloads first**, marked `#230`, until that
   issue closes.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -193,9 +193,15 @@ pre-write list even though the row is committed and both server layers return it
 ([#230](https://github.com/vstorm-co/agenticos/issues/230), about one run in
 eight). So:
 
-- **A fixture step asks the API.** Every step of `seed.setup.ts` asserts through
-  `/api/…`, because its job is that the fixture exists — and a fixture step that
-  fails takes every product spec with it.
+- **A fixture step asks the API, and keeps asking.** Every step of
+  `seed.setup.ts` asserts through `/api/…`, because its job is that the fixture
+  exists — and a fixture step that fails takes every product spec with it. It
+  asks by polling (`nowThere`), never with a single read: a 2xx from this
+  backend means the request was answered, not that the write is readable, because
+  the commit runs in a dependency FastAPI unwinds after the response has gone out
+  ([#353](https://github.com/vstorm-co/agenticos/issues/353)). The one step that
+  read once cost 87 skipped specs three times in a day
+  ([#335](https://github.com/vstorm-co/agenticos/issues/335)).
 - **A product spec that is about the rendering says so**, and reloads first if it
   needs a list it can trust. `vault.spec.ts` has three `page.reload()` calls
   marked `#230`; when that issue closes, they come out.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -195,12 +195,14 @@ eight). So:
 
 - **A fixture step asks the API, and keeps asking.** Every step of
   `seed.setup.ts` asserts through `/api/…`, because its job is that the fixture
-  exists — and a fixture step that fails takes every product spec with it. It
-  asks by polling (`nowThere`), never with a single read: a 2xx from this
-  backend means the request was answered, not that the write is readable, because
-  the commit runs in a dependency FastAPI unwinds after the response has gone out
-  ([#353](https://github.com/vstorm-co/agenticos/issues/353)). The one step that
-  read once cost 87 skipped specs three times in a day
+  exists — and a fixture step that fails takes every product spec with it. After
+  a write it asks by polling (`nowThere`), never with a single read: a 2xx from
+  this backend means the request was answered, not that the write is readable,
+  because the commit runs in a dependency FastAPI unwinds after the response has
+  gone out ([#353](https://github.com/vstorm-co/agenticos/issues/353)). The
+  `alreadyThere` guard each step opens with stays a single read, since it runs
+  before the write. The one *post-write* check that read once cost 87 skipped
+  specs three times in a day
   ([#335](https://github.com/vstorm-co/agenticos/issues/335)).
 - **A product spec that is about the rendering says so**, and reloads first if it
   needs a list it can trust. `vault.spec.ts` has three `page.reload()` calls

--- a/frontend/e2e/seed.setup.ts
+++ b/frontend/e2e/seed.setup.ts
@@ -49,8 +49,8 @@ import {
  * off the reply to sending it (it is emailed, the inviter's screen deliberately
  * never prints it, and a test has no inbox).
  *
- * **Every step asserts through the API, not by finding the new row on screen**,
- * and that line is the whole of #132. A step whose job is "the fixture exists"
+ * **A step asserts through the API, not by finding the new row on screen**, and
+ * that line is the whole of #132. A step whose job is "the fixture exists"
  * used to prove it by waiting for the row to appear in a list — which fails when
  * the list has not caught up, and a failure here skips every product spec behind
  * it, so a browser-side staleness bug arrived on pull requests looking like a
@@ -63,7 +63,11 @@ import {
  * was answered, not that the write is readable. The commit runs in a dependency
  * FastAPI unwinds after the response has gone out (#353), so the next read can
  * arrive at a database the write has not been applied to — measured at 21.7ms
- * on one acceptance. So every check is a poll (`nowThere`), never a read.
+ * on one acceptance. So a check that follows a write is a poll (`nowThere`),
+ * never a single read. The `alreadyThere` guard at the head of each step is one
+ * read on purpose: it runs *before* the write, and the worst a stale answer
+ * costs there is doing work that was already done. `a draft agent exists` is the
+ * remaining exception in either direction — it waits on the Builder's heading.
  *
  * Whether the row *renders* is a product claim and belongs to a product spec —
  * `vault.spec.ts` and `skills.spec.ts` assert exactly that against the rows this
@@ -249,8 +253,8 @@ setup("the organization has connected an MCP server", async ({ page }) => {
 
 setup("a colleague is a member of the organization", async ({ page, browser }) => {
   const organizationId = await activeOrganizationId(page.request);
-  const members = `/api/orgs/${organizationId}/members`;
-  if (await alreadyThere(page.request, members, "email", COLLEAGUE_EMAIL)) return;
+  const membersPath = `/api/orgs/${organizationId}/members`;
+  if (await alreadyThere(page.request, membersPath, "email", COLLEAGUE_EMAIL)) return;
 
   await registerColleague(page.request);
   const token = await ensurePendingInvitation(page, organizationId);
@@ -265,7 +269,7 @@ setup("a colleague is a member of the organization", async ({ page, browser }) =
   // in the file that did: #222 converted four call sites to `nowThere` and did
   // not reach this one, which is why this is the step that turns a fixture
   // project red and takes all eighty-seven product specs with it (#335).
-  await nowThere(page, members, "email", COLLEAGUE_EMAIL);
+  await nowThere(page, membersPath, "email", COLLEAGUE_EMAIL);
 });
 
 /** One field of every row in a collection — what both checks below look at. */
@@ -307,7 +311,8 @@ async function alreadyThere(
  * **Polled because the API is answered before the write is durable**, which is
  * not a courtesy about ordering but a measured property of this backend. A
  * dependency with `yield` has its exit code unwound by FastAPI *after*
- * `await response(...)` (`fastapi/routing.py`, `request_response`), and
+ * `await response(...)` (`fastapi/routing.py`, `request_response`, read at
+ * 0.141.1 — the teardown has moved relative to the send before), and
  * `get_db_session` is where the commit lives — so a 2xx reaches the client with
  * the transaction still open, and the client's next request can read a database
  * the write has not been applied to. Measured against this backend: an

--- a/frontend/e2e/seed.setup.ts
+++ b/frontend/e2e/seed.setup.ts
@@ -59,6 +59,12 @@ import {
  * server layers answer a list containing it, and the page goes on rendering the
  * one without it.
  *
+ * Asking the API is necessary and not sufficient: a 2xx here means the request
+ * was answered, not that the write is readable. The commit runs in a dependency
+ * FastAPI unwinds after the response has gone out (#353), so the next read can
+ * arrive at a database the write has not been applied to — measured at 21.7ms
+ * on one acceptance. So every check is a poll (`nowThere`), never a read.
+ *
  * Whether the row *renders* is a product claim and belongs to a product spec —
  * `vault.spec.ts` and `skills.spec.ts` assert exactly that against the rows this
  * file leaves behind, on a page they loaded themselves. The MCP step has said so
@@ -243,26 +249,34 @@ setup("the organization has connected an MCP server", async ({ page }) => {
 
 setup("a colleague is a member of the organization", async ({ page, browser }) => {
   const organizationId = await activeOrganizationId(page.request);
-
-  const members = await json<{ items: { email: string }[] }>(
-    page.request,
-    `/api/orgs/${organizationId}/members`,
-  );
-  if (members.items.some((member) => member.email === COLLEAGUE_EMAIL)) return;
+  const members = `/api/orgs/${organizationId}/members`;
+  if (await alreadyThere(page.request, members, "email", COLLEAGUE_EMAIL)) return;
 
   await registerColleague(page.request);
   const token = await ensurePendingInvitation(page, organizationId);
   await acceptAsColleague(browser, token);
 
-  const after = await json<{ items: { email: string }[] }>(
-    page.request,
-    `/api/orgs/${organizationId}/members`,
-  );
-  expect(
-    after.items.map((member) => member.email),
-    "the colleague accepted the invitation but is not a member",
-  ).toContain(COLLEAGUE_EMAIL);
+  // `acceptAsColleague` returns only once the colleague's own screen says they
+  // joined, so the server has answered 204 before this line - and that is still
+  // not the same as the row being readable by the owner, because the acceptance
+  // commits *after* the response goes out (#353).
+  //
+  // This step used to read the list once and assert on it. It was the only one
+  // in the file that did: #222 converted four call sites to `nowThere` and did
+  // not reach this one, which is why this is the step that turns a fixture
+  // project red and takes all eighty-seven product specs with it (#335).
+  await nowThere(page, members, "email", COLLEAGUE_EMAIL);
 });
+
+/** One field of every row in a collection — what both checks below look at. */
+async function valuesAt(
+  request: APIRequestContext,
+  path: string,
+  field: string,
+): Promise<unknown[]> {
+  const list = await json<{ items: Record<string, unknown>[] }>(request, path);
+  return list.items.map((item) => item[field]);
+}
 
 /**
  * Whether a row with this value is already in a collection.
@@ -278,8 +292,7 @@ async function alreadyThere(
   field: string,
   value: string,
 ): Promise<boolean> {
-  const list = await json<{ items: Record<string, unknown>[] }>(request, path);
-  return list.items.some((item) => item[field] === value);
+  return (await valuesAt(request, path, field)).includes(value);
 }
 
 /**
@@ -291,15 +304,29 @@ async function alreadyThere(
  * project dependency the whole suite is reported red having run no product spec —
  * three branches paid a diagnosis for that in one day (#132).
  *
- * Polled rather than asked once because it costs nothing to be kind about
- * ordering, and it is the same shape the MCP step has used all along.
+ * **Polled because the API is answered before the write is durable**, which is
+ * not a courtesy about ordering but a measured property of this backend. A
+ * dependency with `yield` has its exit code unwound by FastAPI *after*
+ * `await response(...)` (`fastapi/routing.py`, `request_response`), and
+ * `get_db_session` is where the commit lives — so a 2xx reaches the client with
+ * the transaction still open, and the client's next request can read a database
+ * the write has not been applied to. Measured against this backend: an
+ * acceptance answered 204, and the membership it created was invisible to the
+ * very next read for **21.7ms**. Filed as #353; when it closes, every caller
+ * here can go back to asking once.
+ *
+ * Polling the list and matching on it, rather than polling a boolean, so a
+ * failure prints the values that *were* there. "never listed a row whose email
+ * is colleague@example.com" says the fixture lost; `Received array:
+ * ["admin@example.com"]` says what it lost to, which is the difference between
+ * a race and a write that never happened.
  */
 async function nowThere(page: Page, path: string, field: string, value: string): Promise<void> {
   await expect
-    .poll(() => alreadyThere(page.request, path, field, value), {
-      message: `the write was accepted, but ${path} still lists no ${field} of ${value}`,
+    .poll(() => valuesAt(page.request, path, field), {
+      message: `the write was accepted, but ${path} never listed a row whose ${field} is ${value}`,
     })
-    .toBe(true);
+    .toContain(value);
 }
 
 /** A JSON GET that fails loudly, so a broken fixture reads as a broken fixture. */


### PR DESCRIPTION
The `[seed]` project's last step read `/api/orgs/<id>/members` once, right after
the colleague's acceptance was acknowledged, and asserted the row was in it. When
it lost, Playwright skipped all 87 product specs behind the fixture project and
the job read like a product regression. It now polls, like its four siblings.

## The diagnosis, because the next person to see a red `e2e` will read this

#335 asked which of two things this was. **It is both, and they compose.**

### The proximate cause is a missed conversion

PR #222 introduced `nowThere` and converted four call sites in `seed.setup.ts` —
skills, knowledge bases, secrets, MCP connections. `gh pr diff 222` shows the
membership step appearing only as context: it was never converted, and it went on
reading once. That is why this one step, out of eight, is the one that goes red.

### The reason a single read can lose is a product defect — filed as #353

Writes here are **acknowledged before they commit.** `get_db_session` puts the
commit in a `Depends`-with-`yield` exit code
(`backend/app/db/session.py:34-43`), and FastAPI unwinds that stack *after* the
response has been written to the socket. From `fastapi/routing.py`
(`request_response`, pinned 0.141.1):

```python
async with AsyncExitStack() as request_stack:      # dependencies with yield land here
    scope["fastapi_inner_astack"] = request_stack
    async with AsyncExitStack() as function_stack:
        response = await f(request)
    await response(scope, receive, send)           # the client is answered HERE
    response_awaited = True
# request_stack unwinds HERE: `await session.commit()` runs now
```

`get_request_handler` puts every `Depends` on `fastapi_inner_astack`
(`routing.py:477`) — the outer of the two.

**Evidence, three kinds:**

1. A minimal app on this repo's own pinned FastAPI, with a 200ms sleep standing in
   for the commit: `0.0ms client got 204` / `256.4ms commit finished`.
2. Against the real backend on a local host uvicorn, straight at `:8000` with no
   Next in the way: an acceptance answered 204 whose membership row was **invisible
   to the very next read for 21.7ms** — 1 miss in 45 acceptances.
3. The product's own SQL log with `DB_ECHO`, one sequential client. uvicorn runs
   one event loop, so a second request can only be picked up while the first is
   suspended, and between `await response(...)` and the commit is such a
   suspension. Nine requests in one probe run arrived there. Two of them:

```
DELETE /api/v1/orgs/<org>/members/<user>
  BEGIN 15:33:56.538, still uncommitted when
  POST /api/v1/orgs/<org>/invitations arrived at 15:33:56.548

POST /api/v1/orgs/<org>/invitations
  BEGIN 15:34:00.257, still uncommitted when
  POST /api/v1/invitations/<token>/accept arrived at 15:34:00.291
```

The client had been answered, had the invitation token in its hand, and was
spending it 34ms before the transaction that created it committed. Those two are
ordinary product calls, not test scaffolding.

So the state the fixture reads is genuinely eventually consistent — by tens of
milliseconds, which is wide enough for a loaded two-core runner to lose. Polling
here is not papering over a broken write: the colleague *does* become a member.
What is broken is the acknowledgement contract, and a fixture project that takes
87 specs down is the worst possible place to discover it. **#353 is that defect,
filed with the evidence above and a "how you would know it was fixed" that puts a
regression test somewhere cheaper.** #353 is also a strong candidate root cause for
**#230** and therefore **#154** — #230 ruled the ordering out on one trace where
the commit won by 5ms, which is what most traces look like at 1-in-8.

### What it is not

- **Not another branch's doing.** Three sightings on three unrelated heads on
  2026-08-06: run 31099267560 on `main`, 31103106471 on #333, and again on #323.
  None touch invitations, membership or the frontend. #322, #326 and #334 went
  green through the same job, so it is intermittent rather than broken.
- **Not #346's shape.** A shared unscoped test database is a proven failure mode
  here, but each CI job gets its own Postgres service container and its own
  database, and `playwright.config.ts` runs `workers: 1` with `retries: 0`. Two
  runs cannot reach each other. Ruled out rather than assumed.
- **Not a stale read in the BFF.** `backendFetch` sets no `cache`, Next 16 defaults
  fetch to `no-store`, the route handler reads cookies so it is dynamic, and
  `page.request` is Playwright's own context, which implements no HTTP cache. The
  failing read reached the backend and the backend answered honestly.

## The change

`nowThere` polls the *list* and matches on it rather than polling a boolean, so a
failure prints what was actually there instead of only that it lost:

```
the write was accepted, but /api/orgs/<id>/members never listed a row
whose email is colleague@example.com
Received array: ["admin@example.com"]
```

`alreadyThere` and `nowThere` now share `valuesAt`, so the two checks read a list
the same way. Both docstrings, the file's header, `.claude/rules/testing.md`, the
`e2e-tests` skill and `docs/testing.md` now carry the half of the rule that was
missing: a fixture asserts through the API **and, after a write, polls it**,
because a 2xx means the request was answered and not that the write is readable.
The `alreadyThere` guard each step opens with stays a single read — it runs
*before* the write, where a stale answer only costs doing the work twice.

## The siblings, checked

- Four steps already poll (`nowThere`). Unchanged.
- `ensurePendingInvitation` revokes a leftover invitation and immediately posts a
  new one. That is the same #353 window in the delete direction — and it is exactly
  the overlap in the SQL log above. It can only bite a re-run against a dirty
  database, never CI, which starts fresh. Left alone; noted here.
- `a draft agent exists` still proves itself with a page heading rather than
  through the API, which the file's header does not quite admit. It auto-waits, so
  it is not the shape that failed, and taking the wait out risks the next step's
  navigation. Left alone; worth a look by whoever is next in this file.
- `registerColleague` and `revokeAnyPendingInvitation` assert the write's own
  response, which is right.

## Verified

- **`[seed]`, 31 consecutive local runs, 31 passed** — 20 in one go, which is the
  bar #335 set, then 8 after the `valuesAt` refactor and 3 after the review pass
  below. Against a host uvicorn, a `pgvector/pgvector:pg16` container and a
  `start:standalone` build, deleting the colleague's membership and invitations
  between runs so every run took the full create path.
- **The new assertion is known to be able to fail.** Pointed at an address that
  could never be a member, it failed in 27.3s with the message and `Received
  array` shown above.
- CI green on `7d0a502`, `e2e` included, before the review pass.
- **`make check` — "All checks passed — every CI job except e2e."**

## Not done, and one thing to know

- The diff has **not** been through an automated reviewer: `ai-review` no longer
  runs on a pull request (PR #313 removed the trigger, #311). I reviewed it as a
  maintainer would instead, which found three things and produced the last
  commit: three prose copies had grown a universal ("every check is a poll") that
  a `grep` disproves — `alreadyThere` is a single read by design and
  `a draft agent exists` does not use the API at all, so both are now named where
  the rule is; the FastAPI claim is pinned to the version it was read at, since
  `fastapi>=0.135.3` is a floor and that teardown has moved before; and `members`
  became `membersPath`, because it holds a URL.
- If `tests/test_migrations.py` is red locally it is **#346**, not this branch — a
  constant database name and several worktrees on one Postgres. It passes in
  isolation and in CI, where each job gets its own database.

Closes #335
Refs #353, #222, #230, #154
