### PR TITLE
chore: cut 0.0.71

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,22 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.71] - 2026-08-07
+
+### Fixed
+
+- Ingestion and sync flows were spawned before the transaction that wrote the row
+  they read had committed, so a flow could start, look for its own document row
+  and not find it — an upload answered `processing` that stayed that way.
+  `spawn_after_commit` queues the work on the session and `_managed_session`
+  starts it two statements after `commit()` (#417).
+- `rag-source-sync` cancelled the sync it had just reported starting: `asyncio.run`
+  kills pending tasks on the way out (#439).
+- `POST /rag/documents/{id}/retry` queued nothing and cleared the error message,
+  so a retry was a one-way trip into permanent `processing`. A bare `ValueError`
+  on a decided refusal is now a 400 rather than a 500 (#441).
+
+
 ## [0.0.70] - 2026-08-07
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.70"
+version = "0.0.71"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.70"
+version = "0.0.71"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.70",
+  "version": "0.0.71",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for starting a dispatched flow only after its row is committed (code
landed as #448).

The half 0.0.70 explicitly did not close. Its fix moved the commit in front of
the *response*; a flow is spawned from inside the request, so it still raced.

`BackgroundTasks` threaded through the three services — the issue's own
suggestion — was rejected for a reason worth recording: it would have been
correct **only because of** 0.0.70. Under FastAPI's default scope the dependency
stack unwinds after the response, which is when background tasks run, so they
would have fired before the commit. And three of the four callers (CLI,
WebSocket, worker) have no HTTP response at all, so the guarantee would have been
optional and silently racy wherever it was omitted.

Also rejected: flow-side retry or wait, which makes every consumer responsible
for a producer's bug and cannot tell "not committed yet" from "deleted";
committing earlier in the service, which breaks "repositories never commit"; and
SQLAlchemy's `after_commit`, a sync handler reaching for the running loop from
inside commit machinery.

`get_worker_db_context` turned out to be a duplicate of `_managed_session` and
now is it, so every session lifecycle carries the same guarantee rather than the
HTTP one alone.

Verified locally: `make test` 3428 passed with the platform layer at 100%,
integration 265. Reverting a call site to `spawn` fails the dispatch test and
removing the CLI's drain fails the command test — both checked, not assumed.
**CI has not run** — Actions has been out since 2026-08-06 15:22 UTC.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.71]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #26