### PR TITLE
chore: cut 0.0.75

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,29 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.75] - 2026-08-07
+
+### Fixed
+
+- The admin conversations screen's Owner filter was permanently empty. Its BFF
+  proxy forwarded to a route that has never existed — the path matched
+  `/admin/conversations/{conversation_id}` instead, which 422'd trying to parse a
+  UUID — and both admin proxies dropped `sort_by` and `sort_dir` on the way
+  through (#413).
+- The admin users table drew a `Role` column for a field the API stopped
+  returning in migration `0066`, so it had been blank since. It now renders
+  `conversation_count`, which the backend had been joining for on every page load
+  and nothing read (#414).
+- The skills library marked a skill uninstalled that cannot be installed, so
+  Install answered 409 (#415).
+
+### Added
+
+- `test_bff_forwarded_paths.py` reads every `/api/v1/…` literal out of the route
+  handlers and checks it against the application's own route table, in
+  declaration order, validating each hard-coded segment through the field FastAPI
+  would use. Over 46 forwarded paths it finds exactly one defect — the one above.
+
 ## [0.0.74] - 2026-08-07
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.74"
+version = "0.0.75"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.74"
+version = "0.0.75"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.74",
+  "version": "0.0.75",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for making the admin surface agree with the backend it proxies (code
landed as #444).

Three symptoms of one thing: the admin screens were written against a backend
that has since moved, and nothing checked the two still matched.

The path test is the part that outlives this release. Four of the 46 forwarded
paths look wrong and are not — `/me/slash-commands/builtin`,
`/org/integrations/connectors` and `/users/me` are declared before their `{uuid}`
siblings, so FastAPI reaches them — which is exactly why a human reading the list
would have flagged the wrong ones. It needed `ci_changed_scope.py` amended too:
`frontend/src/app/api/**` is no longer irrelevant to the backend job, or the
guard would skip on the very change it guards.

One thing deliberately not folded in, against my own instruction to fix what you
find: the sweep measured **86 keys in `en.json` that are fragments of TypeScript
source read by nothing**, and 86 deletions across ten namespaces would have
swamped three admin defects in one diff. Measured and posted to #348 instead;
0.0.76's branch is where that belongs.

Verified locally: `make test` 3453 passed with the platform layer at 100%,
frontend 3245 at 100/97.57. Proof by reverting rather than reading — restoring
the deleted proxy fails the new guard with the exact 422 from the issue. One test
passed against its own reverted implementation when first written; the fourth
commit is what fixes that. **CI has not run** — Actions has been out since
2026-08-06 15:22 UTC.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.75]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #348