### PR TITLE
chore: cut 0.0.62

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.62] - 2026-08-07
+
+### Fixed
+
+- None of the ten cases around `mask_generics` in the i18n guard's test file
+  tested it: stub the function to `return text` and all ten still passed, while
+  the guard then reported three false positives over the real tree. It was
+  load-bearing and untested, so a refactor could have broken it with only a
+  tree-wide `make lint` to notice. One case now fails without it.
+
+
 ## [0.0.61] - 2026-08-07
 
 ### Security

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.61"
+version = "0.0.62"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.61"
+version = "0.0.62"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.61",
+  "version": "0.0.62",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for the test that pins mask_generics (code landed as #403).

Found while reviewing #396, which came at the same problem from the other side
and had been overtaken by #363 — `main` passes all five of its tests. This was
the only thing in it not already covered.

The case is `components/icons/brand-icon.tsx` trimmed to the shape that
regressed: a generic closing with `>`, the next `<` several lines below, and
ordinary words between them once the file is read as one string. Verified both
directions — one failure with the masking stubbed, none with it restored.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.62]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #314, #396