### PR TITLE
chore: cut 0.0.54

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,22 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.54] - 2026-08-06
+
+### Fixed
+
+- A knowledge base's sync history came back short. The route read every log
+  carrying that source id, applied `limit` in SQL, and only then dropped the rows
+  belonging to another collection — so the page was cut before the thinning. A
+  source repointed at another base (`SyncSourceUpdate` carries
+  `collection_name`, and earlier runs keep the name they ran against) made a
+  request for twenty runs answer with fewer, `total` described the survivors
+  rather than the source, and there was no way to page past the gap. The source
+  is resolved against the base first now (#233).
+- A source that is not this base's answers `404` rather than `200 []`. Both
+  rendered "no syncs yet", and one of them was a request that should have failed.
+
+
 ## [0.0.53] - 2026-08-06
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.53"
+version = "0.0.54"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.53"
+version = "0.0.54"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for the sync-log paging bug (code landed as #318, authored by Bartek
Ochnik).

Nothing leaked - the old filter was correct about what it excluded, and the
comment above it said so. It was wrong about *when*: `limit` had already cut the
page by the time the filter ran.

Two integration tests, both failing against the old code: a full page of one
source's history comes back full, and a source belonging to another base is
missing rather than empty.

Worth knowing, and recorded on the pull request: the check that decides "is this
source this base's?" compares `collection_name`, and `get_source` is not scoped
by organization. That is unchanged from before this fix, but it means the
refusal is only as strong as #367 - which is open, `severity:critical`, and is
about `POST /kb` accepting an explicit `collection_name` with no claim.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.54]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #367