### PR TITLE
test(frontend): pin mask_generics with a case that fails without it

### DIFF
--- a/backend/tests/test_check_i18n_nodes.py
+++ b/backend/tests/test_check_i18n_nodes.py
@@ -150,3 +150,30 @@ def test_a_message_call_broken_across_lines_is_not_read_as_copy(tmp_path: Path) 
     """The remedy has to pass once the lines are joined, or the rule forbids its own fix."""
     source = '<p>\n  {t("savedModelCount", {\n    count: profiles.length,\n  })}\n</p>\n'
     assert _offences(tmp_path, source) == []
+def test_masking_a_generic_is_what_keeps_a_whole_file_quiet(tmp_path: Path) -> None:
+    """The one case that fails when `mask_generics` stops working.
+
+    Reading the file as one string is what makes a multi-line generic reachable
+    at all, and it is also what makes it dangerous: `SVGProps<SVGSVGElement>`
+    closes with a `>`, the next `<` is a tag several lines below, and everything
+    between them reads as one long text node of ordinary words.
+
+    Worth having because the ten cases above do not test this. Every one of them
+    passes with `mask_generics` stubbed to `return text` - they are kept quiet by
+    the two-word threshold or by holding no `<` at all, not by the masking - so
+    the function could be broken by a refactor and only a tree-wide `make lint`
+    would notice. This snippet is `components/icons/brand-icon.tsx` trimmed to
+    the shape that regressed, and it reports one offence without the mask.
+    """
+    source = (
+        "interface BrandIconProps extends SVGProps<SVGSVGElement> {\n"
+        "  name: BrandName;\n"
+        "}\n"
+        "\n"
+        'export function BrandIcon({ name, "aria-label": ariaLabel, ...props }: BrandIconProps) {\n'
+        "  const Icon = ICONS[name];\n"
+        '  const a11y = ariaLabel ? { role: "img" } : { "aria-hidden": true };\n'
+        "  return <Icon {...a11y} {...props} />;\n"
+        "}\n"
+    )
+    assert _offences(tmp_path, source) == []


### PR DESCRIPTION
## What this adds

One test case, and the reason it is worth a pull request is what finding it revealed.

`test_check_i18n_nodes.py` has ten cases about reading a JSX text node whole. **Stub `mask_generics` to `return text` and all ten still pass.** They are kept quiet by the two-word threshold or by holding no `<` at all — not by the masking. Meanwhile the guard with that function stubbed reports three false positives over the real tree (`usage-strip.tsx`, `brand-icon.tsx`, `custom-icons.tsx`), so it is load-bearing and was simply untested.

A refactor could have broken it and only a tree-wide `make lint` would have said so.

## The case

`components/icons/brand-icon.tsx` trimmed to the shape that regressed: `SVGProps<SVGSVGElement>` closes with a `>`, the next `<` is a tag several lines below, and everything between reads as one long text node of ordinary words once the file is joined.

Verified both directions rather than asserted: **1 failed** with `mask_generics` stubbed, **11 passed** with it restored.

## Where it came from

Reviewing #396. That branch came at the arrow problem from the other side and was overtaken by #363 — main passes all five of its tests — so this is the only thing in it that was not already covered.

Refs #314, #396