### PR TITLE
fix(compose): notice a local worker that is wedged, not just one that is dead

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,6 +13,16 @@ ENVIRONMENT=local
 TIMEZONE=UTC  # IANA timezone: UTC, Europe/Warsaw, America/New_York
 MODELS_CACHE_DIR=./models_cache
 
+# === Development server ===
+# Read by `cli/reload_supervisor.py`, which is PID 1 of the local `app`
+# container and of `make run` — not by app.core.config, so it does nothing in
+# the dev or production stacks.
+#
+# Seconds the worker's event loop may go without turning before the supervisor
+# kills it and starts a replacement. Set it to 0 (or below) while debugging: a
+# breakpoint blocks the event loop, which is exactly what the check looks for.
+# RELOAD_WEDGED_AFTER=15
+
 # === Logfire ===
 # Get your token at https://logfire.pydantic.dev
 LOGFIRE_TOKEN=

--- a/backend/cli/reload_supervisor.py
+++ b/backend/cli/reload_supervisor.py
@@ -31,6 +31,56 @@ Either way the process is reaped, so the zombies are gone in both cases. Neither
 happens once `should_exit` is set: a replacement started while the reloader is
 shutting down is a process nothing will ever stop.
 
+## A worker that is wedged rather than dead
+
+Both branches above key off a process that is *gone*. A worker deadlocked on a
+lock, spinning in a synchronous call, or blocked on a socket that never answers
+has no exit code at all, so the supervisor sees a healthy child and does nothing
+while every request times out (#336).
+
+So the worker also says, from its own event loop, that the loop is turning.
+uvicorn already has the hook: `Config.callback_notify` is awaited by
+`Server.on_tick` every `timeout_notify` seconds, which is the integration point
+systemd's watchdog uses. The callback stamps `time.monotonic()` into a shared
+cell; the supervisor reads the cell on the same quiet poll as everything else,
+and replaces a worker whose loop has not turned for `WEDGED_AFTER` seconds.
+
+Three properties of that choice are the reason for it:
+
+- **It measures liveness, not readiness.** The beat is a callback on an
+  otherwise idle timer, so it costs nothing and answers in milliseconds however
+  loaded the server is. An HTTP probe against the bound port would have been
+  fewer lines, but it traverses the application - so a slow database or a Redis
+  outage would read as a wedged worker and the supervisor would restart-loop a
+  healthy server against a broken dependency. Killing a worker for being slow is
+  worse than ignoring a wedged one.
+- **It sees what a pipe ping cannot.** `Multiprocess` asks the worker over a
+  pipe, and the answer comes from a dedicated thread - which keeps answering
+  while the event loop is blocked, the single most likely way to wedge an async
+  server. A beat that originates *on the loop* is exactly the signal that thread
+  cannot fake.
+- **A wedged worker is killed, not terminated.** `BaseReload.restart` sends
+  `SIGTERM` and joins - and the worker *catches* it, as the graceful shutdown
+  above says. Acting on it therefore needs the event loop to come round, which
+  is the one thing a wedged worker cannot do; a stopped process does not run the
+  handler at all and leaves the signal pending. Either way the join never
+  returns and the supervisor hangs with it. `SIGKILL` cannot be caught, which is
+  what `Multiprocess.keep_subprocess_alive` relies on for a worker it has judged
+  hung.
+
+**What this does not cover**, deliberately:
+
+- **A worker that wedges before it serves.** `main_loop` - and so the first beat
+  - starts only once lifespan startup has finished, so a worker hung on a
+  database connect at boot never beats and is never judged. Judging it would
+  mean a startup grace period long enough to be meaningless on a cold container.
+- **The dev and production stacks.** Neither runs this module: `docker-compose-dev.yml`
+  is a single unsupervised uvicorn and `docker-compose-prod.yml` is `--workers`,
+  where uvicorn's own `Multiprocess` pings over the pipe described above.
+- **A debugger.** A breakpoint blocks the event loop and is indistinguishable
+  from a deadlock by construction, so 15 seconds on one wedges the worker and it
+  is replaced. `RELOAD_WEDGED_AFTER=0` turns the whole check off.
+
 **This module is its own entrypoint** - `python -m cli.reload_supervisor` - and
 imports nothing beyond uvicorn and click on purpose. Reaching it through
 `cli.commands` instead would pull `app.main` into the reloader, and the reloader
@@ -41,10 +91,13 @@ for would be an odd way to fix this.
 """
 
 import logging
+import os
+import time
 from collections.abc import Callable
+from multiprocessing import Value
 from pathlib import Path
 from socket import socket
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 import click
 from uvicorn import Config, Server
@@ -52,6 +105,11 @@ from uvicorn import Config, Server
 # The reload supervisor uvicorn's own `main.run` uses: `WatchFilesReload`, or
 # `StatReload` where watchfiles is missing. `uvicorn[standard]` ships watchfiles.
 from uvicorn.supervisors import ChangeReload
+
+if TYPE_CHECKING:
+    # Generic to the type checker and a plain class at runtime, so every
+    # annotation of it has to be quoted.
+    from multiprocessing.sharedctypes import Synchronized
 
 # uvicorn's `auto` picks the legacy websockets implementation, which fails the
 # handshake against websockets >=14 with an HTTP 500. The dashboard chat is a
@@ -62,11 +120,53 @@ WS_PROTOCOL: Final = "websockets-sansio"
 
 APP: Final = "app.main:app"
 
+# How often the worker's event loop says it is turning, as uvicorn's
+# `timeout_notify`. `Server.on_tick` runs ten times a second and notifies on the
+# first tick past this many seconds, so a beat lands every one to two seconds.
+BEAT_INTERVAL: Final = 1
+
+# How long a worker may go without a beat before it is judged wedged. It is
+# fifteen missed beats rather than a couple, because the cost of the two
+# mistakes is not symmetric: replacing a wedged worker late costs seconds on a
+# laptop, and replacing a healthy one early drops in-flight requests. Fifteen
+# seconds of an event loop not turning is not load - a loaded loop still runs a
+# timer callback in milliseconds - it is blocked, stopped or deadlocked. The
+# supervisor notices within `WEDGED_AFTER` plus one poll, so about twenty
+# seconds, against the ninety a container health check takes to reach a verdict
+# nothing acts on.
+WEDGED_AFTER: Final = 15.0
+
+# Seconds without a beat before a worker is replaced, `0` to switch the check
+# off - which is what somebody sitting on a breakpoint wants, a stopped event
+# loop being indistinguishable from a deadlock.
+WEDGED_AFTER_ENV_VAR: Final = "RELOAD_WEDGED_AFTER"
+
+# The value of the shared cell before the worker's first beat. A worker is
+# judged only once it has beaten at least once, so a slow boot is never mistaken
+# for a wedge.
+NOT_YET_BEATEN: Final = 0.0
+
 logger = logging.getLogger("uvicorn.error")
 
 
+class EventLoopHeartbeat:
+    """The worker's end of the liveness signal, awaited on its own event loop.
+
+    Passed to the worker as `Config.callback_notify`, which means it is pickled
+    into the spawned process along with the shared cell it writes to - allowed
+    because the pickling happens while the child is being spawned, which is the
+    one time `multiprocessing` permits a shared value to cross.
+    """
+
+    def __init__(self, beat: "Synchronized[float]") -> None:
+        self._beat = beat
+
+    async def __call__(self) -> None:
+        self._beat.value = time.monotonic()
+
+
 class SupervisedReload(ChangeReload):
-    """A `--reload` reloader that also notices a worker that died.
+    """A `--reload` reloader that notices a worker that died, and one that wedged.
 
     `ChangeReload` polls for changes with a timeout rather than blocking
     forever, so overriding `should_restart` is enough to get a periodic tick:
@@ -81,11 +181,16 @@ class SupervisedReload(ChangeReload):
         config: Config,
         target: Callable[[list[socket] | None], None],
         sockets: list[socket],
+        *,
+        beat: "Synchronized[float]",
+        wedged_after: float = WEDGED_AFTER,
     ) -> None:
         super().__init__(config, target, sockets)
         # The pid whose ordinary exit has already been reported, so the "waiting
         # for a change" line is written once rather than on every poll.
         self._reported_pid: int | None = None
+        self._beat = beat
+        self._wedged_after = wedged_after
 
     def should_restart(self) -> list[Path] | None:
         # `if changes`, not `is not None`: a change to a file the reload filter
@@ -97,7 +202,19 @@ class SupervisedReload(ChangeReload):
         if changes:
             return changes
         self._replace_a_dead_worker()
+        self._replace_a_wedged_worker()
         return None
+
+    def restart(self) -> None:
+        """Replace the worker, and forget the beat the previous one left behind.
+
+        Every replacement - a file change, a dead worker, a wedged one - arrives
+        here, and every one of them starts a worker that has not beaten yet.
+        Leaving the old worker's beat in the cell would have the new one judged
+        on it and killed on the next poll.
+        """
+        self._beat.value = NOT_YET_BEATEN
+        super().restart()
 
     def _replace_a_dead_worker(self) -> None:
         """Reap a worker that is gone, and replace it if a signal took it.
@@ -133,17 +250,82 @@ class SupervisedReload(ChangeReload):
                 exitcode,
             )
 
+    def _replace_a_wedged_worker(self) -> None:
+        """Replace a worker that is running but whose event loop has stopped turning.
+
+        Judged only on a worker that is still running and has beaten at least
+        once: a worker that has exited is `_replace_a_dead_worker`'s decision,
+        and one that exited on its own is deliberately waiting for a file change
+        rather than for a supervisor to respawn it onto the same traceback.
+        """
+        if self._wedged_after <= 0 or self.should_exit.is_set():
+            # Switched off, or the reloader is on its way out and a replacement
+            # would outlive the supervisor meant to stop it - the same guard
+            # `_replace_a_dead_worker` opens with, for the same reason.
+            return
+
+        if self.process.exitcode is not None:
+            return
+
+        beat = self._beat.value
+        if beat == NOT_YET_BEATEN:
+            return
+
+        silent_for = time.monotonic() - beat
+        if silent_for < self._wedged_after:
+            return
+
+        logger.error(
+            "Server process [%s] has not run its event loop for %.0fs. Killing it and starting a replacement.",
+            self.process.pid,
+            silent_for,
+        )
+        # `SIGKILL`, and not the `SIGTERM` that `restart` would send on its own:
+        # the worker catches `SIGTERM` and acts on it from the event loop, so a
+        # wedged one never acts on it and the join inside `restart` would hang
+        # here forever. Killing first makes that join the no-op it needs to be.
+        self.process.kill()
+        self.process.join()
+        self.restart()
+
+
+def wedged_after_from_environment() -> float:
+    """Read `RELOAD_WEDGED_AFTER`, the one knob on the wedge check.
+
+    Seconds without a beat before the worker is replaced; `0` switches the check
+    off entirely, which is what a breakpoint needs. A value that is not a number
+    raises rather than falling back to the default: a typo that silently
+    restores 15 seconds is how somebody ends up debugging the supervisor.
+    """
+    return float(os.environ.get(WEDGED_AFTER_ENV_VAR, WEDGED_AFTER))
+
 
 def run_reload_server(*, host: str, port: int) -> None:
     """Run the development server under `SupervisedReload`.
 
     The wiring is `uvicorn.main.run`'s own reload branch, with the supervisor
     swapped: bind the socket in the parent so a replacement worker inherits a
-    port that never stopped being bound.
+    port that never stopped being bound, and hand the worker the heartbeat it
+    reports its event loop through.
     """
-    config = Config(APP, host=host, port=port, reload=True, ws=WS_PROTOCOL)
+    beat: Synchronized[float] = Value("d", NOT_YET_BEATEN)
+    config = Config(
+        APP,
+        host=host,
+        port=port,
+        reload=True,
+        ws=WS_PROTOCOL,
+        callback_notify=EventLoopHeartbeat(beat),
+        timeout_notify=BEAT_INTERVAL,
+    )
     server = Server(config=config)
-    SupervisedReload(config, target=server.run, sockets=[config.bind_socket()]).run()
+    SupervisedReload(
+        config,
+        target=server.run,
+        sockets=[config.bind_socket()],
+        beat=beat,
+        wedged_after=wedged_after_from_environment(),
+    ).run()
 
 
 @click.command()

--- a/backend/cli/reload_supervisor.py
+++ b/backend/cli/reload_supervisor.py
@@ -45,7 +45,7 @@ systemd's watchdog uses. The callback stamps `time.monotonic()` into a shared
 cell; the supervisor reads the cell on the same quiet poll as everything else,
 and replaces a worker whose loop has not turned for `WEDGED_AFTER` seconds.
 
-Three properties of that choice are the reason for it:
+Four properties of that choice are the reason for it:
 
 - **It measures liveness, not readiness.** The beat is a callback on an
   otherwise idle timer, so it costs nothing and answers in milliseconds however
@@ -81,6 +81,9 @@ Three properties of that choice are the reason for it:
   - starts only once lifespan startup has finished, so a worker hung on a
   database connect at boot never beats and is never judged. Judging it would
   mean a startup grace period long enough to be meaningless on a cold container.
+  `shutdown` inherits the gap: with nothing to judge it cannot escalate, so
+  Ctrl+C on a worker hung against a Postgres that is down still waits out
+  Docker's grace period.
 - **The dev and production stacks.** Neither runs this module: `docker-compose-dev.yml`
   is a single unsupervised uvicorn and `docker-compose-prod.yml` is `--workers`,
   where uvicorn's own `Multiprocess` pings over the pipe described above.
@@ -138,7 +141,10 @@ BEAT_INTERVAL: Final = 1
 # mistakes is not symmetric: replacing a wedged worker late costs seconds on a
 # laptop, and replacing a healthy one early drops in-flight requests. Fifteen
 # seconds of an event loop not turning is not load - a loaded loop still runs a
-# timer callback in milliseconds - it is blocked, stopped or deadlocked. The
+# timer callback in milliseconds - it is blocked, stopped or deadlocked. It also
+# leaves room for the beat's own jitter: `on_tick` schedules on `time.time()`
+# while the verdict is monotonic, so a backwards clock step delays a beat by the
+# size of the step. Fifteen seconds absorbs that; two would not. The
 # supervisor notices within `WEDGED_AFTER` plus the two polls
 # `POLLS_BEFORE_WEDGED` costs, so about twenty-five seconds, against the ninety a
 # container health check takes to reach a verdict nothing acts on.
@@ -249,11 +255,14 @@ class SupervisedReload(ChangeReload):
         on it and killed on the next poll.
 
         The cell is cleared *after* the replacement, not before. `Server.on_tick`
-        awaits `callback_notify` before it checks `should_exit`, so a worker that
-        has just been sent `SIGTERM` gets one more tick and beats one last time
-        on roughly one restart in ten. Clearing first would hand that beat to the
+        awaits `callback_notify` before it checks `should_exit`, so a worker sent
+        `SIGTERM` inside the second before its next beat is due gets one more
+        tick and beats one last time. Clearing first would hand that beat to the
         replacement, which is then judged on it while it is still importing the
-        application.
+        application. `BaseReload.restart` joins the old worker before it spawns
+        the new one, so by the time this line runs the last gasp has landed and
+        there is nothing left to write the cell but the replacement - which
+        cannot, until lifespan startup finishes seconds later.
         """
         super().restart()
         self._beat.value = NOT_YET_BEATEN
@@ -266,6 +275,13 @@ class SupervisedReload(ChangeReload):
         `docker compose stop` would block until the ten-second grace period ran
         out and Docker killed the container. A worker that is merely running
         still gets `SIGTERM` and still drains its connections.
+
+        There is one shot at this, so the verdict is the instantaneous one -
+        `POLLS_BEFORE_WEDGED` cannot apply to a decision taken once. A healthy
+        worker whose host has just thawed is therefore killed rather than
+        drained. On a development server, dropping the requests in flight beats
+        hanging the terminal, and it is the same trade the container's own
+        `SIGKILL` makes ten seconds later.
         """
         silent_for = self._silent_for()
         if silent_for is not None:
@@ -382,7 +398,7 @@ def run_reload_server(*, host: str, port: int) -> None:
     port that never stopped being bound, and hand the worker the heartbeat it
     reports its event loop through.
     """
-    beat = RawValue("d", NOT_YET_BEATEN)
+    beat: c_double = RawValue("d", NOT_YET_BEATEN)
     config = Config(
         APP,
         host=host,

--- a/backend/cli/reload_supervisor.py
+++ b/backend/cli/reload_supervisor.py
@@ -70,10 +70,10 @@ Three properties of that choice are the reason for it:
   wedged worker blocks until Docker's grace period runs out.
 - **A frozen host is not a wedged worker.** `docker pause`, a frozen cgroup and
   a Docker Desktop VM resuming after the host slept all advance the monotonic
-  clock while *nothing* runs, worker and supervisor alike. So the supervisor
-  measures the gap in its own polling too, and a poll that is itself late by
-  more than the threshold forgives the worker a window rather than killing it
-  for the host's nap.
+  clock while *nothing* runs, worker and supervisor alike, so the first poll
+  after one reads a stale beat that says nothing about the worker. Two
+  consecutive silent polls are therefore needed rather than one: by the second,
+  a healthy worker has beaten again and the verdict clears.
 
 **What this does not cover**, deliberately:
 
@@ -139,10 +139,23 @@ BEAT_INTERVAL: Final = 1
 # laptop, and replacing a healthy one early drops in-flight requests. Fifteen
 # seconds of an event loop not turning is not load - a loaded loop still runs a
 # timer callback in milliseconds - it is blocked, stopped or deadlocked. The
-# supervisor notices within `WEDGED_AFTER` plus one poll, so about twenty
-# seconds, against the ninety a container health check takes to reach a verdict
-# nothing acts on.
+# supervisor notices within `WEDGED_AFTER` plus the two polls
+# `POLLS_BEFORE_WEDGED` costs, so about twenty-five seconds, against the ninety a
+# container health check takes to reach a verdict nothing acts on.
 WEDGED_AFTER: Final = 15.0
+
+# Consecutive silent polls before the worker is replaced. Two, not one, because
+# `docker pause`, a frozen cgroup and a Docker Desktop VM resuming after the host
+# slept all advance the monotonic clock while *nothing* runs - supervisor
+# included - and the first poll after one of those reads a stale beat that says
+# nothing about the worker. By the next poll a healthy worker has beaten again,
+# about a second having passed, and the verdict clears; a wedged one fails both.
+# The reprieve costs one poll of detection, and it is deliberately not measured
+# as a gap in the supervisor's own polling: watchfiles ticks every five seconds
+# or so, so any threshold below that would have compared a poll gap against a
+# smaller number, judged every poll a freeze, and switched the check off in
+# silence.
+POLLS_BEFORE_WEDGED: Final = 2
 
 # Seconds without a beat before a worker is replaced, `0` or below to switch the
 # check off - which is what somebody sitting on a breakpoint wants, a stopped
@@ -210,9 +223,9 @@ class SupervisedReload(ChangeReload):
         self._reported_pid: int | None = None
         self._beat = beat
         self._wedged_after = wedged_after
-        # When the previous poll ran, so a gap in the *supervisor's* own clock
-        # can be told from a gap in the worker's.
-        self._polled_at = time.monotonic()
+        # Consecutive polls that have found the worker silent. One is not a
+        # verdict; `POLLS_BEFORE_WEDGED` explains why.
+        self._silent_polls = 0
 
     def should_restart(self) -> list[Path] | None:
         # `if changes`, not `is not None`: a change to a file the reload filter
@@ -224,8 +237,7 @@ class SupervisedReload(ChangeReload):
         if changes:
             return changes
         self._replace_a_dead_worker()
-        if not self._everything_was_frozen():
-            self._replace_a_wedged_worker()
+        self._replace_a_wedged_worker()
         return None
 
     def restart(self) -> None:
@@ -264,26 +276,6 @@ class SupervisedReload(ChangeReload):
             )
             self.process.kill()
         super().shutdown()
-
-    def _everything_was_frozen(self) -> bool:
-        """Was the *supervisor* stopped too since the last poll, rather than only the worker?
-
-        `docker pause`, a frozen cgroup and a Docker Desktop VM resuming after
-        the host slept all advance the monotonic clock while nothing runs. The
-        worker's silence then says nothing about the worker, so the beat is
-        stamped as though it had just arrived and the worker gets a full window
-        to prove itself - which a healthy one does within a second, and a wedged
-        one fails on the next poll.
-        """
-        if self._wedged_after <= 0:
-            return False
-        now = time.monotonic()
-        since_the_last_poll = now - self._polled_at
-        self._polled_at = now
-        if since_the_last_poll <= self._wedged_after:
-            return False
-        self._beat.value = now
-        return True
 
     def _replace_a_dead_worker(self) -> None:
         """Reap a worker that is gone, and replace it if a signal took it.
@@ -350,6 +342,11 @@ class SupervisedReload(ChangeReload):
 
         silent_for = self._silent_for()
         if silent_for is None:
+            self._silent_polls = 0
+            return
+
+        self._silent_polls += 1
+        if self._silent_polls < POLLS_BEFORE_WEDGED:
             return
 
         logger.error(

--- a/backend/cli/reload_supervisor.py
+++ b/backend/cli/reload_supervisor.py
@@ -66,7 +66,14 @@ Three properties of that choice are the reason for it:
   handler at all and leaves the signal pending. Either way the join never
   returns and the supervisor hangs with it. `SIGKILL` cannot be caught, which is
   what `Multiprocess.keep_subprocess_alive` relies on for a worker it has judged
-  hung.
+  hung. `shutdown` needs the same escalation for the same reason, or Ctrl+C on a
+  wedged worker blocks until Docker's grace period runs out.
+- **A frozen host is not a wedged worker.** `docker pause`, a frozen cgroup and
+  a Docker Desktop VM resuming after the host slept all advance the monotonic
+  clock while *nothing* runs, worker and supervisor alike. So the supervisor
+  measures the gap in its own polling too, and a poll that is itself late by
+  more than the threshold forgives the worker a window rather than killing it
+  for the host's nap.
 
 **What this does not cover**, deliberately:
 
@@ -80,6 +87,11 @@ Three properties of that choice are the reason for it:
 - **A debugger.** A breakpoint blocks the event loop and is indistinguishable
   from a deadlock by construction, so 15 seconds on one wedges the worker and it
   is replaced. `RELOAD_WEDGED_AFTER=0` turns the whole check off.
+- **A worker in uninterruptible sleep.** `SIGKILL` is not delivered to a process
+  in `D` state - a dead network mount is the way in - so the join after it hangs
+  as `SIGTERM` would have. A bounded join would only move the hang into
+  `BaseReload.restart`, which joins again with no timeout, so it is recorded
+  here rather than half-fixed.
 
 **This module is its own entrypoint** - `python -m cli.reload_supervisor` - and
 imports nothing beyond uvicorn and click on purpose. Reaching it through
@@ -94,10 +106,11 @@ import logging
 import os
 import time
 from collections.abc import Callable
-from multiprocessing import Value
+from ctypes import c_double
+from multiprocessing import RawValue
 from pathlib import Path
 from socket import socket
-from typing import TYPE_CHECKING, Final
+from typing import Final
 
 import click
 from uvicorn import Config, Server
@@ -105,11 +118,6 @@ from uvicorn import Config, Server
 # The reload supervisor uvicorn's own `main.run` uses: `WatchFilesReload`, or
 # `StatReload` where watchfiles is missing. `uvicorn[standard]` ships watchfiles.
 from uvicorn.supervisors import ChangeReload
-
-if TYPE_CHECKING:
-    # Generic to the type checker and a plain class at runtime, so every
-    # annotation of it has to be quoted.
-    from multiprocessing.sharedctypes import Synchronized
 
 # uvicorn's `auto` picks the legacy websockets implementation, which fails the
 # handshake against websockets >=14 with an HTTP 500. The dashboard chat is a
@@ -136,9 +144,9 @@ BEAT_INTERVAL: Final = 1
 # nothing acts on.
 WEDGED_AFTER: Final = 15.0
 
-# Seconds without a beat before a worker is replaced, `0` to switch the check
-# off - which is what somebody sitting on a breakpoint wants, a stopped event
-# loop being indistinguishable from a deadlock.
+# Seconds without a beat before a worker is replaced, `0` or below to switch the
+# check off - which is what somebody sitting on a breakpoint wants, a stopped
+# event loop being indistinguishable from a deadlock.
 WEDGED_AFTER_ENV_VAR: Final = "RELOAD_WEDGED_AFTER"
 
 # The value of the shared cell before the worker's first beat. A worker is
@@ -156,9 +164,20 @@ class EventLoopHeartbeat:
     into the spawned process along with the shared cell it writes to - allowed
     because the pickling happens while the child is being spawned, which is the
     one time `multiprocessing` permits a shared value to cross.
+
+    `RawValue` and not `Value`, on two counts. `Value`'s lock is a `SemLock` from
+    the *default* context, which on Linux is `fork` - and uvicorn spawns, so
+    handing the worker one raises `A SemLock created in a fork context is being
+    shared with a process in a spawn context` and the container restart-loops
+    before it serves a request. That is not a macOS symptom, where the default
+    context is already `spawn`, so it appears first in CI or in Docker. And a
+    lock here would be a hazard even where it pickles: a worker killed while
+    holding it - which is exactly what this module does to a wedged one - leaves
+    it held for good, and the supervisor's next read of the cell hangs forever.
+    One aligned 8-byte double, one writer, one reader, no lock to lose.
     """
 
-    def __init__(self, beat: "Synchronized[float]") -> None:
+    def __init__(self, beat: c_double) -> None:
         self._beat = beat
 
     async def __call__(self) -> None:
@@ -182,7 +201,7 @@ class SupervisedReload(ChangeReload):
         target: Callable[[list[socket] | None], None],
         sockets: list[socket],
         *,
-        beat: "Synchronized[float]",
+        beat: c_double,
         wedged_after: float = WEDGED_AFTER,
     ) -> None:
         super().__init__(config, target, sockets)
@@ -191,6 +210,9 @@ class SupervisedReload(ChangeReload):
         self._reported_pid: int | None = None
         self._beat = beat
         self._wedged_after = wedged_after
+        # When the previous poll ran, so a gap in the *supervisor's* own clock
+        # can be told from a gap in the worker's.
+        self._polled_at = time.monotonic()
 
     def should_restart(self) -> list[Path] | None:
         # `if changes`, not `is not None`: a change to a file the reload filter
@@ -202,7 +224,8 @@ class SupervisedReload(ChangeReload):
         if changes:
             return changes
         self._replace_a_dead_worker()
-        self._replace_a_wedged_worker()
+        if not self._everything_was_frozen():
+            self._replace_a_wedged_worker()
         return None
 
     def restart(self) -> None:
@@ -212,9 +235,55 @@ class SupervisedReload(ChangeReload):
         here, and every one of them starts a worker that has not beaten yet.
         Leaving the old worker's beat in the cell would have the new one judged
         on it and killed on the next poll.
+
+        The cell is cleared *after* the replacement, not before. `Server.on_tick`
+        awaits `callback_notify` before it checks `should_exit`, so a worker that
+        has just been sent `SIGTERM` gets one more tick and beats one last time
+        on roughly one restart in ten. Clearing first would hand that beat to the
+        replacement, which is then judged on it while it is still importing the
+        application.
         """
-        self._beat.value = NOT_YET_BEATEN
         super().restart()
+        self._beat.value = NOT_YET_BEATEN
+
+    def shutdown(self) -> None:
+        """Stop the worker, killing it outright if it is wedged.
+
+        `BaseReload.shutdown` sends `SIGTERM` and joins without a timeout, which
+        for a wedged worker is the hang this class exists to avoid: Ctrl+C or
+        `docker compose stop` would block until the ten-second grace period ran
+        out and Docker killed the container. A worker that is merely running
+        still gets `SIGTERM` and still drains its connections.
+        """
+        silent_for = self._silent_for()
+        if silent_for is not None:
+            logger.error(
+                "Server process [%s] has not run its event loop for %.0fs. Killing it rather than waiting.",
+                self.process.pid,
+                silent_for,
+            )
+            self.process.kill()
+        super().shutdown()
+
+    def _everything_was_frozen(self) -> bool:
+        """Was the *supervisor* stopped too since the last poll, rather than only the worker?
+
+        `docker pause`, a frozen cgroup and a Docker Desktop VM resuming after
+        the host slept all advance the monotonic clock while nothing runs. The
+        worker's silence then says nothing about the worker, so the beat is
+        stamped as though it had just arrived and the worker gets a full window
+        to prove itself - which a healthy one does within a second, and a wedged
+        one fails on the next poll.
+        """
+        if self._wedged_after <= 0:
+            return False
+        now = time.monotonic()
+        since_the_last_poll = now - self._polled_at
+        self._polled_at = now
+        if since_the_last_poll <= self._wedged_after:
+            return False
+        self._beat.value = now
+        return True
 
     def _replace_a_dead_worker(self) -> None:
         """Reap a worker that is gone, and replace it if a signal took it.
@@ -250,29 +319,37 @@ class SupervisedReload(ChangeReload):
                 exitcode,
             )
 
-    def _replace_a_wedged_worker(self) -> None:
-        """Replace a worker that is running but whose event loop has stopped turning.
+    def _silent_for(self) -> float | None:
+        """How long the worker's event loop has been silent, if that is a verdict.
 
-        Judged only on a worker that is still running and has beaten at least
-        once: a worker that has exited is `_replace_a_dead_worker`'s decision,
-        and one that exited on its own is deliberately waiting for a file change
-        rather than for a supervisor to respawn it onto the same traceback.
+        `None` means there is nothing to judge, which covers four cases and not
+        only the obvious one: the check is switched off; the worker is not
+        running, so a worker that exited on its own stays waiting for the file
+        change that fixes it rather than being respawned onto the same
+        traceback; the worker has not beaten yet, so a slow boot is not a wedge;
+        or it beat recently enough.
         """
-        if self._wedged_after <= 0 or self.should_exit.is_set():
-            # Switched off, or the reloader is on its way out and a replacement
-            # would outlive the supervisor meant to stop it - the same guard
-            # `_replace_a_dead_worker` opens with, for the same reason.
-            return
-
-        if self.process.exitcode is not None:
-            return
+        if self._wedged_after <= 0 or self.process.exitcode is not None:
+            return None
 
         beat = self._beat.value
         if beat == NOT_YET_BEATEN:
-            return
+            return None
 
         silent_for = time.monotonic() - beat
-        if silent_for < self._wedged_after:
+        return silent_for if silent_for >= self._wedged_after else None
+
+    def _replace_a_wedged_worker(self) -> None:
+        """Replace a worker that is running but whose event loop has stopped turning."""
+        if self.should_exit.is_set():
+            # The reloader is on its way out and a replacement would outlive the
+            # supervisor meant to stop it - the same guard
+            # `_replace_a_dead_worker` opens with, for the same reason. Stopping
+            # a worker that is wedged is `shutdown`'s job, not this one's.
+            return
+
+        silent_for = self._silent_for()
+        if silent_for is None:
             return
 
         logger.error(
@@ -308,7 +385,7 @@ def run_reload_server(*, host: str, port: int) -> None:
     port that never stopped being bound, and hand the worker the heartbeat it
     reports its event loop through.
     """
-    beat: Synchronized[float] = Value("d", NOT_YET_BEATEN)
+    beat = RawValue("d", NOT_YET_BEATEN)
     config = Config(
         APP,
         host=host,

--- a/backend/tests/test_reload_supervisor.py
+++ b/backend/tests/test_reload_supervisor.py
@@ -37,6 +37,7 @@ from cli.reload_supervisor import (
     APP,
     BEAT_INTERVAL,
     NOT_YET_BEATEN,
+    POLLS_BEFORE_WEDGED,
     WEDGED_AFTER,
     WEDGED_AFTER_ENV_VAR,
     WS_PROTOCOL,
@@ -347,9 +348,47 @@ def test_a_worker_whose_event_loop_stopped_turning_is_replaced(
     wedged = FakeWorker(None)
     supervisor.process = wedged
 
-    assert supervisor.should_restart() is None
+    for _ in range(POLLS_BEFORE_WEDGED):
+        assert supervisor.should_restart() is None
+
     assert supervisor.replacements == 1
     assert wedged.killed, "SIGTERM never reaches a wedged worker; the replacement would hang"
+
+
+def test_one_silent_poll_is_not_a_verdict(
+    supervisor: RecordingReload, beat: ctypes.c_double
+) -> None:
+    """`docker pause`, a frozen cgroup, a Docker Desktop VM after the host slept.
+
+    All of them advance the monotonic clock while the supervisor is not running
+    either, so the first poll afterwards reads a stale beat that says nothing
+    about the worker. A healthy one has beaten again by the next poll.
+    """
+    beat.value = time.monotonic() - A_SHORT_WEDGE - 1
+    supervisor.process = FakeWorker(None)
+
+    assert supervisor.should_restart() is None
+    assert supervisor.replacements == 0
+
+    beat.value = time.monotonic()
+
+    assert supervisor.should_restart() is None
+    assert supervisor.replacements == 0
+
+
+def test_the_silent_polls_have_to_be_consecutive(
+    supervisor: RecordingReload, beat: ctypes.c_double
+) -> None:
+    """A worker that beats between two silences is a slow worker, not a wedged one."""
+    supervisor.process = FakeWorker(None)
+
+    for _ in range(POLLS_BEFORE_WEDGED * 3):
+        beat.value = time.monotonic() - A_SHORT_WEDGE - 1
+        supervisor.should_restart()
+        beat.value = time.monotonic()
+        supervisor.should_restart()
+
+    assert supervisor.replacements == 0
 
 
 def test_a_worker_still_beating_is_left_alone(
@@ -387,7 +426,9 @@ def test_a_worker_that_exited_on_its_own_is_not_killed_for_its_stale_beat(
     beat.value = time.monotonic() - A_SHORT_WEDGE - 1
     supervisor.process = FakeWorker(1)
 
-    assert supervisor.should_restart() is None
+    for _ in range(POLLS_BEFORE_WEDGED):
+        assert supervisor.should_restart() is None
+
     assert supervisor.replacements == 0
 
 
@@ -398,8 +439,8 @@ def test_a_replacement_is_not_judged_on_the_beat_of_the_worker_it_replaced(
     beat.value = time.monotonic() - A_SHORT_WEDGE - 1
     supervisor.process = FakeWorker(None)
 
-    supervisor.should_restart()
-    supervisor.should_restart()
+    for _ in range(POLLS_BEFORE_WEDGED * 2):
+        supervisor.should_restart()
 
     assert supervisor.replacements == 1
     assert beat.value == NOT_YET_BEATEN
@@ -413,7 +454,9 @@ def test_a_worker_wedging_during_shutdown_is_not_replaced(
     beat.value = time.monotonic() - A_SHORT_WEDGE - 1
     supervisor.process = FakeWorker(None)
 
-    assert supervisor.should_restart() is None
+    for _ in range(POLLS_BEFORE_WEDGED):
+        assert supervisor.should_restart() is None
+
     assert supervisor.replacements == 0
 
 
@@ -476,39 +519,6 @@ def test_shutting_down_leaves_a_healthy_worker_to_drain(
     assert not healthy.killed
 
 
-def test_a_worker_is_not_judged_on_a_poll_the_supervisor_itself_slept_through(
-    supervisor: RecordingReload, beat: ctypes.c_double
-) -> None:
-    """`docker pause`, a frozen cgroup, a Docker Desktop VM after the host slept.
-
-    Monotonic time advances for the supervisor as well, so the worker's silence
-    says nothing about the worker. It gets a full window to prove itself, and a
-    healthy one takes about a second over it.
-    """
-    supervisor.process = FakeWorker(None)
-    supervisor._polled_at = time.monotonic() - A_SHORT_WEDGE - 1
-    beat.value = time.monotonic() - A_SHORT_WEDGE - 1
-
-    assert supervisor.should_restart() is None
-    assert supervisor.replacements == 0
-    assert beat.value == pytest.approx(time.monotonic(), abs=1)
-
-
-def test_a_worker_still_wedged_after_the_host_wakes_is_replaced(
-    supervisor: RecordingReload, beat: ctypes.c_double
-) -> None:
-    """Forgiving the frozen window is a reprieve, not an exemption."""
-    supervisor.process = FakeWorker(None)
-    supervisor._polled_at = time.monotonic() - A_SHORT_WEDGE - 1
-    beat.value = time.monotonic() - A_SHORT_WEDGE - 1
-    supervisor.should_restart()
-
-    beat.value = time.monotonic() - A_SHORT_WEDGE - 1
-
-    assert supervisor.should_restart() is None
-    assert supervisor.replacements == 1
-
-
 def test_the_wedge_check_can_be_switched_off(
     monkeypatch: pytest.MonkeyPatch, beat: ctypes.c_double
 ) -> None:
@@ -519,7 +529,9 @@ def test_the_wedge_check_can_be_switched_off(
     off.process = FakeWorker(None)
     beat.value = time.monotonic() - A_SHORT_WEDGE - 1
 
-    assert off.should_restart() is None
+    for _ in range(POLLS_BEFORE_WEDGED):
+        assert off.should_restart() is None
+
     assert off.replacements == 0
 
 
@@ -630,6 +642,12 @@ def test_a_worker_stopped_mid_flight_is_killed_and_replaced() -> None:
         _wait_until_beating(beat)
         os.kill(wedged.pid, signal.SIGSTOP)
         time.sleep(A_SHORT_WEDGE * 2)
+
+        # The first silent poll is a reprieve rather than a verdict, so it is
+        # the second that has to survive the thread's deadline below.
+        for _ in range(POLLS_BEFORE_WEDGED - 1):
+            supervisor._replace_a_wedged_worker()
+            assert supervisor.process is wedged
 
         replacing.start()
         replacing.join(timeout=A_PATIENT_WAIT)

--- a/backend/tests/test_reload_supervisor.py
+++ b/backend/tests/test_reload_supervisor.py
@@ -11,6 +11,7 @@ actually runs the supervisor.
 
 import asyncio
 import contextlib
+import ctypes
 import logging
 import os
 import signal
@@ -18,16 +19,15 @@ import subprocess
 import sys
 import threading
 import time
-from multiprocessing import Value
+from multiprocessing import RawValue
 from multiprocessing.context import SpawnProcess
-from multiprocessing.sharedctypes import Synchronized
 from pathlib import Path
 from types import FrameType
 from typing import Any, Final
 
 import pytest
 import yaml
-from uvicorn import Config
+from uvicorn import Config, Server
 from uvicorn._subprocess import get_subprocess
 from uvicorn.supervisors import ChangeReload
 from uvicorn.supervisors.basereload import BaseReload
@@ -116,7 +116,7 @@ class RecordingReload(SupervisedReload):
     `SupervisedReload.restart` itself, and the beat it clears, still run.
     """
 
-    def __init__(self, config: Config, beat: "Synchronized[float]", wedged_after: float) -> None:
+    def __init__(self, config: Config, beat: ctypes.c_double, wedged_after: float) -> None:
         super().__init__(
             config,
             target=lambda sockets: None,
@@ -133,14 +133,36 @@ def _record_the_replacement(self: RecordingReload) -> None:
 
 
 @pytest.fixture
-def beat() -> "Synchronized[float]":
+def beat() -> ctypes.c_double:
     """The cell the worker stamps its event loop into, as `run_reload_server` makes it."""
-    return Value("d", NOT_YET_BEATEN)
+    return RawValue("d", NOT_YET_BEATEN)
+
+
+@pytest.fixture
+def wiring(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Everything `run_reload_server` hands the supervisor, without starting anything.
+
+    Captured as one dict rather than asserted piecemeal because the interesting
+    property is a relationship between two of the arguments: the cell the
+    supervisor reads has to be the cell the worker's heartbeat writes.
+    """
+    captured: dict[str, Any] = {}
+
+    def capture(self: SupervisedReload, config: Config, **kwargs: Any) -> None:
+        captured["config"] = config
+        captured.update(kwargs)
+
+    monkeypatch.setattr(Config, "bind_socket", lambda self: None)
+    monkeypatch.setattr(SupervisedReload, "__init__", capture)
+    monkeypatch.setattr(SupervisedReload, "run", lambda self: None)
+
+    run_reload_server(host="127.0.0.1", port=9999)
+    return captured
 
 
 @pytest.fixture
 def supervisor(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, beat: "Synchronized[float]"
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, beat: ctypes.c_double
 ) -> RecordingReload:
     """A supervisor whose file watcher reports no changes, with its log captured.
 
@@ -266,21 +288,14 @@ def test_a_worker_dying_during_shutdown_is_not_replaced(
 
 
 def test_the_development_server_keeps_the_sansio_websocket_implementation(
-    monkeypatch: pytest.MonkeyPatch,
+    wiring: dict[str, Any],
 ) -> None:
     """uvicorn's `auto` fails the chat handshake against websockets >=14."""
-    captured: list[Config] = []
-    monkeypatch.setattr(Config, "bind_socket", lambda self: None)
-    monkeypatch.setattr(
-        SupervisedReload, "__init__", lambda self, config, **kw: captured.append(config)
-    )
-    monkeypatch.setattr(SupervisedReload, "run", lambda self: None)
+    config: Config = wiring["config"]
 
-    run_reload_server(host="127.0.0.1", port=9999)
-
-    assert captured[0].ws == "websockets-sansio"
-    assert captured[0].should_reload
-    assert (captured[0].host, captured[0].port) == ("127.0.0.1", 9999)
+    assert config.ws == "websockets-sansio"
+    assert config.should_reload
+    assert (config.host, config.port) == ("127.0.0.1", 9999)
 
 
 def test_the_entrypoint_does_not_drag_the_application_into_the_reloader() -> None:
@@ -325,7 +340,7 @@ def test_the_local_stack_runs_the_supervisor_and_not_uvicorns_own_reloader() -> 
 
 
 def test_a_worker_whose_event_loop_stopped_turning_is_replaced(
-    supervisor: RecordingReload, beat: "Synchronized[float]"
+    supervisor: RecordingReload, beat: ctypes.c_double
 ) -> None:
     """The whole of #336: this worker is alive, so nothing else would ever act on it."""
     beat.value = time.monotonic() - A_SHORT_WEDGE - 1
@@ -338,7 +353,7 @@ def test_a_worker_whose_event_loop_stopped_turning_is_replaced(
 
 
 def test_a_worker_still_beating_is_left_alone(
-    supervisor: RecordingReload, beat: "Synchronized[float]"
+    supervisor: RecordingReload, beat: ctypes.c_double
 ) -> None:
     """A slow server is not a wedged one, and replacing it drops requests it was serving."""
     beat.value = time.monotonic()
@@ -362,7 +377,7 @@ def test_a_worker_that_has_not_beaten_yet_is_left_alone(supervisor: RecordingRel
 
 
 def test_a_worker_that_exited_on_its_own_is_not_killed_for_its_stale_beat(
-    supervisor: RecordingReload, beat: "Synchronized[float]"
+    supervisor: RecordingReload, beat: ctypes.c_double
 ) -> None:
     """Its beat stops when it exits, and respawning it loops on the same traceback.
 
@@ -377,7 +392,7 @@ def test_a_worker_that_exited_on_its_own_is_not_killed_for_its_stale_beat(
 
 
 def test_a_replacement_is_not_judged_on_the_beat_of_the_worker_it_replaced(
-    supervisor: RecordingReload, beat: "Synchronized[float]"
+    supervisor: RecordingReload, beat: ctypes.c_double
 ) -> None:
     """Otherwise the first replacement inherits a stale cell and is killed on the next poll."""
     beat.value = time.monotonic() - A_SHORT_WEDGE - 1
@@ -391,7 +406,7 @@ def test_a_replacement_is_not_judged_on_the_beat_of_the_worker_it_replaced(
 
 
 def test_a_worker_wedging_during_shutdown_is_not_replaced(
-    supervisor: RecordingReload, beat: "Synchronized[float]"
+    supervisor: RecordingReload, beat: ctypes.c_double
 ) -> None:
     """A worker stops beating as it shuts down, and its replacement would be an orphan."""
     supervisor.should_exit.set()
@@ -402,8 +417,100 @@ def test_a_worker_wedging_during_shutdown_is_not_replaced(
     assert supervisor.replacements == 0
 
 
+def test_a_last_gasp_beat_from_a_dying_worker_does_not_reach_its_replacement(
+    supervisor: RecordingReload, beat: ctypes.c_double, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`Server.on_tick` beats before it reads `should_exit`.
+
+    So a worker that has just been sent `SIGTERM` gets one more tick and beats
+    one last time, on roughly one restart in ten. Clearing the cell before the
+    replacement rather than after would hand that beat to a process still
+    importing the application, and kill it fifteen seconds into a cold boot.
+    """
+
+    def _beat_on_the_way_out(self: RecordingReload) -> None:
+        beat.value = time.monotonic()
+        _record_the_replacement(self)
+
+    monkeypatch.setattr(BaseReload, "restart", _beat_on_the_way_out)
+    supervisor.process = FakeWorker(-9)
+
+    supervisor.should_restart()
+
+    assert supervisor.replacements == 1
+    assert beat.value == NOT_YET_BEATEN
+
+
+def test_shutting_down_kills_a_wedged_worker_rather_than_waiting_for_it(
+    supervisor: RecordingReload, beat: ctypes.c_double, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`_replace_a_wedged_worker` steps aside during shutdown, so `shutdown` has to act.
+
+    `BaseReload.shutdown` sends `SIGTERM` and joins without a timeout, and a
+    wedged worker never acts on `SIGTERM` - so Ctrl+C would block until Docker
+    killed the container ten seconds later.
+    """
+    stopped: list[bool] = []
+    monkeypatch.setattr(BaseReload, "shutdown", lambda self: stopped.append(True))
+    wedged = FakeWorker(None)
+    supervisor.process = wedged
+    beat.value = time.monotonic() - A_SHORT_WEDGE - 1
+
+    supervisor.shutdown()
+
+    assert wedged.killed
+    assert stopped == [True]
+
+
+def test_shutting_down_leaves_a_healthy_worker_to_drain(
+    supervisor: RecordingReload, beat: ctypes.c_double, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`SIGTERM` is how in-flight requests finish; escalating always would drop them."""
+    monkeypatch.setattr(BaseReload, "shutdown", lambda self: None)
+    healthy = FakeWorker(None)
+    supervisor.process = healthy
+    beat.value = time.monotonic()
+
+    supervisor.shutdown()
+
+    assert not healthy.killed
+
+
+def test_a_worker_is_not_judged_on_a_poll_the_supervisor_itself_slept_through(
+    supervisor: RecordingReload, beat: ctypes.c_double
+) -> None:
+    """`docker pause`, a frozen cgroup, a Docker Desktop VM after the host slept.
+
+    Monotonic time advances for the supervisor as well, so the worker's silence
+    says nothing about the worker. It gets a full window to prove itself, and a
+    healthy one takes about a second over it.
+    """
+    supervisor.process = FakeWorker(None)
+    supervisor._polled_at = time.monotonic() - A_SHORT_WEDGE - 1
+    beat.value = time.monotonic() - A_SHORT_WEDGE - 1
+
+    assert supervisor.should_restart() is None
+    assert supervisor.replacements == 0
+    assert beat.value == pytest.approx(time.monotonic(), abs=1)
+
+
+def test_a_worker_still_wedged_after_the_host_wakes_is_replaced(
+    supervisor: RecordingReload, beat: ctypes.c_double
+) -> None:
+    """Forgiving the frozen window is a reprieve, not an exemption."""
+    supervisor.process = FakeWorker(None)
+    supervisor._polled_at = time.monotonic() - A_SHORT_WEDGE - 1
+    beat.value = time.monotonic() - A_SHORT_WEDGE - 1
+    supervisor.should_restart()
+
+    beat.value = time.monotonic() - A_SHORT_WEDGE - 1
+
+    assert supervisor.should_restart() is None
+    assert supervisor.replacements == 1
+
+
 def test_the_wedge_check_can_be_switched_off(
-    monkeypatch: pytest.MonkeyPatch, beat: "Synchronized[float]"
+    monkeypatch: pytest.MonkeyPatch, beat: ctypes.c_double
 ) -> None:
     """A breakpoint blocks the event loop, and no probe can tell that from a deadlock."""
     monkeypatch.setattr(ChangeReload, "should_restart", lambda self: None)
@@ -417,32 +524,69 @@ def test_the_wedge_check_can_be_switched_off(
 
 
 async def test_the_heartbeat_stamps_the_cell_the_supervisor_reads(
-    beat: "Synchronized[float]",
+    beat: ctypes.c_double,
 ) -> None:
     await EventLoopHeartbeat(beat)()
 
     assert beat.value == pytest.approx(time.monotonic(), abs=1)
 
 
+async def test_uvicorn_awaits_the_heartbeat_on_its_own_tick(beat: ctypes.c_double) -> None:
+    """The hook belongs to uvicorn, so its contract is worth asserting rather than assuming.
+
+    `on_tick` is the body of `main_loop`. If it stopped awaiting
+    `callback_notify` - a rename, a change to what `timeout_notify` means - the
+    cell would never fill, every worker would read as wedged, and every test
+    that fills the cell by hand would still pass.
+    """
+
+    async def nothing(scope: Any, receive: Any, send: Any) -> None:
+        """An application the config can load without importing the platform."""
+
+    config = Config(nothing, callback_notify=EventLoopHeartbeat(beat), timeout_notify=BEAT_INTERVAL)
+    config.load()
+
+    await Server(config).on_tick(counter=0)
+
+    assert beat.value == pytest.approx(time.monotonic(), abs=1)
+
+
 def test_the_worker_reports_its_event_loop_through_uvicorns_notify_hook(
-    monkeypatch: pytest.MonkeyPatch,
+    wiring: dict[str, Any],
 ) -> None:
     """`callback_notify` is awaited by `Server.on_tick`, which is the loop itself.
 
     A thread answering a pipe - what `Multiprocess` asks - keeps answering while
     the loop is blocked, which is the failure this is for.
     """
-    captured: list[Config] = []
-    monkeypatch.setattr(Config, "bind_socket", lambda self: None)
-    monkeypatch.setattr(
-        SupervisedReload, "__init__", lambda self, config, **kw: captured.append(config)
-    )
-    monkeypatch.setattr(SupervisedReload, "run", lambda self: None)
+    config: Config = wiring["config"]
 
-    run_reload_server(host="0.0.0.0", port=8000)
+    assert isinstance(config.callback_notify, EventLoopHeartbeat)
+    assert config.timeout_notify == BEAT_INTERVAL
 
-    assert isinstance(captured[0].callback_notify, EventLoopHeartbeat)
-    assert captured[0].timeout_notify == BEAT_INTERVAL
+
+def test_the_worker_and_the_supervisor_share_one_cell(wiring: dict[str, Any]) -> None:
+    """Two cells would pass every other test and kill a healthy worker every 15 seconds."""
+    heartbeat: EventLoopHeartbeat = wiring["config"].callback_notify
+
+    assert heartbeat._beat is wiring["beat"]
+
+
+def test_the_beat_cell_carries_no_lock(wiring: dict[str, Any]) -> None:
+    """`multiprocessing.Value` here refuses to start the container, and could hang it.
+
+    Its lock is a `SemLock` from the default context, which on Linux is `fork`
+    while uvicorn spawns - so the worker never starts and the container
+    restart-loops with `A SemLock created in a fork context is being shared with
+    a process in a spawn context`. That is invisible on macOS, where the default
+    context is already `spawn`, which is why it is asserted here rather than
+    left to the spawning test below.
+
+    The lock would be a hazard even where it pickles: this module `SIGKILL`s a
+    wedged worker, and one killed while holding the lock leaves it held, so the
+    supervisor's next read of the cell would block for ever.
+    """
+    assert isinstance(wiring["beat"], ctypes.c_double)
 
 
 def test_the_threshold_comes_from_the_environment(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -451,6 +595,14 @@ def test_the_threshold_comes_from_the_environment(monkeypatch: pytest.MonkeyPatc
 
     monkeypatch.setenv(WEDGED_AFTER_ENV_VAR, "0")
     assert wedged_after_from_environment() == 0
+
+
+def test_a_threshold_that_is_not_a_number_is_refused(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Falling back to 15 seconds on a typo is how somebody debugs the supervisor instead."""
+    monkeypatch.setenv(WEDGED_AFTER_ENV_VAR, "off")
+
+    with pytest.raises(ValueError, match="off"):
+        wedged_after_from_environment()
 
 
 def test_a_worker_stopped_mid_flight_is_killed_and_replaced() -> None:
@@ -464,7 +616,7 @@ def test_a_worker_stopped_mid_flight_is_killed_and_replaced() -> None:
     would hang this test rather than fail it, which is why the replacement runs
     on a thread the test refuses to wait on indefinitely.
     """
-    beat: Synchronized[float] = Value("d", NOT_YET_BEATEN)
+    beat: ctypes.c_double = RawValue("d", NOT_YET_BEATEN)
     config = Config(APP, reload=True, ws=WS_PROTOCOL)
     worker = BeatingWorker(EventLoopHeartbeat(beat))
     supervisor = SupervisedReload(
@@ -509,7 +661,7 @@ def _reap(process: SpawnProcess) -> None:
     process.join()
 
 
-def _wait_until_beating(beat: "Synchronized[float]", timeout: float = A_PATIENT_WAIT) -> None:
+def _wait_until_beating(beat: ctypes.c_double, timeout: float = A_PATIENT_WAIT) -> None:
     """Block until the worker has reported its event loop at least once."""
     deadline = time.monotonic() + timeout
     while beat.value == NOT_YET_BEATEN:

--- a/backend/tests/test_reload_supervisor.py
+++ b/backend/tests/test_reload_supervisor.py
@@ -1,28 +1,64 @@
-"""The development server survives a worker the kernel kills.
+"""The development server survives a worker the kernel kills, and one that wedges.
 
-`uvicorn --reload` does not: its reloader watches files and nothing else, so an
-OOM-killed worker leaves a zombie, a reloader still politely watching, and a
-container reporting `Up` with nothing listening (#308). These pin the decision
-the supervisor makes about a worker that is gone - replace it, or wait for the
-edit that fixes it - and that the local stack actually runs the supervisor.
+`uvicorn --reload` survives neither: its reloader watches files and nothing else,
+so an OOM-killed worker leaves a zombie, a reloader still politely watching, and
+a container reporting `Up` with nothing listening (#308) - and a worker that is
+alive but whose event loop has stopped turning is not even that visible (#336).
+These pin the decision the supervisor makes about each - replace it, kill and
+replace it, or wait for the edit that fixes it - and that the local stack
+actually runs the supervisor.
 """
 
+import asyncio
+import contextlib
 import logging
+import os
+import signal
 import subprocess
 import sys
+import threading
+import time
+from multiprocessing import Value
+from multiprocessing.context import SpawnProcess
+from multiprocessing.sharedctypes import Synchronized
 from pathlib import Path
-from typing import Any
+from types import FrameType
+from typing import Any, Final
 
 import pytest
 import yaml
 from uvicorn import Config
+from uvicorn._subprocess import get_subprocess
 from uvicorn.supervisors import ChangeReload
+from uvicorn.supervisors.basereload import BaseReload
 
 from cli import reload_supervisor
-from cli.reload_supervisor import APP, WS_PROTOCOL, SupervisedReload, run_reload_server
+from cli.reload_supervisor import (
+    APP,
+    BEAT_INTERVAL,
+    NOT_YET_BEATEN,
+    WEDGED_AFTER,
+    WEDGED_AFTER_ENV_VAR,
+    WS_PROTOCOL,
+    EventLoopHeartbeat,
+    SupervisedReload,
+    run_reload_server,
+    wedged_after_from_environment,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 LOCAL_COMPOSE = REPO_ROOT / "docker-compose.yml"
+
+# Long enough that no scheduling hiccup on a loaded CI runner reads as a wedge,
+# short enough that the test spends a fraction of a second proving one.
+A_SHORT_WEDGE: Final = 0.5
+
+# What a spawned worker gets to answer in before the test gives up on it. Long
+# because a cold interpreter on a loaded runner is slow, and bounded because the
+# regression it guards against is a supervisor that waits for ever.
+A_PATIENT_WAIT: Final = 30.0
+
+pytestmark = pytest.mark.anyio
 
 
 class FakeWorker:
@@ -31,23 +67,80 @@ class FakeWorker:
     def __init__(self, exitcode: int | None, pid: int = 4242) -> None:
         self.exitcode = exitcode
         self.pid = pid
+        self.killed = False
+
+    def kill(self) -> None:
+        self.killed = True
+        self.exitcode = -signal.SIGKILL
+
+    def join(self) -> None:
+        """A killed process is reaped immediately; a fake one has nothing to wait for."""
+
+
+class BeatingWorker:
+    """A stand-in worker: a real event loop running the real heartbeat.
+
+    Module-level and picklable, because `get_subprocess` spawns rather than
+    forks - the same reason `EventLoopHeartbeat` is a class and not a closure,
+    and the reason this is worth running for real: the shared cell has to
+    survive being pickled into a spawned process, which nothing in-process
+    proves.
+
+    It catches `SIGTERM` and leaves the loop to act on it, which is what
+    `uvicorn.Server.capture_signals` does. Without that the stand-in would die
+    on a signal the real worker survives, and the test below would pass against
+    a supervisor that hangs in production.
+    """
+
+    def __init__(self, heartbeat: EventLoopHeartbeat) -> None:
+        self._heartbeat = heartbeat
+        self._should_exit = False
+
+    def __call__(self, sockets: list[Any] | None = None) -> None:
+        signal.signal(signal.SIGTERM, self._request_exit)
+        asyncio.run(self._beat_until_stopped())
+
+    def _request_exit(self, sig: int, frame: FrameType | None) -> None:
+        self._should_exit = True
+
+    async def _beat_until_stopped(self) -> None:
+        while not self._should_exit:
+            await self._heartbeat()
+            await asyncio.sleep(0.05)
 
 
 class RecordingReload(SupervisedReload):
-    """Records the replacement rather than spawning a real worker."""
+    """Records the replacement rather than spawning a real worker.
 
-    def __init__(self, config: Config) -> None:
-        super().__init__(config, target=lambda sockets: None, sockets=[])
+    Only the spawn is stubbed - `BaseReload.restart` in the fixture below - so
+    `SupervisedReload.restart` itself, and the beat it clears, still run.
+    """
+
+    def __init__(self, config: Config, beat: "Synchronized[float]", wedged_after: float) -> None:
+        super().__init__(
+            config,
+            target=lambda sockets: None,
+            sockets=[],
+            beat=beat,
+            wedged_after=wedged_after,
+        )
         self.replacements = 0
 
-    def restart(self) -> None:
-        self.replacements += 1
-        self.process = FakeWorker(None, pid=self.process.pid + 1)
+
+def _record_the_replacement(self: RecordingReload) -> None:
+    self.replacements += 1
+    self.process = FakeWorker(None, pid=self.process.pid + 1)
+
+
+@pytest.fixture
+def beat() -> "Synchronized[float]":
+    """The cell the worker stamps its event loop into, as `run_reload_server` makes it."""
+    return Value("d", NOT_YET_BEATEN)
 
 
 @pytest.fixture
 def supervisor(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, beat: "Synchronized[float]"
 ) -> RecordingReload:
     """A supervisor whose file watcher reports no changes, with its log captured.
 
@@ -57,7 +150,8 @@ def supervisor(
     the assertions can be about what was written rather than about handlers.
     """
     monkeypatch.setattr(ChangeReload, "should_restart", lambda self: None)
-    reloader = RecordingReload(Config(APP, reload=True, ws=WS_PROTOCOL))
+    monkeypatch.setattr(BaseReload, "restart", _record_the_replacement)
+    reloader = RecordingReload(Config(APP, reload=True, ws=WS_PROTOCOL), beat, A_SHORT_WEDGE)
     monkeypatch.setattr(reload_supervisor, "logger", logging.getLogger("tests.reload_supervisor"))
     caplog.set_level(logging.ERROR, logger="tests.reload_supervisor")
     return reloader
@@ -228,3 +322,196 @@ def test_the_local_stack_runs_the_supervisor_and_not_uvicorns_own_reloader() -> 
         "--port",
         "8000",
     ]
+
+
+def test_a_worker_whose_event_loop_stopped_turning_is_replaced(
+    supervisor: RecordingReload, beat: "Synchronized[float]"
+) -> None:
+    """The whole of #336: this worker is alive, so nothing else would ever act on it."""
+    beat.value = time.monotonic() - A_SHORT_WEDGE - 1
+    wedged = FakeWorker(None)
+    supervisor.process = wedged
+
+    assert supervisor.should_restart() is None
+    assert supervisor.replacements == 1
+    assert wedged.killed, "SIGTERM never reaches a wedged worker; the replacement would hang"
+
+
+def test_a_worker_still_beating_is_left_alone(
+    supervisor: RecordingReload, beat: "Synchronized[float]"
+) -> None:
+    """A slow server is not a wedged one, and replacing it drops requests it was serving."""
+    beat.value = time.monotonic()
+    supervisor.process = FakeWorker(None)
+
+    assert supervisor.should_restart() is None
+    assert supervisor.replacements == 0
+
+
+def test_a_worker_that_has_not_beaten_yet_is_left_alone(supervisor: RecordingReload) -> None:
+    """Booting is not wedging.
+
+    The first beat comes from `main_loop`, which runs only once lifespan startup
+    has finished - so a worker importing the application has an empty cell, and
+    judging it on that is a restart loop against a cold container.
+    """
+    supervisor.process = FakeWorker(None)
+
+    assert supervisor.should_restart() is None
+    assert supervisor.replacements == 0
+
+
+def test_a_worker_that_exited_on_its_own_is_not_killed_for_its_stale_beat(
+    supervisor: RecordingReload, beat: "Synchronized[float]"
+) -> None:
+    """Its beat stops when it exits, and respawning it loops on the same traceback.
+
+    Without the guard, the wedge check would undo the one decision
+    `_replace_a_dead_worker` makes deliberately.
+    """
+    beat.value = time.monotonic() - A_SHORT_WEDGE - 1
+    supervisor.process = FakeWorker(1)
+
+    assert supervisor.should_restart() is None
+    assert supervisor.replacements == 0
+
+
+def test_a_replacement_is_not_judged_on_the_beat_of_the_worker_it_replaced(
+    supervisor: RecordingReload, beat: "Synchronized[float]"
+) -> None:
+    """Otherwise the first replacement inherits a stale cell and is killed on the next poll."""
+    beat.value = time.monotonic() - A_SHORT_WEDGE - 1
+    supervisor.process = FakeWorker(None)
+
+    supervisor.should_restart()
+    supervisor.should_restart()
+
+    assert supervisor.replacements == 1
+    assert beat.value == NOT_YET_BEATEN
+
+
+def test_a_worker_wedging_during_shutdown_is_not_replaced(
+    supervisor: RecordingReload, beat: "Synchronized[float]"
+) -> None:
+    """A worker stops beating as it shuts down, and its replacement would be an orphan."""
+    supervisor.should_exit.set()
+    beat.value = time.monotonic() - A_SHORT_WEDGE - 1
+    supervisor.process = FakeWorker(None)
+
+    assert supervisor.should_restart() is None
+    assert supervisor.replacements == 0
+
+
+def test_the_wedge_check_can_be_switched_off(
+    monkeypatch: pytest.MonkeyPatch, beat: "Synchronized[float]"
+) -> None:
+    """A breakpoint blocks the event loop, and no probe can tell that from a deadlock."""
+    monkeypatch.setattr(ChangeReload, "should_restart", lambda self: None)
+    monkeypatch.setattr(BaseReload, "restart", _record_the_replacement)
+    off = RecordingReload(Config(APP, reload=True, ws=WS_PROTOCOL), beat, wedged_after=0)
+    off.process = FakeWorker(None)
+    beat.value = time.monotonic() - A_SHORT_WEDGE - 1
+
+    assert off.should_restart() is None
+    assert off.replacements == 0
+
+
+async def test_the_heartbeat_stamps_the_cell_the_supervisor_reads(
+    beat: "Synchronized[float]",
+) -> None:
+    await EventLoopHeartbeat(beat)()
+
+    assert beat.value == pytest.approx(time.monotonic(), abs=1)
+
+
+def test_the_worker_reports_its_event_loop_through_uvicorns_notify_hook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`callback_notify` is awaited by `Server.on_tick`, which is the loop itself.
+
+    A thread answering a pipe - what `Multiprocess` asks - keeps answering while
+    the loop is blocked, which is the failure this is for.
+    """
+    captured: list[Config] = []
+    monkeypatch.setattr(Config, "bind_socket", lambda self: None)
+    monkeypatch.setattr(
+        SupervisedReload, "__init__", lambda self, config, **kw: captured.append(config)
+    )
+    monkeypatch.setattr(SupervisedReload, "run", lambda self: None)
+
+    run_reload_server(host="0.0.0.0", port=8000)
+
+    assert isinstance(captured[0].callback_notify, EventLoopHeartbeat)
+    assert captured[0].timeout_notify == BEAT_INTERVAL
+
+
+def test_the_threshold_comes_from_the_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(WEDGED_AFTER_ENV_VAR, raising=False)
+    assert wedged_after_from_environment() == WEDGED_AFTER
+
+    monkeypatch.setenv(WEDGED_AFTER_ENV_VAR, "0")
+    assert wedged_after_from_environment() == 0
+
+
+def test_a_worker_stopped_mid_flight_is_killed_and_replaced() -> None:
+    """The end of #336, against a process that is genuinely alive and not answering.
+
+    `SIGSTOP` is the cheap way to produce one: the process exists, has no exit
+    code, and runs nothing. It is also the case that pins `kill` over
+    `terminate`. The worker catches `SIGTERM` and acts on it from the event
+    loop, so a wedged one never acts on it at all and the join inside
+    `BaseReload.restart` blocks the supervisor for good - a regression that
+    would hang this test rather than fail it, which is why the replacement runs
+    on a thread the test refuses to wait on indefinitely.
+    """
+    beat: Synchronized[float] = Value("d", NOT_YET_BEATEN)
+    config = Config(APP, reload=True, ws=WS_PROTOCOL)
+    worker = BeatingWorker(EventLoopHeartbeat(beat))
+    supervisor = SupervisedReload(
+        config, target=worker, sockets=[], beat=beat, wedged_after=A_SHORT_WEDGE
+    )
+    supervisor.process = get_subprocess(config, target=worker, sockets=[])
+    supervisor.process.start()
+    wedged = supervisor.process
+    replacing = threading.Thread(target=supervisor._replace_a_wedged_worker, daemon=True)
+    try:
+        _wait_until_beating(beat)
+        os.kill(wedged.pid, signal.SIGSTOP)
+        time.sleep(A_SHORT_WEDGE * 2)
+
+        replacing.start()
+        replacing.join(timeout=A_PATIENT_WAIT)
+
+        assert not replacing.is_alive(), "the supervisor is stuck on a worker that ignores SIGTERM"
+        assert wedged.exitcode == -signal.SIGKILL
+        assert supervisor.process is not wedged
+        _wait_until_beating(beat)
+    finally:
+        # The wedged worker goes first and unjoined: a supervisor still stuck on
+        # it has to be let go before its thread can finish, and joining a process
+        # that thread is already joining is how the cleanup deadlocks in turn.
+        _kill(wedged)
+        if replacing.ident is not None:
+            replacing.join(timeout=A_PATIENT_WAIT)
+        _reap(supervisor.process)
+        _reap(wedged)
+
+
+def _kill(process: SpawnProcess) -> None:
+    """Send `SIGKILL` to a process that may already be gone, and do not wait for it."""
+    with contextlib.suppress(ProcessLookupError):
+        os.kill(process.pid, signal.SIGKILL)
+
+
+def _reap(process: SpawnProcess) -> None:
+    """Kill a process and wait for it, a no-op once it has been reaped already."""
+    _kill(process)
+    process.join()
+
+
+def _wait_until_beating(beat: "Synchronized[float]", timeout: float = A_PATIENT_WAIT) -> None:
+    """Block until the worker has reported its event loop at least once."""
+    deadline = time.monotonic() + timeout
+    while beat.value == NOT_YET_BEATEN:
+        assert time.monotonic() < deadline, "the worker never reported a turning event loop"
+        time.sleep(0.05)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,14 @@ services:
     # nothing is listening. `cli/reload_supervisor.py` is the same reloader with
     # a worker the kernel killed replaced within about five seconds.
     #
+    # It also replaces a worker that is alive but whose event loop has stopped
+    # turning - deadlocked, spinning, or stopped - which has no exit code and so
+    # looks healthy to everything else here. The worker beats from its own event
+    # loop and the supervisor replaces it after fifteen silent seconds. Set
+    # `RELOAD_WEDGED_AFTER` in `backend/.env` to change that, or to `0` to switch
+    # it off, which is what a breakpoint needs: a stopped event loop is exactly
+    # what the check is looking for.
+    #
     # It, and not `cli.commands server run --reload`, because that entrypoint
     # imports `app.main` and would put the whole application - 464 MB against
     # 28 MB - inside a reloader that never serves a request.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -149,6 +149,21 @@ watching while no port is listening. Under the supervisor a worker killed by a
 signal is replaced within about five seconds, and one that exited on its own
 still waits for the edit that fixes it, which is what `--reload` is for.
 
+It also replaces a worker that is **wedged** — alive, but with an event loop
+that has stopped turning, which has no exit code and so looks healthy to every
+other recovery path. The worker reports its loop through uvicorn's
+`callback_notify` hook once a second, and a worker silent for fifteen seconds is
+killed and replaced, so about twenty seconds from deadlock to serving again.
+That is liveness and not readiness on purpose: the beat is a timer callback, not
+a request, so a slow database cannot make a healthy server look wedged.
+
+| | |
+|---|---|
+| `RELOAD_WEDGED_AFTER` | Seconds of silence before a worker is replaced. Default `15`; `0` switches the check off |
+
+Switch it off while debugging. A breakpoint blocks the event loop and no probe
+can tell that from a deadlock, so a worker sitting on one is replaced under you.
+
 `server run` also selects the `websockets-sansio` implementation in both modes.
 uvicorn's `auto` picks the legacy one, which fails the handshake against
 websockets >=14 with an HTTP 500 — and the dashboard chat is a WebSocket.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -159,7 +159,7 @@ a request, so a slow database cannot make a healthy server look wedged.
 
 | | |
 |---|---|
-| `RELOAD_WEDGED_AFTER` | Seconds of silence before a worker is replaced. Default `15`; `0` switches the check off |
+| `RELOAD_WEDGED_AFTER` | Seconds of silence before a worker is replaced. Default `15`; `0` or below switches the check off |
 
 Switch it off while debugging. A breakpoint blocks the event loop and no probe
 can tell that from a deadlock, so a worker sitting on one is replaced under you.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -152,8 +152,11 @@ still waits for the edit that fixes it, which is what `--reload` is for.
 It also replaces a worker that is **wedged** — alive, but with an event loop
 that has stopped turning, which has no exit code and so looks healthy to every
 other recovery path. The worker reports its loop through uvicorn's
-`callback_notify` hook once a second, and a worker silent for fifteen seconds is
-killed and replaced, so about twenty seconds from deadlock to serving again.
+`callback_notify` hook once a second, and a worker silent for fifteen seconds
+across two consecutive polls is killed and replaced — about twenty-five seconds
+from deadlock to serving again. Two polls rather than one because `docker pause`
+and a laptop waking from sleep stop the supervisor as well as the worker, and the
+first poll afterwards reads a stale beat that says nothing.
 That is liveness and not readiness on purpose: the beat is a timer callback, not
 a request, so a slow database cannot make a healthy server look wedged.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -203,10 +203,20 @@ make run                                        # uvicorn --reload, supervised
     A worker killed by a signal is now replaced within about five seconds. One
     that exited on its own still waits for the edit that fixes it.
 
+    A **wedged** worker is replaced too — alive, but with an event loop that has
+    stopped turning, which has no exit code and so looks healthy to every other
+    recovery path. It reports its loop to the supervisor once a second, and
+    fifteen seconds of silence gets it killed and replaced. Set
+    `RELOAD_WEDGED_AFTER` in `backend/.env` to change that, or to `0` to switch
+    it off — which is what you want while debugging, because a breakpoint blocks
+    the event loop and no probe can tell that from a deadlock.
+
     This is the reload path only. `make dev-server` runs a single unsupervised
     uvicorn, so a kill takes PID 1 with it and `restart: unless-stopped`
-    restarts the container; `make prod` runs `--workers 4`, where uvicorn's own
-    `Multiprocess` supervisor already replaces a dead worker twice a second.
+    restarts the container, and a wedge is not covered at all; `make prod` runs
+    `--workers 4`, where uvicorn's own `Multiprocess` supervisor replaces a dead
+    worker twice a second and pings the rest over a pipe — which a worker
+    answers from a thread, so a blocked event loop there is invisible.
 
 !!! note "Python is pinned to 3.12"
 


### PR DESCRIPTION
**Stacked on #334** (`fix/dev-backend-restarts-when-its-worker-dies`) and based on
it, not on `main`. #334 replaces a worker that is *gone*; this replaces one that
is *stuck*. Rebased onto its final head (`d2fe3cd`), which has not moved since.

**⚠️ CI has never run on this diff, and cannot.** `.github/workflows/ci.yml`
triggers on `pull_request: branches: [main, master]`, which matches on the
*base* — so a pull request based on a feature branch matches no trigger at all
and `gh pr checks` answers "no checks reported". Not pending, not red: absent.
Filed as #359. The gate here is local, plus the real-container run below.

## The decision

#336 offers three options and asks for a choice rather than a patch. The choice
is **option 2, a liveness probe the supervisor runs itself** — but not the pipe
ping the issue describes, because that one cannot see the failure that matters.

**What "wedged" means here, concretely:** the worker's asyncio event loop has not
run a timer callback for 15 seconds, on two consecutive polls. The worker stamps
`time.monotonic()` into a shared cell from uvicorn's `Config.callback_notify`
hook — awaited by `Server.on_tick`, the integration point systemd's watchdog
uses — once a second. The supervisor reads the cell on the same quiet poll it
already uses to reap a dead worker, so detection costs the threshold plus two
polls: about twenty-five seconds, against the ninety a container health check
takes to reach a verdict nothing acts on.

**Why 15 seconds.** The cost of the two mistakes is not symmetric: replacing a
wedged worker late costs seconds on a laptop, replacing a healthy one early
drops in-flight requests. So the threshold is fifteen missed beats, not two. It
can be that generous *because the beat is not a request*: an idle timer callback
runs in milliseconds however loaded the server is, so fifteen seconds of silence
is not slowness — it is a loop that is blocked, stopped or deadlocked. A busy
server and an unresponsive one do not look alike under this measurement, which
is the whole reason for choosing it. Fifteen also absorbs a backwards clock step,
which two would not: `on_tick` schedules on `time.time()` while the verdict is
monotonic.

**Why two polls and not one.** `docker pause`, a frozen cgroup and a Docker
Desktop VM resuming after the Mac slept all advance the monotonic clock while
*nothing* runs, supervisor included, so the first poll afterwards reads a stale
beat that says nothing about the worker. By the next poll a healthy worker has
beaten again and the verdict clears; a wedged one fails both.

**Why not the two cheaper probes.**

- **An HTTP probe against the bound port** is fewer lines and needs no
  child-side code, but it traverses the application. A slow database or a Redis
  outage would read as a wedged worker, and the supervisor would restart-loop a
  healthy server against a broken dependency. That is readiness, not liveness,
  and killing a worker for being slow is worse than ignoring a wedged one.
- **A pipe ping**, which is what `Multiprocess` does and what #336 suggests, is
  answered by a dedicated thread in the worker. That thread keeps answering
  while the event loop is blocked — the single most likely way to wedge an async
  server, and the exact case #336 names as invisible. A beat originating *on the
  loop* is the one signal that thread cannot fake.

**Why not an external actor** (`autoheal`, or a health-check-driven restarter).
#333 has just made the probes honest, so wiring something to them is a real
option now — but `autoheal` needs the Docker socket, which is root-equivalent
and which `docker-compose.yml` reserves for `sandboxd` behind a profile with a
comment saying so. #334 turned it down on those grounds and #333 did not reopen
them. This needs no socket, no new container and no privilege: the process that
already supervises the worker is the process that judges it.

**A wedged worker is killed, not terminated.** `BaseReload.restart` sends
`SIGTERM` and joins — and uvicorn's worker *catches* `SIGTERM`, so acting on it
needs the event loop to come round, which is the one thing a wedged worker
cannot do. A stopped process does not run the handler at all. Either way the
join never returns and the supervisor hangs with it. `shutdown` needs the same
escalation or Ctrl+C hangs; both have tests.

## Which stacks this covers

**The local stack (`docker-compose.yml`) only** — the only one that runs this
module. Doing that one properly beats gesturing at three:

| Stack | Dead worker | Wedged worker |
|---|---|---|
| `docker-compose.yml` | replaced (#334) | **replaced, this PR** |
| `docker-compose-dev.yml` | container exits, `restart:` acts | **not covered** — #358 |
| `docker-compose-prod.yml` | `Multiprocess` replaces it | pipe ping only, so a blocked loop is invisible — #358 |

## What remains uncovered, plainly

- **The dev and production stacks — #358.** Covering dev means giving it a
  supervisor, i.e. changing what PID 1 of that container is; covering production
  means replacing uvicorn's own `Multiprocess` with a subclass of ours, a much
  worse trade on the stack that serves real traffic than on a laptop. Filed with
  the options and the reasoning rather than dropped.
- **A worker that wedges before it serves.** `main_loop`, and so the first beat,
  starts only after lifespan startup, so a worker hung on a database connect at
  boot never beats and is deliberately never judged — judging it would need a
  startup grace period long enough to be meaningless on a cold container.
  `shutdown` inherits the gap, so Ctrl+C on such a worker still waits out
  Docker's grace period. **#366.**
- **A debugger.** A breakpoint blocks the event loop and no probe can tell that
  from a deadlock. `RELOAD_WEDGED_AFTER=0` switches the check off; documented in
  `docs/commands.md`, `docs/install.md`, `.env.example` and the compose comment,
  because otherwise the first person to attach one loses their worker every
  fifteen seconds and has no idea why.
- **A worker in uninterruptible sleep.** `SIGKILL` is not delivered in `D`
  state, so the join after it hangs as `SIGTERM` would have. A bounded join only
  moves the hang into `BaseReload.restart`, which joins again with no timeout, so
  it is recorded in the docstring rather than half-fixed.
- **An event loop that turns while nothing is served** — the accept loop broken,
  `limit_concurrency` exhausted. That is readiness, and by design this does not
  measure it.

## How it was verified

**Real containers, twice**, in an isolated stack — its own project name, image
tag, container names and port, so it could not disturb the stacks already on the
host. `kill -STOP` on the supervisor's *child*; `SIGSTOP` does nothing to PID 1
of a namespace from inside it, which is what #333 hit, and is not what is being
stopped here. Against the final commit, with `RELOAD_WEDGED_AFTER=5`:

```
16:44:12  worker 8 SIGSTOPped, health 200 immediately before
          ERROR: Server process [8] has not run its event loop for 14s.
                 Killing it and starting a replacement.
16:44:34  serving again
```

Twenty-two seconds, and fourteen seconds of measured silence at the verdict —
the threshold plus the two polls, which is what the docstring claims. Afterwards
`RestartCount` was still `0` with PID 1 at 52 seconds of uptime spanning the
whole episode: **the supervisor recovered it, not Docker.** The first run, before
the review fixes, behaved the same way at 16 seconds under the one-poll rule —
and is what found the defect that would have stopped `make dev` working at all.

**Local gates.** `make lint-backend` clean. `make test` green: 3250 passed, 6
skipped, coverage gate at 100%. `make check` — everything green except
`test-frontend`, which failed three files on 5s test timeouts while a second
worktree ran its own suite on the same machine; re-run alone it is **184 files /
3175 tests passed, exit 0**. That is the documented coverage-timeout trap in
`.claude/rules/testing.md`, and this diff touches no frontend code.
`tests/test_migrations.py` passed here rather than hitting #346.

**33 tests**, of which the interesting one spawns a real worker, waits for it to
beat, `SIGSTOP`s it, and asserts the supervisor kills it with `SIGKILL` and gets
a replacement beating. The stand-in catches `SIGTERM` and acts on it from the
loop, exactly as `Server.capture_signals` does — without that it would die on a
signal the real worker survives and the test would pass against a supervisor
that hangs in production. Reverting `kill` to `terminate` hangs that thread past
240s, which is why the replacement runs on a thread the test refuses to wait on
indefinitely.

## Six defects found and fixed after the first draft

Recorded because two of them were invisible to the test suite on macOS, and one
would have broken the local stack outright.

1. **`multiprocessing.Value` stopped the container booting.** Its lock is a
   `SemLock` from the default context — `fork` on Linux — and uvicorn spawns, so
   pickling it into the worker raised `A SemLock created in a fork context is
   being shared with a process in a spawn context` and `agenticos_backend`
   restart-looped eight times before serving anything. Green throughout on macOS,
   where the default context is already `spawn`. `RawValue` has no lock and
   crosses from either context.
2. **That lock was a hazard even where it pickled.** `Synchronized.value`
   acquires a semaphore on read and write, and one held by a dead process is
   never released. A worker killed inside the setter — which is what this module
   does to a wedged one — would block the supervisor's next read for ever.
3. **A dying worker's last beat reached its replacement.** `on_tick` awaits
   `callback_notify` before it reads `should_exit`, so a worker sent `SIGTERM`
   inside the second before its next beat beats once more. The cell is now
   cleared after the replacement, not before.
4. **`shutdown` hung on a wedged worker**, because the replacement path stands
   aside once `should_exit` is set and handed it to a `SIGTERM` and an unbounded
   join.
5. **The first freeze guard switched the whole check off for any threshold below
   about five seconds** — it compared the poll gap against the threshold, and
   watchfiles polls every ~5.25s, so every poll read as a freeze. Silently. Two
   consecutive verdicts replaced it.
6. **Nothing proved the two ends shared a cell**, or that uvicorn calls the
   heartbeat at all. Two separate cells, or a renamed hook, would have passed
   every test and killed a healthy worker every fifteen seconds for ever.

## Notes

- **This diff has not been through an automated reviewer.** `ai-review` no longer
  runs on a pull request (#311) and the label does nothing, so the review here is
  a manual maintainer pass plus two subagents given the diff and a category to
  hunt in. Defects 1–2 came from the container; 3–6 from those passes.
- `cli/` is in `[tool.ty.src] exclude` and in neither coverage list, so this
  module is type-checked by nothing and its coverage gates nothing. Worth knowing
  when reading "the suite is green".

Closes #336
