### PR TITLE
chore: cut 0.0.66

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,34 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.66] - 2026-08-07
+
+### Security
+
+- `POST /kb` accepted any `collection_name` and never claimed it, so a member with
+  `collections:edit` could point a knowledge base at another organization's vector
+  table and read and write it through every gate that followed. `claim` had
+  exactly one call site, the `/rag` route (#367).
+- A collection name over 45 characters truncated onto another collection's table.
+  The bound is derived from the longest identifier built from a name —
+  `rag_<name>_embedding_idx`, not `rag_<name>` — so a name of 46 to 59 characters
+  truncated only the *index* name, `CREATE INDEX IF NOT EXISTS` then found the
+  first collection's index and built nothing, and the second collection searched
+  unindexed at the first one's width (#368).
+- Upper case is refused. Postgres folds an unquoted identifier, so `Handbook` and
+  `handbook` were two rows, two collections the platform believed distinct, and
+  **one physical table** holding both tenants' vectors — #368's defect reached by
+  another route. Refused rather than normalised: this branch's argument is that an
+  unusable name is turned away, not silently rewritten into something the caller
+  never typed.
+
+### Fixed
+
+- A malformed or reserved collection name answers 400 rather than 500 (#371).
+- Dropping a collection whose name the new rules refuse no longer swallows the
+  refusal and orphan the vector table.
+
+
 ## [0.0.65] - 2026-08-07
 
 ### Security

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.65"
+version = "0.0.66"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.65"
+version = "0.0.66"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.65",
+  "version": "0.0.66",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for claiming and bounding every caller-supplied collection name (code
landed as #431).

One `validate_collection_name` decides shape, length, reserved and the
model-table collision #345 already answered, and it converges on
`app/db/vector_tables.py` rather than becoming a fourth source of truth. Then
once each: `claim` validates and asks the question only it can answer,
`KnowledgeBaseService.create` calls `claim` — including for the *derived* name,
rather than trusting six hex characters — and the store calls the pure function
in `_table`, which is what covers `rag-drop` and the ingestion worker, neither of
which has a route in front of it.

The case-folding hole is worth recording honestly: the branch's own review missed
it, and its own test asserted `"Handbook"` as an ordinary acceptable name. It
would have shipped with a test holding it open. The code already half-knew —
the reserved check calls `.lower()`, which is why `Documents` was refused and
`Handbook` was not.

Fixing it closed a second-order bug rather than patching it: `_collection_exists`
compared `rag_Handbook` against `information_schema.tables`, which stores the
folded name, so search and document listing answered **empty** for any collection
with a capital letter. `_table` now refuses such a name before that comparison is
reachable.

`_derive_collection_name` had to move with the rules — "2024 Reports" derived
`2024_reports`, which the strict shape refuses. Harmless before only because the
KB path reached neither validator; converging them is what would have broken it.

Verified locally: `make check` exit 0, `make test` 3457 passed with the platform
layer at 100%, integration 260 passed against `pgvector/pgvector:pg16`. The five
`/kb` tests were run with the `claim` call removed and all five fail, which makes
them a regression rather than a description. **CI has not run** — Actions has
been out since 2026-08-06 15:22 UTC.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.66]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #422, #436