### PR TITLE
chore: cut 0.0.72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+Nothing yet.
+
+## [0.0.72] - 2026-08-07
+
 ### Fixed
 
 - The dev and production stacks notice a worker whose event loop has stopped

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.71"
+version = "0.0.72"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.71"
+version = "0.0.72"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.71",
+  "version": "0.0.72",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for noticing a wedged worker on every stack (code landed as #430).

The thesis is what makes this small: **every stack already replaces a worker that
is gone; none handled one that is stuck.** So no supervisor is replaced.
Production keeps `Multiprocess` — the self-kill lands in `keep_subprocess_alive`
and is replaced in about half a second, three workers serving throughout. Dev
gets no supervisor at all: PID 1 exits and `restart: unless-stopped` acts. The
local stack is unchanged and keeps its parent-side check, because it is the only
judge that can see a *stopped* process, which cannot run a watchdog of its own.

Rejected, with reasons: a `Multiprocess` subclass with a per-worker beat (four
upstream `Process(...)` call sites, none a factory, in the one process meant to
survive the worker); answering the pipe ping from the event loop (same four
sites, and it makes `timeout_worker_healthcheck` — also the readiness timeout —
the wedge threshold); `--workers 2` on dev; an HTTP probe or `autoheal`
(readiness not liveness, and a root-equivalent socket). Startup stays
deliberately unwatched: judging it risks a restart loop on a cold container.

The container run earned its keep again. **`SIGKILL` to yourself is dropped when
you are PID 1 of a namespace** — the same kernel rule as the `SIGSTOP` one 0.0.39
learned — so the first version logged its verdict and carried on serving nothing.
`os._exit(137)` now, both branches tested.

Left uncovered and said so: the Prefect runner has no lifespan and so no
watchdog, and a worker in `D` state is unchanged because `SIGKILL` is not
delivered there.

Verified locally: 3421 passed at 100.00% with `watchdog.py` in both gate lists,
and the two timing-sensitive files run three times over at load 43 because the
subject *is* timing. Real containers under a throwaway name: production shape
judged at 6s and replaced with `restarts=0`; dev shape `restarts=1`. **CI has not
run** — Actions has been out since 2026-08-06 15:22 UTC.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.72]` section.

No schema change, `SPEC_VERSION` unchanged at 7.