### PR TITLE
feat(agents): record where a run's trace went

### DIFF
--- a/backend/alembic/versions/0010_logfire_project.py
+++ b/backend/alembic/versions/0010_logfire_project.py
@@ -1,0 +1,51 @@
+"""Which Logfire project a trace went to
+
+Revision ID: 0010_logfire_project
+Revises: 0009_align_index_names
+Create Date: 2026-08-07
+
+`agent_runs.logfire_trace_id` has existed since the baseline and has never been
+written. Filling it is only half a deep link: a Logfire URL needs the project as
+well, and a *write* token - which is all the platform ever holds - carries no
+project name. So the slug has to be configured, and it has to be configured
+wherever the token is, or a link points into a project the trace never reached.
+
+Two columns for two levels of that:
+
+`agent_environments.logfire_project` sits beside the token that column already
+holds. An environment redirecting its runs to a client's project supplies both
+halves or neither; it never borrows the spec's slug, because that would pair one
+project's traces with another project's URL. (The third level, an agent's own
+spec, is a spec field rather than a column - `ObservabilitySpec.project`, spec
+version 8.)
+
+`agent_runs.logfire_project` records where the trace actually went, the way
+`provider` and `model_label` record what actually ran. Resolving it at read time
+instead would relabel every historical run the day somebody repoints an agent -
+links into a project those traces are not in.
+
+Both nullable, no backfill and no default. Every existing run has a null trace id
+and therefore no project to name; inventing the deployment's current slug for
+them would claim traces exist that were never exported.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0010_logfire_project"
+down_revision = "0009_align_index_names"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_environments", sa.Column("logfire_project", sa.String(length=128), nullable=True)
+    )
+    op.add_column("agent_runs", sa.Column("logfire_project", sa.String(length=128), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("agent_runs", "logfire_project")
+    op.drop_column("agent_environments", "logfire_project")

--- a/backend/app/agents/observability.py
+++ b/backend/app/agents/observability.py
@@ -14,19 +14,92 @@ a long way from the code that caused it.
 
 The token is unsealed from the vault by the caller and passed in. Nothing here
 reads a secret, logs one, or puts one in a span attribute.
+
+The other half of this module is the *return* trip: recording where a run's
+trace went, so somebody reading run history can open it.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
 
 import logfire
+from opentelemetry import trace
 from pydantic_ai import Agent as PydanticAgent
+
+from app.core.config import settings
+
+if TYPE_CHECKING:
+    from app.agents.spec import AgentSpec
 
 logger = logging.getLogger(__name__)
 
 _instances: dict[tuple[str, str, str], logfire.Logfire] = {}
+
+
+@dataclass(frozen=True)
+class TraceLocation:
+    """Where one run's trace went, as far as this process can know.
+
+    Both halves are needed to open it and neither implies the other: an id
+    without a project is a trace nobody can find, and a project without an id is
+    a link to a search. Stored together on the run for the same reason `provider`
+    and `model_label` are - they record where the run *actually* went, and
+    re-deriving them later would relabel history the day a setting changes.
+    """
+
+    trace_id: str | None
+    project: str | None
+
+
+def trace_location(spec: AgentSpec) -> TraceLocation:
+    """The trace id and project to record for a run of this spec.
+
+    **The id is `None` unless the trace is actually going somewhere.** Spans
+    exist whether or not Logfire has a token - `send_to_logfire="if-token-present"`
+    builds them locally and drops them - so an id read off the span is a
+    syntactically valid identifier that resolves to nothing on a deployment with
+    no Logfire at all. That is the same lie as the `null` column this replaces,
+    written the other way round.
+
+    The project follows **the token**, never the other way about. An agent whose
+    spec or environment redirects its traces exports them to that token's
+    project, so falling back to the deployment's slug there would build a link
+    into a project the trace never reached. A redirected agent whose spec names
+    no project therefore gets no project - the id is still recorded, and whoever
+    holds that token can find it.
+
+    Four outcomes, and each is somebody's real deployment: an agent redirected to
+    a client's project, an agent tracing to the operator's, a deployment with a
+    token and no slug configured (id, no link), and a deployment with no Logfire
+    at all (neither).
+    """
+    observability = spec.observability
+    if observability is not None and observability.token_secret_id is not None:
+        return TraceLocation(trace_id=current_trace_id(), project=observability.project)
+    if not settings.LOGFIRE_TOKEN:
+        return TraceLocation(trace_id=None, project=None)
+    return TraceLocation(trace_id=current_trace_id(), project=settings.LOGFIRE_PROJECT)
+
+
+def current_trace_id() -> str | None:
+    """The trace this code is running inside, as 32 hex characters, or `None`.
+
+    Taken from the active OpenTelemetry span rather than through a Logfire API,
+    because the id a Logfire URL wants is the OTel trace id and Logfire is one of
+    several things that may have started it.
+
+    `None` where there is no span at all - a CLI command, a test, a worker path
+    nothing instruments. OpenTelemetry answers those with an invalid context
+    whose trace id is zero, and `"000...0"` in the column would be an id that
+    resolves to nothing.
+    """
+    context = trace.get_current_span().get_span_context()
+    if not context.is_valid:
+        return None
+    return format(context.trace_id, "032x")
 
 
 def instrument_agent(

--- a/backend/app/agents/spec.py
+++ b/backend/app/agents/spec.py
@@ -43,7 +43,7 @@ from app.agents.capabilities import CapabilityBinding, ToolOverride
 
 logger = logging.getLogger(__name__)
 
-SPEC_VERSION = 7
+SPEC_VERSION = 8
 
 ApprovalMode = Literal["default", "required", "never"]
 
@@ -320,6 +320,13 @@ class ObservabilitySpec(BaseModel):
     The token is a reference, never a value - like every other credential a spec
     names. A spec is exported as YAML into somebody's repository, and a write
     token in a checked-in file is a token that has to be rotated.
+
+    `project` is the other half of that redirection and is *not* a credential: a
+    write token carries no project name, so without it the platform holds a trace
+    id it cannot build a URL for. It travels with the token rather than beside
+    it - see :func:`~app.agents.observability.trace_location` - because a token
+    pointing at one project and a slug at another links into a project the trace
+    never reached, which is worse than no link.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -337,6 +344,14 @@ class ObservabilitySpec(BaseModel):
         default=None,
         max_length=64,
         description="Logfire environment - production, staging, a client's name",
+    )
+    project: str | None = Field(
+        default=None,
+        max_length=128,
+        description=(
+            "The Logfire project the token writes to - 'organization/project' or "
+            "just the project slug. Only used to build a link to a run's trace"
+        ),
     )
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -43,6 +43,11 @@ class Settings(BaseSettings):
     LOGFIRE_TOKEN: str | None = None
     LOGFIRE_SERVICE_NAME: str = "agenticos"
     LOGFIRE_ENVIRONMENT: str = "development"
+    # A write token carries no project name, so a run's trace id cannot be turned
+    # into a URL without these. Unset means runs still record their trace id and
+    # nothing links to it.
+    LOGFIRE_ORGANIZATION: str | None = None
+    LOGFIRE_PROJECT: str | None = None
 
     POSTGRES_HOST: str = "localhost"
     POSTGRES_PORT: int = 5432

--- a/backend/app/db/models/agent_environment.py
+++ b/backend/app/db/models/agent_environment.py
@@ -75,6 +75,10 @@ class AgentEnvironment(Base, TimestampMixin):
         nullable=True,
     )
     service_name: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    # The project that token writes to. Held beside the token rather than
+    # inherited from the spec, because a token pointing at one project and a
+    # slug at another builds a link into a project the trace never reached.
+    logfire_project: Mapped[str | None] = mapped_column(String(128), nullable=True)
 
     created_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
         PG_UUID(as_uuid=True),

--- a/backend/app/db/models/agent_run.py
+++ b/backend/app/db/models/agent_run.py
@@ -185,8 +185,13 @@ class AgentRun(Base, TimestampMixin):
     cost_is_partial: Mapped[bool] = mapped_column(nullable=False, default=False)
 
     # The trace lives in Logfire; we keep the id so the UI can deep-link into it
-    # instead of duplicating spans into our database.
+    # instead of duplicating spans into our database. Null where nothing was
+    # exported - a deployment with no token, or a path no span covers.
     logfire_trace_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    # Which project it went to, recorded rather than re-derived: an agent
+    # repointed at a client's Logfire next month must not relabel the traces
+    # of every run before it. A trace id without this is not a link.
+    logfire_project: Mapped[str | None] = mapped_column(String(128), nullable=True)
 
     # Everything the run needs to pick up where it stopped: the message history
     # as of the parked tool call, and which call each approval belongs to. Set

--- a/backend/app/repositories/agent_environment.py
+++ b/backend/app/repositories/agent_environment.py
@@ -79,6 +79,7 @@ async def create(
     created_by_user_id: UUID | None = None,
     logfire_token_secret_id: UUID | None = None,
     service_name: str | None = None,
+    logfire_project: str | None = None,
 ) -> AgentEnvironment:
     environment = AgentEnvironment(
         organization_id=organization_id,
@@ -89,6 +90,7 @@ async def create(
         created_by_user_id=created_by_user_id,
         logfire_token_secret_id=logfire_token_secret_id,
         service_name=service_name,
+        logfire_project=logfire_project,
     )
     db.add(environment)
     await db.flush()

--- a/backend/app/repositories/agent_run.py
+++ b/backend/app/repositories/agent_run.py
@@ -65,6 +65,7 @@ async def finish_run(
     ended_at: datetime,
     error: str | None = None,
     logfire_trace_id: str | None = None,
+    logfire_project: str | None = None,
     paused_state: dict[str, Any] | None = None,
 ) -> AgentRun:
     run.status = status
@@ -77,8 +78,12 @@ async def finish_run(
     # Written on every finish, not only when parking: a run that ended must not
     # keep the state it was parked with, or it can be resumed a second time.
     run.paused_state = paused_state
+    # Guarded, not assigned: a resume finishes the same row a second time, and
+    # a turn that traced nowhere must not erase the id the first one recorded.
     if logfire_trace_id is not None:
         run.logfire_trace_id = logfire_trace_id
+    if logfire_project is not None:
+        run.logfire_project = logfire_project
     db.add(run)
     await db.flush()
     await db.refresh(run)

--- a/backend/app/schemas/agent_environment.py
+++ b/backend/app/schemas/agent_environment.py
@@ -31,6 +31,11 @@ class EnvironmentCreate(BaseSchema):
         ),
     )
     service_name: str | None = Field(default=None, max_length=128)
+    logfire_project: str | None = Field(
+        default=None,
+        max_length=128,
+        description="The Logfire project that token writes to, for linking to a run's trace",
+    )
 
 
 class EnvironmentUpdate(BaseSchema):
@@ -44,6 +49,7 @@ class EnvironmentUpdate(BaseSchema):
     version_id: UUID | None = None
     logfire_token_secret_id: UUID | None = None
     service_name: str | None = Field(default=None, max_length=128)
+    logfire_project: str | None = Field(default=None, max_length=128)
 
 
 class EnvironmentRead(BaseSchema):
@@ -55,6 +61,7 @@ class EnvironmentRead(BaseSchema):
     is_default: bool
     logfire_token_secret_id: UUID | None = None
     service_name: str | None = None
+    logfire_project: str | None = None
     created_at: datetime
 
 

--- a/backend/app/schemas/agent_run.py
+++ b/backend/app/schemas/agent_run.py
@@ -27,7 +27,19 @@ class AgentRunRead(BaseSchema):
         description="True when a model in this run had no price - the cost is a floor"
     )
     logfire_trace_id: str | None = Field(
-        default=None, description="Deep-link into the full trace; spans are not duplicated here"
+        default=None,
+        description=(
+            "This run's trace in Logfire; spans are not duplicated here. Null "
+            "where nothing was exported - a deployment with no Logfire token"
+        ),
+    )
+    logfire_project: str | None = Field(
+        default=None,
+        description=(
+            "The Logfire project the trace went to, for building a link to it. "
+            "Null where none is configured: the trace id is still real, and a "
+            "client holding that project's token can find it"
+        ),
     )
     error: str | None = None
     started_at: datetime | None = None

--- a/backend/app/services/agent_environment.py
+++ b/backend/app/services/agent_environment.py
@@ -64,6 +64,7 @@ class AgentEnvironmentService:
                 is_default=environment.is_default,
                 logfire_token_secret_id=environment.logfire_token_secret_id,
                 service_name=environment.service_name,
+                logfire_project=environment.logfire_project,
                 created_at=environment.created_at,
             )
             for environment in environments
@@ -107,6 +108,7 @@ class AgentEnvironmentService:
             created_by_user_id=ctx.user_id,
             logfire_token_secret_id=data.logfire_token_secret_id,
             service_name=data.service_name,
+            logfire_project=data.logfire_project,
         )
         await record_audit(
             self.db,

--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -88,6 +88,7 @@ from app.agents.capabilities.subagents import SubagentsConfig, acting_delegate
 from app.agents.deps import AgentDeps
 from app.agents.factory import BuiltAgent, build_agent
 from app.agents.model_resolver import ModelRequestSpec
+from app.agents.observability import trace_location
 from app.agents.spec import (
     AgentSpec,
     CapabilityBindingSpec,
@@ -2258,7 +2259,6 @@ class AgentRunnerService:
         *,
         status: RunStatus,
         error: str | None = None,
-        logfire_trace_id: str | None = None,
         paused_state: PausedRunState | None = None,
         budget_scope: BudgetScope | None = None,
     ) -> AgentRun:
@@ -2280,6 +2280,9 @@ class AgentRunnerService:
         re-derived here, because the alternative is matching a prefix on the
         error message - and it decides who gets mailed: an agent's cap is its
         author's to raise, the organization's is not.
+
+        Where the run's trace went is recorded here too, and taken rather than
+        given: see :func:`~app.agents.observability.trace_location`.
         """
         # Both before the workspace closes, because a run-scoped one is released
         # by `close` and its files are gone afterwards.
@@ -2300,6 +2303,12 @@ class AgentRunnerService:
 
         parked = None if paused_state is None else self._parked_tree(prepared, paused_state)
         ledger = prepared.built.ledger
+        # Resolved here rather than passed in, for the reason the meter is opened
+        # here: a surface that has to remember is a surface that will not, and the
+        # failure - a run with no trace to open - is silent. `finish` runs in every
+        # surface's `finally`, so this reaches the failed run too, which is exactly
+        # the one somebody wants the trace for.
+        traced = trace_location(prepared.spec)
         finished = await agent_run_repo.finish_run(
             self.db,
             run=prepared.run,
@@ -2310,7 +2319,8 @@ class AgentRunnerService:
             cost_is_partial=ledger.has_unpriced_models,
             ended_at=datetime.now(UTC),
             error=error,
-            logfire_trace_id=logfire_trace_id,
+            logfire_trace_id=traced.trace_id,
+            logfire_project=traced.project,
             paused_state=None if parked is None else parked.model_dump(mode="json"),
         )
         # After the parent's row and on every path out of the run, for the reason
@@ -2691,6 +2701,12 @@ class AgentRunnerService:
         environment's *name*, never configured separately, so the tag and the
         environment cannot disagree. A run with no token from either source
         stays untraced rather than tagged into nowhere.
+
+        **The project does not fall through, because it belongs to the token.**
+        Whichever level supplied the token supplies the project with it: an
+        environment's token paired with the spec's project slug would build a
+        link into a project that environment's traces never reached, which is
+        worse than the no link a missing slug gives.
         """
         if environment_id is None:
             return spec
@@ -2700,6 +2716,7 @@ class AgentRunnerService:
         if environment is None:
             return spec
         base = spec.observability
+        redirected = environment.logfire_token_secret_id is not None
         token_secret_id = environment.logfire_token_secret_id or (
             base.token_secret_id if base else None
         )
@@ -2709,6 +2726,7 @@ class AgentRunnerService:
             token_secret_id=token_secret_id,
             service_name=environment.service_name or (base.service_name if base else None),
             environment=environment.name,
+            project=environment.logfire_project if redirected else (base.project if base else None),
         )
         return spec.model_copy(update={"observability": merged})
 

--- a/backend/tests/integration/test_delegation_row_failures.py
+++ b/backend/tests/integration/test_delegation_row_failures.py
@@ -25,6 +25,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.agents.capabilities.budget import SpendEntry, SpendLedger
+from app.agents.spec import AgentSpec
 from app.db.models.agent import Agent, AgentVersion
 from app.db.models.agent_run import AgentRun, RunStatus
 from app.db.models.organization import Organization, OrganizationMember
@@ -109,9 +110,10 @@ def _delegation(agent: Agent, version: AgentVersion, *, task_id: str) -> Recorde
 def _prepared(run: AgentRun, agent: Agent, delegations: list[RecordedDelegation]) -> PreparedRun:
     """A run ready to finish, with the ledger the parent's row is written from.
 
-    `spec`, `built` and `approvals` are what the *run loop* used and this test
-    does not run one: nothing on the path from `finish` to the two writes reads
-    them apart from the ledger.
+    `built` and `approvals` are what the *run loop* used and this test does not
+    run one: nothing on the path from `finish` to the two writes reads them apart
+    from the ledger. `spec` is real, because `finish` does read it - it resolves
+    where the run's trace went from the observability block.
     """
     ledger = SpendLedger(
         entries=[
@@ -127,7 +129,7 @@ def _prepared(run: AgentRun, agent: Agent, delegations: list[RecordedDelegation]
     return PreparedRun(
         run=run,
         agent=agent,
-        spec=MagicMock(),
+        spec=AgentSpec(name="Parent"),
         # An empty channel: this run parked no approvals, so `finish` has none to
         # write. A bare `MagicMock` would make `_write_approvals` try to iterate a
         # mock and fail before the delegation write under test ran.

--- a/backend/tests/integration/test_vector_store_reserved_names.py
+++ b/backend/tests/integration/test_vector_store_reserved_names.py
@@ -39,7 +39,6 @@ async def _no_collection_of_its_own(name: str) -> None:
     answers `None` is the state this helper was always describing, and it is what
     sends the store to its deployment defaults.
     """
-    return None
 
 
 def _store_on(engine: AsyncEngine) -> PgVectorStore:

--- a/backend/tests/test_agent_environments.py
+++ b/backend/tests/test_agent_environments.py
@@ -56,6 +56,7 @@ def _environment(*, agent_id: uuid.UUID, name: str = "dev", is_default: bool = F
         is_default=is_default,
         logfire_token_secret_id=None,
         service_name=None,
+        logfire_project=None,
     )
 
 

--- a/backend/tests/test_agent_observability.py
+++ b/backend/tests/test_agent_observability.py
@@ -83,4 +83,30 @@ class TestSpec:
         from pydantic import ValidationError
 
         with pytest.raises(ValidationError):
-            ObservabilitySpec(project="acme")  # ty: ignore[unknown-argument]
+            ObservabilitySpec(dashboard="acme")  # ty: ignore[unknown-argument]
+
+    def test_a_spec_written_before_the_project_field_still_loads(self):
+        """Every stored spec was. An optional field with a default is what makes
+        that free - and `extra="forbid"` is what makes forgetting it a 500 on the
+        next run of an agent nobody touched."""
+        spec = AgentSpec.model_validate(
+            {
+                "spec_version": 7,
+                "name": "Support",
+                "observability": {"token_secret_id": str(uuid.uuid4()), "environment": "prod"},
+            }
+        )
+
+        assert spec.observability is not None
+        assert spec.observability.project is None
+
+    def test_the_project_survives_a_yaml_round_trip(self):
+        """A spec is exported into a client's repository and read back from it."""
+        spec = AgentSpec(
+            name="Support",
+            observability=ObservabilitySpec(
+                token_secret_id=uuid.uuid4(), project="client-org/client-traces"
+            ),
+        )
+
+        assert AgentSpec.from_yaml(spec.to_yaml()) == spec

--- a/backend/tests/test_agent_runner.py
+++ b/backend/tests/test_agent_runner.py
@@ -14,6 +14,7 @@ from decimal import Decimal
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import logfire
 import pytest
 from pydantic_ai.tools import DeferredToolRequests
 from pydantic_ai.usage import RequestUsage
@@ -22,6 +23,7 @@ from app.agents.capabilities.approval import ApprovalGranted, ApprovalRejected
 from app.agents.capabilities.budget import BudgetExceeded, BudgetScope, SpendLedger
 from app.agents.spec import AgentSpec, CapabilityBindingSpec, ObservabilitySpec
 from app.agents.subagent_runtime import DelegationSpend, DelegationStash, ParkedDelegation
+from app.core.config import settings
 from app.core.exceptions import BadRequestError, NotFoundError, RunExecutionError
 from app.core.permissions import AuthContext, OrgRoleName
 from app.db.models.agent_run import ApprovalStatus, RunStatus, RunSurface
@@ -729,6 +731,78 @@ class TestSkillChangesARunProposed:
             await service.finish(prepared, status=RunStatus.COMPLETED)
 
         service.proposals.record.assert_not_called()
+
+
+class TestRecordingWhereTheTraceWent:
+    """`logfire_trace_id` was documented as a deep link and had never once been
+    written. It is taken in `finish` rather than passed by each surface, for the
+    reason the spend meter is opened there: a surface that has to remember is a
+    surface that will not, and this failure is silent."""
+
+    @staticmethod
+    async def _finished(spec: AgentSpec, status: RunStatus = RunStatus.COMPLETED, **kwargs):
+        service = AgentRunnerService(_db())
+        prepared = _prepared()
+        prepared.spec = spec
+
+        with (
+            logfire.span("a run"),
+            patch.object(settings, "LOGFIRE_TOKEN", "pylf_v1_eu_secret"),
+            patch.object(settings, "LOGFIRE_PROJECT", "vstorm/agenticos"),
+            patch("app.services.agent_runner.agent_run_repo.finish_run", new=AsyncMock()) as finish,
+        ):
+            await service.finish(prepared, status=status, **kwargs)
+
+        return finish.call_args.kwargs
+
+    @pytest.mark.anyio
+    async def test_a_completed_run_records_its_trace_and_its_project(self):
+        recorded = await self._finished(AgentSpec(name="Support"))
+
+        assert len(recorded["logfire_trace_id"]) == 32
+        assert recorded["logfire_project"] == "vstorm/agenticos"
+
+    @pytest.mark.anyio
+    async def test_a_failed_run_records_its_trace_too(self):
+        """The one somebody actually wants the trace for. `finish` runs from every
+        surface's `finally`, which is what makes this reachable at all."""
+        recorded = await self._finished(
+            AgentSpec(name="Support"), status=RunStatus.FAILED, error="provider down"
+        )
+
+        assert recorded["status"] == RunStatus.FAILED.value
+        assert len(recorded["logfire_trace_id"]) == 32
+        assert recorded["logfire_project"] == "vstorm/agenticos"
+
+    @pytest.mark.anyio
+    async def test_a_redirected_agent_records_its_own_project(self):
+        """Not the deployment's, which its traces never reached."""
+        recorded = await self._finished(
+            AgentSpec(
+                name="Support",
+                observability=ObservabilitySpec(
+                    token_secret_id=uuid.uuid4(), project="client-org/client-traces"
+                ),
+            )
+        )
+
+        assert recorded["logfire_project"] == "client-org/client-traces"
+
+    @pytest.mark.anyio
+    async def test_a_deployment_with_no_logfire_records_neither(self):
+        service = AgentRunnerService(_db())
+        prepared = _prepared()
+        prepared.spec = AgentSpec(name="Support")
+
+        with (
+            logfire.span("a run"),
+            patch.object(settings, "LOGFIRE_TOKEN", None),
+            patch("app.services.agent_runner.agent_run_repo.finish_run", new=AsyncMock()) as finish,
+        ):
+            await service.finish(prepared, status=RunStatus.COMPLETED)
+
+        recorded = finish.call_args.kwargs
+        assert (recorded["logfire_trace_id"], recorded["logfire_project"]) == (None, None)
 
 
 class TestRunAccounting:
@@ -1746,7 +1820,11 @@ class TestEnvironmentObservability:
                 token_secret_id=uuid.uuid4(), service_name="from-spec", environment="free-text"
             ),
         )
-        environment = MagicMock(logfire_token_secret_id=env_secret, service_name="from-env")
+        environment = MagicMock(
+            logfire_token_secret_id=env_secret,
+            service_name="from-env",
+            logfire_project="client-org/client-traces",
+        )
         environment.name = "client-prod"
         service = AgentRunnerService(_db())
 
@@ -1770,7 +1848,9 @@ class TestEnvironmentObservability:
             name="Support",
             observability=ObservabilitySpec(token_secret_id=spec_secret, environment="free-text"),
         )
-        environment = MagicMock(logfire_token_secret_id=None, service_name=None)
+        environment = MagicMock(
+            logfire_token_secret_id=None, service_name=None, logfire_project=None
+        )
         environment.name = "dev"
         service = AgentRunnerService(_db())
 
@@ -1788,10 +1868,94 @@ class TestEnvironmentObservability:
         assert merged.observability.environment == "dev"
 
     @pytest.mark.anyio
+    async def test_a_redirecting_environment_brings_its_own_project(self):
+        """The project belongs to the token. Pairing the environment's token with
+        the spec's slug links into a project those traces never reached."""
+        spec = AgentSpec(
+            name="Support",
+            observability=ObservabilitySpec(
+                token_secret_id=uuid.uuid4(), project="operator-org/operator-traces"
+            ),
+        )
+        environment = MagicMock(
+            logfire_token_secret_id=uuid.uuid4(),
+            service_name=None,
+            logfire_project="client-org/client-traces",
+        )
+        environment.name = "client-prod"
+        service = AgentRunnerService(_db())
+
+        with patch(
+            "app.services.agent_runner.agent_environment_repo.get",
+            new=AsyncMock(return_value=environment),
+        ):
+            merged = await service._with_environment_observability(
+                _ctx(), spec, environment_id=uuid.uuid4()
+            )
+
+        assert merged.observability is not None
+        assert merged.observability.project == "client-org/client-traces"
+
+    @pytest.mark.anyio
+    async def test_an_environment_that_redirects_without_a_project_links_nowhere(self):
+        """Rather than borrowing the spec's. No link beats a wrong one."""
+        spec = AgentSpec(
+            name="Support",
+            observability=ObservabilitySpec(
+                token_secret_id=uuid.uuid4(), project="operator-org/operator-traces"
+            ),
+        )
+        environment = MagicMock(
+            logfire_token_secret_id=uuid.uuid4(), service_name=None, logfire_project=None
+        )
+        environment.name = "client-prod"
+        service = AgentRunnerService(_db())
+
+        with patch(
+            "app.services.agent_runner.agent_environment_repo.get",
+            new=AsyncMock(return_value=environment),
+        ):
+            merged = await service._with_environment_observability(
+                _ctx(), spec, environment_id=uuid.uuid4()
+            )
+
+        assert merged.observability is not None
+        assert merged.observability.project is None
+
+    @pytest.mark.anyio
+    async def test_an_environment_that_only_tags_keeps_the_specs_project(self):
+        """It did not redirect, so the spec's token is still what exports - and
+        the spec's project is where those traces are."""
+        spec = AgentSpec(
+            name="Support",
+            observability=ObservabilitySpec(
+                token_secret_id=uuid.uuid4(), project="operator-org/operator-traces"
+            ),
+        )
+        environment = MagicMock(
+            logfire_token_secret_id=None, service_name=None, logfire_project=None
+        )
+        environment.name = "dev"
+        service = AgentRunnerService(_db())
+
+        with patch(
+            "app.services.agent_runner.agent_environment_repo.get",
+            new=AsyncMock(return_value=environment),
+        ):
+            merged = await service._with_environment_observability(
+                _ctx(), spec, environment_id=uuid.uuid4()
+            )
+
+        assert merged.observability is not None
+        assert merged.observability.project == "operator-org/operator-traces"
+
+    @pytest.mark.anyio
     async def test_no_token_from_either_source_stays_untraced(self):
         """A tag into nowhere is not observability - the spec is left alone."""
         spec = AgentSpec(name="Support")
-        environment = MagicMock(logfire_token_secret_id=None, service_name=None)
+        environment = MagicMock(
+            logfire_token_secret_id=None, service_name=None, logfire_project=None
+        )
         environment.name = "dev"
         service = AgentRunnerService(_db())
 

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -96,7 +96,7 @@ def _why_the_server_did_not_answer(url: str) -> str | None:
     try:
         with engine.connect():
             return None
-    except Exception as exc:  # noqa: BLE001 - any failure to connect is the answer
+    except Exception as exc:  # Any failure to connect is the answer, whatever it was.
         return str(exc).strip()
     finally:
         engine.dispose()

--- a/backend/tests/test_model_settings.py
+++ b/backend/tests/test_model_settings.py
@@ -202,7 +202,7 @@ class TestSpecsPublishedBeforeThisExisted:
         assert AgentSpec.from_yaml(spec.to_yaml()) == spec
 
     def test_the_version_records_that_the_shape_changed(self):
-        assert AgentSpec(name="x").spec_version == SPEC_VERSION == 7
+        assert AgentSpec(name="x").spec_version == SPEC_VERSION == 8
 
     def test_a_spec_that_is_not_a_mapping_is_left_to_pydantic(self):
         """The migration must not swallow a malformed document."""

--- a/backend/tests/test_trace_location.py
+++ b/backend/tests/test_trace_location.py
@@ -1,0 +1,112 @@
+"""Where a run's trace went, and whether that is enough to open it.
+
+`agent_runs.logfire_trace_id` existed from the baseline and was never written, so
+the API promised a deep link it had never once delivered. Filling it is only half
+of one: a Logfire URL needs a project, and the only thing the platform ever holds
+is a *write* token, which carries no project name.
+
+So the two travel together, and the tests below are mostly about the ways they
+could come apart - a trace id for a trace that was never exported, or a project
+slug belonging to somewhere else's traces.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import logfire
+import pytest
+from opentelemetry import trace
+
+from app.agents.observability import TraceLocation, current_trace_id, trace_location
+from app.agents.spec import AgentSpec, ObservabilitySpec
+from app.core.config import settings
+
+
+@pytest.fixture
+def inside_a_span():
+    """A real OpenTelemetry span, because the id under test is OpenTelemetry's.
+
+    Faking `get_current_span` would prove the formatting and nothing about where
+    the id comes from - and the id a Logfire URL wants is the OTel trace id,
+    which several things other than Logfire may have started.
+    """
+    with logfire.span("a run"):
+        yield trace.get_current_span().get_span_context()
+
+
+def _redirected(project: str | None) -> AgentSpec:
+    """An agent whose traces go to a Logfire project of its own."""
+    return AgentSpec(
+        name="Support",
+        observability=ObservabilitySpec(token_secret_id=uuid.uuid4(), project=project),
+    )
+
+
+class TestReadingTheTraceId:
+    def test_the_id_is_the_thirty_two_hex_characters_a_logfire_url_wants(self, inside_a_span):
+        found = current_trace_id()
+
+        assert found == format(inside_a_span.trace_id, "032x")
+        assert len(found) == 32
+        assert int(found, 16) == inside_a_span.trace_id
+
+    def test_outside_any_span_there_is_no_id(self):
+        """OpenTelemetry answers with an invalid context whose trace id is zero.
+        `"000...0"` in the column would be an id that resolves to nothing - the
+        same lie as the null it replaces, written the other way round."""
+        assert current_trace_id() is None
+
+
+class TestWhereToRecordItAsGoing:
+    """Four outcomes, and each of them is somebody's real deployment."""
+
+    def test_an_agent_with_its_own_project_records_both(self, inside_a_span):
+        located = trace_location(_redirected("client-org/client-traces"))
+
+        assert located == TraceLocation(
+            trace_id=format(inside_a_span.trace_id, "032x"),
+            project="client-org/client-traces",
+        )
+
+    def test_a_deployment_with_a_token_and_a_slug_records_both(self, inside_a_span):
+        with (
+            patch.object(settings, "LOGFIRE_TOKEN", "pylf_v1_eu_secret"),
+            patch.object(settings, "LOGFIRE_PROJECT", "vstorm/agenticos"),
+        ):
+            located = trace_location(AgentSpec(name="Support"))
+
+        assert located.trace_id == format(inside_a_span.trace_id, "032x")
+        assert located.project == "vstorm/agenticos"
+
+    def test_a_token_with_no_slug_still_records_the_id(self, inside_a_span):
+        """The trace is real and somebody with Logfire access can find it. The
+        missing link is a configuration fact, not a lie in the schema."""
+        with (
+            patch.object(settings, "LOGFIRE_TOKEN", "pylf_v1_eu_secret"),
+            patch.object(settings, "LOGFIRE_PROJECT", None),
+        ):
+            located = trace_location(AgentSpec(name="Support"))
+
+        assert located.trace_id is not None
+        assert located.project is None
+
+    def test_a_deployment_with_no_logfire_records_nothing(self, inside_a_span):
+        """Spans exist whether or not there is a token - `if-token-present` builds
+        them and drops them - so an id read off the span here would name a trace
+        that was never exported anywhere."""
+        with patch.object(settings, "LOGFIRE_TOKEN", None):
+            assert trace_location(AgentSpec(name="Support")) == TraceLocation(None, None)
+
+    def test_a_redirected_agent_never_borrows_the_deployments_slug(self, inside_a_span):
+        """Its traces went to the token's project. The deployment's slug would
+        link into a project they are not in, which is worse than no link."""
+        with (
+            patch.object(settings, "LOGFIRE_TOKEN", "pylf_v1_eu_secret"),
+            patch.object(settings, "LOGFIRE_PROJECT", "vstorm/agenticos"),
+        ):
+            located = trace_location(_redirected(None))
+
+        assert located.trace_id is not None
+        assert located.project is None

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -177,6 +177,31 @@ see RAG below.
 | `LOGFIRE_TOKEN` | (none) | Pydantic Logfire token. Get one at https://logfire.pydantic.dev |
 | `LOGFIRE_SERVICE_NAME` | `agenticos` | Service name in Logfire dashboard |
 | `LOGFIRE_ENVIRONMENT` | `development` | Environment tag |
+| `LOGFIRE_ORGANIZATION` | (none) | The Logfire organization slug, for linking to a run's trace |
+| `LOGFIRE_PROJECT` | (none) | The project slug in it |
+
+### Linking to a run's trace
+
+A run records the trace it produced — `logfire_trace_id` on the run row, and
+alongside it the **project** the trace went to. Both are needed to open it: a
+Logfire URL names a project, and `LOGFIRE_TOKEN` is a *write* token that carries
+no project name. Hence the two extra settings.
+
+**The project follows the token, never the deployment.** An agent whose spec or
+environment redirects its traces exports them to that token's project, so it takes
+its project slug from the same place — `ObservabilitySpec.project`, or the
+environment's own. Falling back to `LOGFIRE_PROJECT` there would build a link into
+a project those traces never reached, which is worse than the no-link a missing
+slug gives.
+
+Four outcomes, all of them somebody's deployment:
+
+| Token | Slug | Recorded |
+|---|---|---|
+| deployment | configured | trace id + project — a link |
+| deployment | unset | trace id only. Real, findable by anyone with Logfire access; no link |
+| agent or environment | on the same level | trace id + that project |
+| none at all | — | neither. Spans still exist locally, but nothing is exported, so an id here would name a trace that is nowhere |
 
 ## Web Search
 


### PR DESCRIPTION
`AgentRunRead.logfire_trace_id` has been documented as *"Deep-link into the full
trace"* since the baseline and has been `null` on every run ever recorded.
`finish_run` writes the column only `if logfire_trace_id is not None`, and no
caller ever passed one — the guard had nothing to guard. Any client written
against the OpenAPI schema built a link that could not resolve.

## Changed

Filling the id is only half a link: a Logfire URL names a project, and the only
thing this platform holds is a **write** token, which carries no project name.

- **`trace_location(spec)`** — one function, four outcomes, all tested. It answers
  both halves together because neither is useful alone.
- **`LOGFIRE_ORGANIZATION` / `LOGFIRE_PROJECT`** settings.
- **`ObservabilitySpec.project`**, `SPEC_VERSION` 7 → 8, YAML export/import.
- **`agent_environments.logfire_project`** — the third level of the chain. The
  issue names one level of redirection; there are two, and the environment's is
  the one that actually runs.
- **`agent_runs.logfire_project`**, written beside the trace id.

**The project follows the token, never the deployment.** An agent redirected to a
client's Logfire exports *there*, so pairing its traces with the operator's slug
links into a project those traces are not in — worse than the no-link a missing
slug gives. That is why the environment merge stopped falling through field by
field for this one field: whichever level supplies the token supplies the project
with it.

Both facts are **recorded on the run** rather than resolved at read time, for the
reason `provider` and `model_label` are on the row: they say where the run
actually went, and re-deriving them would relabel every historical run the day
somebody repoints an agent.

The id is taken in `finish` rather than passed by each surface — the same argument
as the spend meter in #16 (PR #454): a surface that has to remember is a surface
that will not, and the failure is silent. `finish` runs from every surface's
`finally`, so this reaches the failed run too. The unused `logfire_trace_id`
parameter `finish` used to accept is gone.

## One correction to the issue's premise

The issue says a deployment with no `LOGFIRE_TOKEN` produces an all-zero trace id,
so `None` should be stored there. **It does not.** `send_to_logfire="if-token-present"`
builds real spans with real ids and drops them, so an id read off the span there
is a syntactically valid identifier naming a trace that was never exported
anywhere — the same lie as the null column, written the other way round.

The conclusion holds, so the id is recorded only when something is actually
exporting. All-zeros does happen, for a different reason — no active span at all,
in a CLI command or a worker path nothing instruments — and is refused too. Both
are tested against a real OpenTelemetry span rather than a mocked one.

## Testing

`tests/test_trace_location.py` (7) and `TestRecordingWhereTheTraceWent` in
`tests/test_agent_runner.py` (4), plus three on the environment/spec project
pairing. Between them:

- the id is the 32 hex characters a Logfire URL wants, read off a real span;
- **a `failed` run records its trace** — explicitly, since that is the run
  somebody wants it for;
- a token with no slug still records the id (link absent, schema honest);
- a deployment with no Logfire records neither;
- a redirected agent never borrows the deployment's slug, and an environment that
  redirects without a project of its own links nowhere rather than wrongly.

`make test` — 3416 passed, 100.00% on the platform layer. Migration applied,
downgraded to base and re-applied against a throwaway database; `alembic check`
reports no drift.

**`test_an_unknown_key_is_refused` used `project` as its stand-in for an unknown
key**, which is now a real field. It now uses one that is not, and a new test
loads a verbatim `spec_version: 7` document to prove stored specs still validate.

## What is not here — `Refs`, not `Closes`

The issue's last checkbox is the link in **Activity's run detail view**. Those
files belong to `feat/activity-page` / PR #202, being written in another session;
editing them here would guarantee a conflict. This PR gives that view everything
it needs — `logfire_trace_id` and `logfire_project` on `AgentRunRead` — and stops
there. **#206 stays open with that box unticked.**

**Migration number collides with #457.** Both this branch and
`fix/expire-stale-approvals` add a `0010_*` revision on top of `0009`. Whichever
merges second needs its revision renumbered and its `down_revision` repointed;
there is no other interaction between them.

**This branch also carries `test: drop two lint errors main has been failing on`**
(#451, `Closes #407`) — `main` does not pass `make lint-backend`, and the
pre-commit hook made committing impossible without it. That commit drops out of
this diff once #451 merges.

Refs #206
