### PR TITLE
chore: cut 0.0.65

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,36 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.65] - 2026-08-07
+
+### Security
+
+- A Drive file whose name is a path escaped the sync directory. A remote filename
+  is attacker-controlled from this system's point of view — anyone who can share
+  a file into a synced folder chooses it — so the write target is now **resolved
+  and confirmed** to be inside the directory rather than sanitised by
+  substitution, which makes `..`, its encodings, homoglyphs and a pre-existing
+  symlink one question instead of a blacklist that is always one entry short
+  (#370).
+- A sync source's `folder_id` was interpolated into the Drive query unescaped.
+  It is now allowlisted where the query is built — the single funnel both the
+  configured folder and every recursed sub-folder pass through, so rows written
+  before the check are covered too — and asked again by every route that stores a
+  config, not only by create (#369).
+- Two deployment-wide credential fallbacks removed. A tenant's `folder_id` or
+  `bucket` could widen a query running under the **operator's** identity, which
+  turns one field of a source's own configuration into a reach across
+  organizations. The S3 case was the worse of the two: both settings default to
+  empty, so the fallback resolved to `None` and boto3 fell through to the
+  container's own credential chain.
+
+### Changed
+
+- The write target is now `BaseSyncConnector.download_file`'s decision, with
+  connectors implementing `_fetch`. A connector added later cannot choose a path,
+  and a test asserts none overrides it.
+
+
 ## [0.0.64] - 2026-08-07
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.64"
+version = "0.0.65"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.64"
+version = "0.0.65"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.64",
+  "version": "0.0.65",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for the sync connectors trusting no remote name or id (code landed as
#418).

Containment, not substitution. A name that is no component at all — `..`, `.`,
`/`, empty, NUL — is refused; everything else lands inside with spaces and
suffix intact, because the ingestion pipeline routes on the suffix.

Siblings swept rather than assumed: the S3 connector had neither defect
(`Path(key).name`, no interpolation) but inherits containment anyway; the legacy
`sources/google_drive.py` had **both**, and `rag-sync-gdrive --folder-id` reads
the id straight from a shell.

Reviewing the branch found two things its own argument implies but had not
carried out, both fixed before merge:

- **The route-level refusal existed on one write path in three.** `create_source`
  asked the connector; `update_source` and `clone_source` wrote the config
  straight to the row, so a `folder_id` refused at creation could be patched in
  afterwards. Nothing leaked — the sink check still caught it — but the docstring
  and two doc pages claimed the route answers, and for two routes in three that
  was untrue. The merged config is judged now, since a caller patches one field
  and the connector runs the whole thing.
- **The S3 connector still had the credential fallback this branch removed from
  Drive**, and the patch hole above made it reachable: `_encrypt_config` skips
  falsy values, so an empty `access_key_id` is stored verbatim.

And four escape assertions that proved nothing: they used two or three `..`
segments, so the write landed *above* `tmp_path` and the negative assertion was
true either way. One level now.

Verified locally — 3448 passed, integration green against
`pgvector/pgvector:pg16`, and each new test checked against the unfixed code.
**CI has not run and will not**: Actions has been out since 2026-08-06 15:22 UTC.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.65]` section.

No schema change, `SPEC_VERSION` unchanged at 7.