### PR TITLE
chore: cut 0.0.48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,28 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.48] - 2026-08-06
+
+### Fixed
+
+- The **Describe images** model control in Create knowledge base was the agent
+  builder's picker rendered in its lesser branch: a bare radio list, with no
+  provider/model/key form, no way to say whether the chosen profile can
+  authenticate at all, and — on a deployment with no saved profiles — a dead end
+  offering no way out of itself (#305).
+
+### Changed
+
+- `ModelProfilePicker`'s `allowAdd` meant two things at once: show the form, and
+  offer the bin on every saved row. They are now `allowAdd` and `allowRemove`.
+  The knowledge-base dialog gets the first only, so it can create a model and a
+  key but cannot destroy an organization-wide profile that agents point at. The
+  current-model line, which is what says a profile has no key, renders in both
+  shapes.
+- The add-model form in that dialog is gated on `connections:manage`; it posts a
+  model profile, and a control the caller may not use is not rendered.
+
+
 ## [0.0.47] - 2026-08-06
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.47"
+version = "0.0.48"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.47"
+version = "0.0.48"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for the Describe-images model picker (code landed as #322).

Splitting the flag rather than passing `allowAdd` is the whole point: passing
it as it stood would have let a collection dialog delete a model profile that
agents elsewhere are pointed at. The builder passes both flags and keeps
exactly what it had.

Reviewing the change found a permission defect in it: `allowAdd` put a form
posting to an endpoint requiring `connections:manage` inside a dialog gated on
`collections:edit` — a 403 dressed as a control. Fixed here with a refusal
test, along with `disabled` not reaching `InlineSecret`, which let a dialog
mid-save still store an organization-wide secret.

One trade-off left for a human eye and stated in the pull request: the
list-only third caller now draws the current-model line above its own list, so
in that narrow cell the provider and model appear twice.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.48]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #329, #331, #332