### PR TITLE
chore: cut 0.0.46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,28 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.46] - 2026-08-06
+
+### Changed
+
+- A knowledge base is deleted from its own page, not from the card in the list.
+  The only control used to be a hover-revealed trash icon sitting on top of a
+  whole-card link — the most destructive action on the resource, one mis-aimed
+  click away from opening it, on the surface that shows least about what is
+  about to be destroyed. It is now in the detail page's actions menu, behind
+  `collections:edit`, behind a confirmation naming the collection and its real
+  document count, and it is not offered for the default collection, which the
+  server refuses (#303).
+- The three `window.confirm` calls in the knowledge-base pages are proper
+  confirmation dialogs with translated copy. A raw `confirm()` argument is
+  hardcoded English the i18n guard cannot see.
+
+### Fixed
+
+- Both delete dialogs now disable while the request is in flight. A double-click
+  sent a second DELETE and toasted a 404 over a removal that had worked.
+
+
 ## [0.0.45] - 2026-08-06
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.45"
+version = "0.0.46"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.45"
+version = "0.0.46"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for deleting a collection from its own page (code landed as #337).

The card in the list showed a name, a description and a scope; the detail page
shows the document count, the sync sources and what is actually in the
collection — which is what somebody deciding whether to destroy it needs. It
also matches how every other resource here is deleted.

Reviewing the change found two defects in the change itself, both fixed before
merge: delete was offered on the default collection, which the server answers
400 for and which the old card had gated on; and neither dialog had a busy
state.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.46]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #324, #325