### PR TITLE
chore: cut 0.0.73

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.73] - 2026-08-07
+
+### Fixed
+
+- The web chat billed nothing for the embedding calls behind a knowledge search.
+  Metering lived at the call site, so a surface that forgot it under-reported
+  silently: `record_ambient_usage` found no active ledger and dropped the cost,
+  the run's own total was short, the organization's month never saw it, and
+  nothing raised. The meter moved inside `execute` and `iterate`, so every
+  surface that runs an agent is metered by construction rather than by
+  remembering (#16).
+
 ## [0.0.72] - 2026-08-07
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.72"
+version = "0.0.73"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.72"
+version = "0.0.73"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for metering the agent wherever a surface executes it (code landed as
#454, authored by Bartek Ochnik).

The right shape: a meter a caller can forget is a billing hole that reports
nothing rather than reporting wrong, which is the harder kind to notice. Putting
it inside the two methods that run the agent means a new surface is metered
because it ran the agent, not because somebody remembered.

The web chat had run unmetered for its whole life, which is what #16 was about.

Merged without an independent review — the reviewer I set on it ran out of
budget partway. I read the metering change itself and the argument in its
docstring holds. **CI has not run either**: Actions has been out since 2026-08-06
15:22 UTC, so this release, like the twelve before it, carries local verification
only.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.73]` section.

No schema change, `SPEC_VERSION` unchanged at 7.