### PR TITLE
fix(chat): drop the duplicate usePermissions key in the picker's mock

### DIFF
--- a/frontend/src/components/chat/chat-model-picker.test.tsx
+++ b/frontend/src/components/chat/chat-model-picker.test.tsx
@@ -34,9 +34,6 @@ vi.mock("@/hooks", () => ({
   useProviderModels: () => ({ models: listedModels(), source: "curated", isLoading: false }),
   useSecretPurposes: () => ({ purposes: PURPOSES, isLoading: false }),
   useSecrets: () => ({ secrets: listedSecrets(), create: { mutate: vi.fn(), isPending: false } }),
-  usePermissions: () => ({
-    can: (permission: Permission) => held.permissions.includes(permission),
-  }),
 }));
 
 const purpose = (


### PR DESCRIPTION
## What changed

Deleted one of two identical `usePermissions` entries in the `vi.mock("@/hooks", ...)`
factory of `frontend/src/components/chat/chat-model-picker.test.tsx`.

That was enough to make `bun run type-check` exit 0 on `main`. Until now it failed:

```
src/components/chat/chat-model-picker.test.tsx(37,3): error TS1117:
An object literal cannot have multiple properties with the same name.
```

`make lint-frontend` runs `tsc`, and so does CI's `test-frontend` job, so this was red
on every branch cut from `main` — including the four open ones.

## Why nothing caught it

The second entry wins at runtime and its body is identical to the first, so it changed
no behaviour: the suite is green with the duplicate and green without it, same 16
tests. `bun run test:run` and `bun run test:coverage` both pass on this file either
way. `tsc` was the only gate that could see it, and it is not part of "I ran the tests
and they were green" — which is the shape #487 names, and the same one behind #476.

## The issue's attribution is wrong, and the real story is worth recording

#487 blames #360 (`8a6ba58`). That commit touched this file, but only to rewrite two
assertion strings — `git show 8a6ba58 -- <file>` is four lines, none of them in the
mock factory.

It is two pull requests landing the same mock entry a day apart, neither seeing the
other:

- **#433** (`3254969`, *check secrets:edit inside the inline secret form*) appended
  `usePermissions` after `useSecrets`.
- **#442** (`63f250b`, *check the permission before offering the write*) added it again
  in alphabetical position, between `useModelProviders` and `useProviderModels`.

`chat-model-picker.test.tsx` is the only source file both touched. That is why this
happened here and nowhere else, and it is a plain merge collision rather than a
copy-paste inside one edit.

**#442's is the one kept**, because its position preserves the factory's alphabetical
order.

## How it was verified

- `cd frontend && bun run type-check` — exits 0, no output.
- `bunx vitest run src/components/chat/chat-model-picker.test.tsx
  src/components/chat/chat-model-picker.integration.test.tsx` — 2 files, 16 tests,
  passed. Unchanged from before, as expected: the deleted entry never ran.
- **Checked for the same shape elsewhere, two ways.** `tsc` reporting nothing else is
  itself the repo-wide answer for duplicate keys — TS1117 is raised per object
  literal, so a second occurrence anywhere would still be in that output. And for the
  shape `tsc` *cannot* see — two separate `vi.mock` calls naming the same module,
  where the second silently replaces the first — a scan over every test file in
  `frontend/src` found no module mocked twice.

Frontend-only and test-only, so no page under `docs/` describes anything this changes.

Closes #487
