### PR TITLE
chore: cut 0.0.49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,26 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.49] - 2026-08-06
+
+### Changed
+
+- Every place a provider or a provider key is chosen now draws the same row —
+  brand mark, name, an optional masked hint. Choosing an embedding key in Create
+  knowledge base offered bare strings while the agent builder three clicks away
+  drew the mark, and the two did not look like the same product. Ten pickers
+  converge on one primitive, including two that had hand-copied the row and one
+  where two different keys rendered as the same line (#304).
+
+### Fixed
+
+- A provider mark's `<title>` was being used as its option's type-to-search key,
+  so every model in Create knowledge base answered to `openrouter…` rather than
+  to its own name.
+- The tick marking a stored key was inherited by the closed select's trigger,
+  where it reads as "selected" rather than "has a key".
+
+
 ## [0.0.48] - 2026-08-06
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.48"
+version = "0.0.49"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.48"
+version = "0.0.49"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for the provider row (code landed as #330).

The row is one component used in ten places, four of which the issue named,
four more found while reading, and two that had copied it by hand — so the
primitive replaces the copies rather than becoming an eleventh variant.

The typeahead defect is the interesting one: it was nobody's hypothesis. An
accessible `<title>` inside the mark became Radix's search key for the item, so
typing a model name matched nothing. Every row now passes an explicit
`textValue`, pinned by a test.

Also worth recording, because it says something about the rest of the suite:
the review found three of this branch's own tests passing with the
implementation reverted — a tick asserted only as absent, and two `toBeNull()`
cases that a component drawing nothing also satisfies. All rewritten.

Merged after #322, whose change to the same file conflicted; the resolution is
the union of the two imports, which is what #360 had already settled on.
Verified after the rebase with `tsc --noEmit` and the 712 specs covering the
touched components.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.49]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #328, #341