### PR TITLE
chore: cut 0.0.55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.55] - 2026-08-06
+
+### Fixed
+
+- The reserved-names integration test set the vector store's resolver to `None`,
+  which stopped being valid in 0.0.43 when the resolver became required and its
+  `None` short-circuit was deleted. `_for_collection` calls it unconditionally,
+  so the test raised `TypeError: 'NoneType' object is not callable` on every run
+  with a real database. Shipped in 0.0.45 and fixed here.
+
+
 ## [0.0.54] - 2026-08-06
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.54"
+version = "0.0.55"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.54"
+version = "0.0.55"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for a test this batch broke and shipped (code landed as #397).

0.0.43 made `resolver` required on `PgVectorStore` and deleted the check that
short-circuited when it was missing, because that default was what let the
worker forget to pass one silently. 0.0.45's integration test was written
against a base that still had the check, and rebased past its removal - the two
agree textually, so nothing conflicted.

Nothing caught it in between. It fails only where a real pgvector is reachable,
so the unit suite was green, and the branch's own verification had run before
the rebase rather than after.

Worth stating plainly: this was mine, it went out in a release, and it was
found by running the full suite while merging something unrelated rather than
by anything that was supposed to catch it.

Verified: `pytest tests/integration` against `pgvector/pgvector:pg16`, 260
passed, where the same command on the previous commit fails one.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.55]` section.

No schema change, `SPEC_VERSION` unchanged at 7.