### PR TITLE
chore: cut 0.0.83

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.83] - 2026-08-08
+
+### Fixed
+
+- **The Activity page's run list and the RUNS figure only moved on a full page
+  reload.** `useRuns` — read by both the RUNS figure and the Run history tab —
+  carried the app-wide query defaults (`staleTime` five minutes,
+  `refetchOnWindowFocus` off), so after an agent ran, the Runs tab sat at "No
+  runs yet" and the RUNS count at zero beside a Spend tab that already counted
+  the run, until the page was reloaded. It now spreads `DASHBOARD_FRESHNESS`
+  like `useSpend`, `useUsageStats` and `useApprovals`, so returning to the tab
+  refetches. The runs were written and `GET /runs` returned them throughout —
+  this was only a stale client cache. (#499)
+
 ## [0.0.82] - 2026-08-07
 
 ### Added

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.82"
+version = "0.0.83"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.82"
+version = "0.0.83"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.82",
+  "version": "0.0.83",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for [#499](https://github.com/vstorm-co/agenticos/pull/499) — the runs-list freshness fix.

## What is in it

The only change since 0.0.82. `useRuns` — read by the Activity page's RUNS figure and the Run history tab — carried the app-wide five-minute cache and never refetched on focus, so after an agent ran both sat at "no runs" beside a Spend tab that already counted it, until a full page reload. It now spreads `DASHBOARD_FRESHNESS` like `useSpend`, `useUsageStats` and `useApprovals`.

A changelog entry and three version strings (`backend/pyproject.toml`, `frontend/package.json`, `backend/uv.lock`), no code.
