### PR TITLE
fix(rag): refuse a collection name that collides with a model table

### DIFF
--- a/backend/app/commands/rag.py
+++ b/backend/app/commands/rag.py
@@ -24,7 +24,7 @@ from app.commands import command, error, info, success, warning
 from app.db.session import get_db_context
 from app.schemas.sync_source import SyncSourceCreate
 from app.services.embedding_resolution import embeddings_for_collection
-from app.services.rag.config import DocumentExtensions, RAGSettings
+from app.services.rag.config import DEFAULT_COLLECTION_NAME, DocumentExtensions, RAGSettings
 from app.services.rag.documents import DocumentProcessor
 from app.services.rag.embeddings import EmbeddingService
 from app.services.rag.ingestion import IngestionService
@@ -254,8 +254,8 @@ async def ingest_path_async(
 @click.option(
     "--collection",
     "-c",
-    default="documents",
-    help="Collection name (default: documents)",
+    default=DEFAULT_COLLECTION_NAME,
+    help=f"Collection name (default: {DEFAULT_COLLECTION_NAME})",
 )
 @click.option(
     "--recursive/--no-recursive",
@@ -340,8 +340,8 @@ async def search_async(
 @click.option(
     "--collection",
     "-c",
-    default="documents",
-    help="Collection name (default: documents)",
+    default=DEFAULT_COLLECTION_NAME,
+    help=f"Collection name (default: {DEFAULT_COLLECTION_NAME})",
 )
 @click.option(
     "--top-k",
@@ -457,7 +457,7 @@ async def stats_async(settings: RAGSettings, vector_store: BaseVectorStore) -> N
 
 
 @command("rag-sync-gdrive")
-@click.option("--collection", "-c", default="documents", help="Target collection name")
+@click.option("--collection", "-c", default=DEFAULT_COLLECTION_NAME, help="Target collection name")
 @click.option("--folder-id", "-f", default="", help="Google Drive folder ID (empty = root)")
 def rag_sync_gdrive(collection: str, folder_id: str) -> None:
     """Sync documents from Google Drive into a RAG collection."""
@@ -480,7 +480,7 @@ def rag_sync_gdrive(collection: str, folder_id: str) -> None:
 
 
 @command("rag-sync-s3")
-@click.option("--collection", "-c", default="documents", help="Target collection name")
+@click.option("--collection", "-c", default=DEFAULT_COLLECTION_NAME, help="Target collection name")
 @click.option("--prefix", "-p", default="", help="S3 prefix (folder path)")
 @click.option("--bucket", "-b", default="", help="S3 bucket (empty = default from settings)")
 def rag_sync_s3(collection: str, prefix: str, bucket: str) -> None:

--- a/backend/app/db/vector_tables.py
+++ b/backend/app/db/vector_tables.py
@@ -19,10 +19,13 @@ recognise one. Sharing a string is the easy half. The hard half is
 so "starts with `rag_`" is not a safe test, and an exclusion that got it wrong would
 silence real drift in the one table this project ingests through.
 
-Both sides of that ask it now. `alembic/env.py` asks which tables it must not
+Three sides of that ask it now. `alembic/env.py` asks which tables it must not
 compare; `PgVectorStore.list_collections` asks which are collections, and until it
 did, the prefix alone had it reporting `rag_documents` as a collection called
-`documents` (#339). One question, one answer, whichever direction it is read from.
+`documents` (#339); and `collides_with_model_table` asks it of a name nobody has
+created yet, which is the only moment a collection called `documents` can still be
+refused rather than aimed at the tracking table (#345). One question, one answer,
+whichever direction it is read from.
 """
 
 from __future__ import annotations
@@ -62,3 +65,43 @@ def is_runtime_vector_table(name: str, *, metadata: MetaData) -> bool:
         ```
     """
     return name.startswith(VECTOR_TABLE_PREFIX) and name not in metadata.tables
+
+
+def collides_with_model_table(collection: str, *, metadata: MetaData) -> bool:
+    """Whether a collection by this name would land on a table the models own.
+
+    The store names a collection's table by prefixing it, so `documents` lands on
+    `rag_documents` - the table tracking every ingested document in the
+    deployment, for every organization in it. Nothing about that is visible from
+    the name a caller typed, and the consequence is not a confused read:
+    `delete_collection` issues `DROP TABLE IF EXISTS`, so one tenant tidying up
+    their own collection aims it at everybody's tracking (#345).
+
+    This is the same question :func:`is_runtime_vector_table` answers, asked
+    before the table exists, so it is that function inverted rather than a list of
+    reserved names kept alongside it. The reserved set is therefore whatever the
+    models declare: a second `rag_`-prefixed model table added tomorrow is refused
+    without anybody remembering this function is here.
+
+    Args:
+        collection: A collection name as a caller supplied it.
+        metadata: The metadata to judge against, normally `Base.metadata` - with
+            the same caveat :func:`is_runtime_vector_table` carries. A caller that
+            has not imported the models is asserting an empty metadata, and gets
+            "nothing collides" with no error to say so.
+
+    Note:
+        The name is folded first because the store interpolates it into DDL
+        unquoted and Postgres folds an unquoted identifier: `Documents` reaches
+        the same table `documents` does, so a check comparing the name as typed
+        would refuse one spelling and hand the other a `DROP`.
+
+    Example:
+        ```python
+        collides_with_model_table("documents", metadata=Base.metadata)  # True
+        collides_with_model_table("documents_archive", metadata=Base.metadata)  # False
+        ```
+    """
+    return not is_runtime_vector_table(
+        f"{VECTOR_TABLE_PREFIX}{collection.lower()}", metadata=metadata
+    )

--- a/backend/app/schemas/rag.py
+++ b/backend/app/schemas/rag.py
@@ -5,12 +5,15 @@ from typing import Any
 from pydantic import Field, field_validator
 
 from app.schemas.base import BaseSchema
+from app.services.rag.config import DEFAULT_COLLECTION_NAME
 
 
 class RAGSearchRequest(BaseSchema):
     """Parameters for a vector search query."""
 
-    collection_name: str = Field("documents", description="Target collection for search")
+    collection_name: str = Field(
+        DEFAULT_COLLECTION_NAME, description="Target collection for search"
+    )
     collection_names: list[str] | None = Field(
         None, description="Search across multiple collections (overrides collection_name)"
     )
@@ -157,7 +160,7 @@ class RAGRetryResponse(BaseSchema):
 class RAGSyncRequest(BaseSchema):
     """Request to trigger a sync operation."""
 
-    collection_name: str = Field("documents", description="Target collection")
+    collection_name: str = Field(DEFAULT_COLLECTION_NAME, description="Target collection")
     mode: str = Field("full", description="Sync mode: full, new_only, update_only")
     path: str = Field("", description="Source path")
 

--- a/backend/app/services/knowledge_base.py
+++ b/backend/app/services/knowledge_base.py
@@ -5,10 +5,16 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+# Registers every model table on `Base.metadata`, which a caller-chosen collection
+# name is judged against below. The models arrive through `app.repositories` today;
+# naming the dependency here keeps the refusal from resting on somebody else's import.
+import app.db.models  # noqa: F401
 from app.core.exceptions import AuthorizationError, BadRequestError, NotFoundError
 from app.core.permissions import AuthContext, Perm
+from app.db.base import Base
 from app.db.models.knowledge_base import KBScope, KnowledgeBase
 from app.db.models.resource_grant import Visibility
+from app.db.vector_tables import collides_with_model_table
 from app.repositories import knowledge_base_repo, organization_secret_repo, rag_document_repo
 from app.repositories.rag_document import CollectionCounts
 from app.schemas.knowledge_base import (
@@ -35,6 +41,31 @@ def _derive_collection_name(name: str) -> str:
     """Slugify the KB name and append a short random suffix to avoid collisions."""
     slug = re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_") or "kb"
     return f"{slug[:48]}_{secrets.token_hex(3)}"
+
+
+def _refuse_a_model_table_name(collection_name: str | None) -> None:
+    """Refuse a collection whose vector table the models already declare.
+
+    This route is the one that needs its own guard. `POST /rag/collections/{name}`
+    reaches the store, which refuses the name where it builds the table name;
+    creating a knowledge base only writes a row, so nothing would notice until
+    the first ingest hit `rag_documents` - or until the collection was dropped
+    and took every organization's document tracking with it (#345).
+
+    A derived name cannot collide (it carries a random suffix), so this is only
+    ever about a name the caller chose.
+
+    Raises:
+        BadRequestError: The name would land on a table the models own.
+    """
+    if collection_name is None or not collides_with_model_table(
+        collection_name, metadata=Base.metadata
+    ):
+        return
+    raise BadRequestError(
+        message=f"'{collection_name}' is a reserved collection name",
+        details={"collection_name": collection_name},
+    )
 
 
 def _no_knowledge_base(kb_id: UUID) -> NotFoundError:
@@ -224,10 +255,12 @@ class KnowledgeBaseService:
         tenant's embeddings are billed to the tenant rather than the operator.
 
         Raises:
-            BadRequestError: If the named model has no known vector width, or
-                the named key is not an API key this organization holds.
+            BadRequestError: If the named model has no known vector width, the
+                named key is not an API key this organization holds, or the
+                collection name is one the platform's own tables answer to.
         """
         self._check_create_permission(scope=data.scope, ctx=ctx)
+        _refuse_a_model_table_name(data.collection_name)
         config = await self._usable_config(ctx, data.ingestion_config)
         # The creator owns what they create, org scope included: `own` in the
         # permission matrix is meaningless for a row nobody owns, and sharing

--- a/backend/app/services/knowledge_base.py
+++ b/backend/app/services/knowledge_base.py
@@ -46,26 +46,26 @@ def _derive_collection_name(name: str) -> str:
 def _refuse_a_model_table_name(collection_name: str | None) -> None:
     """Refuse a collection whose vector table the models already declare.
 
-    This route is the one that needs its own guard. `POST /rag/collections/{name}`
-    reaches the store, which refuses the name where it builds the table name;
-    creating a knowledge base only writes a row, so nothing would notice until
+    Creating a knowledge base needs its own guard because it never reaches the
+    store: `POST /rag/collections/{name}` is refused where the store builds the
+    table name, but this writes a row and stops, so nothing would notice until
     the first ingest hit `rag_documents` - or until the collection was dropped
-    and took every organization's document tracking with it (#345).
+    and aimed at every organization's document tracking (#345).
 
-    A derived name cannot collide (it carries a random suffix), so this is only
-    ever about a name the caller chose.
+    `None` is the caller leaving the name to :func:`_derive_collection_name`,
+    which cannot collide - it appends a random suffix - so this is only ever
+    about a name somebody chose.
 
     Raises:
         BadRequestError: The name would land on a table the models own.
     """
-    if collection_name is None or not collides_with_model_table(
+    if collection_name is not None and collides_with_model_table(
         collection_name, metadata=Base.metadata
     ):
-        return
-    raise BadRequestError(
-        message=f"'{collection_name}' is a reserved collection name",
-        details={"collection_name": collection_name},
-    )
+        raise BadRequestError(
+            message=f"'{collection_name}' is a reserved collection name",
+            details={"collection_name": collection_name},
+        )
 
 
 def _no_knowledge_base(kb_id: UUID) -> NotFoundError:

--- a/backend/app/services/rag/config.py
+++ b/backend/app/services/rag/config.py
@@ -203,8 +203,9 @@ class PdfParser(BaseModel):
 # `--collection`, aimed the quickstart at `rag_documents` and failed creating an
 # index on a column that table does not have (#345). A name is now refused when the
 # models declare its table, and a default that is refused is not a default, so this
-# moved rather than the refusal being softened. `RAGSettings` also carried a
-# `collection_name` field spelling the same value a fourth time; nothing read it.
+# moved rather than the refusal being softened. `RAGSettings` carried a
+# `collection_name` field spelling the same value once more; nothing read it, so it
+# is gone rather than moved here.
 #
 # `tests/test_reserved_collection_names.py` asserts this never names a model table
 # again, which is the only guard that survives somebody editing the line.

--- a/backend/app/services/rag/config.py
+++ b/backend/app/services/rag/config.py
@@ -195,10 +195,24 @@ class PdfParser(BaseModel):
     liteparse_max_pages: int = 1000
 
 
+# The collection a caller gets when they name none: the `--collection` default on
+# every `rag-*` command, and the one the search and sync request bodies fall back to.
+#
+# It was `documents`, which is the tracking table's own name once the store prefixes
+# it - so the documented first-run ingest, `rag-ingest ./docs/guide.pdf` with no
+# `--collection`, aimed the quickstart at `rag_documents` and failed creating an
+# index on a column that table does not have (#345). A name is now refused when the
+# models declare its table, and a default that is refused is not a default, so this
+# moved rather than the refusal being softened. `RAGSettings` also carried a
+# `collection_name` field spelling the same value a fourth time; nothing read it.
+#
+# `tests/test_reserved_collection_names.py` asserts this never names a model table
+# again, which is the only guard that survives somebody editing the line.
+DEFAULT_COLLECTION_NAME = "default"
+
+
 class RAGSettings(BaseModel):
     """RAG pipeline configuration."""
-
-    collection_name: str = "documents"
 
     allowed_extensions: list[DocumentExtensions] = Field(
         default_factory=lambda: list(DocumentExtensions)

--- a/backend/app/services/rag/vectorstore.py
+++ b/backend/app/services/rag/vectorstore.py
@@ -4,12 +4,19 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 # Registers every model table on `Base.metadata`, which `list_collections` judges a
-# `rag_` table against. Another import already reaches the models today; this one
-# says the listing depends on it, rather than leaving that to a chain belonging to
-# a different concern.
+# `rag_` table against and `_table` refuses a collection name against. Another import
+# already reaches the models today; this one says the store depends on it, rather than
+# leaving that to a chain belonging to a different concern. On an empty metadata both
+# answers invert silently: the listing reports the tracking table as a collection, and
+# a caller may drop it.
 import app.db.models  # noqa: F401
+from app.core.exceptions import BadRequestError
 from app.db.base import Base
-from app.db.vector_tables import VECTOR_TABLE_PREFIX, is_runtime_vector_table
+from app.db.vector_tables import (
+    VECTOR_TABLE_PREFIX,
+    collides_with_model_table,
+    is_runtime_vector_table,
+)
 from app.schemas.rag import RAGDocumentItem, RAGDocumentList
 from app.services.rag.models import (
     CollectionInfo,
@@ -232,8 +239,25 @@ class PgVectorStore(BaseVectorStore):
         The prefix comes from `app/db/vector_tables.py` because `alembic/env.py` has
         to recognise these names to keep them out of `alembic check` - a table created
         here exists in no model and no migration, and read as a table to drop (#288).
+
+        A name whose table the models declare is refused here rather than in
+        `create_collection`, because every method funnels through this one and two
+        of them are destructive. `rag-drop documents --yes` reaches
+        `delete_collection` with no knowledge base, no route and no permission
+        between the operator and `DROP TABLE IF EXISTS` on the tracking table
+        (#345), so a guard on the create path would not have been on that path.
+
+        Raises:
+            ValueError: The name is not a legal identifier.
+            BadRequestError: The collection would land on a table the models own.
         """
-        return f"{VECTOR_TABLE_PREFIX}{_validate_collection_name(name)}"
+        table = f"{VECTOR_TABLE_PREFIX}{_validate_collection_name(name)}"
+        if collides_with_model_table(name, metadata=Base.metadata):
+            raise BadRequestError(
+                message=f"'{name}' is a reserved collection name",
+                details={"collection": name, "table": table.lower()},
+            )
+        return table
 
     async def _for_collection(self, name: str) -> tuple[EmbeddingService, int]:
         """The embedder and vector width this one collection uses.

--- a/backend/tests/integration/test_vector_store_reserved_names.py
+++ b/backend/tests/integration/test_vector_store_reserved_names.py
@@ -41,7 +41,7 @@ def _store_on(engine: AsyncEngine) -> PgVectorStore:
     store = PgVectorStore.__new__(PgVectorStore)
     store.async_session = async_sessionmaker(engine, expire_on_commit=False)
     store._resolver = None
-    store.embedder = None  # ty: ignore[invalid-assignment] - unused without a resolver
+    store.embedder = None
     store.dim = 8
     return store
 

--- a/backend/tests/integration/test_vector_store_reserved_names.py
+++ b/backend/tests/integration/test_vector_store_reserved_names.py
@@ -1,0 +1,102 @@
+"""What the store does to a real `rag_documents`, and to a name beside it.
+
+The unit version (`tests/test_reserved_collection_names.py`) asserts that no
+statement is issued, which is the fix. What it cannot assert is the premise the
+bug rested on: that the name the store builds is a table that is really there,
+holding rows belonging to organizations the caller has never heard of. That
+comes from the database or not at all (#345).
+
+The second test is the other half, and the reason the refusal is derived from
+`Base.metadata` rather than from the name: a collection called
+`documents_archive` still has to be created and dropped for real, against
+pgvector, index and all.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
+
+from app.core.exceptions import BadRequestError
+from app.services.rag.vectorstore import PgVectorStore
+
+pytestmark = pytest.mark.anyio
+
+_A_TRACKED_DOCUMENT = text(
+    "INSERT INTO rag_documents "
+    "(id, collection_name, filename, filesize, filetype, status, chunk_count) "
+    "VALUES (gen_random_uuid(), :collection, 'handbook.pdf', 12, 'pdf', 'indexed', 3)"
+)
+
+
+def _store_on(engine: AsyncEngine) -> PgVectorStore:
+    """A store over this engine, with no resolver and a narrow vector width.
+
+    `__new__` rather than the constructor: that one builds an engine of its own
+    from the deployment settings, which is the database this test is deliberately
+    not using. The width is small because nothing here embeds anything - it only
+    has to be a width pgvector will build an index at.
+    """
+    store = PgVectorStore.__new__(PgVectorStore)
+    store.async_session = async_sessionmaker(engine, expire_on_commit=False)
+    store._resolver = None
+    store.embedder = None  # ty: ignore[invalid-assignment] - unused without a resolver
+    store.dim = 8
+    return store
+
+
+async def test_dropping_a_collection_cannot_reach_the_tracking_table(
+    engine: AsyncEngine,
+) -> None:
+    """The row survives, and it belongs to somebody who never made the call.
+
+    A caller who names their collection `documents` is asking to drop
+    `rag_documents`, and what is in it is every organization's ingestion
+    history - here, a row for a collection with an unrelated name.
+    """
+    async with engine.begin() as connection:
+        await connection.execute(_A_TRACKED_DOCUMENT, {"collection": "another_orgs_handbook"})
+
+    with pytest.raises(BadRequestError) as refused:
+        await _store_on(engine).delete_collection("documents")
+
+    assert refused.value.details == {"collection": "documents", "table": "rag_documents"}
+    async with engine.connect() as connection:
+        surviving = await connection.execute(text("SELECT collection_name FROM rag_documents"))
+        assert [row[0] for row in surviving] == ["another_orgs_handbook"]
+
+
+async def test_a_collection_beside_it_is_created_and_dropped_for_real(
+    engine: AsyncEngine,
+) -> None:
+    """`documents_archive` is a name a too-broad refusal would have taken.
+
+    Run against pgvector rather than mocked: `create_collection` needs the
+    extension and builds an HNSW index, which is the step that fails when a
+    name lands on a table that has no `embedding` column - the loud half of
+    #345, and the reason this case is worth proving end to end.
+    """
+    store = _store_on(engine)
+
+    await store.create_collection("documents_archive")
+
+    async with engine.connect() as connection:
+        created = await connection.execute(
+            text(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_name = 'rag_documents_archive' AND table_schema = 'public'"
+            )
+        )
+        assert created.scalar() == "rag_documents_archive"
+
+    await store.delete_collection("documents_archive")
+
+    async with engine.connect() as connection:
+        remaining = await connection.execute(
+            text(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_name LIKE 'rag_documents%' AND table_schema = 'public'"
+            )
+        )
+        assert [row[0] for row in remaining] == ["rag_documents"]

--- a/backend/tests/test_reserved_collection_names.py
+++ b/backend/tests/test_reserved_collection_names.py
@@ -1,0 +1,204 @@
+"""A collection may not be named after a table the models own.
+
+The store names a collection's table by prefixing it, so a collection called
+`documents` is the model table tracking every ingested document in the
+deployment. Nothing refused the name, and every method reached that table:
+`get_collection_info` answered with the deployment-wide document count,
+`_ensure_collection` created an HNSW index on a column that table has no
+version of, and `delete_collection` issued `DROP TABLE IF EXISTS` on it (#345).
+
+Two guards, because there are two ways in and only one of them is a route. The
+store refuses in `_table`, which every one of its methods funnels through -
+including the one `rag-drop documents --yes` reaches with no service, no route
+and no permission in between. `KnowledgeBaseService.create` refuses as well,
+because it writes a row without going near the store, and a row is enough: the
+collision is waiting for the first ingest.
+
+Neither guard knows the name `documents`. Both ask whether the models declare
+that table, which is what keeps `documents_archive` a collection somebody may
+have.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import app.db.models  # noqa: F401  - registers every table on the metadata
+from app.core.exceptions import BadRequestError
+from app.core.permissions import AuthContext, OrgRoleName
+from app.db.base import Base
+from app.db.vector_tables import VECTOR_TABLE_PREFIX, collides_with_model_table
+from app.schemas.knowledge_base import KnowledgeBaseCreate
+from app.services.knowledge_base import KnowledgeBaseService
+from app.services.rag.config import DEFAULT_COLLECTION_NAME
+from app.services.rag.vectorstore import PgVectorStore
+
+pytestmark = pytest.mark.anyio
+
+
+def _modelled_collection_names() -> list[str]:
+    """The collection name each prefixed model table would answer to."""
+    return sorted(
+        name.removeprefix(VECTOR_TABLE_PREFIX)
+        for name in Base.metadata.tables
+        if name.startswith(VECTOR_TABLE_PREFIX)
+    )
+
+
+class _Session:
+    """Records the statements a store method issues, and answers nothing."""
+
+    def __init__(self, executed: list[str]) -> None:
+        self._executed = executed
+
+    async def __aenter__(self) -> _Session:
+        return self
+
+    async def __aexit__(self, *exc_info: Any) -> None:
+        return None
+
+    async def execute(self, statement: Any, parameters: Any = None) -> MagicMock:
+        self._executed.append(str(statement))
+        return MagicMock()
+
+    async def commit(self) -> None:
+        return None
+
+
+def _store() -> tuple[PgVectorStore, list[str]]:
+    """A store with no engine, and the list of statements it reaches SQL with."""
+    executed: list[str] = []
+    store = PgVectorStore.__new__(PgVectorStore)
+    store.async_session = MagicMock(return_value=_Session(executed))
+    return store, executed
+
+
+def test_the_predicate_answers_for_every_prefixed_model_table() -> None:
+    """Parametrised over the metadata, so a second one added later is covered.
+
+    `documents` is the one that made this a bug; asserting it is present keeps
+    the case from quietly emptying if the model is renamed.
+    """
+    modelled = _modelled_collection_names()
+
+    assert "documents" in modelled
+    for name in modelled:
+        assert collides_with_model_table(name, metadata=Base.metadata)
+
+
+def test_a_name_no_model_declares_is_an_ordinary_collection() -> None:
+    assert not collides_with_model_table("company_handbook", metadata=Base.metadata)
+
+
+def test_the_default_collection_name_is_not_a_model_table() -> None:
+    """The default is what an omitted `--collection` and an omitted field get.
+
+    It was `documents`, which is why the documented first-run ingest aimed at
+    the tracking table. Pinned here rather than trusted, so a future default -
+    or a future model table named after this one - fails a test instead of a
+    deployment.
+    """
+    assert not collides_with_model_table(DEFAULT_COLLECTION_NAME, metadata=Base.metadata)
+
+
+async def test_creating_a_collection_named_after_a_model_table_is_refused() -> None:
+    store, executed = _store()
+
+    with pytest.raises(BadRequestError) as refused:
+        await store.create_collection("documents")
+
+    assert refused.value.details == {"collection": "documents", "table": "rag_documents"}
+    assert executed == []
+
+
+async def test_dropping_one_never_reaches_the_database() -> None:
+    """The regression, and the reason it is asserted on the statements.
+
+    A test that only asserted the table survives would pass without the fix:
+    `ingestion_spend.rag_document_id` references `rag_documents`, so Postgres
+    refuses the `DROP` and the route swallows the error. That refusal belongs to
+    a foreign key on an unrelated table and is one `CASCADE` from being gone.
+    What this fix does is not issue the statement.
+    """
+    store, executed = _store()
+
+    with pytest.raises(BadRequestError):
+        await store.delete_collection("documents")
+
+    assert executed == []
+
+
+async def test_a_spelling_postgres_folds_onto_a_model_table_is_refused_too() -> None:
+    """`rag_Documents` is not a distinct table; unquoted, Postgres folds it.
+
+    The store interpolates the collection into its DDL unquoted, so
+    `DROP TABLE IF EXISTS rag_Documents` drops the tracking table exactly as the
+    lower-case spelling would. A reserved-name check comparing the name as typed
+    would have refused one and handed the other the `DROP`.
+    """
+    store, executed = _store()
+
+    with pytest.raises(BadRequestError):
+        await store.delete_collection("Documents")
+
+    assert executed == []
+
+
+async def test_a_collection_whose_name_only_starts_like_one_still_works() -> None:
+    """`documents_archive` is a collection somebody may reasonably create.
+
+    Reserving the literal `documents`, or anything beginning with it, would
+    answer #345 and take a real collection with it - the case
+    `tests/test_collection_listing.py` pins on the read side.
+    """
+    store, executed = _store()
+
+    await store.delete_collection("documents_archive")
+
+    assert executed == ["DROP TABLE IF EXISTS rag_documents_archive"]
+
+
+class TestKnowledgeBaseCreate:
+    """The other door: a row written with a name the store never sees."""
+
+    @staticmethod
+    def _ctx() -> AuthContext:
+        return AuthContext(
+            user_id=uuid.uuid4(),
+            organization_id=uuid.uuid4(),
+            role=OrgRoleName.OWNER.value,
+            is_app_admin=False,
+        )
+
+    async def test_a_knowledge_base_cannot_claim_a_model_tables_name(self) -> None:
+        service = KnowledgeBaseService(MagicMock())
+        created = AsyncMock()
+
+        with (
+            patch("app.repositories.knowledge_base_repo.create", new=created),
+            pytest.raises(BadRequestError) as refused,
+        ):
+            await service.create(
+                KnowledgeBaseCreate(name="Handbook", collection_name="documents"),
+                ctx=self._ctx(),
+            )
+
+        assert refused.value.details == {"collection_name": "documents"}
+        created.assert_not_awaited()
+
+    async def test_a_near_miss_name_is_still_created(self) -> None:
+        service = KnowledgeBaseService(MagicMock())
+        created = AsyncMock(return_value=MagicMock())
+
+        with patch("app.repositories.knowledge_base_repo.create", new=created):
+            await service.create(
+                KnowledgeBaseCreate(name="Handbook", collection_name="documents_archive"),
+                ctx=self._ctx(),
+            )
+
+        assert created.await_args is not None
+        assert created.await_args.kwargs["collection_name"] == "documents_archive"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -296,8 +296,13 @@ All RAG commands are custom commands invoked via `cmd`:
 
 #### Document Ingestion
 
+The default collection is `default`. A name whose vector table the models already
+declare — `documents`, which prefixed is the ingestion tracking table — is refused
+with a 400 rather than aliased onto it; see
+[File processing](file-processing.md#vector-storage).
+
 ```bash
-# Ingest a single file
+# Ingest a single file into the default collection
 uv run agenticos cmd rag-ingest ./docs/guide.pdf
 
 # Ingest a directory

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -275,6 +275,23 @@ declares it. Matching the prefix alone had it reporting `rag_documents` as a
 collection called `documents` — one nobody created, whose "vector count" was the
 number of ingested documents, and which any caller could then ask to search.
 
+**A collection may not be named after a table the models own**, which is that
+predicate read a third way — asked of a name before its table exists. Creating one
+is refused with a 400, both at the API and in the store itself, because
+`rag-drop <name>` reaches the store with no route in between. The name that made
+this necessary is `documents`: prefixed, it *is* the tracking table, so dropping
+such a collection aimed `DROP TABLE IF EXISTS` at every organization's ingestion
+history. The refusal is derived rather than listed, so a `rag_`-prefixed model
+table added later is covered, and a collection called `documents_archive` — which a
+literal exclusion would have taken with it — is not affected.
+
+`documents` was also the **default** collection, so the CLI quickstart used to aim
+at the tracking table; the default is now `default`. A knowledge base created with
+the old name before this landed still exists and is still deletable, but nothing
+can be ingested into it — delete it and create one under another name. Nothing is
+lost in doing so: an ingest into that collection has never succeeded, because
+building the vector index on a table with no `embedding` column fails.
+
 ### RAG is Global
 
 Collections are shared across **all users**:


### PR DESCRIPTION
_Reopened from #373, which GitHub closed automatically when its base branch `fix/vectorstore-lists-only-real-collections` was deleted on the merge of #347. Rebased onto `main`; the diff is unchanged and is now this branch's own work only._

## What this changes

A collection can no longer be named after a table the models own.

The store names a collection's table by prefixing it, so `documents` is
`rag_documents` — the model table tracking every ingested document in the
deployment, for every organization in it. Nothing refused the name, and every
method reached that table: `get_collection_info` answered with the
deployment-wide document count, `_ensure_collection` built an HNSW index on a
column that table has no version of, and `delete_collection` issued
`DROP TABLE IF EXISTS` on it.

## The three decisions, and why

**Where the reserved set comes from: `Base.metadata`, not a literal.**
`collides_with_model_table(collection, metadata=...)` is `is_runtime_vector_table`
inverted — the predicate #288 wrote for `alembic/env.py` and #347 reads from the
store's listing, now asked of a name *before* its table exists. So there is one
answer to "is this a collection table", read from three directions, and the
reserved set is whatever the models declare: a second `rag_`-prefixed model table
added later is refused without anybody remembering. A hardcoded `{"documents"}`
would also have taken `documents_archive` with it, which #347 pins and a test here
pins again.

One thing that predicate has to do that the others do not: **fold the name**. The
store interpolates the collection into DDL unquoted and Postgres folds an unquoted
identifier, so `DROP TABLE IF EXISTS rag_Documents` drops the tracking table
exactly as the lower-case spelling would. A reserved-name check comparing the name
as typed would have refused one spelling and handed the other the `DROP`. There is
a test for it.

**Where it refuses: the store *and* the service, deliberately.** `_table` is the
funnel every store method passes through, which is what puts the guard on
`rag-drop documents --yes` — no service, no route, no permission between the
operator and the statement. `KnowledgeBaseService.create` refuses as well, because
`POST /kb` writes a row and never touches the store; the row is enough, since the
collision then waits for the first ingest. Not a third guard in
`create_for_rag_collection`: the `/rag` route calls `create_collection` before it,
so a check there would be unreachable.

**What happens to the default: it moved.** `documents` was the `--collection`
default on four commands and the fallback in two request bodies, so the documented
first-run ingest aimed the quickstart at the tracking table — and a default that is
refused is not a default. It is now `DEFAULT_COLLECTION_NAME = "default"`, one
constant the commands and schemas share, pinned by a test that fails if it ever
names a model table again. `RAGSettings.collection_name` spelled the same value
once more and **nothing read it**, so it is deleted rather than moved.

*Why not rename the model table instead.* It frees the name and needs no default
change, and it is worse in three ways. It does not close the class — the refusal
would still be wanted for the next `rag_`-prefixed model table — so it is a
migration *plus* this change rather than instead of it. It is a table rename on
every deployment, with the index and constraint names alembic then compares. And
the downgrade is a trap: once `rag_documents` is free, the very next ingest into a
collection called `documents` creates a vector table with that name, and
`alembic downgrade` then tries to rename the model table back onto it.

## What happens to a deployment that already has one

- **No collection called `documents` has ever held a vector.** `_ensure_collection`
  no-ops its `CREATE TABLE IF NOT EXISTS` onto the model table and then fails
  building the index on a missing `embedding` column, so ingestion has always
  raised before a row was inserted. There is nothing to migrate, and no migration
  here.
- **A `knowledge_bases` row naming it can exist** — `POST /kb` accepts the name and
  calls no store. After this: every store operation on it answers 400 instead of
  reaching `rag_documents`, and it is **still deletable**. `DELETE /rag/collections/documents`
  runs the drop under `contextlib.suppress(Exception)`, so the refusal is swallowed
  exactly where the "table may not exist yet" case already is, and the KB row and
  its tracked-document rows are cleaned up as before. Delete it and create one under
  another name; nothing is lost, per the point above. `collection_name` is not
  updatable by design, so there is no rename path and this PR does not add one.
- **CLI users who relied on the default** now write into `default`. Nothing moves,
  because nothing was ever written under `documents`.

## Two corrections to #345, neither of which changes the fix

Commented on the issue as well, rather than only here.

1. **The `DROP` does not currently succeed.** `ingestion_spend.rag_document_id`
   references `rag_documents` (`ondelete="SET NULL"`, and no `CASCADE` on the
   statement), so Postgres answers `DependentObjectsStillExistError` — verified
   against a database built from the models. The route swallows it, so the failure
   is silent, and it is one `CASCADE` or one dropped `ingestion_spend` from being
   real. **This is why the regression test asserts the statement is never issued
   rather than that the table survives**: the second passes without the fix.
2. **What does work today is the read.** `GET /rag/collections/documents/info`
   answers `SELECT COUNT(*) FROM rag_documents` — every organization's document
   count, to a caller holding `collections:view` on a knowledge base they made
   themselves. That is a live cross-tenant leak and it is closed here.

## How it was verified

| | |
|---|---|
| `tests/test_reserved_collection_names.py` | The predicate over `Base.metadata`, both store guards, the folded spelling, the `documents_archive` near miss, the knowledge-base guard, and the default |
| `tests/integration/test_vector_store_reserved_names.py` | Against a real pgvector: the refusal with a populated `rag_documents` in place, and `documents_archive` created and dropped for real, extension and HNSW index included |

The unit tests were confirmed to fail without the change — with
`collides_with_model_table` stubbed to accept every name, the four behavioural
tests fail and the rest pass.

`make check` green end to end: backend 3275 passed with the platform layer at
100.00%, `db-check` clean, frontend 3175 passed, docs build, audit. **Integration
tests ran rather than skipping** — `pgvector/pgvector:pg16` on 5432. `make check`
also failed first on `lint-frontend` with `eslint: command not found`, which is
#227 in a worktree, not this branch: `bun install` and it is green.

## Stacking, and the CI that has not run

**This is based on `fix/vectorstore-lists-only-real-collections` (#347), which is
itself based on `ci/db-check-runtime-tables` (#338).** `app/db/vector_tables.py` is
#338's work and the predicate this extends is #347's, so **#338 must merge, then
#347, then this**. Reviewing only this branch:
`git diff origin/fix/vectorstore-lists-only-real-collections` — ten files.

**No CI has run on this diff, and none will until the base is `main`.**
`.github/workflows/ci.yml` filters `pull_request: branches: [main, master]`, which
matches on the base, so a stacked pull request reports no checks at all — not red,
not pending, nothing. That is #359. Every verification claim above is local. When
#347 lands I will restack and retarget with `gh pr edit --base main`, and CI will
answer for the first time then.

## Review

The automated reviewer does not run on pull requests (#311/#313) and the label
does nothing, so **this diff has not been through one.** I swept it myself and with
a subagent given the diff and one category to hunt in — every other place a
caller-supplied name reaches SQL, a table name, or a path. That sweep is where the
foreign key above came from, and it filed six issues; two are the same class as
this one and are the ones worth reading:

- **#367** — `POST /kb` takes any `collection_name` and never calls
  `CollectionAccessService.claim`, whose one call site is the `/rag` route. A member
  with `collections:edit` can point a knowledge base at another organization's
  vector table and then read and write it through every gate. Same field, same
  route, different target — refusing a model table does not narrow it, which is why
  it is filed rather than folded in.
- **#368** — nothing bounds a collection name's length, and Postgres truncates an
  identifier at 63 bytes silently, so two names sharing 59 characters are one table
  and either one's `DROP` takes the other.

Also filed: #369 (a sync source's `folder_id` interpolated into the Drive query
unescaped), #370 (a Drive file named with a path escapes the sync directory), #371
(a malformed or reserved name answers 500 — the two older `ValueError`s in the file
this touches, deliberately not restyled here), #372 (admin search does not escape
`LIKE` wildcards). All six are triaged and linked into #168.

## Checks

- [x] Tests cover the new behaviour, and would fail without the change
- [x] `make check` passes — locally, since CI cannot run on this base
- [x] Coverage: `app/db/vector_tables.py` is inside the gate and its new function is
      covered; the platform layer reports 100.00%. `app/services/rag/*` and
      `app/services/knowledge_base.py` are outside it, which is why the invariants
      here are pinned by named tests rather than by a percentage
- [ ] n/a — no capability changed
- [ ] n/a — no migration added, and the section above says why none is needed

Docs: `file-processing.md` gains the third reading of the predicate and the upgrade
note; `commands.md` names the new default beside the `rag-ingest` example that used
to demonstrate the old one. Not folded in: that page still says "only admins can
manage collections", a role model dropped in `0066` — that is #354.

Closes #345

