### PR TITLE
chore: cut 0.0.45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,27 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.45] - 2026-08-06
+
+### Fixed
+
+- A collection could be named after a model table. `_table("documents")` derives
+  `rag_documents`, which is the table tracking every organization's ingested
+  documents, so `GET /rag/collections/documents/info` returned every
+  organization's document count and the delete path issued a `DROP TABLE`
+  against it. Nothing refused the name, and `documents` was the *default*
+  collection name, so the collision sat on the documented first-run path. Both
+  the store and `KnowledgeBaseService.create` now refuse a name that collides
+  with a declared model table (#345).
+
+### Changed
+
+- The default collection name is now `default`, one constant shared by the four
+  `rag-*` commands and two schemas, pinned by a test that fails if it is ever
+  set to a model table's name. `RAGSettings.collection_name` was read nowhere
+  and is deleted.
+
+
 ## [0.0.44] - 2026-08-06
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.44"
+version = "0.0.45"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.44"
+version = "0.0.45"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for the reserved model-table names (code landed as #383, opened in
place of #373 after GitHub closed it on the deletion of its base branch).

The reserved set is whatever the models declare, not a literal — the same
predicate #338 added, inverted. Two guards, deliberately: the store's `_table`,
which is the funnel every store method passes through and is reachable from
`rag-drop` with no service, route or permission; and `KnowledgeBaseService`,
which writes a row without touching the store.

A case-folding bypass was caught in review: Postgres folds unquoted
identifiers, so `rag_Documents` reaches the same table. A name check that
refused one spelling would have handed the other the drop. The predicate folds.

Two corrections to the issue, verified: the `DROP` does not currently succeed —
`ingestion_spend.rag_document_id` references the table with no `CASCADE`, so
Postgres refuses and the route swallows it. The regression test therefore
asserts the statement is never issued, since asserting the table survives
passes without the fix. What is live today is the info endpoint.

No migration: a `documents` collection has never held a vector, because
ingestion always failed building an index on a column that is not there.

Verified with `make check` and integration tests against a real pgvector
container, 258 passed.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.45]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #367, #368, #369, #370, #371, #372