### PR TITLE
chore: cut 0.0.81

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,26 @@ Two things are versioned separately from this file and worth knowing about:
 
 Nothing yet.
 
+## [0.0.81] - 2026-08-07
+
+### Fixed
+
+- **145 more keys came out of `messages/en.json`, and 82 of them had a
+  hand-written Polish translation** — done for nobody, because nothing read the
+  English either. Another 43 messages had their words written out in the source
+  beside the key that held them, so the catalogue looked migrated while the
+  literal stayed on screen. That is worse than an unmigrated string: the guard
+  counted it as handled (#425).
+- A sentence split across two keys, its tail beginning at a full stop, so neither
+  half reads as copy to anything looking at one key at a time.
+
+### Added
+
+- Three rules, all anchored on the **catalogue** rather than the source, so none
+  has to decide what a text node is — which is how two of them reach `.ts` files
+  the offence sweep has never opened: a key nothing reads, a message whose words
+  also sit in the source, and a value opening on `.` `,` `:` `;`.
+
 ## [0.0.80] - 2026-08-07
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.80"
+version = "0.0.81"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.80"
+version = "0.0.81"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.80",
+  "version": "0.0.81",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for a key nothing reads not being a translation (code landed as #447).

The third rule earned its place on its own: three split sentences survived both
of the others, and only it named them.

On #395 — the standing decision that the regex guard has reached its limit —
none of these three reads JSX, so none is another patch to that reading model.
The author says a fourth would be the point to stop, and that is the right place
to draw it.

Rebuilt onto `main` rather than merged: it was stacked on 0.0.80 with 0.0.78
merged in, and by the time it was reached both had landed along with four other
releases, so its own three commits were cherry-picked and the rest dropped as
already present.

**The new rule immediately caught two keys nothing reads, and both were mine** —
left by my own conflict resolutions while merging the releases ahead of it.
`rag.continue` was a real regression: 0.0.78 translated the wizard's hardcoded
"Continue", 0.0.79 rewrote that file, and resolving toward 0.0.79 put the literal
back while leaving the key behind. `chat.runConversationDifferentModel` was
genuinely superseded by 0.0.77. Fixed and deleted respectively — the rule working
on its first contact with a real merge, which is a better argument for it than
any test.

Filed and not fixed: **#446** — `check_i18n.py` never opens a `.ts` file, so
`src/hooks/**` and `src/lib/**` have never been read by its offence sweep, and
that is 406 offences across 91 files, measured. Widening the glob without #395's
parser would be actively wrong, since `; return` reads as a text node.

Verified locally: guard clean, 3325 specs green. **CI has not run** — Actions has
been out since 2026-08-06 15:22 UTC.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock`,
`frontend/package.json`; `CHANGELOG.md` gets the `[0.0.81]` section.

No schema change, `SPEC_VERSION` unchanged at 7.

Refs #395, #446