### PR TITLE
chore: cut 0.0.77

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.77] - 2026-08-07
+
+### Security
+
+- The chat's model picker created an organization-wide model profile without
+  checking `connections:manage`, so anybody who could open a conversation was
+  offered the form and refused by the API (#419).
+- The chat's approval panel offered editable arguments and Submit to anybody a
+  parked run streamed to, though deciding an approval needs `approvals:decide`,
+  which neither `member` nor `builder` holds. The banner and the arguments stay,
+  read-only; the controls become a sentence (#438).
+
 ## [0.0.76] - 2026-08-07
 
 ### Security

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.76"
+version = "0.0.77"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.76"
+version = "0.0.77"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.76",
+  "version": "0.0.77",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for checking the permission before offering the write (code landed as
#442).

Third and fourth surfaces of the defect 0.0.50 and 0.0.76 fixed on the others.
Same conclusion each time — the permission belongs to the write, so the gate goes
in the component that makes it — with the condition differing, which is why they
are four changes rather than one.

One divergence from what I asked for, and the author was right. I said to leave
the reuse path working, since selecting a profile somebody else registered is a
read. They checked: **nothing in this control lists those profiles**, so reaching
one means typing a provider and model id that happen to match, and every other
combination is the 403 the issue is about. The path goes with the form, and the
test asserts it still works for a caller who holds the permission *and posts
nothing* — which is what proves the gate did not turn a read into a write.

The tests wait for `/me/permissions` to resolve before asserting an absence,
because `can()` is false while loading and an early assertion would pass with the
gate deleted. That trap has caught three tests in this repository today.

Merged after 0.0.76, whose `secrets:edit` gate inside `InlineSecret` conflicted
with this in the shared mock and the catalogue. Resolved as the union: the new
`needsConnectionsManage` stays, 0.0.76's trimmed `noProviderKey` wins because it
removed the form the old "Add one below" promised, and the mock holds both
permissions — the form needs one, the inline secret inside it needs the other.
576 specs green on the result.

**CI has not run** — Actions has been out since 2026-08-06 15:22 UTC.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.77]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #141