### PR TITLE
chore: cut 0.0.76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,22 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.76] - 2026-08-07
+
+### Security
+
+- `InlineSecret` offered a vault write at seven call sites and only one checked
+  `secrets:edit`, so six of them showed the form and let the API answer 403. The
+  permission is now checked inside the component, because every call site posts
+  the same endpoint — a per-caller gate is one condition written seven times and
+  forgotten six of them (#361).
+
+### Fixed
+
+- Two test fixtures answered `/me/permissions` with a list, which is a `TypeError`
+  inside `usePermissions` rather than "no permissions" — so those specs had been
+  passing for the wrong reason.
+
 ## [0.0.75] - 2026-08-07
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.75"
+version = "0.0.76"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.75"
+version = "0.0.76"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.75",
+  "version": "0.0.76",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for checking secrets:edit inside the inline secret form (code landed as
#433).

The interesting part is the counter-argument being checked rather than waved
away. #361 worried that each caller's lead-in sentence goes wrong once the form
disappears; that turned out to hold for exactly one caller, `AddModel`, which
already picks its sentence on the permission and so decides for itself whether to
render the component at all. It is untouched. The other six say something that
stays true either way, so a refusal is a line replacing a button — with every
picker beside it still working, because choosing a key somebody else stored is
not a write.

Proof by reverting: the gate removed gives exactly eight failures — one refusal
test per surface plus two on the component — and nothing else. Each refusal
asserts the sentence as well as the absent button, so a block rendering nothing
would not satisfy it.

Verified locally: `bunx vitest run` 3259 tests green, coverage gate met at
100/97.56. **CI has not run** — Actions has been out since 2026-08-06 15:22 UTC.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.76]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #419