### PR TITLE
chore: cut 0.0.67

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,26 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.67] - 2026-08-07
+
+### Security
+
+- A failed ingest stored a vendor SDK's exception text in `rag_documents.error_message`
+  and the dashboard rendered it. An embedding or vector-store client's message can
+  carry an endpoint, a key fragment, a bucket name or an internal host — and stored,
+  that is a durable leak read later by whoever looks at a failed upload, rather than
+  the transient one 0.0.38 closed on the HTTP path. Nine sites now record the stage,
+  the exception **type** as a symbol, and what to do about it; the text goes to the
+  worker log (#423).
+
+### Fixed
+
+- The outermost ingestion handler overwrote the innermost one's message, so a parse
+  failure — the commonest path — reported "could not be ingested" rather than "could
+  not be read". Harmless while all three wrote the same `str(exc)`; not harmless once
+  the innermost knew which stage had failed.
+
+
 ## [0.0.66] - 2026-08-07
 
 ### Security

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.66"
+version = "0.0.67"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.66"
+version = "0.0.67"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.66",
+  "version": "0.0.67",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for a failed ingest saying what failed rather than where (code landed as
#443).

The same exception 0.0.38 stopped reaching an HTTP body, taken through the
ingestion path instead. Worse than the HTTP case, because it persists.

`AppException` and `BudgetExceeded` pass through whole — they are written in this
repository, and "No embedding credential is configured" or "$40.15 of a $40.00
limit" is the useful answer. A bare `RuntimeError` we raised is deliberately not
treated as ours: the LiteParse wrapper interpolates an absolute temporary path
into one.

Nothing is deleted. Every site logs with `logger.exception`, which recovers the
traceback the old `logger.error(..., e)` dropped, and the flows re-raise so
Prefect keeps it.

**One caveat that matters and is stated in the pull request**: this moves detail
"to the log where it is safe", and the log is not currently safe. #440 —
verified — shows `PiiRedactionFilter` is attached to the root *logger*, which
never sees a record propagated from a module logger, so it has never redacted
anything; and the Prefect worker never calls `setup_logging` at all. The branch
corrects a docstring that claimed otherwise rather than pretending. #440 is open.

Two exclusions left deliberately, both argued: `vectorstore.py:258`, where the
table name is the caller's own collection name, and `sandbox_workspace._reason`,
which is our own component and needs its own evidence rather than a line in a RAG
branch.

Verified locally — `make test` 3415 passed at 100% coverage, integration 260
passed against `pgvector/pgvector:pg16`, no schema change so no migration. Each
behavioural test checked against the restored sources: 4 failed, 6 passed.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.67]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #437, #440