### PR TITLE
chore: cut 0.0.79

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,33 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.79] - 2026-08-07
+
+### Fixed
+
+- A failed sync source was drawn exactly like a successful one. `SyncStatusBadge`
+  tested `status === "failed"`, which the worker never writes — it writes `done`
+  and `error` — so every finished and every failed sync fell through to the same
+  grey token (#356).
+- The document badge twenty lines above it was wrong the same way, and worse:
+  three of its four keys (`completed`, `pending`, `failed`) are names nothing
+  writes, against the service's `processing`/`done`/`error`. It had been "fixed"
+  onto that wrong vocabulary once already.
+- `/rag`'s status icon drew anything it did not recognise as a spinner, so a
+  cancelled sync spun for the life of the page.
+- The sync wizard's target-collection picker could not be reached from any of its
+  three call sites, so "Add source" on `/rag` — where the tab lists the whole
+  organization's sources — filed against whichever collection the sidebar
+  happened to have selected, invisibly (#434).
+- Creating a collection on `/rag` reported every refusal as "Failed to create
+  collection", discarding the server's own message — which is what made 0.0.66's
+  better 400 invisible on the only screen that creates one by name (#436).
+
+### Added
+
+- `frontend/src/lib/rag-status.ts` — one source for the vocabulary, naming the
+  three columns that share it and what writes each.
+
 ## [0.0.78] - 2026-08-07
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.78"
+version = "0.0.79"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.78"
+version = "0.0.79"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.78",
+  "version": "0.0.79",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for saying what actually happened on the sync and RAG surface (code
landed as #445).

The reported bug was one instance of four, which is the argument for sweeping a
vocabulary rather than fixing the comparison somebody noticed. Deliberately not a
union on the wire type: the column is a free `String(20)`, and the lying union
`"pending" | "processing" | "completed" | "failed" | string` is exactly where the
bad keys came from.

#434 turned out to be a reachable path somebody broke rather than dead code. The
predicate required `defaultCollection` to be absent *and* `collections` to be
non-empty, and no call site could satisfy both.

Merged after 0.0.78, and the collision between them is adjudicated in this
branch's favour: 0.0.78 moved the collection picker's physical-name qualifier
into `SelectItem`'s `trailing` slot, and this deletes `label` from the type
entirely — only `/rag` draws that picker and collections there have no display
name distinct from `collection_name`, so there is nothing left to qualify.
0.0.78's `Continue` translation is untouched.

No new issues: the backend half — `rag_document.py` counting `status ==
"completed"`, so `indexed` is always zero — is already #148, and the untranslated
template-literal toasts are already #395 and #141.

Verified locally: every new spec run against unfixed `main` in a throwaway
worktree — status 4 of 5 fail, wizard 2 of 4, create-collection 5 of 5 — and the
ones passing on both are named as the behaviour this preserves rather than
counted as proof. 3302 specs green after the merge. **CI has not run** — Actions
has been out since 2026-08-06 15:22 UTC.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.79]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #148, #325