### PR TITLE
chore: cut 0.0.43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,30 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.43] - 2026-08-06
+
+### Fixed
+
+- Document ingestion ignored the collection's own embedding key and model. The
+  worker built its vector store with no resolver, so the collection's
+  `embedding_secret_id` — validated and stored when the collection was created —
+  was never read. On a deployment with no `OPENROUTER_API_KEY` this crashed with
+  advice to set one; where both were set it was worse than a crash, billing the
+  deployment's account while the UI said the organization's key paid. The
+  collection's recorded model was ignored the same way, so a collection could be
+  indexed by one model and searched by another (#306).
+- The three ways key resolution can silently fall back to the deployment key —
+  a missing secret row, an unseal failure, the wrong kind — now reach the flow
+  log the operator reads, and the error names the collection and which key it
+  tried.
+
+### Changed
+
+- `resolver` is now required on `PgVectorStore` rather than defaulting to `None`.
+  Five call sites passed it and one forgot; the default is what made forgetting
+  silent.
+
+
 ## [0.0.42] - 2026-08-06
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.42"
+version = "0.0.43"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.42"
+version = "0.0.43"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for ingestion using the collection's key (code landed as #323).

An organization that chose its own OpenRouter key for a collection had that key
silently unused on every upload. Every other construction of the vector store
passed the resolver; the one that did not was the background path every
document actually takes.

The default is removed rather than made explicit, because a silent fallback is
what the defect was.

Also resolved: the docstring claiming an upload checks that the collection's
model and the deployment's still agree. No such check exists and none should —
a collection deliberately keeps the model it was built with. The docstring now
says what `check_embedding_model` actually does, and that the old claim was
wrong.

Verified with integration tests against a real pgvector container, 255 passed.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.43]` section.

No schema change, `SPEC_VERSION` unchanged at 7.