### PR TITLE
chore: cut 0.0.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,26 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.39] - 2026-08-06
+
+### Fixed
+
+- `prefect-runner` had never once passed a health check and never could. It runs
+  the backend image, which carried a `HEALTHCHECK` written for the API, and the
+  runner serves no HTTP. A status that is red unconditionally is not a status: a
+  dead runner looked exactly like a live one, and nothing could depend on it
+  becoming healthy. The runner now serves Prefect's own `/health` on 8080 and is
+  probed against it (#310).
+- The API's own probe passed on a 500 — it fetched the health endpoint and
+  ignored the status. It now raises for status, with a 30s start period.
+
+### Changed
+
+- The `HEALTHCHECK` moved out of `backend/Dockerfile` and into the `app` and
+  `prefect-runner` service definitions in all three compose files. An image with
+  two consumers should not assert what only one of them can satisfy.
+
+
 ## [0.0.38] - 2026-08-06
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.38"
+version = "0.0.39"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.38"
+version = "0.0.39"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for the Prefect runner's health probe (code landed as #333).

The runner inherited the API's HTTP health check from the image and reported
`unhealthy` from the moment it started, in production as well as dev. That hid
the failure it should have caught, made `depends_on: service_healthy` unusable
against it, and taught everyone to ignore the column.

Verified against real containers in an isolated stack: healthy at t+15s,
unhealthy 42s after the Prefect API went away, healthy again 21s after it came
back. One honest substitution — the failure was induced by removing the API
rather than by stopping the runner process, because SIGSTOP is ignored for PID
1 of a namespace.

`aserve(webserver=True)` was checked against the installed Prefect 3.8.1 rather
than taken from the issue: it forwards to `Runner`, the server runs on a daemon
thread, and `/health` answers 503 once a poll is 20s overdue.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.39]` section.

No schema change, `SPEC_VERSION` unchanged at 7.