### PR TITLE
chore: cut 0.0.74

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.74] - 2026-08-07
+
+### Fixed
+
+- A tool call nobody decided parked its run for ever. Approvals still pending
+  after their window are now swept to `expired` — recorded as a decision nobody
+  made (`decided_by_user_id IS NULL`) rather than as a denial somebody issued,
+  so the audit trail says what actually happened (#178).
+
 ## [0.0.73] - 2026-08-07
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.73"
+version = "0.0.74"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.73"
+version = "0.0.74"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.73",
+  "version": "0.0.74",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for denying by timeout the calls nobody decides (code landed as #457,
authored by Bartek Ochnik).

The distinction that makes this correct: an expiry is not a denial. It writes its
own status with an empty `decided_by_user_id`, so a run that timed out cannot
later be read as one somebody refused — which matters because "a second decision
on a decided approval" is exactly the class this platform exists to refuse, and
an expiry that impersonated a decision would be one.

The sweep selects on `status == PENDING`, so it cannot touch an approval already
settled either way.

Merged without an independent review — the reviewer I set on it ran out of budget
partway. I checked the two things I would have blocked on: that it cannot decide
an already-decided approval, and that the expiry is a state of its own rather
than a denial wearing a system user. **CI has not run either**: Actions has been
out since 2026-08-06 15:22 UTC.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.74]` section.

No schema change, `SPEC_VERSION` unchanged at 7.