### PR TITLE
fix(db): commit the request's transaction before the response is sent

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -41,7 +41,7 @@ async def delete(db: AsyncSession, entity_id: UUID) -> Entity | None:
 ```
 
 Rules:
-- ALWAYS `db.flush()` + `db.refresh()`, NEVER `db.commit()` — session auto-commits in `get_db_session`
+- ALWAYS `db.flush()` + `db.refresh()`, NEVER `db.commit()` — the request's session commits once, after the route returns and *before* the response is written (`docs/architecture.md#the-requests-transaction`)
 - Use keyword-only args after `db`: `create(db, *, email: str, name: str)`
 - Return the entity (or None for get/delete), never return IDs or dicts
 - Functions are async (PostgreSQL via asyncpg)
@@ -108,12 +108,18 @@ Rules for thick subpackages:
 Use `Annotated` type aliases — never raw `Depends()` in route signatures:
 
 ```python
-DBSession = Annotated[AsyncSession, Depends(get_db_session)]
+DBSession = Annotated[AsyncSession, Depends(get_db_session, scope="function")]
 UserSvc = Annotated[UserService, Depends(get_user_service)]
 CurrentUser = Annotated[User, Depends(get_current_user)]
 CurrentAppAdmin = Annotated[User, Depends(_require_app_admin)]
 Auth = Annotated[AuthContext, Depends(get_auth_context)]
 ```
+
+`scope="function"` on `DBSession` is load-bearing. It is what commits the
+transaction *before* the response is written, so a 2xx means the write is
+readable; FastAPI's default for a dependency with `yield` puts the commit after
+the answer has gone out, which is #353. A bare `Depends(get_db_session)`
+anywhere reintroduces it, and `tests/api/test_db_session_scope.py` fails on one.
 
 Service factories take `DBSession` and return service instances:
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -71,10 +71,11 @@ Traps, each of which has cost a red job here:
   `element(s) not found` for a refusal it never looked at (#132). And a **fixture** step
   asserts through the API, never on the row appearing - the refetch after a write is
   sometimes answered with the pre-write list (#230), which is a product bug and must not
-  be reported as a broken fixture. It asserts by **polling** that API, because a 2xx
-  from this backend says the request was answered and not that the write is readable:
-  the commit runs after the response goes out (#353). One step read once instead and
-  took all 87 specs down three times in a day (#335).
+  be reported as a broken fixture. It asserts by **polling** that API. The backend half
+  of that is fixed - a 2xx now means the write is readable, because the commit lands
+  before the response goes out (#353) - but #230 is a browser-side staleness nobody has
+  closed, so the polling stays until it is. One step read once instead and took all 87
+  specs down three times in a day (#335).
 - **Coverage instrumentation slows tests enough to trip a 5s `testTimeout`.** A
   heavy spec that passes under `test:run` can time out under `test:coverage`; re-run
   before believing it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,8 +54,11 @@ changes" is. Concretely, in this repo:
 
 Easy to violate, cross-cutting, and each one has been violated here at least once.
 
-- Repositories use `db.flush()` + `db.refresh()`, **never** `db.commit()` — the session
-  auto-commits via `get_db_session`.
+- Repositories use `db.flush()` + `db.refresh()`, **never** `db.commit()` — the request's
+  session commits once, after the route returns and **before the response is written**.
+  That ordering is `scope="function"` on the `DBSession` alias and nothing else; a bare
+  `Depends(get_db_session)` puts the commit after the answer has gone out, which is #353.
+  `docs/architecture.md#the-requests-transaction` has the order and its three consequences.
 - Routes call services only — **never** import or call a repository directly.
 - **`require(...)` gates belong on collection routes, not per-resource ones.** Listing,
   creating and reading catalogs carry a permission gate; anything acting on *one* agent,

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -59,10 +59,11 @@ being made about it.
 Taking this alias costs a second session, because FastAPI's dependency cache
 keys on the computed scope: the export endpoint holds this one *and* the
 function-scoped one its authentication resolves through, on two pool
-connections, in two transactions. That is tolerable for a read - the two see
-consistent data under `READ COMMITTED` either way - and unavoidable while
-authentication reads the database. Do not build on it: a *write* split across
-the two would be two transactions that can half-commit.
+connections, in two transactions. Unavoidable while authentication reads the
+database, and free for a read - under `READ COMMITTED` every statement takes a
+fresh snapshot anyway, so one transaction guarantees these two reads no more
+than two do. Do not build on it: a *write* split across the two is two
+transactions that can half-commit.
 """
 from uuid import UUID
 

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -1,6 +1,15 @@
 """API dependencies.
 
 Dependency injection factories for services, repositories, and authentication.
+
+**The session aliases below decide when the transaction commits.** A dependency
+with `yield` runs its exit code when the exit stack it was registered on
+unwinds, and FastAPI keeps two of them per request: the *function* stack, which
+unwinds after the path operation returns and **before** the response is sent,
+and the *request* stack, which unwinds **after**. `scope=` on `Depends` chooses
+between them, and `"request"` is the default for a generator dependency - which
+is why every write in this API used to be acknowledged before it was durable
+(#353).
 """
 # ruff: noqa: I001 - Imports structured for Jinja2 template conditionals
 
@@ -18,7 +27,43 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_db_session
 
-DBSession = Annotated[AsyncSession, Depends(get_db_session)]
+DBSession = Annotated[AsyncSession, Depends(get_db_session, scope="function")]
+"""The request's session, committed before the response leaves the process.
+
+`scope="function"` is load-bearing, not decoration: it puts the commit on the
+exit stack FastAPI unwinds *between* the path operation returning and the
+response being written, so a 2xx means the write is readable rather than merely
+accepted. Without it a client acting on its own 2xx - a browser refetching after
+a mutation, an agent reading back what it just wrote, an E2E fixture - can be
+answered from a database the write has not reached (#353, #230, #335).
+
+A failed request is unaffected in ordering and unchanged in behaviour: the
+exception unwinds this stack too, so the rollback still happens, and it still
+happens before the error response is built.
+"""
+
+StreamingDBSession = Annotated[AsyncSession, Depends(get_db_session, scope="request")]
+"""A session that outlives the response start, for a body produced while sending.
+
+A `StreamingResponse` over a generator is iterated during `await response(...)`,
+which is after the function stack has unwound - so a body that pages through the
+database needs the session to survive that long, and this alias is the only
+supported way to ask for one.
+
+**Read-only.** Its transaction resolves after the client has been answered,
+which is exactly the ordering #353 is about, so a write made through it is a
+write nobody can be told the truth about. One endpoint uses it: the ratings
+export. `tests/api/test_db_session_scope.py` refuses a second without a decision
+being made about it.
+
+Taking this alias costs a second session, because FastAPI's dependency cache
+keys on the computed scope: the export endpoint holds this one *and* the
+function-scoped one its authentication resolves through, on two pool
+connections, in two transactions. That is tolerable for a read - the two see
+consistent data under `READ COMMITTED` either way - and unavoidable while
+authentication reads the database. Do not build on it: a *write* split across
+the two would be two transactions that can half-commit.
+"""
 from uuid import UUID
 
 from app.db.session import get_db_context
@@ -109,6 +154,21 @@ def get_rating_service(db: DBSession) -> MessageRatingService:
 
 
 MessageRatingSvc = Annotated[MessageRatingService, Depends(get_rating_service)]
+
+
+def get_streaming_rating_service(db: StreamingDBSession) -> MessageRatingService:
+    """The ratings service for the CSV export, and nothing else.
+
+    `MessageRatingService.export_all_ratings` is an async generator that pages
+    through the database as the CSV is written, so it runs while the response is
+    being sent - after an ordinary `DBSession` has committed and closed. The
+    export writes nothing, which is what makes a request-scoped session
+    acceptable here; see `StreamingDBSession`.
+    """
+    return MessageRatingService(db)
+
+
+StreamingMessageRatingSvc = Annotated[MessageRatingService, Depends(get_streaming_rating_service)]
 from app.services.rag_document import RAGDocumentService
 from app.services.rag_sync import RAGSyncService
 from app.services.sync_source import SyncSourceService

--- a/backend/app/api/routes/v1/admin_ratings.py
+++ b/backend/app/api/routes/v1/admin_ratings.py
@@ -3,7 +3,7 @@ from typing import Any, Literal
 from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse, StreamingResponse
 
-from app.api.deps import CurrentAppAdmin, MessageRatingSvc
+from app.api.deps import CurrentAppAdmin, MessageRatingSvc, StreamingMessageRatingSvc
 from app.schemas.message_rating import MessageRatingList, RatingSummary
 
 router = APIRouter()
@@ -40,7 +40,7 @@ async def get_rating_summary(
 
 @router.get("/export", response_model=None)
 async def export_ratings(
-    rating_service: MessageRatingSvc,
+    rating_service: StreamingMessageRatingSvc,
     _: CurrentAppAdmin,
     export_format: Literal["json", "csv"] = Query("json", description="Export format"),
     rating_filter: int | None = Query(None, ge=-1, le=1, description="Filter by rating value"),
@@ -49,6 +49,11 @@ async def export_ratings(
     """Export all ratings as JSON or CSV (admin only).
 
     CSV is streamed row-by-row; JSON collects into a single document.
+
+    The one endpoint on a `StreamingDBSession`: the CSV generator reads its next
+    page after the response has started, which an ordinary `DBSession` has
+    already committed and closed by. It reads and never writes, so nothing here
+    depends on the acknowledgement ordering #353 is about.
     """
     result = await rating_service.export_ratings(
         export_format=export_format,

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -45,9 +45,21 @@ async def _managed_session(
 
 
 async def get_db_session() -> AsyncGenerator[AsyncSession, None]:
-    """Get async database session for FastAPI dependency injection.
+    """The request's session, for FastAPI dependency injection.
 
-    Use this with FastAPI Depends().
+    **Depend on it through `app.api.deps.DBSession`, never through a bare
+    `Depends(get_db_session)`.** The alias declares `scope="function"`, and that
+    is what decides whether a client can act on its own 2xx: the code after the
+    `yield` above runs when the exit stack it was registered on unwinds, and
+    FastAPI's default for a generator dependency is the stack that unwinds
+    *after* `await response(scope, receive, send)` - after the answer has gone
+    out. A bare `Depends(get_db_session)` therefore reintroduces #353, in which a
+    membership row was invisible to the very next request for 21.7ms and an
+    invitation token was spent 34ms before the transaction that minted it
+    committed.
+
+    `tests/api/test_db_session_scope.py` walks the mounted routes and refuses
+    one that asks for a session any other way.
     """
     async with _managed_session(async_session_maker) as session:
         yield session

--- a/backend/app/services/health.py
+++ b/backend/app/services/health.py
@@ -103,6 +103,28 @@ def _not_checked(key: str, because: str) -> SystemCheck:
     return SystemCheck(key=key, status="not_checked", detail=f"not checked: {because}")
 
 
+async def _abandon_the_transaction(db: AsyncSession) -> None:
+    """Leave the session usable after a probe's query has failed on it.
+
+    A statement that raises leaves its transaction in a failed state, and every
+    later use of that session - including the commit the request's session
+    dependency performs on the way out - raises too. That commit now runs
+    *before* the response is written (#353), so without this the endpoint an
+    operator reads because something is wrong answers 500 instead of the 503 it
+    diagnosed. Before #353 the same commit failed after the 503 had been sent,
+    which merely logged a traceback per readiness probe and told Starlette its
+    response had already started.
+
+    A rollback here does no I/O: the session either never acquired a connection
+    or holds one already invalidated. It is still guarded, because a session
+    that cannot be reset is not a reason for a health endpoint to raise.
+    """
+    try:
+        await db.rollback()
+    except Exception:
+        logger.warning("could not reset the session after a failed health probe", exc_info=True)
+
+
 async def probe_database(db: AsyncSession) -> SystemCheck:
     """Round-trip a trivial query.
 
@@ -115,9 +137,11 @@ async def probe_database(db: AsyncSession) -> SystemCheck:
         async with asyncio.timeout(PROBE_TIMEOUT_SECONDS):
             await db.execute(text("SELECT 1"))
     except TimeoutError:
+        await _abandon_the_transaction(db)
         return _timed_out("database", "SELECT 1")
     except Exception as exc:
         logger.warning("database health probe failed", exc_info=True)
+        await _abandon_the_transaction(db)
         return SystemCheck(key="database", status="unhealthy", detail=f"SELECT 1 failed: {exc}")
     return SystemCheck(
         key="database",
@@ -182,9 +206,11 @@ async def probe_vector_store(db: AsyncSession) -> SystemCheck:
                 )
             tables = (await db.execute(_EMBEDDING_TABLE_COUNT)).scalar_one()
     except TimeoutError:
+        await _abandon_the_transaction(db)
         return _timed_out("vector_store", "the pgvector catalog query")
     except Exception as exc:
         logger.warning("vector store health probe failed", exc_info=True)
+        await _abandon_the_transaction(db)
         return SystemCheck(
             key="vector_store",
             status="unhealthy",
@@ -223,9 +249,11 @@ async def probe_model_access(db: AsyncSession) -> SystemCheck:
             ).where(ModelProfile.secret_id.is_not(None))
             profiles, organizations = (await db.execute(usable)).one()
     except TimeoutError:
+        await _abandon_the_transaction(db)
         return _timed_out("model_access", "the model profile query")
     except Exception as exc:
         logger.warning("model access health probe failed", exc_info=True)
+        await _abandon_the_transaction(db)
         return SystemCheck(
             key="model_access",
             status="unhealthy",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,7 +16,11 @@ dependencies = [
     # bumps them, the `dependency-freshness` workflow tries the newest of
     # everything on a schedule, and Dependabot opens the PR. A cap here (it was
     # `<0.137`) turns all three into no-ops.
-    "fastapi>=0.135.3",
+    # The floor is a correctness floor, not a taste one: `Depends(..., scope=)`
+    # is what makes the request's transaction commit before the response is sent
+    # (#353), and an older FastAPI answers `TypeError` at import rather than
+    # quietly reverting - but only 0.141.1 has been run against this suite.
+    "fastapi>=0.141.1",
     "uvicorn[standard]>=0.52.0",
     "pydantic[email]>=2.13.4",
     "pydantic-settings>=2.14.2",

--- a/backend/tests/api/test_db_session_scope.py
+++ b/backend/tests/api/test_db_session_scope.py
@@ -12,8 +12,8 @@ through `DBSession` - a bare `Depends(get_db_session)`, or a new alias that
 forgets the scope. That is what this walks the routing table for.
 """
 
-from collections.abc import Iterator
-from typing import Any, Protocol, cast
+from collections.abc import Callable, Iterator
+from typing import Protocol
 
 from fastapi.dependencies.models import Dependant
 from fastapi.routing import APIRoute, APIWebSocketRoute
@@ -38,17 +38,27 @@ _STREAMING_ENDPOINTS = {
 _A_ROUTING_TABLE = 100
 
 
-class _RouteGroup(Protocol):
-    """A mounted `include_router`, which since FastAPI 0.141 nests its routes.
+class _MountedEndpoint(Protocol):
+    """One endpoint as FastAPI's router resolves it, with its path already joined.
 
-    `app.routes` no longer holds a flat list of `APIRoute`: `include_router`
-    leaves one `_IncludedRouter` behind and the routes hang off it, reachable
-    only through this method. It is unversioned surface, so the walk below is
-    written to notice when it stops answering rather than to quietly return
-    nothing - which is what `_A_ROUTING_TABLE` is for.
+    Structural, because the class behind it is `fastapi.routing.
+    _EffectiveRouteContext` and private. `dependant` is optional: a plain
+    Starlette route mounted on the router - a redirect, a static mount - has no
+    dependency tree.
     """
 
-    def effective_route_contexts(self) -> Iterator[Any]: ...
+    path: str
+    methods: set[str] | None
+    dependant: Dependant | None
+
+
+# How a mounted `include_router` hands over its routes. Since FastAPI 0.141
+# `app.routes` no longer holds a flat list of `APIRoute`: `include_router` leaves
+# one `_IncludedRouter` behind and the routes hang off it, reachable only through
+# this method. Unversioned surface, so the walk below is written to notice when
+# it stops answering rather than to quietly return nothing - which is what
+# `_A_ROUTING_TABLE` is for.
+_RouteGroup = Callable[[], Iterator[_MountedEndpoint]]
 
 
 def _every_dependant(dependant: Dependant) -> Iterator[Dependant]:
@@ -64,15 +74,13 @@ def _session_scopes(dependant: Dependant) -> list[str | None]:
 def _endpoints() -> Iterator[tuple[str, str, Dependant]]:
     """Every mounted endpoint as (method, full path, its dependency tree)."""
     for route in app.routes:
-        group = getattr(route, "effective_route_contexts", None)
+        group: _RouteGroup | None = getattr(route, "effective_route_contexts", None)
         if group is not None:
-            for context in cast(_RouteGroup, route).effective_route_contexts():
-                # A plain Starlette route mounted on the router - a redirect, a
-                # static mount - has no dependency tree to walk.
-                if context.dependant is None:
+            for endpoint in group():
+                if endpoint.dependant is None:
                     continue
-                for method in sorted(context.methods or ["WEBSOCKET"]):
-                    yield method, context.path, context.dependant
+                for method in sorted(endpoint.methods or ["WEBSOCKET"]):
+                    yield method, endpoint.path, endpoint.dependant
         elif isinstance(route, APIRoute):
             for method in sorted(route.methods):
                 yield method, route.path, route.dependant

--- a/backend/tests/api/test_db_session_scope.py
+++ b/backend/tests/api/test_db_session_scope.py
@@ -1,0 +1,132 @@
+"""Every mounted route gets a session that commits before the response is sent.
+
+The ordering itself is proved against a real database in
+`tests/integration/test_commit_before_response.py`. This file guards the wiring
+that ordering depends on, because the wiring is one keyword argument on one
+`Depends` and losing it is silent: the suite stays green, every route keeps
+answering 2xx, and the only symptom is that a client acting on its own 2xx is
+sometimes answered from a database the write has not reached (#353).
+
+A new route reintroduces the defect by asking for a session any way other than
+through `DBSession` - a bare `Depends(get_db_session)`, or a new alias that
+forgets the scope. That is what this walks the routing table for.
+"""
+
+from collections.abc import Iterator
+from typing import Any, Protocol, cast
+
+from fastapi.dependencies.models import Dependant
+from fastapi.routing import APIRoute, APIWebSocketRoute
+
+from app.db.session import get_db_session
+from app.main import app
+
+# Endpoints allowed a `scope="request"` session, and the reason each one is.
+# A body produced while the response is being sent needs the session to outlive
+# the response start; the price is that its transaction resolves after the
+# client has been answered, so an endpoint may only be added here if it writes
+# nothing. See `app.api.deps.StreamingDBSession`.
+_STREAMING_ENDPOINTS = {
+    # Pages through the ratings table as it writes CSV rows.
+    ("GET", "/api/v1/admin/ratings/export"),
+}
+
+# What `test_the_walk_reached_the_routing_table` insists on finding. Well under
+# the ~200 session-taking endpoints mounted today, so ordinary growth and
+# ordinary deletion both leave it alone; it exists to fail when the walk itself
+# stops working rather than to count routes.
+_A_ROUTING_TABLE = 100
+
+
+class _RouteGroup(Protocol):
+    """A mounted `include_router`, which since FastAPI 0.141 nests its routes.
+
+    `app.routes` no longer holds a flat list of `APIRoute`: `include_router`
+    leaves one `_IncludedRouter` behind and the routes hang off it, reachable
+    only through this method. It is unversioned surface, so the walk below is
+    written to notice when it stops answering rather than to quietly return
+    nothing - which is what `_A_ROUTING_TABLE` is for.
+    """
+
+    def effective_route_contexts(self) -> Iterator[Any]: ...
+
+
+def _every_dependant(dependant: Dependant) -> Iterator[Dependant]:
+    yield dependant
+    for sub_dependant in dependant.dependencies:
+        yield from _every_dependant(sub_dependant)
+
+
+def _session_scopes(dependant: Dependant) -> list[str | None]:
+    return [sub.scope for sub in _every_dependant(dependant) if sub.call is get_db_session]
+
+
+def _endpoints() -> Iterator[tuple[str, str, Dependant]]:
+    """Every mounted endpoint as (method, full path, its dependency tree)."""
+    for route in app.routes:
+        group = getattr(route, "effective_route_contexts", None)
+        if group is not None:
+            for context in cast(_RouteGroup, route).effective_route_contexts():
+                # A plain Starlette route mounted on the router - a redirect, a
+                # static mount - has no dependency tree to walk.
+                if context.dependant is None:
+                    continue
+                for method in sorted(context.methods or ["WEBSOCKET"]):
+                    yield method, context.path, context.dependant
+        elif isinstance(route, APIRoute):
+            for method in sorted(route.methods):
+                yield method, route.path, route.dependant
+        elif isinstance(route, APIWebSocketRoute):
+            yield "WEBSOCKET", route.path, route.dependant
+
+
+def test_every_route_commits_its_transaction_before_answering() -> None:
+    """No route may take a session whose commit lands after the response."""
+    late = [
+        (method, path)
+        for method, path, dependant in _endpoints()
+        for scope in _session_scopes(dependant)
+        if scope != "function" and (method, path) not in _STREAMING_ENDPOINTS
+    ]
+    assert not late, (
+        "these routes hold a session whose transaction resolves after the response "
+        "has been sent, so a 2xx from them does not mean the write is readable "
+        f"(#353). Depend on `app.api.deps.DBSession`: {late}"
+    )
+
+
+def test_the_streaming_session_is_confined_to_the_endpoints_that_declare_it() -> None:
+    """A request-scoped session is an exception, and the list of them is closed.
+
+    Without this, `StreamingDBSession` is a way to opt out of the fix that costs
+    one import and explains itself to nobody.
+    """
+    streaming = {
+        (method, path)
+        for method, path, dependant in _endpoints()
+        for scope in _session_scopes(dependant)
+        if scope == "request"
+    }
+    assert streaming == _STREAMING_ENDPOINTS, (
+        "an endpoint took a request-scoped session without being listed in "
+        "_STREAMING_ENDPOINTS, or one listed there no longer takes one. A body "
+        "produced after the response starts is the only reason to have one, and "
+        "it may not write."
+    )
+
+
+def test_the_walk_reached_the_routing_table() -> None:
+    """The two assertions above pass vacuously if the walk finds nothing.
+
+    They did, the first time this file was written: `app.routes` holds one
+    `_IncludedRouter` rather than 264 `APIRoute`s, so a walk that only knew
+    about `APIRoute` reported a clean routing table it had never looked at.
+    """
+    with_a_session = [
+        (method, path) for method, path, dependant in _endpoints() if _session_scopes(dependant)
+    ]
+    assert len(with_a_session) > _A_ROUTING_TABLE, (
+        "the walk found almost no endpoint holding a database session, which "
+        "means FastAPI changed how a mounted router exposes its routes and the "
+        f"two assertions above stopped checking anything: {len(with_a_session)}"
+    )

--- a/backend/tests/integration/test_commit_before_response.py
+++ b/backend/tests/integration/test_commit_before_response.py
@@ -20,7 +20,7 @@ real route takes - which is the thing being checked - through the same
 `BaseHTTPMiddleware` the real app puts in front of them.
 """
 
-from collections.abc import AsyncGenerator, Awaitable, Callable
+from collections.abc import AsyncGenerator
 from typing import Any
 from uuid import UUID, uuid4
 
@@ -94,26 +94,27 @@ async def _committed(engine: AsyncEngine, row_id: UUID) -> bool:
         return found.scalar_one_or_none() is not None
 
 
-async def _post(
-    app: FastAPI, path: str, row_id: UUID, at_response_start: Callable[[], Awaitable[None]]
-) -> int:
-    """Drive the app over ASGI, calling back the instant the answer goes out.
+async def _post(path: str, row_id: UUID, engine: AsyncEngine) -> tuple[int, bool]:
+    """Drive the app over ASGI, reading the row the instant the answer goes out.
+
+    Answers the response's status and whether the row was visible to `engine` at
+    the moment `http.response.start` was handed to the transport.
 
     `httpx`'s `ASGITransport` would do the driving, but it hands back a finished
-    response - by which time the ordering being asserted has already happened
-    one way or the other. The callback runs inside `send`, so it observes the
-    request suspended at exactly the point the client is being answered.
+    response - by which time the ordering being asserted has already happened one
+    way or the other. The read below happens inside `send`, with the request
+    suspended at exactly the point the client is being answered.
     """
-    status_code: int | None = None
+    app = _app()
+    answered: tuple[int, bool] | None = None
 
     async def receive() -> dict[str, Any]:
         return {"type": "http.request", "body": b"", "more_body": False}
 
     async def send(message: dict[str, Any]) -> None:
-        nonlocal status_code
+        nonlocal answered
         if message["type"] == "http.response.start":
-            status_code = message["status"]
-            await at_response_start()
+            answered = (message["status"], await _committed(engine, row_id))
 
     await app(
         {
@@ -134,8 +135,8 @@ async def _post(
         receive,
         send,
     )
-    assert status_code is not None, "the app never started a response"
-    return status_code
+    assert answered is not None, "the app never started a response"
+    return answered
 
 
 async def test_a_write_is_readable_by_the_time_its_answer_goes_out(
@@ -143,14 +144,11 @@ async def test_a_write_is_readable_by_the_time_its_answer_goes_out(
 ) -> None:
     """The whole of #353, in one assertion."""
     row_id = uuid4()
-    visible: list[bool] = []
 
-    status_code = await _post(
-        _app(), "/write", row_id, lambda: _record(visible, probe_table, row_id)
-    )
+    status_code, visible = await _post("/write", row_id, probe_table)
 
     assert status_code == status.HTTP_204_NO_CONTENT
-    assert visible == [True], (
+    assert visible, (
         "the client was answered 204 while the row was still uncommitted, so a "
         "client acting on that 204 can be answered from a database the write has "
         "not reached (#353)"
@@ -165,18 +163,16 @@ async def test_a_failed_write_is_rolled_back_by_the_time_its_refusal_goes_out(
     A refusal a caller can act on is worth as much as an acknowledgement it can
     act on. If the rollback landed after the 404, a caller retrying on that 404
     could collide with a row that was about to disappear.
+
+    This half passed before #353 too - an exception unwinds both of FastAPI's
+    exit stacks before its handler builds a response - and is here because
+    nothing said so, and because `scope="function"` is exactly the sort of change
+    that could have quietly moved it.
     """
     row_id = uuid4()
-    visible: list[bool] = []
 
-    status_code = await _post(
-        _app(), "/write-then-fail", row_id, lambda: _record(visible, probe_table, row_id)
-    )
+    status_code, visible = await _post("/write-then-fail", row_id, probe_table)
 
     assert status_code == status.HTTP_404_NOT_FOUND
-    assert visible == [False]
+    assert not visible
     assert not await _committed(probe_table, row_id), "the rolled-back row arrived later"
-
-
-async def _record(into: list[bool], engine: AsyncEngine, row_id: UUID) -> None:
-    into.append(await _committed(engine, row_id))

--- a/backend/tests/integration/test_commit_before_response.py
+++ b/backend/tests/integration/test_commit_before_response.py
@@ -1,0 +1,182 @@
+"""A 2xx from this API means the write is readable, not merely accepted.
+
+#353: `get_db_session` commits in the exit code of a dependency with `yield`,
+and FastAPI's default is to unwind that stack *after* `await response(scope,
+receive, send)`. So the answer went out first and the transaction committed
+afterwards - measured at 21.7ms on a real backend, with a membership row
+invisible to the very next request and an invitation token spent 34ms before
+the transaction that minted it committed.
+
+The tests here do not sample that race, they observe the ordering directly: the
+app is driven as a bare ASGI application, and the moment `http.response.start`
+is handed to the transport, a *second* connection is asked whether the row is
+there. Under `READ COMMITTED` that connection can only see committed work, so
+the answer is a fact about the ordering rather than a bet on timing. Against the
+ordering this file was written to fix, it is `False` every single time.
+
+The application under test is built here rather than imported: it is one route,
+so what failed is unambiguous, and it takes the same `DBSession` alias every
+real route takes - which is the thing being checked - through the same
+`BaseHTTPMiddleware` the real app puts in front of them.
+"""
+
+from collections.abc import AsyncGenerator, Awaitable, Callable
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import FastAPI, Response, status
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from app.api.deps import DBSession
+from app.api.exception_handlers import register_exception_handlers
+from app.core.exceptions import NotFoundError
+from app.core.middleware import RequestIDMiddleware
+from app.db.session import engine as app_engine
+
+pytestmark = pytest.mark.anyio
+
+# Spelled out in each statement rather than interpolated from a constant: ruff
+# reads an f-string reaching a cursor as SQL injection (S608) and is right to,
+# even where the value is a literal three lines up.
+_CREATE = "CREATE TABLE commit_ordering_probe (id uuid PRIMARY KEY)"
+_DROP = "DROP TABLE IF EXISTS commit_ordering_probe"
+_INSERT = "INSERT INTO commit_ordering_probe (id) VALUES (:id)"
+_SELECT = "SELECT 1 FROM commit_ordering_probe WHERE id = :id"
+
+
+@pytest.fixture
+async def probe_table(engine: AsyncEngine) -> AsyncGenerator[AsyncEngine, None]:
+    """A table to write one row into, and the engine that watches for it.
+
+    Not one of the product's own tables on purpose: this asserts a property of
+    the request lifecycle, and it should not start failing because a model grew
+    a `NOT NULL` column. The cost of being outside the metadata is that the
+    `engine` fixture's `drop_all` does not reach it, so it is dropped here.
+    """
+    async with engine.begin() as connection:
+        await connection.execute(text(_DROP))
+        await connection.execute(text(_CREATE))
+    yield engine
+    async with engine.begin() as connection:
+        await connection.execute(text(_DROP))
+    # The routes below go through the real `get_db_session`, which draws from
+    # the module-level engine's pool. anyio gives each test its own event loop,
+    # so a connection left in that pool by this test is one the next test finds
+    # attached to a loop that no longer exists ("got Future attached to a
+    # different loop"). Returned here, on the loop that opened them.
+    await app_engine.dispose()
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(RequestIDMiddleware)
+    register_exception_handlers(app)
+
+    @app.post("/write", status_code=status.HTTP_204_NO_CONTENT)
+    async def write(row_id: UUID, db: DBSession) -> Response:
+        await db.execute(text(_INSERT), {"id": row_id})
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    @app.post("/write-then-fail", status_code=status.HTTP_204_NO_CONTENT)
+    async def write_then_fail(row_id: UUID, db: DBSession) -> Response:
+        await db.execute(text(_INSERT), {"id": row_id})
+        raise NotFoundError(message="decided after the write", details={"row_id": row_id})
+
+    return app
+
+
+async def _committed(engine: AsyncEngine, row_id: UUID) -> bool:
+    """Is the row visible to a connection that is not the request's?"""
+    async with engine.connect() as connection:
+        found = await connection.execute(text(_SELECT), {"id": row_id})
+        return found.scalar_one_or_none() is not None
+
+
+async def _post(
+    app: FastAPI, path: str, row_id: UUID, at_response_start: Callable[[], Awaitable[None]]
+) -> int:
+    """Drive the app over ASGI, calling back the instant the answer goes out.
+
+    `httpx`'s `ASGITransport` would do the driving, but it hands back a finished
+    response - by which time the ordering being asserted has already happened
+    one way or the other. The callback runs inside `send`, so it observes the
+    request suspended at exactly the point the client is being answered.
+    """
+    status_code: int | None = None
+
+    async def receive() -> dict[str, Any]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message: dict[str, Any]) -> None:
+        nonlocal status_code
+        if message["type"] == "http.response.start":
+            status_code = message["status"]
+            await at_response_start()
+
+    await app(
+        {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.3"},
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": path,
+            "raw_path": path.encode(),
+            "query_string": f"row_id={row_id}".encode(),
+            "root_path": "",
+            "headers": [(b"host", b"testserver")],
+            "client": ("testclient", 50000),
+            "server": ("testserver", 80),
+            "state": {},
+        },
+        receive,
+        send,
+    )
+    assert status_code is not None, "the app never started a response"
+    return status_code
+
+
+async def test_a_write_is_readable_by_the_time_its_answer_goes_out(
+    probe_table: AsyncEngine,
+) -> None:
+    """The whole of #353, in one assertion."""
+    row_id = uuid4()
+    visible: list[bool] = []
+
+    status_code = await _post(
+        _app(), "/write", row_id, lambda: _record(visible, probe_table, row_id)
+    )
+
+    assert status_code == status.HTTP_204_NO_CONTENT
+    assert visible == [True], (
+        "the client was answered 204 while the row was still uncommitted, so a "
+        "client acting on that 204 can be answered from a database the write has "
+        "not reached (#353)"
+    )
+
+
+async def test_a_failed_write_is_rolled_back_by_the_time_its_refusal_goes_out(
+    probe_table: AsyncEngine,
+) -> None:
+    """The other half: an error response must not outrun its own rollback.
+
+    A refusal a caller can act on is worth as much as an acknowledgement it can
+    act on. If the rollback landed after the 404, a caller retrying on that 404
+    could collide with a row that was about to disappear.
+    """
+    row_id = uuid4()
+    visible: list[bool] = []
+
+    status_code = await _post(
+        _app(), "/write-then-fail", row_id, lambda: _record(visible, probe_table, row_id)
+    )
+
+    assert status_code == status.HTTP_404_NOT_FOUND
+    assert visible == [False]
+    assert not await _committed(probe_table, row_id), "the rolled-back row arrived later"
+
+
+async def _record(into: list[bool], engine: AsyncEngine, row_id: UUID) -> None:
+    into.append(await _committed(engine, row_id))

--- a/backend/tests/test_health_probes.py
+++ b/backend/tests/test_health_probes.py
@@ -40,18 +40,29 @@ class _Result:
 
 
 class _Session:
-    """A session that answers queries from a queue, raises, or never returns."""
+    """A session that answers queries from a queue, raises, or never returns.
+
+    It records `rollback` because a probe that swallows a failed query has to
+    reset the transaction it broke: the request's session commits *before* the
+    response is written, so an abandoned transaction turns the 503 the probe
+    diagnosed into a 500 (#416). A fake without `rollback` would let that pass -
+    `AttributeError` is an exception like any other, and the guard in
+    `_abandon_the_transaction` would swallow it.
+    """
 
     def __init__(
         self,
         *answers: Any,
         raises: Exception | None = None,
         hangs: bool = False,
+        rollback_raises: Exception | None = None,
     ) -> None:
         self._answers = list(answers)
         self._raises = raises
         self._hangs = hangs
+        self._rollback_raises = rollback_raises
         self.queries = 0
+        self.rolled_back = False
 
     async def execute(self, statement: Any) -> _Result:
         self.queries += 1
@@ -61,6 +72,11 @@ class _Session:
             raise self._raises
         assert self._answers, "the probe ran more queries than the fake was given"
         return _Result(self._answers.pop(0))
+
+    async def rollback(self) -> None:
+        if self._rollback_raises is not None:
+            raise self._rollback_raises
+        self.rolled_back = True
 
 
 class _Redis:
@@ -119,6 +135,52 @@ class TestDatabaseProbe:
 
         assert check.status == "unhealthy"
         assert "did not answer within" in check.detail
+
+    async def test_a_refused_query_leaves_the_session_usable(self) -> None:
+        """Diagnosing a broken database must not break the response carrying it.
+
+        A statement that raised leaves the transaction aborted, and the request's
+        session commits on the way out - before the response is written, since
+        #353. Without the rollback the endpoint an operator reads *because*
+        something is wrong answers 500 rather than the 503 it worked out (#416).
+        """
+        session = _Session(raises=RuntimeError("connection refused"))
+
+        await health.probe_database(session)  # type: ignore[arg-type]
+
+        assert session.rolled_back
+
+    async def test_a_hanging_query_leaves_the_session_usable(self, impatient: None) -> None:
+        """The timeout path abandons the transaction too.
+
+        It is the likelier of the two in production - a database under load
+        answers slowly before it stops answering - and it leaves the session in
+        the same state.
+        """
+        session = _Session(hangs=True)
+
+        await health.probe_database(session)  # type: ignore[arg-type]
+
+        assert session.rolled_back
+
+    async def test_a_session_that_cannot_be_reset_still_answers_with_the_diagnosis(
+        self,
+    ) -> None:
+        """The guard around the rollback, and the reason it is there.
+
+        A session too broken to roll back is not a reason for a health endpoint
+        to raise - that is the one thing every probe in this module refuses to
+        do. The commit after it will fail, and that is the honest floor.
+        """
+        session = _Session(
+            raises=RuntimeError("connection refused"),
+            rollback_raises=RuntimeError("the connection is gone"),
+        )
+
+        check = await health.probe_database(session)  # type: ignore[arg-type]
+
+        assert check.status == "unhealthy"
+        assert not session.rolled_back
 
 
 class TestRedisProbe:

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -87,7 +87,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.43.62" },
     { name = "click", specifier = ">=8.1.0" },
     { name = "cryptography", specifier = ">=50.0.0" },
-    { name = "fastapi", specifier = ">=0.135.3" },
+    { name = "fastapi", specifier = ">=0.141.1" },
     { name = "fastapi-cache2", specifier = ">=0.2.2" },
     { name = "genai-prices", specifier = ">=0.0.72" },
     { name = "google-api-python-client", specifier = ">=2.0.0" },

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,7 +89,8 @@ type rather than as data access.
 ### Repositories (`repositories/`)
 - Database operations only
 - No business logic
-- Uses `db.flush()` not `commit()` (the dependency-injected session manages transactions)
+- Uses `db.flush()` not `commit()` — the request's session owns the transaction,
+  and [commits it before the response is sent](#the-requests-transaction)
 - Returns domain models
 
 ### Schemas (`schemas/`)
@@ -104,6 +105,60 @@ type rather than as data access.
 - Pluggable sync adapters that implement `BaseSyncConnector`
 - Each connector provides `list_files()` and `download_file()`
 - Registered in `CONNECTOR_REGISTRY` for discovery at runtime
+
+## The request's transaction
+
+One request, one session, one transaction, committed in one place — and the place
+matters as much as the fact.
+
+A route asks for `DBSession` (`app/api/deps.py`), which resolves `get_db_session`
+(`app/db/session.py`). Everything below the route shares that one session:
+services take it in their constructor, repositories take it as their first
+argument, and neither ever calls `commit()`. `flush()` sends the statements so
+the row has an id and the constraints have been checked; the commit happens once,
+on the way out.
+
+**On the way out means before the response is written.** The alias declares
+`Depends(get_db_session, scope="function")`, which registers the session's exit
+code on the exit stack FastAPI unwinds between the path operation returning and
+`await response(scope, receive, send)`. So the order for a request is:
+
+1. the route returns, and `response_model` serializes what it returned;
+2. the transaction commits — or, if anything raised, rolls back;
+3. the response is written to the socket;
+4. the session is closed.
+
+That ordering is the whole contract, and it is what lets a client act on its own
+answer: **a 2xx means the write is readable, not merely accepted.** FastAPI's
+default for a dependency with `yield` is `scope="request"`, which puts steps 2
+and 3 the other way round — and did here until [#353][353], where an acceptance
+answered 204 while the membership row it created stayed invisible to the very
+next request for 21.7ms, and an invitation token was spent 34ms before the
+transaction that minted it committed.
+
+Three consequences worth knowing before writing a route:
+
+- **A commit that fails is a 500, not a log line.** The response has not been
+  written yet, so a deferred constraint or a lost connection reaches the client
+  as an error rather than being discovered behind an already-sent 2xx.
+- **Anything that swallows a database error must reset the session.** A statement
+  that raised leaves its transaction aborted, and the commit in step 2 raises
+  too. The health probes (`app/services/health.py`) are the case in the codebase:
+  they refuse to propagate, on purpose, so they roll back before returning.
+- **A body produced while the response is being sent needs a different session.**
+  A `StreamingResponse` over a generator is iterated during step 3, by which time
+  the session is closed. Those endpoints take `StreamingDBSession`, which keeps
+  FastAPI's default scope and is therefore read-only: its transaction resolves
+  after the client has been answered. Exactly one endpoint uses it — the ratings
+  CSV export — and `tests/api/test_db_session_scope.py` refuses a second without
+  a decision being made about it.
+
+Work that outlives the request does not use this session at all. WebSocket
+handlers and CLI commands open `get_db_context()`, and worker tasks
+`get_worker_db_context()`; both commit on a clean exit of their own `async with`,
+which has nothing to do with a response.
+
+[353]: https://github.com/vstorm-co/agenticos/issues/353
 
 ## Agent runs: a capability never fetches
 

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -54,7 +54,10 @@ All current services follow this pattern: `UserService`, `ConversationService`,
 ## Repository Layer Pattern
 
 Repositories handle data access only. They contain **no** business logic and
-always use `flush()` instead of `commit()` so the caller controls transactions:
+always use `flush()` instead of `commit()`, because the request's session owns
+the transaction and commits it once — after the route returns and *before* the
+response is written, which is what makes a 2xx mean the write is readable. See
+[the request's transaction](architecture.md#the-requests-transaction).
 
 ```python
 class ConversationRepository:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -196,13 +196,17 @@ eight). So:
 - **A fixture step asks the API, and keeps asking.** Every step of
   `seed.setup.ts` asserts through `/api/…`, because its job is that the fixture
   exists — and a fixture step that fails takes every product spec with it. After
-  a write it asks by polling (`nowThere`), never with a single read: a 2xx from
-  this backend means the request was answered, not that the write is readable,
-  because the commit runs in a dependency FastAPI unwinds after the response has
-  gone out ([#353](https://github.com/vstorm-co/agenticos/issues/353)). The
-  `alreadyThere` guard each step opens with stays a single read, since it runs
-  before the write. The one *post-write* check that read once cost 87 skipped
-  specs three times in a day
+  a write it asks by polling (`nowThere`), never with a single read. That began
+  as a workaround: a 2xx from this backend used to mean the request was answered
+  and not that the write was readable, because the commit ran in a dependency
+  FastAPI unwinds after the response has gone out
+  ([#353](https://github.com/vstorm-co/agenticos/issues/353)). **That is fixed**
+  — the commit now lands before the answer does — and the polling stays anyway,
+  because a fixture is the wrong place to discover that some *other* write is
+  slower than its acknowledgement, and because `nowThere` prints the rows it did
+  see where a single read prints nothing. The `alreadyThere` guard each step
+  opens with is a single read on purpose, since it runs before the write. The one
+  *post-write* check that read once cost 87 skipped specs three times in a day
   ([#335](https://github.com/vstorm-co/agenticos/issues/335)).
 - **A product spec that is about the rendering says so**, and reloads first if it
   needs a list it can trust. `vault.spec.ts` has three `page.reload()` calls

--- a/frontend/e2e/seed.setup.ts
+++ b/frontend/e2e/seed.setup.ts
@@ -59,13 +59,16 @@ import {
  * server layers answer a list containing it, and the page goes on rendering the
  * one without it.
  *
- * Asking the API is necessary and not sufficient: a 2xx here means the request
- * was answered, not that the write is readable. The commit runs in a dependency
- * FastAPI unwinds after the response has gone out (#353), so the next read can
- * arrive at a database the write has not been applied to — measured at 21.7ms
- * on one acceptance. So a check that follows a write is a poll (`nowThere`),
- * never a single read. The `alreadyThere` guard at the head of each step is one
- * read on purpose: it runs *before* the write, and the worst a stale answer
+ * Asking the API used to be necessary and not sufficient: a 2xx meant the
+ * request was answered, not that the write was readable, because the commit ran
+ * in a dependency FastAPI unwinds after the response has gone out — measured at
+ * 21.7ms on one acceptance. That is #353, and it is fixed: the commit now lands
+ * before the answer does. A check that follows a write is still a poll
+ * (`nowThere`) rather than a single read, deliberately and no longer for that
+ * reason — a fixture is the wrong place to find out that some other write is
+ * slower than its acknowledgement, and a poll says what it did see where a
+ * single read says nothing. The `alreadyThere` guard at the head of each step is
+ * one read on purpose: it runs *before* the write, and the worst a stale answer
  * costs there is doing work that was already done. `a draft agent exists` is the
  * remaining exception in either direction — it waits on the Builder's heading.
  *
@@ -261,9 +264,9 @@ setup("a colleague is a member of the organization", async ({ page, browser }) =
   await acceptAsColleague(browser, token);
 
   // `acceptAsColleague` returns only once the colleague's own screen says they
-  // joined, so the server has answered 204 before this line - and that is still
-  // not the same as the row being readable by the owner, because the acceptance
-  // commits *after* the response goes out (#353).
+  // joined, so the server has answered 204 before this line. Since #353 that
+  // does mean the membership row is readable; before it, the acceptance
+  // committed *after* the response went out, which is what this step lost to.
   //
   // This step used to read the list once and assert on it. It was the only one
   // in the file that did: #222 converted four call sites to `nowThere` and did
@@ -308,17 +311,20 @@ async function alreadyThere(
  * project dependency the whole suite is reported red having run no product spec —
  * three branches paid a diagnosis for that in one day (#132).
  *
- * **Polled because the API is answered before the write is durable**, which is
- * not a courtesy about ordering but a measured property of this backend. A
- * dependency with `yield` has its exit code unwound by FastAPI *after*
- * `await response(...)` (`fastapi/routing.py`, `request_response`, read at
- * 0.141.1 — the teardown has moved relative to the send before), and
- * `get_db_session` is where the commit lives — so a 2xx reaches the client with
- * the transaction still open, and the client's next request can read a database
- * the write has not been applied to. Measured against this backend: an
- * acceptance answered 204, and the membership it created was invisible to the
- * very next read for **21.7ms**. Filed as #353; when it closes, every caller
- * here can go back to asking once.
+ * **Polled, though the API is no longer answered before the write is durable.**
+ * It used to be: a dependency with `yield` has its exit code unwound by FastAPI
+ * *after* `await response(...)`, and `get_db_session` is where the commit lives,
+ * so a 2xx reached the client with the transaction still open — an acceptance
+ * answered 204 and the membership it created was invisible to the very next read
+ * for **21.7ms**. #353 moved that commit onto the exit stack FastAPI unwinds
+ * *before* the send (`Depends(get_db_session, scope="function")`), and
+ * `backend/tests/integration/test_commit_before_response.py` holds it there.
+ *
+ * The polling stays. Reverting these call sites to a single read is a change
+ * only twenty green runs of this project can justify, and the ordering it would
+ * be relying on is a backend property this file cannot see. It also costs
+ * nothing when the write is already durable — the first poll answers — while
+ * buying a failure message that names the rows that *were* there.
  *
  * Polling the list and matching on it, rather than polling a boolean, so a
  * failure prints the values that *were* there. "never listed a row whose email


### PR DESCRIPTION
Every write in this API was acknowledged **before its transaction committed**, so
a client acting on its own 2xx — which is what every client does — could issue
its next request against a database the write had not reached. Measured on #353:
a membership row invisible to the very next read for 21.7ms, and an invitation
token spent 34ms before the transaction that minted it committed.

## The decision

`get_db_session` is a dependency with `yield` and commits in its exit code.
FastAPI unwinds that exit stack **after** `await response(scope, receive, send)`
— so the commit is in the right place and the *stack* is the wrong one.

FastAPI has a parameter for exactly this, public and documented:

```python
DBSession = Annotated[AsyncSession, Depends(get_db_session, scope="function")]
```

`scope="function"` registers the dependency on the exit stack that unwinds after
the path operation returns and **before** the response is written
(`fastapi/dependencies/utils.py:663`, `fastapi/routing.py:141-145`). Nothing else
in the codebase changes: repositories still `flush()` and `refresh()` and never
`commit()`, routes still call services only, and a failed request still rolls
back — the exception unwinds the same stack, so the rollback now also lands
before the error response is built.

The order for a request is now: route returns → `response_model` serializes →
**commit** (or rollback) → response written → session closed.

### The failure path is the second correctness win, and it is invisible in the diff

The one-line change reads as being about commits. It is equally about rollbacks.
An exception raised in a route unwinds the **same** exit stack, so the rollback
also moves from after the error response to before it. Previously a caller could
be told 404 or 409 while the partial write that caused it was still open —
so a caller retrying on that refusal could collide with rows that were about to
disappear, and a `NotFoundError` raised after a `flush()` was a refusal the
database had not yet agreed to. Now the refusal is as durable as the
acknowledgement: by the time either reaches the client, the transaction is
settled.

`test_a_failed_write_is_rolled_back_by_the_time_its_refusal_goes_out` asserts
it. It is honest about passing before this change too — an exception already
unwound both of FastAPI's stacks before the handler built a response — and it is
there because nothing said so, and because `scope=` is exactly the sort of change
that could have quietly moved it.

### Weighed and rejected

| Rejected | Why |
|---|---|
| Commit inside each route | Correct, and a change to every write in the codebase that nothing enforces. A route that forgets is silent. |
| An ASGI middleware committing in a `send` wrapper before forwarding `http.response.start` | Works, but splits one transaction decision across two files. The middleware sits *outside* the route's exception handling, so it has to be *told* the request failed rather than seeing it — a status-code heuristic, or a flag on `request.state`. |
| A custom `APIRoute` class | Same semantics, every router to touch (`include_router` preserves the sub-router's route class), and a convention each new route file has to remember. |
| Document the contract instead | Leaves every HTTP client of the platform exposed — an agent, a channel adapter, a customer's script. #230 and #335 are the visible tip, not the extent. |

## Two consequences handled here rather than found later

A subagent swept every call site for assumptions about the old ordering. Two
mattered:

- **The ratings CSV export** streams its body from the database *after* the
  response starts, so an ordinary `DBSession` would be closed under it. It takes
  a new `StreamingDBSession` — FastAPI's default scope, read-only, explained in
  its docstring, and confined by a test to the one endpoint that declares it.
- **The health probes** swallow a failed query on purpose so a diagnosis is not a
  500, but left the session's transaction aborted. On the old ordering that
  commit failed behind an already-sent 503 and was only noise; on this one it
  runs first and turns the intended 503 into a **500**, on the endpoint an
  operator reads *because* something is wrong. They reset the session instead.
  Filed as #416, **fixed here** — shipping the two apart would land a known
  regression.

Everything else the sweep checked is clean: no `BackgroundTasks`, no `@cache()`
on any route, no session captured into a closure or a task, no other
`Depends`-with-`yield` in `app/`, no WebSocket route on `DBSession` (they use
`get_db_context`), and no bare `Depends(get_db_session)` anywhere.

## Verification — CI could not run

GitHub Actions has been in a major outage (workflow runs failing or delayed in
starting; 150+ queued, zero in progress), and the automated reviewer is off under
#311. **Nothing on this branch has been checked by CI.** What was run locally
instead, against a `pgvector/pgvector:pg16` container:

This machine is running eight worktrees against one Postgres — load average 31,
38 concurrent test databases, the integration suite at roughly one test per 30
seconds. So `make check` end to end was **not** chased to completion. What
follows is what actually finished, and what did not:

| Target | |
|---|---|
| `make test-integration` | **green**, 262 passed, run twice |
| `tests/api/` | **green**, 364 passed |
| backend suite minus `tests/integration`, with coverage | **green**, 3150 passed, 0 failed; coverage 99.44%, explained below |
| `make test-frontend-cov` | **green**, 192 files, 3245 tests — after one timeout that was not this branch's, below |
| `make build-frontend` | **green** |
| `make lint-frontend` | **green** — eslint, prettier, tsc |
| `make db-check` | **green** — no schema change here, and alembic agrees |
| `make docs-build` | **green** under `--strict` |
| `make audit` | **green** — no known vulnerabilities |
| ruff on this branch's files | **green**, `check` and `format --check` |
| `make lint` in full | **red on #407 only**, see below |
| `make test` (both halves together, as CI runs it) | **not completed** — started, green through everything it reached including both new tests, abandoned to the load. Its two halves each ran green separately. |
| `make check` end to end | **not completed**, for the same reason |
| `make test-e2e`, `make test-migrations` | not run — seeded backend, and no schema change |

**The frontend timeout.** `create-kb-dialog.test.tsx` timed out at 5660ms against
the 5000ms `testTimeout`, in a run where the other 3244 tests passed. That is the
trap `.claude/rules/testing.md` documents verbatim — "coverage instrumentation
slows tests enough to trip a 5s `testTimeout`… re-run before believing it" — and
on re-run it passes in 17s, six of six, with the whole suite green at 3245 of
3245. This branch changes **no** file under `frontend/src`; its only frontend
edit is a comment block in `frontend/e2e/seed.setup.ts`, which vitest does not
run.

**About that 99.44%.** The two halves of `make test` were run separately because
the machine could not hold both — so the coverage number comes from a run with
`tests/integration` omitted, and it is short by exactly the three modules that
suite covers: `repositories/organization_secret.py` (33%),
`services/organization_secret.py` (94%) and `repositories/resource_grant.py`
(93%). **This branch touches none of the three.** The one gated module it does
touch, `app/services/health.py`, reports **100%** in that run — `app/api/deps.py`,
`app/db/session.py` and `app/api/routes/v1/admin_ratings.py` are not in the
platform-layer include list. So the gate is very likely green when the two halves
run together, as CI runs them, but that specific claim is the one thing here I
have not been able to demonstrate.

**What CI would still add**, and the only things a reviewer should not assume from
the table above: the coverage gate measured over the combined suite, and `e2e`.
Everything else in `check` finished green.

**About that red lint.** `main` at `16a31b9` carries two ruff errors that landed
during the outage — `RET501` in `tests/integration/test_vector_store_reserved_names.py`
and `RUF100` in `tests/test_migrations.py` — so every branch cut today starts red
on a gate it did not break. They are #407, fixed in #426, and deliberately **not**
fixed here: an earlier revision of this branch did fix them and the commit was
dropped by rebase once #426 was pointed out, because two branches fixing the same
two lines is a conflict rather than a favour. `uv run ruff check` and
`uv run ruff format --check` are clean on every file this branch touches.

Two commit bodies were amended after that rebase, because each listed a `make
lint` run that was true while the branch carried the lint fix and stopped being
true when it was dropped. A commit claiming a verification it no longer has
outlives the pull request that would have explained it.

The regression test is the important one, and it is **deterministic rather than a
sample**. `tests/integration/test_commit_before_response.py` drives the app as a
bare ASGI application and asks a *second* connection whether the row is there at
the instant `http.response.start` is handed to the transport; under
`READ COMMITTED` that connection can only see committed work.

- Against the previous ordering it fails on **every** run.
- With this change it passes on **every** run.

`tests/api/test_db_session_scope.py` walks the mounted routing table and refuses
a route that takes a session any other way. Also verified red against the
previous ordering. It carries its own canary: `app.routes` holds one
`_IncludedRouter` rather than 264 `APIRoute`s since FastAPI 0.141, and the first
draft of that walk reported a clean routing table it had never looked at.

Not run: `make test-e2e` (needs a seeded backend, and 20 runs to say anything
about a flake) and `make test-migrations` (no schema change here).

## What is still open

- **#230 is not closed, and this rules #353 out as its cause.** #230's own trace
  shows the commit winning by 5ms; on this ordering it always wins. So #230 is
  browser-side, its `Cache-Control` hypothesis is the live one, and the three
  `#230`-marked reloads in `vault.spec.ts` stay.
- **The E2E seed's polls stay.** #353 is what makes reverting them to single
  reads possible, and that is justified by twenty green runs of the `seed`
  project rather than by an argument — evidence this branch cannot produce with
  Actions down. The comments no longer explain the polling by an ordering that is
  fixed; they say plainly why it stays, so the next reader does not take it for
  an oversight.
- **#417, filed and not fixed.** Document ingestion, RAG sync and source sync
  spawn their background flow *before* the endpoint returns, so the flow can read
  by id a row the request has not committed. This change neither causes nor
  closes it — the window is the same width — and closing it means deferring the
  spawn past the commit through three services, which is a reviewable change of
  its own.

## The FastAPI floor

`fastapi>=0.135.3` → `>=0.141.1`. `scope=` is now a correctness dependency, and
0.141.1 is the version this was verified against rather than the earliest one
carrying the parameter. An older FastAPI raises `TypeError` at import rather than
quietly reverting to the old ordering, which is the failure mode worth having.

## Docs

`docs/architecture.md` gains **The request's transaction** — the order, and the
three things that follow from it. Six places named the old behaviour as fact and
would have been confidently wrong if left: `CLAUDE.md`,
`.claude/rules/architecture.md` (which also showed the alias without its
`scope=`), `.claude/rules/testing.md`, `docs/testing.md`, and two comment blocks
in `frontend/e2e/seed.setup.ts`. `python3 scripts/docs_drift.py` is clean.

Closes #353, #416
Refs #230, #335, #417
