### PR TITLE
ci: check every pull request, bound every job, drop a stale claim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,30 @@ name: CI
 # Work reaches `main` by pull request from a short-lived branch, so the pull
 # request is where these run. The push trigger covers the merge itself - a
 # branch CI ignores is a branch whose status badge means nothing.
+#
+# **`pull_request` carries no `branches:` filter, and that is the point of #359.**
+# That filter matches on the *base*, so a pull request stacked on another feature
+# branch - which is what two branches touching one file are told to do here - matched
+# no trigger at all and ran nothing. Not red, not pending: `gh pr checks` answered
+# "no checks reported" and the rollup was empty, which reads as "still starting" to
+# anybody who does not go looking. Four pull requests merged that way on 2026-08-06,
+# each verified only on somebody's laptop, and the gap closed only when the child was
+# retargeted to `main` after the parent merged - the moment nobody waits seven minutes
+# for a branch that has looked settled for a day.
+#
+# Two things make this cheap rather than a doubling of the bill. The `changes` job
+# below already skips the three expensive suites a diff cannot affect, and it reads
+# `pulls/{n}/files`, which is the diff against *that* pull request's own base - so a
+# stacked child is classified on its own changes rather than on its parent's. And the
+# `concurrency` group is keyed on `github.ref`, so a stacked branch cancels its own
+# superseded runs like any other.
+#
+# The `push` trigger stays pinned to `main`: a branch push is already covered by its
+# pull request, and widening it would run everything twice.
 on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
 
 # One run per branch. `CLAUDE.md` asks for a commit and a push per finished piece,
 # which is right - but with nothing cancelling, each push started a fresh 24-minute

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,20 @@ concurrency:
 permissions:
   contents: read
 
+# **Every job carries a `timeout-minutes`, and #364 is why.** `changes` was the only
+# one that did, so the other seven inherited GitHub's default of 360 minutes: one
+# stalled job would have held a required status check for six hours with nothing in
+# this repository ending it sooner. Nothing has been observed to stall - this is a
+# bound on the tail, not a fix for something seen.
+#
+# Each is set several times the job's observed worst case rather than just above it.
+# The bound exists to end a stall, and a timeout tight enough to trim a legitimately
+# cold cache is a red build for a reason unrelated to the diff. Measured on run
+# 31116003994, a full matrix on `main`: changes 7s, lint 22s, Security Scan 14s,
+# docker 2m30s, docs 4m34s, test-frontend 5m08s, test 7m43s, e2e 8m01s.
+#
+# `backend/tests/test_ci_workflow.py` asserts that a job added later carries one too,
+# and that none is so generous it bounds nothing.
 jobs:
   changes:
     # Which of the three expensive suites this pull request can provably not
@@ -124,6 +138,7 @@ jobs:
     # tracked file rather than a subtree, and a suite that skips is only defensible
     # while something still looks at the whole tree.
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -182,6 +197,7 @@ jobs:
     # check is a pass, so that is a green merge button over a suite that never ran.
     if: ${{ !cancelled() && needs.changes.outputs.backend != 'false' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     services:
       postgres:
         # pgvector, not stock postgres: the RAG store runs
@@ -284,6 +300,7 @@ jobs:
     needs: changes
     if: ${{ !cancelled() && needs.changes.outputs.frontend != 'false' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -336,6 +353,7 @@ jobs:
     # backend, so it is only skippable for a change that touches neither.
     if: ${{ !cancelled() && needs.changes.outputs.e2e != 'false' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     services:
       postgres:
         # pgvector, not stock postgres: the RAG store runs
@@ -513,6 +531,7 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -545,6 +564,7 @@ jobs:
 
   docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -573,6 +593,7 @@ jobs:
 
   docker:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: [lint, test]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:

--- a/backend/tests/test_ci_workflow.py
+++ b/backend/tests/test_ci_workflow.py
@@ -72,16 +72,29 @@ class TestEveryPullRequestIsChecked:
             "worse: the required checks never report and the merge button stays grey."
         )
 
-    def test_the_whole_workflow_is_not_filtered_by_path(self, workflow: dict[str, Any]) -> None:
+    def test_no_trigger_is_filtered_by_path(self, triggers: dict[str, Any]) -> None:
         """A job-level `if:` skips and satisfies a required check; a `paths:` filter never reports.
 
         `docs/branching.md` records why the change-scope gate had to be written as
         the former. This is the assertion that keeps it written that way.
+
+        It reads the `on:` block, because that is the only place GitHub looks for a
+        path filter. The first spelling of this asserted `"paths" not in workflow`
+        against the *top level* of the file, where the schema has no `paths` key to
+        find - so it passed whatever anybody wrote, a `paths:` under `push`
+        included, and guarded nothing.
         """
-        assert "paths" not in workflow, (
-            "a workflow-level `paths:` filter stops the required contexts being posted, so "
-            "`main`'s ruleset waits for checks that will never arrive - see "
-            "docs/branching.md. Gate the individual jobs instead."
+        filtered = sorted(
+            event
+            for event, config in triggers.items()
+            if {"paths", "paths-ignore"} & set(config or {})
+        )
+        assert not filtered, (
+            f"the {filtered} trigger(s) filter on a path. A filtered-out workflow never posts "
+            "its required contexts at all, so `main`'s ruleset waits for checks that will "
+            "never arrive and the merge button stays grey forever - see docs/branching.md. "
+            "Gate the individual jobs on `changes` instead, where a skip still satisfies the "
+            "check."
         )
 
 

--- a/backend/tests/test_ci_workflow.py
+++ b/backend/tests/test_ci_workflow.py
@@ -1,15 +1,22 @@
 """Properties of `ci.yml` itself whose failure mode is a build that looks fine.
 
 `test_ci_parity.py` next door asks whether `make check` runs what CI runs. This
-file asks a different question about the same file: whether CI *runs at all*.
+file asks a different question about the same file: whether CI *runs at all*, and
+whether it is bounded when it does.
 
-`pull_request: branches: [main, master]` matches on the **base**, so a pull request
-stacked on a feature branch matched no trigger and executed nothing. The checks list
-was then empty rather than red - "no checks reported", which reads as *starting*
-rather than *absent* - and four pull requests merged that way in one day (#359).
+  - `pull_request: branches: [main, master]` matches on the **base**, so a pull
+    request stacked on a feature branch matched no trigger and executed nothing.
+    The checks list was then empty rather than red - "no checks reported", which
+    reads as *starting* rather than *absent* - and four pull requests merged that
+    way in one day (#359).
+  - `changes` was the only job declaring `timeout-minutes`, so every other job
+    inherited GitHub's default of 360 minutes. Nothing has been observed to stall;
+    the point is that if one did, its required check would be held for six hours
+    and nothing in this repository would end it sooner (#364).
 
-That is not testable by running CI, which is the whole difficulty: a workflow that
-does not trigger produces no evidence at all.
+Neither is testable by running CI, which is the whole difficulty: a workflow that
+does not trigger produces no evidence at all, and a bound is only exercised by the
+incident it exists to shorten.
 """
 
 from __future__ import annotations
@@ -22,6 +29,12 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+# The ceiling on any one job's `timeout-minutes`. Set against the slowest job this
+# workflow has ever run - `e2e` at 8m01s on run 31116003994, a full matrix on `main` -
+# with room for a cold cache on top. A bound much beyond that is the 360-minute
+# default with extra steps.
+MAX_TIMEOUT_MINUTES = 30
 
 
 @pytest.fixture(scope="module")
@@ -69,4 +82,28 @@ class TestEveryPullRequestIsChecked:
             "a workflow-level `paths:` filter stops the required contexts being posted, so "
             "`main`'s ruleset waits for checks that will never arrive - see "
             "docs/branching.md. Gate the individual jobs instead."
+        )
+
+
+class TestEveryJobBoundsItsOwnRuntime:
+    """Six hours of a hung job is a required check nothing in this repository ends."""
+
+    def test_every_job_declares_a_timeout(self, workflow: dict[str, Any]) -> None:
+        missing = sorted(
+            name for name, job in workflow["jobs"].items() if "timeout-minutes" not in job
+        )
+        assert not missing, (
+            f"{missing} declare no `timeout-minutes`, so each inherits GitHub's default of "
+            "360 minutes - #364. Give the job a bound several times its observed worst case."
+        )
+
+    def test_no_timeout_is_so_generous_it_bounds_nothing(self, workflow: dict[str, Any]) -> None:
+        excessive = sorted(
+            name
+            for name, job in workflow["jobs"].items()
+            if job.get("timeout-minutes", 0) > MAX_TIMEOUT_MINUTES
+        )
+        assert not excessive, (
+            f"{excessive} allow more than {MAX_TIMEOUT_MINUTES} minutes, which is several "
+            "times the slowest job this workflow has ever run."
         )

--- a/backend/tests/test_ci_workflow.py
+++ b/backend/tests/test_ci_workflow.py
@@ -1,0 +1,72 @@
+"""Properties of `ci.yml` itself whose failure mode is a build that looks fine.
+
+`test_ci_parity.py` next door asks whether `make check` runs what CI runs. This
+file asks a different question about the same file: whether CI *runs at all*.
+
+`pull_request: branches: [main, master]` matches on the **base**, so a pull request
+stacked on a feature branch matched no trigger and executed nothing. The checks list
+was then empty rather than red - "no checks reported", which reads as *starting*
+rather than *absent* - and four pull requests merged that way in one day (#359).
+
+That is not testable by running CI, which is the whole difficulty: a workflow that
+does not trigger produces no evidence at all.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict[str, Any]:
+    with WORKFLOW.open() as handle:
+        loaded: dict[str, Any] = yaml.safe_load(handle)
+    return loaded
+
+
+@pytest.fixture(scope="module")
+def triggers(workflow: dict[str, Any]) -> dict[str, Any]:
+    """The `on:` block.
+
+    Keyed by `True`, not by `"on"`. YAML 1.1 resolves a bare `on` to a boolean and
+    PyYAML implements 1.1, so the obvious spelling of this lookup raises `KeyError`
+    against a workflow that is perfectly valid to GitHub.
+    """
+    block: dict[str, Any] = workflow[True]
+    return block
+
+
+class TestEveryPullRequestIsChecked:
+    """A pull request that runs nothing must not be possible to open."""
+
+    def test_the_pull_request_trigger_matches_whatever_the_base_is(
+        self, triggers: dict[str, Any]
+    ) -> None:
+        assert "pull_request" in triggers, "CI no longer runs on pull requests at all"
+        event = triggers["pull_request"]
+        filters = sorted(set(event or {}) & {"branches", "branches-ignore", "paths"})
+        assert not filters, (
+            f"the `pull_request` trigger filters on {filters}. A `branches` filter matches "
+            "the base, so a pull request stacked on a feature branch would run no jobs and "
+            "report an empty checks list rather than a red one - #359. A `paths` filter is "
+            "worse: the required checks never report and the merge button stays grey."
+        )
+
+    def test_the_whole_workflow_is_not_filtered_by_path(self, workflow: dict[str, Any]) -> None:
+        """A job-level `if:` skips and satisfies a required check; a `paths:` filter never reports.
+
+        `docs/branching.md` records why the change-scope gate had to be written as
+        the former. This is the assertion that keeps it written that way.
+        """
+        assert "paths" not in workflow, (
+            "a workflow-level `paths:` filter stops the required contexts being posted, so "
+            "`main`'s ruleset waits for checks that will never arrive - see "
+            "docs/branching.md. Gate the individual jobs instead."
+        )

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -301,15 +301,21 @@ Documents -> Parse -> Chunk -> Embed -> Vector Store
 User Query -> Embed -> Search -> Rerank? -> Results -> Agent Prompt
 ```
 
-### Key Principle: RAG is Global
+### Key Principle: the collection is the unit of access
 
-**Collections are shared across ALL users.** There is no per-user document
-isolation. This means:
+**Collections are not global.** Each one is owned by a `knowledge_bases` row, and
+that row is the only half of the pair that knows an organization — so every `/rag`
+and `/kb` route resolves the name through `app/services/collection_access.py` before
+touching a vector, a document or a sync source. Reading takes `collections:view`
+reaching that row and writing takes `collections:edit`, either of which an explicit
+grant widens on one collection without promoting anybody.
 
-- Any authenticated user can **search** any collection.
-- Only **admins** can create/delete collections, upload documents, configure sync
-  sources, and view sync logs.
-- The knowledge base serves as an organization-wide shared resource.
+Within a collection there is no per-document isolation: reaching one reaches every
+document in it.
+
+[Who may reach a collection](file-processing.md#who-may-reach-a-collection) is the
+whole rule, scope by scope and operation by operation. This page does not keep a
+second copy of it.
 
 ### Components
 
@@ -327,7 +333,8 @@ isolation. This means:
 Documents can be ingested via:
 
 1. **CLI** -- `uv run agenticos cmd rag-ingest <path>`
-2. **API** -- `POST /api/v1/rag/collections/{name}/ingest` (admin only, file upload)
+2. **API** -- `POST /api/v1/rag/collections/{name}/ingest` (file upload, gated on
+   `collections:edit` reaching that collection)
 3. **Sync Sources** -- Configured connectors (Google Drive, S3) that pull documents
    on a schedule or on-demand.
 

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -79,6 +79,38 @@ first version of this got wrong:
 What a change set skips is printed in the `changes` job's log. Locally nothing is
 skipped: `make check` runs the whole set.
 
+### A stacked pull request runs CI too
+
+Two branches that edit the same file are told to stack — the second is opened
+against the first rather than against `main` — so `ci.yml`'s `pull_request` trigger
+carries **no `branches:` filter**. That filter matches on the *base*, and while it
+was there a stacked pull request matched no trigger and ran nothing at all
+([#359](https://github.com/vstorm-co/agenticos/issues/359)).
+
+The dangerous half was not the missing run, it was how it read. A pull request with
+no jobs shows an **empty** checks list, not a red one: `gh pr checks` answers "no
+checks reported" and the rollup is empty, which looks like a run that has not started
+yet. Four pull requests merged that way in one day, each verified only on a laptop.
+Nothing closed the gap until the child was retargeted to `main` after its parent
+merged, which is precisely when nobody waits for a fresh seven-minute run.
+
+It costs little: the `changes` job classifies a stacked child on its own diff — it
+reads `pulls/{n}/files`, which is the comparison against that pull request's own base
+— and the concurrency group below cancels the child's superseded runs like any
+other's.
+
+That the trigger carries no base filter is asserted rather than assumed, in
+`backend/tests/test_ci_workflow.py`. It has to be: a workflow that does not trigger
+produces no evidence that it did not, so nothing about a run can reveal the
+regression.
+
+Two limits worth stating plainly. **A green stacked pull request was checked against
+its parent, not against `main`** — checks belong to a head commit, so retargeting
+carries the old result forward unchanged; that is inherent to stacking rather than
+something a trigger can fix, and it is a reason to keep stacks short. And **CodeQL is
+not configured here**: it runs from GitHub's default setup, whose triggers are not in
+this repository, so whether it reads a stacked pull request is not ours to decide.
+
 ### One run per branch
 
 `ci.yml` carries a concurrency group keyed on `github.ref`, so pushing again to a

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -102,7 +102,8 @@ other's.
 That the trigger carries no base filter is asserted rather than assumed, in
 `backend/tests/test_ci_workflow.py`. It has to be: a workflow that does not trigger
 produces no evidence that it did not, so nothing about a run can reveal the
-regression.
+regression. The same file asserts the other property no run can show — that every
+job bounds its own runtime, below.
 
 Two limits worth stating plainly. **A green stacked pull request was checked against
 its parent, not against `main`** — checks belong to a head commit, so retargeting
@@ -110,6 +111,31 @@ carries the old result forward unchanged; that is inherent to stacking rather th
 something a trigger can fix, and it is a reason to keep stacks short. And **CodeQL is
 not configured here**: it runs from GitHub's default setup, whose triggers are not in
 this repository, so whether it reads a stacked pull request is not ours to decide.
+
+### Every job bounds its own runtime
+
+`changes` was the only job in `ci.yml` carrying a `timeout-minutes`, so the other
+seven inherited GitHub's default of **360 minutes**
+([#364](https://github.com/vstorm-co/agenticos/issues/364)). Nothing has ever been
+observed to stall here — this bounds the tail rather than fixing something seen — but
+if one did, its required status check would be held for six hours and nothing in this
+repository would end it sooner.
+
+| Job | Bound | Observed |
+|---|---|---|
+| `changes` | 5 | 7s |
+| `lint` | 10 | 22s |
+| `Security Scan` | 10 | 14s |
+| `docs` | 15 | 4m34s |
+| `test-frontend` | 20 | 5m08s |
+| `docker` | 20 | 2m30s |
+| `test` | 25 | 7m43s |
+| `e2e` | 25 | 8m01s |
+
+Observed times are from run 31116003994, a full matrix on `main`. Each bound is
+several times its job rather than just above it: the timeout exists to end a stall,
+and one tight enough to trim a legitimately cold cache is a red build for a reason
+unrelated to the diff.
 
 ### One run per branch
 

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -1,7 +1,9 @@
 # File Processing
 
-This document covers how files are handled in two contexts: chat file uploads
-(user-facing) and RAG document ingestion (admin/CLI).
+This document covers how files are handled in two contexts: chat file uploads,
+which belong to the person who made them, and RAG document ingestion, which
+belongs to a collection and is gated on
+[who may reach it](#who-may-reach-a-collection).
 
 ## Chat File Uploads
 
@@ -143,8 +145,10 @@ The `ChatFile` database model tracks uploaded files:
 - Only the file owner can download their files (`GET /files/{id}`).
 - The `FileUploadService.get_user_file()` method compares `chat_file.user_id`
   against the requesting user's ID. Returns `NotFoundError` on mismatch.
-- There is no admin override -- admins cannot access other users' chat files
-  through the file API.
+- **Ownership is the whole rule, and nothing widens it.** No permission, no
+  organization role and no grant reaches another person's chat file through this
+  API — unlike a collection, which a grant can open up. The comparison is against
+  `user_id` and there is no second branch to hold a wider case.
 
 ## RAG Document Ingestion
 
@@ -292,15 +296,53 @@ can be ingested into it — delete it and create one under another name. Nothing
 lost in doing so: an ingest into that collection has never succeeded, because
 building the vector index on a table with no `embedding` column fails.
 
-### RAG is Global
+### Who may reach a collection
 
-Collections are shared across **all users**:
+Collections are not global, and nobody inside an organization is an "admin" for
+this purpose — there are no roles on a route here, only permissions
+([permissions](permissions.md)).
 
-- Any authenticated user can search any collection via `POST /rag/search` or
-  through the AI agent's RAG tool.
-- Only admins can manage collections, upload documents, configure sync sources,
-  and view ingestion logs.
-- There is no per-user document isolation.
+A collection has two names. One is the vector table the chunks live in, which is a
+string any caller can type into a URL; the other is the `knowledge_bases` row that
+owns it, and only that row knows an organization. **The row is the authority**: every
+`/rag` and `/kb` route resolves the name through it, in
+`app/services/collection_access.py`, before touching a vector, a document or a sync
+source. The listing and the per-resource routes read the rule from that one place,
+because it was two copies of it — `/rag/collections` filtering by organization while
+`/rag/collections/{name}/info` did not — that once let one tenant read another's.
+
+Three scopes on the row, and no fourth:
+
+| Scope | May read | May write |
+|---|---|---|
+| `personal` | its owner | its owner |
+| `org` | `collections:view` reaching the row | `collections:edit` reaching the row |
+| `app` | anybody in the deployment | the deployment superadmin (`is_app_admin`) |
+
+"Reaching the row" is `resolve_access`, the same decision every shareable resource
+takes: the caller's scope for that permission, widened by any explicit grant on that
+one collection. A grant widens what a role allows and never narrows it, so **a Viewer
+holding an explicit `edit` grant can manage that collection** — the case a role gate
+would refuse before ever looking. That is why the per-resource routes carry no
+`require(...)` and hand the decision to the service instead.
+
+What that buys, per operation:
+
+| | |
+|---|---|
+| Search — `POST /rag/search`, and the agent's retrieval tool | `collections:view`. Every collection named is resolved before the first vector is read, and one the caller cannot reach refuses the **whole** search rather than being quietly dropped from it |
+| Read — listing collections and documents, collection stats, a document's parsed text or original file, sync and ingestion logs | `collections:view`, and each answer holds only the collections that caller can reach |
+| Write — creating and dropping a collection, uploading, ingesting, retrying, deleting a document, configuring or cancelling a sync source | `collections:edit` |
+| `POST /rag/sync/local` | The one exception, and it keeps `is_app_admin`: its `path` names a directory on the **server** rather than anything a tenant owns, so opening it to `collections:edit` would hand every member a read of arbitrary server files, ingested into a collection they can then search |
+
+A refusal is reported as **"Collection not found"**, with the same message and details
+an absent collection produces. Anything else turns the API into an oracle: these names
+are derived from what people call their knowledge bases, so confirming that
+`acme_handbook_d1fac1` exists somewhere is already information.
+
+**Within a collection there is no per-document isolation.** Access is decided at the
+collection, so reaching one reaches every document in it — which is the thing to weigh
+when deciding what to ingest where.
 
 ### Document Tracking
 

--- a/docs/howto/configure-sync-sources.md
+++ b/docs/howto/configure-sync-sources.md
@@ -208,8 +208,11 @@ For MinIO, the endpoint is typically `http://minio:9000` (Docker) or
 
 ## API Reference
 
-All sync source endpoints live under `/api/v1/rag/sync/`. They require
-admin-level authentication when JWT auth is enabled.
+All sync source endpoints live under `/api/v1/rag/sync/`. Listing takes
+`collections:view` and everything that changes a source takes `collections:edit`,
+in both cases reaching the collection the source belongs to — there is no admin
+role in it. See
+[who may reach a collection](../file-processing.md#who-may-reach-a-collection).
 
 ### Sync Sources CRUD
 

--- a/docs/howto/use-ratings.md
+++ b/docs/howto/use-ratings.md
@@ -129,4 +129,7 @@ For programmatic access to ratings data, use the admin API endpoints:
 | `/admin/ratings/export` | GET | Export ratings (JSON/CSV) |
 | `/admin/conversations` | GET | List all conversations |
 
-All admin endpoints require admin authentication via JWT token.
+Every `/admin` endpoint is gated on `CurrentAppAdmin` — a signed-in user whose
+`users.is_app_admin` is true. That is the **deployment** superadmin, not a role inside
+an organization: there is no `users.role` column and no organization role reaches
+these routes. See [permissions](../permissions.md#layer-1-usersis_app_admin-the-deployment-superadmin).


### PR DESCRIPTION
Three small things, two of them about CI telling the truth and one about a
page that stopped being true two migrations ago. They share a branch because
none of them touches what the others touch.

## #359 — a stacked pull request ran no CI, and said nothing

`ci.yml` triggered on `pull_request: branches: [main, master]`. That filter
matches on the **base**, so a pull request opened against another feature
branch matched no trigger and executed nothing at all. Stacking is not an
accident here — it is what two branches touching one file are told to do.

The missing run is the smaller half. A pull request with no jobs shows an
**empty** checks list rather than a red one: `gh pr checks` answers "no checks
reported" and the rollup is absent, not pending, which reads as "still
starting" to anybody who does not go looking. Four pull requests merged that
way on 2026-08-06, each verified only on somebody's laptop, and the gap closed
only when the child was retargeted to `main` after its parent merged —
precisely when nobody waits seven minutes for a branch that has looked settled
for a day.

**What I chose, and why.** The `branches:` filter is dropped rather than
extended. Any list of bases is a list somebody has to remember to extend, and
the property the issue asks for — that the absence of an answer is visible — is
best had by making a pull request without CI impossible to open.

Deliberately *not* a `paths:` filter or a workflow-level gate of any kind. A
filtered-out workflow never posts its required contexts, so `main`'s ruleset
would wait for six checks that never arrive and the merge button would stay
grey forever; that distinction is the one v0.0.35 records, and the reason the
change-scope gate is a job-level `if:`. A **skipped** required check is a pass;
a check that never reports is a permanent block. Nothing here changes which
jobs are required, so `docs/branching.md`'s table and
`tests/test_ci_parity.py` are untouched by it.

It stays cheap. `changes` classifies a stacked child on its own diff — it reads
`pulls/{n}/files`, which compares against that pull request's own base — and
the concurrency group is keyed on `github.ref`, so a stacked branch cancels its
superseded runs like any other. `push` stays pinned to `main`.

**Two claims in the issue that do not hold**, both checked:

- There is no `codeql.yml` in this repository. CodeQL runs from GitHub's
  **default setup** (`gh api repos/vstorm-co/agenticos/code-scanning/default-setup`
  → `configured`, five languages, weekly), whose triggers are not ours to edit.
- `ai-review.yml` has no `pull_request` trigger at all today (#311), and the
  re-enable snippet in its own header carries no base filter — so nothing there
  needs changing either.

**Two limits I could not remove**, both written into `docs/branching.md` rather
than left for the next person: a green stacked pull request was checked against
its parent and not against `main` (checks belong to a head commit, so
retargeting carries the old verdict forward — an argument for short stacks),
and CodeQL is above.

## #364 — every job now bounds its own runtime

`changes` was the only job with a `timeout-minutes`, so the other seven
inherited GitHub's default of 360 minutes: one stalled job would hold a
required check for six hours with nothing here ending it sooner.

Taking the issue as its author corrected it — the original claim that a `test`
job hung for 100 minutes was a misreading of a local process's elapsed time,
and nothing has ever been observed to stall. This is a bound on the tail.

| Job | Bound | Observed |
|---|---|---|
| `changes` | 5 (unchanged) | 7s |
| `lint` | 10 | 22s |
| `Security Scan` | 10 | 14s |
| `docs` | 15 | 4m34s |
| `test-frontend` | 20 | 5m08s |
| `docker` | 20 | 2m30s |
| `test` | 25 | 7m43s |
| `e2e` | 25 | 8m01s |

Observed on run 31116003994, a full matrix on `main`. Each bound is several
times its job rather than just above it: the timeout exists to end a stall, and
one tight enough to trim a legitimately cold cache is a red build about
nothing. `docs` is the argument for that headroom — 4m34s on that run against
17s on run 31110850073, the difference being a cold uv cache.

The issue suggested `tests/test_ci_parity.py` for the guard. It went into a new
`backend/tests/test_ci_workflow.py` instead: parity's subject is whether
`make check` runs what CI runs, and a runtime bound is not part of that claim.
The new file asserts both properties nothing about a run can reveal — that the
trigger carries no base filter, and that every job declares a bound and none
exceeds 30 minutes.

## #354 — "only admins can manage collections" has not been true since `0066`

`docs/file-processing.md` described the role model this project dropped: there
are no admins inside an organization, and `users.role`, `UserRole`,
`RoleChecker` and `CurrentAdmin` are all gone. The heading above it — "RAG is
Global" — was the same mistake one level up, since collections are scoped by
organization and by `resolve_access`.

It was wrong in the direction that matters: it said a case the platform allows
is impossible. A Viewer holding an explicit `edit` grant *can* manage that one
collection, because a grant widens what a role allows and never narrows it.

Restructured rather than patched, because the heading was the claim. "Who may
reach a collection" now describes the three knowledge-base scopes, what
`collections:view` and `collections:edit` buy per operation, the one route that
legitimately keeps `is_app_admin` (`POST /rag/sync/local`, whose `path` names a
directory on the server), that a refusal reports "not found" so the API is not
an oracle, and that access is decided per collection rather than per document.
`docs/permissions.md` stays the source of truth and is linked, not paraphrased.

**The sweep is the larger half.** `architecture.md` carried the same claim in
full, under its own "Key Principle: RAG is Global" heading — a second copy that
had been disagreeing with reality for as long as the first, and one that
grepping for "only admins" does not find, because it is written
`Only **admins**`. It is now four sentences pointing at the page that owns the
rule. Three more sites went with it: the same file's "admin only" ingest
endpoint, `howto/configure-sync-sources.md`'s "require admin-level
authentication" (the endpoints take `collections:view` / `collections:edit`),
`howto/use-ratings.md`'s "all admin endpoints require admin authentication"
(those routes are `CurrentAppAdmin`, the deployment flag, outside organizations
entirely), and `file-processing.md`'s own opening line, which introduced
ingestion as "admin/CLI". The `admins` audience in `governance.md` is a real
spec keyword and was left alone.

## Found and fixed here — #407

`main` does not pass its own lint. `make lint-backend` on `16a31b9` reports two
ruff errors (`RET501` and `RUF100`), both introduced by pull requests merged
during today's Actions outage with their whole check list still **pending** —
`gh pr checks 397` and `gh pr checks 302` still say so. Every branch cut from
`main` therefore starts red on a gate it did not break, this one included.

Filed as #407 and fixed here rather than separately, per Kacper's call for this
batch: a branch about CI honesty cannot honestly leave `main` red. Fixed by
hand rather than with `--fix`, because the autofix deletes the reasoning along
with the line — the stub's docstring is *about* answering `None`, and the
`noqa` carried the reason its broad `except` is deliberate.

## How this was verified — and what could not be

**GitHub Actions is in a major outage** (incident opened 15:22 UTC; 150+ runs
queued, none in progress). That is worth stating plainly on a pull request
whose subject is a check that looks like it passed when it never ran.

Demonstrated locally:

- `make check` — lint, backend tests with the 100% platform gate, `db-check`,
  frontend coverage (100% statements/functions/lines, 97.56% branches), the
  frontend build, `docs-build --strict`, and the audit. The first pass tripped
  the documented 5s `testTimeout` under coverage instrumentation on two chat
  specs (`file-preview`, `chat-parts`) — this machine was running three other
  worktrees' suites at the time. Both pass on their own and the gate passes on
  a re-run; nothing in this branch touches `frontend/`.
- `backend/tests/test_ci_workflow.py`, including confirming it **fails** when
  the `branches: [main, master]` filter is put back — the regression is proved,
  not asserted.
- `make docs-build` clean under `--strict`, plus both new cross-reference
  anchors checked in the built HTML, since `--strict` does not validate
  fragments.
- `yamlfmt` and `zizmor` over the edited workflow.

**Argued, not demonstrated:**

- That a stacked pull request now runs CI. No run has executed anywhere today.
  The nearest thing to proof is the test above plus the trigger semantics,
  which is why the test exists.
- Every `timeout-minutes` value. A timeout is only exercised by the incident it
  exists to shorten; what is checkable is that the workflow parses, that every
  job carries one, and that the numbers sit well above the measured times
  quoted.
- That the `changes` job classifies a stacked child correctly. It follows from
  `pulls/{n}/files` comparing against the pull request's own base, and has not
  been observed.

At the moment this opened, `gh pr checks 426` listed **only** the three CodeQL
contexts, all `queued`, and `ci.yml` had created no run for it at all — the same
repo-wide, across every open pull request. So this pull request's own checks
list is, right now, an example of exactly the ambiguity #359 is about, for an
unrelated reason. It should fill in on its own once the platform recovers; if
it does not, that is the first thing to look at rather than the diff.

The first pull request opened after Actions recovers is the real test of #359,
and it will be this one if it is stacked on nothing — so somebody should open a
throwaway stacked pull request once runs start moving again and confirm the
checks list is populated rather than empty.

The automated reviewer is off (#311/#313), so I did the maintainer pass myself:
re-read the whole diff, swept `docs/` and `.claude/` for the rest of the stale
role vocabulary rather than the one sentence filed, and checked the two
neighbouring workflows the issue named.

Closes #359, #364, #354
Closes #407
