### PR TITLE
chore: cut 0.0.70

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,24 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.70] - 2026-08-07
+
+### Fixed
+
+- A write was answered before its transaction committed, so the next read could
+  miss it. `get_db_session` commits in the exit code of a `Depends`-with-`yield`,
+  and FastAPI unwinds that stack **after** the response has been written — so a
+  2xx said the request had been handled, not that the write was readable. One
+  keyword argument, `scope="function"`, moves the commit in front of the response
+  (#353).
+- A failed request now rolls back before the error response is built rather than
+  after it, because the exception unwinds the same stack. A caller could be told
+  404 while the partial write causing it was still open.
+- A failed health probe left the session's transaction aborted, which on the new
+  ordering turned an intended 503 into a 500 — on the endpoint an operator reads
+  when something is already wrong (#416).
+
+
 ## [0.0.69] - 2026-08-07
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.69"
+version = "0.0.70"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.69"
+version = "0.0.70"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.69",
+  "version": "0.0.70",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for committing before the response goes out (code landed as #428).

Measured three ways before it was fixed: a minimal app on the pinned FastAPI —
`0.0ms client got 204` against `256.4ms commit finished`; the real backend, where
a membership row was invisible to the very next read for 21.7ms, 1 miss in 45;
and the product's own SQL log showing nine requests arriving while the previous
transaction was still open, including a `POST /invitations` whose token was being
spent 34ms before the transaction that minted it committed.

The fix is a documented public parameter, which is the good news. I verified it
independently before merging, because the whole change rests on it: on FastAPI
0.141.1 `Depends` takes `scope: Optional[Literal['function','request']]`, and its
own docstring says `"function"` ends the dependency "after the path operation
function ends, but **before** the response is sent back to the client".

Rejected, with reasons in the commit body: committing in each route
(unenforceable, silent when forgotten); an ASGI `send`-wrapper middleware (sits
outside the route's exception handling, so it must be *told* the request failed);
a custom `APIRoute` class; and documenting the contract instead, which leaves
every HTTP client exposed.

Two consequences of the new ordering were found by sweeping for code that assumed
the old one, and handled here: the ratings CSV export streams from the database
after the response starts and takes an explicit read-only session, and the health
probes reset theirs.

The regression test is deterministic rather than sampled — it drives the app as a
bare ASGI app and asks a *second connection* what is visible at the instant
`http.response.start` reaches the transport.

**This rules #353 out as the cause of #230**, which I had claimed and was wrong
about: #230's own trace shows the commit winning by 5ms.

Verified locally: integration green twice (262), `tests/api/` 364, the backend
suite minus integration 3150 with coverage. **CI has not run** — Actions has been
out since 2026-08-06 15:22 UTC.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.70]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #230, #335, #417