### PR TITLE
feat(sandbox): expose host-wide session counts beside the ceilings

### DIFF
--- a/backend/app/schemas/sandbox_connection.py
+++ b/backend/app/schemas/sandbox_connection.py
@@ -306,12 +306,31 @@ class SandboxSessionList(BaseSchema):
     `tenant` is deliberately absent from the rows: every one of them is this
     organization's, because the service is asked for all of them and the ones
     belonging to other tenants are dropped before this is built.
+
+    `host_session_count` and `host_open_count` are the two host-wide numerators
+    that make `limit` and `open_limit` dividable, the way `len(sessions)` already
+    divides against `tenant_limit`. They count every tenant on the host, taken
+    before the tenant filter, so a caller refused a session while under their own
+    ceiling can see the host itself is full rather than reading the daemon's logs.
+    Two aggregate integers naming nothing - a long way from the rows the filter
+    withholds - and the route is gated on `connections:view`, the authority to
+    watch a host rather than any member's. `None` on a Daytona connection, which
+    enforces no ceilings of ours and so has no counts to divide, matching how
+    `limit`/`open_limit`/`tenant_limit` are already `None` there.
     """
 
     sessions: list[SandboxSessionRead] = Field(default_factory=list)
     limit: int | None = None
     open_limit: int | None = None
     tenant_limit: int | None = None
+    host_session_count: int | None = Field(
+        default=None,
+        description="Resident sandboxes host-wide, before the tenant filter; the numerator for `limit`.",
+    )
+    host_open_count: int | None = Field(
+        default=None,
+        description="Open sessions host-wide (resident and hibernated); the numerator for `open_limit`.",
+    )
 
 
 class SandboxEventRead(BaseSchema):

--- a/backend/app/services/sandbox_connection.py
+++ b/backend/app/services/sandbox_connection.py
@@ -535,6 +535,18 @@ class SandboxConnectionService:
         that format a schema - the first change to it would mislabel every row.
         The row already carries the agent and the conversation, so it is joined.
 
+        The two host-wide counts are taken from the unfiltered list before the
+        filter narrows it, so `limit` and `open_limit` gain the numerators
+        `tenant_limit` already has - the answer to "why was I refused a session
+        while under my own ceiling". Each divides against what its ceiling bounds:
+        `open_limit` (`SANDBOXD_MAX_OPEN_SESSIONS`) caps every session that
+        exists, resident or hibernated, so `host_open_count` is the whole list;
+        `limit` (`SANDBOXD_MAX_SESSIONS`) caps only the resident ones, which the
+        service marks `state == "running"` - a hibernated session frees its slot
+        and is never resident, and a crashed session keeps its resident slot until
+        it is reaped, so `state` rather than `alive` is what the resident ceiling
+        actually bounds. No extra daemon call: the unfiltered list is already here.
+
         Args:
             usage: Also sample memory and CPU. Off by default because the service
                 pays a daemon round trip per sandbox for it.
@@ -553,9 +565,12 @@ class SandboxConnectionService:
             resolved, f"/sessions?usage={'true' if usage else 'false'}", connection_id
         )
         tenant = str(ctx.organization_id)
-        mine = [
-            session for session in payload.get("sessions", []) if session.get("tenant") == tenant
-        ]
+        all_sessions = payload.get("sessions", [])
+        mine = [session for session in all_sessions if session.get("tenant") == tenant]
+        payload["host_open_count"] = len(all_sessions)
+        payload["host_session_count"] = sum(
+            1 for session in all_sessions if session.get("state") == "running"
+        )
         payload["sessions"] = await self._attributed(ctx, mine)
         payload["kind"] = resolved.kind
         return payload

--- a/backend/tests/api/test_sandbox_connection_routes.py
+++ b/backend/tests/api/test_sandbox_connection_routes.py
@@ -72,7 +72,10 @@ def service() -> MagicMock:
                 }
             ],
             "limit": 20,
+            "open_limit": 100,
             "tenant_limit": 5,
+            "host_session_count": 12,
+            "host_open_count": 30,
         }
     )
     stub.session_events = AsyncMock(
@@ -208,6 +211,16 @@ class TestTheSessions:
         body = response.json()
         assert body["sessions"][0]["session_id"] == "xc-1"
         assert body["tenant_limit"] == 5
+
+    async def test_the_host_wide_counts_ride_alongside_the_ceilings(self, client) -> None:
+        """Both numerators reach the response through `response_model`, so the two
+        host ceilings become dividable the way the per-tenant one already is."""
+        async with client() as opened:
+            response = await opened.get(_url(f"/{_CONNECTION_ID}/sessions"))
+
+        body = response.json()
+        assert body["host_session_count"] == 12
+        assert body["host_open_count"] == 30
 
     async def test_a_row_names_the_agent_rather_than_only_a_hex_string(self, client) -> None:
         """Read from `agent_workspaces`; the id is deliberately not decoded."""

--- a/backend/tests/test_sandbox_connections.py
+++ b/backend/tests/test_sandbox_connections.py
@@ -36,6 +36,7 @@ from app.schemas.sandbox_connection import (
     SandboxConnectionCreate,
     SandboxConnectionUpdate,
     SandboxProbeRequest,
+    SandboxSessionList,
 )
 from app.services.sandbox_connection import (
     LOCAL_TOKEN_SECRET_NAME,
@@ -794,7 +795,7 @@ class TestReadingTheSessions:
         )
         _serve(monkeypatch, _Response(200, {"sessions": [{"session_id": "stray"}]}))
 
-        assert await service.sessions(_ctx(), row.id) == {"sessions": [], "kind": "docker"}
+        assert (await service.sessions(_ctx(), row.id))["sessions"] == []
 
     async def test_a_session_is_named_by_the_row_rather_than_by_decoding_its_id(self, monkeypatch):
         """Parsing the scope key back out would make its format a schema, and the
@@ -878,6 +879,94 @@ class TestReadingTheSessions:
             await service.sessions(_ctx(), row.id)
 
         assert "did not answer" in refused.value.message
+
+    async def test_the_host_wide_total_counts_rows_the_org_view_filters_out(self, monkeypatch):
+        """The point of the two counts: an operator whose own view is short of its
+        ceiling can still see the host is full of another tenant's work. Taken
+        before the filter, so they count every tenant while the rows count one."""
+        row = _row()
+        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
+        monkeypatch.setattr(
+            agent_workspace_repo, "list_for_organization", AsyncMock(return_value=[])
+        )
+        ctx = _ctx()
+        _serve(
+            monkeypatch,
+            _Response(
+                200,
+                {
+                    "sessions": [
+                        {
+                            "session_id": "mine",
+                            "tenant": str(ctx.organization_id),
+                            "state": "running",
+                        },
+                        {"session_id": "theirs-1", "tenant": str(uuid.uuid4()), "state": "running"},
+                        {"session_id": "theirs-2", "tenant": str(uuid.uuid4()), "state": "running"},
+                    ],
+                    "limit": 40,
+                    "open_limit": 100,
+                },
+            ),
+        )
+
+        listing = await service.sessions(ctx, row.id)
+
+        assert [entry["session_id"] for entry in listing["sessions"]] == ["mine"]
+        assert listing["host_session_count"] == 3
+        assert listing["host_open_count"] == 3
+
+    async def test_open_counts_every_session_but_resident_counts_only_the_running_ones(
+        self, monkeypatch
+    ):
+        """`open_limit` bounds every session that exists, so `host_open_count` is
+        the whole list; `limit` bounds only the resident ones, which the service
+        marks `state == "running"`. A hibernated session frees its slot, and a
+        crashed session keeps its resident slot until it is reaped and so still
+        reads `running` while `alive` is false - `state`, not `alive`, is what the
+        resident ceiling counts, or a full host would look like it had room."""
+        row = _row()
+        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
+        monkeypatch.setattr(
+            agent_workspace_repo, "list_for_organization", AsyncMock(return_value=[])
+        )
+        _serve(
+            monkeypatch,
+            _Response(
+                200,
+                {
+                    "sessions": [
+                        {"session_id": "running", "state": "running", "alive": True},
+                        {"session_id": "hibernated", "state": "hibernated", "alive": False},
+                        {"session_id": "crashed", "state": "running", "alive": False},
+                    ],
+                    "limit": 40,
+                    "open_limit": 100,
+                },
+            ),
+        )
+
+        listing = await service.sessions(_ctx(), row.id)
+
+        assert listing["host_open_count"] == 3
+        assert listing["host_session_count"] == 2
+
+    async def test_daytona_has_no_host_wide_totals_to_divide(self, monkeypatch):
+        """It enforces no ceilings of ours, so there is nothing to be a numerator
+        for; both counts default to `None` the way the ceilings already do."""
+        row = _row(kind="daytona", base_url=None)
+        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
+
+        listing = await service.sessions(_ctx(), row.id)
+
+        assert "host_session_count" not in listing
+        assert "host_open_count" not in listing
+        built = SandboxSessionList(**listing)
+        assert built.host_session_count is None
+        assert built.host_open_count is None
 
 
 class TestSamplingOneSandbox:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -443,15 +443,21 @@ answers the same three questions in its own section, for a caller holding
 `connections:manage`; memory is behind a switch there for the same reason it is on
 the screen, because the service samples each sandbox individually for it.
 
-**`SANDBOXD_MAX_SESSIONS_PER_TENANT` is the only one of the three ceilings anything
-renders as a fraction**, and that is a property of the answer rather than a choice
-about the view. The session listing is filtered to the caller's organization but
-carries `SANDBOXD_MAX_SESSIONS` and `SANDBOXD_MAX_OPEN_SESSIONS` through from the
-service untouched, so those two count every tenant on the host while the rows count
-one. There is no host-wide resident or open *count* in any response, so nothing puts
-a bar against them; they are named as host-wide ceilings beside the per-organization
-figure instead. If an agent is refused a session while that figure is short of its
-ceiling, the host is full of somebody else's work.
+**All three ceilings now divide.** The session listing is filtered to the caller's
+organization but carries `SANDBOXD_MAX_SESSIONS` and `SANDBOXD_MAX_OPEN_SESSIONS`
+through from the service untouched, so those two count every tenant on the host while
+the rows count one - `len(sessions)` divides only against `SANDBOXD_MAX_SESSIONS_PER_TENANT`.
+The response carries two host-wide numerators for the other pair, taken from the
+unfiltered list before the filter narrows it: `host_session_count`, the resident
+sandboxes the service marks `state == "running"`, against `limit`; and
+`host_open_count`, every session that exists resident or hibernated, against
+`open_limit`. Now the capacity card can say why a session was refused while this
+organization is short of its own ceiling: the host itself is full of somebody else's
+work. That the two are host-wide is a deliberate, narrow disclosure - two aggregate
+integers naming nothing, a long way from the session rows the filter withholds, and
+the listing is gated on `connections:view`, the authority to watch a host rather than
+any member's. They are `None` on a Daytona connection, which enforces no ceilings of
+ours to divide.
 
 That listing is **filtered, not forwarded**. One `sandboxd` answers for every
 organization that registered a connection at its address, so passing its response


### PR DESCRIPTION
## Summary

`GET /api/v1/sandbox-connections/{id}/sessions` returned three host ceilings but only one honest numerator. `len(sessions)` is scoped to the caller's organization, so it divides against `tenant_limit` and nothing else; against `limit` (`SANDBOXD_MAX_SESSIONS`) and `open_limit` (`SANDBOXD_MAX_OPEN_SESSIONS`), both host-wide, it mixes an org-scoped numerator with a host-wide denominator. An operator under their own ceiling and still being refused a session had no way to see the host was full of another tenant's work.

This publishes the two host-wide numerators so all three ceilings divide. They come from the daemon's unfiltered session list in `SandboxConnectionService.sessions()`, taken **before** the tenant filter — a `len()` and a `sum()`, no extra daemon call.

## Fields added

Two fields on `SandboxSessionList`, each `int | None = None`:

- `host_session_count` — resident sandboxes host-wide, the numerator for `limit`.
- `host_open_count` — open sessions host-wide (resident and hibernated), the numerator for `open_limit`.

## The open predicate

Verified against the sandboxd contract (`pydantic_ai_backends` `remote/wire.py` + `remote/server.py`), **not** guessed — and it is the inverse of the naive reading:

- `open_limit` (`SANDBOXD_MAX_OPEN_SESSIONS`) bounds every session that *exists*, resident or hibernated → `host_open_count = len(all_sessions)`.
- `limit` (`SANDBOXD_MAX_SESSIONS`) bounds only the *resident* sandboxes, which the service marks `state == "running"` → `host_session_count = sum(1 for s if s["state"] == "running")`.

`state`, not `alive`: a crashed session keeps its resident slot until it is reaped while reporting `alive` false, so an `alive`-based count would undercount against the very ceiling it divides and make a full host look like it had room. A hibernated session frees its slot and is never resident. Both counts are `None` on a Daytona connection, which enforces no ceilings of ours.

## Trade-off

Publishing host-wide totals is a deliberate, narrow disclosure: two aggregate integers naming nothing, a long way from the session rows the tenant filter withholds. The listing route is gated on `connections:view` — the authority to watch a host, distinct from an arbitrary member, and the permission that exists precisely to answer "why did that agent get a 429". (Note: the linked issue and my task brief referred to `connections:manage`; the route is in fact gated on `connections:view`, which is the more on-point authority for this read.)

## Verified

- New service tests: the cross-tenant numerator (counts rows the org view filters out), the resident-vs-open predicate including the crashed-resident case that pins `state` over `alive`, and the Daytona `None` path.
- A route test proves both fields ride through `response_model=SandboxSessionList`.
- `make test` green at 100% platform-layer coverage; `make lint-backend` clean; `make docs-build` (`--strict`) clean.
- `docs/configuration.md` updated to describe the two numerators and the trade-off.

Consuming the counts in the #129 capacity card is frontend work, deliberately left out of this backend-only change.

Closes #453
