### PR TITLE
test: drop two lint errors main has been failing on

### DIFF
--- a/backend/tests/integration/test_vector_store_reserved_names.py
+++ b/backend/tests/integration/test_vector_store_reserved_names.py
@@ -39,7 +39,6 @@ async def _no_collection_of_its_own(name: str) -> None:
     answers `None` is the state this helper was always describing, and it is what
     sends the store to its deployment defaults.
     """
-    return None
 
 
 def _store_on(engine: AsyncEngine) -> PgVectorStore:

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -96,7 +96,7 @@ def _why_the_server_did_not_answer(url: str) -> str | None:
     try:
         with engine.connect():
             return None
-    except Exception as exc:  # noqa: BLE001 - any failure to connect is the answer
+    except Exception as exc:  # Any failure to connect is the answer, whatever it was.
         return str(exc).strip()
     finally:
         engine.dispose()


### PR DESCRIPTION
`make lint-backend` exits non-zero on `main` (`16a31b9`), so every branch cut from it
starts red on a gate it did not break. This removes the two errors.

It also unblocks committing at all: the pre-commit `ruff check` hook runs
`--fix` over the whole tree rather than the staged paths, so it rewrote these two
files under every commit and then refused the commit for having modified them —
and on the retry, its stash of the unstaged fix conflicted with the fix it was
re-applying. Nothing could be committed in this repository without either fixing
these or skipping the hook.

## Changed

- `backend/tests/integration/test_vector_store_reserved_names.py` — `RET501`. The
  stub's whole body was `return None`. Deleted rather than shortened to `return`:
  a function whose body is a docstring already answers `None`, and this one's
  docstring says so.
- `backend/tests/test_migrations.py` — `RUF100`. `# noqa: BLE001` for a rule this
  project does not select, so ruff reported the suppression itself as dead. The
  explanation it carried is kept as an ordinary comment; only the directive is gone.

Neither is a defect in the change that introduced it — both merged during the
GitHub Actions outage of 2026-08-06 with their check lists pending, which #407
documents in full.

## Verified

- `make lint-backend` exits `0` (it exits `1` on `main`).
- `uv run pytest tests/test_migrations.py` — 4 skipped, as on `main`; the chain
  tests need a database. `test_vector_store_reserved_names.py` is an integration
  test and skips for the same reason. Neither file's behaviour changes: one
  deleted statement was redundant with falling off the end of a `-> None`
  function, and the other change is inside a comment.

Closes #407
