### PR TITLE
chore: cut 0.0.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,23 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.41] - 2026-08-06
+
+### Fixed
+
+- The local supervisor replaced a worker that had died but ignored one that was
+  alive and not answering — deadlocked on a lock, spinning, or blocked on a
+  socket that never replies. Such a worker has no exit code, so the supervisor
+  saw a healthy child and did nothing while the container served no requests.
+  The worker now stamps a monotonic beat from uvicorn's `callback_notify`, and a
+  worker silent across two consecutive polls is replaced (#336).
+
+### Added
+
+- `RELOAD_WEDGED_AFTER` — how long a worker may go without running its event
+  loop before it is treated as wedged. Set it to `0` under a debugger.
+
+
 ## [0.0.40] - 2026-08-06
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.40"
+version = "0.0.41"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.40"
+version = "0.0.41"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for the wedged worker nothing recovered (code landed as #357).

The remedy is deliberately not either of the two the issue suggested. An HTTP
probe traverses the application, so a slow database would restart-loop a
healthy server against a broken dependency — that is readiness, not liveness. A
pipe ping is answered by a thread, which keeps answering while the event loop is
blocked, which is the exact case being hunted. The beat comes from inside the
loop instead.

A wedged worker is SIGKILLed rather than SIGTERMed: uvicorn catches SIGTERM and
needs the loop to act on it, so the join would hang the supervisor for good.

Verified against real containers, which earned their keep: the first attempt
used `multiprocessing.Value`, whose lock is a fork-context semaphore while
uvicorn spawns, and the container restart-looped eight times before serving
anything. `RawValue` fixes it and removes a second hazard, a semaphore held by
a SIGKILLed worker hanging the next read for ever.

Scope is the local stack only. What is left uncovered is filed, not implied:
#358 for the dev and production stacks, #366 for a worker that wedges before
its first beat.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.41]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #358, #366