### PR TITLE
test(rag): stub a resolver in the reserved-names integration test

### DIFF
--- a/backend/tests/integration/test_vector_store_reserved_names.py
+++ b/backend/tests/integration/test_vector_store_reserved_names.py
@@ -30,8 +30,20 @@ _A_TRACKED_DOCUMENT = text(
 )
 
 
+async def _no_collection_of_its_own(name: str) -> None:
+    """A resolver that answers "nothing recorded for this one".
+
+    Not `None` in place of the resolver: `resolver` is a required argument since
+    #306, and `_for_collection` calls it unconditionally rather than checking it
+    first - that check was what made forgetting to pass one silent. A stub that
+    answers `None` is the state this helper was always describing, and it is what
+    sends the store to its deployment defaults.
+    """
+    return None
+
+
 def _store_on(engine: AsyncEngine) -> PgVectorStore:
-    """A store over this engine, with no resolver and a narrow vector width.
+    """A store over this engine, with no recorded embeddings and a narrow width.
 
     `__new__` rather than the constructor: that one builds an engine of its own
     from the deployment settings, which is the database this test is deliberately
@@ -40,7 +52,7 @@ def _store_on(engine: AsyncEngine) -> PgVectorStore:
     """
     store = PgVectorStore.__new__(PgVectorStore)
     store.async_session = async_sessionmaker(engine, expire_on_commit=False)
-    store._resolver = None
+    store._resolver = _no_collection_of_its_own
     store.embedder = None
     store.dim = 8
     return store


### PR DESCRIPTION
## What this fixes

`test_a_collection_beside_it_is_created_and_dropped_for_real` fails on every run that has a database:

```
TypeError: 'NoneType' object is not callable
app/services/rag/vectorstore.py:278: in _for_collection
```

`_store_on` set `_resolver = None`. That was the contract before #306, which made `resolver` required and deleted the `if self._resolver is None` short-circuit — deliberately, because the default was what let the worker forget to pass one silently. `_for_collection` now calls it unconditionally.

## Mine, and it shipped

This went out in **0.0.45**. The branch was written against a base that still had the short-circuit and was rebased past its removal. The two agree textually, so nothing conflicted, and no unit test noticed because this only fails where a real pgvector is reachable — it passed everywhere except the one place that matters.

## The fix

A stub resolver answering `None`, which is the state the helper's docstring always described and what sends the store to its deployment defaults. Same shape #306 used for the one other test that had set the attribute by hand.

## Verified

`pytest tests/integration` against a real `pgvector/pgvector:pg16`: **260 passed**, where the same command on `main` fails one.