### PR TITLE
fix(sandbox): keep the kind the sessions route sets

### DIFF
--- a/backend/app/schemas/sandbox_connection.py
+++ b/backend/app/schemas/sandbox_connection.py
@@ -309,6 +309,9 @@ class SandboxSessionList(BaseSchema):
     """
 
     sessions: list[SandboxSessionRead] = Field(default_factory=list)
+    kind: Literal["docker", "daytona"] = Field(
+        description="Which sort of host answered, so an empty daytona listing is told apart from an idle docker one",
+    )
     limit: int | None = None
     open_limit: int | None = None
     tenant_limit: int | None = None

--- a/backend/tests/api/test_sandbox_connection_routes.py
+++ b/backend/tests/api/test_sandbox_connection_routes.py
@@ -71,6 +71,7 @@ def service() -> MagicMock:
                     "scope": "conversation",
                 }
             ],
+            "kind": "docker",
             "limit": 20,
             "tenant_limit": 5,
         }
@@ -208,6 +209,29 @@ class TestTheSessions:
         body = response.json()
         assert body["sessions"][0]["session_id"] == "xc-1"
         assert body["tenant_limit"] == 5
+
+    async def test_the_response_says_which_sort_of_host_answered(self, client) -> None:
+        """The service sets `kind` on this payload; the response model must keep it."""
+        async with client() as opened:
+            response = await opened.get(_url(f"/{_CONNECTION_ID}/sessions"))
+
+        assert response.json()["kind"] == "docker"
+
+    async def test_a_daytona_connection_is_told_apart_from_an_idle_docker_host(
+        self, client, service
+    ) -> None:
+        """A Daytona host holds none of our sessions by design, and an idle Docker
+        host holds none by chance; both list nothing, so only `kind` distinguishes
+        them - and it must survive serialization to do so."""
+        service.sessions = AsyncMock(return_value={"sessions": [], "kind": "daytona"})
+
+        async with client() as opened:
+            response = await opened.get(_url(f"/{_CONNECTION_ID}/sessions"))
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["kind"] == "daytona"
+        assert body["sessions"] == []
 
     async def test_a_row_names_the_agent_rather_than_only_a_hex_string(self, client) -> None:
         """Read from `agent_workspaces`; the id is deliberately not decoded."""


### PR DESCRIPTION
## Summary

`SandboxConnectionService.sessions()` sets `kind` on both of its return paths — `daytona` on the non-docker path and `resolved.kind` on the docker one — but `SandboxSessionList` never declared the field, so `response_model=SandboxSessionList` stripped it before it reached a client. A Daytona host answered `{"sessions": [], "kind": "daytona"}` was received byte-for-byte identical to an idle docker host (`{"sessions": [], "limit": null, "open_limit": null, "tenant_limit": null}`), so a client reading only this endpoint could not tell "holds none of our sessions by design" from "running nothing".

This adds `kind: Literal["docker", "daytona"]` to `SandboxSessionList`, matching the Literal the input schemas already use and the two values `CONNECTION_KINDS` allows. It is **required, not optional**: the service sets it on both paths unconditionally, so a `| None` default would be an unreachable branch this repo forbids.

## `SandboxEventList` intentionally left alone

The issue mentions `SandboxEventList` too, but `session_events()` never sets `kind` on its payload (it returns `{"events": [], "latest_seq": 0}` on the non-docker path and the service response as-is on the docker one). Declaring `kind` there would be a field written nowhere — the exact mirror of the bug being fixed. So the diff stays scoped to what the code actually supports.

## Verified

New API tests in `tests/api/test_sandbox_connection_routes.py`: one asserts a docker listing carries `kind == "docker"`, and `test_a_daytona_connection_is_told_apart_from_an_idle_docker_host` proves a daytona listing survives serialization and is distinguishable from an idle docker host. `make test` green at 100% platform-layer coverage; `make lint-backend` clean. No docs page states this endpoint's response shape field-by-field, and `scripts/docs_drift.py` reports nothing owed — the field is purely additive.

Closes #450
