### PR TITLE
chore: cut 0.0.50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,26 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.50] - 2026-08-06
+
+### Fixed
+
+- The embedding Model select in Create knowledge base never showed its value —
+  it said "Loading models…" for as long as the dialog was open, while the list
+  below it was populated. Radix writes the new value onto a hidden native select
+  and dispatches `change` before the items have registered their options, so the
+  value read back was empty and clobbered the state. This is the one choice in
+  the dialog that cannot be revisited, since a collection's embedding width is
+  frozen at creation (#328).
+- The agent builder offered the add-model form to anyone who could open it,
+  though submitting needs `connections:manage`, and the store-a-key form inside
+  it never checked `secrets:edit`. A control the caller may not use is not
+  rendered (#329).
+- Two buttons in the same dialog were both called "Add a key" while writing
+  different secrets. By accessible name they were indistinguishable, so a screen
+  reader heard the same button twice (#331).
+
+
 ## [0.0.49] - 2026-08-06
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.49"
+version = "0.0.50"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.49"
+version = "0.0.50"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for the create-collection dialog (code landed as #360).

The Radix mechanism was confirmed against the library source rather than taken
from the issue, and the source showed the gap is wider than reported: the
options are registered out of a DocumentFragment, so they trail the value by
two renders, and the bubble input exists only inside a form.

#329's scope had shifted under it — the knowledge-base half arrived with #322 —
so what landed here is the builder's two flags and the `secrets:edit` gate,
which covers both surfaces because the component is shared. The pull request
attributes the split.

Every new assertion was run against the unfixed code by stashing the fix, not
by reading it. One of this change's own labels was wrong and caught that way:
"Add {name} key" rendered "Add Daytona API key key" at a call site whose
suggested name already ends in the noun, and the suite was green because that
spec mocks the component away.

Merged after #322 and #330, both of which this branch had already merged and
resolved. Verified after restacking with `tsc --noEmit` and 732 specs.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.50]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #361, #365