### PR TITLE
fix(vault): check secrets:edit inside the inline secret form

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -799,7 +799,7 @@
     "modelPicker": {
       "chooseProvider": "Choose a provider",
       "model": "Model",
-      "noProviderKey": "No {provider} key in the vault yet. Add one below.",
+      "noProviderKey": "No {provider} key in the vault yet.",
       "provider": "Provider",
       "runModel": "Run on this model"
     },
@@ -2991,6 +2991,7 @@
     "shownNextPickerWhich": "Shown next to the picker - which account this is, whose it is, anything the next person needs.",
     "storeSecret": "Store secret",
     "storedOrganizationAposS": "Stored in this organization's vault, encrypted, and never shown again.",
+    "storingNeedsPermission": "Storing a key needs a permission you do not hold. Somebody who can manage this organization's vault has to add it.",
     "usedBy": "Used by",
     "visibilityOrg": "Organization",
     "visibilityPrivate": "Private",

--- a/frontend/src/components/agents/capability-settings.integration.test.tsx
+++ b/frontend/src/components/agents/capability-settings.integration.test.tsx
@@ -7,6 +7,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CapabilitySettings } from "./capability-settings";
 import { ApiError, apiClient } from "@/lib/api-client";
 import type { CapabilityBindingSpec, CapabilityCatalogEntry } from "@/types/agents";
+import { Perm } from "@/types/permissions";
+import type { Permission } from "@/types/permissions";
 import type { Secret } from "@/types/secrets";
 
 vi.mock("@/lib/api-client", async () => {
@@ -87,11 +89,23 @@ function wrapper({ children }: { children: ReactNode }) {
   return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
 }
 
+/** What the caller may do. Storing a key from this card is `secrets:edit`. */
+const state = { permissions: [] as Permission[] };
+
 /** The vault answers with these. */
 function serve(secrets: Secret[]) {
   vi.mocked(apiClient.get).mockImplementation(async (path: string) => {
     if (path === "/secrets") return { items: secrets, total: secrets.length };
     if (path === "/secrets/kinds") return { items: [], total: 0 };
+    // A list shape here is not "no permissions", it is a `TypeError` inside
+    // `usePermissions`.
+    if (path === "/me/permissions")
+      return {
+        organization_id: "org-1",
+        role: "builder",
+        is_app_admin: false,
+        permissions: state.permissions.map((permission) => ({ permission, scope: "all" })),
+      };
     throw new Error(`unexpected GET ${path}`);
   });
 }
@@ -131,6 +145,7 @@ const picker = () => screen.getByLabelText("Secret");
 
 beforeEach(() => {
   vi.clearAllMocks();
+  state.permissions = [Perm.secretsEdit];
 });
 
 /**
@@ -187,7 +202,23 @@ describe("CapabilitySettings secret picker", () => {
 
     expect(await screen.findByText("No api_key secret in the vault")).toBeInTheDocument();
     expect(picker()).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Add a key: Weather" })).toBeInTheDocument();
+    // Awaited, not read: the form is a vault write, so it waits for the caller's
+    // permissions the way `usePermissions` waits for anything - answering false
+    // until it knows, rather than offering a control it may have to take back.
+    expect(await screen.findByRole("button", { name: "Add a key: Weather" })).toBeInTheDocument();
+  });
+
+  it("offers no such form to a caller who may not write to the vault", async () => {
+    // Binding a capability is `agents:edit`; storing the key it calls with is
+    // `secrets:edit`. A member holding the first and not the second was shown the
+    // form and refused by `POST /secrets` after pasting a key in (#361).
+    state.permissions = [];
+    serve([AWS_SECRET]);
+    mount(binding());
+
+    expect(await screen.findByText("No api_key secret in the vault")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Add a key: Weather" })).toBeNull();
+    expect(screen.getByText(/permission you do not hold/)).toBeInTheDocument();
   });
 
   it("binds the secret that was chosen, by id", async () => {

--- a/frontend/src/components/agents/observability-card.test.tsx
+++ b/frontend/src/components/agents/observability-card.test.tsx
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ObservabilityCard } from "./observability-card";
 import type { ObservabilitySpec } from "@/types/agents";
+import { Perm } from "@/types/permissions";
+import type { Permission } from "@/types/permissions";
 
 interface Secret {
   id: string;
@@ -18,9 +20,17 @@ const state = {
   // The inline form writes through `useSecrets().create`, and what this card owes
   // it is the callback: a key added there is the key selected here.
   create: { mutate: vi.fn(), isPending: false },
+  // And whether it may write at all: storing the token is `secrets:edit`, which
+  // an agent editor need not hold.
+  permissions: [] as Permission[],
 };
 
-vi.mock("@/hooks", () => ({ useSecrets: () => state }));
+vi.mock("@/hooks", () => ({
+  useSecrets: () => state,
+  usePermissions: () => ({
+    can: (permission: Permission) => state.permissions.includes(permission),
+  }),
+}));
 
 function secret(overrides: Partial<Secret> = {}): Secret {
   return {
@@ -43,6 +53,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   state.secrets = [secret()];
   state.create = { mutate: vi.fn(), isPending: false };
+  state.permissions = [Perm.secretsEdit];
 });
 
 describe("the tracing card", () => {
@@ -90,6 +101,19 @@ describe("the tracing card", () => {
       screen.getByRole("button", { name: "Add a key: Logfire write token" }),
     ).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open the Vault/ })).toBeInTheDocument();
+  });
+
+  it("offers no such form to somebody who may not write to the vault", () => {
+    // Editing an agent is `agents:edit`; storing the token it traces with is
+    // `secrets:edit`, and this card asked nobody until #361. The picker stays -
+    // the deployment's own project is still a choice - and only the write goes.
+    state.secrets = [];
+    state.permissions = [];
+    mount();
+
+    expect(screen.getByLabelText("Write token")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Add a key: Logfire write token" })).toBeNull();
+    expect(screen.getByText(/permission you do not hold/)).toBeInTheDocument();
   });
 
   it("selects a token added inline, so nobody has to re-pick it", async () => {

--- a/frontend/src/components/chat/chat-model-picker.test.tsx
+++ b/frontend/src/components/chat/chat-model-picker.test.tsx
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ChatModelPicker } from "./chat-model-picker";
 import type { ProviderModel } from "@/hooks/use-model-providers";
+import { Perm } from "@/types/permissions";
+import type { Permission } from "@/types/permissions";
 import type { SecretPurpose } from "@/types/secrets";
 import type { ModelProfile } from "@/types/providers";
 
@@ -11,6 +13,12 @@ const listedProfiles = vi.fn<() => ModelProfile[]>(() => []);
 const listedSecrets = vi.fn<() => { id: string; purpose: string }[]>(() => []);
 const listedModels = vi.fn<() => ProviderModel[]>(() => []);
 const mutateAsync = vi.fn();
+/**
+ * Two permissions, and this picker needs both to be fully usable: choosing a
+ * model creates an organization-wide profile (`connections:manage`), and the key
+ * it runs on is a vault write (`secrets:edit`).
+ */
+const held: { permissions: Permission[] } = { permissions: [] };
 
 vi.mock("@/hooks", () => ({
   useModelProviders: () => ({
@@ -20,6 +28,9 @@ vi.mock("@/hooks", () => ({
   useProviderModels: () => ({ models: listedModels(), source: "curated", isLoading: false }),
   useSecretPurposes: () => ({ purposes: PURPOSES, isLoading: false }),
   useSecrets: () => ({ secrets: listedSecrets(), create: { mutate: vi.fn(), isPending: false } }),
+  usePermissions: () => ({
+    can: (permission: Permission) => held.permissions.includes(permission),
+  }),
 }));
 
 const purpose = (
@@ -62,6 +73,7 @@ beforeEach(() => {
   listedProfiles.mockReturnValue([]);
   listedSecrets.mockReturnValue([]);
   listedModels.mockReturnValue([]);
+  held.permissions = [Perm.connectionsManage, Perm.secretsEdit];
 });
 
 describe("the chat's two-step model picker", () => {
@@ -199,5 +211,33 @@ describe("the chat's two-step model picker", () => {
 
     expect(screen.getByText("Team gpt-5")).toBeInTheDocument();
     expect(screen.getByText("openai · gpt-5")).toBeInTheDocument();
+  });
+});
+
+describe("storing the key the chosen model runs on", () => {
+  /**
+   * `POST /secrets` is `secrets:edit`, which is not what lets somebody open this
+   * popover - so a member who may run an agent was offered the form and refused
+   * after pasting a key in (#361).
+   */
+
+  it("offers the key form to a caller who may write to the vault", async () => {
+    render(<ChatModelPicker value={null} onChange={vi.fn()} />);
+    await pickProvider("OpenAI");
+
+    expect(screen.getByRole("button", { name: "Add a key: OpenAI" })).toBeInTheDocument();
+  });
+
+  it("keeps the model form and drops only the key form without secrets:edit", async () => {
+    // The two are separable: `connections:manage` really does allow defining a
+    // profile on a key somebody else stored, and taking the whole picker away
+    // for want of `secrets:edit` would refuse something they hold.
+    held.permissions = [Perm.connectionsManage];
+    render(<ChatModelPicker value={null} onChange={vi.fn()} />);
+    await pickProvider("OpenAI");
+
+    expect(screen.getByRole("button", { name: "Run on this model" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Add a key: OpenAI" })).toBeNull();
+    expect(screen.getByText(/permission you do not hold/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/kb/create-kb-dialog.integration.test.tsx
+++ b/frontend/src/components/kb/create-kb-dialog.integration.test.tsx
@@ -6,6 +6,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CreateKBDialog } from "./create-kb-dialog";
 import { apiClient } from "@/lib/api-client";
+import { Perm } from "@/types/permissions";
+import type { Permission } from "@/types/permissions";
 
 /**
  * The Embeddings section of Create knowledge base, as somebody reading it sees it.
@@ -62,8 +64,17 @@ async function openParsing() {
   await userEvent.click(screen.getByText("How documents are parsed"));
 }
 
+/** What the caller may do, which decides whether either key can be stored here. */
+const state = { permissions: [] as Permission[] };
+
+/** Mount the dialog. Called by each test, so a test can set the caller up first. */
+function show() {
+  render(<CreateKBDialog open onOpenChange={vi.fn()} />, { wrapper });
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
+  state.permissions = [Perm.connectionsManage, Perm.secretsEdit];
   vi.mocked(apiClient.get).mockImplementation(async (path: string) => {
     if (path === "/secrets") return SECRETS;
     if (path === "/rag/embedding-models") return EMBEDDING_MODELS;
@@ -75,10 +86,7 @@ beforeEach(() => {
         organization_id: "org-1",
         role: "builder",
         is_app_admin: false,
-        permissions: [
-          { permission: "connections:manage", scope: "all" },
-          { permission: "secrets:edit", scope: "all" },
-        ],
+        permissions: state.permissions.map((permission) => ({ permission, scope: "all" })),
       };
     if (path === "/providers/catalog")
       return {
@@ -110,11 +118,11 @@ beforeEach(() => {
     if (path === "/providers/openai/models") return { items: [], total: 0, source: null };
     return { items: [], total: 0 };
   });
-  render(<CreateKBDialog open onOpenChange={vi.fn()} />, { wrapper });
 });
 
 describe("the embedding key picker", () => {
   it("draws the mark for every key it offers, and its masked tail", async () => {
+    show();
     await openEmbeddings();
     await userEvent.click(screen.getByLabelText("Key"));
 
@@ -127,6 +135,7 @@ describe("the embedding key picker", () => {
     // `EmbeddingService` sends every embedding request to openrouter.ai, on the
     // deployment's key when a collection names none - so the two rows are the
     // same service and reading as two different things was the bug.
+    show();
     await openEmbeddings();
     await userEvent.click(screen.getByLabelText("Key"));
 
@@ -136,6 +145,7 @@ describe("the embedding key picker", () => {
   });
 
   it("offers no key that cannot pay for embeddings", async () => {
+    show();
     await openEmbeddings();
     await userEvent.click(screen.getByLabelText("Key"));
 
@@ -143,6 +153,7 @@ describe("the embedding key picker", () => {
   });
 
   it("shows the selected key's mark on the closed trigger", async () => {
+    show();
     await openEmbeddings();
 
     expect(markIn(screen.getByLabelText("Key"))).toBe("OpenRouter");
@@ -157,6 +168,7 @@ describe("the embedding model picker", () => {
     // Radix select before its options exist writes the value onto a hidden
     // native `<select>` with no matching `<option>`, reads `""` back out of the
     // change event, and hands that to `onValueChange`, which is `setState`.
+    show();
     await openEmbeddings();
 
     expect(await screen.findByLabelText("Model")).toHaveTextContent("text-embedding-3-large");
@@ -167,11 +179,14 @@ describe("the embedding model picker", () => {
     // Asserted before the query resolves, which is the state the placeholder is
     // for: no select at all, because one whose value arrives after its options
     // is the bug above.
+    show();
+
     expect(screen.getByText("Loading models…")).toBeInTheDocument();
     expect(screen.queryByLabelText("Model")).toBeNull();
   });
 
   it("draws the mark of the key that pays, beside every model id", async () => {
+    show();
     await openEmbeddings();
     await userEvent.click(screen.getByLabelText("Model"));
 
@@ -181,6 +196,7 @@ describe("the embedding model picker", () => {
   });
 
   it("says which model an untouched deployment would use, in the list", async () => {
+    show();
     await openEmbeddings();
     await userEvent.click(screen.getByLabelText("Model"));
 
@@ -199,6 +215,7 @@ describe("the two keys this dialog can store", () => {
    */
 
   it("names each of them, so neither of them is just 'a key'", async () => {
+    show();
     await openEmbeddings();
     await openParsing();
     await userEvent.click(screen.getByLabelText("Describe images"));
@@ -211,5 +228,25 @@ describe("the two keys this dialog can store", () => {
       screen.getByRole("button", { name: "Add a key: OpenRouter (embeddings)" }),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Add a key: OpenAI" })).toBeInTheDocument();
+  });
+
+  it("offers neither to a caller who may not write to the vault", async () => {
+    // `collections:edit` is what opens this dialog; storing the embedding key is
+    // `secrets:edit`, and a member holding the first and not the second was shown
+    // both forms and refused by `POST /secrets` after pasting a key in (#361).
+    state.permissions = [Perm.connectionsManage];
+    show();
+    await openEmbeddings();
+    await openParsing();
+    await userEvent.click(screen.getByLabelText("Describe images"));
+    await userEvent.click(await screen.findByLabelText("Provider"));
+    await userEvent.click(screen.getByRole("option", { name: /OpenAI/ }));
+
+    expect(screen.queryByRole("button", { name: "Add a key: OpenRouter (embeddings)" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Add a key: OpenAI" })).toBeNull();
+    // Two sentences, not silence, one per offer: the inline form says it here,
+    // and the model panel says it in its own words because a disabled Add model
+    // with nothing beside it explains nothing.
+    expect(screen.getAllByText(/permission you do not hold/)).toHaveLength(2);
   });
 });

--- a/frontend/src/components/kb/create-kb-dialog.test.tsx
+++ b/frontend/src/components/kb/create-kb-dialog.test.tsx
@@ -41,14 +41,18 @@ describe("CreateKBDialog", () => {
     // Every list this dialog reads is empty, except the one that is not a list:
     // `/rag/embedding-models` answers `{default, models}`, and the model select
     // is built from it rather than tolerating whatever arrives.
-    vi.mocked(apiClient.get).mockImplementation(async (path: string) =>
-      path === "/rag/embedding-models"
-        ? {
-            default: "text-embedding-3-large",
-            models: [{ model: "text-embedding-3-large", dim: 3072 }],
-          }
-        : { items: [], total: 0 },
-    );
+    vi.mocked(apiClient.get).mockImplementation(async (path: string) => {
+      if (path === "/rag/embedding-models")
+        return {
+          default: "text-embedding-3-large",
+          models: [{ model: "text-embedding-3-large", dim: 3072 }],
+        };
+      // Nor is `/me/permissions`, which the two key forms read: a list shape
+      // there is a `TypeError` in `usePermissions`, not "no permissions".
+      if (path === "/me/permissions")
+        return { organization_id: "org-1", role: "member", is_app_admin: false, permissions: [] };
+      return { items: [], total: 0 };
+    });
     vi.mocked(apiClient.post).mockResolvedValue({ id: "kb-1", name: "Handbook" });
     render(<CreateKBDialog open onOpenChange={vi.fn()} />, { wrapper });
   });

--- a/frontend/src/components/kb/ingestion-settings.integration.test.tsx
+++ b/frontend/src/components/kb/ingestion-settings.integration.test.tsx
@@ -123,6 +123,18 @@ function show(modelProfileId: string | null = null, disabled = false) {
   );
 }
 
+/** The form with LlamaParse chosen, which is what renders its key picker. */
+function showLlamaParse() {
+  render(
+    <IngestionSettings
+      idPrefix="test"
+      value={{ ...DEFAULT_INGESTION_CONFIG, pdf_parser: "llamaparse" }}
+      onChange={vi.fn()}
+    />,
+    { wrapper },
+  );
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   state.profiles = [profile()];
@@ -227,5 +239,33 @@ describe("the model that describes the images", () => {
 
     await waitFor(() => expect(screen.getByText("Use a saved model (1)")).toBeInTheDocument());
     expect(screen.queryByRole("button", { name: /^Remove/ })).toBeNull();
+  });
+});
+
+describe("the LlamaParse key", () => {
+  /**
+   * The second vault write this panel offers, and a different one: it says whose
+   * account each parse is billed to. It reads the same permission as every other
+   * one - `POST /secrets` is `secrets:edit` whichever form posted it - and until
+   * #361 it asked nobody.
+   */
+
+  it("can be stored here rather than in another tab", async () => {
+    showLlamaParse();
+
+    expect(
+      await screen.findByRole("button", { name: "Add a key: LlamaParse" }),
+    ).toBeInTheDocument();
+  });
+
+  it("is not offered to a caller who may not write to the vault", async () => {
+    state.permissions = [Perm.collectionsEdit];
+    showLlamaParse();
+
+    // The picker itself stays - the deployment's own key is still a choice
+    // somebody with `collections:edit` may make - and only the write goes.
+    expect(await screen.findByLabelText("LlamaParse key")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Add a key: LlamaParse" })).toBeNull();
+    expect(screen.getByText(/permission you do not hold/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/kb/ingestion-settings.test.tsx
+++ b/frontend/src/components/kb/ingestion-settings.test.tsx
@@ -93,13 +93,32 @@ describe("IngestionSettings", () => {
     // Both are called after the service they are for, because that is what the
     // inline form suggests - so with only a name in the row, "whose account is
     // billed" was a choice between two identical options.
-    vi.mocked(apiClient.get).mockResolvedValue({
-      items: [
-        { id: "s-1", name: "LlamaParse", hint: "3123", purpose: "llamaparse", kind: "api_key" },
-        { id: "s-2", name: "LlamaParse", hint: "9999", purpose: "llamaparse", kind: "api_key" },
-      ],
-      total: 2,
-    });
+    // Per path rather than for every one of them: the key form beside this
+    // picker reads `/me/permissions`, and a list shape there is a `TypeError`
+    // in `usePermissions` rather than "no permissions".
+    vi.mocked(apiClient.get).mockImplementation(async (path: string) =>
+      path === "/me/permissions"
+        ? { organization_id: "org-1", role: "member", is_app_admin: false, permissions: [] }
+        : {
+            items: [
+              {
+                id: "s-1",
+                name: "LlamaParse",
+                hint: "3123",
+                purpose: "llamaparse",
+                kind: "api_key",
+              },
+              {
+                id: "s-2",
+                name: "LlamaParse",
+                hint: "9999",
+                purpose: "llamaparse",
+                kind: "api_key",
+              },
+            ],
+            total: 2,
+          },
+    );
     show({ pdf_parser: "llamaparse" });
 
     await userEvent.click(screen.getByLabelText("LlamaParse key"));

--- a/frontend/src/components/sandboxes/connection-dialog.integration.test.tsx
+++ b/frontend/src/components/sandboxes/connection-dialog.integration.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ConnectionDialog } from "./connection-dialog";
+import { Perm } from "@/types/permissions";
+import type { Permission } from "@/types/permissions";
+
+/**
+ * The vault write this dialog offers, with the real form rather than a stand-in.
+ *
+ * `connection-dialog.test.tsx` mocks `InlineSecret` away, which is right for
+ * everything it asserts - what the dialog owes the form is a callback - and is
+ * exactly why the missing permission check survived there. This renders the real
+ * one, so the two halves of #361 are asserted on the surface that has them:
+ * storing a sandbox provider's key is `secrets:edit`, and this dialog exists for
+ * `connections:manage`.
+ */
+
+const state = vi.hoisted(() => ({
+  permissions: [] as Permission[],
+  create: { mutate: vi.fn(), isPending: false },
+}));
+
+vi.mock("@/hooks", () => ({
+  useSecrets: () => ({ secrets: [], create: state.create }),
+  useLocalSandboxService: () => ({
+    local: null,
+    runtimes: [],
+    isLoading: false,
+    storeCredential: vi.fn(),
+    probe: vi.fn(),
+  }),
+  usePermissions: () => ({
+    can: (permission: Permission) => state.permissions.includes(permission),
+  }),
+}));
+
+function mount() {
+  render(
+    <ConnectionDialog
+      editing={null}
+      onOpenChange={vi.fn()}
+      onSubmit={vi.fn().mockResolvedValue(undefined)}
+    />,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.permissions = [Perm.connectionsManage, Perm.secretsEdit];
+  state.create = { mutate: vi.fn(), isPending: false };
+});
+
+describe("storing a sandbox service's token from the connection dialog", () => {
+  it("offers the form to a caller who may write to the vault", () => {
+    mount();
+
+    expect(
+      screen.getByRole("button", { name: "Add a key: Sandbox service token" }),
+    ).toBeInTheDocument();
+  });
+
+  it("offers none without secrets:edit, and says who can", () => {
+    // `connections:manage` is what opens this dialog; the token it authenticates
+    // with is a separate write, and an operator registering a service somebody
+    // else's key already covers holds the first and not the second.
+    state.permissions = [Perm.connectionsManage];
+    mount();
+
+    expect(screen.queryByRole("button", { name: "Add a key: Sandbox service token" })).toBeNull();
+    // The credential picker stays: choosing a key that is already stored is not
+    // a write, and the dialog is still usable for one.
+    expect(screen.getByLabelText("Credential")).toBeInTheDocument();
+    expect(screen.getByText(/permission you do not hold/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/vault/inline-secret.test.tsx
+++ b/frontend/src/components/vault/inline-secret.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { InlineSecret } from "./inline-secret";
+import { Perm } from "@/types/permissions";
+import type { Permission } from "@/types/permissions";
 
 /**
  * What the button that opens the inline vault form is called.
@@ -14,9 +16,18 @@ import { InlineSecret } from "./inline-secret";
  * finished.
  */
 
+const held: { permissions: Permission[] } = { permissions: [] };
+
 vi.mock("@/hooks", () => ({
   useSecrets: () => ({ create: { mutate: vi.fn(), isPending: false } }),
+  usePermissions: () => ({
+    can: (permission: Permission) => held.permissions.includes(permission),
+  }),
 }));
+
+beforeEach(() => {
+  held.permissions = [Perm.secretsEdit];
+});
 
 function mount(suggestedName: string) {
   render(
@@ -45,5 +56,44 @@ describe("the inline vault form's button", () => {
 
     expect(screen.getByRole("button", { name: "Add a key: Daytona API key" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /key key/ })).toBeNull();
+  });
+});
+
+describe("who is offered the form at all", () => {
+  /**
+   * The write is `POST /secrets`, which is `Perm.SECRETS_EDIT` and nothing else -
+   * the same permission whichever page rendered this. So the check lives here
+   * rather than at seven call sites, six of which had forgotten it (#361), and a
+   * caller who cannot make the write is told so instead of finding out from a
+   * 403 after pasting a key in.
+   */
+
+  it("offers it to a caller holding secrets:edit", () => {
+    mount("OpenAI");
+
+    expect(screen.getByRole("button", { name: "Add a key: OpenAI" })).toBeInTheDocument();
+    expect(screen.queryByText(/permission you do not hold/)).toBeNull();
+  });
+
+  it("offers no form, and says why, without it", () => {
+    held.permissions = [];
+    mount("OpenAI");
+
+    expect(screen.queryByRole("button", { name: "Add a key: OpenAI" })).toBeNull();
+    // Paired with the sentence deliberately: rendering nothing at all would
+    // satisfy the `toBeNull` above and leave the picker beside it a blank gap
+    // with no account of itself, which is the state this component exists to
+    // remove.
+    expect(screen.getByText(/permission you do not hold/)).toBeInTheDocument();
+  });
+
+  it("offers no way to the Vault page either, which refuses the same write", () => {
+    // The link is unconditional for a caller who may write: it is where the
+    // shapes this form cannot store are stored. For one who may not, it is a
+    // second door onto the same refusal.
+    held.permissions = [];
+    mount("OpenAI");
+
+    expect(screen.queryByRole("link", { name: /Open the Vault/ })).toBeNull();
   });
 });

--- a/frontend/src/components/vault/inline-secret.test.tsx
+++ b/frontend/src/components/vault/inline-secret.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { InlineSecret } from "./inline-secret";
@@ -17,25 +18,29 @@ import type { Permission } from "@/types/permissions";
  */
 
 const held: { permissions: Permission[] } = { permissions: [] };
+/** The write itself. Hoisted so a test can assert it was never sent. */
+const storeKey = vi.hoisted(() => vi.fn());
 
 vi.mock("@/hooks", () => ({
-  useSecrets: () => ({ create: { mutate: vi.fn(), isPending: false } }),
+  useSecrets: () => ({ create: { mutate: storeKey, isPending: false } }),
   usePermissions: () => ({
     can: (permission: Permission) => held.permissions.includes(permission),
   }),
 }));
 
 beforeEach(() => {
+  vi.clearAllMocks();
   held.permissions = [Perm.secretsEdit];
 });
 
-function mount(suggestedName: string) {
-  render(
+function mount(suggestedName: string, disabled = false) {
+  return render(
     <InlineSecret
       kind="api_key"
       purpose="openai"
       suggestedName={suggestedName}
       onCreated={vi.fn()}
+      disabled={disabled}
     />,
   );
 }
@@ -95,5 +100,50 @@ describe("who is offered the form at all", () => {
     mount("OpenAI");
 
     expect(screen.queryByRole("link", { name: /Open the Vault/ })).toBeNull();
+  });
+});
+
+describe("a surface that has gone read-only under an open form", () => {
+  /**
+   * `disabled` is what a caller passes when its own form may no longer be
+   * written to - a dialog mid-save (`ingestion-dialog.tsx` passes `isSaving`,
+   * `create-kb-dialog.tsx` passes `isSubmitting`), a panel somebody may only
+   * read. It gated the button that *opens* this form and nothing else, so a
+   * form already open kept an enabled Save and stored an organization-wide
+   * secret out from under the surface that had just said no. Same shape as the
+   * permission gate above: the check belongs on the write, not on the way in.
+   */
+
+  it("does not store a key once the caller has disabled the form", async () => {
+    const { rerender } = mount("OpenAI");
+    await userEvent.click(screen.getByRole("button", { name: "Add a key: OpenAI" }));
+    await userEvent.type(screen.getByLabelText("Key"), "sk-live-1234");
+
+    rerender(
+      <InlineSecret
+        kind="api_key"
+        purpose="openai"
+        suggestedName="OpenAI"
+        onCreated={vi.fn()}
+        disabled
+      />,
+    );
+
+    const save = screen.getByRole("button", { name: "Save key" });
+    expect(save).toBeDisabled();
+    await userEvent.click(save);
+    expect(storeKey).not.toHaveBeenCalled();
+  });
+
+  it("still stores it when nothing has said otherwise", async () => {
+    mount("OpenAI");
+    await userEvent.click(screen.getByRole("button", { name: "Add a key: OpenAI" }));
+    await userEvent.type(screen.getByLabelText("Key"), "sk-live-1234");
+    await userEvent.click(screen.getByRole("button", { name: "Save key" }));
+
+    expect(storeKey).toHaveBeenCalledWith(
+      { name: "OpenAI", value: { kind: "api_key", api_key: "sk-live-1234" }, purpose: "openai" },
+      expect.anything(),
+    );
   });
 });

--- a/frontend/src/components/vault/inline-secret.tsx
+++ b/frontend/src/components/vault/inline-secret.tsx
@@ -200,10 +200,17 @@ export function InlineSecret({
       </div>
 
       <div className="flex flex-wrap items-center gap-2">
+        {/* `disabled` again, not only on the button that opened this. A caller
+            passes it when its own surface may no longer be written to - a dialog
+            mid-save, a panel somebody may only read - and gating only the way in
+            left a form already open with a live Save, storing an
+            organization-wide secret out from under the surface that had just
+            said no. Same rule as the permission above: the check belongs on the
+            write. */}
         <Button
           type="button"
           size="sm"
-          disabled={create.isPending || !name.trim() || !value.trim()}
+          disabled={disabled || create.isPending || !name.trim() || !value.trim()}
           onClick={submit}
         >
           {t("saveKey")}

--- a/frontend/src/components/vault/inline-secret.tsx
+++ b/frontend/src/components/vault/inline-secret.tsx
@@ -4,8 +4,9 @@ import { useState } from "react";
 import { ExternalLink, Eye, EyeOff, KeyRound, Plus } from "lucide-react";
 
 import { Button, Input, Label } from "@/components/ui";
-import { useSecrets } from "@/hooks";
+import { usePermissions, useSecrets } from "@/hooks";
 import { ROUTES } from "@/lib/constants";
+import { Perm } from "@/types/permissions";
 import type { StorableSecretKind } from "@/types/secrets";
 import { useTranslations } from "next-intl";
 
@@ -62,6 +63,18 @@ interface InlineSecretProps {
  * it is not conditional: a picker that offers only the keys already stored, with
  * nowhere to go when the shape needed is not an opaque token, is a dead end. It
  * opens in a new tab so the half-filled form behind it survives.
+ *
+ * **It checks `secrets:edit` itself.** The permission belongs to the write, not to
+ * the surface: every one of these seven call sites posts the same `POST /secrets`,
+ * which is gated on `Perm.SECRETS_EDIT` and on nothing else. A gate at each caller
+ * is the same condition written seven times and forgotten six of them - which is
+ * exactly what happened, and is #361. The counter-argument was that a caller's own
+ * lead-in sentence goes wrong once the form disappears; that is true of one caller,
+ * `AddModel`, which already chooses its sentence on the same permission and so
+ * decides for itself whether to render this at all. The other six say something
+ * that stays true either way ("this key bills embeddings", "stored in the vault
+ * under Tracing"), so a refusal here is a line replacing a button rather than a
+ * panel going quiet.
  */
 export function InlineSecret({
   kind,
@@ -73,10 +86,19 @@ export function InlineSecret({
 }: InlineSecretProps) {
   const t = useTranslations("vault");
   const { create } = useSecrets();
+  const { can } = usePermissions();
   const [open, setOpen] = useState(false);
   const [name, setName] = useState(suggestedName);
   const [value, setValue] = useState("");
   const [revealed, setRevealed] = useState(false);
+
+  // Before the button, not on it: a disabled control still says "you could do
+  // this", and the answer here is that somebody else has to. Said rather than
+  // rendered blank, because the picker above it is empty for the same reason and
+  // a silent gap is the state this component was written to remove.
+  if (!can(Perm.secretsEdit)) {
+    return <p className="text-muted-foreground text-xs">{t("storingNeedsPermission")}</p>;
+  }
 
   if (!open) {
     return (


### PR DESCRIPTION
`InlineSecret` writes an organization-wide vault secret and asked nobody whether
the caller may make that write. Six of its seven call sites offered the key field
to anybody who could see the page and answered 403 from `POST /secrets` after the
key had been pasted in — the collection's embedding key, a LlamaParse key, a
Logfire write token, the chat's model-provider key, a capability's service key,
and a sandbox provider's key. #329 fixed the seventh, `AddModel`, at the call
site.

## Where the gate went, and why

**Inside the component.** The permission belongs to the write, not to the
surface: all seven call sites post the same `POST /secrets`, gated on
`Perm.SECRETS_EDIT` and on nothing else. A gate at each caller is one condition
written seven times and forgotten six of them, which is precisely what happened.

#361 argued for the other shape, on the grounds that each caller wraps the form
in a sentence of its own that goes wrong once the form disappears. Having read
all seven: that is true of exactly one caller, `AddModel`, and it already chooses
its sentence on `can(Perm.secretsEdit)` and so decides for itself whether to
render this at all — unchanged here, including the `disabled` it passes down so a
dialog mid-save cannot still store a secret. The other six say something that
stays true either way ("this key bills embeddings", "stored in the vault under
Tracing", "whose account each parse is billed to"), so a refusal is a line
replacing a button rather than a panel going quiet, and every picker beside it
keeps working: choosing a key somebody else already stored is not a write.

The Vault link goes with the form. It is unconditional for a caller who may
write, because the shapes this form cannot store are stored there; for one who
may not it is a second door onto the same refusal.

One sentence of copy changed with it: `chat.modelPicker.noProviderKey` said "Add
one below", which is a promise the block below no longer keeps for everybody.

## The same reasoning, for whoever takes #419

#419 is this defect one permission over and one component along:
`ChatModelPicker` posts `/providers/model-profiles`, which is
`Perm.CONNECTIONS_MANAGE`, and asks nobody — so an Operator who may run an agent
is offered a provider, a model field and a button that answers 403. **Not fixed
here.** The argument above applies to it unchanged, and #419 now carries it: the
gate belongs inside `ChatModelPicker` rather than in `chat-controls.tsx`, and it
should take the whole form rather than only the submit, because the picker's
reuse path needs a provider-and-model somebody has typed exactly and nothing in
that control lists them. `chat-model-picker.test.tsx` already has the
`usePermissions` mock and the `secrets:edit` pair from this branch, so the
fixture for it is in place.

## Tests

Both directions at every surface, plus the component itself — a caller with
`secrets:edit` sees the form, one without it sees the sentence and no button:

| Surface | Where |
|---|---|
| `InlineSecret` itself | `vault/inline-secret.test.tsx` |
| the collection's embedding key | `kb/create-kb-dialog.integration.test.tsx` |
| the LlamaParse key | `kb/ingestion-settings.integration.test.tsx` |
| the Logfire write token | `agents/observability-card.test.tsx` |
| the capability's service key | `agents/capability-settings.integration.test.tsx` |
| the chat's model-provider key | `chat/chat-model-picker.test.tsx` |
| the sandbox provider's key | `sandboxes/connection-dialog.integration.test.tsx` (new) |

Four sit in a file named `*.integration.test.tsx`; three sit in the sibling
`.test.tsx` that already renders the real component against mocked data — the
same layer as `add-model.integration.test.tsx`, under an older filename, and
renaming them would be blame churn for a naming nit. `connection-dialog.test.tsx`
mocks `InlineSecret` away, which is right for what it asserts and is exactly why
the missing check survived there, so the new file renders the real one.

**Reverting the gate fails exactly the eight refusal tests and nothing else** —
one per surface plus the two on the component. Checked by reverting, not by
reading:

```
FAIL agents/capability-settings.integration.test.tsx > offers no such form to a caller who may not write to the vault
FAIL agents/observability-card.test.tsx             > offers no such form to somebody who may not write to the vault
FAIL chat/chat-model-picker.test.tsx                > keeps the model form and drops only the key form without secrets:edit
FAIL kb/create-kb-dialog.integration.test.tsx       > offers neither to a caller who may not write to the vault
FAIL kb/ingestion-settings.integration.test.tsx     > is not offered to a caller who may not write to the vault
FAIL sandboxes/connection-dialog.integration.test.tsx > offers none without secrets:edit, and says who can
FAIL vault/inline-secret.test.tsx                   > offers no form, and says why, without it
FAIL vault/inline-secret.test.tsx                   > offers no way to the Vault page either, which refuses the same write
```

Each refusal asserts the sentence as well as the absent button: a block that
rendered nothing at all would satisfy the `toBeNull` on its own, and that is a
different bug rather than this fix.

Two test-fixture bugs found on the way and fixed here:
`kb/ingestion-settings.test.tsx` and `kb/create-kb-dialog.test.tsx` answered a
list shape at `/me/permissions`, which is a `TypeError` inside `usePermissions`
rather than "no permissions".

## Verification — CI could not run

**GitHub Actions has been in a major outage since 15:22 UTC**, so this branch has
no checks and will not get any. Local verification is the whole gate. What ran,
from the repository root:

- `make lint-frontend` — eslint, prettier, tsc: clean
- `python3 scripts/check_i18n.py` — clean
- `bunx vitest run` — 193 files, 3259 tests, all passing
- `bun run test:coverage` — the gate CI applies, met
- `make build-frontend`
- `python3 scripts/docs_drift.py` — nothing owed

What did **not** run: `make check` in full, because it stops at
`make lint-backend`, which is **red on `main` and not from this branch** —
`RET501` and `RUF100` in two Python test files, filed as #407 and fixed in #426.
Nothing here touches the backend, so `make test`, `db-check`, `docs-build` and
the audit were not re-run either; the diff is `frontend/` only.

The automated reviewer is off (#311/#313), so the maintainer pass is mine: I read
each of the seven call sites and its surrounding copy before choosing where the
gate goes, swept the siblings of every file touched, and reviewed the diff as a
reviewer would.

Closes #361
