### PR TITLE
fix(api): declare no-store on responses the backend leaves unmarked

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -60,6 +60,12 @@ There is no `(marketing)` route group.
   translator, so it holds *keys* and the component translates at the point of use;
   a pure helper either answers with a key or takes `t`.
 - Keep components under ~100 lines; extract when they grow.
+- **A response with no `Cache-Control` is not a response nobody caches.**
+  `platform-proxy.ts` stamps `no-store` on anything the backend left unmarked: every
+  answer on this surface depends on a cookie, a permission set and the organization
+  header, and a list refetched right after a write must reach the server. A
+  hand-rolled route file owes the same header - the proxy is the only place that
+  applies it for you.
 - Do not hand-edit `src/lib/mcp-logos.generated.ts` — run `bun run gen:mcp-logos`.
 
 ## Permissions

--- a/frontend/src/lib/platform-proxy.test.ts
+++ b/frontend/src/lib/platform-proxy.test.ts
@@ -177,6 +177,30 @@ describe("platformProxy", () => {
     expect(response.status).toBe(204);
     expect(await response.text()).toBe("");
   });
+
+  it("refuses to let a list be cached when the backend named no policy", async () => {
+    // Silence is not "do not cache". A 200 with no `Cache-Control`, no `ETag` and
+    // no `Last-Modified` is one the browser may reuse on its own judgement - so a
+    // list refetched right after a write could be answered without the server
+    // being asked, and the page kept rendering the row it had just created as
+    // absent (#230). Every answer here depends on a cookie, a permission set and
+    // an organization header, so there is nothing to cache in the first place.
+    backendReplies('{"items":[],"total":0}');
+
+    const response = await platformProxy().GET(request("/api/secrets"));
+
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("still lets the backend choose a policy where it has one", async () => {
+    // The catalog icons and the embed bundle are cacheable and say so. A proxy
+    // that overrode them would be inventing a policy rather than forwarding one.
+    backendReplies("{}", { headers: { "cache-control": "public, max-age=86400, immutable" } });
+
+    const response = await platformProxy().GET(request("/api/catalog/icons/github.svg"));
+
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=86400, immutable");
+  });
 });
 
 // -- the sweeps ---------------------------------------------------------------

--- a/frontend/src/lib/platform-proxy.ts
+++ b/frontend/src/lib/platform-proxy.ts
@@ -45,11 +45,25 @@ const WITH_BODY = new Set(["POST", "PUT", "PATCH"]);
  * Response headers that describe the body and must survive the hop.
  *
  * A proxy forwards what the origin said rather than inventing a policy of its
- * own: `Content-Disposition` is how a download gets its filename, and caching a
- * response the backend never marked cacheable is the backend's decision to make,
- * not this file's.
+ * own: `Content-Disposition` is how a download gets its filename, and a
+ * `Cache-Control` the backend chose - the catalog icons, an embed bundle - is
+ * the backend's decision to make.
  */
 const DESCRIBES_THE_BODY = ["content-type", "content-disposition", "cache-control"];
+
+/**
+ * What a response gets when the backend named no policy at all.
+ *
+ * Silence is not the same as "do not cache". A 200 with no `Cache-Control`, no
+ * `ETag` and no `Last-Modified` is a response the browser may reuse on its own
+ * judgement, and every mutable collection on this surface arrived that way - so a
+ * list refetched immediately after a write could be answered without the server
+ * being asked, and the page went on rendering the row it had just created as
+ * absent (#230). Nothing here is cacheable by default anyway: every answer
+ * depends on the caller's cookie, their permissions and the organization header,
+ * which is the same reason the outbound `fetch` below is `no-store`.
+ */
+const NO_POLICY_MEANS = "no-store";
 
 type Handler = (request: NextRequest) => Promise<Response>;
 
@@ -70,6 +84,7 @@ function describingHeaders(source: Headers): Headers {
     if (value) headers.set(name, value);
   }
   if (!headers.has("content-type")) headers.set("content-type", "application/json");
+  if (!headers.has("cache-control")) headers.set("cache-control", NO_POLICY_MEANS);
   return headers;
 }
 


### PR DESCRIPTION
## What this changes

Every JSON response the platform proxy returns now carries a cache policy. It
carried none: no `Cache-Control`, no `ETag`, no `Last-Modified`, on every mutable
collection on the surface. `platform-proxy.ts` forwards a policy when the backend
sets one, and for JSON the backend sets none — so what reached the browser was a 200
it may reuse on its own judgement. **Silence is not "do not cache".**

That is the leading suspect in #230: a vault list refetched immediately after a write
is answered with the pre-write body, byte for byte, and nothing refetches again, so a
stored secret can stay off the list until something reloads the page.

## Why this way

**Two layers ruled out by reading before touching anything.** The backend does not
cache this list — no Redis, no cache header anywhere near
`app/api/routes/v1/secrets.py`, and the only endpoints that set `Cache-Control` at all
are the catalog icons, the embed bundle and two RAG binaries. And the proxy's own
outbound `fetch` already says `cache: "no-store"`. The undeclared hop was the response
the proxy hands back, which is also the one place that can declare it for the whole
surface.

**The header is right whether or not it closes the race.** Every answer here depends
on a cookie, a permission set and an organization header; there is nothing on this
surface a shared or heuristic cache may keep. One line in `describingHeaders` covers
`/api/secrets`, `/api/skills`, `/api/agents`, `/api/kb` and every other list a mutation
invalidates. A backend that *does* name a policy still wins — there is a test for each
direction, because a proxy that overrode the icons' `immutable` would be inventing a
policy rather than forwarding one.

**Not `refetchInterval`, not a delay, not a `staleTime`.** Those move the race or hide
it. The only thing changed is a statement of fact about what may be cached.

## Checks

- [x] Tests cover the new behaviour, and would fail without the change — reverting
      `platform-proxy.ts` fails `refuses to let a list be cached when the backend
      named no policy`
- [x] `make check` — see the exception below, which this diff cannot reach
- [x] Frontend coverage gate: 3247 passed, 100% lines/statements/functions
- [ ] n/a — no capability changed
- [ ] n/a — no migration

`make lint`, `make test-frontend-cov`, `make build-frontend`, `make docs-build` and
`make audit` are green.

**`make test` was red on one integration test when this branch was cut, and it was not
this branch** — that was `test_vector_store_reserved_names.py` setting `_resolver = None`
against a contract #306 had already made required. Fixed on `main` in v0.0.55 (#397),
and #404 is closed as a duplicate of it. Rebased onto `main`, so this branch no longer
carries it.

## Notes for the reviewer

**This closes #230 on the fix, not on a measurement, and that is worth stating.** The
issue is explicit that its own suspect is unproven — the backend log shows the refetch
*did* reach the server, which a pure cache hit would not have produced — and settling
it needs the reproduction the issue describes: a seeded stack (postgres, host uvicorn,
production frontend build) and fifty-odd Playwright seed runs at about one failure in
eight. That has not been run here.

The header is right either way. An undeclared cache policy on every mutable collection
the proxy serves is a defect on its own terms, whatever it did or did not cause in the
vault, and it is the fix the issue asks for first.

The three `page.reload()` calls in `frontend/e2e/vault.spec.ts` marked `#230` stay in
this diff. Whoever takes them out is running the real test of this fix: the flake was
measured at roughly one failure in eight, so it wants repeated runs of the suite rather
than the single green one this branch would give it. If it flakes then, that is
information — `no-store` was not the whole cause, and #230 comes back with a run count
behind it.

One thing measured for whoever does: the issue's second suspect — "why did the page
issue two `GET /api/secrets` on load" — is narrower than it looked. The vault page holds
exactly **one** `useSecrets()`, so the second request is not a second consumer of the
hook. With `staleTime` unset on that list, a second observer mounting after the first
fetch resolves is enough to explain it, and that is worth confirming before anything is
changed about it.

`.claude/rules/frontend.md` now states the policy, because the hand-rolled binary
routes under `/api/files` and `/api/users/avatar` do not go through this proxy and owe
the header themselves.

Closes #230
Refs #154



