### PR TITLE
fix(rag): a failed ingest says what failed, not where

### DIFF
--- a/.claude/rules/exceptions-security.md
+++ b/.claude/rules/exceptions-security.md
@@ -39,6 +39,19 @@ Exception handlers in `api/exception_handlers.py` automatically:
 - Return consistent JSON error format, `details` included
 - Add `WWW-Authenticate: Bearer` header on 401
 
+**A column that holds a failure takes the same rule, and takes it harder.**
+`rag_documents.error_message`, `sync_logs.error_message` and
+`sync_sources.last_error` are rendered in the product to everyone who can see
+the collection, and a body is read once where a row is read weeks later. So
+`error_message=str(exc)` is the same defect as `details={"error": str(e)}`, and
+`app/services/rag/failures.py` is the answer to it: what the stage was, what
+class of thing raised, and what the reader can do - with the client's own text
+in the `logger.exception` beside the call, never in the column (#423). Our own
+refusals - an `AppException`, a `BudgetExceeded` - are passed through whole,
+because their messages are written in this repository. A bare `RuntimeError`
+we raised is not: one of them interpolates the absolute path of a temporary
+file.
+
 ## Security Patterns
 
 JWT auth (`core/security.py`):

--- a/backend/app/commands/rag.py
+++ b/backend/app/commands/rag.py
@@ -27,6 +27,7 @@ from app.services.embedding_resolution import embeddings_for_collection
 from app.services.rag.config import DEFAULT_COLLECTION_NAME, DocumentExtensions, RAGSettings
 from app.services.rag.documents import DocumentProcessor
 from app.services.rag.embeddings import EmbeddingService
+from app.services.rag.failures import IngestionStage, failure_summary
 from app.services.rag.ingestion import IngestionService
 from app.services.rag.retrieval import RetrievalService
 from app.services.rag.sources.google_drive import GoogleDriveSource
@@ -223,9 +224,16 @@ async def ingest_path_async(
                         )
             except Exception as e:
                 error_count += 1
+                # The operator running this command reads the whole exception on
+                # their own terminal; the row they leave behind is read on the
+                # documents page by anyone in the organization, so it gets the
+                # summary (#423).
                 tqdm.write(f"  ✗ {filepath.name}: {e!s}")
                 async with get_db_context() as db:
-                    await RAGDocumentService(db).fail_ingestion(doc_id, error_message=str(e))
+                    await RAGDocumentService(db).fail_ingestion(
+                        doc_id,
+                        error_message=failure_summary(e, stage=IngestionStage.INGEST),
+                    )
 
     async with get_db_context() as db:
         await RAGSyncService(db).complete_sync(

--- a/backend/app/services/rag/failures.py
+++ b/backend/app/services/rag/failures.py
@@ -12,10 +12,15 @@ weeks later (#423).
 
 So the exception's own text stays in the `logger.exception` beside the call and
 goes no further, and what is stored says which stage gave up, what class of
-thing raised, and what the reader can do about it. Nothing is deleted - the log
-is where an operator already looks, `PiiRedactionFilter` scrubs it on the way
-out, and a flow that re-raises still puts the whole traceback in its Prefect
-run.
+thing raised, and what the reader can do about it. Nothing is deleted: the log
+is where an operator already looks, and a flow that re-raises still puts the
+whole traceback in its Prefect run.
+
+The log is a smaller audience than the column, not a safe one. `setup_logging`
+puts `PiiRedactionFilter` on the *root logger*, where it never sees a record
+from a module logger, and the Prefect worker does not call it at all - so
+nothing scrubs these lines today (#440). That is why the rule here is where the
+text may go, rather than what it is allowed to contain.
 """
 
 from __future__ import annotations

--- a/backend/app/services/rag/failures.py
+++ b/backend/app/services/rag/failures.py
@@ -1,0 +1,105 @@
+"""What a failed ingest is allowed to say, and where the rest of it goes.
+
+`rag_documents.error_message` and `sync_logs.error_message` are stored columns,
+rendered on the documents page and in a source's sync history to every member
+who can see the collection. Both used to hold `str(exc)` from whatever raised -
+an embedding client, `httpx`, `boto3`, the Google Drive client - and a provider
+SDK puts the failing request in its message, which routinely means an endpoint,
+an internal host, a bucket, or a URL with a key in its query string. That is the
+leak #342 fixed in an HTTP body, with a longer life and a wider audience: a body
+is read once by the caller, a column is read by anyone who opens a failed ingest
+weeks later (#423).
+
+So the exception's own text stays in the `logger.exception` beside the call and
+goes no further, and what is stored says which stage gave up, what class of
+thing raised, and what the reader can do about it. Nothing is deleted - the log
+is where an operator already looks, `PiiRedactionFilter` scrubs it on the way
+out, and a flow that re-raises still puts the whole traceback in its Prefect
+run.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from app.agents.capabilities.budget import BudgetExceeded
+from app.core.exceptions import AppException
+
+
+class IngestionStage(Enum):
+    """Which stage of an ingest gave up, and what its reader can do about it.
+
+    The stage is named by the call site rather than inferred, because by the
+    time an exception is caught the only thing that still knows whether the
+    file was being parsed or embedded is the `try` it came out of. Each member
+    carries the sentence stored for it and the advice that follows: two strings
+    on the member rather than two lookup tables, so a stage cannot be added
+    with nothing to say.
+    """
+
+    PARSE = (
+        "The file could not be read",
+        "check that it opens, and that this collection's parser handles the format",
+    )
+    INDEX = (
+        "The document could not be indexed",
+        "check the collection's embedding credential, then retry the upload",
+    )
+    RECORD = (
+        "The document was indexed but its record was not updated",
+        "retry the upload",
+    )
+    INGEST = (
+        "The document could not be ingested",
+        "retry the upload",
+    )
+    SYNC = (
+        "The sync did not finish",
+        "check the source's credential, then run it again",
+    )
+
+    def __init__(self, summary: str, advice: str) -> None:
+        self.summary = summary
+        self.advice = advice
+
+
+def failure_summary(exc: BaseException, *, stage: IngestionStage) -> str:
+    """The sentence a failed ingest may store, for an exception it may not.
+
+    Ours is kept whole. An `AppException` and a `BudgetExceeded` are written in
+    this repository, so their messages are controlled strings - and they are the
+    most useful thing an operator can be shown: "No embedding credential is
+    configured for this collection", "$12.03 spent of a $10.00 limit". Losing
+    those to a generic sentence would answer the question the issue asks about
+    ("is it a credential, the file, or the upstream?") with a shrug.
+
+    Anything else is a foreign `__str__` and only its *type* is safe to store. A
+    class name still carries the diagnosis a reader can act on - whether the
+    upstream timed out, refused the credential or could not open the file - and
+    a class name has never carried an endpoint, a bucket or a key. Note that our
+    own bare `RuntimeError`s count as foreign here, and rightly: the LiteParse
+    wrapper interpolates the absolute path of a temporary file into one.
+
+    A group is unwrapped to its first cause first. The connector and MCP clients
+    run on anyio task groups, so a failure arrives as "unhandled errors in a
+    TaskGroup", which names nothing at all - the same unwrapping
+    `probe_error_message` does in `app/agents/mcp.py`.
+    """
+    cause = _root_cause(exc)
+    if isinstance(cause, AppException | BudgetExceeded):
+        return str(cause)
+    return (
+        f"{stage.summary} ({type(cause).__name__}) - {stage.advice}. "
+        "The worker log has the full error."
+    )
+
+
+def _root_cause(exc: BaseException) -> BaseException:
+    """The first leaf of a nested `BaseExceptionGroup`, or *exc* itself.
+
+    No guard on the group being empty: `BaseExceptionGroup` refuses an empty
+    sequence at construction, so a group always has a first leaf.
+    """
+    while isinstance(exc, BaseExceptionGroup):
+        exc = exc.exceptions[0]
+    return exc

--- a/backend/app/services/rag/ingestion.py
+++ b/backend/app/services/rag/ingestion.py
@@ -8,6 +8,7 @@ from app.core.config import settings
 from app.services.embedding_resolution import embeddings_for_collection
 from app.services.rag.documents import DocumentProcessor
 from app.services.rag.embeddings import EmbeddingService
+from app.services.rag.failures import IngestionStage, failure_summary
 from app.services.rag.models import Document, IngestionResult, IngestionStatus
 from app.services.rag.vectorstore import BaseVectorStore
 from app.services.rag.vectorstore import PgVectorStore as VectorStore
@@ -85,10 +86,21 @@ class IngestionService:
         replace: bool = True,
         source_path: str = "",
     ) -> IngestionResult:
-        """`source_path` accepts URI schemes like gdrive://id or s3://bucket/key."""
+        """`source_path` accepts URI schemes like gdrive://id or s3://bucket/key.
+
+        Parsing and indexing are caught separately so that the failure this
+        returns can say which of the two gave up. It is the one thing the
+        caller cannot work out afterwards, and the difference between a file
+        this collection's parser does not read and an embedding credential the
+        provider refused.
+        """
         try:
             document: Document = await self.processor.process_file(filepath)
+        except Exception as exc:
+            logger.exception("Parsing failed for %s", filepath.name)
+            return self._failed(exc, stage=IngestionStage.PARSE, filename=filepath.name)
 
+        try:
             if source_path:
                 document.metadata.source_path = source_path
                 document.metadata.filename = Path(source_path).name
@@ -134,13 +146,26 @@ class IngestionService:
                 message=f"Successfully {action} '{filepath.name}'",
             )
 
-        except Exception as e:
-            logger.error("Ingestion error for %s: %s", filepath.name, e)
-            return IngestionResult(
-                status=IngestionStatus.ERROR,
-                error_message=str(e),
-                message=f"Failed to process {filepath.name}",
-            )
+        except Exception as exc:
+            logger.exception("Indexing failed for %s", filepath.name)
+            return self._failed(exc, stage=IngestionStage.INDEX, filename=filepath.name)
+
+    @staticmethod
+    def _failed(exc: Exception, *, stage: IngestionStage, filename: str) -> IngestionResult:
+        """The failure a caller may store, for an exception it may not.
+
+        `error_message` reaches `rag_documents` and the documents page, so it
+        carries the stage and the exception's type rather than its text - see
+        `app.services.rag.failures` for why (#423). The text itself is in the
+        `logger.exception` above each call, which also replaced a
+        `logger.error(..., e)` that dropped the traceback: that traceback is now
+        the only full copy of what the upstream said.
+        """
+        return IngestionResult(
+            status=IngestionStatus.ERROR,
+            error_message=failure_summary(exc, stage=stage),
+            message=f"Failed to process {filename}",
+        )
 
     async def find_existing(self, collection_name: str, source_path: str) -> str | None:
         return await self._find_existing_by_source(collection_name, source_path)

--- a/backend/app/worker/background/rag.py
+++ b/backend/app/worker/background/rag.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from app.db.session import get_db_context
 from app.services.rag.connectors import CONNECTOR_REGISTRY
+from app.services.rag.failures import IngestionStage, failure_summary
 from app.services.rag.ingestion import IngestionService
 
 logger = logging.getLogger(__name__)
@@ -39,9 +40,15 @@ async def ingest_document_in_background(
                 rag_document_id, vector_document_id=result.document_id
             )
     except Exception as exc:
-        logger.error("background_ingestion_failed: %s", exc)
+        # Swallowed on purpose - this is the fallback handler, and nothing above
+        # it would report the failure - so this log line is the only copy of the
+        # upstream's own text. What goes on the row is a summary (#423).
+        logger.exception("background_ingestion_failed for %s", source_path)
         async with get_db_context() as db:
-            await RAGDocumentService(db).fail_ingestion(rag_document_id, error_message=str(exc))
+            await RAGDocumentService(db).fail_ingestion(
+                rag_document_id,
+                error_message=failure_summary(exc, stage=IngestionStage.INGEST),
+            )
     finally:
         Path(filepath).unlink(missing_ok=True)
 
@@ -138,5 +145,9 @@ async def sync_source_in_background(source_id: str, sync_log_id: str) -> None:
                 failed=failed,
             )
         except Exception as exc:
-            logger.error("source_sync_failed: %s", exc)
-            await sync_svc.complete_sync(sync_log_id, status="error", error_message=str(exc))
+            logger.exception("source_sync_failed for %s", source_id)
+            await sync_svc.complete_sync(
+                sync_log_id,
+                status="error",
+                error_message=failure_summary(exc, stage=IngestionStage.SYNC),
+            )

--- a/backend/app/worker/tasks/rag_tasks.py
+++ b/backend/app/worker/tasks/rag_tasks.py
@@ -289,11 +289,15 @@ async def _run_ingestion(
                 source_path=source_path,
             )
     except Exception as exc:
-        logger.exception("Indexing failed for %s", source_path)
+        # `ingest_file` reports a failed parse or a failed index by returning
+        # one, so what reaches here escaped the metering window instead - the
+        # budget, or the pipeline itself. Which stage it was is not knowable
+        # from here, and the stage below says so.
+        logger.exception("Ingestion failed for %s", source_path)
         await _update_status(
             rag_document_id,
             "error",
-            error_message=failure_summary(exc, stage=IngestionStage.INDEX),
+            error_message=failure_summary(exc, stage=IngestionStage.INGEST),
         )
         raise
     finally:
@@ -457,12 +461,24 @@ async def _run_sync(
 async def _update_status(
     rag_document_id: str, status: str, error_message: str | None = None
 ) -> None:
+    """Put a status on the document row, and let the first failure keep it.
+
+    One collapse is reported by up to three handlers here: the stage that
+    raised, the check that a *returned* failure is not `done`, and the flow's
+    own backstop - and they run innermost first. The innermost is the specific
+    one ("could not be indexed, check the collection's embedding credential");
+    the outermost only knows the ingest failed. Overwriting therefore replaces
+    the useful sentence with the vague one, which mattered from the moment the
+    column stopped holding the same `str(exc)` at every level (#423).
+    """
     from app.services.rag_document import RAGDocumentService
 
     try:
         async with get_worker_db_context() as db:
             doc_svc = RAGDocumentService(db)
             if status == "error":
+                if (await doc_svc.get_document(rag_document_id)).status == "error":
+                    return
                 await doc_svc.fail_ingestion(
                     rag_document_id, error_message=error_message or "Unknown error"
                 )

--- a/backend/app/worker/tasks/rag_tasks.py
+++ b/backend/app/worker/tasks/rag_tasks.py
@@ -31,6 +31,7 @@ from app.services.ingestion_config import (
 from app.services.rag.config import DocumentExtensions
 from app.services.rag.connectors import CONNECTOR_REGISTRY
 from app.services.rag.embeddings import EmbeddingService
+from app.services.rag.failures import IngestionStage, failure_summary
 from app.services.rag.ingestion import IngestionService
 from app.services.rag.models import IngestionStatus
 from app.services.rag.vectorstore import EmbeddingResolver
@@ -194,15 +195,25 @@ async def ingest_document_flow(
     source_path: str,
     replace: bool = False,
 ) -> dict[str, Any]:
-    """Process a document: parse, chunk, embed, store in vector DB."""
+    """Process a document: parse, chunk, embed, store in vector DB.
+
+    The row this puts an error on is read on the documents page, so what lands
+    there is a summary rather than the exception's own text (#423). The text
+    itself is in this flow's log twice over - the line below, and the traceback
+    Prefect records because the failure is re-raised.
+    """
     logger.info("Starting ingestion: %s -> %s", source_path, collection_name)
     try:
         return await _run_ingestion(
             rag_document_id, collection_name, filepath, source_path, replace
         )
     except Exception as exc:
-        logger.error("Ingestion failed: %s", exc)
-        await _update_status(rag_document_id, "error", error_message=str(exc))
+        logger.exception("Ingestion failed for %s", source_path)
+        await _update_status(
+            rag_document_id,
+            "error",
+            error_message=failure_summary(exc, stage=IngestionStage.INGEST),
+        )
         raise
 
 
@@ -215,8 +226,10 @@ async def sync_collection_flow(
     try:
         return await _run_sync(sync_log_id, source, collection_name, mode, path)
     except Exception as exc:
-        logger.error("Sync failed: %s", exc)
-        await _update_sync_log(sync_log_id, "error", error_message=str(exc))
+        logger.exception("Sync failed for %s -> %s", source, collection_name)
+        await _update_sync_log(
+            sync_log_id, "error", error_message=failure_summary(exc, stage=IngestionStage.SYNC)
+        )
         raise
 
 
@@ -275,8 +288,13 @@ async def _run_ingestion(
                 replace=replace,
                 source_path=source_path,
             )
-    except Exception as e:
-        await _update_status(rag_document_id, "error", error_message=str(e))
+    except Exception as exc:
+        logger.exception("Indexing failed for %s", source_path)
+        await _update_status(
+            rag_document_id,
+            "error",
+            error_message=failure_summary(exc, stage=IngestionStage.INDEX),
+        )
         raise
     finally:
         await _record_embedding_spend(
@@ -301,8 +319,13 @@ async def _run_ingestion(
             await RAGDocumentService(db).complete_ingestion(
                 rag_document_id, vector_document_id=result.document_id
             )
-    except Exception as e:
-        await _update_status(rag_document_id, "error", error_message=str(e))
+    except Exception as exc:
+        logger.exception("Indexed %s but could not record it", source_path)
+        await _update_status(
+            rag_document_id,
+            "error",
+            error_message=failure_summary(exc, stage=IngestionStage.RECORD),
+        )
         raise
 
     logger.info("Ingestion complete: %s", source_path)
@@ -502,11 +525,14 @@ async def _run_source_sync(source_id: str, sync_log_id: str | None = None) -> di
             try:
                 await assert_organization_within_budget(db, organization_id)
             except BudgetExceeded as exc:
-                await RAGSyncService(db).complete_sync(
-                    log_id, status="error", error_message=str(exc)
-                )
-                await source_svc.update_after_sync(source_id, status="error", error=str(exc))
-                return {"status": "error", "message": str(exc)}
+                # Through `failure_summary` like every other stored failure,
+                # which hands this one back whole: the ceiling and both numbers
+                # are ours, they are the organization's own, and they are what
+                # the person reading a stopped sync needs (#423).
+                reason = failure_summary(exc, stage=IngestionStage.SYNC)
+                await RAGSyncService(db).complete_sync(log_id, status="error", error_message=reason)
+                await source_svc.update_after_sync(source_id, status="error", error=reason)
+                return {"status": "error", "message": reason}
 
         ingestion_svc = await _ingestion_service_for(
             db,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -363,6 +363,7 @@ include = [
     "app/services/health.py",
     "app/services/email/templates.py",
     "app/services/ingestion_config.py",
+    "app/services/rag/failures.py",
     # Who hears that a run stopped on its budget or parked on an approval. The
     # emails are the only signal for a run nobody was watching — a Slack
     # mention, a schedule — so a silent failure here is indistinguishable from
@@ -501,6 +502,11 @@ include = [
     # whose collection, on whose model credential — which is platform layer,
     # and is the difference between a setting and a policy.
     "app/services/ingestion_config.py",
+    # What a failed ingest is allowed to say. The rest of the RAG pipeline is
+    # template-inherited and reported rather than gated, but this module decides
+    # what leaves a worker for a stored column the whole organization reads —
+    # the same judgement the vault and the exception handlers are held to.
+    "app/services/rag/failures.py",
     # Who hears that a run stopped on its budget or parked on an approval. The
     # emails are the only signal for a run nobody was watching — a Slack
     # mention, a schedule — so a silent failure here is indistinguishable from

--- a/backend/tests/test_rag_failure_messages.py
+++ b/backend/tests/test_rag_failure_messages.py
@@ -32,7 +32,7 @@ from app.services.rag.failures import IngestionStage, failure_summary
 from app.services.rag.ingestion import IngestionService
 from app.services.rag.models import IngestionStatus
 from app.worker.background.rag import ingest_document_in_background
-from app.worker.tasks.rag_tasks import _run_ingestion
+from app.worker.tasks.rag_tasks import _run_ingestion, _update_status
 
 pytestmark = pytest.mark.anyio
 
@@ -214,7 +214,7 @@ class TestWhatTheWorkerWritesToTheRow:
     async def _db():
         yield MagicMock()
 
-    async def test_the_flow_records_a_summary_when_indexing_raises(self):
+    async def test_the_flow_records_a_summary_when_the_pipeline_raises(self):
         """`_run_ingestion` is where an upload's failure becomes a row.
 
         `ingest_file` returns its failures rather than raising them, so this
@@ -223,7 +223,7 @@ class TestWhatTheWorkerWritesToTheRow:
         """
         documents = MagicMock()
         documents.return_value.get_document = AsyncMock(
-            return_value=MagicMock(organization_id=None, ingestion_config={})
+            return_value=MagicMock(organization_id=None, ingestion_config={}, status="processing")
         )
         documents.return_value.fail_ingestion = AsyncMock()
         pipeline = MagicMock()
@@ -243,7 +243,28 @@ class TestWhatTheWorkerWritesToTheRow:
 
         stored = documents.return_value.fail_ingestion.await_args.kwargs["error_message"]
         _assert_leaks_nothing(stored)
-        assert stored.startswith("The document could not be indexed (AuthenticationError)")
+        assert stored.startswith("The document could not be ingested (AuthenticationError)")
+
+    async def test_the_first_handler_to_report_a_failure_is_the_one_that_is_kept(self):
+        """Three handlers report one collapse, and they run innermost first.
+
+        The innermost knows the stage - "could not be indexed, check the
+        collection's embedding credential"; the flow's backstop only knows the
+        ingest failed. While every level wrote the same `str(exc)` the order did
+        not matter; now the outermost write would replace the useful sentence
+        with the vague one.
+        """
+        documents = MagicMock()
+        documents.return_value.get_document = AsyncMock(return_value=MagicMock(status="error"))
+        documents.return_value.fail_ingestion = AsyncMock()
+
+        with (
+            patch("app.worker.tasks.rag_tasks.get_worker_db_context", self._db),
+            patch("app.services.rag_document.RAGDocumentService", documents),
+        ):
+            await _update_status(str(uuid.uuid4()), "error", error_message="the vague one")
+
+        documents.return_value.fail_ingestion.assert_not_awaited()
 
     async def test_the_in_process_fallback_records_a_summary_too(
         self, caplog: pytest.LogCaptureFixture

--- a/backend/tests/test_rag_failure_messages.py
+++ b/backend/tests/test_rag_failure_messages.py
@@ -1,0 +1,278 @@
+"""A failed ingest says what failed, not where (#423).
+
+`rag_documents.error_message` and `sync_logs.error_message` are stored columns
+rendered to every member who can see the collection, and they held `str(exc)`
+from whatever raised - an embedding client, `httpx`, `boto3`. A provider SDK
+puts the failing request in its message, and a URL carries a key in its query
+string, so the leak #342 fixed in an HTTP body was still being *written down*
+on the ingestion path.
+
+Every test here asserts both halves, because moving the diagnosis is the fix
+and deleting it would be a different bug: the stored string carries none of the
+upstream's text, and the log line carries all of it. Most of these call sites
+are template-inherited worker code that `make coverage-all` reports and no gate
+enforces, which is the reason to pin the behaviour by name rather than to trust
+a percentage.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from contextlib import asynccontextmanager
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.agents.capabilities.budget import BudgetExceeded, BudgetScope
+from app.core.exceptions import ConfigurationError
+from app.services.rag.failures import IngestionStage, failure_summary
+from app.services.rag.ingestion import IngestionService
+from app.services.rag.models import IngestionStatus
+from app.worker.background.rag import ingest_document_in_background
+from app.worker.tasks.rag_tasks import _run_ingestion
+
+pytestmark = pytest.mark.anyio
+
+# What an embedding client actually says when a key is wrong: the endpoint it
+# called, and the key it called it with.
+_VENDOR_TEXT = (
+    "Error code: 401 - authentication failed for "
+    "https://embeddings.internal.acme.example/v1/embeddings?api-key=sk-live-9f3ca2"
+)
+
+
+class AuthenticationError(Exception):
+    """Stands in for a provider SDK's exception - the name is the point.
+
+    A vendor class name is a symbol rather than a value, which is why the
+    summary is allowed to keep it: it says the credential was refused without
+    saying which host refused it.
+    """
+
+
+def _vendor_failure() -> AuthenticationError:
+    return AuthenticationError(_VENDOR_TEXT)
+
+
+def _assert_leaks_nothing(stored: str) -> None:
+    assert "sk-live-9f3ca2" not in stored
+    assert "embeddings.internal.acme.example" not in stored
+    assert "Error code: 401" not in stored
+
+
+class TestWhatMayBeStored:
+    def test_a_vendor_exception_reaches_the_column_as_a_stage_and_a_type(self):
+        summary = failure_summary(_vendor_failure(), stage=IngestionStage.INDEX)
+
+        _assert_leaks_nothing(summary)
+        assert summary == (
+            "The document could not be indexed (AuthenticationError) - check the "
+            "collection's embedding credential, then retry the upload. "
+            "The worker log has the full error."
+        )
+
+    def test_the_stage_the_call_site_names_is_the_stage_the_reader_is_told(self):
+        """Which stage gave up is the one thing the reader cannot work out."""
+        assert failure_summary(_vendor_failure(), stage=IngestionStage.PARSE).startswith(
+            "The file could not be read (AuthenticationError)"
+        )
+        assert failure_summary(_vendor_failure(), stage=IngestionStage.SYNC).startswith(
+            "The sync did not finish (AuthenticationError)"
+        )
+        assert failure_summary(_vendor_failure(), stage=IngestionStage.RECORD).startswith(
+            "The document was indexed but its record was not updated (AuthenticationError)"
+        )
+
+    def test_our_own_refusal_is_kept_whole(self):
+        """An `AppException`'s message is written in this repository.
+
+        Replacing "no embedding credential is configured for this collection"
+        with a generic sentence would answer the question the reader is asking -
+        credential, file, or upstream - with a shrug.
+        """
+        ours = ConfigurationError(
+            message="No embedding credential is configured for the collection's key",
+            details={"setting": "OPENROUTER_API_KEY"},
+        )
+
+        assert failure_summary(ours, stage=IngestionStage.INDEX) == (
+            "No embedding credential is configured for the collection's key"
+        )
+
+    def test_a_budget_refusal_keeps_its_numbers(self):
+        """`BudgetExceeded` is ours too, and the numbers are the organization's.
+
+        The worker refuses a queued document at the cap and puts that refusal on
+        the row deliberately - reducing it to "(BudgetExceeded)" would undo it.
+        """
+        refusal = BudgetExceeded(
+            limit_usd=Decimal("40.00"),
+            spent_usd=Decimal("40.15"),
+            scope=BudgetScope.ORGANIZATION,
+        )
+
+        assert failure_summary(refusal, stage=IngestionStage.SYNC) == (
+            "Organization monthly budget exhausted: $40.1500 spent of $40.00 limit"
+        )
+
+    def test_a_task_group_is_unwrapped_before_it_is_named(self):
+        """The connector clients run on anyio task groups.
+
+        Their failures arrive as "unhandled errors in a TaskGroup", which names
+        nothing at all - so the type reported is the leaf's, not the group's.
+        """
+        nested = ExceptionGroup(
+            "unhandled errors in a TaskGroup",
+            [ExceptionGroup("inner", [_vendor_failure()])],
+        )
+
+        summary = failure_summary(nested, stage=IngestionStage.SYNC)
+
+        _assert_leaks_nothing(summary)
+        assert "(AuthenticationError)" in summary
+        assert "TaskGroup" not in summary
+
+    def test_every_stage_says_something_and_advises_something(self):
+        for stage in IngestionStage:
+            assert stage.summary and stage.advice
+            assert not stage.summary.endswith(".")
+
+
+class TestTheIngestionServiceMovesItToTheLog:
+    """`IngestionService.ingest_file` is where the text used to be born."""
+
+    @staticmethod
+    def _service(*, parse: AsyncMock, insert: AsyncMock) -> IngestionService:
+        processor = MagicMock(process_file=parse)
+        store = MagicMock(insert_document=insert)
+        return IngestionService(processor=processor, vector_store=store)
+
+    @staticmethod
+    def _document() -> MagicMock:
+        return MagicMock(
+            id="doc-1",
+            chunked_pages=[],
+            metadata=MagicMock(source_path="", content_hash=None),
+        )
+
+    async def test_an_indexing_failure_stores_a_summary_and_logs_the_upstream(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        service = self._service(
+            parse=AsyncMock(return_value=self._document()),
+            insert=AsyncMock(side_effect=_vendor_failure()),
+        )
+
+        with caplog.at_level(logging.ERROR, logger="app.services.rag.ingestion"):
+            result = await service.ingest_file(
+                filepath=Path("/srv/uploads/handbook.pdf"), collection_name="kb_ops", replace=False
+            )
+
+        assert result.status is IngestionStatus.ERROR
+        assert result.error_message is not None
+        _assert_leaks_nothing(result.error_message)
+        assert "(AuthenticationError)" in result.error_message
+        # Moved, not deleted: the whole of it, with a traceback, one line away.
+        assert _VENDOR_TEXT in caplog.text
+        assert "Indexing failed for handbook.pdf" in caplog.text
+
+    async def test_a_parse_failure_says_parse_rather_than_index(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        """The parser's own message names the temporary file it was handed.
+
+        `LiteParseParser` raises `RuntimeError(f"LiteParse: file not found:
+        {filepath}")`, so even our own text here is a server path - the reason
+        the rule is "ours means an `AppException`", not "ours means we wrote it".
+        """
+        service = self._service(
+            parse=AsyncMock(
+                side_effect=RuntimeError("LiteParse: file not found: /srv/tmp/x7/handbook.pdf")
+            ),
+            insert=AsyncMock(),
+        )
+
+        with caplog.at_level(logging.ERROR, logger="app.services.rag.ingestion"):
+            result = await service.ingest_file(
+                filepath=Path("/srv/tmp/x7/handbook.pdf"), collection_name="kb_ops"
+            )
+
+        assert result.error_message is not None
+        assert "/srv/tmp/x7" not in result.error_message
+        assert result.error_message.startswith("The file could not be read (RuntimeError)")
+        assert "/srv/tmp/x7/handbook.pdf" in caplog.text
+
+
+class TestWhatTheWorkerWritesToTheRow:
+    """The two handlers that put a failure on `rag_documents` for a reader."""
+
+    @staticmethod
+    @asynccontextmanager
+    async def _db():
+        yield MagicMock()
+
+    async def test_the_flow_records_a_summary_when_indexing_raises(self):
+        """`_run_ingestion` is where an upload's failure becomes a row.
+
+        `ingest_file` returns its failures rather than raising them, so this
+        handler catches what escapes the metering window - and used to write
+        `str(e)` to the column the documents page renders.
+        """
+        documents = MagicMock()
+        documents.return_value.get_document = AsyncMock(
+            return_value=MagicMock(organization_id=None, ingestion_config={})
+        )
+        documents.return_value.fail_ingestion = AsyncMock()
+        pipeline = MagicMock()
+        pipeline.ingest_file = AsyncMock(side_effect=_vendor_failure())
+
+        with (
+            patch("app.worker.tasks.rag_tasks.get_worker_db_context", self._db),
+            patch("app.services.rag_document.RAGDocumentService", documents),
+            patch(
+                "app.worker.tasks.rag_tasks._ingestion_service_for",
+                new=AsyncMock(return_value=pipeline),
+            ),
+            patch("app.worker.tasks.rag_tasks._record_embedding_spend", new=AsyncMock()),
+            pytest.raises(AuthenticationError),
+        ):
+            await _run_ingestion(str(uuid.uuid4()), "kb_ops", "/srv/uploads/f.pdf", "f.pdf", False)
+
+        stored = documents.return_value.fail_ingestion.await_args.kwargs["error_message"]
+        _assert_leaks_nothing(stored)
+        assert stored.startswith("The document could not be indexed (AuthenticationError)")
+
+    async def test_the_in_process_fallback_records_a_summary_too(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        """`app/worker/background/rag.py` swallows, so its log is the only copy."""
+        documents = MagicMock()
+        documents.return_value.fail_ingestion = AsyncMock()
+
+        with (
+            patch("app.worker.background.rag.get_db_context", self._db),
+            patch("app.services.rag_document.RAGDocumentService", documents),
+            patch.object(
+                IngestionService,
+                "from_settings",
+                MagicMock(
+                    return_value=MagicMock(ingest_file=AsyncMock(side_effect=_vendor_failure()))
+                ),
+            ),
+            caplog.at_level(logging.ERROR, logger="app.worker.background.rag"),
+        ):
+            await ingest_document_in_background(
+                rag_document_id=str(uuid.uuid4()),
+                collection_name="kb_ops",
+                filepath="/srv/uploads/never-written.pdf",
+                source_path="handbook.pdf",
+                replace=False,
+            )
+
+        stored = documents.return_value.fail_ingestion.await_args.kwargs["error_message"]
+        _assert_leaks_nothing(stored)
+        assert stored.startswith("The document could not be ingested (AuthenticationError)")
+        assert _VENDOR_TEXT in caplog.text

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -343,6 +343,11 @@ because a class name is a symbol: it says the credential was refused or the
 upstream timed out without naming the host that said so. **The advice** is what
 the reader can actually do.
 
+One failure is reported by up to three handlers — the stage that raised, the
+check that a returned failure is not `done`, and the flow's backstop — and the
+**first** one to record it keeps the row, because it is the innermost and the
+most specific. A retry clears the message, so the next attempt records its own.
+
 A refusal this platform raised itself is passed through whole instead, because
 its message is written here and is the most useful thing to show: *"No embedding
 credential is configured for this collection"*, *"Organization monthly budget

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -314,7 +314,7 @@ Ingested documents are tracked in the SQL database via the `RAGDocument` model:
 | `filesize` | File size in bytes |
 | `filetype` | File extension (without dot) |
 | `status` | `processing`, `done`, or `error` |
-| `error_message` | Error details (if status is `error`) |
+| `error_message` | What failed, if `status` is `error` — see below |
 | `vector_document_id` | ID in the vector store |
 | `chunk_count` | Number of chunks created |
 | `storage_path` | Path to original file (for re-ingestion/download) |
@@ -322,6 +322,41 @@ Ingested documents are tracked in the SQL database via the `RAGDocument` model:
 | `completed_at` | Ingestion completion time |
 
 Failed ingestions can be retried via `POST /rag/documents/{id}/retry`.
+
+### What a failed ingest says
+
+`error_message` is a stored column, rendered on the documents page and in a
+source's sync history to everyone who can see the collection. So it carries a
+summary rather than whatever the client that failed happened to say:
+
+```
+The document could not be indexed (AuthenticationError) - check the
+collection's embedding credential, then retry the upload. The worker log has
+the full error.
+```
+
+Three parts, and each is there for a reason. **The stage** — parsing, indexing,
+recording the outcome, or a whole sync — is the one thing the reader cannot
+work out afterwards, and it separates a file this collection's parser does not
+read from a credential the provider refused. **The exception's type** is kept
+because a class name is a symbol: it says the credential was refused or the
+upstream timed out without naming the host that said so. **The advice** is what
+the reader can actually do.
+
+A refusal this platform raised itself is passed through whole instead, because
+its message is written here and is the most useful thing to show: *"No embedding
+credential is configured for this collection"*, *"Organization monthly budget
+exhausted: $40.15 spent of $40.00 limit"*.
+
+What is **not** stored is the failing client's own text. A provider SDK, `httpx`,
+`boto3` and the Google Drive client all put the request they were making into
+their exception message, which routinely means an endpoint, an internal host, a
+bucket, or a URL with a key in its query string — and unlike an HTTP error body,
+a column is read again weeks later by anyone who opens the failed document. That
+text is not lost: every one of these call sites logs it with `logger.exception`,
+so the worker log has the message and the traceback, and a Prefect flow that
+re-raises has both in its run. `app/services/rag/failures.py` is where the two
+are separated; `PiiRedactionFilter` scrubs the log on the way out.
 
 
 ### Sync Operations

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -356,7 +356,13 @@ a column is read again weeks later by anyone who opens the failed document. That
 text is not lost: every one of these call sites logs it with `logger.exception`,
 so the worker log has the message and the traceback, and a Prefect flow that
 re-raises has both in its run. `app/services/rag/failures.py` is where the two
-are separated; `PiiRedactionFilter` scrubs the log on the way out.
+are separated.
+
+The log is a smaller audience than the column, not a safe one — treat a worker
+log as something only operators read, and see [#440] for why the redaction
+filter this deployment ships does not currently scrub it.
+
+[#440]: https://github.com/vstorm-co/agenticos/issues/440
 
 
 ### Sync Operations


### PR DESCRIPTION
`rag_documents.error_message` and `sync_logs.error_message` are stored columns
rendered on the documents page and in a source's sync history to every member
who can see the collection, and they held `str(exc)` from whatever raised — an
embedding client, `httpx`, `boto3`, the Google Drive client. A provider SDK puts
the failing request in its message, so a wrong embedding key wrote the endpoint
it called and the key it called it with into a column read weeks later by
whoever opens the failed ingest. Same defect as #342, longer life: a body is
read once, a row is read whenever somebody looks.

Nine call sites, one new module.

| Site | Was | Is |
|---|---|---|
| `services/rag/ingestion.py:141` | `error_message=str(e)` | the stage plus the exception's type; parse and index are now caught separately so the stage is real |
| `worker/tasks/rag_tasks.py:205` | `error_message=str(exc)` | `failure_summary(exc, stage=INGEST)` |
| `rag_tasks.py:219` | `str(exc)` | `stage=SYNC` |
| `rag_tasks.py:279` | `str(e)` | `stage=INGEST` — see "relabelled" below |
| `rag_tasks.py:305` | `str(e)` | `stage=RECORD` |
| `rag_tasks.py:506` | `str(exc)` on `BudgetExceeded` | through the same function, which hands that one back whole |
| `worker/background/rag.py:44` | `str(exc)` | `stage=INGEST` |
| `background/rag.py:142` | `str(exc)` | `stage=SYNC` |
| `commands/rag.py:228` | `str(e)` | `stage=INGEST`; the CLI operator still gets the whole exception on their own terminal |

What a row now says:

```
The document could not be indexed (AuthenticationError) - check the collection's
embedding credential, then retry the upload. The worker log has the full error.
```

Three parts, each earning its place. **The stage** is the one thing the reader
cannot work out afterwards, and separates a file this collection's parser does
not read from a credential the provider refused. **The type** is kept because a
class name is a symbol: it says the credential was refused or the upstream timed
out without naming the host that said so. **The advice** is what they can do.

**Ours is kept whole.** An `AppException` and a `BudgetExceeded` are written in
this repository, and "No embedding credential is configured for this collection"
and "$40.15 spent of a $40.00 limit" are the most useful things an operator can
be shown — reducing those to a class name would answer #423's own question
("credential, file, or upstream?") with a shrug. A bare `RuntimeError` we raised
is *not* ours for this purpose, and that distinction is load-bearing: the
LiteParse wrapper interpolates the absolute path of a temporary file into one.

**Nothing is deleted.** Every site logs the exception with `logger.exception`
rather than the `logger.error(..., e)` it replaced — which also recovers the
traceback that call never had — and the three flows re-raise, so Prefect keeps
the whole thing in the run.

`app/services/rag/failures.py` joins the platform layer in both lists in
`pyproject.toml`. The rest of the RAG pipeline is template-inherited and
reported rather than gated, but this module decides what leaves a worker for a
stored, rendered column, which is the judgement the vault and the exception
handlers are held to.

## The two exclusions the issue asked about — both left, both for their own reason

- **`vectorstore.py:258`** keeps `{"collection": name, "table": …}`. Unchanged.
  The table is `rag_` plus the collection name the caller supplied, and the
  prefix is documented; it describes nothing the caller did not provide. Same
  adjudication as #432.
- **`sandbox_workspace._reason`** keeps the sandbox backend's own text.
  Unchanged. It is our component rather than a vendor SDK, its docstring
  defends naming `workspace_root` for the commonest cause, and — the reason I
  did not take it anyway — this branch's rule would not fire on it: the test
  for "may this be stored" is whether the string was written here, and that one
  was. Worth revisiting under its own issue, with the same evidence #423 has;
  not worth changing inside a branch about the RAG columns.
- A third, not in the issue: **`_run_sync`'s `f"Path not found: {path}"`**.
  Unchanged, same category as the collection name — a local-directory sync
  names a path an operator typed into the source.

## A bug found reviewing my own diff, fixed here

**The outermost handler was overwriting the innermost's message.** One collapse
is reported by up to three handlers, innermost first, each calling
`_update_status`. While all three wrote the same `str(exc)` the last write was
harmless; it stopped being harmless in the first commit here, because the
innermost is the one that knows the stage. On the commonest path of all — a
document that fails to parse — `ingest_file` returned the specific summary, the
`RuntimeError` raised after it was caught one frame up, and the row ended up
saying "could not be ingested" instead of "could not be read". `_update_status`
now leaves a row that already says `error` alone; `retry_ingestion` clears it,
so the next attempt records its own. Found by me, in this branch, so no separate
issue — the commit body carries it.

Also **relabelled** `rag_tasks.py:279` from INDEX to INGEST. `ingest_file`
reports a failed parse or index by *returning* it, so what reaches that `except`
escaped the metering window instead — the budget, or the pipeline build. Which
stage it was is not knowable there, and claiming "indexed" was a guess.

## Two bugs found and deliberately **not** fixed here, both filed triaged

Kacper's standing instruction on this branch was to fix what I find rather than
defer it. I am deferring these two anyway, and saying so plainly rather than
quietly:

- **#437 — a failed agent run stores the model client's exception text, and the
  chat socket sends it live.** `agent_runner.py:2810`, `agent_chat.py:349`,
  `agent_session.py:306`. `severity:medium`. The third link in the same chain
  (#342 → #423 → #437), but a different subsystem, and **what a failed run tells
  the person waiting for it is a product decision**: "context length exceeded"
  and "model not found" are failures users act on themselves, and a class name
  would take both away. That needs its own answer, not a port of this one. It is
  also in the gated platform layer, so it lands with tests across three
  services.
- **#440 — `PiiRedactionFilter` redacts nothing.** `severity:high`. It is
  attached to the root *logger*, where it only sees records logged on the root
  logger itself; a propagated record reaches the ancestors' handlers without
  touching their filters, and every line in this codebase comes from a module
  logger. The Prefect worker never calls `setup_logging` at all. Demonstrated in
  the issue.

  **This one nearly went into the branch**, because an earlier draft of the new
  module's docstring claimed the log it moves text into is scrubbed. It is not,
  and the third commit here corrects that claim rather than making it true —
  fixing the filter needs a test per process (uvicorn, a Prefect flow
  subprocess, the CLI), since attaching to the handlers instead only works if
  the handlers exist yet, and shipping it half-right would be the second time
  this control is believed to work. Nothing here makes it worse: those lines
  already logged the same text.

## Does #432 need to land first?

**No — they are independent, and either order works.** No file overlaps: #432 is
`agents/capabilities/knowledge`, `email/templates`, `model_profile`,
`admin_users` and `sandbox_connection`; this is the RAG pipeline, the worker and
the CLI. The one shared file is `.claude/rules/exceptions-security.md`, and this
branch's paragraph is placed *after* the exception-handler list precisely so it
does not collide with the hunk #432 adds *before* it. Reading #432 first is
worth it for a reviewer — the vocabulary here is deliberately its vocabulary —
but nothing here depends on it merging.

## Verification — CI is out, so this is the whole gate

**GitHub Actions has been in a major outage since 15:22 UTC**; checks stay
`pending` and are not a signal. The automated reviewer is off separately
(#311). Everything below is local, on Python 3.12.9, against a real
`pgvector/pgvector:pg16` (`docker ps` confirms the image).

- `make test` — **3415 passed, 6 skipped, coverage 100.00%** on the platform
  layer, with `app/services/rag/failures.py` now inside it.
- `make test-integration` — **260 passed** in 1m56.
- `make db-check` — no new upgrade operations. Nothing changed shape:
  `error_message` was and stays `Text`, which is why there is no migration.
- `make lint-backend` — `ruff format --check` (530 files), `ty check` (exit 0,
  nothing in the new module), `check_backticks`, `check_i18n` and
  `make lint-spelling` all pass. `ruff check` fails on the two findings of
  **#407**, which are pre-existing on `main`, are fixed in **#426**, and are in
  `tests/test_migrations.py` — nothing in this diff is flagged.
- `make docs-build` — clean.
- **Not run:** `e2e` (needs a seeded backend), and the frontend half of
  `make check`. No frontend file changed — the columns are rendered by
  `rag/page.tsx`, `kb/[id]/page.tsx` and `sync-source-logs.tsx` and none of them
  needed touching, because the fix is that what they render is now safe — so
  CI's `test-frontend` would skip on changed paths anyway. `make check` as a
  single run was not attempted: the machine is at high load and a full suite has
  taken seventeen minutes, so its constituent targets were run individually
  instead, which is the same set minus the frontend two.

**Each behavioural test fails without its fix**, checked by restoring
`ingestion.py`, `rag_tasks.py` and `background/rag.py` from `origin/main` and
re-running: 4 failed, 6 passed — the six being the unit tests of the new module,
which the restore does not touch. The failure in each case is the vendor string
arriving in the stored value verbatim.

The maintainer pass is mine — the reviewer is off, and it found the
overwrite bug above, the mislabelled stage, and #440.

## Docs

`docs/file-processing.md` said `error_message` was "error details", which was
true of a column holding a provider SDK's `__str__` and is not true of this one.
It now has a **What a failed ingest says** section: the three parts and why each
is there, which refusals pass through whole, what is not stored and where it
went instead, which of three handlers' messages the row keeps, and a pointer to
#440 so nobody reads "it goes to the log" as "it is safe there".
`.claude/rules/exceptions-security.md` gets the general form beside "a value,
not a row": a stored, rendered column is `details` with a longer life.

Closes #423
