### PR TITLE
chore: cut 0.0.60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.60] - 2026-08-07
+
+### Fixed
+
+- `main` did not pass `make lint-backend`. Two ruff findings — `RET501` and a
+  `RUF100` for a `noqa` naming a rule this project does not select — arrived with
+  PRs merged during the GitHub Actions outage, when every check sat `pending` and
+  nobody could see them. Because the pre-commit hook runs `ruff check . --fix`
+  over the whole tree regardless of what is staged, it kept rewriting those two
+  files into unrelated commits and rolling them back, so every branch cut from
+  `main` started red on a gate it had not broken (#407).
+
+
 ## [0.0.59] - 2026-08-06
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.59"
+version = "0.0.60"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.59"
+version = "0.0.60"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for the two lint errors main has been failing on (code landed as #451,
authored by Bartek Ochnik).

First of the batch on purpose. This is what unblocked everybody else: with
`main` red, the pre-commit hook pulled those two files into every commit made
anywhere in the repository and then failed on having modified them, so six
branches spent the day committing with `--no-verify` and running the hook's
checks by hand.

Five of us filed the same issue within minutes of each other (#406, #407, #408,
#409, #410) because every branch hit it before touching anything; four were
closed as duplicates of #407.

The minimal fix of the two on offer. #426 carried its own version bundled with
three unrelated changes, and drops it on rebase.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.60]` section.

No schema change, `SPEC_VERSION` unchanged at 7.