### PR TITLE
chore: cut 0.0.80

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,23 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.80] - 2026-08-07
+
+### Fixed
+
+- **166 values came out of `messages/en.json`**: 18 Tailwind class lists, still
+  being read back through `cn(t("…"))` so a translator opening `pl.json` was
+  asked to translate CSS, and 148 fragments of JavaScript source that nothing
+  read at all. The catalogue goes 2849 → 2696 (#348).
+- `check_i18n.py` could not see copy passed through a prop it did not know:
+  `READABLE_ATTRS` had no `noun`, so `<Pager>` took one from six call sites as a
+  plain English word and rendered `3 of 40 skills` under `pl`, where no plural
+  can agree with the count. The word is inside the message now (#362).
+- The knowledge-base document table told a Viewer to drag in files they may not
+  upload (#349).
+- `SharingPanel` interpolated an English noun into five sentences and pluralised
+  it with an `s` (#420).
+
 ## [0.0.79] - 2026-08-07
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.79"
+version = "0.0.80"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.79"
+version = "0.0.80"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.79",
+  "version": "0.0.80",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for taking the code out of the catalogue (code landed as #427).

The real count is 166, against the 19 the issue names and the "about 144" its own
comment estimated. The 24 nobody had counted carry no keyword at all — a ternary
between JSX branches leaves `") : isUser ? ("`, a cut statement leaves
`"; return"` — so three shape rules reach them: no sentence begins with a closing
bracket, ends with an opening one, or ends on `return`.

`frontend/messages/catalog.test.ts` is the mechanism, and it runs over the
*catalogue* rather than the source, because the guard is blind to both shapes by
construction.

Verified mechanically rather than by reading: all 18 class lists inlined token
for token against the pre-merge catalogue, and none of the 166 deleted keys
reachable by a static read, a dynamic template or a table of names.

Reviewing it found three assertions that prove nothing — a drift check for drift
that is structurally impossible, a case passing identically on `main`, and a
`pl.json` half that never held any of the three shapes. They are kept as forward
guards and **labelled as such**, with the pull request splitting which assertions
prove the fix from which do not. That distinction is the point: none of them is
wrong to keep, each was wrong to present as evidence.

Verified locally: 3313 specs green after merging `main`, coverage gate met, guard
clean over 2696 messages. **CI has not run** — Actions has been out since
2026-08-06 15:22 UTC.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.80]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #395, #425