### PR TITLE
feat(dashboard): add the sandbox capacity, sessions and runtime cards

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -438,7 +438,20 @@ organization's open sandboxes on its default host — runtime, what shares each 
 idle time, and memory against its own ceiling when asked — plus the activity log
 per sandbox: which paths were read, which commands ran, and how each went. Neither
 file contents nor command output is recorded by the service, which is what keeps
-an audit trail from becoming a way to read another agent's work.
+an audit trail from becoming a way to read another agent's work. The dashboard
+answers the same three questions in its own section, for a caller holding
+`connections:manage`; memory is behind a switch there for the same reason it is on
+the screen, because the service samples each sandbox individually for it.
+
+**`SANDBOXD_MAX_SESSIONS_PER_TENANT` is the only one of the three ceilings anything
+renders as a fraction**, and that is a property of the answer rather than a choice
+about the view. The session listing is filtered to the caller's organization but
+carries `SANDBOXD_MAX_SESSIONS` and `SANDBOXD_MAX_OPEN_SESSIONS` through from the
+service untouched, so those two count every tenant on the host while the rows count
+one. There is no host-wide resident or open *count* in any response, so nothing puts
+a bar against them; they are named as host-wide ceilings beside the per-organization
+figure instead. If an agent is refused a session while that figure is short of its
+ceiling, the host is full of somebody else's work.
 
 That listing is **filtered, not forwarded**. One `sandboxd` answers for every
 organization that registered a connection at its address, so passing its response
@@ -452,8 +465,13 @@ ceiling behind each alias (`SANDBOXD_RUNTIMES`, `SANDBOXD_MEM_LIMIT`,
 `SANDBOXD_NETWORK_MODE`, `SANDBOXD_MAX_SESSIONS_PER_TENANT` and the rest) are its
 own boot configuration, and there is deliberately no endpoint to write them: a
 browser that could reconfigure the process holding the Docker socket would own the
-host. The Sandboxes screen *reads* them so what is in force is visible, and the
-Builder offers an agent only the aliases the service will actually accept.
+host. The Sandboxes screen and the dashboard's runtimes card both *read* them so
+what is in force is visible, and the Builder offers an agent only the aliases the
+service will actually accept.
+
+Neither view asks a Daytona connection any of this. It publishes no allowlist of its
+own and holds none of our sessions to enumerate — what it permits is a setting on
+that account, and what runs there is visible in its own dashboard.
 
 ## Messaging Channels
 

--- a/docs/design/dashboard-demo.md
+++ b/docs/design/dashboard-demo.md
@@ -95,7 +95,9 @@ The layouts, in the order each page reads:
   the adoption count that summarises it), then *People &amp; quality* —
   members with a per-role split and a "View members" link, beside the
   answer-quality trend. Members is deliberately **not** under Needs
-  attention: a headcount is context, not a queue. Workspace last.
+  attention: a headcount is context, not a queue. Then *Where agents run
+  code* — the sandbox zone #129 added, gated on `connections:manage`.
+  Workspace last.
 - **Operator** — *Needs attention* first and widest: the approvals queue
   beside recent failures, because both are the operator's inbox. Then
   *Health* (outcomes, latency, answer quality), then usage, workspace last.
@@ -105,7 +107,10 @@ The layouts, in the order each page reads:
   `agent_runs.agent_version_id`), adoption per agent, recent failures,
   answer quality, and the plumbing their agents stand on: MCP server health
   and knowledge-sync freshness, both of which fail quietly and take the
-  agent's tools or its knowledge with them. Then org usage. A builder holds
+  agent's tools or its knowledge with them. Then org usage, then the sandbox
+  zone — a builder is who gives an agent code execution, so the memory
+  ceiling it dies on is their question, and they hold `connections:manage`
+  where the operator does not. A builder holds
   `runs:view`, so the data is the same; the page just leads with what a
   builder can act on. (This also removes the old sore spot: builder held one
   small governance card and three-quarters of a row of air.)
@@ -449,9 +454,6 @@ the product.
   navigation, not a request flow.
 - **An audit strip** (`audit:read`) — the audit log has its own page;
   duplicating it here earns nothing yet.
-- **Sandbox capacity / sessions / activity** — issue #129 owns that view and
-  its data layer already exists. The zone model absorbs it cleanly later: one
-  more section, gated on `connections:manage`.
 - **Deployment-wide time series.** `/admin/stats` is point-in-time counts;
   giving the app admin adoption curves would mean cross-tenant aggregation
   with its own questions. The strip stays counts-plus-health for now.

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -904,7 +904,8 @@
       "workspace": "Your workspace",
       "build": "Your agents",
       "adoption": "How your builds behave",
-      "health": "Health"
+      "health": "Health",
+      "sandboxes": "Where agents run code"
     },
     "actions": {
       "newChat": "New chat",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1267,6 +1267,26 @@
           "title": "Sandboxes run on Daytona",
           "description": "Sessions opened there appear in that account's own dashboard, not here."
         }
+      },
+      "sandbox-policy": {
+        "title": "Sandbox runtimes",
+        "ceilings": {
+          "perOrganization": "This organization",
+          "hostResident": "Resident, host-wide",
+          "hostOpen": "Open, host-wide"
+        },
+        "default": "default",
+        "noMemoryCeiling": "no ceiling",
+        "noRuntime": "This service allows no runtime, so no agent can run code on it.",
+        "subline": "Ceilings, not counts - the host-wide two are shared with every organization on it. All of this is the service's own environment, set where it starts.",
+        "empty": {
+          "title": "No sandbox host registered",
+          "description": "Register one and the runtimes it allows land here."
+        },
+        "elsewhere": {
+          "title": "Sandboxes run on Daytona",
+          "description": "Daytona publishes no allowlist of its own - what it permits is a setting on that account."
+        }
       }
     }
   },

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1232,6 +1232,41 @@
           "title": "No sandbox host registered",
           "description": "Register one and the room left for agents to run code lands here."
         }
+      },
+      "sandbox-sessions": {
+        "title": "Open sandboxes",
+        "runningOn": "on {name}",
+        "sampleUsage": "Memory",
+        "sampleUsageHint": "Sample memory and CPU - one round trip to the host per sandbox",
+        "nothingRunning": "Nothing is running. A sandbox opens the first time an agent runs code.",
+        "unattributed": "No agent recorded",
+        "memoryOfLimit": "{used} of {limit}",
+        "activityOf": "Show what was done in sandbox {id}",
+        "showActivity": "Activity",
+        "hideActivity": "Hide",
+        "noActivity": "Nothing recorded for this sandbox yet.",
+        "tookMs": "{ms}ms",
+        "scope": {
+          "run": "one run only",
+          "agent": "shared across the whole agent",
+          "conversation": "shared in one conversation",
+          "channel": "shared in one channel",
+          "user": "shared by one person",
+          "unknown": "a scope this version does not recognise"
+        },
+        "idle": {
+          "seconds": "{count}s idle",
+          "minutes": "{count}m idle",
+          "hours": "{count}h idle"
+        },
+        "empty": {
+          "title": "No sandbox host registered",
+          "description": "Register one and the sandboxes your agents open land here."
+        },
+        "elsewhere": {
+          "title": "Sandboxes run on Daytona",
+          "description": "Sessions opened there appear in that account's own dashboard, not here."
+        }
       }
     }
   },

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1221,6 +1221,17 @@
           "title": "Nothing shared yet",
           "description": "When somebody shares an agent, a collection or a skill, it counts here."
         }
+      },
+      "sandbox-capacity": {
+        "title": "Sandbox capacity",
+        "openOfTenantLimit": "{used} of {limit}",
+        "openUncapped": "{count, plural, =1 {1 open} other {# open}}",
+        "elsewhere": "Runs on Daytona - those sandboxes are counted in that account, not here.",
+        "subline": "Open sandboxes against the ceiling that applies to this organization - the one a 429 comes from. The host's own ceilings are under Sandbox runtimes.",
+        "empty": {
+          "title": "No sandbox host registered",
+          "description": "Register one and the room left for agents to run code lands here."
+        }
       }
     }
   },

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1228,7 +1228,8 @@
         "openOfTenantLimit": "{used} of {limit}",
         "openUncapped": "{count, plural, =1 {1 open} other {# open}}",
         "elsewhere": "Runs on Daytona - those sandboxes are counted in that account, not here.",
-        "subline": "Open sandboxes against the ceiling that applies to this organization - the one a 429 comes from. The host's own ceilings are under Sandbox runtimes.",
+        "subline": "Open sandboxes against the ceiling that applies to this organization - the number a 429 comes from.",
+        "hostUncounted": "How full a host itself is cannot be shown here. Its own two ceilings are shared with every organization on it and no count of them is published, so this is the only figure that divides. Being refused a sandbox while this one is short of its ceiling means somebody else filled the host.",
         "empty": {
           "title": "No sandbox host registered",
           "description": "Register one and the room left for agents to run code lands here."
@@ -1279,7 +1280,7 @@
         "default": "default",
         "noMemoryCeiling": "no ceiling",
         "noRuntime": "This service allows no runtime, so no agent can run code on it.",
-        "subline": "Ceilings, not counts - the host-wide two are shared with every organization on it. All of this is the service's own environment, set where it starts.",
+        "subline": "Ceilings, not counts. The host-wide two are shared with every organization on it and nothing publishes how many are in use, so only the per-organization figure can be drawn as a fraction. All of this is the service's own environment, set where it starts.",
         "empty": {
           "title": "No sandbox host registered",
           "description": "Register one and the runtimes it allows land here."

--- a/frontend/src/app/[locale]/(dashboard)/dashboard/dashboard.integration.test.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/dashboard/dashboard.integration.test.tsx
@@ -119,7 +119,22 @@ const RATINGS = {
 };
 
 function respond(path: string, options?: { params?: Record<string, string> }): unknown {
+  // The sandbox cards carry their query in the path rather than in params, so
+  // they are matched before the switch. What they answer is exercised properly in
+  // `widgets/sandbox.integration.test.tsx`; here it only has to be well-shaped.
+  if (path.startsWith("/sandbox-connections/")) {
+    return path.includes("/policy")
+      ? { kind: "docker", runtimes: [], default_runtime: null, max_sessions_per_tenant: 8 }
+      : { sessions: [], limit: null, open_limit: null, tenant_limit: 8 };
+  }
   switch (path) {
+    case "/sandbox-connections":
+      return {
+        items: [
+          { id: "sb1", name: "Local Docker", kind: "docker", is_default: true, is_active: true },
+        ],
+        total: 1,
+      };
     case "/stats/usage":
       if (options?.params?.group_by === "user") {
         return { ...USAGE, by_user: PEOPLE };
@@ -274,12 +289,13 @@ beforeEach(() => {
 });
 
 describe("the steward's dashboard", () => {
-  it("renders the four sections and reads org-scoped usage", async () => {
+  it("renders the five sections and reads org-scoped usage", async () => {
     render(<DashboardPage />, { wrapper });
 
     expect(screen.getByText("dashboard.sections.attention")).toBeInTheDocument();
     expect(screen.getByText("dashboard.sections.usage")).toBeInTheDocument();
     expect(screen.getByText("dashboard.sections.people")).toBeInTheDocument();
+    expect(screen.getByText("dashboard.sections.sandboxes")).toBeInTheDocument();
     expect(screen.getByText("dashboard.sections.workspace")).toBeInTheDocument();
     expect(screen.queryByText("dashboard.sections.deployment")).not.toBeInTheDocument();
 
@@ -355,6 +371,30 @@ describe("the steward's dashboard", () => {
     expect(screen.queryByText("dashboard.sections.attention")).not.toBeInTheDocument();
     // "deployment" is somebody else's section; a pasted URL cannot conjure it.
     expect(screen.queryByText("dashboard.sections.deployment")).not.toBeInTheDocument();
+  });
+});
+
+describe("the sandbox section", () => {
+  it("is there for a caller holding connections:manage, and asks the host about itself", async () => {
+    auth.can = holds("connections:manage");
+
+    render(<DashboardPage />, { wrapper });
+
+    expect(screen.getByText("dashboard.sections.sandboxes")).toBeInTheDocument();
+    await waitFor(() => expect(callsTo("/sandbox-connections").length).toBeGreaterThan(0));
+  });
+
+  it("is absent without it, and the browser never asks where agents run code", async () => {
+    // Not rendered, not rendered-then-403: an operator holds every other
+    // org-wide permission and still does not hold this one (`ROLE_PERMS`).
+    auth.role = "operator";
+    auth.can = holds("agents:view", "agents:run", "approvals:decide", "runs:view");
+
+    render(<DashboardPage />, { wrapper });
+
+    await waitFor(() => expect(callsTo("/stats/usage").length).toBeGreaterThan(0));
+    expect(screen.queryByText("dashboard.sections.sandboxes")).not.toBeInTheDocument();
+    expect(callsTo("/sandbox-connections")).toHaveLength(0);
   });
 });
 

--- a/frontend/src/components/dashboard/widgets/index.ts
+++ b/frontend/src/components/dashboard/widgets/index.ts
@@ -31,6 +31,7 @@ import { PlatformWidget } from "./platform";
 import { PlatformRatingsWidget } from "./platform-ratings";
 import { RecentFailuresWidget } from "./recent-failures";
 import { RunsWidget } from "./runs";
+import { SandboxCapacityWidget } from "./sandbox-capacity";
 import { SharedWithYouWidget } from "./shared-with-you";
 import { SpendWidget } from "./spend";
 import { SurfacesWidget } from "./surfaces";
@@ -66,6 +67,7 @@ export const WIDGET_COMPONENTS: Record<WidgetId, ComponentType<DashboardWidgetPr
   "my-top-agents": MyTopAgentsWidget,
   "my-quality": MyQualityWidget,
   "shared-with-you": SharedWithYouWidget,
+  "sandbox-capacity": SandboxCapacityWidget,
 };
 
 export type { DashboardWidgetProps } from "./types";

--- a/frontend/src/components/dashboard/widgets/index.ts
+++ b/frontend/src/components/dashboard/widgets/index.ts
@@ -32,6 +32,7 @@ import { PlatformRatingsWidget } from "./platform-ratings";
 import { RecentFailuresWidget } from "./recent-failures";
 import { RunsWidget } from "./runs";
 import { SandboxCapacityWidget } from "./sandbox-capacity";
+import { SandboxSessionsWidget } from "./sandbox-sessions";
 import { SharedWithYouWidget } from "./shared-with-you";
 import { SpendWidget } from "./spend";
 import { SurfacesWidget } from "./surfaces";
@@ -68,6 +69,7 @@ export const WIDGET_COMPONENTS: Record<WidgetId, ComponentType<DashboardWidgetPr
   "my-quality": MyQualityWidget,
   "shared-with-you": SharedWithYouWidget,
   "sandbox-capacity": SandboxCapacityWidget,
+  "sandbox-sessions": SandboxSessionsWidget,
 };
 
 export type { DashboardWidgetProps } from "./types";

--- a/frontend/src/components/dashboard/widgets/index.ts
+++ b/frontend/src/components/dashboard/widgets/index.ts
@@ -32,6 +32,7 @@ import { PlatformRatingsWidget } from "./platform-ratings";
 import { RecentFailuresWidget } from "./recent-failures";
 import { RunsWidget } from "./runs";
 import { SandboxCapacityWidget } from "./sandbox-capacity";
+import { SandboxPolicyWidget } from "./sandbox-policy";
 import { SandboxSessionsWidget } from "./sandbox-sessions";
 import { SharedWithYouWidget } from "./shared-with-you";
 import { SpendWidget } from "./spend";
@@ -70,6 +71,7 @@ export const WIDGET_COMPONENTS: Record<WidgetId, ComponentType<DashboardWidgetPr
   "shared-with-you": SharedWithYouWidget,
   "sandbox-capacity": SandboxCapacityWidget,
   "sandbox-sessions": SandboxSessionsWidget,
+  "sandbox-policy": SandboxPolicyWidget,
 };
 
 export type { DashboardWidgetProps } from "./types";

--- a/frontend/src/components/dashboard/widgets/sandbox-activity.tsx
+++ b/frontend/src/components/dashboard/widgets/sandbox-activity.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+import { useSandboxEvents } from "@/hooks";
+import { cn } from "@/lib/utils";
+import { WidgetSkeleton } from "../widget-states";
+
+/**
+ * What was done inside one sandbox: paths read, commands run, how each went.
+ *
+ * Not a card of its own, and it could not be one - `DashboardWidgetProps` carries
+ * no session and the events route takes one. A feed across every open sandbox
+ * would be a request per sandbox on load, which is the cost `usage=true` is
+ * opt-in to avoid. So it hangs off the row whose log it is.
+ *
+ * Paths and commands, never their contents or their output: the service records
+ * neither, which is what keeps this an audit of an agent's work rather than a way
+ * to read it.
+ */
+export function SandboxActivity({
+  connectionId,
+  sessionId,
+}: {
+  connectionId: string;
+  sessionId: string;
+}) {
+  const t = useTranslations("dashboard.widgets.sandbox-sessions");
+  const { log, error } = useSandboxEvents(connectionId, sessionId);
+
+  if (error !== null) return <p className="text-destructive text-xs">{error}</p>;
+  if (log === null) return <WidgetSkeleton rows={2} className="py-0" />;
+  if (log.events.length === 0)
+    return <p className="text-muted-foreground text-xs">{t("noActivity")}</p>;
+
+  return (
+    <ul className="bg-muted max-h-40 space-y-1 overflow-auto rounded-md p-2">
+      {log.events.map((event) => (
+        <li
+          key={event.seq}
+          className={cn("flex items-baseline gap-2 text-xs", !event.ok && "text-destructive")}
+        >
+          <span className="shrink-0 font-mono">{event.op}</span>
+          <span className="text-muted-foreground min-w-0 flex-1 truncate font-mono">
+            {event.target}
+          </span>
+          <span className="text-muted-foreground shrink-0 tabular-nums">
+            {t("tookMs", { ms: Math.round(event.duration_ms) })}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/components/dashboard/widgets/sandbox-capacity.tsx
+++ b/frontend/src/components/dashboard/widgets/sandbox-capacity.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+import { useSandboxConnections, useSandboxSessions } from "@/hooks";
+import { holdsSessions, tenantShare, watchableConnections } from "@/lib/dashboard/sandbox";
+import type { SandboxConnectionRecord } from "@/lib/sandbox-connections-api";
+import { cn } from "@/lib/utils";
+import { WidgetFrame } from "../widget-frame";
+import { WidgetEmptyBody, WidgetErrorBody, WidgetSkeleton } from "../widget-states";
+import type { DashboardWidgetProps } from "./types";
+
+/**
+ * How much room this organization has left on each host it runs sandboxes on.
+ *
+ * The card that answers "why did an agent just get a 429": the host refuses a
+ * session once the organization reaches `max_sessions_per_tenant`, and nothing
+ * else on the page says so.
+ *
+ * One figure per connection, and deliberately only one. The host's own ceilings
+ * arrive on the same response, but there is no count to put against them - see
+ * `lib/dashboard/sandbox.ts` - so they are shown as ceilings by the policy card
+ * rather than as a fraction here. A row per connection rather than the default
+ * host alone, because the 429 came from whichever one the agent resolved to.
+ *
+ * Ignores the period filter: every figure here is true only of this moment.
+ */
+export function SandboxCapacityWidget({ title, seeAll }: DashboardWidgetProps) {
+  const t = useTranslations("dashboard.widgets.sandbox-capacity");
+  const { connections, isLoading, error, refresh } = useSandboxConnections();
+  const hosts = watchableConnections(connections);
+
+  return (
+    <WidgetFrame title={title} seeAll={seeAll}>
+      {isLoading ? (
+        <WidgetSkeleton />
+      ) : error !== null ? (
+        <WidgetErrorBody onRetry={() => void refresh()} />
+      ) : hosts.length === 0 ? (
+        <WidgetEmptyBody title={t("empty.title")} description={t("empty.description")} />
+      ) : (
+        <div className="flex h-full flex-col justify-between gap-3">
+          <ul className="space-y-3">
+            {hosts.map((host) => (
+              <HostCapacity key={host.id} connection={host} />
+            ))}
+          </ul>
+          <p className="text-muted-foreground text-xs">{t("subline")}</p>
+        </div>
+      )}
+    </WidgetFrame>
+  );
+}
+
+/** One host's figure, asked of that host. */
+function HostCapacity({ connection }: { connection: SandboxConnectionRecord }) {
+  const t = useTranslations("dashboard.widgets.sandbox-capacity");
+  // A connection holding none of our sessions is not asked at all: it would
+  // answer with the empty list an idle container host answers with.
+  const counted = holdsSessions(connection);
+  const { listing, error } = useSandboxSessions(counted ? connection.id : null);
+  const share = listing === null ? null : tenantShare(listing);
+
+  return (
+    <li className="space-y-1.5 text-xs">
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-foreground truncate font-medium">{connection.name}</span>
+        {share !== null ? (
+          <span className="text-foreground shrink-0 tabular-nums">
+            {share.limit === null
+              ? t("openUncapped", { count: share.used })
+              : t("openOfTenantLimit", { used: share.used, limit: share.limit })}
+          </span>
+        ) : null}
+      </div>
+      {!counted ? (
+        <p className="text-muted-foreground">{t("elsewhere")}</p>
+      ) : error !== null ? (
+        // The host's own sentence, which says whether it is unreachable or its
+        // credential was rotated away. Rendering "0 open" for either is the
+        // failure #129 calls an empty view and a dead host being the same
+        // pixels. No Retry: this query already re-asks every ten seconds.
+        <p className="text-destructive">{error}</p>
+      ) : share === null ? (
+        <WidgetSkeleton rows={1} className="py-0" />
+      ) : share.percent !== null ? (
+        <CapacityTrack percent={share.percent} />
+      ) : null}
+    </li>
+  );
+}
+
+/**
+ * The fraction as a bar. Decorative: the same numbers are printed beside it, so
+ * colour is never the only channel carrying "this host is nearly full".
+ */
+function CapacityTrack({ percent }: { percent: number }) {
+  return (
+    <div className="bg-foreground/5 h-1.5 overflow-hidden rounded-full">
+      <div
+        className={cn(
+          "h-full rounded-full",
+          percent >= 90 ? "bg-destructive" : percent >= 70 ? "bg-warning" : "bg-chart",
+        )}
+        style={{ width: `${percent}%` }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/widgets/sandbox-capacity.tsx
+++ b/frontend/src/components/dashboard/widgets/sandbox-capacity.tsx
@@ -45,7 +45,17 @@ export function SandboxCapacityWidget({ title, seeAll }: DashboardWidgetProps) {
               <HostCapacity key={host.id} connection={host} />
             ))}
           </ul>
-          <p className="text-muted-foreground text-xs">{t("subline")}</p>
+          <div className="space-y-1">
+            <p className="text-muted-foreground text-xs">{t("subline")}</p>
+            {/* On screen, not only in a docstring. A reader who is refused a
+                sandbox while this card shows room to spare would otherwise have
+                no way to learn that the missing figure is missing rather than
+                zero - which is the same failure as an unreachable host reading
+                as idle, one level up. */}
+            <p className="text-muted-foreground/80 text-[11px] leading-snug">
+              {t("hostUncounted")}
+            </p>
+          </div>
         </div>
       )}
     </WidgetFrame>

--- a/frontend/src/components/dashboard/widgets/sandbox-policy.tsx
+++ b/frontend/src/components/dashboard/widgets/sandbox-policy.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+import { Badge } from "@/components/ui";
+import { useSandboxConnections, useSandboxPolicy } from "@/hooks";
+import { holdsSessions, primaryConnection } from "@/lib/dashboard/sandbox";
+import type { SandboxPolicy } from "@/lib/sandbox-connections-api";
+import { WidgetFrame } from "../widget-frame";
+import { WidgetEmptyBody, WidgetErrorBody, WidgetSkeleton } from "../widget-states";
+import type { DashboardWidgetProps } from "./types";
+
+/**
+ * What the host allows: the runtimes an agent may ask for, and the ceilings.
+ *
+ * Read-only by design rather than by omission. These are `sandboxd`'s own boot
+ * configuration, and an endpoint letting a browser change them would be an
+ * endpoint that reconfigures the process holding the Docker socket. They are here
+ * so that what is in force is *visible* - an operator whose agents keep dying on
+ * a memory limit has somewhere to look.
+ *
+ * This is also where `max_sessions` and `max_open_sessions` belong. They are
+ * ceilings for every organization on the host, so there is no count of ours to
+ * put against them; naming them host-wide is the honest rendering, and the
+ * capacity card draws the one fraction that does divide cleanly.
+ */
+export function SandboxPolicyWidget({ title, seeAll }: DashboardWidgetProps) {
+  const t = useTranslations("dashboard.widgets.sandbox-policy");
+  const { connections, isLoading, error, refresh } = useSandboxConnections();
+  const host = primaryConnection(connections);
+  // Daytona publishes no allowlist of its own, so it is not asked: what it
+  // permits is an account setting on their side.
+  const asked = host !== null && holdsSessions(host) ? host.id : null;
+  const policy = useSandboxPolicy(asked);
+
+  return (
+    <WidgetFrame title={title} seeAll={seeAll}>
+      {isLoading ? (
+        <WidgetSkeleton />
+      ) : error !== null ? (
+        <WidgetErrorBody onRetry={() => void refresh()} />
+      ) : host === null ? (
+        <WidgetEmptyBody title={t("empty.title")} description={t("empty.description")} />
+      ) : asked === null ? (
+        <WidgetEmptyBody title={t("elsewhere.title")} description={t("elsewhere.description")} />
+      ) : policy.error !== null ? (
+        <WidgetErrorBody onRetry={policy.refetch} />
+      ) : policy.policy === null ? (
+        // Still being asked. `policy.isLoading` is deliberately not read: the
+        // absent answer is the same condition, and two ways to spell it leaves
+        // one of them unreachable.
+        <WidgetSkeleton />
+      ) : (
+        <PolicyBody policy={policy.policy} />
+      )}
+    </WidgetFrame>
+  );
+}
+
+/** Which ceilings this service publishes, in the order a reader needs them. */
+function ceilingsOf(policy: SandboxPolicy): { key: string; value: number }[] {
+  return [
+    { key: "perOrganization", value: policy.max_sessions_per_tenant },
+    { key: "hostResident", value: policy.max_sessions },
+    { key: "hostOpen", value: policy.max_open_sessions },
+  ].filter((row): row is { key: string; value: number } => row.value !== null);
+}
+
+function PolicyBody({ policy }: { policy: SandboxPolicy }) {
+  const t = useTranslations("dashboard.widgets.sandbox-policy");
+  const ceilings = ceilingsOf(policy);
+
+  return (
+    <div className="flex h-full flex-col gap-3">
+      {ceilings.length > 0 ? (
+        <dl className="grid grid-cols-3 gap-x-3 text-xs">
+          {ceilings.map((row) => (
+            <div key={row.key}>
+              <dt className="text-muted-foreground truncate">{t(`ceilings.${row.key}`)}</dt>
+              <dd className="text-foreground font-medium tabular-nums">{row.value}</dd>
+            </div>
+          ))}
+        </dl>
+      ) : null}
+      {policy.runtimes.length === 0 ? (
+        // Not an empty state: a service allowing no runtime is a service on which
+        // no agent can run code at all.
+        <p className="text-destructive text-xs">{t("noRuntime")}</p>
+      ) : (
+        <ul className="min-h-0 flex-1 space-y-1.5 overflow-auto">
+          {policy.runtimes.map((runtime) => (
+            <li key={runtime.alias} className="flex items-center gap-2 text-xs">
+              <span className="text-foreground shrink-0 font-mono">{runtime.alias}</span>
+              {runtime.alias === policy.default_runtime ? (
+                <Badge variant="secondary" className="shrink-0">
+                  {t("default")}
+                </Badge>
+              ) : null}
+              <span className="text-muted-foreground min-w-0 flex-1 truncate">
+                {runtime.description}
+              </span>
+              <span className="text-foreground shrink-0 tabular-nums">
+                {runtime.mem_limit ?? t("noMemoryCeiling")}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+      <p className="text-muted-foreground text-xs">{t("subline")}</p>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/widgets/sandbox-sessions.tsx
+++ b/frontend/src/components/dashboard/widgets/sandbox-sessions.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+
+import { Badge, Button, Switch } from "@/components/ui";
+import { useAgents, useSandboxConnections, useSandboxSessions } from "@/hooks";
+import {
+  holdsSessions,
+  idleLabel,
+  memoryLabel,
+  primaryConnection,
+  scopeKey,
+} from "@/lib/dashboard/sandbox";
+import type { SandboxConnectionRecord, SandboxSession } from "@/lib/sandbox-connections-api";
+import { SandboxActivity } from "./sandbox-activity";
+import { WidgetFrame } from "../widget-frame";
+import { WidgetEmptyBody, WidgetErrorBody, WidgetSkeleton } from "../widget-states";
+import type { DashboardWidgetProps } from "./types";
+
+/**
+ * Every sandbox this organization has open on the host its agents resolve to.
+ *
+ * The default connection, not all of them: capacity is the card that covers
+ * every host, and a dashboard card cannot be a table across several. Its "see
+ * all" is the Sandboxes page, which is where the rest of them live.
+ *
+ * Memory and CPU are behind the switch because the service samples each sandbox
+ * individually for them - a card listing twenty would otherwise buy twenty daemon
+ * round trips on load, every ten seconds. The listing arrives already filtered to
+ * this organization, so nothing here filters it again.
+ *
+ * Ignores the period filter: a sandbox is either open now or it is not.
+ */
+export function SandboxSessionsWidget({ title, seeAll }: DashboardWidgetProps) {
+  const t = useTranslations("dashboard.widgets.sandbox-sessions");
+  const [usage, setUsage] = useState(false);
+  const { connections, isLoading, error, refresh } = useSandboxConnections();
+  const host = primaryConnection(connections);
+
+  return (
+    <WidgetFrame title={title} seeAll={seeAll}>
+      {isLoading ? (
+        <WidgetSkeleton />
+      ) : error !== null ? (
+        <WidgetErrorBody onRetry={() => void refresh()} />
+      ) : host === null ? (
+        <WidgetEmptyBody title={t("empty.title")} description={t("empty.description")} />
+      ) : !holdsSessions(host) ? (
+        <WidgetEmptyBody title={t("elsewhere.title")} description={t("elsewhere.description")} />
+      ) : (
+        <div className="flex min-h-0 flex-1 flex-col gap-3">
+          <div className="flex items-center justify-between gap-2 text-xs">
+            <p className="text-muted-foreground truncate">{t("runningOn", { name: host.name })}</p>
+            <label className="flex shrink-0 items-center gap-2">
+              <span className="text-muted-foreground">{t("sampleUsage")}</span>
+              <Switch
+                checked={usage}
+                onCheckedChange={setUsage}
+                aria-label={t("sampleUsageHint")}
+              />
+            </label>
+          </div>
+          <HostSessions connection={host} usage={usage} />
+        </div>
+      )}
+    </WidgetFrame>
+  );
+}
+
+/** One host's open sandboxes, asked of that host. */
+function HostSessions({
+  connection,
+  usage,
+}: {
+  connection: SandboxConnectionRecord;
+  usage: boolean;
+}) {
+  const t = useTranslations("dashboard.widgets.sandbox-sessions");
+  const [watching, setWatching] = useState<string | null>(null);
+  const { listing, error } = useSandboxSessions(connection.id, usage);
+  const { agents } = useAgents();
+  const names = new Map(agents.map((agent) => [agent.id, agent.name]));
+
+  // The host's own sentence rather than an empty list: it says whether nothing is
+  // running, the service is unreachable, or its credential was rotated away.
+  if (error !== null) return <p className="text-destructive text-xs">{error}</p>;
+  if (listing === null) return <WidgetSkeleton rows={3} />;
+  if (listing.sessions.length === 0)
+    return <p className="text-muted-foreground text-xs">{t("nothingRunning")}</p>;
+
+  return (
+    <ul className="min-h-0 flex-1 space-y-2.5 overflow-auto">
+      {listing.sessions.map((session) => (
+        <SessionRow
+          key={session.session_id}
+          connectionId={connection.id}
+          session={session}
+          agentName={session.agent_id === null ? undefined : names.get(session.agent_id)}
+          watching={watching === session.session_id}
+          onToggle={() => setWatching(watching === session.session_id ? null : session.session_id)}
+        />
+      ))}
+    </ul>
+  );
+}
+
+interface SessionRowProps {
+  connectionId: string;
+  session: SandboxSession;
+  /** Absent for a `run`-scoped sandbox, which has no workspace row to join. */
+  agentName?: string;
+  watching: boolean;
+  onToggle: () => void;
+}
+
+function SessionRow({ connectionId, session, agentName, watching, onToggle }: SessionRowProps) {
+  const t = useTranslations("dashboard.widgets.sandbox-sessions");
+  const idle = idleLabel(session.idle_seconds);
+  const memory = memoryLabel(session);
+
+  return (
+    <li className="space-y-1.5">
+      <div className="flex items-center gap-2 text-xs">
+        {/* Hibernated is not dead: the sandbox was stopped to free a slot, and
+            its files and its log are both still there. */}
+        <Badge variant={session.alive ? "secondary" : "outline"} className="shrink-0">
+          {session.state}
+        </Badge>
+        <span className="min-w-0 flex-1">
+          <span className="text-foreground block truncate">{agentName ?? t("unattributed")}</span>
+          <span className="text-muted-foreground block truncate">{t(scopeKey(session.scope))}</span>
+        </span>
+        <span className="text-muted-foreground shrink-0 font-mono">{session.runtime}</span>
+        <span className="text-muted-foreground shrink-0 tabular-nums">
+          {t(idle.key, { count: idle.count })}
+        </span>
+        {memory !== null ? (
+          <span className="text-foreground shrink-0 tabular-nums">
+            {memory.limit === null
+              ? memory.used
+              : t("memoryOfLimit", { used: memory.used, limit: memory.limit })}
+          </span>
+        ) : null}
+        <Button
+          variant="ghost"
+          size="sm"
+          className="shrink-0"
+          aria-label={t("activityOf", { id: session.session_id })}
+          onClick={onToggle}
+        >
+          {watching ? t("hideActivity") : t("showActivity")}
+        </Button>
+      </div>
+      {watching ? (
+        <SandboxActivity connectionId={connectionId} sessionId={session.session_id} />
+      ) : null}
+    </li>
+  );
+}

--- a/frontend/src/components/dashboard/widgets/sandbox.integration.test.tsx
+++ b/frontend/src/components/dashboard/widgets/sandbox.integration.test.tsx
@@ -1,0 +1,242 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render as renderBare, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SandboxCapacityWidget } from "./sandbox-capacity";
+import { ApiError, apiClient } from "@/lib/api-client";
+import type { Period } from "@/lib/dashboard/period";
+import type {
+  SandboxConnectionRecord,
+  SandboxSession,
+  SandboxSessionList,
+} from "@/lib/sandbox-connections-api";
+
+/**
+ * The sandbox cards against a host that answers - and against one that does not.
+ *
+ * `next-intl` is not stubbed here (see `vitest.setup.ts`), so every assertion is
+ * on the copy a reader sees. That matters most for the figures: "3 of 8" proves
+ * the card divided by the ceiling that applies to this organization, and a test
+ * asserting on a key could not tell that from "3 of 40".
+ */
+
+vi.mock("@/lib/api-client", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api-client")>("@/lib/api-client");
+  return { ...actual, apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() } };
+});
+
+/** Every sandbox card ignores the period; one value serves all of them. */
+const PERIOD: Period = { preset: "30d", from: "2026-07-07", to: "2026-08-05" };
+
+function render(ui: React.ReactElement) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return renderBare(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+function connection(overrides: Partial<SandboxConnectionRecord> = {}): SandboxConnectionRecord {
+  return {
+    id: "c-1",
+    name: "Local Docker",
+    kind: "docker",
+    base_url: "http://sandboxd:8080",
+    secret_id: "s-1",
+    default_runtime: "python",
+    is_default: true,
+    is_active: true,
+    created_at: "2026-08-03T00:00:00Z",
+    updated_at: null,
+    ...overrides,
+  };
+}
+
+function session(overrides: Partial<SandboxSession> = {}): SandboxSession {
+  return {
+    session_id: "cc-abcd1234-1111",
+    runtime: "python",
+    alive: true,
+    state: "running",
+    created_at: 1_760_000_000,
+    last_activity: 1_760_000_100,
+    idle_seconds: 12,
+    usage: null,
+    agent_id: "a-1",
+    conversation_id: "conv-1",
+    scope: "conversation",
+    ...overrides,
+  };
+}
+
+interface HostFixture {
+  connection: SandboxConnectionRecord;
+  listing?: Partial<SandboxSessionList>;
+  /** The sentence a host answers with instead of a listing. */
+  fails?: string;
+}
+
+/** A deployment's registered hosts, each answering for itself. */
+function deployment(...hosts: HostFixture[]) {
+  vi.mocked(apiClient.get).mockImplementation(async (path: string) => {
+    if (path === "/sandbox-connections") {
+      return { items: hosts.map((host) => host.connection), total: hosts.length };
+    }
+    const asked = /^\/sandbox-connections\/([^/]+)\/sessions/.exec(path);
+    if (asked !== null) {
+      const host = hosts.find((candidate) => candidate.connection.id === asked[1]);
+      if (host?.fails !== undefined) throw new ApiError(502, host.fails);
+      return {
+        sessions: [],
+        limit: null,
+        open_limit: null,
+        tenant_limit: null,
+        ...host?.listing,
+      };
+    }
+    throw new ApiError(404, `nothing serves ${path}`);
+  });
+}
+
+/** Which hosts the card actually asked about. */
+function sessionsAskedFor(): string[] {
+  return vi
+    .mocked(apiClient.get)
+    .mock.calls.map(([path]) => /^\/sandbox-connections\/([^/]+)\/sessions/.exec(path)?.[1])
+    .filter((id): id is string => id !== undefined);
+}
+
+function tracks(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll("[style*='width']")).map(
+    (element) => element.className,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(apiClient.get).mockReset();
+});
+
+describe("the sandbox capacity card", () => {
+  it("counts this organization's sandboxes against the ceiling that applies to it", async () => {
+    deployment({
+      connection: connection({ name: "sandboxd-eu" }),
+      listing: { sessions: [session(), session(), session()], tenant_limit: 8 },
+    });
+
+    render(<SandboxCapacityWidget title="Sandbox capacity" period={PERIOD} />);
+
+    expect(await screen.findByText("3 of 8")).toBeInTheDocument();
+    expect(screen.getByText("sandboxd-eu")).toBeInTheDocument();
+  });
+
+  it("never divides by the host's ceilings, which count every tenant on it", async () => {
+    // The whole host allows 40 resident and 20 open; two of them are ours. "2 of
+    // 40" would name a ceiling that is not the one refusing us a session, so
+    // there is no fraction here at all - only what we hold.
+    deployment({
+      connection: connection(),
+      listing: { sessions: [session(), session()], limit: 40, open_limit: 20 },
+    });
+
+    const { container } = render(
+      <SandboxCapacityWidget title="Sandbox capacity" period={PERIOD} />,
+    );
+
+    expect(await screen.findByText("2 open")).toBeInTheDocument();
+    expect(screen.queryByText("2 of 40")).not.toBeInTheDocument();
+    expect(screen.queryByText("2 of 20")).not.toBeInTheDocument();
+    // And no bar either: a track needs a denominator this response cannot give.
+    expect(tracks(container)).toEqual([]);
+  });
+
+  it("says one sandbox is open rather than building the plural from English", async () => {
+    deployment({ connection: connection(), listing: { sessions: [session()] } });
+
+    render(<SandboxCapacityWidget title="Sandbox capacity" period={PERIOD} />);
+
+    expect(await screen.findByText("1 open")).toBeInTheDocument();
+  });
+
+  it("warns by colour as well as by number as a host fills up", async () => {
+    deployment(
+      {
+        connection: connection({ id: "calm", name: "Calm" }),
+        listing: { sessions: [session()], tenant_limit: 8 },
+      },
+      {
+        connection: connection({ id: "busy", name: "Busy", is_default: false }),
+        listing: { sessions: [session(), session(), session()], tenant_limit: 4 },
+      },
+      {
+        connection: connection({ id: "full", name: "Full", is_default: false }),
+        listing: { sessions: [session(), session(), session(), session()], tenant_limit: 4 },
+      },
+    );
+
+    const { container } = render(
+      <SandboxCapacityWidget title="Sandbox capacity" period={PERIOD} />,
+    );
+
+    await screen.findByText("1 of 8");
+    await waitFor(() => expect(tracks(container)).toHaveLength(3));
+    const [calm, busy, full] = tracks(container);
+    expect(calm).toContain("bg-chart");
+    expect(busy).toContain("bg-warning");
+    expect(full).toContain("bg-destructive");
+  });
+
+  it("says a host is unreachable instead of reporting it as idle", async () => {
+    deployment({
+      connection: connection({ name: "sandboxd-eu" }),
+      fails: "The sandbox service did not answer: connection refused",
+    });
+
+    render(<SandboxCapacityWidget title="Sandbox capacity" period={PERIOD} />);
+
+    expect(await screen.findByText(/connection refused/)).toBeInTheDocument();
+    // The failure that #129 calls an empty view and a dead host being the same
+    // pixels: a card reading "0 open" for a host nobody can reach.
+    expect(screen.queryByText("0 open")).not.toBeInTheDocument();
+  });
+
+  it("tells a Daytona connection apart from an idle host, and asks it nothing", async () => {
+    deployment({ connection: connection({ kind: "daytona", base_url: null }) });
+
+    render(<SandboxCapacityWidget title="Sandbox capacity" period={PERIOD} />);
+
+    expect(await screen.findByText(/counted in that account/)).toBeInTheDocument();
+    expect(sessionsAskedFor()).toEqual([]);
+  });
+
+  it("leaves out a connection no agent can reach any more", async () => {
+    deployment(
+      { connection: connection({ id: "live", name: "Live" }), listing: { sessions: [session()] } },
+      { connection: connection({ id: "gone", name: "Retired", is_active: false }) },
+    );
+
+    render(<SandboxCapacityWidget title="Sandbox capacity" period={PERIOD} />);
+
+    await screen.findByText("Live");
+    expect(screen.queryByText("Retired")).not.toBeInTheDocument();
+    expect(sessionsAskedFor()).toEqual(["live"]);
+  });
+
+  it("says no host is registered rather than showing an empty list", async () => {
+    deployment();
+
+    render(<SandboxCapacityWidget title="Sandbox capacity" period={PERIOD} />);
+
+    expect(await screen.findByText("No sandbox host registered")).toBeInTheDocument();
+  });
+
+  it("says the listing failed, and asks again when told to", async () => {
+    vi.mocked(apiClient.get).mockRejectedValue(new ApiError(502, "Bad Gateway"));
+
+    render(<SandboxCapacityWidget title="Sandbox capacity" period={PERIOD} />);
+
+    expect(await screen.findByText("Couldn't load this")).toBeInTheDocument();
+    expect(screen.queryByText("No sandbox host registered")).not.toBeInTheDocument();
+
+    deployment({ connection: connection({ name: "Back up" }), listing: { sessions: [session()] } });
+    screen.getByRole("button", { name: "Retry" }).click();
+
+    expect(await screen.findByText("Back up")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/widgets/sandbox.integration.test.tsx
+++ b/frontend/src/components/dashboard/widgets/sandbox.integration.test.tsx
@@ -238,8 +238,29 @@ describe("the sandbox capacity card", () => {
     expect(await screen.findByText("2 open")).toBeInTheDocument();
     expect(screen.queryByText("2 of 40")).not.toBeInTheDocument();
     expect(screen.queryByText("2 of 20")).not.toBeInTheDocument();
+    // Neither ceiling reaches the card at all, in any wording: this asserts on
+    // the rendered text rather than on two guessed phrasings, because the
+    // failure being guarded is a plausible-looking ratio and there are several
+    // ways to write one.
+    expect(container.textContent).not.toContain("40");
+    expect(container.textContent).not.toContain("20");
     // And no bar either: a track needs a denominator this response cannot give.
     expect(tracks(container)).toEqual([]);
+  });
+
+  it("says on screen that how full the host is cannot be shown, and what that means", async () => {
+    // The figure a reader needs is absent, and absence is not self-explaining.
+    // Without this sentence, being refused a sandbox while the card shows room
+    // to spare reads as the card being wrong.
+    deployment({
+      connection: connection(),
+      listing: { sessions: [session()], tenant_limit: 8 },
+    });
+
+    render(<SandboxCapacityWidget title="Sandbox capacity" period={PERIOD} />);
+
+    expect(await screen.findByText(/How full a host itself is cannot be shown here/)).toBeVisible();
+    expect(screen.getByText(/somebody else filled the host/)).toBeVisible();
   });
 
   it("says one sandbox is open rather than building the plural from English", async () => {

--- a/frontend/src/components/dashboard/widgets/sandbox.integration.test.tsx
+++ b/frontend/src/components/dashboard/widgets/sandbox.integration.test.tsx
@@ -4,12 +4,15 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SandboxCapacityWidget } from "./sandbox-capacity";
+import { SandboxPolicyWidget } from "./sandbox-policy";
 import { SandboxSessionsWidget } from "./sandbox-sessions";
 import { ApiError, apiClient } from "@/lib/api-client";
 import type { Period } from "@/lib/dashboard/period";
 import type {
   SandboxConnectionRecord,
   SandboxEvent,
+  SandboxPolicy,
+  SandboxRuntime,
   SandboxSession,
   SandboxSessionList,
 } from "@/lib/sandbox-connections-api";
@@ -82,6 +85,19 @@ function event(overrides: Partial<SandboxEvent> = {}): SandboxEvent {
   };
 }
 
+function runtime(overrides: Partial<SandboxRuntime> = {}): SandboxRuntime {
+  return {
+    alias: "python",
+    image: "python:3.12-slim",
+    description: "Python with the standard library",
+    builds: false,
+    mem_limit: "512m",
+    cpus: 1,
+    network_mode: "none",
+    ...overrides,
+  };
+}
+
 interface HostFixture {
   connection: SandboxConnectionRecord;
   listing?: Partial<SandboxSessionList>;
@@ -89,6 +105,8 @@ interface HostFixture {
   fails?: string;
   /** Per session id: the log it answers with, or the sentence it fails with. */
   logs?: Record<string, SandboxEvent[] | string>;
+  /** What it allows, or the sentence it fails the policy call with. */
+  allows?: Partial<SandboxPolicy> | string;
 }
 
 /**
@@ -99,6 +117,7 @@ let agentRows: { id: string; name: string }[] = [];
 
 const SESSIONS = /^\/sandbox-connections\/([^/]+)\/sessions\?/;
 const EVENTS = /^\/sandbox-connections\/([^/]+)\/sessions\/([^/?]+)\/events/;
+const POLICY = /^\/sandbox-connections\/([^/]+)\/policy$/;
 
 /** A deployment's registered hosts, each answering for itself. */
 function deployment(...hosts: HostFixture[]) {
@@ -108,6 +127,23 @@ function deployment(...hosts: HostFixture[]) {
     }
     if (path === "/agents") {
       return { items: agentRows, total: agentRows.length };
+    }
+    const allowed = POLICY.exec(path);
+    if (allowed !== null) {
+      const answer = hosts.find((candidate) => candidate.connection.id === allowed[1])?.allows;
+      if (typeof answer === "string") throw new ApiError(502, answer);
+      return {
+        kind: "docker",
+        runtimes: [],
+        default_runtime: null,
+        max_sessions: null,
+        max_open_sessions: null,
+        max_sessions_per_tenant: null,
+        idle_timeout: null,
+        workspace_root: null,
+        persist_containers: null,
+        ...answer,
+      };
     }
     const log = EVENTS.exec(path);
     if (log !== null) {
@@ -143,6 +179,14 @@ function sessionsAskedFor(): string[] {
   return vi
     .mocked(apiClient.get)
     .mock.calls.map(([path]) => SESSIONS.exec(path)?.[1])
+    .filter((id): id is string => id !== undefined);
+}
+
+/** Which hosts were asked what they allow. */
+function policiesAskedFor(): string[] {
+  return vi
+    .mocked(apiClient.get)
+    .mock.calls.map(([path]) => POLICY.exec(path)?.[1])
     .filter((id): id is string => id !== undefined);
 }
 
@@ -526,5 +570,128 @@ describe("the open-sandboxes card", () => {
     await userEvent.click(screen.getByRole("button", { name: "Retry" }));
 
     expect(await screen.findByText("Support triage")).toBeInTheDocument();
+  });
+});
+
+describe("the sandbox runtimes card", () => {
+  function card() {
+    return <SandboxPolicyWidget title="Sandbox runtimes" period={PERIOD} />;
+  }
+
+  it("names the host's ceilings as ceilings, never as a fraction", async () => {
+    // This is where `max_sessions` and `max_open_sessions` belong: they are the
+    // whole host's, so there is no count of ours to divide them by.
+    deployment({
+      connection: connection(),
+      allows: {
+        runtimes: [runtime()],
+        max_sessions_per_tenant: 8,
+        max_sessions: 40,
+        max_open_sessions: 20,
+      },
+    });
+
+    render(card());
+
+    expect(await screen.findByText("Resident, host-wide")).toBeInTheDocument();
+    expect(screen.getByText("Open, host-wide")).toBeInTheDocument();
+    expect(screen.getByText("This organization")).toBeInTheDocument();
+    expect(screen.getByText("40")).toBeInTheDocument();
+    expect(screen.queryByText("0 of 40")).not.toBeInTheDocument();
+  });
+
+  it("names only the ceilings the service publishes", async () => {
+    deployment({ connection: connection(), allows: { runtimes: [runtime()] } });
+
+    render(card());
+
+    await screen.findByText("python");
+    expect(screen.queryByText("Resident, host-wide")).not.toBeInTheDocument();
+    expect(screen.queryByText("This organization")).not.toBeInTheDocument();
+  });
+
+  it("lists each allowed runtime with the memory ceiling behind it", async () => {
+    deployment({
+      connection: connection(),
+      allows: {
+        runtimes: [runtime(), runtime({ alias: "node", mem_limit: "1g" })],
+        default_runtime: "python",
+      },
+    });
+
+    render(card());
+
+    expect(await screen.findByText("python")).toBeInTheDocument();
+    expect(screen.getByText("512m")).toBeInTheDocument();
+    expect(screen.getByText("node")).toBeInTheDocument();
+    expect(screen.getByText("1g")).toBeInTheDocument();
+    expect(screen.getByText("default")).toBeInTheDocument();
+  });
+
+  it("says a runtime the host caps nothing on has no ceiling", async () => {
+    deployment({ connection: connection(), allows: { runtimes: [runtime({ mem_limit: null })] } });
+
+    render(card());
+
+    expect(await screen.findByText("no ceiling")).toBeInTheDocument();
+  });
+
+  it("treats a service allowing no runtime as a fault, not as an empty card", async () => {
+    // Nothing can run code on it at all, which is not the same news as "no
+    // sandbox host is registered".
+    deployment({ connection: connection(), allows: { runtimes: [] } });
+
+    render(card());
+
+    expect(
+      await screen.findByText("This service allows no runtime, so no agent can run code on it."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("No sandbox host registered")).not.toBeInTheDocument();
+  });
+
+  it("says the allowlist could not be read, and asks the host again when told to", async () => {
+    // Nothing polls this one, so the Retry is the only way back - which is why
+    // `useSandboxPolicy` exposes a refetch at all.
+    deployment({ connection: connection(), allows: "The sandbox service did not answer" });
+
+    render(card());
+    expect(await screen.findByText("Couldn't load this")).toBeInTheDocument();
+
+    deployment({ connection: connection(), allows: { runtimes: [runtime({ alias: "ruby" })] } });
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(await screen.findByText("ruby")).toBeInTheDocument();
+  });
+
+  it("does not ask Daytona for an allowlist it does not publish", async () => {
+    deployment({ connection: connection({ kind: "daytona", base_url: null }) });
+
+    render(card());
+
+    expect(await screen.findByText("Sandboxes run on Daytona")).toBeInTheDocument();
+    expect(policiesAskedFor()).toEqual([]);
+  });
+
+  it("says no host is registered rather than showing an empty allowlist", async () => {
+    deployment();
+
+    render(card());
+
+    expect(await screen.findByText("No sandbox host registered")).toBeInTheDocument();
+    expect(policiesAskedFor()).toEqual([]);
+  });
+
+  it("says the connection listing failed rather than blaming the host", async () => {
+    vi.mocked(apiClient.get).mockRejectedValue(new ApiError(502, "Bad Gateway"));
+
+    render(card());
+
+    expect(await screen.findByText("Couldn't load this")).toBeInTheDocument();
+    expect(screen.queryByText("No sandbox host registered")).not.toBeInTheDocument();
+
+    deployment({ connection: connection(), allows: { runtimes: [runtime({ alias: "go" })] } });
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(await screen.findByText("go")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/dashboard/widgets/sandbox.integration.test.tsx
+++ b/frontend/src/components/dashboard/widgets/sandbox.integration.test.tsx
@@ -1,12 +1,15 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render as renderBare, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SandboxCapacityWidget } from "./sandbox-capacity";
+import { SandboxSessionsWidget } from "./sandbox-sessions";
 import { ApiError, apiClient } from "@/lib/api-client";
 import type { Period } from "@/lib/dashboard/period";
 import type {
   SandboxConnectionRecord,
+  SandboxEvent,
   SandboxSession,
   SandboxSessionList,
 } from "@/lib/sandbox-connections-api";
@@ -66,12 +69,36 @@ function session(overrides: Partial<SandboxSession> = {}): SandboxSession {
   };
 }
 
+function event(overrides: Partial<SandboxEvent> = {}): SandboxEvent {
+  return {
+    seq: 1,
+    at: 1_760_000_050,
+    op: "write_file",
+    target: "/workspace/report.py",
+    ok: true,
+    detail: "",
+    duration_ms: 18.4,
+    ...overrides,
+  };
+}
+
 interface HostFixture {
   connection: SandboxConnectionRecord;
   listing?: Partial<SandboxSessionList>;
   /** The sentence a host answers with instead of a listing. */
   fails?: string;
+  /** Per session id: the log it answers with, or the sentence it fails with. */
+  logs?: Record<string, SandboxEvent[] | string>;
 }
+
+/**
+ * The agents this caller can read - where a session row's name comes from.
+ * Reset per test, so one can drop the row a session points at.
+ */
+let agentRows: { id: string; name: string }[] = [];
+
+const SESSIONS = /^\/sandbox-connections\/([^/]+)\/sessions\?/;
+const EVENTS = /^\/sandbox-connections\/([^/]+)\/sessions\/([^/?]+)\/events/;
 
 /** A deployment's registered hosts, each answering for itself. */
 function deployment(...hosts: HostFixture[]) {
@@ -79,17 +106,33 @@ function deployment(...hosts: HostFixture[]) {
     if (path === "/sandbox-connections") {
       return { items: hosts.map((host) => host.connection), total: hosts.length };
     }
-    const asked = /^\/sandbox-connections\/([^/]+)\/sessions/.exec(path);
+    if (path === "/agents") {
+      return { items: agentRows, total: agentRows.length };
+    }
+    const log = EVENTS.exec(path);
+    if (log !== null) {
+      const answer = hosts.find((candidate) => candidate.connection.id === log[1])?.logs?.[
+        log[2] as string
+      ];
+      if (typeof answer === "string") throw new ApiError(502, answer);
+      return { events: answer ?? [], latest_seq: answer?.at(-1)?.seq ?? 0 };
+    }
+    const asked = SESSIONS.exec(path);
     if (asked !== null) {
       const host = hosts.find((candidate) => candidate.connection.id === asked[1]);
       if (host?.fails !== undefined) throw new ApiError(502, host.fails);
-      return {
-        sessions: [],
+      const answer = {
+        sessions: [] as SandboxSession[],
         limit: null,
         open_limit: null,
         tenant_limit: null,
         ...host?.listing,
       };
+      // The service samples memory and CPU only when asked to, so neither does
+      // this: a fixture that always carried a usage block would let a card pass
+      // that reads memory without ever paying for it.
+      if (path.endsWith("usage=true")) return answer;
+      return { ...answer, sessions: answer.sessions.map((row) => ({ ...row, usage: null })) };
     }
     throw new ApiError(404, `nothing serves ${path}`);
   });
@@ -99,8 +142,16 @@ function deployment(...hosts: HostFixture[]) {
 function sessionsAskedFor(): string[] {
   return vi
     .mocked(apiClient.get)
-    .mock.calls.map(([path]) => /^\/sandbox-connections\/([^/]+)\/sessions/.exec(path)?.[1])
+    .mock.calls.map(([path]) => SESSIONS.exec(path)?.[1])
     .filter((id): id is string => id !== undefined);
+}
+
+/** Whether the card ever paid for a usage sample, and how often. */
+function sampledUsage(): string[] {
+  return vi
+    .mocked(apiClient.get)
+    .mock.calls.map(([path]) => path)
+    .filter((path) => SESSIONS.test(path) && path.endsWith("usage=true"));
 }
 
 function tracks(container: HTMLElement): string[] {
@@ -111,6 +162,7 @@ function tracks(container: HTMLElement): string[] {
 
 beforeEach(() => {
   vi.mocked(apiClient.get).mockReset();
+  agentRows = [{ id: "a-1", name: "Support triage" }];
 });
 
 describe("the sandbox capacity card", () => {
@@ -238,5 +290,241 @@ describe("the sandbox capacity card", () => {
     screen.getByRole("button", { name: "Retry" }).click();
 
     expect(await screen.findByText("Back up")).toBeInTheDocument();
+  });
+});
+
+describe("the open-sandboxes card", () => {
+  function card() {
+    return <SandboxSessionsWidget title="Open sandboxes" period={PERIOD} />;
+  }
+
+  it("names the agent, what shares the sandbox, its runtime, state and idle time", async () => {
+    deployment({
+      connection: connection({ name: "sandboxd-eu" }),
+      listing: { sessions: [session()] },
+    });
+
+    render(card());
+
+    expect(await screen.findByText("Support triage")).toBeInTheDocument();
+    expect(screen.getByText("shared in one conversation")).toBeInTheDocument();
+    expect(screen.getByText("python")).toBeInTheDocument();
+    expect(screen.getByText("running")).toBeInTheDocument();
+    expect(screen.getByText("12s idle")).toBeInTheDocument();
+    expect(screen.getByText("on sandboxd-eu")).toBeInTheDocument();
+  });
+
+  it("does not sample memory on load, and does once asked", async () => {
+    // The whole reason usage is a switch: the service pays a daemon round trip
+    // per sandbox for it, and this listing refetches every ten seconds.
+    deployment({
+      connection: connection(),
+      listing: {
+        sessions: [
+          session({
+            usage: { memory_bytes: 64 * 1024 * 1024, memory_limit_bytes: 512 * 1024 * 1024 },
+          }),
+        ],
+      },
+    });
+
+    render(card());
+    await screen.findByText("Support triage");
+    expect(sampledUsage()).toEqual([]);
+    expect(screen.queryByText("64.0 MB of 512.0 MB")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("switch"));
+
+    expect(await screen.findByText("64.0 MB of 512.0 MB")).toBeInTheDocument();
+    expect(sampledUsage().length).toBeGreaterThan(0);
+  });
+
+  it("reads memory alone when the host set that sandbox no ceiling", async () => {
+    deployment({
+      connection: connection(),
+      listing: { sessions: [session({ usage: { memory_bytes: 2048, memory_limit_bytes: null } })] },
+    });
+
+    render(card());
+    await screen.findByText("Support triage");
+    await userEvent.click(screen.getByRole("switch"));
+
+    expect(await screen.findByText("2.0 KB")).toBeInTheDocument();
+  });
+
+  it("says no agent was recorded for a run-scoped sandbox rather than guessing one", async () => {
+    // A `run` scope has no `agent_workspaces` row by design, so there is nothing
+    // to have joined - and the session id is not decoded to invent one.
+    deployment({
+      connection: connection(),
+      listing: { sessions: [session({ agent_id: null, conversation_id: null, scope: null })] },
+    });
+
+    render(card());
+
+    expect(await screen.findByText("No agent recorded")).toBeInTheDocument();
+    expect(screen.getByText("one run only")).toBeInTheDocument();
+  });
+
+  it("says no agent was recorded when the row points at one this caller cannot read", async () => {
+    agentRows = [];
+    deployment({ connection: connection(), listing: { sessions: [session()] } });
+
+    render(card());
+
+    expect(await screen.findByText("No agent recorded")).toBeInTheDocument();
+  });
+
+  it("shows a hibernated sandbox as itself - stopped to free a slot, not gone", async () => {
+    deployment({
+      connection: connection(),
+      listing: { sessions: [session({ alive: false, state: "hibernated" })] },
+    });
+
+    render(card());
+
+    expect(await screen.findByText("hibernated")).toBeInTheDocument();
+  });
+
+  it.each([
+    [90, "2m idle"],
+    [7_200, "2h idle"],
+  ])("reads %ss of idleness as %s", async (idle_seconds, expected) => {
+    deployment({ connection: connection(), listing: { sessions: [session({ idle_seconds })] } });
+
+    render(card());
+
+    expect(await screen.findByText(expected)).toBeInTheDocument();
+  });
+
+  it("opens one sandbox's activity log, and closes it again", async () => {
+    deployment({
+      connection: connection(),
+      listing: { sessions: [session({ session_id: "cc-1" })] },
+      logs: { "cc-1": [event({ target: "/workspace/report.py" })] },
+    });
+
+    render(card());
+    await userEvent.click(await screen.findByRole("button", { name: /Show what was done/ }));
+
+    expect(await screen.findByText("/workspace/report.py")).toBeInTheDocument();
+    expect(screen.getByText("write_file")).toBeInTheDocument();
+    expect(screen.getByText("18ms")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /Show what was done/ }));
+
+    expect(screen.queryByText("/workspace/report.py")).not.toBeInTheDocument();
+  });
+
+  it("marks an operation that failed inside the sandbox", async () => {
+    deployment({
+      connection: connection(),
+      listing: { sessions: [session({ session_id: "cc-1" })] },
+      logs: { "cc-1": [event({ seq: 1 }), event({ seq: 2, op: "run", ok: false })] },
+    });
+
+    const { container } = render(card());
+    await userEvent.click(await screen.findByRole("button", { name: /Show what was done/ }));
+    await screen.findByText("run");
+
+    const failed = container.querySelectorAll("li.text-destructive");
+    expect(failed).toHaveLength(1);
+  });
+
+  it("says a log that could not be read failed, rather than showing it as empty", async () => {
+    deployment({
+      connection: connection(),
+      listing: { sessions: [session({ session_id: "cc-1" })] },
+      logs: { "cc-1": "That activity log could not be read: 502" },
+    });
+
+    render(card());
+    await userEvent.click(await screen.findByRole("button", { name: /Show what was done/ }));
+
+    expect(await screen.findByText(/could not be read/)).toBeInTheDocument();
+    expect(screen.queryByText("Nothing recorded for this sandbox yet.")).not.toBeInTheDocument();
+  });
+
+  it("says nothing has been recorded for a sandbox that has done nothing", async () => {
+    deployment({
+      connection: connection(),
+      listing: { sessions: [session({ session_id: "cc-1" })] },
+    });
+
+    render(card());
+    await userEvent.click(await screen.findByRole("button", { name: /Show what was done/ }));
+
+    expect(await screen.findByText("Nothing recorded for this sandbox yet.")).toBeInTheDocument();
+  });
+
+  it("says the host is unreachable instead of saying nothing is running", async () => {
+    deployment({
+      connection: connection(),
+      fails: "The sandbox service did not answer: connection refused",
+    });
+
+    render(card());
+
+    expect(await screen.findByText(/connection refused/)).toBeInTheDocument();
+    expect(
+      screen.queryByText("Nothing is running. A sandbox opens the first time an agent runs code."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("says nothing is running when the host answers with an empty listing", async () => {
+    deployment({ connection: connection() });
+
+    render(card());
+
+    expect(
+      await screen.findByText(
+        "Nothing is running. A sandbox opens the first time an agent runs code.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("reads only the default host, since capacity is the card covering them all", async () => {
+    deployment(
+      { connection: connection({ id: "other", name: "Other", is_default: false }) },
+      {
+        connection: connection({ id: "chosen", name: "Chosen", is_default: true }),
+        listing: { sessions: [session()] },
+      },
+    );
+
+    render(card());
+
+    await screen.findByText("Support triage");
+    expect(sessionsAskedFor()).toEqual(["chosen"]);
+  });
+
+  it("says a Daytona host keeps its sessions elsewhere, and asks it nothing", async () => {
+    deployment({ connection: connection({ kind: "daytona", base_url: null }) });
+
+    render(card());
+
+    expect(await screen.findByText("Sandboxes run on Daytona")).toBeInTheDocument();
+    expect(sessionsAskedFor()).toEqual([]);
+  });
+
+  it("says no host is registered rather than listing nothing", async () => {
+    deployment();
+
+    render(card());
+
+    expect(await screen.findByText("No sandbox host registered")).toBeInTheDocument();
+  });
+
+  it("says the connection listing failed, and asks again when told to", async () => {
+    vi.mocked(apiClient.get).mockRejectedValue(new ApiError(502, "Bad Gateway"));
+
+    render(card());
+
+    expect(await screen.findByText("Couldn't load this")).toBeInTheDocument();
+
+    deployment({ connection: connection(), listing: { sessions: [session()] } });
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(await screen.findByText("Support triage")).toBeInTheDocument();
   });
 });

--- a/frontend/src/hooks/use-sandbox-connections.test.tsx
+++ b/frontend/src/hooks/use-sandbox-connections.test.tsx
@@ -190,6 +190,19 @@ describe("useSandboxPolicy", () => {
 
     await waitFor(() => expect(result.current.error).toBe("The sandbox service did not answer"));
   });
+
+  it("asks the host again on request, which is the only way back from a failure", async () => {
+    // Nothing polls this query, so a host that was down when the page loaded
+    // stays down on screen until somebody says try again.
+    vi.mocked(api.readSandboxPolicy).mockRejectedValueOnce(new Error("did not answer"));
+    const { result } = renderHook(() => useSandboxPolicy("c-1"), { wrapper });
+    await waitFor(() => expect(result.current.error).toBe("did not answer"));
+
+    act(() => result.current.refetch());
+
+    await waitFor(() => expect(result.current.policy).toEqual(POLICY));
+    expect(result.current.error).toBeNull();
+  });
 });
 
 describe("useSandboxSessions", () => {

--- a/frontend/src/hooks/use-sandbox-connections.ts
+++ b/frontend/src/hooks/use-sandbox-connections.ts
@@ -108,6 +108,8 @@ interface UseSandboxPolicyResult {
   isLoading: boolean;
   /** Why the service could not be asked. A string, because it is shown as one. */
   error: string | null;
+  /** Ask again. Nothing here polls, so a failure stays until somebody retries. */
+  refetch: () => void;
 }
 
 /**
@@ -123,6 +125,7 @@ export function useSandboxPolicy(connectionId: string | null): UseSandboxPolicyR
     data: policy = null,
     isLoading,
     error,
+    refetch,
   } = useQuery({
     queryKey: qk.sandboxConnections.policy(connectionId ?? "none"),
     queryFn: () => readSandboxPolicy(connectionId as string),
@@ -136,6 +139,7 @@ export function useSandboxPolicy(connectionId: string | null): UseSandboxPolicyR
     isLoading: connectionId !== null && isLoading,
     error:
       error instanceof Error ? error.message : error ? "The sandbox service did not answer" : null,
+    refetch: () => void refetch(),
   };
 }
 

--- a/frontend/src/lib/dashboard/layouts.test.ts
+++ b/frontend/src/lib/dashboard/layouts.test.ts
@@ -60,6 +60,17 @@ describe("the layouts", () => {
       expect(LAYOUTS[audience][0]?.titleKey).toBeNull();
     }
   });
+
+  it("offers the sandbox section only where a gate could pass it", () => {
+    // `connections:manage` is held by owner, admin and builder - and not by
+    // operator, whatever the persona suggests (`ROLE_PERMS`). Listing the section
+    // on the operator layout would be an entry no caller can ever see.
+    const carrying = AUDIENCES.filter((audience) =>
+      LAYOUTS[audience].some((section) => section.id === "sandboxes"),
+    );
+
+    expect(carrying).toEqual(["app_admin", "steward", "builder"]);
+  });
 });
 
 describe("visibleSections", () => {
@@ -99,5 +110,24 @@ describe("visibleSections", () => {
     const sections = visibleSections("steward", () => true, false);
 
     expect(sections.map((section) => section.id)).not.toContain("deployment");
+  });
+
+  it("withholds the sandbox section, heading included, without connections:manage", () => {
+    // Not rendered and then 403'd: a caller who cannot ask a host what it runs
+    // must not be told the section exists.
+    const sections = visibleSections("steward", holds(Perm.runsView, Perm.membersManage), false);
+
+    expect(sections.map((section) => section.id)).not.toContain("sandboxes");
+  });
+
+  it("gives the sandbox section to a caller holding connections:manage and nothing else", () => {
+    const sections = visibleSections("builder", holds(Perm.connectionsManage), false);
+
+    expect(sections.map((section) => section.id)).toEqual(["sandboxes"]);
+    expect(sections[0]?.entries.map((entry) => entry.widget)).toEqual([
+      "sandbox-capacity",
+      "sandbox-policy",
+      "sandbox-sessions",
+    ]);
   });
 });

--- a/frontend/src/lib/dashboard/layouts.ts
+++ b/frontend/src/lib/dashboard/layouts.ts
@@ -68,6 +68,25 @@ export const SPAN_CLASS: Record<Span, string> = {
   s12: "lg:col-span-12",
 };
 
+/**
+ * Where agents run code, for the audiences that hold `connections:manage`.
+ *
+ * Owner, admin and builder hold it; **operator does not** - read off
+ * `ROLE_PERMS` in `app/core/permissions.py` rather than off the persona, which
+ * points the other way. The section is therefore absent from the operator
+ * layout instead of being listed there and gated away: a layout entry no gate
+ * can ever pass is dead data. See #129 for the gap that leaves.
+ */
+const SANDBOX_SECTION: SectionDef = {
+  id: "sandboxes",
+  titleKey: "sandboxes",
+  entries: [
+    { widget: "sandbox-capacity", span: "s5" },
+    { widget: "sandbox-policy", span: "s7" },
+    { widget: "sandbox-sessions", span: "s12" },
+  ],
+};
+
 const STEWARD_SECTIONS: SectionDef[] = [
   {
     id: "attention",
@@ -103,6 +122,7 @@ const STEWARD_SECTIONS: SectionDef[] = [
       { widget: "org-ratings", span: "s6" },
     ],
   },
+  SANDBOX_SECTION,
   {
     id: "workspace",
     titleKey: "workspace",
@@ -202,6 +222,10 @@ export const LAYOUTS: Record<AudienceId, SectionDef[]> = {
         { widget: "top-people", span: "s12" },
       ],
     },
+    // A builder is who gives an agent the code-execution capability, so the
+    // memory ceiling their agents die on is their own question as much as an
+    // operator's - and they hold `connections:manage` where the operator does not.
+    SANDBOX_SECTION,
     {
       id: "activity",
       titleKey: null,

--- a/frontend/src/lib/dashboard/registry.test.ts
+++ b/frontend/src/lib/dashboard/registry.test.ts
@@ -43,11 +43,12 @@ const GATE_TABLE: Record<WidgetId, Permission | "app_admin"> = {
   "shared-with-you": Perm.agentsView,
   "sandbox-capacity": Perm.connectionsManage,
   "sandbox-sessions": Perm.connectionsManage,
+  "sandbox-policy": Perm.connectionsManage,
 };
 
 describe("the widget catalog", () => {
-  it("holds all twenty-nine widgets", () => {
-    expect(WIDGET_IDS).toHaveLength(29);
+  it("holds all thirty widgets", () => {
+    expect(WIDGET_IDS).toHaveLength(30);
   });
 
   it.each(WIDGET_IDS)("%s opens on exactly its own permission", (id) => {

--- a/frontend/src/lib/dashboard/registry.test.ts
+++ b/frontend/src/lib/dashboard/registry.test.ts
@@ -41,11 +41,12 @@ const GATE_TABLE: Record<WidgetId, Permission | "app_admin"> = {
   "my-top-agents": Perm.agentsRun,
   "my-quality": Perm.agentsRun,
   "shared-with-you": Perm.agentsView,
+  "sandbox-capacity": Perm.connectionsManage,
 };
 
 describe("the widget catalog", () => {
-  it("holds all twenty-seven widgets", () => {
-    expect(WIDGET_IDS).toHaveLength(27);
+  it("holds all twenty-eight widgets", () => {
+    expect(WIDGET_IDS).toHaveLength(28);
   });
 
   it.each(WIDGET_IDS)("%s opens on exactly its own permission", (id) => {

--- a/frontend/src/lib/dashboard/registry.test.ts
+++ b/frontend/src/lib/dashboard/registry.test.ts
@@ -42,11 +42,12 @@ const GATE_TABLE: Record<WidgetId, Permission | "app_admin"> = {
   "my-quality": Perm.agentsRun,
   "shared-with-you": Perm.agentsView,
   "sandbox-capacity": Perm.connectionsManage,
+  "sandbox-sessions": Perm.connectionsManage,
 };
 
 describe("the widget catalog", () => {
-  it("holds all twenty-eight widgets", () => {
-    expect(WIDGET_IDS).toHaveLength(28);
+  it("holds all twenty-nine widgets", () => {
+    expect(WIDGET_IDS).toHaveLength(29);
   });
 
   it.each(WIDGET_IDS)("%s opens on exactly its own permission", (id) => {

--- a/frontend/src/lib/dashboard/registry.ts
+++ b/frontend/src/lib/dashboard/registry.ts
@@ -47,7 +47,8 @@ export type WidgetId =
   | "my-top-agents"
   | "my-quality"
   | "shared-with-you"
-  | "sandbox-capacity";
+  | "sandbox-capacity"
+  | "sandbox-sessions";
 
 /** The closed set of card widths the grid supports (12 columns). */
 export type Span = "s3" | "s4" | "s5" | "s6" | "s7" | "s8" | "s12";
@@ -160,6 +161,12 @@ export const WIDGETS: Record<WidgetId, WidgetDef> = {
     id: "sandbox-capacity",
     gate: holds(Perm.connectionsManage),
     defaultSpan: "s5",
+    seeAll: ROUTES.SANDBOXES,
+  },
+  "sandbox-sessions": {
+    id: "sandbox-sessions",
+    gate: holds(Perm.connectionsManage),
+    defaultSpan: "s12",
     seeAll: ROUTES.SANDBOXES,
   },
 };

--- a/frontend/src/lib/dashboard/registry.ts
+++ b/frontend/src/lib/dashboard/registry.ts
@@ -46,7 +46,8 @@ export type WidgetId =
   | "my-activity"
   | "my-top-agents"
   | "my-quality"
-  | "shared-with-you";
+  | "shared-with-you"
+  | "sandbox-capacity";
 
 /** The closed set of card widths the grid supports (12 columns). */
 export type Span = "s3" | "s4" | "s5" | "s6" | "s7" | "s8" | "s12";
@@ -150,6 +151,16 @@ export const WIDGETS: Record<WidgetId, WidgetDef> = {
     id: "shared-with-you",
     gate: holds(Perm.agentsView),
     defaultSpan: "s4",
+  },
+  // The sandbox cards are read-only views of a host, and `connections:manage`
+  // is the permission that already gates every route behind them - there is no
+  // narrower "watch a connection" scope, so this is the honest gate rather than
+  // the ideal one.
+  "sandbox-capacity": {
+    id: "sandbox-capacity",
+    gate: holds(Perm.connectionsManage),
+    defaultSpan: "s5",
+    seeAll: ROUTES.SANDBOXES,
   },
 };
 

--- a/frontend/src/lib/dashboard/registry.ts
+++ b/frontend/src/lib/dashboard/registry.ts
@@ -48,7 +48,8 @@ export type WidgetId =
   | "my-quality"
   | "shared-with-you"
   | "sandbox-capacity"
-  | "sandbox-sessions";
+  | "sandbox-sessions"
+  | "sandbox-policy";
 
 /** The closed set of card widths the grid supports (12 columns). */
 export type Span = "s3" | "s4" | "s5" | "s6" | "s7" | "s8" | "s12";
@@ -167,6 +168,12 @@ export const WIDGETS: Record<WidgetId, WidgetDef> = {
     id: "sandbox-sessions",
     gate: holds(Perm.connectionsManage),
     defaultSpan: "s12",
+    seeAll: ROUTES.SANDBOXES,
+  },
+  "sandbox-policy": {
+    id: "sandbox-policy",
+    gate: holds(Perm.connectionsManage),
+    defaultSpan: "s7",
     seeAll: ROUTES.SANDBOXES,
   },
 };

--- a/frontend/src/lib/dashboard/sandbox.test.ts
+++ b/frontend/src/lib/dashboard/sandbox.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  holdsSessions,
+  idleLabel,
+  memoryLabel,
+  primaryConnection,
+  scopeKey,
+  tenantShare,
+  watchableConnections,
+} from "./sandbox";
+import type {
+  SandboxConnectionRecord,
+  SandboxSession,
+  SandboxSessionList,
+} from "@/lib/sandbox-connections-api";
+
+function connection(overrides: Partial<SandboxConnectionRecord> = {}): SandboxConnectionRecord {
+  return {
+    id: "c-1",
+    name: "Local Docker",
+    kind: "docker",
+    base_url: "http://sandboxd:8080",
+    secret_id: "s-1",
+    default_runtime: null,
+    is_default: false,
+    is_active: true,
+    created_at: "2026-08-03T00:00:00Z",
+    updated_at: null,
+    ...overrides,
+  };
+}
+
+function session(overrides: Partial<SandboxSession> = {}): SandboxSession {
+  return {
+    session_id: "cc-abcd1234-ffff",
+    runtime: "python",
+    alive: true,
+    state: "running",
+    created_at: 1_760_000_000,
+    last_activity: 1_760_000_100,
+    idle_seconds: 12,
+    usage: null,
+    agent_id: "a-1",
+    conversation_id: "conv-1",
+    scope: "conversation",
+    ...overrides,
+  };
+}
+
+function listing(overrides: Partial<SandboxSessionList> = {}): SandboxSessionList {
+  return { sessions: [], limit: null, open_limit: null, tenant_limit: null, ...overrides };
+}
+
+describe("watchableConnections", () => {
+  it("drops a connection nobody's agent can reach any more", () => {
+    const rows = watchableConnections([
+      connection({ id: "live" }),
+      connection({ id: "retired", is_active: false }),
+    ]);
+
+    expect(rows.map((row) => row.id)).toEqual(["live"]);
+  });
+});
+
+describe("primaryConnection", () => {
+  it("is the default, because that is the host an agent naming none gets", () => {
+    const chosen = primaryConnection([
+      connection({ id: "other" }),
+      connection({ id: "default", is_default: true }),
+    ]);
+
+    expect(chosen?.id).toBe("default");
+  });
+
+  it("falls back to the first active host rather than showing an empty card", () => {
+    const chosen = primaryConnection([
+      connection({ id: "retired", is_active: false, is_default: true }),
+      connection({ id: "running" }),
+    ]);
+
+    expect(chosen?.id).toBe("running");
+  });
+
+  it("is null for a deployment that registered none", () => {
+    expect(primaryConnection([])).toBeNull();
+  });
+});
+
+describe("holdsSessions", () => {
+  it("is true of a container host, whose sessions we opened and can count", () => {
+    expect(holdsSessions(connection({ kind: "docker" }))).toBe(true);
+  });
+
+  it("is false of Daytona, which is not the same thing as an idle host", () => {
+    // Both answer with an empty list, and the `kind` the service puts beside it
+    // is dropped by the response model - so the row is the only witness.
+    expect(holdsSessions(connection({ kind: "daytona" }))).toBe(false);
+  });
+});
+
+describe("tenantShare", () => {
+  it("divides this organization's sessions by the ceiling that applies to it", () => {
+    const share = tenantShare(listing({ sessions: [session(), session()], tenant_limit: 8 }));
+
+    expect(share).toEqual({ used: 2, limit: 8, percent: 25 });
+  });
+
+  it("never divides by the host's own ceilings, which count every tenant", () => {
+    // `limit` 40 and `open_limit` 20 are the whole host's; two sessions are ours.
+    // 2/40 would read as 5% of a ceiling that is not the one refusing us.
+    const share = tenantShare(
+      listing({ sessions: [session(), session()], limit: 40, open_limit: 20 }),
+    );
+
+    expect(share).toEqual({ used: 2, limit: null, percent: null });
+  });
+
+  it("answers with no percentage when the ceiling is zero rather than dividing by it", () => {
+    expect(tenantShare(listing({ tenant_limit: 0 })).percent).toBeNull();
+  });
+
+  it("clamps at full, so a host over its own ceiling does not draw past the track", () => {
+    const share = tenantShare(
+      listing({ sessions: [session(), session(), session()], tenant_limit: 2 }),
+    );
+
+    expect(share.percent).toBe(100);
+  });
+});
+
+describe("scopeKey", () => {
+  it.each([
+    ["agent", "scope.agent"],
+    ["conversation", "scope.conversation"],
+    ["channel", "scope.channel"],
+    ["user", "scope.user"],
+  ])("%s shares a sandbox with %s", (scope, expected) => {
+    expect(scopeKey(scope)).toBe(expected);
+  });
+
+  it("reads no scope as a single run, which has no workspace row by design", () => {
+    expect(scopeKey(null)).toBe("scope.run");
+  });
+
+  it("says a scope it does not know is unknown instead of guessing the widest one", () => {
+    // Who may read a sandbox's files is exactly what the scope says; calling a
+    // sixth one "the whole agent" describes the wrong set of people.
+    expect(scopeKey("workspace")).toBe("scope.unknown");
+  });
+});
+
+describe("idleLabel", () => {
+  it.each([
+    [12, "idle.seconds", 12],
+    [59.6, "idle.seconds", 60],
+    [90, "idle.minutes", 2],
+    [7_200, "idle.hours", 2],
+  ])("%ss idle -> %s %s", (seconds, key, count) => {
+    expect(idleLabel(seconds)).toEqual({ key, count });
+  });
+});
+
+describe("memoryLabel", () => {
+  it("reads a sample against the ceiling of that sandbox alone", () => {
+    const label = memoryLabel(
+      session({ usage: { memory_bytes: 64 * 1024 * 1024, memory_limit_bytes: 512 * 1024 * 1024 } }),
+    );
+
+    expect(label).toEqual({ used: "64.0 MB", limit: "512.0 MB" });
+  });
+
+  it("reads a sample the host set no ceiling for", () => {
+    const label = memoryLabel(session({ usage: { memory_bytes: 1024, memory_limit_bytes: null } }));
+
+    expect(label).toEqual({ used: "1.0 KB", limit: null });
+  });
+
+  it("is null when usage was never sampled, which is the normal case", () => {
+    expect(memoryLabel(session({ usage: null }))).toBeNull();
+  });
+
+  it("is null when the host answered with a usage block holding no memory figure", () => {
+    expect(memoryLabel(session({ usage: { cpu_percent: 4 } }))).toBeNull();
+    expect(memoryLabel(session({ usage: { memory_bytes: null } }))).toBeNull();
+  });
+});

--- a/frontend/src/lib/dashboard/sandbox.ts
+++ b/frontend/src/lib/dashboard/sandbox.ts
@@ -1,0 +1,127 @@
+/**
+ * What the sandbox cards decide before they render anything.
+ *
+ * Out of the React for the reason the rest of `lib/dashboard` is: a decision
+ * taken inside a component is a decision only a mounted query client can test.
+ * Two of the ones here encode a limit of today's API rather than a preference,
+ * and both are load-bearing.
+ *
+ * **There is no client-side count for the host's own ceilings.**
+ * `GET /sandbox-connections/{id}/sessions` filters its rows to the caller's
+ * organization and passes `limit` and `open_limit` through from the daemon
+ * untouched, so those two are ceilings for *every* tenant on the host while
+ * `sessions.length` counts one. `sessions.length / limit` is a fraction whose
+ * halves disagree, and a wrong number is worse than no number - which is why
+ * {@link tenantShare} divides by `tenant_limit` and by nothing else, and why the
+ * host's ceilings are rendered as ceilings.
+ *
+ * **Whether a connection holds sessions at all is a fact about the row, not
+ * about the answer.** A Daytona connection answers with an empty list, which is
+ * the same shape an idle Docker host answers with, and the `kind` the service
+ * puts beside it is dropped by the response model. So {@link holdsSessions} asks
+ * the connection record, which carries `kind` already.
+ */
+
+import { formatBytes } from "@/lib/utils";
+import type {
+  SandboxConnectionRecord,
+  SandboxSession,
+  SandboxSessionList,
+} from "@/lib/sandbox-connections-api";
+
+/** The connections worth asking about: the ones an agent can still reach. */
+export function watchableConnections(
+  connections: SandboxConnectionRecord[],
+): SandboxConnectionRecord[] {
+  return connections.filter((connection) => connection.is_active);
+}
+
+/**
+ * The one connection the per-session cards read.
+ *
+ * The default, because that is the host an agent naming none resolves to, and
+ * the capacity card is the one that covers every connection. Falls back to the
+ * first active one so a deployment that registered a host without promoting it
+ * is not shown an empty card about a host that is running things.
+ */
+export function primaryConnection(
+  connections: SandboxConnectionRecord[],
+): SandboxConnectionRecord | null {
+  const watchable = watchableConnections(connections);
+  return watchable.find((connection) => connection.is_default) ?? watchable[0] ?? null;
+}
+
+/** Whether sandboxes of ours run here at all - see the note on this module. */
+export function holdsSessions(connection: SandboxConnectionRecord): boolean {
+  return connection.kind === "docker";
+}
+
+export interface TenantShare {
+  /** This organization's open sandboxes. Every row in the listing is ours. */
+  used: number;
+  /** The ceiling that applies to this organization, or null if it sets none. */
+  limit: number | null;
+  /** `used` against `limit` as a percentage, or null when there is no ceiling. */
+  percent: number | null;
+}
+
+/**
+ * The only honest fraction this API supports: ours against our own ceiling.
+ *
+ * This is the number that answers "why did an agent just get a 429" - the host
+ * refuses a session because the organization is at `max_sessions_per_tenant`,
+ * and nothing else on the page says so.
+ */
+export function tenantShare(listing: SandboxSessionList): TenantShare {
+  const used = listing.sessions.length;
+  const limit = listing.tenant_limit;
+  const bounded = limit !== null && limit > 0;
+  return {
+    used,
+    limit,
+    percent: bounded ? Math.min(Math.round((used / limit) * 100), 100) : null,
+  };
+}
+
+const SCOPE_KEYS: Record<string, string> = {
+  agent: "scope.agent",
+  conversation: "scope.conversation",
+  channel: "scope.channel",
+  user: "scope.user",
+};
+
+/**
+ * An i18n key for what shares one sandbox, never the sentence itself.
+ *
+ * `null` is a `run`-scoped sandbox rather than an attribution that went missing:
+ * it has no `agent_workspaces` row by design, so there was never a row to join.
+ * A scope this vocabulary does not know is reported as unknown rather than
+ * folded into the widest one - who can read a sandbox's files is exactly what
+ * the scope says, and guessing it wrong describes the wrong set of people.
+ */
+export function scopeKey(scope: string | null): string {
+  if (scope === null) return "scope.run";
+  return SCOPE_KEYS[scope] ?? "scope.unknown";
+}
+
+/** Seconds since a sandbox last did anything, as a message key and a number. */
+export function idleLabel(seconds: number): { key: string; count: number } {
+  if (seconds < 60) return { key: "idle.seconds", count: Math.round(seconds) };
+  if (seconds < 3600) return { key: "idle.minutes", count: Math.round(seconds / 60) };
+  return { key: "idle.hours", count: Math.round(seconds / 3600) };
+}
+
+/**
+ * Memory against the ceiling of that sandbox alone, already formatted.
+ *
+ * Null when the sample was never taken, which is the normal case: sampling costs
+ * the service a daemon round trip per sandbox, so it is asked for by hand.
+ */
+export function memoryLabel(
+  session: SandboxSession,
+): { used: string; limit: string | null } | null {
+  const used = session.usage?.memory_bytes;
+  if (used === null || used === undefined) return null;
+  const limit = session.usage?.memory_limit_bytes;
+  return { used: formatBytes(used), limit: limit ? formatBytes(limit) : null };
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -26,6 +26,10 @@ export default defineConfig({
         "src/stores/**",
         "src/hooks/**",
         "src/components/agents/**/*.{ts,tsx}",
+        // The sandbox cards only, not the whole widget directory: the twenty-seven
+        // cards #149 added are outside the gate, and pulling them in with a
+        // directory glob would make this branch responsible for covering them.
+        "src/components/dashboard/widgets/sandbox-*.tsx",
         "src/components/orgs/**/*.tsx",
         "src/components/runs/**/*.tsx",
         "src/components/sandboxes/**/*.tsx",


### PR DESCRIPTION
## Summary

The sandbox half of the dashboard, built as #149's design note said it would be:
**one section and three cards in the existing registry**, gated on
`connections:manage`. No new route, no new layout, and nothing new in `src/lib`
except pure decision logic — the data layer from #36 was already there and typed.

The section is *Where agents run code*, and it answers the three questions an
operator has when an agent dies inside a container: how much room is left, what is
running, and what the host allows.

## Related Issue

Closes #129

The case for `Closes` rather than `Refs` is at the end of the capacity section below,
because it turns on which of the three ceilings can be computed at all. Read it before
merging — the judgement is stated there so it can be overruled.

#149 has merged, so this now targets `main` and CI runs on it for the first time.

Refs #449, #450, #453 and #459 — filed while building this, none of them blocking.
#452 as well; its state is in the notes at the end.

### Rebased, not merged

The branch was cut from `feat/dashboard-page-demo`, which reached `main` as a **squash**
— so #149's 31 commits are in `main` as one commit and were still on this branch as 31.
A `git merge origin/main` reported ten conflicts, four of them `add/add` on files #149
*added* (`layouts.ts`, `registry.ts`, `widgets/index.ts`, `dashboard-demo.md`), which
would have meant re-resolving somebody else's diff by hand.

`git rebase --onto origin/main ca6294a` replays this branch's seven commits and nothing
else. It applied **with no conflicts at all**, because `main` already holds #149's
content and these diffs sit on top of it. History was rewritten, so the push was
`--force-with-lease`; the branch is now exactly seven commits ahead of `main` and zero
behind.

## Added

**Three cards, not four.** One per deliverable except that the activity log is inside
the sessions card rather than beside it, and the reason is structural rather than
aesthetic: `DashboardWidgetProps` carries `{title, period, seeAll}` and nothing else,
so a widget cannot be told which session to read, and the events route takes one. A
standalone activity card would need its own session picker duplicating the table next
to it; a feed merged across every open sandbox would be one request per sandbox on
load, which is exactly the cost `usage=true` is opt-in to avoid. So it hangs off the
row whose log it is, the way `components/sandboxes/sessions-panel.tsx` already does
it.

| Card | Span | Reads |
|---|---|---|
| `sandbox-capacity` | s5 | every active connection — this organization's open sandboxes against the ceiling that applies to it |
| `sandbox-policy` | s7 | the default host's runtime allowlist, the memory ceiling behind each alias, and the three session ceilings |
| `sandbox-sessions` | s12 | the default host's sandboxes: agent, what shares it, runtime, state, idle, memory — with its activity log per row |

**`src/lib/dashboard/sandbox.ts`** holds what the cards decide before rendering —
which connection to read, whether it holds sessions of ours at all, and the one
fraction that divides honestly. It sits beside the registry and the layouts for the
same reason those do: a decision taken inside a component is a decision only a
mounted query client can test.

**One hook gained one field.** `useSandboxPolicy` now returns `refetch`. Nothing polls
that query — a stale runtime list is worse than none, because it offers an alias the
service will refuse — so a host that was down at page load stays down on screen until
somebody asks again, and `WidgetErrorBody`'s Retry needs something to call. The
sessions query already polls every ten seconds, so its failures need no Retry and
have none.

## The capacity number: which ceiling this divides by, and why

**`sessions.length / limit` is a fraction whose halves disagree, and this branch does
not draw it.**

`SandboxConnectionService.sessions()` filters `sessions` to the caller's organization
and passes `limit` and `open_limit` through from the daemon untouched
(`backend/app/services/sandbox_connection.py:549-558`). Those two are
`SANDBOXD_MAX_SESSIONS` and `SANDBOXD_MAX_OPEN_SESSIONS` — ceilings across every
tenant on the host — while the rows count one tenant. There is no host-wide *count*
in any response, so two of the three ceilings have no numerator.

Given the choice between rendering only what divides and proposing a backend change
that returns the missing counts, **this takes the first**, and not by omission:

- the honest fraction — this organization against `tenant_limit` — is also *the* number
  the issue asks for. It is the one a 429 comes from, and it is what
  `tenantShare()` computes and the only thing that gets a bar;
- the host-wide two are rendered **as ceilings**, on the runtimes card, labelled
  "Resident, host-wide" and "Open, host-wide" beside the per-organization one. No
  numerator, no track, and the card's subline says they are shared with every
  organization on the host;
- a test asserts the absence. `"2 of 40"` must not appear for two sessions on a
  forty-slot host, because the plausible version of this card is precisely the one
  that draws that bar.

**And the card says so on screen**, not only here and not only in a docstring.
Absence does not explain itself: somebody refused a sandbox while the card shows room
to spare cannot tell a missing figure from a zero, and reads the card as wrong. So it
carries, under the figures — *"How full a host itself is cannot be shown here. Its own
two ceilings are shared with every organization on it and no count of them is
published, so this is the only figure that divides. Being refused a sandbox while this
one is short of its ceiling means somebody else filled the host."* The runtimes card
carries the matching half beside its ceilings. Both are asserted by tests, because a
sentence that explains an absence is as load-bearing as the absence.

The backend change is **#453**, filed rather than folded in. It is a `len()` on a list
the service already holds, but it carries a question a frontend branch should not
answer alone: whether a host-wide count is a cross-tenant disclosure. It is one
integer that names nobody — and it does tell one tenant that others are busy on a
host they were told is theirs to watch.

### Why `Closes #129` and not `Refs #129`

Worth stating rather than leaving to the keyword. **All six of the issue's "Done when"
boxes are met** — capacity, sessions and the activity log render; the runtime
allowlist and its ceilings are visible; an unreachable host says so per card;
`usage=true` is opt-in; the tests are integration against a mocked API rather than
Playwright; the coverage gate is green with the new files in `include`.

Against that, **"What to build" item 1 names three ratios and one shipped.** That is
not a third of the work deferred by choice — two of the three cannot be computed from
any response this API returns, and the alternative to leaving them out was inventing a
denominator. A card that ticked item 1 by drawing `sessions.length / limit` would be
worse than one that does not, and the issue's own acceptance list is what says what
done means. #453 is the remainder, it is filed with the design question it depends on,
and the card is honest on screen about what it cannot show in the meantime.

If a reviewer would rather this stayed open until #453 lands, say so and it becomes
`Refs` — the judgement is stated here precisely so it can be overruled.

## The Daytona ambiguity, reported: it needed no schema change

**`GET .../sessions` sets `kind` and the response model throws it away**
(`sandbox_connection.py:547` and `:557`; `SandboxSessionList` does not declare the
field). So a Daytona connection answers byte-for-byte what an idle Docker host
answers, and a client reading only that endpoint cannot tell "this connection holds
none of our sessions by design" from "this host is running nothing". Filed as **#450**
— the sibling policy endpoint *does* declare `kind`, so the two disagree.

**Nothing here was touched to work around it, and no schema change is needed.** The
connections listing already carries `kind` on every row
(`SandboxConnectionRead.kind`), which is authoritative, already typed, and available
before any sessions call. `holdsSessions()` reads it, and a non-Docker connection is
therefore **not asked at all** — it renders its own sentence and saves a round trip.
Tests assert both halves: the distinct copy, and that no `/sessions` or `/policy`
request is issued for it.

## Which audiences get the section, which is not the one the issue assumes

Read off `ROLE_PERMS` (`backend/app/core/permissions.py:163`) rather than off the
persona, and the two point in different directions. `connections:manage` is held by
**owner, admin and builder**. **Operator does not hold it** — so the audience #129 is
written for, "an operator whose agents keep hitting a memory limit", is the one role
that cannot see the answer.

The section therefore goes to `app_admin`, `steward` and `builder`, and is **absent
from the operator layout** rather than listed there and gated away: an entry no gate
can ever pass is dead data, and `layouts.test.ts` asserts exactly which three
audiences carry it. Builder keeps it on its own merits rather than by inheritance — a
builder is who gives an agent code execution, so the memory ceiling it dies on is
their question too.

The gap is **#449**, with two ways out costed. Widening a permission is not a frontend
branch's call.

## Changed

- `docs/configuration.md` — the Sandboxes screen was documented as the only place
  these answers can be read. It also gains the fact an operator reading
  `SANDBOXD_MAX_SESSIONS` could not have got anywhere: it is the only one of the three
  ceilings nothing divides by, and an agent refused a session while the
  per-organization figure is short of its ceiling means the host is full of another
  tenant's work.
- `docs/design/dashboard-demo.md` — the sandbox view was listed under *Deliberately
  out of v1*, which stops being true here. Removed from that list and written into the
  two audience layouts that carry it, so the note keeps describing the page that
  exists.
- `vitest.config.ts` — coverage `include` gains `dashboard/widgets/sandbox-*.tsx`, a
  `sandbox-*` glob rather than a directory one. The twenty-seven cards from #149 are
  outside the gate and pulling them in with `widgets/**` would make this branch
  responsible for covering them.

## Testing

No CI runs on this branch, so this is the whole of the verification. Every target was
run individually, because `make check` stops at its first failing one.

- **67 new tests.** 61 in the two new files — 24 unit on `lib/dashboard/sandbox.ts`,
  37 integration on the cards against a mocked host — plus 6 added to existing suites:
  3 on the layouts, 2 on the page, 1 on the hook.
- **100% statements, branches and functions** on all five new files, read per file out
  of `coverage-final.json` rather than off the summary line.
- `make test-frontend-cov` — **204 files, 3447 tests**, 100% statements / functions /
  lines and 97.71% branches against the 97.5% gate.
- `make test` — **3508 passed, 6 skipped**, backend platform layer at 100%. Run on
  this exact tree; the branch touches no backend file.
- `make lint-frontend` (eslint, prettier, `tsc`) · `make lint-spelling` (codespell,
  whole tree) · `make build-frontend` · `make docs-build --strict` — green.
- `lint-backend` step by step, since its first command fails for a reason that is not
  this branch: `ruff format --check` 537 files clean, `ty check` **exit 0** (64
  diagnostics, all warnings, all pre-existing), `check_backticks.py` clean,
  `check_i18n.py` clean at 3103 messages.

The integration tests do not stub `next-intl`, so every assertion is on the copy a
reader sees: `"3 of 8"` proves the card divided by the per-tenant ceiling in a way an
assertion on a message key could not tell from `"3 of 40"`. The fixture also honours
`usage=`, stripping the usage block when the query says `false` — a mock that always
carried one would let a card pass that reads memory without ever paying for the
sample.

What the refusals cover: a host that cannot be reached says so instead of reading as
idle (both cards, both asserted against the empty-state copy appearing); a caller
without `connections:manage` gets no section, no heading, and their browser never
requests `/sandbox-connections` at all; `usage=true` is absent from every request
until the switch is thrown; a `run`-scoped sandbox says no agent was recorded rather
than decoding the session id.

## Notes for reviewers

**Both of yesterday's red targets are somebody else's and both are resolved on
`main`:** #451 merged and fixed the two ruff findings this branch was reporting
(#476 covers the one formatting error left, from another branch), and the `h2`
`CVE-2026-71554` I filed as #459 is fixed on `main` and arrives here with the rebase.
Neither needs anything from this branch.

**`db-check` still does not pass locally, and not from this branch** — the local
Postgres is stamped at `0011_drop_expired_approval`, a revision from another branch's
chain, so `alembic check` cannot resolve it. An artifact of a shared dev database;
this branch touches no model and no migration, and CI's own database has neither
problem.

**One local-only failure worth naming so nobody chases it:** `tsc` failed once after
the rebase on `.next/types/validator.ts` referencing
`src/app/api/admin/conversations/users/route.js`, a route that no longer exists. That
is a stale generated-type cache from a `build-frontend` run against the pre-rebase
tree, not a source error — `rm -rf frontend/.next` and it is green.

**On #450 specifically.** The card does not infer the connection's kind from a
payload that withholds it: `SandboxConnectionRead.kind` is declared and reaches the
browser on `GET /sandbox-connections`, which every sandbox card issues first, and
`holdsSessions()` reads it from there. So nothing on screen implies knowledge the
response does not carry, and a Daytona connection is told apart from an idle Docker
host before either `/sessions` or `/policy` is called — asserted by tests on both the
copy and the absent requests. #450 remains a real inconsistency in the API's own
answer and needs no change here.

**Not reviewed by the automated reviewer** — it is off (#311), so this diff was read
as a maintainer would: the registry's three rules held (gates take
`(can, isAppAdmin)`; span and title ride the layout entry; catalog metadata from day
one, so #213 can offer these cards), the existing panels under
`components/sandboxes/` were read and left alone, and every skeleton branch was
checked for reachability — `sandbox-policy.tsx` deliberately does not read
`policy.isLoading`, because the absent answer is the same condition and two ways to
spell it leaves one unreachable.

**One deliberate difference from the existing panel.** `scopeKey()` reports an
unrecognised scope as unknown; `sessions-panel.tsx` folds it into "the whole agent".
Who may read a sandbox's files is exactly what the scope says, so guessing describes
the wrong set of people. The panel is not changed — that is its own diff, and this one
is scoped to the dashboard.

**The four issues could not be put on the `VstormOS` project.** `gh issue create
--project VstormOS` answers `'VstormOS' not found` and `gh project list --owner
vstorm-co` answers `missing required scopes [read:project]`. #434 through #446 have no
project either, which reads as the same wall rather than an oversight;
`gh auth refresh -s read:project,project` is what fixes it. Labels, type, milestone
and assignee are set on all four.

