### PR TITLE
chore: cut 0.0.53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,20 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.53] - 2026-08-06
+
+### Fixed
+
+- The double-backtick guard skipped every directory called `worktrees`, which was
+  the wrong rule twice over: it silently stopped reading a `docs/worktrees/` that
+  is only a directory with a name, and it still walked a git worktree placed
+  anywhere else. It now detects a nested checkout — a `.git` file or directory —
+  and declines to descend into it, which is what the rule always meant (#225).
+- The self-exemption matched one absolute path, so every copy of the script under
+  a worktree was reported as three findings on a line nobody had edited. It
+  matches the file's name now, and `--fix` is safe on a copy for the same reason.
+
+
 ## [0.0.52] - 2026-08-06
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.52"
+version = "0.0.53"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.52"
+version = "0.0.53"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for the backtick guard's scan boundary (code landed as #343, authored
by Bartek Ochnik).

The original defect was that no commit could be made with a worktree open: the
hook walks the tree rather than a staged list, found the copies of itself under
`.claude/worktrees/`, and failed on the error message it was about to print.
Excluding the directory name fixed that and traded it for a quieter mistake, so
this replaces the name with the property.

Verified against the real thing rather than the unit tests alone: `walk()` over
a checkout with twelve worktrees open reads 1311 files and none under
`.claude/worktrees/`.

One behaviour change noted in review and left as it is: an unreadable directory
now ends the run with a traceback where `rglob` used to skip it silently. That
is the safer half of the trade - the guard no longer reports a clean tree it
could not fully read.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.53]` section.

No schema change, `SPEC_VERSION` unchanged at 7.