### PR TITLE
fix(api): a refusal describes the refusal, not the server

### DIFF
--- a/.claude/rules/exceptions-security.md
+++ b/.claude/rules/exceptions-security.md
@@ -33,6 +33,16 @@ same applies to the caller's own input: `exc.errors(include_url=False,
 include_input=False)` - a form needs to know which field is wrong, not to be sent a
 copy of what it posted.
 
+**And the refusal, not the server.** `str(exc)` from a vendor SDK is not a
+controlled string - provider clients put the failing request URL in the message and
+a URL carries a key in its query string - and an absolute path says where the
+container keeps its files. Neither is deleted: it goes in the `logger.exception`
+line beside the raise, and `details` names what the reader can act on (#342). A URL
+the refusal is *about* is named by its field rather than repeated, because the
+handler logs `details` too - `{"field": "base_url"}`, never the endpoint with the
+password still in it. An audit entry is `details` with a longer life and takes the
+same rule: `{"fields": sorted(update_data)}`, not the body that was submitted.
+
 Exception handlers in `api/exception_handlers.py` automatically:
 - Map to HTTP status codes
 - Log with structured context (path, method, error code)

--- a/.claude/rules/exceptions-security.md
+++ b/.claude/rules/exceptions-security.md
@@ -33,15 +33,16 @@ same applies to the caller's own input: `exc.errors(include_url=False,
 include_input=False)` - a form needs to know which field is wrong, not to be sent a
 copy of what it posted.
 
-**And the refusal, not the server.** `str(exc)` from a vendor SDK is not a
-controlled string - provider clients put the failing request URL in the message and
-a URL carries a key in its query string - and an absolute path says where the
-container keeps its files. Neither is deleted: it goes in the `logger.exception`
-line beside the raise, and `details` names what the reader can act on (#342). A URL
-the refusal is *about* is named by its field rather than repeated, because the
-handler logs `details` too - `{"field": "base_url"}`, never the endpoint with the
-password still in it. An audit entry is `details` with a longer life and takes the
-same rule: `{"fields": sorted(update_data)}`, not the body that was submitted.
+**And the refusal, not the server** - in `message` as much as in `details`, since
+the envelope carries both and the handler logs both on one line. `str(exc)` from a
+vendor SDK is not a controlled string - provider clients put the failing request
+URL in the message and a URL carries a key in its query string - and an absolute
+path says where the container keeps its files. Neither is deleted: it goes in the
+`logger.exception` line beside the raise, and the refusal names what the reader
+can act on (#342). A URL the refusal is *about* is named by its field rather than
+repeated - `{"field": "base_url"}`, never the endpoint with the password still in
+it. An audit entry is `details` with a longer life and takes the same rule:
+`{"fields": sorted(update_data)}`, not the body that was submitted (#412).
 
 Exception handlers in `api/exception_handlers.py` automatically:
 - Map to HTTP status codes

--- a/backend/app/agents/capabilities/knowledge/_search.py
+++ b/backend/app/agents/capabilities/knowledge/_search.py
@@ -86,8 +86,9 @@ async def search_knowledge_base(
         return "No active knowledge bases selected for this conversation."
 
     service: Any = get_retrieval_service()
+    one_collection = len(resolved) == 1
     try:
-        if len(resolved) == 1:
+        if one_collection:
             results = await service.retrieve(query=query, collection_name=resolved[0], limit=top_k)
         else:
             results = await service.retrieve_multi(
@@ -99,10 +100,19 @@ async def search_knowledge_base(
         # it as "search failed" would replace that with a symptom.
         raise
     except Exception as e:
+        # The upstream text stays here and goes no further. `details` is
+        # serialized into the response body, and `str(e)` on an embedding or
+        # vector-store client is not a controlled string: provider SDKs put the
+        # failing request URL in the message, and a URL carries a key in its
+        # query string. What the caller can act on is which collections were
+        # searched and how, so that is what the refusal carries (agenticos#342).
         logger.exception("Knowledge base search failed")
         raise ExternalServiceError(
             message="Knowledge base search failed",
-            details={"query": query, "error": str(e)},
+            details={
+                "collections": resolved,
+                "operation": "retrieve" if one_collection else "retrieve_multi",
+            },
         ) from e
 
     return _format_results(results)

--- a/backend/app/api/routes/v1/admin_users.py
+++ b/backend/app/api/routes/v1/admin_users.py
@@ -47,6 +47,14 @@ async def update_user(
     db: DBSession,
     service: UserSvc,
 ) -> Any:
+    """Update a user as the deployment's administrator.
+
+    The audit entry records *which* fields were set, not what they were set to.
+    `UserUpdate` carries `password`, so dumping the submitted body wrote the
+    plaintext an administrator typed into `app_admin_audit_logs.details`, where
+    it sat in a JSONB column for as long as the trail is kept (agenticos#342).
+    The names are what the trail is for - the values are on the row.
+    """
     user = await service.update(user_id, user_in)
     await record_audit(
         db,
@@ -54,7 +62,7 @@ async def update_user(
         action="admin.user.update",
         target_type="user",
         target_id=str(user_id),
-        details=user_in.model_dump(exclude_unset=True),
+        details={"fields": sorted(user_in.model_dump(exclude_unset=True))},
         ip_address=request.client.host if request.client else None,
     )
     return user

--- a/backend/app/api/routes/v1/admin_users.py
+++ b/backend/app/api/routes/v1/admin_users.py
@@ -47,22 +47,21 @@ async def update_user(
     db: DBSession,
     service: UserSvc,
 ) -> Any:
-    """Update a user as the deployment's administrator.
-
-    The audit entry records *which* fields were set, not what they were set to.
-    `UserUpdate` carries `password`, so dumping the submitted body wrote the
-    plaintext an administrator typed into `app_admin_audit_logs.details`, where
-    it sat in a JSONB column for as long as the trail is kept (agenticos#342).
-    The names are what the trail is for - the values are on the row.
-    """
     user = await service.update(user_id, user_in)
+    # Which fields were set, never what they were set to. `UserUpdate` carries
+    # `password`, so dumping the submitted body wrote the plaintext an
+    # administrator typed into `app_admin_audit_logs.details`, where it sat in a
+    # JSONB column for as long as the trail is kept (agenticos#412). The names
+    # are what the trail is for; the values are on the row. `model_fields_set`
+    # rather than `model_dump`, so the plaintext is not even built to be thrown
+    # away.
     await record_audit(
         db,
         actor_user_id=admin.id,
         action="admin.user.update",
         target_type="user",
         target_id=str(user_id),
-        details={"fields": sorted(user_in.model_dump(exclude_unset=True))},
+        details={"fields": sorted(user_in.model_fields_set)},
         ip_address=request.client.host if request.client else None,
     )
     return user

--- a/backend/app/schemas/sandbox_connection.py
+++ b/backend/app/schemas/sandbox_connection.py
@@ -49,6 +49,12 @@ def _service_address(value: str) -> str:
       beats failing on a stack trace.
     * **A missing host**, which is a typo rather than an attack, and would
       otherwise be fetched as a relative path against an empty base.
+    * **Credentials in the URL.** A connection authenticates with a vault-held
+      token, so a `user:pass@` here is at best ignored and at worst the only
+      copy of a password - and the address is named back in every refusal this
+      service raises, which puts it in the response and in the log line beside
+      it (agenticos#342). `validate_endpoint_url` and `validate_webhook_url`
+      have refused it all along; this validator did not.
     * **Link-local addresses and the metadata hostnames**, because
       `169.254.169.254` and `metadata.google.internal` are never a sandbox
       service and are the one target where a single unauthenticated GET is worth
@@ -70,6 +76,11 @@ def _service_address(value: str) -> str:
     host = parsed.hostname
     if not host:
         raise ValueError("A sandbox service address must name a host")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError(
+            "A sandbox service address must not carry credentials in the URL - "
+            "the connection authenticates with the key you pick for it"
+        )
     if host.lower() in _METADATA_HOSTS:
         raise ValueError("That host is an instance-metadata service, not a sandbox service")
     try:

--- a/backend/app/services/email/templates.py
+++ b/backend/app/services/email/templates.py
@@ -1,9 +1,18 @@
-"""Template loader - reads pre-rendered HTML/text from `emails/compiled/`."""
+"""Template loader - reads pre-rendered HTML/text from `emails/compiled/`.
 
+`EmailTemplateError` is an `AppException`, so everything it carries reaches a
+caller as a 500 body. Where the templates were looked for is an operator's
+question and is answered in the log; the refusal names the template, which is
+the only part of this a reader can act on (agenticos#342).
+"""
+
+import logging
 from pathlib import Path
 from typing import Any
 
 from app.services.email.exceptions import EmailTemplateError
+
+logger = logging.getLogger(__name__)
 
 # Where the compiled templates sit, relative to whichever ancestor holds them.
 _COMPILED_RELATIVE = Path("emails") / "compiled"
@@ -33,18 +42,23 @@ def _compiled_dir() -> Path:
         candidate = parent / _COMPILED_RELATIVE
         if candidate.is_dir():
             return candidate
+    logger.error(
+        "Compiled email templates not found",
+        extra={"searched_for": str(_COMPILED_RELATIVE), "searched_from": str(_SEARCH_ORIGIN)},
+    )
     raise EmailTemplateError(
         message=f"Compiled email template directory '{_COMPILED_RELATIVE}' not found",
-        details={"searched_from": str(_SEARCH_ORIGIN)},
+        details={"directory": str(_COMPILED_RELATIVE)},
     )
 
 
 def _load_raw(key: str, ext: str) -> str:
     path = _compiled_dir() / f"{key}.{ext}"
     if not path.exists():
+        logger.error("Email template not found", extra={"template": key, "path": str(path)})
         raise EmailTemplateError(
             message=f"Email template '{key}.{ext}' not found",
-            details={"path": str(path)},
+            details={"template": key, "format": ext},
         )
     return path.read_text(encoding="utf-8")
 

--- a/backend/app/services/model_profile.py
+++ b/backend/app/services/model_profile.py
@@ -70,6 +70,14 @@ async def validate_endpoint_url(url: str) -> str:
     remains of the SSRF posture here is the permission gate: only members who
     may manage connections can store an endpoint at all.
 
+    Every refusal here names the *field*, never the URL it was given. The last
+    of the three exists because an endpoint sometimes arrives with a password in
+    it, and `details` is both serialized into the response and logged by the
+    exception handler - so echoing the value back would write the credential
+    this check exists to refuse into the deployment's logs (agenticos#342). The
+    scheme check reaches the same URLs (`ftp://user:pass@host`), so all three
+    answer the same way.
+
     Raises:
         BadRequestError: If the URL is malformed, uses another scheme, or
             carries credentials.
@@ -78,11 +86,11 @@ async def validate_endpoint_url(url: str) -> str:
     if parsed.scheme not in _ALLOWED_ENDPOINT_SCHEMES:
         raise BadRequestError(
             message="A model endpoint must be an http or https URL",
-            details={"base_url": url},
+            details={"field": "base_url"},
         )
     if not parsed.hostname:
         raise BadRequestError(
-            message="A model endpoint must include a host", details={"base_url": url}
+            message="A model endpoint must include a host", details={"field": "base_url"}
         )
     if parsed.username is not None or parsed.password is not None:
         raise BadRequestError(
@@ -90,7 +98,7 @@ async def validate_endpoint_url(url: str) -> str:
                 "A model endpoint must not carry credentials in the URL - store the key "
                 "on the credential instead"
             ),
-            details={"base_url": url},
+            details={"field": "base_url"},
         )
     return url
 
@@ -163,7 +171,7 @@ class ModelProfileService:
                         f"{spec.name} has no endpoint setting - its SDK always talks to the "
                         "provider's own API, so a custom URL here would be ignored"
                     ),
-                    details={"provider": provider, "base_url": base_url},
+                    details={"provider": provider, "field": "base_url"},
                 )
             base_url = await validate_endpoint_url(base_url)
         elif spec.keyless and secret_id is None:

--- a/backend/app/services/sandbox_connection.py
+++ b/backend/app/services/sandbox_connection.py
@@ -378,7 +378,10 @@ class SandboxConnectionService:
             base_url=data.base_url,
             token=secret.api_key.get_secret_value(),
             path="/policy",
-            details={"base_url": data.base_url},
+            # The field, not the address it was given - the same answer
+            # `_check_shape` gives sixteen lines down, and for the reason in
+            # agenticos#342: `details` is logged as well as serialized.
+            details={"field": "base_url"},
         )
         payload["kind"] = "docker"
         return payload

--- a/backend/tests/api/test_error_envelope.py
+++ b/backend/tests/api/test_error_envelope.py
@@ -21,14 +21,15 @@ from datetime import UTC, datetime
 from decimal import Decimal
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
 import pytest
 from fastapi.exceptions import RequestValidationError
-from httpx import AsyncClient
+from httpx import AsyncClient, Response
 
 from app.agents.capabilities.budget import BudgetExceeded, BudgetScope
+from app.agents.capabilities.knowledge._search import search_knowledge_base
 from app.api import deps
 from app.api.exception_handlers import (
     _field_path,
@@ -37,10 +38,12 @@ from app.api.exception_handlers import (
     validation_exception_handler,
 )
 from app.core.config import settings
-from app.core.exceptions import NotFoundError
+from app.core.exceptions import AppException, ExternalServiceError, NotFoundError
 from app.main import app
 from app.repositories import user_repo
 from app.schemas.message_rating import RatingValue
+from app.services.email import templates
+from app.services.email.exceptions import EmailTemplateError
 
 
 class TestFieldPath:
@@ -327,3 +330,141 @@ class TestDetailsSurviveSerialization:
             "limit_usd": "40.10",
             "spent_usd": "40.15",
         }
+
+
+class TestDetailsDescribeTheRefusalNotTheServer:
+    """What `details` carries is a decision now, so it is asserted like one.
+
+    Making the envelope reliable (#307) also made it reliable at carrying the
+    wrong thing: two call sites put an upstream client's exception text and a
+    container's absolute paths into a body a caller reads (#342). A refusal
+    names what the reader can act on; where the server looked and what a vendor
+    SDK's `__str__` said belong in the log.
+
+    Both are exercised through the app rather than asserted on the exception,
+    because the leak is what reaches the wire - the same vehicle the class above
+    uses, `GET /users/avatar/{user_id}`, whose handler is the global one.
+    """
+
+    @staticmethod
+    async def _refusal_on_the_wire(client: AsyncClient, exc: AppException) -> Response:
+        service = MagicMock()
+        service.get_by_id = AsyncMock(side_effect=exc)
+        app.dependency_overrides[deps.get_user_service] = lambda: service
+        return await client.get(f"{settings.API_V1_STR}/users/avatar/{uuid4()}")
+
+    @pytest.mark.anyio
+    async def test_a_failed_knowledge_search_names_the_collections_not_the_upstream(
+        self, client: AsyncClient
+    ):
+        """A provider SDK puts the failing request in its message, key and all.
+
+        `str(e)` on an embedding client is not a controlled string, and the 503
+        it was pasted into is readable by anyone who can talk to an agent.
+        """
+        upstream = RuntimeError(
+            "Error code: 401 - authentication failed for "
+            "https://openrouter.ai/api/v1/embeddings?api-key=sk-live-9f3ca2"
+        )
+        service = MagicMock()
+        service.retrieve = AsyncMock(side_effect=upstream)
+        with (
+            patch(
+                "app.agents.capabilities.knowledge._search.get_retrieval_service",
+                return_value=service,
+            ),
+            pytest.raises(ExternalServiceError) as refusal,
+        ):
+            await search_knowledge_base(query="our refund policy", kb_collection_names=["kb_ops"])
+
+        response = await self._refusal_on_the_wire(client, refusal.value)
+
+        assert response.status_code == 503
+        assert response.json()["error"]["details"] == {
+            "collections": ["kb_ops"],
+            "operation": "retrieve",
+        }
+        assert "sk-live-9f3ca2" not in response.text
+        assert "openrouter.ai" not in response.text
+
+    @pytest.mark.anyio
+    async def test_a_search_over_several_collections_names_the_operation_it_used(
+        self, client: AsyncClient
+    ):
+        """Which path was taken is the operator's first question and is free to answer."""
+        service = MagicMock()
+        service.retrieve_multi = AsyncMock(side_effect=RuntimeError("pgvector: no such table"))
+        with (
+            patch(
+                "app.agents.capabilities.knowledge._search.get_retrieval_service",
+                return_value=service,
+            ),
+            pytest.raises(ExternalServiceError) as refusal,
+        ):
+            await search_knowledge_base(query="x", kb_collection_names=["kb_ops", "kb_hr"])
+
+        response = await self._refusal_on_the_wire(client, refusal.value)
+
+        assert response.json()["error"]["details"] == {
+            "collections": ["kb_ops", "kb_hr"],
+            "operation": "retrieve_multi",
+        }
+        assert "pgvector" not in response.text
+
+    @pytest.mark.anyio
+    async def test_a_missing_email_template_names_the_template_not_the_container_path(
+        self, client: AsyncClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """`EmailTemplateError` is an `AppException`, so its `details` is a 500 body.
+
+        It used to hold the absolute path the container looked at, which tells a
+        caller where the deployment keeps its files and tells them nothing about
+        the email that did not send.
+        """
+        (tmp_path / "srv" / "emails" / "compiled").mkdir(parents=True)
+        monkeypatch.setattr(templates, "_SEARCH_ORIGIN", tmp_path / "srv" / "pkg" / "templates.py")
+
+        with pytest.raises(EmailTemplateError) as refusal:
+            templates.render_email("password_reset", {})
+
+        response = await self._refusal_on_the_wire(client, refusal.value)
+
+        assert response.status_code == 500
+        assert response.json()["error"]["details"] == {
+            "template": "password_reset",
+            "format": "html",
+        }
+        assert str(tmp_path) not in response.text
+
+    @pytest.mark.anyio
+    async def test_a_missing_template_directory_does_not_say_where_it_looked(
+        self, client: AsyncClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The other half of the same leak: the search origin is an install path."""
+        monkeypatch.setattr(templates, "_SEARCH_ORIGIN", tmp_path / "nowhere" / "templates.py")
+
+        with pytest.raises(EmailTemplateError) as refusal:
+            templates._compiled_dir()
+
+        response = await self._refusal_on_the_wire(client, refusal.value)
+
+        assert response.json()["error"]["details"] == {
+            "directory": str(templates._COMPILED_RELATIVE)
+        }
+        assert str(tmp_path) not in response.text
+
+    @pytest.mark.anyio
+    async def test_an_endpoint_with_a_password_in_it_is_refused_without_repeating_it(
+        self, client: AsyncClient
+    ):
+        """The refusal is *about* the credential in the URL, so echoing it back
+        would write it into the response and into the handler's log line."""
+        from app.services.model_profile import validate_endpoint_url
+
+        with pytest.raises(AppException) as refusal:
+            await validate_endpoint_url("https://svc:hunter2@models.internal/v1")
+
+        response = await self._refusal_on_the_wire(client, refusal.value)
+
+        assert response.json()["error"]["details"] == {"field": "base_url"}
+        assert "hunter2" not in response.text

--- a/backend/tests/api/test_error_envelope.py
+++ b/backend/tests/api/test_error_envelope.py
@@ -38,12 +38,18 @@ from app.api.exception_handlers import (
     validation_exception_handler,
 )
 from app.core.config import settings
-from app.core.exceptions import AppException, ExternalServiceError, NotFoundError
+from app.core.exceptions import (
+    AppException,
+    BadRequestError,
+    ExternalServiceError,
+    NotFoundError,
+)
 from app.main import app
 from app.repositories import user_repo
 from app.schemas.message_rating import RatingValue
 from app.services.email import templates
 from app.services.email.exceptions import EmailTemplateError
+from app.services.model_profile import validate_endpoint_url
 
 
 class TestFieldPath:
@@ -341,9 +347,12 @@ class TestDetailsDescribeTheRefusalNotTheServer:
     names what the reader can act on; where the server looked and what a vendor
     SDK's `__str__` said belong in the log.
 
-    Both are exercised through the app rather than asserted on the exception,
-    because the leak is what reaches the wire - the same vehicle the class above
-    uses, `GET /users/avatar/{user_id}`, whose handler is the global one.
+    Each refusal is raised by the real call site and then carried through the
+    app, because what a service put in `details` and what a caller can read are
+    two assertions and only the second one is the defect. The vehicle is the
+    class above's - `GET /users/avatar/{user_id}` with the service mocked to
+    raise it - so none of these travels its own route; the handler is global,
+    and it is the handler that decides what reaches the wire.
     """
 
     @staticmethod
@@ -458,10 +467,13 @@ class TestDetailsDescribeTheRefusalNotTheServer:
         self, client: AsyncClient
     ):
         """The refusal is *about* the credential in the URL, so echoing it back
-        would write it into the response and into the handler's log line."""
-        from app.services.model_profile import validate_endpoint_url
+        would write it into the response and into the handler's log line.
 
-        with pytest.raises(AppException) as refusal:
+        The substring assertion is not a restatement of the one above it: the
+        envelope carries `message` as well as `details`, and a refusal that
+        named the endpoint in prose would leak the same password.
+        """
+        with pytest.raises(BadRequestError) as refusal:
             await validate_endpoint_url("https://svc:hunter2@models.internal/v1")
 
         response = await self._refusal_on_the_wire(client, refusal.value)

--- a/backend/tests/api/test_users.py
+++ b/backend/tests/api/test_users.py
@@ -254,4 +254,3 @@ async def test_an_admin_password_change_is_audited_by_field_not_by_value(
     entry = mock_db_session.add.call_args.args[0]
     assert entry.action == "admin.user.update"
     assert entry.details == {"fields": ["full_name", "password"]}
-    assert "correct-horse-battery" not in str(entry.details)

--- a/backend/tests/api/test_users.py
+++ b/backend/tests/api/test_users.py
@@ -230,3 +230,28 @@ async def test_delete_user_by_id_not_found(
 
     response = await superuser_client.delete(f"{settings.API_V1_STR}/users/{uuid4()}")
     assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_an_admin_password_change_is_audited_by_field_not_by_value(
+    superuser_client: AsyncClient,
+    mock_user: MockUser,
+    mock_db_session,
+):
+    """The trail records what an administrator changed, never what they typed.
+
+    `UserUpdate` carries `password`, and the audit entry used to be the request
+    body dumped whole - so resetting a password for somebody wrote their new
+    plaintext into `app_admin_audit_logs.details`, a JSONB column that outlives
+    the session and is readable by anything that can read the trail (#342).
+    """
+    response = await superuser_client.patch(
+        f"{settings.API_V1_STR}/admin/users/{mock_user.id}",
+        json={"password": "correct-horse-battery", "full_name": "Renamed"},
+    )
+
+    assert response.status_code == 200
+    entry = mock_db_session.add.call_args.args[0]
+    assert entry.action == "admin.user.update"
+    assert entry.details == {"fields": ["full_name", "password"]}
+    assert "correct-horse-battery" not in str(entry.details)

--- a/backend/tests/test_sandbox_connections.py
+++ b/backend/tests/test_sandbox_connections.py
@@ -730,7 +730,23 @@ class TestTestingAnAddressBeforeItIsSaved:
             )
 
         assert "http://typo:8080 did not answer" in refused.value.message
-        assert refused.value.details == {"base_url": "http://typo:8080"}
+        # The message names the address the operator typed; `details` names the
+        # field, because it is logged as well as returned (agenticos#342).
+        assert refused.value.details == {"field": "base_url"}
+
+    async def test_an_address_carrying_a_password_is_refused_before_it_is_stored(self):
+        """A `user:pass@` here would be echoed back by every refusal below.
+
+        The service names the address it could not reach in `message`, and the
+        handler logs `message` and `details` together - so an address allowed to
+        carry a credential is a credential written to the deployment's log the
+        first time the port is wrong. It is refused at the schema instead, which
+        is where `validate_endpoint_url` and `validate_webhook_url` refuse it.
+        """
+        with pytest.raises(ValidationError) as refused:
+            SandboxProbeRequest(base_url="http://svc:hunter2@sandboxd:8080", secret_id=uuid.uuid4())
+
+        assert "must not carry credentials" in str(refused.value)
 
 
 class TestReadingTheSessions:

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -106,6 +106,25 @@ string form, a `datetime` in ISO 8601, an `Enum` as its value. Money is the
 exception worth knowing: a `Decimal` encodes to a float, so a cost or a cap is
 stringified by the code that raises.
 
+**`details` describes the refusal, not the server.** Everything it holds is read
+by whoever was refused, so it names the field, the id or the resource they can
+act on - never a filesystem path, an upstream client's exception text, a setting's
+*value*, or the caller's own credential echoed back. The diagnosis is not deleted,
+it moves: the path the loader searched and the vendor SDK's message go in the log
+line beside the raise, where an operator reads them and a caller does not.
+
+```python
+except Exception as exc:
+    logger.exception("Knowledge base search failed")   # the upstream text stays here
+    raise ExternalServiceError(
+        message="Knowledge base search failed",
+        details={"collections": names, "operation": "retrieve"},
+    ) from exc
+```
+
+The same applies to an audit entry, which is `details` with a longer life: record
+*which* fields an administrator changed, not the values they submitted.
+
 ## Schema Patterns
 
 Separate schemas for different operations:

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -106,11 +106,13 @@ string form, a `datetime` in ISO 8601, an `Enum` as its value. Money is the
 exception worth knowing: a `Decimal` encodes to a float, so a cost or a cap is
 stringified by the code that raises.
 
-**`details` describes the refusal, not the server.** Everything it holds is read
-by whoever was refused, so it names the field, the id or the resource they can
-act on - never a filesystem path, an upstream client's exception text, a setting's
-*value*, or the caller's own credential echoed back. The diagnosis is not deleted,
-it moves: the path the loader searched and the vendor SDK's message go in the log
+**A refusal describes the refusal, not the server.** Everything in `details` is
+read by whoever was refused, so it names the field, the id or the resource they
+can act on - never a filesystem path, an upstream client's exception text, or a
+setting whose value describes the deployment rather than a limit the caller is
+being held to (`max_mb` and `seats_limit` are exactly what a caller can act on;
+where the container keeps its templates is not). The diagnosis is not deleted, it
+moves: the path the loader searched and the vendor SDK's message go in the log
 line beside the raise, where an operator reads them and a caller does not.
 
 ```python
@@ -121,6 +123,11 @@ except Exception as exc:
         details={"collections": names, "operation": "retrieve"},
     ) from exc
 ```
+
+`message` is held to the same bar - the envelope carries it and the handler logs
+it on the same line, so a sentence naming the endpoint leaks whatever the field
+was refused for carrying. A URL the refusal is *about* is named by its field:
+`{"field": "base_url"}`, never the endpoint with the password still in it.
 
 The same applies to an audit entry, which is `details` with a longer life: record
 *which* fields an administrator changed, not the values they submitted.


### PR DESCRIPTION
A domain exception's `details` is serialized into the response body, so what a
service puts there is what the person refused reads — and since #326 it reliably
reaches the wire, which is what makes this worth fixing now. #342 named two call
sites putting the server there instead of the refusal. Fixing the class meant
reading **all 301 `details=` sites in `backend/app`**, plus every `message=` that
interpolates an exception, a path or a setting.

Five sites changed. The diagnosis is not deleted anywhere — it moves into the log
line beside the raise.

| Site | Was | Is |
|---|---|---|
| `agents/capabilities/knowledge/_search.py:105` | `{"query": …, "error": str(e)}` on a 503 | `{"collections": […], "operation": "retrieve"}`; the upstream text stays in the `logger.exception` that was already there |
| `services/email/templates.py:38` | `{"searched_from": "/abs/container/path"}` on a 500 | `{"directory": "emails/compiled"}`; the search origin moves to a new log line — the module had no logger at all |
| `services/email/templates.py:47` | `{"path": "/abs/container/path"}` | `{"template": key, "format": ext}` |
| `services/model_profile.py:81,85,93,166` | `{"base_url": url}` in all four | `{"field": "base_url"}` — one of those refusals exists *because* the URL carries a password, and the handler logs `details` as well as serializing it |
| `api/routes/v1/admin_users.py:57` | `user_in.model_dump(exclude_unset=True)` into the audit entry | `{"fields": sorted(user_in.model_fields_set)}` |

`str(e)` on an embedding client is not a controlled string: provider SDKs put the
failing request in the message, and a URL carries a key in its query string.

## Two bugs found on the way, both fixed here

Kacper asked for these in this pull request rather than deferred; both are filed
so the defect is recorded rather than only mentioned in a diff.

- **[#412](https://github.com/vstorm-co/agenticos/issues/412) — an admin's password
  reset was written to the audit trail in plaintext.** `UserUpdate` carries
  `password`, so `PATCH /admin/users/{id}` stored what the administrator typed in
  `app_admin_audit_logs.details`, a JSONB column that outlives the session. An
  audit entry is `details` with a longer life, which is why it belongs in this
  branch. `severity:high`.
- **A sandbox address could carry a password, and every refusal repeated it.**
  `probe_policy` passed `details={"base_url": data.base_url}` straight from the
  request body while `_check_shape` sixteen lines below already answered
  `{"field": "base_url"}` — and `ServiceAddress`, unlike `validate_endpoint_url`
  and `validate_webhook_url`, did not refuse userinfo. So
  `http://svc:hunter2@sandboxd:8080` validated, reached the response, and reached
  the log line. Fixed at the schema rather than at each reporter; a connection
  authenticates with a vault-held token, so there is nothing a `user:pass@` here
  can be for. Found reviewing this branch's own diff, so no separate issue — the
  commit body carries it.

## Found and deliberately left

- **[#423](https://github.com/vstorm-co/agenticos/issues/423) — filed, and not
  this branch's to fix.**
  The same `str(exc)`, from the same embedding client, taken through *ingestion*
  is stored in `rag_documents.error_message` and rendered verbatim on the
  documents page. Nine call sites across the worker, the ingestion service and a
  CLI command, all template-inherited and outside the coverage gate, plus a
  decision about what the column should carry and a frontend that renders it.
  That is its own change, not a line in a branch about `details`.
- `services/rag/vectorstore.py:258` keeps `{"collection": name, "table": …}`. The
  table is `rag_` plus the collection name the caller supplied and the prefix is
  documented — it describes nothing the caller did not provide.
- `services/sandbox_workspace.py:774,879` keeps `message=_reason(exc)`, which is
  the sandbox backend's own text. Its docstring defends it: for the commonest
  cause it names `workspace_root`, the difference between a one-line fix and a bug
  report. It is our own component, not a vendor SDK. Worth revisiting, not worth
  changing blind.
- `services/mcp_connection.py:654` keeps the server URL in its audit entry, as its
  comment already adjudicates: `validate_mcp_url` refuses userinfo and the URL is
  on the row anyway.
- `_search.py` keeps `"operation"` even though it is derivable from the length of
  `collections`, because #342 asks for "the collection and the operation" and that
  is the issue's own definition of fixed.

## Verification — CI could not run

**GitHub Actions has been in a major outage since 15:22 UTC** — recovering, but
finishing nothing — and the automated reviewer is off (#311/#313), so the label
does nothing either. Nothing here was checked by CI. Locally, against a real
`pgvector/pgvector:pg16`:

- `make test` — **3411 passed, 6 skipped, coverage 100.00%** on the platform layer.
- `make lint-backend` — clean apart from the two findings of **#407**, which are
  pre-existing on `main` and fixed in #426. Nothing in this diff is flagged:
  `ruff check` over the paths it touches, `ruff format --check`, and `ty` are all
  clean.
- `make lint-frontend`, both guards (`check_backticks`, `check_i18n`) and
  `codespell` — pass.
- `python3 scripts/docs_drift.py` — no drift.

A full `make check` was started three times and never finished: eight worktrees
were sharing one Postgres at load 40 (#215) and a run was taking seventeen
minutes, so the halves covering this diff were run instead. **`e2e` was not run**
(needs a seeded backend), and no frontend code changed.

**Each new test fails without its fix**, checked by reverting the change under it:
the knowledge-search one on the API key in the 503 body, the email pair on the
`tmp_path` in the 500, the audit one on `{"password": "correct-horse-battery"}` in
the entry. The wire tests raise from the real call site and carry the exception
through the app, because what a service passes and what a caller reads are two
different assertions and only the second is the defect.

The maintainer pass is mine, not the reviewer's: a subagent was given the diff and
the categories to hunt in, and everything under "found on the way" plus half the
test cleanups came from it.

Neighbouring work: **#418** (the Drive connector) was read before this branch went
near anything RAG-shaped — it lands `details={"field": …}` on the same instinct, and
the two do not overlap. Its `docs/patterns.md` hunk is a different section.

## Docs

`docs/patterns.md` and `.claude/rules/exceptions-security.md` say the rule the code
now follows, covering `message` as well as `details` — the envelope carries both and
the handler logs both on one line.

Closes #342
Closes #412
