### PR TITLE
chore: cut 0.0.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,23 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.37] - 2026-08-06
+
+### Fixed
+
+- The `ai-review` workflow concluded `success` when it had produced no review at
+  all, and posted "the reviewer did not produce a result" — a sentence that reads
+  like a verdict on the diff. Eleven pull requests merged unreviewed before anyone
+  noticed. A run is now classified `reviewed`, `declined` or `broken`; `broken`
+  fails the job and the comment says the reviewer failed, carrying what Codex
+  printed. A cancelled run no longer reports the reviewer as dead, and a broken
+  re-run no longer deletes the previous run's inline findings (#311).
+
+The cause of the Codex failure itself is an enforced spend limit on the OpenAI
+project, recorded on #311. The `pull_request` trigger stays off until that is
+lifted.
+
+
 ## [0.0.36] - 2026-08-06
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.36"
+version = "0.0.37"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.36"
+version = "0.0.37"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for the reviewer that failed silently (code landed as #352).

Every `ai-review` run since 2026-08-05 evening died about twelve seconds into
Codex, concluded `success`, and posted a sentence indistinguishable from "the
diff is clean". The reason was twelve lines above the stack trace in a green
job: the OpenAI project had reached its enforced spend limit.

The workflow now fails when it produced nothing and says so in the comment,
with Codex's own output read back out of the job log. Exercised twice against
the live failure by dispatching at a real pull request.

Raising the spend limit and restoring the `pull_request` trigger are still
outstanding; #311 stays open for them.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.37]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #311, #351