### PR TITLE
chore: cut 0.0.78

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,24 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.78] - 2026-08-07
+
+### Fixed
+
+- Seven select triggers repeated a badge that only means something in the list —
+  "deployment default", "not on this host" — where a comparison against the other
+  options has nothing to compare against. They move into `SelectItem`'s `trailing`
+  slot, which renders outside `ItemText` and so is not inherited by the closed
+  trigger (#341).
+- Create knowledge base could not say the embedding-model list had *failed*:
+  loading and refused were the same pixels. Refused now has its own branch and
+  names the default the collection will get anyway (#365).
+- The runtime field lost its only warning when the badge moved, and
+  `connection-dialog` saves `default_runtime` without validating it — so you could
+  probe a host, pick an alias it had just refused, and save with nothing
+  dissenting. An explicit line under the field restores it, and restores it for
+  screen readers too, since Radix names an option by `ItemText` alone.
+
 ## [0.0.77] - 2026-08-07
 
 ### Security

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.77"
+version = "0.0.78"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.77"
+version = "0.0.78"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.77",
+  "version": "0.0.78",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for keeping a comparative badge in the list (code landed as #435).

The `trailing` slot 0.0.49 added for exactly this, applied to the seven callers
that still inherited their badge into the trigger.

Proof by reverting, done per file rather than in aggregate: each of the eight
changed sources restored to `main` on its own, its test file re-run, and the
failures counted — 1, 1, 1, 2, 1, 2, 2, 3. Every regression test asserts both
halves, and the trigger half is `not.toHaveTextContent` rather than
`queryByText`, because the old markup sometimes glued the badge to the label in
one text node. That mattered: three existing tests matched badges through
`getByRole("option", { name })`, which stops working once `trailing` leaves the
accessible name.

The runtime-field warning is a regression this branch introduced and its own
review caught — the sort of thing that only shows up if you ask what the moved
element was doing, rather than whether it still renders.

Verified locally: `make test-frontend-cov` 100/100/100 with 97.58% branches,
`make build-frontend` and the i18n guard green. The coverage run needed a second
attempt — eight timeouts at load 40 in files this branch never touched, clean at
load 5. **CI has not run** — Actions has been out since 2026-08-06 15:22 UTC.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.78]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #425, #434