### PR TITLE
fix(budgets): meter the agent wherever a surface executes it

### DIFF
--- a/backend/app/services/agent_chat.py
+++ b/backend/app/services/agent_chat.py
@@ -310,11 +310,9 @@ class ChatAgentRunner:
         budget_scope: BudgetScope | None = None
         output = ""
         try:
-            async with prepared.built.agent.iter(
+            async with prepared.iterate(
                 user_input,
-                deps=prepared.deps,
                 message_history=message_history,
-                usage_limits=prepared.built.usage_limits,
             ) as agent_run:
                 await stream(agent_run)
 

--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -55,7 +55,8 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections import Counter
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
@@ -64,7 +65,9 @@ from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic_ai import Agent as PydanticAgent
-from pydantic_ai.messages import ModelMessagesTypeAdapter
+from pydantic_ai.messages import ModelMessage, ModelMessagesTypeAdapter, UserContent
+from pydantic_ai.run import AgentRun as AgentIteration
+from pydantic_ai.run import AgentRunResult
 from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults, ToolApproved
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -890,6 +893,59 @@ class PreparedRun:
     @property
     def deps(self) -> AgentDeps:
         return self.built.deps
+
+    async def execute(
+        self,
+        user_prompt: str | Sequence[UserContent] | None,
+        *,
+        message_history: Sequence[ModelMessage] | None,
+        deferred_tool_results: DeferredToolResults | None,
+    ) -> AgentRunResult[str | DeferredToolRequests]:
+        """Run the agent to an answer, metered.
+
+        The non-streaming half of :meth:`iterate`, and it exists for the same
+        reason.
+        """
+        with metered_by(self.built.ledger):
+            return await self.built.agent.run(
+                user_prompt,
+                deps=self.built.deps,
+                message_history=message_history,
+                deferred_tool_results=deferred_tool_results,
+                usage_limits=self.built.usage_limits,
+            )
+
+    @asynccontextmanager
+    async def iterate(
+        self,
+        user_prompt: str | Sequence[UserContent] | None,
+        *,
+        message_history: Sequence[ModelMessage] | None,
+    ) -> AsyncIterator[AgentIteration[AgentDeps, str | DeferredToolRequests]]:
+        """Iterate the agent's graph, metered, for a surface that streams.
+
+        **The meter is here rather than at the call site because a surface that
+        forgets it bills nothing and says nothing.** `metered_by` is what books
+        the spend a request wrapper cannot see - the embedding call behind a
+        knowledge search - to this run's ledger. Miss it and
+        :func:`~app.agents.capabilities.budget.record_ambient_usage` finds no
+        active ledger and drops the cost silently: the run under-reports, the
+        organization's month never sees it, and nothing raises. The web chat ran
+        that way for its whole life (agenticos#16), which is the argument for the
+        agent being unreachable from a surface except through here.
+
+        Yields the library's run object, so the caller drives the graph and
+        decides what to forward. It stays readable after the block closes; the
+        outcome is taken from it there.
+        """
+        with metered_by(self.built.ledger):
+            async with self.built.agent.iter(
+                user_prompt,
+                deps=self.built.deps,
+                message_history=message_history,
+                usage_limits=self.built.usage_limits,
+            ) as iteration:
+                yield iteration
 
 
 @dataclass
@@ -2767,17 +2823,11 @@ class AgentRunnerService:
         paused: PausedRunState | None = None
         budget_scope: BudgetScope | None = None
         try:
-            # `metered_by` books what the request wrapper cannot see - the
-            # embedding calls a knowledge search makes - to this run's ledger,
-            # so they land in `cost_usd` next to the model requests.
-            with metered_by(prepared.built.ledger):
-                result = await prepared.built.agent.run(
-                    user_prompt,
-                    deps=prepared.built.deps,
-                    message_history=message_history,
-                    deferred_tool_results=deferred_tool_results,
-                    usage_limits=prepared.built.usage_limits,
-                )
+            result = await prepared.execute(
+                user_prompt,
+                message_history=message_history,
+                deferred_tool_results=deferred_tool_results,
+            )
             if isinstance(result.output, DeferredToolRequests):
                 paused = PausedRunState(
                     messages=ModelMessagesTypeAdapter.dump_python(

--- a/backend/tests/integration/test_vector_store_reserved_names.py
+++ b/backend/tests/integration/test_vector_store_reserved_names.py
@@ -39,7 +39,6 @@ async def _no_collection_of_its_own(name: str) -> None:
     answers `None` is the state this helper was always describing, and it is what
     sends the store to its deployment defaults.
     """
-    return None
 
 
 def _store_on(engine: AsyncEngine) -> PgVectorStore:

--- a/backend/tests/test_agent_chat.py
+++ b/backend/tests/test_agent_chat.py
@@ -17,14 +17,21 @@ import asyncio
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
+from decimal import Decimal
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic_ai.tools import DeferredToolRequests
+from pydantic_ai.usage import RequestUsage
 
-from app.agents.capabilities.budget import BudgetExceeded, BudgetScope
+from app.agents.capabilities.budget import (
+    BudgetExceeded,
+    BudgetScope,
+    SpendLedger,
+    record_ambient_usage,
+)
 from app.agents.deps import AgentDeps
 from app.core.exceptions import AuthorizationError, BadRequestError
 from app.core.permissions import OrgRoleName
@@ -36,6 +43,7 @@ from app.services.agent_chat import (
     requested_environment_id,
     requested_model_profile_id,
 )
+from app.services.agent_runner import AgentRunnerService, PreparedRun
 
 pytestmark = pytest.mark.anyio
 
@@ -172,15 +180,25 @@ def _agent_run(output: object) -> MagicMock:
     return agent_run
 
 
-def _prepared(output: object = "the refund window is 30 days") -> MagicMock:
-    """A run the runner has already opened, with its agent stubbed."""
-    prepared = MagicMock()
-    prepared.run = MagicMock(id=uuid.uuid4())
-    prepared.deps = AgentDeps()
-    prepared.built.model_label = "gpt-4.1"
-    prepared.built.agent.iter = MagicMock(return_value=_Iteration(_agent_run(output)))
-    prepared.approvals.parked = {"approval-1": "call-1"}
-    return prepared
+def _prepared(output: object = "the refund window is 30 days") -> PreparedRun:
+    """A run the runner has already opened, with its agent stubbed.
+
+    A real `PreparedRun`, because `iterate` is what opens the spend meter -
+    mocking the prepared run would mock that away and leave the accounting
+    tests proving only that the chat called something.
+    """
+    built = MagicMock()
+    built.model_label = "gpt-4.1"
+    built.ledger = SpendLedger()
+    built.deps = AgentDeps()
+    built.agent.iter = MagicMock(return_value=_Iteration(_agent_run(output)))
+    return PreparedRun(
+        run=MagicMock(id=uuid.uuid4()),
+        agent=MagicMock(),
+        spec=MagicMock(),
+        built=built,
+        approvals=MagicMock(parked={"approval-1": "call-1"}, requested=[]),
+    )
 
 
 def _membership(role: OrgRoleName = OrgRoleName.MEMBER) -> MagicMock:
@@ -338,6 +356,98 @@ class TestWhoTheRunBelongsTo:
                 await _run(_db())
 
             runner.prepare.assert_not_called()
+
+
+class TestMeteringWhatTheTurnEmbedded:
+    """A knowledge search embeds the question, and somebody has to pay for it.
+
+    The embedding service is process-global - it serves every run and every
+    ingestion job at once - so it books through a context variable rather than
+    an argument, and a surface that opens no meter drops the cost on the floor.
+    Silently: no exception, no warning, a run that reports less than it spent
+    and an organization's month that never sees it. The chat did exactly that
+    for its whole life (agenticos#16), which is why the meter now belongs to the
+    prepared run rather than to whoever remembered to open it.
+    """
+
+    @staticmethod
+    @contextmanager
+    def _billed(*prepared: PreparedRun) -> Iterator[AsyncMock]:
+        """Run turns against a real `finish`, and hand back the rows it wrote.
+
+        `finish` bills from the ledger, so a test asserting on the ledger would
+        be asserting on the object it is trying to prove reaches the row. This
+        reads the row.
+        """
+        with (
+            patch("app.services.agent_chat.member_repo") as members,
+            patch.object(AgentRunnerService, "prepare", AsyncMock(side_effect=prepared)),
+            patch(
+                "app.services.agent_runner.agent_run_repo.finish_run", new=AsyncMock()
+            ) as finish_run,
+        ):
+            members.get = AsyncMock(return_value=_membership())
+            yield finish_run
+
+    @staticmethod
+    def _searches(tokens: int = 1000, provider: str | None = "openai"):
+        """A turn whose tool embeds something while the agent is working."""
+
+        async def stream(agent_run: Any) -> None:
+            record_ambient_usage(
+                "text-embedding-3-small", RequestUsage(input_tokens=tokens), provider
+            )
+
+        return stream
+
+    async def test_an_embedding_made_during_the_turn_reaches_the_runs_cost(self):
+        with self._billed(_prepared()) as finish_run:
+            await _run(_db(), stream=self._searches())
+
+        billed = finish_run.await_args.kwargs
+        assert billed["cost_usd"] == Decimal("0.00002")
+        assert billed["input_tokens"] == 1000
+
+    async def test_an_unpriced_embedding_makes_the_turns_cost_a_floor(self):
+        """`cost_is_partial` is what the chat draws its `+` from. An embedding
+        model nobody prices costs something, and reporting the run's total as
+        exact would say the opposite of what is known."""
+        with self._billed(_prepared()) as finish_run:
+            await _run(_db(), stream=self._searches(provider=None))
+
+        billed = finish_run.await_args.kwargs
+        assert (billed["cost_usd"], billed["cost_is_partial"]) == (Decimal(0), True)
+
+    async def test_two_chats_in_one_process_do_not_bill_each_other(self):
+        """Every socket in a deployment is served by one process, so the meter is
+        a context variable rather than a field - and the reason to prove it is
+        that the failure would be a person paying for a stranger's search.
+
+        The barrier makes the overlap real: neither turn embeds until both are
+        inside their own metered block, and neither leaves until both have.
+        """
+        first, second = _prepared(), _prepared()
+        overlapping = asyncio.Barrier(2)
+
+        def embeds(tokens: int):
+            async def stream(agent_run: Any) -> None:
+                await overlapping.wait()
+                record_ambient_usage(
+                    "text-embedding-3-small", RequestUsage(input_tokens=tokens), "openai"
+                )
+                await overlapping.wait()
+
+            return stream
+
+        with self._billed(first, second):
+            await asyncio.gather(
+                _run(_db(), stream=embeds(1000)),
+                _run(_db(), stream=embeds(2000)),
+            )
+
+        ledgers = [first.built.ledger, second.built.ledger]
+        assert [len(ledger.entries) for ledger in ledgers] == [1, 1]
+        assert sorted(ledger.input_tokens for ledger in ledgers) == [1000, 2000]
 
 
 class TestRecordingTheRun:

--- a/backend/tests/test_agent_runner.py
+++ b/backend/tests/test_agent_runner.py
@@ -30,6 +30,7 @@ from app.services.agent_runner import (
     ApprovalChannel,
     ParkedApproval,
     PausedRunState,
+    PreparedRun,
     RecordedDelegation,
     month_start,
 )
@@ -55,18 +56,25 @@ def _db(monthly_budget_usd: Decimal | None = None):
     return db
 
 
-def _prepared(ledger: SpendLedger | None = None):
-    prepared = MagicMock()
-    prepared.run = MagicMock(id=uuid.uuid4())
-    prepared.built = MagicMock()
-    prepared.built.ledger = ledger or SpendLedger()
-    prepared.approvals.parked = {}
-    # Real containers, not mocks: `finish` walks both to fold the delegation tree
-    # into whatever parked state the surface reported, and a `MagicMock` is not
-    # iterable. An agent that never delegated leaves them empty.
-    prepared.approvals.requested = []
-    prepared.stash = DelegationStash()
-    return prepared
+def _prepared(ledger: SpendLedger | None = None) -> PreparedRun:
+    """A run with its agent stubbed - but a real `PreparedRun`, and a real ledger.
+
+    Mocking the prepared run itself would mock away `execute`, which is what
+    opens the spend meter: the test would prove the runner calls something and
+    nothing at all about what the run was billed.
+    """
+    built = MagicMock()
+    built.ledger = ledger or SpendLedger()
+    return PreparedRun(
+        run=MagicMock(id=uuid.uuid4()),
+        agent=MagicMock(),
+        spec=MagicMock(),
+        built=built,
+        # Real containers, not mocks: `finish` walks both to fold the delegation
+        # tree into whatever parked state the surface reported, and a `MagicMock`
+        # is not iterable. An agent that never delegated leaves them empty.
+        approvals=MagicMock(parked={}, requested=[]),
+    )
 
 
 def _parked_run(**overrides):
@@ -577,8 +585,7 @@ class TestFilesAcrossOneTurn:
     async def test_an_attachment_is_routed_against_the_workspace_the_run_opened(self):
         service = AgentRunnerService(_db())
         prepared = _prepared()
-        prepared.outbound = []
-        prepared.outbound_refused = []
+        prepared.workspace = MagicMock()
         service.prepare = AsyncMock(return_value=prepared)
         service._run = AsyncMock(return_value=("answered", prepared.run))
         built = AsyncMock(return_value="a prompt with a reference")
@@ -650,11 +657,8 @@ class TestFilesAcrossOneTurn:
     async def test_a_run_with_no_workspace_produces_nothing_to_send(self):
         service = AgentRunnerService(_db())
         prepared = _prepared()
-        prepared.workspace = None
-        prepared.outbound = []
-        prepared.outbound_refused = []
 
-        service._collect_outbound(prepared)
+        await service._collect_outbound(prepared)
 
         assert prepared.outbound == []
 
@@ -662,8 +666,7 @@ class TestFilesAcrossOneTurn:
     async def test_what_the_workspace_gained_is_read_before_it_closes(self):
         service = AgentRunnerService(_db())
         prepared = _prepared()
-        prepared.outbound = []
-        prepared.outbound_refused = []
+        prepared.workspace = MagicMock()
         prepared.workspace_at_start = {"/run.py"}
 
         with patch("app.services.agent_runner.files_written", new_callable=AsyncMock) as written:
@@ -688,6 +691,8 @@ class TestSkillChangesARunProposed:
         service = AgentRunnerService(_db())
         prepared = _prepared()
         prepared.ctx = MagicMock(organization_id=uuid.uuid4())
+        prepared.workspace = MagicMock()
+        prepared.materialised_skills = MagicMock()
         change = MagicMock()
         record = AsyncMock(return_value=[MagicMock()])
         service.proposals = MagicMock(record=record)
@@ -708,6 +713,8 @@ class TestSkillChangesARunProposed:
         service = AgentRunnerService(_db())
         prepared = _prepared()
         prepared.ctx = MagicMock(organization_id=uuid.uuid4())
+        prepared.workspace = MagicMock()
+        prepared.materialised_skills = MagicMock()
         service.proposals = MagicMock(record=AsyncMock(side_effect=RuntimeError("name taken")))
 
         with (
@@ -719,10 +726,27 @@ class TestSkillChangesARunProposed:
         assert finish.call_args.kwargs["status"] == RunStatus.COMPLETED.value
 
     @pytest.mark.anyio
+    async def test_a_run_that_left_its_skills_alone_proposes_nothing(self):
+        """The ordinary case. A proposal per run would make the queue meaningless."""
+        service = AgentRunnerService(_db())
+        prepared = _prepared()
+        prepared.ctx = MagicMock(organization_id=uuid.uuid4())
+        prepared.workspace = MagicMock()
+        prepared.materialised_skills = MagicMock()
+        service.proposals = MagicMock(record=AsyncMock())
+
+        with (
+            patch("app.services.agent_runner.collect_changes", return_value=[]),
+            patch("app.services.agent_runner.agent_run_repo.finish_run", new=AsyncMock()),
+        ):
+            await service.finish(prepared, status=RunStatus.COMPLETED)
+
+        service.proposals.record.assert_not_called()
+
+    @pytest.mark.anyio
     async def test_a_run_with_no_workspace_proposes_nothing(self):
         service = AgentRunnerService(_db())
         prepared = _prepared()
-        prepared.workspace = None
         service.proposals = MagicMock(record=AsyncMock())
 
         with patch("app.services.agent_runner.agent_run_repo.finish_run", new=AsyncMock()):

--- a/backend/tests/test_agent_session.py
+++ b/backend/tests/test_agent_session.py
@@ -95,7 +95,7 @@ from app.agents.subagent_runtime import (
 from app.core.exceptions import AuthorizationError, BadRequestError
 from app.db.models.agent_run import RunStatus
 from app.services.agent_chat import ChatTurn
-from app.services.agent_runner import ParkedApproval
+from app.services.agent_runner import ParkedApproval, PreparedRun
 from app.services.agent_session import AgentSession
 from app.services.usage_report import UsageReport
 
@@ -1428,21 +1428,23 @@ class _Turn:
         )
         return MagicMock()
 
-    def _prepared(self, agent: PydanticAgent[Any, Any]) -> MagicMock:
-        prepared = MagicMock()
-        prepared.run = MagicMock(id=uuid4(), agent_version_id=uuid4())
-        prepared.agent = MagicMock(id=uuid4())
-        prepared.deps = AgentDeps(organization_id=uuid4(), run_id=uuid4())
-        prepared.workspace = None
-        prepared.spec.budget = None
-        prepared.approvals.parked = {}
-        prepared.approvals.requested = []
-        prepared.built.agent = agent
-        prepared.built.ledger = self.ledger
-        prepared.built.model_label = "gpt-4.1"
+    def _prepared(self, agent: PydanticAgent[Any, Any]) -> PreparedRun:
+        """A real `PreparedRun`: `iterate` is what meters the turn, so a mock of
+        the prepared run would never reach the agent this class assembled."""
+        built = MagicMock()
+        built.agent = agent
+        built.ledger = self.ledger
+        built.model_label = "gpt-4.1"
+        built.deps = AgentDeps(organization_id=uuid4(), run_id=uuid4())
         # Real `None` rather than a mock: Pydantic AI reads this per request.
-        prepared.built.usage_limits = None
-        return prepared
+        built.usage_limits = None
+        return PreparedRun(
+            run=MagicMock(id=uuid4(), agent_version_id=uuid4()),
+            agent=MagicMock(id=uuid4()),
+            spec=MagicMock(budget=None),
+            built=built,
+            approvals=MagicMock(parked={}, requested=[]),
+        )
 
     @contextmanager
     def patched(self) -> Iterator[None]:

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -96,7 +96,7 @@ def _why_the_server_did_not_answer(url: str) -> str | None:
     try:
         with engine.connect():
             return None
-    except Exception as exc:  # noqa: BLE001 - any failure to connect is the answer
+    except Exception as exc:  # Any failure to connect is the answer, whatever it was.
         return str(exc).strip()
     finally:
         engine.dispose()

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -45,6 +45,19 @@ one expensive call every time.
     to the session context - which rolls back on any exception and is never
     reached at all on cancellation.
 
+### A run costs more than its model requests
+
+A knowledge search embeds the question before it can search it, and that embedding
+is billed to the run that asked for it. The embedding service is process-global -
+it serves every run and every ingestion job at once - so it books against whichever
+run is *currently metered* rather than taking a budget as an argument.
+
+Which makes the meter something a surface can forget, and forgetting it is silent:
+no exception and no warning, just a run that reports less than it spent and an
+organization's month that never sees it. So the meter belongs to the prepared run
+rather than to the surface. Opening one is not a step a new surface has to know
+about, because there is no way to execute a prepared agent without it.
+
 ### Delegation spends the parent's budget
 
 A run can contain another agent's whole conversation - see


### PR DESCRIPTION
A knowledge search embeds the question before it can search, and the embedding
service is process-global — it serves every run and every ingestion job at once,
so it books through a context variable rather than an argument. A caller that
opens no meter has its spend dropped: `record_ambient_usage` finds no active
ledger and returns.

**The web chat opened none, for its whole life.** Every knowledge search on the
product's primary surface was invisible — the run's `cost_usd` short by it,
`cost_is_partial` not set so the UI showed no `+`, and the organization's monthly
total never seeing it. Nothing raised, and the non-streaming runner had been
correct all along, which is what made this a bug neither file showed on its own.

## Changed

Wrapping the chat's iteration in `metered_by` would fix this surface and leave the
next one to remember, so the issue's better option is the one taken here: the meter
moves onto `PreparedRun`.

- `PreparedRun.execute` — the surface that awaits an answer.
- `PreparedRun.iterate` — the surface that streams, an async context manager
  yielding the library's run object so the caller still drives the graph.

Both open the ledger. Neither surface touches `built.agent` any more — those were
the only two references in the codebase — so there is no longer a way to run a
prepared agent unmetered.

## Testing

`tests/test_agent_chat.py::TestMeteringWhatTheTurnEmbedded`:

- an embedding made mid-turn reaches `finish`'s `cost_usd` and `input_tokens`;
- an unpriced one records zero and flags the total a floor, which is what the
  chat's `+` is drawn from;
- **two turns held inside their metered blocks by an `asyncio.Barrier` bill only
  their own.** That last is the property a per-surface `with` block would not
  have given: the meter is a context variable and every socket in a deployment
  shares one process, so the failure it guards against is a person paying for a
  stranger's search.

These assert on the row `finish` writes rather than on the ledger — the ledger is
the object under test, so asserting on it would be asserting on itself.

`make test` — 3404 passed, 100.00% on the platform layer.

## Notes for reviewers

**The test helpers that stood in for a prepared run were mocks of it**, so they
would have mocked the meter away with everything else. They now build a real
`PreparedRun` around a stubbed agent, in all three files that had one. That cost
three tests their implicit workspace: `MagicMock` had been answering for fields
whose real default is `None`, and one of them turned out to be asserting on a
`_collect_outbound` it never awaited. Both branches of `_propose_skill_changes`
that those mocks had been covering by accident now have tests of their own.

**This branch also carries `test: drop two lint errors main has been failing on`**
(#451, `Closes #407`). `main` does not pass `make lint-backend`, and the
pre-commit `ruff --fix` hook rewrites those two files under every commit and then
refuses it — nothing could be committed here without them. That commit will drop
out of this diff once #451 merges.

Closes #16
