### PR TITLE
chore: cut 0.0.52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.52] - 2026-08-06
+
+### Fixed
+
+- `scripts/check_i18n.py` skipped any line containing `=>`, because a type like
+  `(() => Promise<void>) | null` reads as a text node to a regex — and an inline
+  handler is the most common thing on a JSX line, so the exemption was far wider
+  than the problem. It also matched nothing when a text node spanned two lines,
+  which the formatter does freely. The guard now masks generics rather than
+  skipping the line, and reads interpolation rules over the whole file (#314).
+- 55 strings across 30 files that those two blind spots had been hiding,
+  including two menu items sitting between translated siblings, and English
+  compiled into the two model-picker components (#332).
+
+
 ## [0.0.51] - 2026-08-06
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.51"
+version = "0.0.52"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.51"
+version = "0.0.52"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for the i18n guard reading a text node whole (code landed as #363).

The discriminator is the interesting part. Ungating the arrow skip on its own
reports eleven false positives, so the fix is not removing the condition: a
generic's `<` is welded to the identifier it parameterises, where a JSX tag
opens after whitespace, `(`, `{` or `>` and never after a name. With generics
masked instead of lines skipped, the sweep reports exactly the two real
offences and nothing else.

Ten test cases, four that must be reported and six near-misses that must not —
a guard that cries wolf is a guard that gets ignored.

Left out with the measurement recorded rather than guessed: `JSX_TEXT` still
reads one line at a time, and joining it the same way is 70 more nodes across
42 files. That belongs to #141, which already owns the class.

Merged last of the batch on purpose, since a stricter lint gate sweeps
everything that landed before it. Resolving that merge found a real defect and
it is fixed here: the knowledge-base copy spec answered `/rag/embedding-models`
with a list, which was harmless until #360 built the model select straight off
`models`. Whole frontend suite green afterwards, 3245 passed, and the guard
reports clean over 2849 messages.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.52]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #141, #348, #362