### PR TITLE
chore: cut 0.0.68

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,28 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.68] - 2026-08-07
+
+### Security
+
+- An app admin's password reset was written to the audit trail in plaintext. The
+  request body was dumped into `app_admin_audit_logs.details`, so resetting a
+  password recorded it (#412).
+- A refusal's `details` described the server rather than the refusal: an upstream
+  client's exception text on a 503, container filesystem paths on a 500, and a
+  provider base URL echoed back on four validation errors — one of which exists
+  *because* the URL carries a password. The diagnosis moves to the log; the
+  response names the field that explains the refusal (#342).
+- A sandbox address could carry userinfo, which `probe_policy` echoed into both
+  the response and the log. `ServiceAddress` was the only one of the three URL
+  validators not refusing credentials.
+
+### Fixed
+
+- The capability registry echoed a rejected configuration back to the caller in a
+  400, unlike the identical call one module over.
+
+
 ## [0.0.67] - 2026-08-07
 
 ### Security

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.67"
+version = "0.0.68"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.67"
+version = "0.0.68"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.67",
+  "version": "0.0.68",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for a refusal describing the refusal (code landed as #432).

All 301 `details=` sites read, plus every `message=` interpolating an exception, a
path or a setting. Five changed — the sweep is the point, because the two the
issue named were the two somebody had noticed rather than the two that existed.

The audit one is the serious find and was not in the issue: it fell out of
reading the sweep's own results. Filed as #412 and fixed in the same change.

This is worth having *now* rather than earlier because 0.0.38 made `details`
reliably serialized. Before that, a value that could not be encoded took the
whole response down and never reached the wire; after it, everything in `details`
arrives.

Left deliberately, with reasons on the pull request: the same vendor text stored
in `rag_documents.error_message` is a different surface and is #423, released in
0.0.67.

Verified locally — `make test` 3411 passed, 100.00% coverage; each new test fails
without its fix. **CI has not run**: Actions has been out since 2026-08-06 15:22
UTC.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.68]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #423