### PR TITLE
feat(approvals): deny by timeout the calls nobody decides

### DIFF
--- a/backend/alembic/versions/0010_audit_without_an_actor.py
+++ b/backend/alembic/versions/0010_audit_without_an_actor.py
@@ -1,0 +1,56 @@
+"""An audit entry the platform wrote itself
+
+Revision ID: 0010_audit_without_an_actor
+Revises: 0009_align_index_names
+Create Date: 2026-08-06
+
+`actor_user_id` was `NOT NULL` because every action the log recorded arrived
+from a person: an admin promoting somebody, a share granted, a skill published.
+The approval expiry sweep is the first that does not. Nobody decided - that is
+precisely what it records - so there is no id to put in the column, and the two
+alternatives are worse than a null: writing the run's owner asserts a decision
+they did not make, and writing nothing at all leaves the one approvals outcome
+with no trail behind it.
+
+So null here means "the platform, on a schedule", and it is the only thing it
+can mean: every caller with an actor still passes one, and a null cannot be
+produced by an authenticated path.
+
+No backfill and no default. Every existing row was written by a person and
+already names them.
+
+Irreversible in one direction only, which is why the downgrade deletes rather
+than fails: restoring `NOT NULL` with actorless rows present would abort the
+migration outright and leave a deployment unable to go back at all. The rows it
+removes are expiry entries, whose facts are still on the `tool_approvals` rows
+themselves - `status = 'expired'`, `decided_by_user_id IS NULL`, `decided_at`.
+The trail thins; it does not disappear.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0010_audit_without_an_actor"
+down_revision = "0009_align_index_names"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "app_admin_audit_logs",
+        "actor_user_id",
+        existing_type=sa.dialects.postgresql.UUID(as_uuid=True),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.execute("DELETE FROM app_admin_audit_logs WHERE actor_user_id IS NULL")
+    op.alter_column(
+        "app_admin_audit_logs",
+        "actor_user_id",
+        existing_type=sa.dialects.postgresql.UUID(as_uuid=True),
+        nullable=False,
+    )

--- a/backend/app/core/audit.py
+++ b/backend/app/core/audit.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 async def record_audit(
     db,
     *,
-    actor_user_id: UUID,
+    actor_user_id: UUID | None,
     action: str,
     organization_id: UUID | None = None,
     target_type: str | None = None,
@@ -20,7 +20,13 @@ async def record_audit(
     details: dict[str, Any] | None = None,
     ip_address: str | None = None,
 ) -> None:
-    """Persist an audit log entry. Failures are logged but do not raise."""
+    """Persist an audit log entry. Failures are logged but do not raise.
+
+    `actor_user_id` is `None` for the one caller that has no actor: the approval
+    expiry sweep, which records that *nobody* decided. It is required rather than
+    defaulted, so passing no actor stays a deliberate act at each call site
+    instead of the thing that happens when an argument is forgotten.
+    """
     try:
         entry = AppAdminAuditLog(
             actor_user_id=actor_user_id,

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -90,6 +90,13 @@ class Settings(BaseSettings):
 
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30  # 30 minutes
     REFRESH_TOKEN_EXPIRE_MINUTES: int = 60 * 24 * 7  # 7 days
+    # How long a parked tool call waits before the sweep denies it by timeout.
+    # Three days spans a weekend, which is the gap an approval most often falls
+    # into: the one that arrives on Friday afternoon is the one nobody decides,
+    # and expiring it on Saturday would be expiring it for being asked at the
+    # wrong hour. Long enough that a decision is never taken away from someone
+    # who was going to make it; short enough that the queue has a ceiling.
+    APPROVAL_EXPIRY_HOURS: int = 72
     ALGORITHM: str = "HS256"
     FRONTEND_URL: str = "http://localhost:3000"
     PUBLIC_BASE_URL: str = "http://localhost:8000"

--- a/backend/app/db/models/audit_log.py
+++ b/backend/app/db/models/audit_log.py
@@ -16,7 +16,12 @@ class AppAdminAuditLog(Base, TimestampMixin):
     __tablename__ = "app_admin_audit_logs"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    actor_user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    # Null is "the platform, on a schedule" - an approval the expiry sweep
+    # settled because nobody decided it. That is the only thing it can mean:
+    # every authenticated path has a subject and passes it.
+    actor_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), nullable=True, index=True
+    )
     organization_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), nullable=True, index=True
     )

--- a/backend/app/repositories/agent_run.py
+++ b/backend/app/repositories/agent_run.py
@@ -484,12 +484,43 @@ async def list_approvals_for_run(
     return list(result.scalars().all())
 
 
+async def list_stale_approvals(
+    db: AsyncSession, *, older_than: datetime, limit: int = 500
+) -> list[ToolApproval]:
+    """Every approval still pending that was raised before `older_than`.
+
+    **Deliberately not scoped to an organization**, and the only query here that
+    is not. Its caller is a schedule rather than a request: there is no tenant on
+    a sweep, and one that took an organization would have to be handed every
+    organization in the deployment by something that enumerated them - which is
+    the same read with a loop around it and one more place to leave a tenant out.
+    Nothing is returned to a caller who could see it; the rows go to the sweep,
+    which settles each in its own organization. Do not copy this shape into
+    anything a route can reach.
+
+    `limit` bounds one pass rather than the work: a backlog is expired over
+    several sweeps instead of one transaction holding every stale row in the
+    deployment. Oldest first, so the ones that have waited longest go first and a
+    backlog drains in the order it accumulated.
+    """
+    result = await db.execute(
+        select(ToolApproval)
+        .where(
+            ToolApproval.status == ApprovalStatus.PENDING.value,
+            ToolApproval.created_at < older_than,
+        )
+        .order_by(ToolApproval.created_at.asc())
+        .limit(limit)
+    )
+    return list(result.scalars().all())
+
+
 async def decide_approval(
     db: AsyncSession,
     *,
     approval: ToolApproval,
     status: str,
-    decided_by_user_id: UUID,
+    decided_by_user_id: UUID | None,
     decided_at: datetime,
     note: str | None = None,
 ) -> ToolApproval:

--- a/backend/app/schemas/audit.py
+++ b/backend/app/schemas/audit.py
@@ -11,7 +11,8 @@ class AuditEntryRead(BaseSchema):
     """One recorded action."""
 
     id: UUID
-    actor_user_id: UUID
+    actor_user_id: UUID | None = None
+    """Who did it, or `None` where the platform did - see `record_audit`."""
     action: str
     target_type: str | None = None
     target_id: str | None = None

--- a/backend/app/services/approvals.py
+++ b/backend/app/services/approvals.py
@@ -14,16 +14,17 @@ the model cannot change its mind between asking and acting.
 from __future__ import annotations
 
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.audit import record_audit
+from app.core.config import settings
 from app.core.exceptions import BadRequestError, NotFoundError
 from app.core.permissions import AuthContext
-from app.db.models.agent_run import ApprovalStatus, ToolApproval
+from app.db.models.agent_run import ApprovalStatus, RunStatus, ToolApproval
 from app.repositories import agent_run_repo
 
 logger = logging.getLogger(__name__)
@@ -133,10 +134,131 @@ class ApprovalService:
             decided_at=datetime.now(UTC),
             note=note,
         )
+        await self._record_decision(approval, status, actor_user_id=ctx.subject_id, note=note)
+        return decided
+
+    async def expire_stale(self) -> int:
+        """Deny by timeout every parked call nobody decided in time.
+
+        **The point of this is the run, not the row.** An approval left pending
+        keeps its run in `awaiting_approval` for ever: the queue grows without a
+        ceiling, and a person looking at run history sees work that is neither
+        finished nor going to be. So each expired call is followed down to the
+        run behind it, and the run is ended.
+
+        `cancelled` rather than a status of its own. Nobody came back, and that
+        is what `cancelled` already means here - "the caller went away, and the
+        tokens spent up to here were still spent". `failed` would be worse than
+        imprecise: it puts a run that worked correctly into the filter an
+        operator uses to find ones that did not, which is the same reasoning that
+        gave `budget_exceeded` a status instead of leaving it under `failed`.
+
+        The run is *not* continued the way a rejection is. A rejected call is
+        settled by `resume`, which replays the denial and runs the agent again -
+        a model request, against an organization's own keys, costing money. On a
+        schedule, for a run nobody is waiting on, that is not a thing to do
+        unasked. An expiry ends the run where it stopped.
+
+        **This is the one place in this codebase that reads across every
+        organization**, because a schedule has no tenant to be scoped to. See
+        :func:`~app.repositories.agent_run.list_stale_approvals`. Every write
+        below is still made in the row's own organization.
+
+        Returns:
+            How many approvals were expired. Zero on the ordinary sweep, which
+            is why the flow logs only when it is not.
+        """
+        now = datetime.now(UTC)
+        stale = await agent_run_repo.list_stale_approvals(
+            self.db, older_than=now - timedelta(hours=settings.APPROVAL_EXPIRY_HOURS)
+        )
+        if not stale:
+            return 0
+
+        for approval in stale:
+            await agent_run_repo.decide_approval(
+                self.db,
+                approval=approval,
+                status=ApprovalStatus.EXPIRED.value,
+                # Nobody decided it. A run's owner written here would read as a
+                # rejection they made, which is the one claim this must not make.
+                decided_by_user_id=None,
+                decided_at=now,
+            )
+            await self._record_decision(
+                approval, ApprovalStatus.EXPIRED, actor_user_id=None, note=None
+            )
+
+        settled = 0
+        for run_id, organization_id in {
+            (approval.run_id, approval.organization_id) for approval in stale
+        }:
+            settled += await self._settle_expired_run(
+                run_id, organization_id=organization_id, at=now
+            )
+
+        logger.info("Approval sweep: expired %d approval(s), ended %d run(s)", len(stale), settled)
+        return len(stale)
+
+    async def _settle_expired_run(
+        self, run_id: UUID, *, organization_id: UUID, at: datetime
+    ) -> int:
+        """End one parked run whose calls have all been decided one way or another.
+
+        Returns 1 if this ended a run, 0 if it left one alone - which is the
+        ordinary answer for a run with a second call still inside its window. A
+        run parks on *all* of its outstanding calls at once, so ending it while
+        one is still pending would take away a decision somebody can still make.
+        """
+        run = await agent_run_repo.get_run(self.db, run_id, organization_id=organization_id)
+        if run is None or run.status != RunStatus.AWAITING_APPROVAL.value:
+            return 0
+        approvals = await agent_run_repo.list_approvals_for_run(
+            self.db, run_id=run_id, organization_id=organization_id
+        )
+        if any(approval.status == ApprovalStatus.PENDING.value for approval in approvals):
+            return 0
+
+        await agent_run_repo.finish_run(
+            self.db,
+            run=run,
+            status=RunStatus.CANCELLED.value,
+            # What it spent stands. The run reached a gated tool, so the model
+            # requests before it were real, and re-deriving them from anywhere
+            # but the row would be inventing a second answer to what it cost.
+            input_tokens=run.input_tokens,
+            output_tokens=run.output_tokens,
+            cost_usd=run.cost_usd,
+            cost_is_partial=run.cost_is_partial,
+            ended_at=at,
+            error=(
+                f"No decision within {settings.APPROVAL_EXPIRY_HOURS}h - "
+                "the parked tool call expired"
+            ),
+            # Cleared by passing nothing, which is what makes the run
+            # un-resumable: state left on an ended run is state somebody replays.
+            paused_state=None,
+        )
+        return 1
+
+    async def _record_decision(
+        self,
+        approval: ToolApproval,
+        status: ApprovalStatus,
+        *,
+        actor_user_id: UUID | None,
+        note: str | None,
+    ) -> None:
+        """Write one decision to the audit trail, however it was reached.
+
+        One shape for all three outcomes, so an expiry cannot come to be recorded
+        with less than a rejection is. `actor_user_id` is `None` only for an
+        expiry, where it carries the fact: nobody decided this.
+        """
         await record_audit(
             self.db,
-            actor_user_id=ctx.subject_id,
-            organization_id=ctx.organization_id,
+            actor_user_id=actor_user_id,
+            organization_id=approval.organization_id,
             action=f"approval.{status.value}",
             target_type="tool_approval",
             target_id=str(approval.id),
@@ -149,4 +271,3 @@ class ApprovalService:
                 "note": note,
             },
         )
-        return decided

--- a/backend/app/worker/prefect_app.py
+++ b/backend/app/worker/prefect_app.py
@@ -26,6 +26,7 @@ from prefect import aserve
 from prefect.client.schemas.schedules import IntervalSchedule
 
 from app.core.config import settings
+from app.worker.tasks.approval_tasks import approval_expiry_sweep_flow
 from app.worker.tasks.mcp_tasks import mcp_connection_sweep_flow
 from app.worker.tasks.rag_tasks import (
     check_scheduled_syncs_flow,
@@ -63,6 +64,15 @@ async def main() -> None:
         await mcp_connection_sweep_flow.ato_deployment(
             name="mcp-connection-sweep",
             schedules=[IntervalSchedule(interval=900)],
+        )
+    )
+    # Hourly, against a threshold measured in days: precision here buys nothing,
+    # and an approval expiring 40 minutes late has cost nobody anything. One
+    # query an hour, which on the ordinary sweep returns no rows and stops.
+    deployments.append(
+        await approval_expiry_sweep_flow.ato_deployment(
+            name="approval-expiry-sweep",
+            schedules=[IntervalSchedule(interval=3600)],
         )
     )
     # Usage reports. An interval rather than a cron because the schedule only

--- a/backend/app/worker/tasks/approval_tasks.py
+++ b/backend/app/worker/tasks/approval_tasks.py
@@ -1,0 +1,37 @@
+"""Scheduled upkeep for the approvals queue.
+
+One flow, for a queue that otherwise only grows. A tool call parked on a human
+waits indefinitely: nothing in a request path can expire it, because the whole
+point is that no request is coming. So the ceiling has to be a schedule.
+
+What it protects is not the queue's length but the run behind each row. A parked
+run sits in `awaiting_approval` until somebody decides, and an approval nobody
+decides is a run that is neither finished nor going to be - which is what the
+dashboard's oldest-waiting age inherits, and what run history shows for ever.
+"""
+
+import logging
+
+from prefect import flow
+
+from app.db.session import get_db_context
+from app.services.approvals import ApprovalService
+
+logger = logging.getLogger(__name__)
+
+
+@flow(name="approval-expiry-sweep")
+async def approval_expiry_sweep_flow() -> int:
+    """Deny by timeout every parked call past `APPROVAL_EXPIRY_HOURS`, and end its run.
+
+    Returns how many approvals were expired, so a flow run's result says what it
+    found without anybody reading the logs.
+    """
+    async with get_db_context() as db:
+        expired = await ApprovalService(db).expire_stale()
+
+    if expired:
+        # Worth a warning rather than an info: each one is a decision somebody
+        # was asked for and did not make, and the agent's work was thrown away.
+        logger.warning("Approval sweep: %d approval(s) expired undecided", expired)
+    return expired

--- a/backend/tests/integration/test_vector_store_reserved_names.py
+++ b/backend/tests/integration/test_vector_store_reserved_names.py
@@ -39,7 +39,6 @@ async def _no_collection_of_its_own(name: str) -> None:
     answers `None` is the state this helper was always describing, and it is what
     sends the store to its deployment defaults.
     """
-    return None
 
 
 def _store_on(engine: AsyncEngine) -> PgVectorStore:

--- a/backend/tests/test_approval_expiry.py
+++ b/backend/tests/test_approval_expiry.py
@@ -1,0 +1,292 @@
+"""Tests for expiring a tool call nobody decided.
+
+An approval waits on a person, so nothing in a request path can end one: the
+whole point is that no request is coming. That leaves a schedule, and a schedule
+is the one caller here with no tenant and no actor - which is what most of these
+tests are about. What it writes has to be a denial by timeout on the *run*, in
+the row's own organization, saying plainly that nobody decided.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.config import settings
+from app.core.exceptions import BadRequestError
+from app.core.permissions import AuthContext, OrgRoleName
+from app.db.models.agent_run import ApprovalStatus, RunStatus
+from app.services.approvals import ApprovalService
+from app.worker.tasks.approval_tasks import approval_expiry_sweep_flow
+
+pytestmark = pytest.mark.anyio
+
+
+def _db() -> MagicMock:
+    return MagicMock(flush=AsyncMock(), refresh=AsyncMock(), add=MagicMock())
+
+
+def _approval(
+    *,
+    run_id: uuid.UUID | None = None,
+    organization_id: uuid.UUID | None = None,
+    status: str = ApprovalStatus.PENDING.value,
+) -> MagicMock:
+    return MagicMock(
+        id=uuid.uuid4(),
+        run_id=run_id or uuid.uuid4(),
+        organization_id=organization_id or uuid.uuid4(),
+        status=status,
+        tool_id="send_email",
+        tool_args={"to": "customer@example.com"},
+    )
+
+
+def _parked_run(status: str = RunStatus.AWAITING_APPROVAL.value) -> MagicMock:
+    """A run row as it looks while it waits on a decision."""
+    return MagicMock(
+        id=uuid.uuid4(),
+        status=status,
+        input_tokens=1200,
+        output_tokens=340,
+        cost_usd=Decimal("0.0210"),
+        cost_is_partial=False,
+    )
+
+
+class _Sweep:
+    """One `expire_stale` run with the repository stubbed around it.
+
+    Every patch target is on the service's own module, so what is exercised is
+    the service: which rows it asks for, what it writes on each, and which runs
+    it decides to end.
+    """
+
+    def __init__(
+        self,
+        stale: list[MagicMock],
+        *,
+        run: MagicMock | None = None,
+        for_run: list[MagicMock] | None = None,
+    ) -> None:
+        self.stale = stale
+        self.run = run
+        self.for_run = for_run if for_run is not None else stale
+
+    async def __aenter__(self) -> _Sweep:
+        self._patches = {
+            "list_stale_approvals": AsyncMock(return_value=self.stale),
+            "decide_approval": AsyncMock(side_effect=self._decide),
+            "get_run": AsyncMock(return_value=self.run),
+            "list_approvals_for_run": AsyncMock(return_value=self.for_run),
+            "finish_run": AsyncMock(),
+        }
+        self._ctx = patch.multiple("app.services.approvals.agent_run_repo", **self._patches)
+        self._ctx.start()
+        self._audit = patch("app.services.approvals.record_audit", new=AsyncMock())
+        self.audit = self._audit.start()
+        self.expired = await ApprovalService(_db()).expire_stale()
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> bool:
+        self._audit.stop()
+        self._ctx.stop()
+        return False
+
+    @staticmethod
+    async def _decide(db, *, approval, status, **kwargs) -> MagicMock:
+        """Write the status onto the row, the way the repository would.
+
+        Without this the row stays `pending` in memory and the run would be
+        settled by a test that had not actually expired anything.
+        """
+        approval.status = status
+        return approval
+
+    def __getattr__(self, name: str) -> AsyncMock:
+        return self._patches[name]
+
+
+class TestWhichApprovalsAreSweptUp:
+    async def test_the_window_moves_with_the_setting(self):
+        """ "Configurable age" is the whole of what the operator controls here."""
+        with patch.object(settings, "APPROVAL_EXPIRY_HOURS", 5):
+            before = datetime.now(UTC)
+            async with _Sweep([]) as sweep:
+                after = datetime.now(UTC)
+
+            cutoff = sweep.list_stale_approvals.await_args.kwargs["older_than"]
+            assert before - timedelta(hours=5) <= cutoff <= after - timedelta(hours=5)
+
+    async def test_a_sweep_that_finds_nothing_writes_nothing(self):
+        """The ordinary case, hourly, for ever. It must not touch a row or a run."""
+        async with _Sweep([]) as sweep:
+            pass
+
+        assert sweep.expired == 0
+        sweep.decide_approval.assert_not_awaited()
+        sweep.finish_run.assert_not_awaited()
+        sweep.audit.assert_not_awaited()
+
+
+class TestWhatAnExpiryRecords:
+    async def test_an_expired_call_names_nobody_as_its_decider(self):
+        """Nobody decided - that is the whole fact. Writing the run's owner here
+        would record a rejection they never made."""
+        approval = _approval()
+
+        async with _Sweep([approval], run=_parked_run()) as sweep:
+            pass
+
+        written = sweep.decide_approval.await_args.kwargs
+        assert written["status"] == ApprovalStatus.EXPIRED.value
+        assert written["decided_by_user_id"] is None
+        assert written["decided_at"] is not None
+
+    async def test_every_expiry_reaches_the_audit_trail_in_its_own_organization(self):
+        """A schedule crosses tenants to find the rows; what it writes must not."""
+        first, second = _approval(), _approval()
+
+        async with _Sweep([first, second], run=_parked_run()) as sweep:
+            pass
+
+        entries = {call.kwargs["target_id"]: call.kwargs for call in sweep.audit.await_args_list}
+        assert set(entries) == {str(first.id), str(second.id)}
+        for approval in (first, second):
+            entry = entries[str(approval.id)]
+            assert entry["organization_id"] == approval.organization_id
+            assert entry["action"] == "approval.expired"
+            assert entry["actor_user_id"] is None
+            assert entry["details"]["tool_args"] == {"to": "customer@example.com"}
+
+
+class TestTheRunBehindIt:
+    """The point of the sweep. A row flipped to `expired` above a run still
+    parked would have moved the problem rather than fixed it."""
+
+    async def test_the_parked_run_is_ended(self):
+        approval = _approval()
+        run = _parked_run()
+
+        async with _Sweep([approval], run=run) as sweep:
+            pass
+
+        ended = sweep.finish_run.await_args.kwargs
+        assert ended["run"] is run
+        assert ended["status"] == RunStatus.CANCELLED.value
+        assert str(settings.APPROVAL_EXPIRY_HOURS) in ended["error"]
+
+    async def test_the_ended_run_cannot_be_resumed(self):
+        """`paused_state` is what a resume replays from. Left behind, a run
+        expired for want of a decision can still be continued by anyone who
+        knows its id."""
+        async with _Sweep([_approval()], run=_parked_run()) as sweep:
+            pass
+
+        assert sweep.finish_run.await_args.kwargs["paused_state"] is None
+
+    async def test_what_the_run_spent_before_it_parked_stands(self):
+        """It reached a gated tool, so the model requests before it were real.
+        A settle that zeroed them would take money out of the month."""
+        run = _parked_run()
+
+        async with _Sweep([_approval()], run=run) as sweep:
+            pass
+
+        ended = sweep.finish_run.await_args.kwargs
+        assert (ended["input_tokens"], ended["output_tokens"]) == (1200, 340)
+        assert (ended["cost_usd"], ended["cost_is_partial"]) == (Decimal("0.0210"), False)
+
+    async def test_a_run_with_a_second_call_still_inside_the_window_is_left_parked(self):
+        """A run parks on all of its outstanding calls at once. Ending it while
+        one is still decidable takes the decision away from whoever was going to
+        make it."""
+        run_id = uuid.uuid4()
+        organization_id = uuid.uuid4()
+        stale = _approval(run_id=run_id, organization_id=organization_id)
+        fresh = _approval(run_id=run_id, organization_id=organization_id)
+
+        async with _Sweep([stale], run=_parked_run(), for_run=[stale, fresh]) as sweep:
+            assert sweep.expired == 1
+
+        sweep.finish_run.assert_not_awaited()
+
+    async def test_a_run_that_is_no_longer_parked_is_left_alone(self):
+        """It was resumed between the read and the write - the decision that
+        settled it was somebody's, and the sweep must not write over it."""
+        async with _Sweep(
+            [_approval()], run=_parked_run(status=RunStatus.COMPLETED.value)
+        ) as sweep:
+            pass
+
+        sweep.finish_run.assert_not_awaited()
+
+    async def test_an_approval_whose_run_has_gone_expires_anyway(self):
+        """The row outlives nothing here - a deleted run cascades - but a read
+        that answers `None` must not stop the sweep partway through a batch."""
+        async with _Sweep([_approval()], run=None) as sweep:
+            assert sweep.expired == 1
+
+        sweep.finish_run.assert_not_awaited()
+
+    async def test_two_runs_are_each_settled_once(self):
+        """Two calls on one run must not end it twice, and two runs must both end."""
+        shared = uuid.uuid4()
+        organization_id = uuid.uuid4()
+        together = [
+            _approval(run_id=shared, organization_id=organization_id),
+            _approval(run_id=shared, organization_id=organization_id),
+        ]
+        alone = _approval(organization_id=organization_id)
+
+        async with _Sweep([*together, alone], run=_parked_run()) as sweep:
+            assert sweep.expired == 3
+
+        assert sweep.finish_run.await_count == 2
+
+
+class TestASweptRowIsDecided:
+    async def test_a_person_deciding_a_call_the_sweep_expired_is_refused(self):
+        """The race is real: a decision arriving a second after the sweep. One
+        approval, one outcome - a second decision would make the trail ambiguous
+        about what authorised the action."""
+        ctx = AuthContext(
+            user_id=uuid.uuid4(), organization_id=uuid.uuid4(), role=OrgRoleName.OPERATOR
+        )
+        expired = _approval(status=ApprovalStatus.EXPIRED.value)
+
+        with (
+            patch(
+                "app.services.approvals.agent_run_repo.get_approval",
+                new=AsyncMock(return_value=expired),
+            ),
+            patch(
+                "app.services.approvals.agent_run_repo.decide_approval", new=AsyncMock()
+            ) as decide,
+            pytest.raises(BadRequestError, match="already expired"),
+        ):
+            await ApprovalService(_db()).decide(ctx, expired.id, approved=True)
+
+        decide.assert_not_awaited()
+
+
+class TestTheScheduledSweep:
+    """The flow around the service. Thin on purpose - what it must not do is
+    swallow the count, since that is all a Prefect run reports."""
+
+    async def test_the_flow_answers_with_what_it_expired(self):
+        with (
+            patch("app.worker.tasks.approval_tasks.get_db_context") as db_context,
+            patch(
+                "app.worker.tasks.approval_tasks.ApprovalService",
+                return_value=MagicMock(expire_stale=AsyncMock(return_value=3)),
+            ),
+        ):
+            db_context.return_value.__aenter__ = AsyncMock(return_value=_db())
+            db_context.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            assert await approval_expiry_sweep_flow() == 3

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -96,7 +96,7 @@ def _why_the_server_did_not_answer(url: str) -> str | None:
     try:
         with engine.connect():
             return None
-    except Exception as exc:  # noqa: BLE001 - any failure to connect is the answer
+    except Exception as exc:  # Any failure to connect is the answer, whatever it was.
         return str(exc).strip()
     finally:
         engine.dispose()

--- a/backend/tests/test_prefect_app.py
+++ b/backend/tests/test_prefect_app.py
@@ -79,6 +79,7 @@ async def test_every_deployment_is_registered_before_the_runner_starts(
         "sync-collection",
         "rag-sync-check",
         "mcp-connection-sweep",
+        "approval-expiry-sweep",
         "weekly-usage-report",
         "monthly-usage-report",
     }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -158,6 +158,20 @@ There is no `HEALTHCHECK` in `backend/Dockerfile`. The image is started as two
 different processes — the API and this runner — and a probe for one is a
 permanent false alarm on the other, so each service definition carries its own.
 
+### Approval expiry
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `APPROVAL_EXPIRY_HOURS` | `72` | How long a parked tool call waits before the hourly sweep denies it by timeout |
+
+Three days because it has to span a weekend: the approval that arrives on Friday
+afternoon is the one nobody decides, and expiring it on Saturday would be expiring
+it for having been asked at the wrong hour. Shorten it where a queue is watched
+during the working day and a stale ask is worse than a slow one; lengthen it where
+approvals are a weekly ritual. Expiring a call also **ends its run** — see
+[Governance](governance.md#a-decision-nobody-makes) for what that settles and what
+it deliberately leaves alone.
+
 ## AI Models — configured in the app, not here
 
 Chat models are not environment variables. Each organization stores its own

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -274,7 +274,8 @@ Four properties worth knowing:
   deploy, an MCP connection unshared. The spec is assembled before the run leaves
   the approval queue, so a refusal there refuses the *attempt*: the decision
   stands and resuming works again once the spec does.
-- **A decided approval cannot be decided twice.** The second decision is refused.
+- **A decided approval cannot be decided twice.** The second decision is refused —
+  including a decision arriving a second after the expiry sweep took the call.
 - **`required` works on any capability**, not only side-effecting ones. "This only
   reads, but in my organization somebody approves it anyway" is a real decision
   and is expressible.
@@ -284,6 +285,36 @@ Four properties worth knowing:
   when the run parks rather than as each call is gated, because the calls run
   concurrently and the run's database session is not concurrency-safe
   ([#169](https://github.com/vstorm-co/agenticos/issues/169)).
+
+### A decision nobody makes
+
+An approval waits on a person, and some of them wait for ever: the reviewer left,
+the tool was asked for on a Friday, nobody knew it was theirs to decide. Nothing in
+a request path can end one — the whole premise is that no request is coming — so an
+hourly sweep denies by timeout anything still pending past `APPROVAL_EXPIRY_HOURS`
+(three days by default, which spans a weekend).
+
+**It is the run that matters, not the row.** An approval left pending keeps its run
+in `awaiting_approval` indefinitely: work that is neither finished nor going to be,
+sitting in run history and in the oldest-waiting age on the dashboard. So the sweep
+follows each expired call down to the run behind it and ends it, `cancelled` —
+nobody came back, and what it spent before it parked stands.
+
+Three things it deliberately does not do:
+
+- **It does not continue the run.** A *rejected* call is settled by resuming: the
+  denial is replayed and the agent carries on to an answer. That is a model request
+  against the organization's own keys, and making one on a schedule, for a run
+  nobody is waiting on, is not a cost to incur unasked.
+- **It does not end a run with a call still inside its window.** A run parks on all
+  of its outstanding calls at once, so it is ended only when none of them is pending.
+- **It does not name a decider.** `decided_by_user_id` stays null and so does the
+  audit entry's actor, because that is the fact being recorded. Null there means the
+  platform on a schedule, and nothing else can produce one.
+
+This is the only read in the codebase that crosses every organization, for the
+reason a schedule has no tenant to be scoped to. Every write it makes is still in
+the row's own organization.
 
 ### An approval inside a delegation
 


### PR DESCRIPTION
`ApprovalStatus.EXPIRED` was defined and permitted by the `ck_tool_approval_status`
CHECK constraint, and nothing had ever assigned it. A tool call nobody decided
stayed `pending` for ever, and **its run stayed in `awaiting_approval`** — work that
is neither finished nor going to be, in run history and in the dashboard's
oldest-waiting age, with no ceiling on either.

The issue offered a real expiry path or dropping the enum. This builds the path.

## Changed

- **`ApprovalService.expire_stale`** — deny by timeout everything still pending past
  `APPROVAL_EXPIRY_HOURS`, then follow each expired call down to the run behind it
  and end it.
- **`agent_run_repo.list_stale_approvals`** — the one read here that crosses every
  organization, because a schedule has no tenant. Said so in the docstring, with why
  and with "do not copy this into anything a route can reach": the next person to
  read it will be deciding whether it is a tenant leak.
- **`app/worker/tasks/approval_tasks.py`** + an hourly `IntervalSchedule` in
  `prefect_app.py`. Hourly against a threshold in days — an approval expiring forty
  minutes late has cost nobody anything.
- **`APPROVAL_EXPIRY_HOURS`, default 72.** Three days because it has to span a
  weekend: the approval that arrives on Friday afternoon is the one nobody decides,
  and expiring it on Saturday would be expiring it for having been asked at the
  wrong hour.
- **Migration `0010`** — see below.

**The run ends `cancelled`.** Nobody came back, which is what that status already
means here, and what it spent before it parked stands. `failed` would put a run that
worked correctly into the filter an operator uses to find ones that did not — the
same reasoning that gave `budget_exceeded` a status rather than leaving it under
`failed`. No new terminal status was invented.

Three things it deliberately does not do:

- **It does not continue the run.** This is where the issue's framing and the code
  part company, and it is worth being explicit: `decide(approved=False)` does not
  settle a run at all. A rejection is settled by `resume`, which replays the denial
  and **runs the agent again** — a model request, against the organization's own
  keys. On a schedule, for a run nobody is waiting on, that is not a cost to incur
  unasked. So there was no rejection-settle to factor out; the two differ because
  one has a person waiting and the other has nobody.
- **It does not end a run with a second call still inside its window.** A run parks
  on all of its outstanding calls at once.
- **It does not name a decider.** `decided_by_user_id` stays null, and so does the
  audit entry's actor, because that is the fact being recorded.

## Migration 0010 — an audit entry with no actor

That last point needed one. `app_admin_audit_logs.actor_user_id` was `NOT NULL`,
every action it had ever recorded having come from a person, so an actorless entry
could not be written at all. Null now means "the platform, on a schedule" and can
mean nothing else — no authenticated path can produce one.

The downgrade **deletes** those rows rather than failing. Restoring `NOT NULL`
underneath them would abort the migration and leave a deployment unable to go back
at all; what it removes is still on the `tool_approvals` rows themselves
(`status = 'expired'`, `decided_by_user_id IS NULL`, `decided_at`).

## Testing

`tests/test_approval_expiry.py` — 13 tests. Beyond the issue's own (a pending
approval past the threshold becomes `expired`, its run leaves `awaiting_approval`):

- one *under* the threshold leaves the run parked, and an already-decided one is
  untouched;
- the run's tokens, cost and `cost_is_partial` survive the settle unchanged;
- `paused_state` is cleared, so a run expired for want of a decision cannot then be
  resumed by anyone holding its id;
- each expiry's audit entry lands in **its own** organization, with a null actor;
- two calls on one run end it once, two runs both end;
- **a person clicking Approve one second after the sweep gets a 400.** `decide`
  already refused anything not `PENDING` — verified rather than changed, and now
  covered.

`make test` — 3413 passed, 100.00% on the platform layer. The migration was applied,
downgraded to base and re-applied against a throwaway database; `alembic check`
reports no drift.

## Notes for reviewers

**Found while working this, filed, not fixed here:** #456 — `invitation_repo.expire_stale`
has no caller either, and an invitation clicked past its expiry is written `revoked`
rather than `expired`. Same defect, second place. Left alone on purpose; the shape
this PR adds is what it should copy.

**This branch also carries `test: drop two lint errors main has been failing on`**
(#451, `Closes #407`). `main` does not pass `make lint-backend`, and the pre-commit
`ruff --fix` hook rewrites those two files under every commit and then refuses it —
nothing could be committed here without them. That commit drops out of this diff
once #451 merges.

Closes #178
