### PR TITLE
chore: cut 0.0.56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,25 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.56] - 2026-08-06
+
+### Changed
+
+- The last four route handlers that read a repository directly now go through a
+  service, which is what `.claude/rules/architecture.md` has always asked for:
+  the audit listing, a knowledge base's sync logs, an org integration's sync
+  logs, and the vault key a provider catalog is fetched with (#232).
+- `AuditService` is new. The `/audit` route held "an entry belongs to exactly one
+  organization" as a keyword argument it filled in itself, which is a scope no
+  service test can see and one the next reader of that entity would have had to
+  know to repeat.
+- Both surfaces showing a sync source's history read it through
+  `SyncSourceService.list_logs` rather than each carrying its own query and its
+  own copy of the same twelve-field mapping.
+- The provider-listing key moves out of a private helper in the route and into
+  `OrganizationSecretService`, so nothing in the HTTP layer unseals a secret.
+
+
 ## [0.0.55] - 2026-08-06
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.55"
+version = "0.0.56"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.55"
+version = "0.0.56"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for the last four route-layer reads (code landed as #321, authored by
Bartek Ochnik).

Mostly a refactor, and the guard test that comes with it is the durable half:
`test_route_layering.py` now fails if a handler imports a repository again.

Merged after 0.0.54, which took the sync-log paging fix out of this branch and
released it on its own - the same defect, found while doing this work. What is
left here is the layering, which is why the two are separate versions rather
than one.

Reviewed on the pull request, where I raised the placement of the `AuditService`
import and then withdrew it: `deps.py` already imports about thirty services
next to their factories rather than at the top, and the factory docstring
matches every other one in the file. The convention was right and my reading of
it was not.

Verified after rebasing: 178 tests across the touched modules and the
integration flows, and the full backend suite green.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.56]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #197, #367