### PR TITLE
chore: cut 0.0.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,22 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.36] - 2026-08-06
+
+### Fixed
+
+- The end-to-end suite's `[seed]` project asserted the colleague's membership
+  with a single read. When it lost, Playwright skipped everything that depends
+  on the fixture and reported the whole suite red having exercised no product
+  code at all — three times in one day, on unrelated branches. The step now
+  polls the API and, when it does give up, prints what it actually saw
+  (#335).
+
+The underlying cause is filed rather than fixed: this backend answers a write
+before the transaction commits, so a 2xx says the request was handled and not
+that the write is readable (#353).
+
+
 ## [0.0.35] - 2026-08-06
 
 Nothing in this release changes what the product does. It changes what CI costs,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.35"
+version = "0.0.36"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.35"
+version = "0.0.36"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for the e2e seed fixture that took the whole suite down (code landed
as #355).

`seed.setup.ts` asserted the colleague's membership once, immediately. Being a
project dependency, a loss there skipped all 87 specs and reported red having
run no product spec — seen on `main` and on two unrelated branches within a few
hours. The step now polls and names what it observed on failure.

Verified by 31 consecutive local `[seed]` runs and by the assertion being shown
to fail against an address that could never be a member.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.36]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #353