### PR TITLE
chore: cut 0.0.69

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,25 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.69] - 2026-08-07
+
+### Fixed
+
+- Admin user and conversation search did not escape `LIKE` wildcards, so a caller
+  typing `%` or `_` changed what the query meant rather than searching for it: `_`
+  matched any single character and `%` matched everything, which is a wrong-rows
+  bug and a cheap way to make an admin listing scan far more than it should. All
+  three sites now go through one helper on SQLAlchemy's `icontains(autoescape=True)`
+  (#372).
+- Admin listings sorted on nullable columns without ordering nulls, so the emptiest
+  rows led page one (#411).
+
+### Removed
+
+- `escape_sql_like` in `core/sanitize.py` — dead, and half-right in a way that
+  would have been worse than nothing had anything called it.
+
+
 ## [0.0.68] - 2026-08-07
 
 ### Security

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.68"
+version = "0.0.69"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.68"
+version = "0.0.69"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.68",
+  "version": "0.0.69",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for escaping LIKE wildcards (code landed as #429).

Not injection — the query was parameterised — but a correctness bug, and the
sweep is what makes it worth a release rather than two edits: six `LIKE` sites
read, three needed fixing, one was correct but hand-rolled and now shares the
helper, one is a module constant re-filtered afterwards and was left, and one was
an enum named `LIKE` that is not SQL at all.

The interesting find is `/`: **SQLAlchemy's escape character is the forward
slash**, so it is both a thing people type and the character the pattern
re-purposes. An escape that handles `%` and `_` and forgets itself turns
`q1/2026` into `q12026` — the wrong row, not no rows.

Proved by mutation rather than assertion. Escaping removed: 9 of 12 fail.
An escape that forgets its own character: exactly the 2 slash tests fail and
nothing else. The slash tests do **not** fail on unescaped `LIKE`, and their
docstring says so, so nobody later deletes them as redundant. Two `%` tests
originally passed unescaped and were rewritten — noted on the pull request rather
than quietly fixed.

Verified locally: `make test` 3140 passed, `make test-integration` 275 passed
with 17 new integration tests. **CI has not run** — Actions has been out since
2026-08-06 15:22 UTC.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.69]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #413, #414, #415