### PR TITLE
chore: cut 0.0.64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,20 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.64] - 2026-08-07
+
+### Fixed
+
+- Every JSON response the platform proxy returns now declares a cache policy. It
+  carried none — no `Cache-Control`, no `ETag`, no `Last-Modified` — on every
+  mutable collection on the surface, and silence is not "do not cache": a 200
+  with no policy is one the browser may reuse on its own judgement. Every answer
+  here depends on a cookie, a permission set and an organization header, so there
+  is nothing on this surface a shared or heuristic cache may keep. A backend that
+  does name a policy still wins, which is how the catalog icons and the embed
+  bundle keep theirs.
+
+
 ## [0.0.63] - 2026-08-07
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.63"
+version = "0.0.64"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.63"
+version = "0.0.64"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.63",
+  "version": "0.0.64",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for the cache policy the proxy never declared (code landed as #405,
authored by Bartek Ochnik).

Declared once in `describingHeaders` rather than per route, which is what stops
the next hand-rolled route file having the same hole.

Checked before merging, because "no-store on everything" is the kind of change
that quietly breaks a download: four backend endpoints set `Cache-Control` —
`knowledge_bases.py:217`, `rag.py:381`, `catalog_icons.py:28`, `embed.py:94` —
and the first three are proxied and forwarded, since `cache-control` was already
in `DESCRIBES_THE_BODY`. The embed bundle has no Next route at all.
`/api/files/[id]` sets its own `private, max-age=3600` in the route file and
keeps it, because the new line only fires when the header is absent. Nothing
loses caching.

Worth recording what this does **not** fix. I told the author #353 was the likely
cause of #230 and put it in the pull request body; that was wrong, and the work
on #353 disproved it — #230's own trace shows the commit winning by 5ms, so the
write was committed before the refetch was answered. Their original instinct
was better than my correction to it, and the `Cache-Control` hypothesis is the
live one again. #230 stays open.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.64]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #230