### PR TITLE
chore: cut 0.0.58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,26 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.58] - 2026-08-06
+
+### Fixed
+
+- `make install` did not create `backend/.env`, the third thing a fresh checkout
+  is missing. Everything running on the host reads it — `db-check`, `db-upgrade`,
+  `run`, and pytest through `app.core.config` — so without one
+  `POSTGRES_PASSWORD` is empty and `alembic check` is refused with
+  `fe_sendauth: no password supplied`, four minutes into `make check`. It is
+  copied from the example, once, and an existing file is never overwritten (#299).
+- `REDIS_PASSWORD` carried a live placeholder in the example. Copied into a dev
+  `.env` it made every request fail against a local redis that has no
+  `requirepass`, and in a deployed stack it let `change-me-in-production` be
+  inherited from an example file. It is commented out in both directions now,
+  and the deployed compose files already refuse to start without a real one.
+- The empty `SANDBOXD_TOKEN=` in the example did not match the `^SANDBOXD_TOKEN=.`
+  that `make dev` greps for, so a fresh checkout ended up with the key twice and
+  worked only by last-wins. The assignment is gone; the comment stays.
+
+
 ## [0.0.57] - 2026-08-06
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.57"
+version = "0.0.58"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.57"
+version = "0.0.58"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for `backend/.env` in the setup path (code landed as #327, authored by
Bartek Ochnik).

Third and last of the three things #227 and #299 are about. `make install` is
the whole documented setup path, and it now prepares all three: the env file,
the backend virtualenv, the git hooks, and the frontend toolchain, in that
order.

The order is deliberate and came out of reviewing #300: the `.env` copy is a
local `cp` with nothing to fail on, so it goes first, and `bun install` is the
step most likely to fail on a given machine, so it goes last - a partial failure
leaves the git hooks installed rather than leaving somebody with nothing
refusing a commit on `main`.

Two things came out of the review and are in this release rather than a
follow-up. The empty `SANDBOXD_TOKEN=` is one: it does not match the grep in
`make dev`, so with the env file now always present, every fresh checkout would
have carried the key twice and worked only because both dotenv and compose take
the last one. Verified end to end on a scratch copy - one line, not two.

Checked before worrying about them, and both fine: the default `SECRET_KEY`
cannot reach production (`config.py:84` refuses it outright), and no CI job runs
`make install`, so nothing on a runner inherits a generated env file.

**CI had not finished when this merged**, with today's releases queued ahead of
it. `test_ci_parity.py` was run locally instead, 19 tests, green.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.58]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #227