### PR TITLE
chore: cut 0.0.57

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,27 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.57] - 2026-08-06
+
+### Fixed
+
+- `make install` did not install the frontend toolchain, so a fresh checkout
+  could not run `make check` at all: eslint, prettier, tsc, vitest and next live
+  only in `frontend/node_modules`, and the first four minutes of `check` are the
+  backend half, so it said `eslint: command not found` well after you had walked
+  away (#227).
+
+### Changed
+
+- `test_ci_parity.py` now holds the setup commands to the mirror-image rule: a
+  gating job may prepare its runner however it likes, as long as `make install`
+  prepares a laptop the same way. The next toolchain CI adds has to land in
+  `install` or be exempted with a written reason.
+- `make quickstart` no longer claims to install dependencies in `docs/commands.md`.
+  It is `quickstart: dev`, and nothing in that chain reaches `install` — which
+  sent people down exactly the road this release closes.
+
+
 ## [0.0.56] - 2026-08-06
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.56"
+version = "0.0.57"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.56"
+version = "0.0.57"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for the frontend toolchain in the setup path (code landed as #300,
authored by Bartek Ochnik).

The parity test is the durable half. Comparing the *steps* CI runs was never the
whole claim: `check` ran every command CI runs and still could not run at all in
a fresh checkout, because nothing in the documented setup installed
`node_modules`.

Reviewed, and one thing changed before merge: `bun install` had been placed in
front of the pre-commit block. Make stops at the first failing line, so a machine
where the frontend install fails - no network, a proxy, a lockfile wanting a
newer bun - ended up with no git hooks at all, including the one that refuses a
commit on `main`, behind an error message about bun. The hooks go first now and
the reason sits above the target.

**CI had not finished when this merged.** Thirty-nine runs were queued behind
today's releases, so the checks were still pending; `test_ci_parity.py` was run
locally instead and passes, 17 tests.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.57]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #299