### PR TITLE
chore: cut 0.0.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,27 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.38] - 2026-08-06
+
+### Fixed
+
+- A domain exception carrying a `UUID` in its `details` was delivered as a bodiless
+  500 instead of the refusal it described. `JSONResponse` serializes with plain
+  `json.dumps`, which cannot encode a `UUID`, so the exception handler raised on
+  the way out — after it had already logged the refusal, which is why the log and
+  the response disagreed. A browser session kept across a database reset hit this
+  on every `GET /api/v1/auth/me`. All three response-building handlers now encode
+  `details` through `jsonable_encoder` (#307).
+- The capability registry echoed a rejected configuration back to the caller in a
+  400, unlike the identical call one module over.
+
+### Changed
+
+- `.claude/rules/exceptions-security.md` showed `details={"user_id": str(user_id)}`,
+  which contradicted both the code and `architecture.md`. Domain exceptions pass
+  the value; the encoder handles it. The one exception, money, says why.
+
+
 ## [0.0.37] - 2026-08-06
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.37"
+version = "0.0.38"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.37"
+version = "0.0.38"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for the error envelope that never arrived (code landed as #326).

Every path raising a domain exception with a raw UUID in `details` answered a
bare 500 with no body, so a client could not tell an unknown id from a broken
server and the documented error contract was honoured on no such path.

Encoded once in the handler rather than stringified at the call sites: that is
twenty edits enforceable only by review, and the twenty-first is written next
month.

Worth recording: the issue estimated about twenty call sites passing a raw
UUID. An AST pass over `backend/app` found two, both in `UserService`. Four of
the five files it named take `str`. Two was enough.

Ten tests, eight of which fail without the fix. A review sweep over all 226
`details=` call sites found one further leak, fixed here.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.38]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #342