### PR TITLE
chore: cut 0.0.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,22 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.42] - 2026-08-06
+
+### Fixed
+
+- `make db-check` failed on any database that had ingested a document. Alembic
+  compared the models against the live schema and saw the per-collection vector
+  tables the RAG store creates at runtime, which no migration declares, so it
+  reported drift that no migration could ever resolve (#288).
+
+### Added
+
+- `app/db/vector_tables.py` — `is_runtime_vector_table`, one predicate for
+  "is this table a runtime vector table rather than a declared model", read from
+  `Base.metadata` rather than from a name pattern.
+
+
 ## [0.0.41] - 2026-08-06
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.41"
+version = "0.0.42"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.41"
+version = "0.0.42"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for alembic check against a real database (code landed as #338,
authored by Bartek Ochnik).

`make db-check` runs in `make check` and in CI, and on any developer database
that had ingested a document it failed against tables created by the RAG store
at runtime. The predicate that fixes it is also what two later changes build on.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.42]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #299