### PR TITLE
fix(ci): give the test suite one Postgres password, not two defaults

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,6 +7,8 @@ See: https://anyio.readthedocs.io/en/stable/testing.html
 # ruff: noqa: I001 - Imports structured for Jinja2 template conditionals
 
 import os
+import re
+from pathlib import Path
 
 # Before anything imports `app.core.config`, and therefore before anything can
 # open a connection: point every database name in this process at a test
@@ -35,6 +37,54 @@ import os
 # refused by the guard in the integration conftest instead of being made to look
 # like one.
 os.environ["POSTGRES_DB"] = f"{os.environ.get('POSTGRES_DB', 'agenticos_test')}_p{os.getpid()}"
+
+
+def _a_password_is_already_configured() -> bool:
+    """Would `app.core.config` resolve a Postgres password from somewhere?
+
+    The `.env` search mirrors `find_env_file`, which cannot be imported here:
+    importing `app.core.config` is precisely what this block has to precede.
+    An empty assignment does not count, because `env_ignore_empty` discards it.
+    """
+    if os.environ.get("POSTGRES_PASSWORD"):
+        return True
+    for directory in (Path.cwd(), Path.cwd().parent):
+        env_file = directory / ".env"
+        if env_file.exists():
+            return any(
+                re.match(r"\s*POSTGRES_PASSWORD\s*=\s*\S", line)
+                for line in env_file.read_text().splitlines()
+            )
+    return False
+
+
+# The credential those same two engines authenticate with, resolved here for the
+# same reason as the name above: `app/db/session.py` builds its engine at import
+# time, so anything the settings object must hold has to be in the environment
+# before it is constructed.
+#
+# `tests/integration/conftest.py` used to default this to "postgres" while
+# `app/core/config.py` defaults it to empty, and no test could tell, because
+# every one of them connected through the fixture's engine. The first test to
+# drive the *application's* engine found the disagreement: on a checkout with no
+# `backend/.env` - which is every git worktree, the file being untracked - it
+# failed to authenticate while the rest of the suite passed, which reads exactly
+# like a regression of whatever branch it turned up on (#485).
+#
+# The empty default in `app/core/config.py` stays, and this is deliberately not a
+# second copy of it. `make install` is built around that empty default: with no
+# `.env`, `alembic check` is refused with `fe_sendauth: no password supplied`,
+# which is a missing file announcing itself rather than a guessed credential
+# reaching a database. What is defaulted here is what the test suite connects
+# with, in one place, and `tests/integration/conftest.py` reads it back off the
+# settings object rather than defaulting it again.
+#
+# Seeded only when nothing else supplies one - unlike the database name above,
+# where overriding a developer's `.env` is the entire point. Here it would swap a
+# real password for a guess, so a `.env` that names one keeps it, and the
+# integration fixture now honours it too instead of ignoring it.
+if not _a_password_is_already_configured():
+    os.environ["POSTGRES_PASSWORD"] = "postgres"
 
 from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, MagicMock

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -32,6 +32,7 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 
+from app.core.config import settings
 from app.db.base import Base
 
 # Where to connect to issue `CREATE DATABASE` / `DROP DATABASE`, neither of
@@ -41,11 +42,20 @@ _MAINTENANCE_DATABASE = "postgres"
 
 
 def _database_url(name: str) -> str:
-    host = os.getenv("POSTGRES_HOST", "localhost")
-    port = os.getenv("POSTGRES_PORT", "5432")
-    user = os.getenv("POSTGRES_USER", "postgres")
-    password = os.getenv("POSTGRES_PASSWORD", "postgres")
-    return f"postgresql+asyncpg://{user}:{password}@{host}:{port}/{name}"
+    """Where the application would connect, with the database name replaced.
+
+    Every part but the name comes from `settings`, so this engine and the one in
+    `app/db/session.py` cannot disagree about where they are connecting or as
+    whom. They did: this function defaulted the password to "postgres" while
+    `app/core/config.py` defaults it to empty, which no test could see until one
+    drove the application's engine directly and failed to authenticate on any
+    checkout without a `backend/.env` (#485). `tests/conftest.py` seeds the
+    fallback, in the only place that still precedes the settings object.
+    """
+    return (
+        f"postgresql+asyncpg://{settings.POSTGRES_USER}:{settings.POSTGRES_PASSWORD}"
+        f"@{settings.POSTGRES_HOST}:{settings.POSTGRES_PORT}/{name}"
+    )
 
 
 async def _reachable(url: str) -> bool:

--- a/backend/tests/test_integration_database_isolation.py
+++ b/backend/tests/test_integration_database_isolation.py
@@ -1,22 +1,30 @@
-"""What keeps two integration runs on one machine out of each other's tables.
+"""Where the integration fixture connects, and that nobody else is there.
 
-`tests/integration/conftest.py` calls `drop_all` unconditionally, so everything
-that makes the suite safe to run twice at once is a name: one nobody else uses,
-and a guard on what that name is allowed to be. Both used to hold only because
-the name was constant, which is exactly what made two runs destroy each other
-(#189) - so the derivation is asserted here rather than assumed.
+Two engines reach the same database: the fixture's, built in
+`tests/integration/conftest.py`, and the application's, built at import time in
+`app/db/session.py`. Every part of the address they resolve separately is a part
+they can disagree about, and both halves of that have now cost a day.
 
-These are unit tests on purpose. The guard has to answer before a database is
-touched, and it is the one part of the fixture a run without Postgres can still
+`drop_all` is unconditional, so what makes the suite safe to run twice at once
+is a name nobody else uses, plus a guard on what that name may be. Both held
+only because the name was constant - which is what made two runs destroy each
+other (#189) - so the derivation is asserted rather than assumed. And the
+credentials were resolved twice with different fallbacks, which nothing could
+see until a test drove the application's engine instead of the fixture's (#485).
+
+These are unit tests on purpose. They have to answer before a database is
+touched, and they are the part of the fixture a run without Postgres can still
 check.
 """
 
 import os
+from pathlib import Path
 
 import pytest
 
 from app.core.config import settings
-from tests.integration.conftest import _refuse_a_real_database
+from tests.conftest import _a_password_is_already_configured
+from tests.integration.conftest import _database_url, _refuse_a_real_database
 
 
 def test_the_database_this_process_uses_is_named_after_this_process() -> None:
@@ -38,6 +46,75 @@ def test_the_application_settings_name_the_database_the_fixture_creates() -> Non
     """
     assert os.environ["POSTGRES_DB"] == settings.POSTGRES_DB
     assert settings.DATABASE_URL.endswith(f"/{os.environ['POSTGRES_DB']}")
+
+
+def test_the_fixture_addresses_the_database_with_the_settings_it_is_given(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fixture must read the address, not resolve one of its own.
+
+    It used to read the environment directly and default the password to
+    "postgres" where `app/core/config.py` defaults it to empty. Asserting the
+    resolved value cannot catch that - on a machine with a `backend/.env`, and
+    in CI, the two agree by luck - so what is pinned here is that the fixture
+    carries whatever the settings hold, which fails anywhere if it goes back to
+    reading `os.getenv` (#485).
+    """
+    monkeypatch.setattr(settings, "POSTGRES_USER", "somebody")
+    monkeypatch.setattr(settings, "POSTGRES_PASSWORD", "a-password-no-default-invents")
+
+    assert "somebody:a-password-no-default-invents@" in _database_url("agenticos_test")
+
+
+def test_the_test_suite_has_a_password_to_connect_with() -> None:
+    """`app/core/config.py` defaults it to empty, and empty cannot authenticate."""
+    assert settings.POSTGRES_PASSWORD
+
+
+def test_a_checkout_with_no_env_file_is_given_a_password(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The worktree case, which is how every parallel branch here is worked.
+
+    `backend/.env` is untracked, so it does not come across to a new worktree and
+    nothing else supplies the credential.
+    """
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    monkeypatch.delenv("POSTGRES_PASSWORD", raising=False)
+    monkeypatch.chdir(checkout)
+
+    assert not _a_password_is_already_configured()
+
+
+def test_a_password_somebody_configured_is_not_replaced_by_the_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Seeding over a real one would swap a working password for a guess.
+
+    The opposite of the database name, which is overridden precisely because a
+    developer's own value is the dangerous one.
+    """
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    (checkout / ".env").write_text("POSTGRES_PASSWORD=somebodys-own-password\n")
+    monkeypatch.delenv("POSTGRES_PASSWORD", raising=False)
+    monkeypatch.chdir(checkout)
+
+    assert _a_password_is_already_configured()
+
+
+def test_an_env_file_assigning_nothing_does_not_count_as_a_password(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`env_ignore_empty` discards it, so the settings fall back to empty too."""
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    (checkout / ".env").write_text("POSTGRES_PASSWORD=\n")
+    monkeypatch.delenv("POSTGRES_PASSWORD", raising=False)
+    monkeypatch.chdir(checkout)
+
+    assert not _a_password_is_already_configured()
 
 
 def test_the_name_this_process_derived_is_one_the_guard_accepts() -> None:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -237,6 +237,22 @@ The suite still refuses any database whose name does not contain `test` or `ci`:
 drops tables unconditionally, so the guard is the only thing between it and a
 development database.
 
+**The credential is resolved once, in `tests/conftest.py`, and everything reads it
+back off the settings object.** Two engines reach that database — the fixture's, and
+the application's, built at import time in `app/db/session.py` — and a test asking
+whether a write is visible needs both. They used to resolve the password separately,
+the fixture defaulting to `postgres` where `app/core/config.py` defaults to empty, and
+nothing could see it while every test connected through the fixture. The first one to
+drive the application's engine failed to authenticate on a checkout with no
+`backend/.env` — which is **every git worktree**, the file being untracked — two
+failures against a full green everywhere else, reading exactly like a branch
+regression ([#485](https://github.com/vstorm-co/agenticos/issues/485)). The suite now
+seeds `POSTGRES_PASSWORD=postgres` before the settings object is built, and only when
+neither the environment nor a `.env` supplies one, so a real password is never
+replaced by the default. `app/core/config.py` still defaults it to empty, which is
+what makes a missing `.env` announce itself in `alembic check` rather than reaching a
+database with a guess.
+
 ### The migration suite has a third one
 
 `tests/test_migrations.py` applies the whole chain to an empty database and rolls it


### PR DESCRIPTION
## What changed

The test suite resolves its Postgres password **once**, and both engines read that
one value.

- `tests/integration/conftest.py` — `_database_url` now builds from `settings`
  instead of re-reading the environment with fallbacks of its own. Host, port, user
  and password all come from the same object the application uses.
- `tests/conftest.py` — seeds `POSTGRES_PASSWORD=postgres` into the environment
  before `app.core.config` is imported, and only when nothing else supplies one.
- `docs/testing.md` — says integration tests need the credential and that a worktree
  does not inherit one.

Two failures on any checkout without a `backend/.env` become zero:

```
asyncpg.exceptions.InvalidPasswordError: password authentication failed for user "postgres"
```

## Why only those two tests

Two engines reach the integration database: the fixture's, and the application's,
built at import time in `app/db/session.py`. They resolved the password separately —
`os.getenv("POSTGRES_PASSWORD", "postgres")` in the fixture against
`POSTGRES_PASSWORD: str = ""` in `app/core/config.py` — and nothing could see the
disagreement while every test connected through the fixture.
`test_commit_before_response.py` is the first test to drive the *application's*
engine, which is the whole point of it, so it is the first to notice.

## `app/core/config.py` is unchanged, on purpose

#485 offers defaulting it to `"postgres"` there and calls that the likely fix. It is
not, and the reason is worth recording: **four places state the opposite and depend
on it.**

- `Makefile:191` — "Without one `POSTGRES_PASSWORD` defaults to empty and
  `alembic check` is refused with `fe_sendauth: no password supplied`"
- `docs/install.md:184` — the same sentence, as the reason `make install` creates
  `backend/.env`
- `docs/configuration.md:111` — the table row `POSTGRES_PASSWORD | (empty)`
- `tests/test_ci_parity.py:253` — the reasoning behind
  `test_install_creates_the_env_file_the_host_checks_read`

A missing `.env` announcing itself as `fe_sendauth: no password supplied` is what
`make install` is built around, and it beats silently reaching a database with a
guessed credential.

The issue's second suggestion — exporting from `tests/integration/conftest.py` —
**cannot work as written**: `tests/conftest.py` imports `app.main` at module level and
pytest loads the parent conftest first, so the settings object already exists by the
time the integration conftest is read. The seed has to live in the root conftest,
which is exactly where the per-pid `POSTGRES_DB` derivation already lives, for the
same reason.

## One default, and it does not overwrite a real password

The seed applies only when neither the environment nor a `.env` supplies one — the
opposite of the database name above it, where overriding a developer's own value is
the entire point. Here it would swap a working password for a guess.

One deliberate side effect: the fixture now *honours* a `.env` password it used to
ignore. A developer whose Postgres has a real password previously had the whole
integration suite skip (the fixture's hardcoded `postgres` could not reach it); now it
runs.

## How it was verified

- **Reproduced first**: 2 failed on this worktree, 2 passed with
  `POSTGRES_PASSWORD=postgres` in front of the same command.
- **Each half reverted in turn, and the new tests fail without it.** The fixture half
  fails *even on a machine that has a password*, because it pins that `_database_url`
  carries whatever `settings` hold rather than asserting a resolved value — the
  resolved values agree by luck in CI and on any checkout with a `.env`, so a test
  written that way would have caught nothing.
- **Reverting only the seed turns the two failures into a silent skip**: the
  maintenance URL is unauthenticated too, so `_reachable` answers no and the module
  skips itself. Both halves are load-bearing. CI cannot go green that way — the
  fixture raises instead of skipping when `CI` is set.
- `make test` — **3671 passed, 6 skipped, coverage 100.00%, gate reached.**
  `tests/integration/` plus the isolation file is 292 passed.
- `make docs-build` (`--strict`) and `python3 scripts/docs_drift.py` clean.
- `ruff check` and `ruff format --check` clean on all three Python files; `ty check`
  exits 0 with the same 69 diagnostics before and after this change.

## CI state — green

`lint`, `test` (backend suite, 100% coverage gate), `docs`, CodeQL and the security
scan all pass; `mergeStateStatus` is `CLEAN`.

Two notes for anyone reading the run history, since neither is this branch:

- **`e2e` failed once and passed on a re-run of the same commit.** The failure was
  `agents.spec.ts:363` ("a tool renamed for one agent sticks"), where a reload after a
  draft save read the pre-save draft — a flake, and an instance of the open
  [#230](https://github.com/vstorm-co/agenticos/issues/230) browser-side staleness, not
  anything here: none of this branch's four files (three pytest, one docs page) is
  imported by the e2e job, which runs `uvicorn` + Playwright. Filed as
  [#492](https://github.com/vstorm-co/agenticos/issues/492).
- **The first push showed `lint` red**, from
  [#476](https://github.com/vstorm-co/agenticos/issues/476) (a `ruff format` blank line
  inherited from `main`). #149 has since fixed #476 on `main`, so `lint` is green here.
  While it was open the `ruff-format` pre-commit hook (`pass_filenames: false`,
  whole-tree) made *every* Python commit unable to pass pre-commit, so this commit was
  made with `SKIP=ruff-format` after checking `ruff format --check` on its own three
  files; the check is moot now that `main` is clean. Documented on #476.

Closes #485
