### PR TITLE
chore: cut 0.0.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,25 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.40] - 2026-08-06
+
+### Fixed
+
+- When the kernel killed the reloader's worker in the local stack — an OOM kill
+  being the realistic way — nothing reaped it and nothing replaced it. PID 1
+  stayed alive, so the container reported `Up`, Docker's restart policy never
+  fired, and every request timed out with no log line because the process that
+  would have written it was gone. A supervisor now replaces a worker that dies,
+  the way uvicorn already does on the `--workers` path (#308).
+
+### Added
+
+- `backend/cli/reload_supervisor.py`, a dedicated entrypoint. It deliberately
+  does not import the application: routing PID 1 through `cli.commands` cost
+  464 MB against 28 MB, which is the whole application inside the one process
+  whose job is to survive an OOM kill.
+
+
 ## [0.0.39] - 2026-08-06
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.39"
+version = "0.0.40"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.39"
+version = "0.0.40"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for the local reloader that did not come back (code landed as #334).

Three findings worth keeping, because the issue was wrong about each:

uvicorn cannot be made to exit when its child dies. `BaseReload.run` reacts to
file changes and signals and never reads `self.process.exitcode`, so no flag
achieves it — only a wrapper. And exiting is the wrong remedy anyway: replacing
the worker is 2s against three 30s health checks plus a container restart.

Production is not saved by its restart policy. `--workers 4` means uvicorn
replaces a killed worker in place and the container never exits. The dev-only
framing holds; the mechanism is different from the one described.

`kill -9 1` from inside a container does nothing — the kernel drops signals to
a PID namespace's init from within it. A first test run read as "survived" when
nothing had been signalled.

Verified against real containers: the issue's `ps` output reproduced exactly,
then 2s recovery with no zombies.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.40]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #336