### PR TITLE
chore: cut 0.0.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,31 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.47] - 2026-08-06
+
+### Fixed
+
+- The knowledge-base detail page stated the size of the page the table had
+  loaded, not the size of the collection. A collection holding fifty-seven
+  documents said "20 documents" under its own title, and pressing Load more made
+  the number climb, which reads as ingestion happening rather than the page
+  correcting itself. The document count now reads the collection's total; the
+  vector count says plainly that it counts what is loaded, until everything is
+  (#324).
+- Nine strings in the knowledge-base pages rendered in English under any locale —
+  single words below the guard's threshold, text nodes alone on a line, copy
+  behind an `&&`, and a schedule read as "every 30m". Two of them are counts and
+  are now ICU plurals (#325).
+- Drag-and-drop upload compared a translated string against the browser's
+  `DataTransfer` type. Under Polish that comparison could never match, so
+  dropping a file would have done nothing.
+
+### Changed
+
+- A Tailwind class list was being stored in `messages/en.json` and read through
+  the translator, so a translator opening `pl.json` was asked to translate CSS.
+
+
 ## [0.0.46] - 2026-08-06
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.46"
+version = "0.0.47"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.46"
+version = "0.0.47"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for the knowledge-base counts and the copy the guard could not see
(code landed as #386, opened in place of #350 after GitHub closed it on the
deletion of its base branch).

No backend total was added for the vector count. `GET /kb/{id}` returns the
bare row and leaves the counters at zero deliberately; a new contract to serve
one line of chrome is not the trade. The label says which number it is instead,
and the document count — the actual acceptance criterion — reads the total.

The drag-and-drop defect was found while working the copy and is the reason
this class of bug is worth chasing: it is not cosmetic, it silently disables a
feature in every locale but English.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.47]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #348, #349, #356, #359