### PR TITLE
fix(runs): refetch the runs list when the tab regains focus

### DIFF
--- a/frontend/src/hooks/use-runs.test.tsx
+++ b/frontend/src/hooks/use-runs.test.tsx
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider, focusManager } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -170,5 +170,34 @@ describe("useSpend", () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(apiClient.get).toHaveBeenCalledWith("/spend", { params: { days: "7" } });
     expect(result.current.spend?.month_to_date_usd).toBe("1.23");
+  });
+});
+
+describe("dashboard freshness", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  /** The app's real defaults - without them this test proves nothing. */
+  function appWrapper({ children }: { children: ReactNode }) {
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, staleTime: 5 * 60 * 1000, refetchOnWindowFocus: false },
+      },
+    });
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  }
+
+  it("asks again when the tab regains focus", async () => {
+    // The RUNS figure and Run history read this while an agent runs elsewhere,
+    // so on the app-wide five-minute cache they would sit at "0 runs" beside a
+    // Spend tab that already counted them until a full page reload.
+    vi.mocked(apiClient.get).mockResolvedValue({ items: [], total: 0 });
+    const { result } = renderHook(() => useRuns(), { wrapper: appWrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(apiClient.get).toHaveBeenCalledTimes(1);
+
+    focusManager.setFocused(false);
+    focusManager.setFocused(true);
+
+    await waitFor(() => expect(apiClient.get).toHaveBeenCalledTimes(2));
   });
 });

--- a/frontend/src/hooks/use-runs.ts
+++ b/frontend/src/hooks/use-runs.ts
@@ -44,6 +44,11 @@ export function useRuns(agentId?: string, options?: { enabled?: boolean; started
       );
     },
     enabled: options?.enabled ?? true,
+    // The RUNS figure and the Run history tab are left open while an agent runs
+    // and read back on return, so they carry the dashboard's freshness like the
+    // spend figure beside them; on the app-wide five-minute cache the list only
+    // moves on a full page reload.
+    ...DASHBOARD_FRESHNESS,
   });
   return { runs: data?.items ?? [], total: data?.total ?? 0, isLoading, error, refetch };
 }


### PR DESCRIPTION
## Summary

The Activity page's **RUNS** figure and **Run history** tab kept showing `0` / "No runs yet" after an agent had run, while the **Spend** tab beside them already counted the same runs with their cost. `useRuns` was the one dashboard query missing `DASHBOARD_FRESHNESS`, so on the app-wide 5-minute cache (`staleTime: 5 min`, `refetchOnWindowFocus: false`) it only refreshed on a full page reload — the exact symptom `query-freshness.ts` documents. Spreading `DASHBOARD_FRESHNESS` into it, as `useSpend`, `useUsageStats` and `useApprovals` already do, makes the figure and the list refetch when the tab regains focus.

## Related issue

Closes #497

## Changed

- `frontend/src/hooks/use-runs.ts` — `useRuns` now spreads `DASHBOARD_FRESHNESS` (`staleTime: 0`, `refetchOnWindowFocus: true`), matching the other dashboard hooks. Fixes both consumers at once: the RUNS figure (`activity-figures.tsx`) and the Run history tab (`run-history-tab.tsx`).

## Testing

- New regression test in `use-runs.test.tsx` — "asks again when the tab regains focus", mirroring `use-usage-stats.test.tsx`. Verified it **fails without** the change and passes with it.
- `bun run type-check`, `bun run lint`, `bun run test:coverage` all green locally (branches 97.71% ≥ 97.5% gate; statements / functions / lines 100%).

## Notes for reviewers

- Backend and data are unaffected: confirmed against the database that the runs are top-level rows in `agent_runs` and `GET /runs` returns them — the "0" was purely a stale client cache. No backend change.
- Scoped to `useRuns`. `useDelegatedRuns` / `useRun` are on-demand drill-ins rather than background-watched figures, so they keep the app default deliberately.
