### PR TITLE
chore: cut 0.0.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.44] - 2026-08-06
+
+### Fixed
+
+- `PgVectorStore.list_collections()` reported a collection called `documents`
+  that does not exist. It matched every table by name prefix, and `rag_documents`
+  — the model table tracking ingested documents — matched. The listing has held
+  that phantom on every deployment since the table existed, and `rag-stats`
+  reported the row count of that tracking table as a vector count. Collection
+  membership is now decided by `is_runtime_vector_table`, the same predicate
+  alembic uses, so the two answer from one source (#339).
+- The prefix match also treated `_` as a SQL wildcard, so a table named
+  `ragXfoo` listed as a collection called `Xfoo`.
+
+
 ## [0.0.43] - 2026-08-06
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.43"
+version = "0.0.44"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.43"
+version = "0.0.44"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for the phantom collection (code landed as #347).

The knowledge-base page lists from `knowledge_bases`, so the phantom never
reached that surface. What read it was the store's own view of what exists —
existence checks, and the commands. A caller trusting the answer could ask for
`documents` and get a table with none of the columns it expects.

No hardcoded name: a collection genuinely called `documents_archive` still
lists, pinned by a test, which any `!= "documents"` reading would have broken.

Verified with integration tests against a real pgvector container.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.44]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #345, #354