### PR TITLE
chore: cut 0.0.63

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,29 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.63] - 2026-08-07
+
+### Fixed
+
+- A stacked pull request ran no CI at all, and its checks list was empty rather
+  than red. `ci.yml` triggered on `pull_request: branches: [main, master]`, which
+  matches on the **base**, so a branch opened against another branch matched no
+  trigger — and an empty check list reads as "still running" rather than "nobody
+  looked". Four pull requests merged that way in one day, each verified only
+  locally. The trigger no longer filters on the base (#359).
+- `docs/file-processing.md` described a platform-admin RAG model this project
+  replaced: "any authenticated user can search any collection", "only admins can
+  manage them". All three claims were false, and the same paragraph sat under its
+  own heading in `docs/architecture.md`, which a search for "only admins" misses
+  because that copy reads `Only **admins**` (#354).
+
+### Changed
+
+- Every CI job now carries a `timeout-minutes`, each several times its measured
+  runtime. Only `changes` had one, so a hung job ran to the platform default
+  rather than to a number somebody chose (#364).
+
+
 ## [0.0.62] - 2026-08-07
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.62"
+version = "0.0.63"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.62"
+version = "0.0.63"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.62",
+  "version": "0.0.63",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for the CI trigger, the job timeouts and a stale access claim (code
landed as #426).

The trigger is the one that matters. Dropping the `branches:` filter rather than
extending the list, because any list is one somebody has to remember to extend,
and the property wanted here is that a pull request without CI cannot be opened
at all.

Deliberately not a `paths:` filter and not a workflow-level gate: a filtered-out
workflow never posts its required contexts, so `main`'s ruleset would wait for
six checks that never arrive and the merge button would stay grey for ever. A
**skipped** required check is a pass; a check that never reports is a permanent
block. That distinction is v0.0.35's, and it is why this is a job-level change.

Two claims in the issue did not survive checking and are recorded on it: there is
no `codeql.yml` in this repository — CodeQL runs from GitHub's default setup,
whose triggers are not here — and `ai-review.yml` has had no `pull_request`
trigger at all since #313.

The docs half was the larger one. The stale paragraph had a twin under a
different heading in `architecture.md`, so the fix is a rewrite of both rather
than an edit of the sentence the issue quoted.

Its lint commit is dropped: 0.0.60 landed the minimal fix for #407 first, and
this branch rebased without it.

**Nothing here was demonstrated by running it.** GitHub Actions has been in a
major outage since 2026-08-06 15:22 UTC, so a change to when CI runs could not
be proven by CI. `make check`, `test_ci_parity.py` and the new
`test_ci_workflow.py` are green locally, and the pull request says which
conclusions are argued rather than shown.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.63]` section.

No schema change, `SPEC_VERSION` unchanged at 7.