### PR TITLE
chore: cut 0.0.51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.51] - 2026-08-06
+
+### Fixed
+
+- `scripts/check_i18n.py` walked past two shapes of hardcoded copy: a sentence
+  that begins with a word before its interpolation, and a count built with a
+  lambda rather than an ICU plural. Both render in English under any locale, and
+  `make lint` reported clean over them (#249).
+
+
 ## [0.0.50] - 2026-08-06
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.50"
+version = "0.0.51"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.50"
+version = "0.0.51"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for the i18n guard's word-first and lambda-count blind spots (code
landed as #315, authored by Bartek Ochnik).

Merged after a conflict with #386, which had removed the three catalog entries
this branch still carried — two duplicate "Files" keys and a Tailwind class
list. Resolved in favour of `main`, by a merge commit rather than a rebase so
the original history stays intact, and the guard was run on the result: clean,
2800 messages.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.51]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #199