### PR TITLE
build(deps): bump h2 past CVE-2026-71554

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1768,15 +1768,15 @@ wheels = [
 
 [[package]]
 name = "h2"
-version = "4.4.0"
+version = "4.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hpack" },
     { name = "hyperframe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/d4/a7d6fb3f58be99d65cbf2d3f766896217a2921d0f3ab10711c45dc1519ee/h2-4.4.0.tar.gz", hash = "sha256:46b551bdcdc7e83cf5c04d0bf93badb8a939bd2287d9fee1abb23a445b9e0580", size = 2156691, upload-time = "2026-07-23T19:14:19.442Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/85/7c366e69d84c17bb778fe41419e1fbcce3033d5b7ce29bbffff0a98b859f/h2-4.4.1.tar.gz", hash = "sha256:4e866ffb1a869ae14dd9b5e6beb5c24a13da0495ad72b65925ded182521c1516", size = 2157281, upload-time = "2026-08-03T11:45:09.509Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/df/5b14a118322d6097cb9bb30ec6bacad268e546a8ecfcb1f6d0de618dac2f/h2-4.4.0-py3-none-any.whl", hash = "sha256:6acffe1aeab79098d7eb0f8385c1add11f2c7a94815f6fa2b7060eeddee3d87c", size = 62368, upload-time = "2026-07-23T19:14:16.143Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/e85faf23bd72a92d1921e37d674ca56eb298a3c8be31fdecef0ff2b3aaac/h2-4.4.1-py3-none-any.whl", hash = "sha256:0e25f1462b23c9cb82d9eb02e28bc706dac2a68cb457c6a0d74d63c8a2a5d0e6", size = 62636, upload-time = "2026-08-03T11:44:59.164Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`make audit` has been red on every branch in the repository, including `main`,
since 2026-08-03: pip-audit reports `h2 4.4.0` as vulnerable to CVE-2026-71554,
fixed in 4.4.1. No diff on any open pull request can explain it, and every W1
branch needs a green `Security Scan` job to merge — that job is the `audit`
target, and on `fix/drive-connector-trusts-no-remote-name` it dies on exactly
`h2 4.4.0 CVE-2026-71554` → `make: *** [Makefile:377: audit] Error 1`.

## What the advisory says

[GHSA-6hr6-w5qg-qmwg](https://github.com/python-hyper/h2/security/advisories/GHSA-6hr6-w5qg-qmwg),
CVSS 5.3 moderate, CWE-444 request smuggling. `h2 <= 4.4.0` accepts a request
header block carrying more than one `Host` header and forwards every one of them
to the consuming application, so a consumer that downgrades HTTP/2 to HTTP/1.1
emits two `Host` lines and can be made to disagree with its upstream about where
one request ends.

**It is the server role that is exposed, and this deployment has none.** The flaw
is in validating an inbound *request*; a malicious server's *response* cannot
reach it. That is the direction that would have mattered here, since every agent
run talks HTTP to third-party hosts — providers, MCP servers, sandbox daemons,
connectors — so it is worth stating rather than leaving to inference. Concretely:

- `h2` is transitive via `prefect -> httpx[http2]`; that is the only edge in
  `uv.lock` that pulls it in.
- Nothing under `backend/app` passes `http2=True` — there is no `http2` string in
  the backend source at all.
- Prefect's own `enable_http2` defaults to `False`, so `h2` is not merely
  unexposed here; by default it is never instantiated.
- The ASGI server is `uvicorn[standard]`, which speaks HTTP/1.1 only. No
  hypercorn, nothing serving HTTP/2.

A routine bump, then. Clearing the gate is the whole of the reason to make it.

## What the lock moved

`uv lock --upgrade-package h2` moved **`h2` and nothing else** — three lines, the
version and its two artifact URLs. Nothing else was pulled in or bumped.

`requirements-audit.txt` is generated by the `audit` target and gitignored
(`.gitignore:119`), so it is not in this diff. Regenerated from the lockfile, its
line 262 now reads `h2==4.4.1` — the same line #459 named.

## Verification

- `make audit` → `No known vulnerabilities found`.
- `make test` → 3400 passed, 10 skipped, 100% coverage, on Python 3.12.13.

**How far that second half reaches:** no test in this suite opens an HTTP/2
stream, so it proves the bump broke no import and no existing path — not that the
h2 stack itself still works. Nothing exercises it at runtime by default either,
per the paragraph above. Worth saying plainly, because an HTTP/2 bump under
`httpx` is exactly the kind of change that stays invisible until a stream breaks.

Closes #459
