### PR TITLE
chore: cut 0.0.59

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,25 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.59] - 2026-08-06
+
+### Fixed
+
+- `tests/test_migrations.py` ran for the first time. It needed a database called
+  `agenticos_migrations_test`, a missing one became a module-level skip, and
+  nothing in the repository ever created it — so the only assertions that
+  `downgrade()` works at all reported "4 skipped" into a green build on every CI
+  run this project has ever had (#234). The module creates that database before
+  its first test and drops it after its last, with the process id in the name so
+  two runs on one machine cannot drop each other's mid-upgrade (#346).
+- A remaining skip now means one thing only: no Postgres answered. Under `CI` it
+  is not a skip at all but a failure, because a declared service container that
+  did not come up is not a laptop without Docker.
+- The probe says *why* the server did not answer. A Postgres that is up and
+  refusing — a wrong password, a database in recovery — used to be reported as a
+  container that never started.
+
+
 ## [0.0.58] - 2026-08-06
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.58"
+version = "0.0.59"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.58"
+version = "0.0.59"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for the migration suite actually running (code landed as #302, authored
by Bartek Ochnik).

Four tests that apply the whole chain and roll it back, skipped on every runner
since they were written, over a database nothing created. A skip is not a
failure, so the build was green the entire time - the same shape as #143 and
#165, applied to the one module that proves `downgrade()` is real.

Two fixes for the price of one: the process id in the database name closes #346,
filed hours earlier today after two `make check` runs in different worktrees
dropped each other's chain mid-upgrade. Same defect as #189, one file over.

One change from review. `_server_answers` flattened every failure to a bool, so
a server that is up and refusing came out as "the service container did not come
up" - the one diagnosis this module is otherwise careful not to make. It carries
the reason now, and that paid for itself immediately: running the suite in a
worktree with no `backend/.env` had been advising `make docker-db` while that
database was up and listening, when the real answer was `fe_sendauth: no
password supplied`.

Verified against a real Postgres 16: `pytest tests/test_migrations.py
tests/test_migration_suite_database.py` → 10 passed, and the temporary database
is gone from `pg_database` afterwards.

**CI had not finished when this merged**, with today's releases queued ahead of
it; the verification above is local.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.59]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #183, #189, #288, #299