### PR TITLE
fix(chat): show and record what a run did after it was approved, as one turn

### DIFF
--- a/backend/app/api/routes/v1/runs.py
+++ b/backend/app/api/routes/v1/runs.py
@@ -21,7 +21,7 @@ from app.db.models.agent_run import (
     RunSurface,
 )
 from app.repositories.agent_run import ApprovalFilters, RunFilters
-from app.schemas.agent import AgentRunResult, RunStep
+from app.schemas.agent import AgentRunResult, RunStep, SettledCall
 from app.schemas.agent_run import (
     AgentRunList,
     AgentRunRead,
@@ -190,6 +190,13 @@ async def resume_run(run_id: UUID, service: AgentRunnerSvc, ctx: Auth) -> Any:
                 result=call.result,
             )
             for call in segment.tool_calls
+        ],
+        # And what the approved call returned. It belongs to a step the caller
+        # drew before the run parked, so it updates that step rather than adding
+        # one - the alternative is the same command twice in one turn.
+        settled=[
+            SettledCall(tool_call_id=tool_call_id, result=result)
+            for tool_call_id, result in segment.settled.items()
         ],
         # Empty unless the continuation stopped again, which it does whenever the
         # agent reaches a second gated call. Without it a caller was told the run is

--- a/backend/app/api/routes/v1/runs.py
+++ b/backend/app/api/routes/v1/runs.py
@@ -21,7 +21,7 @@ from app.db.models.agent_run import (
     RunSurface,
 )
 from app.repositories.agent_run import ApprovalFilters, RunFilters
-from app.schemas.agent import AgentRunResult
+from app.schemas.agent import AgentRunResult, RunStep
 from app.schemas.agent_run import (
     AgentRunList,
     AgentRunRead,
@@ -169,14 +169,28 @@ async def resume_run(run_id: UUID, service: AgentRunnerSvc, ctx: Auth) -> Any:
     last outstanding call is what makes this call possible, not what performs
     it.
     """
-    output, run = await service.resume(ctx, run_id)
+    segment = await service.resume(ctx, run_id)
+    run = segment.run
     return AgentRunResult(
         run_id=run.id,
-        output=output,
+        output=segment.output,
         status=run.status,
         cost_usd=run.cost_usd,
         input_tokens=run.input_tokens,
         output_tokens=run.output_tokens,
+        # What the continuation actually did. Nothing else carries it: the run
+        # executes inside this request rather than on the socket the conversation
+        # streams, so a caller given only the answer had to draw the second half
+        # of a turn out of nothing.
+        steps=[
+            RunStep(
+                tool_call_id=call.tool_call_id,
+                tool_name=call.tool_name,
+                args=call.args,
+                result=call.result,
+            )
+            for call in segment.tool_calls
+        ],
         # Empty unless the continuation stopped again, which it does whenever the
         # agent reaches a second gated call. Without it a caller was told the run is
         # still awaiting approval and given nothing to approve.

--- a/backend/app/repositories/conversation.py
+++ b/backend/app/repositories/conversation.py
@@ -573,6 +573,35 @@ async def get_tool_calls_by_message(
     return list(result.scalars().all())
 
 
+async def get_open_tool_call_in_run(
+    db: AsyncSession, *, run_id: UUID, tool_call_id: str
+) -> ToolCall | None:
+    """A call this run made that has not returned yet, by the provider's own id.
+
+    The row a gated call leaves behind. It is written when the run parks - with no
+    result, because it has not run - and the thing that finally runs it is a
+    *resume*, whose messages carry the return without the call it belongs to. So
+    the only way back to the row is this lookup.
+
+    Scoped by run rather than by conversation: a provider's `tool_call_id` is
+    unique within a run and a conversation holds many runs, so the run is the
+    boundary that is true rather than the one that happens to work.
+    """
+    query = (
+        select(ToolCall)
+        .join(Message, Message.id == ToolCall.message_id)
+        .where(
+            Message.run_id == run_id,
+            ToolCall.tool_call_id == tool_call_id,
+            ToolCall.completed_at.is_(None),
+        )
+        .order_by(ToolCall.started_at.asc())
+        .limit(1)
+    )
+    result = await db.execute(query)
+    return result.scalar_one_or_none()
+
+
 async def create_tool_call(
     db: AsyncSession,
     *,

--- a/backend/app/schemas/agent.py
+++ b/backend/app/schemas/agent.py
@@ -289,6 +289,24 @@ class ParkedCall(BaseSchema):
     tool_args: dict[str, Any] = Field(default_factory=dict)
 
 
+class RunStep(BaseSchema):
+    """One tool call an execution of a run made, and what came back from it."""
+
+    tool_call_id: str = Field(
+        description="The provider's id for the call, so a surface can match it to a step it drew."
+    )
+    tool_name: str
+    args: dict[str, Any] = Field(default_factory=dict)
+    result: str | None = Field(
+        default=None,
+        description=(
+            "What the tool returned, or the retry message when it failed. Null on the "
+            "call the run is parked on - it has not run yet, and it is the one being "
+            "decided."
+        ),
+    )
+
+
 class AgentRunResult(BaseSchema):
     """What the agent answered, and what the run cost."""
 
@@ -298,6 +316,16 @@ class AgentRunResult(BaseSchema):
     cost_usd: Decimal
     input_tokens: int
     output_tokens: int
+    steps: list[RunStep] = Field(
+        default_factory=list,
+        description=(
+            "What *this* execution called, in order. A resumed run streams nothing - the "
+            "continuation runs over HTTP - so without this a surface could show the answer "
+            "and none of the work behind it: approving a call appeared to do nothing, and "
+            "a second approval request arrived for a step that had never been drawn. Empty "
+            "on a run that called nothing."
+        ),
+    )
     parked: list[ParkedCall] = Field(
         default_factory=list,
         description=(

--- a/backend/app/schemas/agent.py
+++ b/backend/app/schemas/agent.py
@@ -307,6 +307,15 @@ class RunStep(BaseSchema):
     )
 
 
+class SettledCall(BaseSchema):
+    """What a call the run had already made finally returned."""
+
+    tool_call_id: str = Field(
+        description="The step a surface already drew, which is the one to update rather than add."
+    )
+    result: str
+
+
 class AgentRunResult(BaseSchema):
     """What the agent answered, and what the run cost."""
 
@@ -324,6 +333,15 @@ class AgentRunResult(BaseSchema):
             "and none of the work behind it: approving a call appeared to do nothing, and "
             "a second approval request arrived for a step that had never been drawn. Empty "
             "on a run that called nothing."
+        ),
+    )
+    settled: list[SettledCall] = Field(
+        default_factory=list,
+        description=(
+            "What the calls this execution *inherited* returned - on a resume, the very "
+            "call somebody approved. It was made by the previous execution, so it is not "
+            "in `steps`; it belongs to a step the caller already drew. Empty on a run "
+            "that inherited nothing."
         ),
     )
     parked: list[ParkedCall] = Field(

--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -1206,6 +1206,33 @@ def _observability_of(stored: dict[str, Any]) -> ObservabilitySpec | None:
         return None
 
 
+@dataclass(frozen=True)
+class RunSegment:
+    """One execution of a run, and what it did while it lasted.
+
+    A run is executed once when it is started and once more every time somebody
+    approves what it parked on, so "the run" and "this execution of it" are
+    different things and only the second one knows what the model just called.
+
+    `tool_calls` is that difference made available to a caller. The resume
+    endpoint is why it exists: a continuation runs over HTTP rather than the
+    socket a conversation streams, so its `tool_call` frames reach nobody, and a
+    client that was handed only the answer had no way to draw the steps that
+    produced it. Approving a call showed nothing happening and then asked for a
+    second approval nothing on screen accounted for.
+
+    Attributes:
+        output: What the agent answered, empty when it parked again or stopped.
+        run: The run row, as `finish` left it.
+        tool_calls: What this execution called, in order, each with what came
+            back - `None` on the call the run is now parked on.
+    """
+
+    output: str
+    run: AgentRun
+    tool_calls: list[RecordedToolCall]
+
+
 def _prompt_text(user_prompt: str | list[Any] | None) -> str | None:
     """The words to record as the user's turn, if there are any.
 
@@ -2588,7 +2615,7 @@ class AgentRunnerService:
             assembled = await AttachmentRouter(
                 prepared.workspace.backend if prepared.workspace is not None else None
             ).build_prompt(prompt, attachments)
-        answered = await self._run(
+        segment = await self._run(
             prepared,
             user_prompt=assembled,
             message_history=message_history,
@@ -2598,7 +2625,7 @@ class AgentRunnerService:
             outbound.extend(prepared.outbound)
         if outbound_refused is not None:
             outbound_refused.extend(prepared.outbound_refused)
-        return answered
+        return segment.output, segment.run
 
     async def parked_calls(self, ctx: AuthContext, run: AgentRun) -> list[ParkedCall]:
         """What this run is waiting on a decision for, right now.
@@ -2634,7 +2661,7 @@ class AgentRunnerService:
             if approval.status == "pending"
         ]
 
-    async def resume(self, ctx: AuthContext, run_id: UUID) -> tuple[str, AgentRun]:
+    async def resume(self, ctx: AuthContext, run_id: UUID) -> RunSegment:
         """Continue a parked run now that its tool calls have been decided.
 
         Runs the *version the run was parked on*, not whatever is published now:
@@ -2655,6 +2682,14 @@ class AgentRunnerService:
         secret deleted since the park, a removed model profile or a capability
         dropped in a deploy refuses this attempt rather than the run: the
         decision stands, and resuming works again once the spec does.
+
+        Returns:
+            The continuation as a :class:`RunSegment` - what it answered, the row,
+            and **what it called on the way there**. The last of those is the only
+            record a caller gets: the continuation runs over HTTP rather than the
+            socket a conversation streams, so nothing announces its tool calls, and
+            a surface handed just the answer drew a turn in which approving a call
+            was followed by a second approval request for work it could not show.
 
         Raises:
             NotFoundError: If the run is not in this organization.
@@ -2883,7 +2918,7 @@ class AgentRunnerService:
         user_prompt: str | list[Any] | None,
         message_history: list[Any] | None,
         deferred_tool_results: DeferredToolResults | None,
-    ) -> tuple[str, AgentRun]:
+    ) -> RunSegment:
         """Execute the agent and account for it, however it ends.
 
         The one place a run is executed, so a parked call, a budget stop, a
@@ -2985,7 +3020,7 @@ class AgentRunnerService:
             # run missing from history is a run nobody is accountable for.
             await self.db.commit()
 
-        return output, prepared.run
+        return RunSegment(output=output, run=prepared.run, tool_calls=called)
 
     async def list_runs(
         self,

--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -155,7 +155,12 @@ from app.services.skill_workspace import MaterialisedSkills, collect_changes
 from app.services.skill_workspace import materialise as materialise_skills
 from app.services.skills import SkillService
 from app.services.spend import month_start, organization_monthly_spend
-from app.services.transcript import RecordedToolCall, TranscriptService, tool_calls_in
+from app.services.transcript import (
+    RecordedToolCall,
+    TranscriptService,
+    settled_calls_in,
+    tool_calls_in,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1226,11 +1231,16 @@ class RunSegment:
         run: The run row, as `finish` left it.
         tool_calls: What this execution called, in order, each with what came
             back - `None` on the call the run is now parked on.
+        settled: What the calls it *inherited* returned, by tool call id. A resume
+            runs the call somebody approved, and that call was made by the previous
+            execution - so its return arrives here without it, and it belongs to a
+            step already on screen rather than to a new one.
     """
 
     output: str
     run: AgentRun
     tool_calls: list[RecordedToolCall]
+    settled: dict[str, str]
 
 
 def _prompt_text(user_prompt: str | list[Any] | None) -> str | None:
@@ -2953,6 +2963,7 @@ class AgentRunnerService:
         paused: PausedRunState | None = None
         budget_scope: BudgetScope | None = None
         called: list[RecordedToolCall] = []
+        settled: dict[str, str] = {}
         try:
             result = await prepared.execute(
                 user_prompt,
@@ -2962,7 +2973,14 @@ class AgentRunnerService:
             # `new_messages`, not `all_messages`: a resumed run is handed
             # everything up to the park as history, and the wider list would
             # write the first attempt's calls again under the same run.
-            called = tool_calls_in(result.new_messages())
+            new_messages = result.new_messages()
+            called = tool_calls_in(new_messages)
+            # And what the *inherited* calls returned. On a resume the approved
+            # call was made by the previous execution, so only its return is new -
+            # `tool_calls_in` has nothing to hang it on and drops it, which left
+            # the one call a person reviewed as the one call with no recorded
+            # output anywhere (agenticos#506).
+            settled = settled_calls_in(new_messages)
             if isinstance(result.output, DeferredToolRequests):
                 paused = PausedRunState(
                     messages=ModelMessagesTypeAdapter.dump_python(
@@ -3011,6 +3029,7 @@ class AgentRunnerService:
                 prompt=_prompt_text(user_prompt),
                 answer=output,
                 tool_calls=called,
+                settled=settled,
                 model_label=prepared.built.model_label,
             )
             # Committed here rather than left to the session context: that exit
@@ -3020,7 +3039,7 @@ class AgentRunnerService:
             # run missing from history is a run nobody is accountable for.
             await self.db.commit()
 
-        return RunSegment(output=output, run=prepared.run, tool_calls=called)
+        return RunSegment(output=output, run=prepared.run, tool_calls=called, settled=settled)
 
     async def list_runs(
         self,

--- a/backend/app/services/approvals.py
+++ b/backend/app/services/approvals.py
@@ -24,11 +24,25 @@ from app.core.audit import record_audit
 from app.core.config import settings
 from app.core.exceptions import BadRequestError, NotFoundError
 from app.core.permissions import AuthContext
-from app.db.models.agent_run import ApprovalStatus, RunStatus, ToolApproval
+from app.db.models.agent_run import AgentRun, ApprovalStatus, RunStatus, ToolApproval
 from app.repositories import agent_run_repo
 from app.repositories.agent_run import ApprovalFilters, ApprovalRow
+from app.services.transcript import TranscriptService
 
 logger = logging.getLogger(__name__)
+
+
+def _parked_tool_call_ids(run: AgentRun) -> list[str]:
+    """The steps this run stopped on, off the state it parked with.
+
+    `paused_state["tool_call_ids"]` maps approval id to the call it parked, which
+    is the only link between an approval row and the step in the transcript -
+    the approval itself does not carry one. Empty for a run parked before that map
+    was stored, which is a step that cannot be closed rather than one to guess at.
+    """
+    state = run.paused_state or {}
+    parked: dict[str, str] = state.get("tool_call_ids", {})
+    return list(parked.values())
 
 
 class ApprovalService:
@@ -231,6 +245,13 @@ class ApprovalService:
         ordinary answer for a run with a second call still inside its window. A
         run parks on *all* of its outstanding calls at once, so ending it while
         one is still pending would take away a decision somebody can still make.
+
+        The transcript is closed here too, and this is the only place that can do
+        it. Every other ending runs the call and records what it returned; an
+        expiry runs nothing, so the step written when the run parked would stay
+        *open* for ever - and a reader coming back to the conversation sees a
+        command apparently still executing, days after the run it belonged to was
+        cancelled.
         """
         run = await agent_run_repo.get_run(self.db, run_id, organization_id=organization_id)
         if run is None or run.status != RunStatus.AWAITING_APPROVAL.value:
@@ -241,6 +262,16 @@ class ApprovalService:
         if any(approval.status == ApprovalStatus.PENDING.value for approval in approvals):
             return 0
 
+        # Before `finish_run`, which clears the state these ids come from.
+        await TranscriptService(self.db).record(
+            run,
+            prompt=None,
+            answer="",
+            settled=dict.fromkeys(
+                _parked_tool_call_ids(run),
+                f"Not performed: no decision within {settings.APPROVAL_EXPIRY_HOURS}h.",
+            ),
+        )
         await agent_run_repo.finish_run(
             self.db,
             run=run,

--- a/backend/app/services/transcript.py
+++ b/backend/app/services/transcript.py
@@ -25,7 +25,7 @@ must not make the run inside it unaccountable.
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
@@ -105,6 +105,33 @@ def tool_calls_in(messages: Sequence[ModelMessage]) -> list[RecordedToolCall]:
     ]
 
 
+def settled_calls_in(messages: Sequence[ModelMessage]) -> dict[str, str]:
+    """Returns that arrived without the call they belong to, by tool call id.
+
+    The other half of :func:`tool_calls_in`, and the shape a resume produces. A
+    parked call is replayed against a history that already holds its
+    `ToolCallPart`, so what is *new* is only its `ToolReturnPart` - which
+    `tool_calls_in` drops, having nothing to hang it on. That is why the one call
+    a person deliberately reviewed was the one whose output the transcript did not
+    hold: the row was written open when the run parked and nothing ever closed it.
+
+    An orphan return outside a resume would mean a provider answered a call nobody
+    made, so this is empty for an ordinary run.
+    """
+    called = {
+        part.tool_call_id
+        for message in messages
+        for part in message.parts
+        if isinstance(part, ToolCallPart)
+    }
+    return {
+        part.tool_call_id: str(part.content)
+        for message in messages
+        for part in message.parts
+        if isinstance(part, ToolReturnPart | RetryPromptPart) and part.tool_call_id not in called
+    }
+
+
 class TranscriptService:
     """Writes a run's turns into the conversation the run belongs to."""
 
@@ -118,6 +145,7 @@ class TranscriptService:
         prompt: str | None,
         answer: str,
         tool_calls: Sequence[RecordedToolCall] = (),
+        settled: Mapping[str, str] | None = None,
         model_label: str | None = None,
     ) -> None:
         """Write whatever this run produced, and never fail the run for it.
@@ -135,6 +163,13 @@ class TranscriptService:
         money, it changed a workspace, and history showed the run going straight
         from one approval to the next. The tool calls are the record of what
         happened; the answer is only how it ended.
+
+        `settled` closes rows this run wrote *earlier*, which is the only way an
+        approved call's output is ever recorded: the row was created open when the
+        run parked, and the resume that finally ran it produces the return without
+        the call it belongs to (:func:`settled_calls_in`). So the one call somebody
+        deliberately reviewed used to be the one call the transcript showed
+        finishing with nothing under it.
 
         Never raises, and never poisons the session it shares with the caller.
         The answer has already been produced and the money already spent; losing
@@ -162,6 +197,8 @@ class TranscriptService:
                         content=prompt,
                         run_id=run.id,
                     )
+                for tool_call_id, result in (settled or {}).items():
+                    await self._settle(run, tool_call_id=tool_call_id, result=result)
                 if answer or tool_calls:
                     await self._answer(
                         run.conversation_id,
@@ -180,6 +217,23 @@ class TranscriptService:
                 "transcript_write_failed",
                 extra={"run_id": str(run.id), "conversation_id": str(run.conversation_id)},
             )
+
+    async def _settle(self, run: AgentRun, *, tool_call_id: str, result: str) -> None:
+        """Close a call this run left open, if the row is still open.
+
+        Silent when there is no such row. A return with no call in the transcript
+        is a call that was never written - a surface that recorded nothing, or a
+        run whose park predates the write - and inventing a row here would put a
+        step in a turn that has no other trace of it.
+        """
+        row = await conversation_repo.get_open_tool_call_in_run(
+            self.db, run_id=run.id, tool_call_id=tool_call_id
+        )
+        if row is None:
+            return
+        await conversation_repo.complete_tool_call(
+            self.db, db_tool_call=row, result=result, completed_at=datetime.now(UTC)
+        )
 
     async def _answer(
         self,

--- a/backend/app/services/transcript.py
+++ b/backend/app/services/transcript.py
@@ -124,9 +124,17 @@ class TranscriptService:
 
         `prompt` is `None` where there is nothing new to record: a resumed run
         picks up at the tool call it stopped on, and inventing a user turn there
-        would put words in somebody's mouth. An empty `answer` is not written
-        either - a run that parked on an approval or broke has no answer, and a
-        blank assistant message reads as the agent replying with silence.
+        would put words in somebody's mouth.
+
+        An empty `answer` is written when the run called something, and skipped
+        when it did not. A blank assistant message with nothing under it reads as
+        the agent replying with silence, but a run that parked, broke or was
+        stopped mid-work *did* things - and gating the write on the answer meant
+        none of them were recorded. A continuation that ran a command and then
+        parked on a second one wrote nothing at all: the command ran, it cost
+        money, it changed a workspace, and history showed the run going straight
+        from one approval to the next. The tool calls are the record of what
+        happened; the answer is only how it ended.
 
         Never raises, and never poisons the session it shares with the caller.
         The answer has already been produced and the money already spent; losing
@@ -154,7 +162,7 @@ class TranscriptService:
                         content=prompt,
                         run_id=run.id,
                     )
-                if answer:
+                if answer or tool_calls:
                     await self._answer(
                         run.conversation_id,
                         run,

--- a/backend/tests/api/test_platform_routes.py
+++ b/backend/tests/api/test_platform_routes.py
@@ -38,8 +38,10 @@ from app.core.exceptions import NotFoundError, RunExecutionError
 from app.core.permissions import ROLE_PERMS, AuthContext, OrgRoleName, Perm, Scope
 from app.db.models.resource_grant import Visibility
 from app.main import app
+from app.services.agent_runner import RunSegment
 from app.services.sharing import SharingService
 from app.services.stats import StatsService
+from app.services.transcript import RecordedToolCall
 
 pytestmark = pytest.mark.anyio
 
@@ -896,6 +898,64 @@ class TestResumeConveysAFailedContinuation:
         body = response.json()
         assert body["error"]["code"] == "RUN_EXECUTION_FAILED"
         assert body["error"]["details"] == {"run_id": str(run_id), "status": "failed"}
+
+
+class TestResumeAnswersWithWhatTheContinuationDid:
+    """The steps of the second half of a turn, which nothing else carries.
+
+    A continuation executes inside this request rather than on the socket the
+    conversation streams, so its tool calls reach no client unless this response
+    holds them. Without them a surface could draw the approved call finishing and
+    nothing after it - which is how approving a command showed no command running,
+    and a second approval request arrived for a step that had never appeared.
+    """
+
+    async def test_the_continuations_tool_calls_are_in_the_response(
+        self, as_role: ClientFactory, synthetic_roles: None
+    ) -> None:
+        run = MagicMock(
+            id=uuid4(),
+            status="awaiting_approval",
+            cost_usd=Decimal("0.02"),
+            input_tokens=13,
+            output_tokens=7,
+        )
+
+        class _Resuming:
+            async def resume(self, *args: Any, **kwargs: Any) -> Any:
+                return RunSegment(
+                    output="",
+                    run=run,
+                    tool_calls=[
+                        RecordedToolCall(
+                            tool_call_id="call-1",
+                            tool_name="execute",
+                            args={"command": "python read.py"},
+                            result="6 sheets",
+                        ),
+                        RecordedToolCall(
+                            tool_call_id="call-2",
+                            tool_name="execute",
+                            args={"command": "python parse.py"},
+                        ),
+                    ],
+                )
+
+            async def parked_calls(self, *args: Any, **kwargs: Any) -> list[Any]:
+                return []
+
+        overrides = {deps.get_agent_runner_service: lambda: _Resuming()}
+        async with as_role(only(Perm.APPROVALS_DECIDE), overrides) as client:
+            response = await client.post(_url(f"/runs/{run.id}/resume"))
+
+        assert response.status_code == 200
+        steps = response.json()["steps"]
+        assert [(step["tool_name"], step["args"], step["result"]) for step in steps] == [
+            ("execute", {"command": "python read.py"}, "6 sheets"),
+            # The call the run has parked on again: no result, because it has not
+            # run - it is the one being decided.
+            ("execute", {"command": "python parse.py"}, None),
+        ]
 
 
 # -- the stats routes, whose gate is the scope parameter ----------------------

--- a/backend/tests/api/test_platform_routes.py
+++ b/backend/tests/api/test_platform_routes.py
@@ -926,6 +926,7 @@ class TestResumeAnswersWithWhatTheContinuationDid:
                 return RunSegment(
                     output="",
                     run=run,
+                    settled={"call-0": "read 6 sheets"},
                     tool_calls=[
                         RecordedToolCall(
                             tool_call_id="call-1",
@@ -956,6 +957,10 @@ class TestResumeAnswersWithWhatTheContinuationDid:
             # run - it is the one being decided.
             ("execute", {"command": "python parse.py"}, None),
         ]
+        # And what the call the approver decided returned. It is not a step - the
+        # caller drew that one before the run parked - so it arrives separately and
+        # updates it, rather than putting the same command in the turn twice.
+        assert response.json()["settled"] == [{"tool_call_id": "call-0", "result": "read 6 sheets"}]
 
 
 # -- the stats routes, whose gate is the scope parameter ----------------------

--- a/backend/tests/integration/test_message_run_link.py
+++ b/backend/tests/integration/test_message_run_link.py
@@ -24,7 +24,7 @@ from sqlalchemy import select
 from app.agents.spec import AgentSpec
 from app.db.models.agent import Agent
 from app.db.models.agent_run import AgentRun
-from app.db.models.conversation import Conversation, Message
+from app.db.models.conversation import Conversation, Message, ToolCall
 from app.db.models.organization import Organization
 from app.db.models.resource_grant import Visibility
 from app.db.models.user import User
@@ -276,3 +276,83 @@ class TestLinkingAPromptWrittenBeforeItsRun:
 
         assert elsewhere.run_id is None
         assert await _transcript_of(db, run) == []
+
+
+class TestFindingTheCallAnApprovalLeftOpen:
+    """`get_open_tool_call_in_run` against real rows.
+
+    A gated call's row is written when the run parks, with no result. The thing
+    that finally runs it is a resume, whose messages carry the return without the
+    call it belongs to - so this lookup is the only way back to the row, and what
+    it lands on decides whether an approved command's output is recorded at all.
+    """
+
+    async def _call(self, db, message: Message, *, tool_call_id: str, completed: bool) -> ToolCall:
+        call = ToolCall(
+            id=uuid.uuid4(),
+            message_id=message.id,
+            tool_call_id=tool_call_id,
+            tool_name="execute",
+            args={"command": "python read.py"},
+            started_at=_START,
+            status="completed" if completed else "running",
+            completed_at=_START + timedelta(seconds=2) if completed else None,
+        )
+        db.add(call)
+        await db.flush()
+        return call
+
+    async def test_the_open_call_this_run_made_is_the_one_found(self, db) -> None:
+        organization = await _org(db)
+        owner = await _user(db)
+        agent = await _agent(db, organization, owner)
+        conversation = await _conversation(db, organization, owner)
+        run = await _run(db, conversation, agent, started_at=_START, ended_at=None)
+        parked = await _turn(db, conversation, role="assistant", content="", at=_START, run=run)
+        call = await self._call(db, parked, tool_call_id="call-1", completed=False)
+
+        found = await conversation_repo.get_open_tool_call_in_run(
+            db, run_id=run.id, tool_call_id="call-1"
+        )
+
+        assert found is not None and found.id == call.id
+
+    async def test_a_call_that_already_returned_is_not_settled_twice(self, db) -> None:
+        """Its result is recorded. Finding it again would overwrite what one call
+        returned with what a later one did."""
+        organization = await _org(db)
+        owner = await _user(db)
+        agent = await _agent(db, organization, owner)
+        conversation = await _conversation(db, organization, owner)
+        run = await _run(db, conversation, agent, started_at=_START, ended_at=None)
+        turn = await _turn(db, conversation, role="assistant", content="", at=_START, run=run)
+        await self._call(db, turn, tool_call_id="call-1", completed=True)
+
+        found = await conversation_repo.get_open_tool_call_in_run(
+            db, run_id=run.id, tool_call_id="call-1"
+        )
+
+        assert found is None
+
+    async def test_another_runs_call_with_the_same_id_is_left_alone(self, db) -> None:
+        """The run is the boundary, not the conversation. Two runs in one thread
+        can carry the same provider id, and settling the wrong one writes an
+        answer into a turn nobody was deciding about."""
+        organization = await _org(db)
+        owner = await _user(db)
+        agent = await _agent(db, organization, owner)
+        conversation = await _conversation(db, organization, owner)
+        mine = await _run(db, conversation, agent, started_at=_START, ended_at=None)
+        theirs = await _run(
+            db, conversation, agent, started_at=_START + timedelta(minutes=1), ended_at=None
+        )
+        their_turn = await _turn(
+            db, conversation, role="assistant", content="", at=_START, run=theirs
+        )
+        await self._call(db, their_turn, tool_call_id="call-1", completed=False)
+
+        found = await conversation_repo.get_open_tool_call_in_run(
+            db, run_id=mine.id, tool_call_id="call-1"
+        )
+
+        assert found is None

--- a/backend/tests/test_agent_runner.py
+++ b/backend/tests/test_agent_runner.py
@@ -33,6 +33,7 @@ from app.services.agent_runner import (
     PausedRunState,
     PreparedRun,
     RecordedDelegation,
+    RunSegment,
     month_start,
 )
 from app.services.approvals import ApprovalService
@@ -584,7 +585,9 @@ class TestFilesAcrossOneTurn:
         prepared = _prepared()
         prepared.workspace = MagicMock()
         service.prepare = AsyncMock(return_value=prepared)
-        service._run = AsyncMock(return_value=("answered", prepared.run))
+        service._run = AsyncMock(
+            return_value=RunSegment(output="answered", run=prepared.run, tool_calls=[])
+        )
         built = AsyncMock(return_value="a prompt with a reference")
 
         with patch("app.services.agent_runner.AttachmentRouter") as router:
@@ -605,7 +608,9 @@ class TestFilesAcrossOneTurn:
         prepared.outbound = []
         prepared.outbound_refused = []
         service.prepare = AsyncMock(return_value=prepared)
-        service._run = AsyncMock(return_value=("answered", prepared.run))
+        service._run = AsyncMock(
+            return_value=RunSegment(output="answered", run=prepared.run, tool_calls=[])
+        )
 
         with patch("app.services.agent_runner.AttachmentRouter") as router:
             await service.execute(MagicMock(), uuid.uuid4(), "hello")
@@ -622,7 +627,9 @@ class TestFilesAcrossOneTurn:
         prepared.outbound = [produced]
         prepared.outbound_refused = ["/huge.csv"]
         service.prepare = AsyncMock(return_value=prepared)
-        service._run = AsyncMock(return_value=("answered", prepared.run))
+        service._run = AsyncMock(
+            return_value=RunSegment(output="answered", run=prepared.run, tool_calls=[])
+        )
 
         outbound: list[Any] = []
         refused: list[str] = []
@@ -644,7 +651,9 @@ class TestFilesAcrossOneTurn:
         prepared.outbound = [MagicMock()]
         prepared.outbound_refused = []
         service.prepare = AsyncMock(return_value=prepared)
-        service._run = AsyncMock(return_value=("answered", prepared.run))
+        service._run = AsyncMock(
+            return_value=RunSegment(output="answered", run=prepared.run, tool_calls=[])
+        )
 
         answer, _run = await service.execute(MagicMock(), uuid.uuid4(), "hello")
 
@@ -1308,9 +1317,9 @@ class TestResume:
             ),
             patch.object(service.skills, "resolve_for_agent", new=AsyncMock(return_value=[])),
         ):
-            output, _ = await service.resume(_ctx(), run.id)
+            segment = await service.resume(_ctx(), run.id)
 
-        assert output == "sent"
+        assert segment.output == "sent"
         assert finish.call_args.kwargs["status"] == RunStatus.COMPLETED.value
 
         deferred = built.agent.run.call_args.kwargs["deferred_tool_results"]
@@ -1364,6 +1373,73 @@ class TestResume:
 
         written = record.await_args.kwargs
         assert (written["prompt"], written["answer"]) == (None, "sent")
+
+    @pytest.mark.anyio
+    async def test_a_continuation_hands_back_what_it_called(self):
+        """The only account of the second half of a turn.
+
+        A continuation runs inside the resume request, not on the socket the
+        conversation streams, so no `tool_call` frame announces what it did. A
+        caller handed only the answer drew the approved call finishing and nothing
+        after it - so approving looked like it had done nothing, and the next
+        approval request arrived for a step that had never appeared.
+        """
+        service = AgentRunnerService(_db())
+        approval = self._approval(status=ApprovalStatus.APPROVED.value, tool_args={})
+        run = _parked_run(
+            paused_state={"messages": [], "tool_call_ids": {str(approval.id): "call-1"}}
+        )
+        built = self._built()
+        built.agent.run = AsyncMock(
+            return_value=MagicMock(
+                output="six sheets",
+                new_messages=lambda: [
+                    ModelResponse(
+                        parts=[
+                            ToolCallPart(
+                                tool_name="execute",
+                                args={"command": "python read.py"},
+                                tool_call_id="call-2",
+                            )
+                        ]
+                    ),
+                    ModelRequest(
+                        parts=[
+                            ToolReturnPart(
+                                tool_name="execute", content="6 sheets", tool_call_id="call-2"
+                            )
+                        ]
+                    ),
+                ],
+            )
+        )
+
+        with (
+            patch(
+                "app.services.agent_runner.agent_run_repo.claim_parked_run",
+                new=AsyncMock(return_value=run),
+            ),
+            patch(
+                "app.services.agent_runner.agent_run_repo.list_approvals_for_run",
+                new=AsyncMock(return_value=[approval]),
+            ),
+            patch(
+                "app.services.agent_runner.agent_repo.get_version",
+                new=AsyncMock(return_value=self._version()),
+            ),
+            patch("app.services.agent_runner.build_agent", return_value=built),
+            patch("app.services.agent_runner.agent_run_repo.finish_run", new=AsyncMock()),
+            patch.object(service.registry, "get", new=AsyncMock(return_value=MagicMock())),
+            patch.object(
+                service.models, "resolve", new=AsyncMock(return_value=MagicMock(label="gpt-4.1"))
+            ),
+            patch.object(service.skills, "resolve_for_agent", new=AsyncMock(return_value=[])),
+        ):
+            segment = await service.resume(_ctx(), run.id)
+
+        assert [(call.tool_name, call.args, call.result) for call in segment.tool_calls] == [
+            ("execute", {"command": "python read.py"}, "6 sheets")
+        ]
 
     @pytest.mark.anyio
     async def test_a_resumed_run_keeps_the_spend_it_had_already_booked(self):

--- a/backend/tests/test_agent_runner.py
+++ b/backend/tests/test_agent_runner.py
@@ -586,7 +586,7 @@ class TestFilesAcrossOneTurn:
         prepared.workspace = MagicMock()
         service.prepare = AsyncMock(return_value=prepared)
         service._run = AsyncMock(
-            return_value=RunSegment(output="answered", run=prepared.run, tool_calls=[])
+            return_value=RunSegment(output="answered", run=prepared.run, tool_calls=[], settled={})
         )
         built = AsyncMock(return_value="a prompt with a reference")
 
@@ -609,7 +609,7 @@ class TestFilesAcrossOneTurn:
         prepared.outbound_refused = []
         service.prepare = AsyncMock(return_value=prepared)
         service._run = AsyncMock(
-            return_value=RunSegment(output="answered", run=prepared.run, tool_calls=[])
+            return_value=RunSegment(output="answered", run=prepared.run, tool_calls=[], settled={})
         )
 
         with patch("app.services.agent_runner.AttachmentRouter") as router:
@@ -628,7 +628,7 @@ class TestFilesAcrossOneTurn:
         prepared.outbound_refused = ["/huge.csv"]
         service.prepare = AsyncMock(return_value=prepared)
         service._run = AsyncMock(
-            return_value=RunSegment(output="answered", run=prepared.run, tool_calls=[])
+            return_value=RunSegment(output="answered", run=prepared.run, tool_calls=[], settled={})
         )
 
         outbound: list[Any] = []
@@ -652,7 +652,7 @@ class TestFilesAcrossOneTurn:
         prepared.outbound_refused = []
         service.prepare = AsyncMock(return_value=prepared)
         service._run = AsyncMock(
-            return_value=RunSegment(output="answered", run=prepared.run, tool_calls=[])
+            return_value=RunSegment(output="answered", run=prepared.run, tool_calls=[], settled={})
         )
 
         answer, _run = await service.execute(MagicMock(), uuid.uuid4(), "hello")

--- a/backend/tests/test_approval_expiry.py
+++ b/backend/tests/test_approval_expiry.py
@@ -46,11 +46,20 @@ def _approval(
     )
 
 
-def _parked_run(status: str = RunStatus.AWAITING_APPROVAL.value) -> MagicMock:
+def _parked_run(
+    status: str = RunStatus.AWAITING_APPROVAL.value,
+    *,
+    paused_state: dict | None = None,
+) -> MagicMock:
     """A run row as it looks while it waits on a decision."""
     return MagicMock(
         id=uuid.uuid4(),
         status=status,
+        paused_state=(
+            {"messages": [], "tool_call_ids": {str(uuid.uuid4()): "call-1"}}
+            if paused_state is None
+            else paused_state
+        ),
         input_tokens=1200,
         output_tokens=340,
         cost_usd=Decimal("0.0210"),
@@ -89,10 +98,16 @@ class _Sweep:
         self._ctx.start()
         self._audit = patch("app.services.approvals.record_audit", new=AsyncMock())
         self.audit = self._audit.start()
+        # The transcript write is the service's own, so it is stubbed at the same
+        # boundary as the repository rather than left to fail into `record`'s
+        # own exception handler - which is what "passing" would have meant.
+        self._transcript = patch("app.services.approvals.TranscriptService")
+        self.record = self._transcript.start().return_value.record = AsyncMock()
         self.expired = await ApprovalService(_db()).expire_stale()
         return self
 
     async def __aexit__(self, *exc_info: object) -> bool:
+        self._transcript.stop()
         self._audit.stop()
         self._ctx.stop()
         return False
@@ -200,6 +215,31 @@ class TestTheRunBehindIt:
         ended = sweep.finish_run.await_args.kwargs
         assert (ended["input_tokens"], ended["output_tokens"]) == (1200, 340)
         assert (ended["cost_usd"], ended["cost_is_partial"]) == (Decimal("0.0210"), False)
+
+    async def test_the_step_it_parked_on_stops_looking_like_it_is_running(self):
+        """Every other ending runs the call and records what came back. An expiry
+        runs nothing, so the step written when the run parked stayed *open* - and
+        a reader coming back to the conversation saw a command apparently still
+        executing days after the run was cancelled.
+
+        Written before `finish_run`, which clears the state the ids come from."""
+        async with _Sweep([_approval()], run=_parked_run()) as sweep:
+            pass
+
+        written = sweep.record.await_args.kwargs
+        assert list(written["settled"]) == ["call-1"]
+        assert str(settings.APPROVAL_EXPIRY_HOURS) in written["settled"]["call-1"]
+        # No turn is invented for it: nothing was said and nothing was called.
+        assert (written["prompt"], written["answer"]) == (None, "")
+
+    async def test_a_run_parked_before_the_step_map_existed_settles_nothing(self):
+        """The map from approval to tool call is the only link there is. Without
+        it the step cannot be closed - which is a step left open, not one to
+        guess at."""
+        async with _Sweep([_approval()], run=_parked_run(paused_state={"messages": []})) as sweep:
+            pass
+
+        assert sweep.record.await_args.kwargs["settled"] == {}
 
     async def test_a_run_with_a_second_call_still_inside_the_window_is_left_parked(self):
         """A run parks on all of its outstanding calls at once. Ending it while

--- a/backend/tests/test_subagent_resolution.py
+++ b/backend/tests/test_subagent_resolution.py
@@ -1609,9 +1609,9 @@ class TestResumingIntoADelegation:
             patch(f"{RUNNER}.build_agent") as build,
         ):
             build.return_value.agent.run = AsyncMock(return_value=MagicMock(output="continued"))
-            output, _ = await service.resume(_ctx(), run.id)
+            segment = await service.resume(_ctx(), run.id)
 
-        assert output == "continued"
+        assert segment.output == "continued"
         runtime = build.call_args_list[0].kwargs["resources"][SUBAGENT_RUNTIME_RESOURCE]
         assert list(runtime.stash.resuming) == [parked_at]
         # And the replay is told to run that `task` call again, which is what puts

--- a/backend/tests/test_transcript.py
+++ b/backend/tests/test_transcript.py
@@ -8,10 +8,11 @@ channel bot's own write recorded two lines of text and dropped the tool calls,
 the model and the version.
 
 These tests are about the rows, not about the calls: what a reader of run history
-can see afterwards, and - just as much - what is deliberately not written. A
-blank assistant message for a run that parked would read as the agent answering
-with silence, and an invented user turn on a resume would put words in somebody's
-mouth.
+can see afterwards, and - just as much - what is deliberately not written. An
+assistant message with neither an answer nor a call under it would read as the
+agent replying with silence, and an invented user turn on a resume would put
+words in somebody's mouth. A run that answered nothing but *did* something is the
+opposite case, and it is written: the calls are what happened.
 """
 
 from __future__ import annotations
@@ -232,15 +233,51 @@ class TestWritingTheTranscript:
             "assistant"
         ]
 
-    async def test_a_run_that_produced_no_answer_still_records_the_question(self, conversations):
-        """A run that parked, was stopped or broke. A blank assistant message
-        would read as the agent replying with silence - and the question is what
-        makes the run interpretable at all."""
+    async def test_a_run_that_produced_no_answer_and_called_nothing_records_the_question(
+        self, conversations
+    ):
+        """A run refused or stopped before it did anything. An assistant message
+        with nothing under it would read as the agent replying with silence - and
+        the question is what makes the run interpretable at all."""
         await TranscriptService(_session()).record(_run(), prompt="charge it", answer="")
 
         assert [call.kwargs["role"] for call in conversations.create_message.await_args_list] == [
             "user"
         ]
+
+    async def test_a_continuation_that_parked_again_still_records_what_it_ran(self, conversations):
+        """The shape a resumed run stops in, and the one that used to vanish.
+
+        A continuation runs the approved call, then reaches a second gated one and
+        parks: no answer, so nothing was written at all - not the command that ran,
+        not what it returned. It ran, it cost money and it changed a workspace, and
+        history showed the run going from one approval straight to the next.
+        """
+        await TranscriptService(_session()).record(
+            _run(),
+            prompt=None,
+            answer="",
+            tool_calls=[
+                RecordedToolCall(
+                    tool_call_id="c1",
+                    tool_name="execute",
+                    args={"command": "python read.py"},
+                    result="6 sheets",
+                ),
+                RecordedToolCall(
+                    tool_call_id="c2", tool_name="execute", args={"command": "python parse.py"}
+                ),
+            ],
+        )
+
+        answer = conversations.create_message.await_args.kwargs
+        assert (answer["role"], answer["content"]) == ("assistant", "")
+        assert [
+            call.kwargs["tool_call_id"] for call in conversations.create_tool_call.await_args_list
+        ] == ["c1", "c2"]
+        # The one the run is now parked on is left open; the one that ran is not.
+        conversations.complete_tool_call.assert_awaited_once()
+        assert conversations.complete_tool_call.await_args.kwargs["result"] == "6 sheets"
 
     async def test_a_run_with_no_conversation_writes_nothing(self, conversations):
         """The API may run an agent without one. There is nowhere to write a

--- a/backend/tests/test_transcript.py
+++ b/backend/tests/test_transcript.py
@@ -33,7 +33,12 @@ from pydantic_ai.messages import (
     UserPromptPart,
 )
 
-from app.services.transcript import RecordedToolCall, TranscriptService, tool_calls_in
+from app.services.transcript import (
+    RecordedToolCall,
+    TranscriptService,
+    settled_calls_in,
+    tool_calls_in,
+)
 
 pytestmark = pytest.mark.anyio
 
@@ -146,6 +151,47 @@ class TestReadingToolCallsOffARun:
         )
 
         assert calls == []
+
+
+class TestReadingWhatAnInheritedCallReturned:
+    """The half `tool_calls_in` drops, which is the whole of a resume's work.
+
+    An approved call was made by the execution that parked, so a resume produces
+    its return and not the call - and a return with nothing to hang it on is
+    dropped. That is why the one call somebody deliberately reviewed was the one
+    call whose output the transcript did not hold.
+    """
+
+    def test_a_return_with_no_call_beside_it_is_what_the_approved_call_produced(self):
+        settled = settled_calls_in([_returned("execute", "c1", "6 sheets")])
+
+        assert settled == {"c1": "6 sheets"}
+
+    def test_a_call_made_and_returned_here_is_not_an_inherited_one(self):
+        """It is a step of its own, and `tool_calls_in` already has it. Counting
+        it twice would settle a row that is not open and draw the call twice."""
+        settled = settled_calls_in(
+            [_called("execute", "c1", command="ls"), _returned("execute", "c1", "a b c")]
+        )
+
+        assert settled == {}
+
+    def test_a_refusal_settles_the_call_too(self):
+        """A call the model was told to retry did happen and did fail. Leaving the
+        row open would read as "still running" for ever."""
+        settled = settled_calls_in(
+            [
+                ModelRequest(
+                    parts=[
+                        RetryPromptPart(
+                            content="no such file", tool_name="execute", tool_call_id="c1"
+                        )
+                    ]
+                )
+            ]
+        )
+
+        assert settled == {"c1": "no such file"}
 
 
 class TestWritingTheTranscript:
@@ -278,6 +324,35 @@ class TestWritingTheTranscript:
         # The one the run is now parked on is left open; the one that ran is not.
         conversations.complete_tool_call.assert_awaited_once()
         assert conversations.complete_tool_call.await_args.kwargs["result"] == "6 sheets"
+
+    async def test_the_approved_call_gets_the_result_it_was_waiting_for(self, conversations):
+        """The row the run left open when it parked, closed by the resume that ran
+        it. Without this the one call a person reviewed is the one call that opens
+        onto nothing, live and after a reload (agenticos#506)."""
+        row = MagicMock(id=uuid.uuid4())
+        conversations.get_open_tool_call_in_run = AsyncMock(return_value=row)
+        run = _run()
+
+        await TranscriptService(_session()).record(
+            run, prompt=None, answer="Six sheets.", settled={"c1": "6 sheets"}
+        )
+
+        looked_up = conversations.get_open_tool_call_in_run.await_args.kwargs
+        assert (looked_up["run_id"], looked_up["tool_call_id"]) == (run.id, "c1")
+        completed = conversations.complete_tool_call.await_args.kwargs
+        assert (completed["db_tool_call"], completed["result"]) == (row, "6 sheets")
+
+    async def test_a_result_for_a_call_nothing_recorded_writes_no_row(self, conversations):
+        """A return with no step in the transcript belongs to a call that was
+        never written. Inventing a row would put a step in a turn that has no
+        other trace of it."""
+        conversations.get_open_tool_call_in_run = AsyncMock(return_value=None)
+
+        await TranscriptService(_session()).record(
+            _run(), prompt=None, answer="done", settled={"c1": "6 sheets"}
+        )
+
+        conversations.complete_tool_call.assert_not_awaited()
 
     async def test_a_run_with_no_conversation_writes_nothing(self, conversations):
         """The API may run an agent without one. There is nowhere to write a

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -250,7 +250,7 @@ is stored is what its reader actually saw.
 | `@mention` on a channel | The same, with the handle stripped from the recorded prompt |
 | Embedded widget | The same. The visitor is anonymous; the run and the turns belong to the widget's owner |
 | HTTP API | The same when the call carries a `conversation_id`. Nothing without one — there is no thread to write a turn into, and the run row is still the record that it happened |
-| A run resumed after an approval | Its continuation — the answer and the calls it made. No user turn: it picks up at the call it stopped on, and inventing a question would put words in somebody's mouth |
+| A run resumed after an approval | Its continuation — the answer and the calls it made, and the calls even when there is no answer, which is what a continuation that parks again on a second gated call has. No user turn: it picks up at the call it stopped on, and inventing a question would put words in somebody's mouth |
 
 Two things are deliberately not recorded. A channel reply's **delivery notes** — *this
 file was too large to send* — stay out of the transcript: they are about what the
@@ -348,6 +348,26 @@ nests under the right panel rather than under whichever one started most recentl
 A child's text is never folded into the
 parent's answer: that would put words in the parent's mouth its own model never
 generated, and the conversation is persisted with them.
+
+**An approved call is not the end of the turn, and the rest of it is drawn too.**
+Approving continues the run over HTTP, so nothing about the continuation arrives on
+this conversation's socket: its steps come back in the resume's own answer and are
+appended as one more assistant turn — the calls it made, then what it said. Without
+them the second half of a turn was invisible, and a run that parked twice was the
+worst version of it: approve a command, watch nothing happen, and be asked to
+approve a second command with no step on screen accounting for the first. The
+newly parked call is drawn in that turn as *waiting for a person*, which is also
+the step the next decision is written back onto.
+
+**And the panel belongs to its conversation, not to the tab.** Opening another
+thread takes the approval panel and any pending question off screen, the way it
+already takes the delegation panels. Left there the approval was not merely
+stale but actionable: *Approve* still decided the call, from under a different
+agent's transcript, and the step it settles is in messages that are no longer
+loaded — so nothing on screen changed to say it had happened. Clearing it loses
+nothing, because the approvals queue holds the same row. The one transition that
+is not a switch is a first turn learning its own conversation id mid-stream, and
+the panel survives that.
 
 A delegate can stop for a person too — a gated tool inside a specialist parks the
 whole turn in the approval queue. The panel then closes into a *waiting for a

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -372,6 +372,13 @@ because absent means "not recorded" rather than "the same run". Live, the run id
 arrives on the `tool_approval_required` frame, which is the only frame that names
 it and the only turn that needs it; on a reload it comes off the stored message.
 
+**The time and the cost go under the end of the turn**, once, however many messages
+it took. A run reports what it has spent when it *parks*, so the figure is recorded
+on the first segment — drawn there it sat halfway up the answer, with nothing under
+the end of it. The last segment shows the run's total: each figure is cumulative as
+at that point, so the later one supersedes the earlier rather than being added to
+it, and the continuation takes its numbers from the resume's own answer.
+
 **What the approved call returned is recorded on the step that was approved.** The
 row is written open when the run parks — it has not run yet — and the resume that
 finally runs it produces the *return* without the call it belongs to, because that
@@ -379,6 +386,16 @@ call was made by the previous execution. So it settles the existing row rather t
 writing a new step: the alternative is the same command twice in one turn, and the
 alternative to *that* was the one call somebody deliberately reviewed being the one
 call that opened onto nothing.
+
+**A replayed step never animates.** A tool call is stored as running until
+something records its outcome, and not every ending records one: an approval that
+expires runs nothing, so the step it parked on was written open and stayed that
+way. Read back, it pulsed in the present tense under a conversation that had ended
+days earlier, promising a result nothing was going to deliver. So the sweep that
+expires an approval now closes the step too — the one ending that never ran the
+call — and a replayed call still marked in flight renders as **unfinished**: past
+tense, no spinner, no result. Not an error and not a success; the outcome nobody
+wrote down.
 
 **And the panel belongs to its conversation, not to the tab.** Opening another
 thread takes the approval panel and any pending question off screen, the way it

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -359,6 +359,27 @@ approve a second command with no step on screen accounting for the first. The
 newly parked call is drawn in that turn as *waiting for a person*, which is also
 the step the next decision is written back onto.
 
+**One run is one turn on screen, however many messages it took.** A run that parks
+writes what it had done so far, and each continuation is written as it happens
+rather than folded back into the message before it — rewriting a turn somebody has
+already read is worse than appending to it. So one run can leave three assistant
+rows, and drawing three avatars and three agent names down the page reads as three
+agents answering one question. `MessageList` groups *consecutive* assistant
+messages carrying the same `run_id` into one turn: the avatar and the name once, at
+the top. Consecutive is part of the rule — a person speaking between two segments
+means the turn genuinely restarts — and a message with no run recorded never groups,
+because absent means "not recorded" rather than "the same run". Live, the run id
+arrives on the `tool_approval_required` frame, which is the only frame that names
+it and the only turn that needs it; on a reload it comes off the stored message.
+
+**What the approved call returned is recorded on the step that was approved.** The
+row is written open when the run parks — it has not run yet — and the resume that
+finally runs it produces the *return* without the call it belongs to, because that
+call was made by the previous execution. So it settles the existing row rather than
+writing a new step: the alternative is the same command twice in one turn, and the
+alternative to *that* was the one call somebody deliberately reviewed being the one
+call that opened onto nothing.
+
 **And the panel belongs to its conversation, not to the tab.** Opening another
 thread takes the approval panel and any pending question off screen, the way it
 already takes the delegation panels. Left there the approval was not merely

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -445,6 +445,14 @@ Four properties worth knowing:
   streams, so nothing announced its calls, and the transcript write was skipped
   for a segment with no answer. A run that read a file, then asked to run a second
   command, showed nothing between the two approvals and recorded nothing either.
+- **And what the approved call itself returned lands on the step that was
+  approved.** It arrives separately from the continuation's own calls (`settled`,
+  not `steps`), because it was made by the execution that parked: the resume
+  produces its return without the call it belongs to, so it closes a row already
+  written rather than opening a new one. Recording it as a step would put the same
+  command in the turn twice; not recording it at all — which is what happened
+  until it did — made the one call somebody deliberately reviewed the one call with
+  no output anywhere.
 - **It stays resumable if continuing it fails.** A run is continued on the version
   it parked on, and that version's spec may have stopped building since - a secret
   a binding names deleted, a model profile removed, a capability dropped in a

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -437,6 +437,14 @@ Four properties worth knowing:
 
 - **A parked run is resumable.** Its message history is stored, so the decision is
   applied to the conversation it belongs to rather than starting again.
+- **A continuation says what it did.** `POST /runs/{id}/resume` answers with the
+  tool calls the continuation made, in order, each with what came back — and the
+  transcript records them whether or not it reached an answer. Both halves used to
+  be missing, and one approval could hide an unbounded amount of work: the agent
+  ran inside the resume request rather than on the socket the conversation
+  streams, so nothing announced its calls, and the transcript write was skipped
+  for a segment with no answer. A run that read a file, then asked to run a second
+  command, showed nothing between the two approvals and recorded nothing either.
 - **It stays resumable if continuing it fails.** A run is continued on the version
   it parked on, and that version's spec may have stopped building since - a secret
   a binding names deleted, a model profile removed, a capability dropped in a

--- a/frontend/src/components/chat/message-item.test.tsx
+++ b/frontend/src/components/chat/message-item.test.tsx
@@ -79,6 +79,7 @@ function item(
     agent?: Agent;
     onRegenerate?: () => void;
     groupPosition?: "first" | "middle" | "last" | "single";
+    continuesTurn?: boolean;
   } = {},
 ) {
   return render(<MessageItem message={message(overrides)} {...props} />);
@@ -717,5 +718,27 @@ describe("the step a reopened turn leaves open", () => {
 
     expect(screen.getByTestId("tool-old-1")).toHaveAttribute("data-open", "false");
     expect(screen.getByTestId("tool-old-2")).toHaveAttribute("data-open", "true");
+  });
+});
+
+describe("a segment that continues the turn above it", () => {
+  it("names the agent once, at the top of the turn", () => {
+    // A run that parked on an approval leaves several messages. Repeating the
+    // avatar and the name on each one read as three agents answering one
+    // question - see `continuesTurn` in `MessageList`.
+    item({}, { agent: { id: "a-1", name: "Support" } as Agent, continuesTurn: true });
+
+    expect(screen.queryByText("Support")).toBeNull();
+  });
+
+  it("keeps the gutter, so the whole turn stays in one column", () => {
+    const { container } = item(
+      {},
+      { agent: { id: "a-1", name: "Support" } as Agent, continuesTurn: true },
+    );
+
+    // The avatar slot is still rendered and still the same size - empty rather
+    // than absent, and hidden from a screen reader because it says nothing.
+    expect(container.querySelector('[aria-hidden="true"].rounded-full')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/chat/message-item.test.tsx
+++ b/frontend/src/components/chat/message-item.test.tsx
@@ -6,7 +6,7 @@ import { MessageItem, mustShowEveryStep, runsOf } from "./message-item";
 import { useAuthStore, useChatStore, useFilePreviewStore } from "@/stores";
 import { useSourcesPanelStore } from "@/stores/sources-panel-store";
 import type { Agent } from "@/types/agents";
-import type { ChatMessage, ChatMessageFile, MessagePart, ToolCall } from "@/types";
+import type { ChatMessage, ChatMessageFile, MessagePart, ToolCall, TurnUsage } from "@/types";
 
 vi.mock("./markdown-content", () => ({
   MarkdownContent: ({
@@ -80,6 +80,8 @@ function item(
     onRegenerate?: () => void;
     groupPosition?: "first" | "middle" | "last" | "single";
     continuesTurn?: boolean;
+    endsTurn?: boolean;
+    turnUsage?: TurnUsage;
   } = {},
 ) {
   return render(<MessageItem message={message(overrides)} {...props} />);
@@ -740,5 +742,43 @@ describe("a segment that continues the turn above it", () => {
     // The avatar slot is still rendered and still the same size - empty rather
     // than absent, and hidden from a screen reader because it says nothing.
     expect(container.querySelector('[aria-hidden="true"].rounded-full')).toBeInTheDocument();
+  });
+});
+
+describe("the footer of a turn drawn in several messages", () => {
+  const USAGE: TurnUsage = {
+    input_tokens: 6603,
+    output_tokens: 189,
+    cost_usd: 0.0133,
+    budget_percent: null,
+    agent_budget_percent: null,
+    sandbox: null,
+  };
+
+  it("says nothing under a segment the turn continues past", () => {
+    // The run reports what it has spent when it parks, so this used to put the
+    // time, the tokens and the cost halfway up the answer.
+    const { unmount } = item({ content: "Waiting.", usage: USAGE }, { endsTurn: false });
+    expect(screen.queryByText(/6,603/)).toBeNull();
+    unmount();
+
+    // The same message where the turn does end, so the absence above is the
+    // grouping and not a query that matches nothing.
+    item({ content: "Waiting.", usage: USAGE });
+    expect(screen.getByText(/6,603/)).toBeInTheDocument();
+  });
+
+  it("draws the turn's figure under the message that ends it", () => {
+    // Recorded on an earlier segment, shown under the last one - one figure for
+    // one turn, where the answer actually ends.
+    item({ content: "Six sheets." }, { turnUsage: USAGE });
+
+    expect(screen.getByText(/6,603/)).toBeInTheDocument();
+  });
+
+  it("falls back to its own figure when it is the whole turn", () => {
+    item({ content: "Six sheets.", usage: USAGE });
+
+    expect(screen.getByText(/6,603/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/chat/message-item.tsx
+++ b/frontend/src/components/chat/message-item.tsx
@@ -216,6 +216,16 @@ interface MessageItemProps {
   /** The agent that produced this turn, when one did. */
   agent?: Agent;
   groupPosition?: "first" | "middle" | "last" | "single";
+  /**
+   * This message continues the turn above it rather than starting one.
+   *
+   * True for the later segments of a run that parked on an approval and was
+   * resumed - see `continuesTurn` in `MessageList`. The avatar and the agent's
+   * name are drawn once at the top of the turn; a segment that repeated them made
+   * one run read as three agents answering the same question. The gutter is kept
+   * empty rather than removed, so the whole turn stays in one column.
+   */
+  continuesTurn?: boolean;
   onRegenerate?: () => void;
 }
 
@@ -223,6 +233,7 @@ export function MessageItem({
   message,
   agent,
   groupPosition,
+  continuesTurn = false,
   openLastStep = false,
   onRegenerate,
 }: MessageItemProps) {
@@ -243,6 +254,9 @@ export function MessageItem({
       className={cn(
         "group relative flex gap-2 overflow-visible sm:gap-4",
         isGrouped ? "py-2 sm:py-3" : "py-3 sm:py-4",
+        // Tight against the segment above, because it is the same turn: the
+        // ordinary gap between messages would read as a pause the run never took.
+        continuesTurn && "pt-0",
         isUser && "flex-row-reverse",
       )}
     >
@@ -260,13 +274,20 @@ export function MessageItem({
         />
       )}
       <div
+        aria-hidden={continuesTurn}
         className={cn(
           "z-10 flex h-8 w-8 flex-shrink-0 items-center justify-center overflow-hidden rounded-full sm:h-9 sm:w-9",
-          isUser ? "bg-foreground text-background" : "bg-muted text-foreground",
-          isGrouped && !isUser && "ring-background ring-2",
+          // Empty, not absent: the gutter is what keeps every segment of the turn
+          // in one column under the avatar that opened it.
+          continuesTurn
+            ? "bg-transparent"
+            : isUser
+              ? "bg-foreground text-background"
+              : "bg-muted text-foreground",
+          isGrouped && !isUser && !continuesTurn && "ring-background ring-2",
         )}
       >
-        {isUser && authUser?.avatar_url ? (
+        {continuesTurn ? null : isUser && authUser?.avatar_url ? (
           <Image
             src={`/api/users/avatar/${authUser.id}?v=${avatarVersion}`}
             alt=""
@@ -298,7 +319,7 @@ export function MessageItem({
         {/* Which agent answered, on the turn it answered. A conversation that
             switched agents mid-way says so, instead of relabelling the whole
             thread with whatever is selected now. */}
-        {!isUser && agent && (
+        {!isUser && agent && !continuesTurn && (
           <p className="text-foreground/55 font-mono text-[10px] tracking-wider uppercase">
             {agent.name}
             {/* The version, where the transcript recorded one. An agent gets

--- a/frontend/src/components/chat/message-item.tsx
+++ b/frontend/src/components/chat/message-item.tsx
@@ -3,7 +3,7 @@
 import { AgentAvatar } from "@/components/agents/agent-avatar";
 import { cn } from "@/lib/utils";
 import { toolEntry } from "@/lib/tool-catalog";
-import type { ChatMessage, ChatMessageFile, MessagePart } from "@/types";
+import type { ChatMessage, ChatMessageFile, MessagePart, TurnUsage } from "@/types";
 import type { Agent } from "@/types/agents";
 import { ToolCallCard } from "./tool-call-card";
 import { AgentSteps } from "./agent-step";
@@ -226,6 +226,24 @@ interface MessageItemProps {
    * empty rather than removed, so the whole turn stays in one column.
    */
   continuesTurn?: boolean;
+  /**
+   * The turn ends here, so the time and the cost belong under this message.
+   *
+   * False for every segment of a grouped turn but the last. A run reports what it
+   * has spent when it *parks*, so the footer drawn from the message that carries
+   * the figure put the time, the tokens and the cost halfway up the answer, with
+   * nothing under the end of it. Defaults to true: a message that is its own turn
+   * ends it.
+   */
+  endsTurn?: boolean;
+  /**
+   * What the whole turn cost, when that was recorded on an earlier segment of it.
+   *
+   * Passed rather than read off the message for the reason above - `MessageList`
+   * is the only thing that can see the turn. Absent falls back to this message's
+   * own figure, which is the same thing for a turn of one message.
+   */
+  turnUsage?: TurnUsage;
   onRegenerate?: () => void;
 }
 
@@ -234,6 +252,8 @@ export function MessageItem({
   agent,
   groupPosition,
   continuesTurn = false,
+  endsTurn = true,
+  turnUsage,
   openLastStep = false,
   onRegenerate,
 }: MessageItemProps) {
@@ -245,6 +265,9 @@ export function MessageItem({
   const { user: authUser, avatarVersion } = useAuthStore();
   const isGrouped = groupPosition && groupPosition !== "single";
 
+  // The turn's cost, which a grouped turn recorded on the segment that parked
+  // rather than on the one the footer is drawn under.
+  const footerUsage = turnUsage ?? message.usage;
   const sources = !isUser ? extractSources(message) : [];
   const hasSources = sources.length > 0 && !message.isStreaming;
   const onCiteClick = hasSources ? (index: number) => openSources(sources, index) : undefined;
@@ -491,7 +514,7 @@ export function MessageItem({
           </div>
         )}
 
-        {!message.isStreaming && message.content && (
+        {!message.isStreaming && message.content && endsTurn && (
           <div className={cn("flex items-center gap-2", isUser && "flex-row-reverse")}>
             {message.timestamp && (
               <span className="text-muted-foreground text-[10px]">
@@ -501,7 +524,7 @@ export function MessageItem({
                 })}
               </span>
             )}
-            {!isUser && message.usage && <MessageCost usage={message.usage} />}
+            {!isUser && footerUsage && <MessageCost usage={footerUsage} />}
             <CopyButton
               text={message.content}
               className={cn(

--- a/frontend/src/components/chat/message-list.test.tsx
+++ b/frontend/src/components/chat/message-list.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { MessageList, lastToolTurnIndex } from "./message-list";
+import { MessageList, continuesTurn, lastToolTurnIndex } from "./message-list";
 import type { ChatMessage } from "@/types";
 
 const state = vi.hoisted(() => ({
@@ -10,6 +10,7 @@ const state = vi.hoisted(() => ({
     id: string;
     agent?: string;
     groupPosition?: string;
+    continuesTurn: boolean;
     canRegenerate: boolean;
     openLastStep: boolean;
   }[],
@@ -24,12 +25,14 @@ vi.mock("./message-item", () => ({
     message,
     agent,
     groupPosition,
+    continuesTurn,
     openLastStep,
     onRegenerate,
   }: {
     message: ChatMessage;
     agent?: { name: string };
     groupPosition?: string;
+    continuesTurn?: boolean;
     openLastStep?: boolean;
     onRegenerate?: () => void;
   }) => {
@@ -37,6 +40,7 @@ vi.mock("./message-item", () => ({
       id: message.id,
       agent: agent?.name,
       groupPosition,
+      continuesTurn: continuesTurn === true,
       canRegenerate: onRegenerate !== undefined,
       openLastStep: openLastStep === true,
     });
@@ -296,5 +300,57 @@ describe("the last turn that used a tool", () => {
     ];
 
     expect(lastToolTurnIndex(messages)).toBe(-1);
+  });
+});
+
+describe("one run drawn as one turn", () => {
+  it("continues the turn for the next segment of the same run", () => {
+    // A run parks on an approval, somebody decides, it runs again. Each segment
+    // is its own message - three avatars and three agent names down the page for
+    // one question, which reads as three agents having answered it.
+    const messages = [
+      message({ id: "a", runId: "r-9" }),
+      message({ id: "b", runId: "r-9" }),
+      message({ id: "c", runId: "r-9" }),
+    ];
+
+    expect([0, 1, 2].map((i) => continuesTurn(messages, i))).toEqual([false, true, true]);
+  });
+
+  it("starts a new turn for a different run", () => {
+    const messages = [message({ id: "a", runId: "r-9" }), message({ id: "b", runId: "r-10" })];
+
+    expect(continuesTurn(messages, 1)).toBe(false);
+  });
+
+  it("never groups messages with no run recorded", () => {
+    // Absent is "not recorded", not "the same run". Guessing from adjacency
+    // would fold two unrelated answers into one turn.
+    const messages = [message({ id: "a" }), message({ id: "b" })];
+
+    expect(continuesTurn(messages, 1)).toBe(false);
+  });
+
+  it("restarts the turn when the person said something in between", () => {
+    // Two segments of one run with a question between them is not one turn: the
+    // person spoke, and the answer after that is a reply to them.
+    const messages = [
+      message({ id: "a", runId: "r-9" }),
+      message({ id: "u", role: "user", content: "wait", runId: "r-9" }),
+      message({ id: "b", runId: "r-9" }),
+    ];
+
+    expect(continuesTurn(messages, 2)).toBe(false);
+  });
+
+  it("hands the flag to the item", () => {
+    render(
+      <MessageList
+        messages={[message({ id: "m-1", runId: "r-9" }), message({ id: "m-2", runId: "r-9" })]}
+      />,
+    );
+
+    expect(rendered("m-1")?.continuesTurn).toBe(false);
+    expect(rendered("m-2")?.continuesTurn).toBe(true);
   });
 });

--- a/frontend/src/components/chat/message-list.test.tsx
+++ b/frontend/src/components/chat/message-list.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { MessageList, continuesTurn, lastToolTurnIndex } from "./message-list";
+import { MessageList, continuesTurn, endsTurn, lastToolTurnIndex, turnUsage } from "./message-list";
 import type { ChatMessage } from "@/types";
 
 const state = vi.hoisted(() => ({
@@ -352,5 +352,61 @@ describe("one run drawn as one turn", () => {
 
     expect(rendered("m-1")?.continuesTurn).toBe(false);
     expect(rendered("m-2")?.continuesTurn).toBe(true);
+  });
+});
+
+describe("where a turn's time and cost belong", () => {
+  const USAGE = {
+    input_tokens: 6603,
+    output_tokens: 189,
+    cost_usd: 0.0133,
+    budget_percent: null,
+    agent_budget_percent: null,
+    sandbox: null,
+  };
+
+  it("ends the turn on its last segment, not on every one", () => {
+    const messages = [
+      message({ id: "a", runId: "r-9" }),
+      message({ id: "b", runId: "r-9" }),
+      message({ id: "c", runId: "r-9" }),
+    ];
+
+    expect([0, 1, 2].map((i) => endsTurn(messages, i))).toEqual([false, false, true]);
+  });
+
+  it("ends a turn of one message on that message", () => {
+    expect(endsTurn([message({ id: "a" })], 0)).toBe(true);
+  });
+
+  it("carries the figure forward from the segment that recorded it", () => {
+    // A run reports what it has spent when it *parks*, so the cost sat on the
+    // first segment - halfway up the answer, with nothing under the end of it.
+    const messages = [
+      message({ id: "a", runId: "r-9", usage: USAGE }),
+      message({ id: "b", runId: "r-9" }),
+    ];
+
+    expect(turnUsage(messages, 1)).toBe(USAGE);
+  });
+
+  it("prefers the last figure in the turn, which is the run's total by then", () => {
+    const later = { ...USAGE, cost_usd: 0.0201 };
+    const messages = [
+      message({ id: "a", runId: "r-9", usage: USAGE }),
+      message({ id: "b", runId: "r-9", usage: later }),
+    ];
+
+    expect(turnUsage(messages, 1)).toBe(later);
+  });
+
+  it("never reaches back past the turn it belongs to", () => {
+    // The previous answer's cost is not this answer's cost.
+    const messages = [
+      message({ id: "a", runId: "r-8", usage: USAGE }),
+      message({ id: "b", runId: "r-9" }),
+    ];
+
+    expect(turnUsage(messages, 1)).toBeUndefined();
   });
 });

--- a/frontend/src/components/chat/message-list.tsx
+++ b/frontend/src/components/chat/message-list.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from "react";
 
 import { useAgents } from "@/hooks";
-import type { ChatMessage } from "@/types";
+import type { ChatMessage, TurnUsage } from "@/types";
 import { MessageItem } from "./message-item";
 
 interface MessageListProps {
@@ -58,6 +58,32 @@ export function continuesTurn(messages: ChatMessage[], index: number): boolean {
   return message.runId !== undefined && message.runId === previous.runId;
 }
 
+/** Whether the turn ends here, so the time and the cost belong under this message. */
+export function endsTurn(messages: ChatMessage[], index: number): boolean {
+  return !continuesTurn(messages, index + 1);
+}
+
+/**
+ * What the turn cost, wherever in it that was recorded.
+ *
+ * The figure belongs to the turn and not to the segment that happened to carry
+ * it: a run reports what it has spent when it parks, which is the *first*
+ * segment, so a footer drawn from the message it sits on put the tokens and the
+ * cost in the middle of the answer with nothing under the end of it.
+ *
+ * The last segment that recorded anything wins, because each figure is the run's
+ * total as at that point rather than that segment's own share - summing them
+ * would count the first segment twice.
+ */
+export function turnUsage(messages: ChatMessage[], index: number): TurnUsage | undefined {
+  // The walk cannot run off the start: `continuesTurn` is false at index 0, which
+  // is what stops it, so no bound is needed and none is written - a guard that
+  // cannot fail is a line no test can reach.
+  let at = index;
+  while (messages[at]?.usage === undefined && continuesTurn(messages, at)) at--;
+  return messages[at]?.usage;
+}
+
 export function MessageList({ messages, onRegenerate }: MessageListProps) {
   // Agents are resolved here rather than stamped onto the message, so a renamed
   // agent is labelled by its current name and a new picture appears on old
@@ -100,6 +126,8 @@ export function MessageList({ messages, onRegenerate }: MessageListProps) {
           agent={message.agentId ? byId.get(message.agentId) : undefined}
           groupPosition={getGroupPosition(message)}
           continuesTurn={continuesTurn(messages, index)}
+          endsTurn={endsTurn(messages, index)}
+          turnUsage={turnUsage(messages, index)}
           openLastStep={index === openStepsAt}
           onRegenerate={
             onRegenerate && index === lastAssistantIndex && !message.isStreaming

--- a/frontend/src/components/chat/message-list.tsx
+++ b/frontend/src/components/chat/message-list.tsx
@@ -32,6 +32,32 @@ export function lastToolTurnIndex(messages: ChatMessage[]): number {
   return -1;
 }
 
+/**
+ * Whether this message continues the turn above it rather than starting one.
+ *
+ * One run can leave several assistant messages. It parks on an approval, somebody
+ * decides, it runs again - and each segment is written as it happens, because
+ * folding it back into the message before it would rewrite a turn somebody has
+ * already read. That is right for the transcript and wrong on screen: one run
+ * drew three avatars and three agent names down the page, which reads as three
+ * agents answering one question.
+ *
+ * So consecutive assistant messages of the same run are drawn as one turn - the
+ * avatar and the name once, at the top. Consecutive is part of the rule, not an
+ * optimisation: a user message between two segments means the person said
+ * something in between, and the turn genuinely restarts there.
+ *
+ * No run id never groups. It is "not recorded", not "its own run", and guessing
+ * from adjacency would fold two unrelated answers into one turn.
+ */
+export function continuesTurn(messages: ChatMessage[], index: number): boolean {
+  const message = messages[index];
+  const previous = messages[index - 1];
+  if (message === undefined || previous === undefined) return false;
+  if (message.role !== "assistant" || previous.role !== "assistant") return false;
+  return message.runId !== undefined && message.runId === previous.runId;
+}
+
 export function MessageList({ messages, onRegenerate }: MessageListProps) {
   // Agents are resolved here rather than stamped onto the message, so a renamed
   // agent is labelled by its current name and a new picture appears on old
@@ -73,6 +99,7 @@ export function MessageList({ messages, onRegenerate }: MessageListProps) {
           message={message}
           agent={message.agentId ? byId.get(message.agentId) : undefined}
           groupPosition={getGroupPosition(message)}
+          continuesTurn={continuesTurn(messages, index)}
           openLastStep={index === openStepsAt}
           onRegenerate={
             onRegenerate && index === lastAssistantIndex && !message.isStreaming

--- a/frontend/src/components/chat/tool-call-card.test.tsx
+++ b/frontend/src/components/chat/tool-call-card.test.tsx
@@ -104,6 +104,18 @@ describe("a tool call in the transcript", () => {
     expect(screen.queryByLabelText("Running")).toBeNull();
   });
 
+  it("says a replayed call that never finished in the past tense, without a spinner", () => {
+    // The step of an expired approval, or of a run that broke mid-call. Nothing
+    // on this screen can finish it, so an animation promises a result that is
+    // never coming - it pulsed forever under a conversation that ended days ago.
+    card({ name: "search_documents", status: "unfinished", result: undefined });
+
+    expect(screen.queryByText("Searching the documents")).toBeNull();
+    expect(screen.getByText("Knowledge Base Search")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Running")).toBeNull();
+    expect(screen.queryByLabelText("Failed")).toBeNull();
+  });
+
   it("reads a workspace call as a sentence about the file", () => {
     const { unmount } = card({
       name: "write_file",

--- a/frontend/src/hooks/use-chat.test.tsx
+++ b/frontend/src/hooks/use-chat.test.tsx
@@ -1035,6 +1035,195 @@ describe("useChat - approvals and questions", () => {
     expect(answers.at(-1)?.content).toBe("Done - 3 rows deleted.");
   });
 
+  it("takes the approval panel off screen when another conversation is opened", () => {
+    // It followed the reader from thread to thread. Worse than stale: *Approve*
+    // still worked, so a call could be decided from under another agent's
+    // transcript - and the step it settles lives in messages that are no longer
+    // loaded, so nothing on screen changed to say it had been. The row is not lost
+    // by clearing the panel; the approvals queue holds it.
+    useConversationStore.getState().setCurrentConversationId("c-1");
+    const { result } = renderHook(() => useChat(), { wrapper });
+    receive("tool_approval_required", {
+      run_id: "r-9",
+      action_requests: [{ id: "ar-1", tool_call_id: "tc-1", tool_name: "execute", args: {} }],
+      review_configs: [],
+    });
+    expect(result.current.pendingApproval).not.toBeNull();
+
+    act(() => {
+      useConversationStore.getState().setCurrentConversationId("c-2");
+    });
+
+    expect(result.current.pendingApproval).toBeNull();
+  });
+
+  it("takes a pending question off screen when another conversation is opened", () => {
+    // The same, one turn earlier: answering here would put words typed under one
+    // transcript into a turn belonging to another.
+    useConversationStore.getState().setCurrentConversationId("c-1");
+    const { result } = renderHook(() => useChat(), { wrapper });
+    receive("ask_user", {
+      questions: [{ question: "Which sheet?", options: ["Plan"], allow_custom: true }],
+    });
+    expect(result.current.pendingQuestions).not.toBeNull();
+
+    act(() => {
+      useConversationStore.getState().setCurrentConversationId("c-2");
+    });
+
+    expect(result.current.pendingQuestions).toBeNull();
+  });
+
+  it("keeps the panel through the turn that creates its own conversation", () => {
+    // A first message parks on an approval: `conversation_created` arrives mid-turn
+    // and moves the id from null to a real one. That is not a switch, and clearing
+    // there would take the panel off the turn that is still on screen.
+    const { result } = renderHook(() => useChat(), { wrapper });
+    receive("tool_approval_required", {
+      run_id: "r-9",
+      action_requests: [{ id: "ar-1", tool_call_id: "tc-1", tool_name: "execute", args: {} }],
+      review_configs: [],
+    });
+
+    act(() => {
+      receive("conversation_created", { conversation_id: "c-new" });
+    });
+
+    expect(result.current.pendingApproval).not.toBeNull();
+  });
+
+  it("draws what the continuation did, not just what it answered", async () => {
+    // The whole second half of a turn used to be invisible. A continuation runs
+    // inside the resume request, so its `tool_call` frames go to that response and
+    // never to this socket: approving a command showed the approved step finishing
+    // and nothing else, then an answer that accounted for work nobody had seen.
+    post.mockImplementation((url: string) =>
+      url.endsWith("/resume")
+        ? Promise.resolve({
+            run_id: "r-9",
+            output: "Six sheets.",
+            status: "completed",
+            steps: [
+              // The decided call comes back with the segment on some providers.
+              // Its step is already on screen in the turn that parked, so drawing
+              // it again would show one command twice.
+              { tool_call_id: "tc-1", tool_name: "execute", args: {}, result: "ok" },
+              {
+                tool_call_id: "tc-2",
+                tool_name: "execute",
+                args: { command: "python parse.py" },
+                result: "6 sheets",
+              },
+            ],
+            parked: [],
+          })
+        : Promise.resolve({}),
+    );
+    const { result } = renderHook(() => useChat(), { wrapper });
+    receive("model_request_start", {});
+    receive("tool_call", { tool_call_id: "tc-1", tool_name: "execute", args: {} });
+    receive("tool_approval_required", {
+      run_id: "r-9",
+      action_requests: [{ id: "ar-1", tool_call_id: "tc-1", tool_name: "execute", args: {} }],
+      review_configs: [],
+    });
+    receive("complete", {});
+
+    await act(async () => {
+      await result.current.sendResumeDecisions([{ type: "approve" }]);
+    });
+
+    const continuation = useChatStore.getState().messages.at(-1);
+    expect(continuation?.parts?.map((part) => part.toolCall?.id ?? part.type)).toEqual([
+      "tc-2",
+      "text",
+    ]);
+    expect(continuation?.parts?.[0]?.toolCall).toMatchObject({
+      name: "execute",
+      args: { command: "python parse.py" },
+      result: "6 sheets",
+      status: "completed",
+    });
+    expect(continuation?.content).toBe("Six sheets.");
+  });
+
+  it("draws the step the continuation parked on, and decides against that step", async () => {
+    // The sequence in the report: approve, see nothing happen, get asked to approve
+    // again. The second gated call had no step anywhere, and the panel still pointed
+    // at the first turn - so the decision after it was written back onto a tool call
+    // that message does not contain.
+    post.mockImplementation((url: string) =>
+      url.endsWith("/resume")
+        ? Promise.resolve({
+            run_id: "r-9",
+            output: "",
+            status: "awaiting_approval",
+            steps: [
+              {
+                tool_call_id: "tc-2",
+                tool_name: "execute",
+                args: { command: "python parse.py" },
+                result: null,
+              },
+            ],
+            parked: [
+              {
+                id: "ar-2",
+                tool_call_id: "tc-2",
+                tool_name: "execute",
+                tool_args: { command: "python parse.py" },
+              },
+            ],
+          })
+        : Promise.resolve({}),
+    );
+    const { result } = renderHook(() => useChat(), { wrapper });
+    receive("model_request_start", {});
+    receive("tool_call", { tool_call_id: "tc-1", tool_name: "execute", args: {} });
+    receive("tool_approval_required", {
+      run_id: "r-9",
+      action_requests: [{ id: "ar-1", tool_call_id: "tc-1", tool_name: "execute", args: {} }],
+      review_configs: [],
+    });
+    receive("complete", {});
+
+    await act(async () => {
+      await result.current.sendResumeDecisions([{ type: "approve" }]);
+    });
+
+    const continuation = useChatStore.getState().messages.at(-1);
+    const step = continuation?.parts?.find((part) => part.toolCall?.id === "tc-2");
+    // `awaiting_approval`, not a spinner: it produces no result until somebody
+    // decides, which is what the panel below is asking.
+    expect(step?.toolCall?.status).toBe("awaiting_approval");
+    expect(result.current.pendingApproval?.messageId).toBe(continuation?.id);
+  });
+
+  it("adds no continuation message when the resume produced nothing", async () => {
+    // A resume into a refusal: nothing called, nothing said. A blank assistant
+    // message there reads as the agent answering with silence.
+    post.mockImplementation((url: string) =>
+      url.endsWith("/resume")
+        ? Promise.resolve({ run_id: "r-9", output: "", status: "completed", steps: [], parked: [] })
+        : Promise.resolve({}),
+    );
+    const { result } = renderHook(() => useChat(), { wrapper });
+    receive("model_request_start", {});
+    receive("tool_approval_required", {
+      run_id: "r-9",
+      action_requests: [{ id: "ar-1", tool_call_id: "tc-1", tool_name: "execute", args: {} }],
+      review_configs: [],
+    });
+    receive("complete", {});
+    const before = useChatStore.getState().messages.length;
+
+    await act(async () => {
+      await result.current.sendResumeDecisions([{ type: "reject" }]);
+    });
+
+    expect(useChatStore.getState().messages).toHaveLength(before);
+  });
+
   it("closes a parked delegate's panel once the run is approved and resumes", async () => {
     // The crux of agenticos#173. A sync delegate parks on an approval and its panel
     // reads "waiting for approval". The resume runs over HTTP - no delegation frames

--- a/frontend/src/hooks/use-chat.test.tsx
+++ b/frontend/src/hooks/use-chat.test.tsx
@@ -1147,6 +1147,69 @@ describe("useChat - approvals and questions", () => {
     expect(continuation?.content).toBe("Six sheets.");
   });
 
+  it("puts the continuation in the same turn as the message that parked", async () => {
+    // One run, one turn. The segments are separate messages - each is written as
+    // it happens rather than folded back into the one before it - so the run id is
+    // what tells the list they are one answer and not three agents.
+    post.mockImplementation((url: string) =>
+      url.endsWith("/resume")
+        ? Promise.resolve({ run_id: "r-9", output: "Six sheets.", status: "completed" })
+        : Promise.resolve({}),
+    );
+    const { result } = renderHook(() => useChat(), { wrapper });
+    receive("model_request_start", {});
+    receive("tool_approval_required", {
+      run_id: "r-9",
+      action_requests: [{ id: "ar-1", tool_call_id: "tc-1", tool_name: "execute", args: {} }],
+      review_configs: [],
+    });
+    receive("complete", {});
+
+    await act(async () => {
+      await result.current.sendResumeDecisions([{ type: "approve" }]);
+    });
+
+    const assistants = useChatStore
+      .getState()
+      .messages.filter((message) => message.role === "assistant");
+    expect(assistants.map((message) => message.runId)).toEqual(["r-9", "r-9"]);
+  });
+
+  it("shows what the approved call returned, on the step that was approved", async () => {
+    // The one call somebody deliberately reviewed used to be the one that opened
+    // onto nothing: it was made by the execution that parked, so the resume
+    // produces only its return and there is no step to hang it on but this one.
+    post.mockImplementation((url: string) =>
+      url.endsWith("/resume")
+        ? Promise.resolve({
+            run_id: "r-9",
+            output: "Six sheets.",
+            status: "completed",
+            settled: [{ tool_call_id: "tc-1", result: "6 sheets" }],
+          })
+        : Promise.resolve({}),
+    );
+    const { result } = renderHook(() => useChat(), { wrapper });
+    receive("model_request_start", {});
+    receive("tool_call", { tool_call_id: "tc-1", tool_name: "execute", args: {} });
+    receive("tool_approval_required", {
+      run_id: "r-9",
+      action_requests: [{ id: "ar-1", tool_call_id: "tc-1", tool_name: "execute", args: {} }],
+      review_configs: [],
+    });
+    receive("complete", {});
+
+    await act(async () => {
+      await result.current.sendResumeDecisions([{ type: "approve" }]);
+    });
+
+    const approved = useChatStore
+      .getState()
+      .messages.flatMap((message) => message.parts ?? [])
+      .find((part) => part.toolCall?.id === "tc-1");
+    expect(approved?.toolCall).toMatchObject({ status: "completed", result: "6 sheets" });
+  });
+
   it("draws the step the continuation parked on, and decides against that step", async () => {
     // The sequence in the report: approve, see nothing happen, get asked to approve
     // again. The second gated call had no step anywhere, and the panel still pointed

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -28,6 +28,7 @@ import {
   resolveAwaitingOnResume,
   resumeFailureStatus,
 } from "@/lib/delegations";
+import { buildAssistantParts } from "@/lib/conversation-to-chat";
 import { WS_URL } from "@/lib/constants";
 import { toast } from "sonner";
 
@@ -622,13 +623,23 @@ export function useChat(options: UseChatOptions = {}) {
     setDelegations([]);
   }, [tenantId, clearQueued]);
 
-  // The other half: a delegation belongs to a run in *this* conversation, and the
-  // panels are drawn under whatever transcript is on screen. Switching to another
-  // conversation clears the messages and the queue and used to leave the panels, so
-  // the previous thread's specialist names, prompts, streamed answers and costs were
-  // drawn under the new one - until the next message, which is the only other thing
-  // that clears them. Cleared here rather than on `complete`, which the panels
-  // deliberately outlive: a background delegation reports after the parent answered.
+  // The other half: a delegation, an approval and a question all belong to a run in
+  // *this* conversation, and all three are drawn over whatever transcript is on
+  // screen. Switching to another conversation clears the messages and the queue and
+  // used to leave them, so the previous thread's specialist names, prompts, streamed
+  // answers and costs were drawn under the new one - until the next message, which is
+  // the only other thing that clears them. Cleared here rather than on `complete`,
+  // which the panels deliberately outlive: a background delegation reports after the
+  // parent answered.
+  //
+  // The approval panel is the worst of the three, because it is not only stale but
+  // actionable: an *approve* under another agent's transcript decides a call the
+  // person is no longer looking at, and its `messageId` points into a conversation
+  // whose messages are gone, so the step it settles is settled nowhere. It is not
+  // lost by clearing it - the approvals queue holds the same rows, and reopening the
+  // conversation is not what the decision needs. A question is cleared for the same
+  // reason in reverse: answering it here would put words typed under one transcript
+  // into a turn belonging to another.
   //
   // Not keyed by conversation, deliberately. A turn that creates its conversation
   // learns the id from `conversation_created` mid-stream, so the key would move under
@@ -640,15 +651,18 @@ export function useChat(options: UseChatOptions = {}) {
   //
   // A layout effect for the reason the one above is one: before the paint, so no
   // frame of the previous conversation's panels is shown under this one's transcript.
-  const delegationsBelongTo = useRef(activeConversationId);
+  const panelsBelongTo = useRef(activeConversationId);
   useLayoutEffect(() => {
-    const previous = delegationsBelongTo.current;
-    delegationsBelongTo.current = activeConversationId;
+    const previous = panelsBelongTo.current;
+    panelsBelongTo.current = activeConversationId;
     // `previous === null` is the turn that just created its conversation being told
     // its id, not a different conversation being opened - clearing there would throw
-    // away the panels of the turn still streaming.
+    // away the panels of the turn still streaming, and a first turn that parks on an
+    // approval is exactly that turn.
     if (previous === activeConversationId || previous === null) return;
     setDelegations([]);
+    setPendingApproval(null);
+    setPendingQuestions(null);
   }, [activeConversationId]);
 
   /** Record one decision on the `approvals` row it belongs to. */
@@ -726,9 +740,64 @@ export function useChat(options: UseChatOptions = {}) {
         // parks on it. Nothing announces that here - the resume ran over HTTP, so
         // no `tool_approval_required` frame arrives - so the panel used to close on
         // a run that was still blocked, and the only way to finish it was the
-        // approvals queue on another page. Re-open it on the same turn, which is
-        // where the new step was drawn.
+        // approvals queue on another page.
         const parkedAgain = resumed.parked ?? [];
+        const parkedAgainIds = new Set(parkedAgain.map((call) => call.tool_call_id));
+        // What the continuation did, as steps. Nothing else carries them: the
+        // agent ran inside the resume request, so its `tool_call` frames went to
+        // that response and not to this socket. Drawing only the answer left the
+        // second half of the turn missing - approve a command and nothing appears
+        // to run, then a second approval arrives for a step nobody has seen, and
+        // the transcript ends with a reply that accounts for neither.
+        //
+        // The calls just decided are dropped: their steps are already on screen in
+        // the message that parked, and were marked finished above.
+        const decided = new Set(parked.actionRequests.map((request) => request.tool_call_id));
+        const steps: ToolCall[] = (resumed.steps ?? [])
+          .filter((step) => !decided.has(step.tool_call_id))
+          .map((step) => ({
+            id: step.tool_call_id,
+            name: step.tool_name,
+            args: step.args,
+            result: step.result ?? undefined,
+            // A call with a pending approval against it has not run and never
+            // will until somebody decides - the state the panel below is asking
+            // about, not a spinner that resolves.
+            status: parkedAgainIds.has(step.tool_call_id) ? "awaiting_approval" : "completed",
+          }));
+        // **The answer is shown, not discarded.** `resume_run` runs the agent and
+        // returns what it said, but it returns it *here* - over HTTP, to the caller
+        // - and not over the socket this conversation is streaming. So the reply
+        // used to exist and be thrown away: the panel vanished, a toast said the
+        // run was continuing, and the chat then sat unchanged forever. Reloading
+        // the page showed the finished turn, which is how this looked like an
+        // approval that did nothing.
+        //
+        // One message for the whole continuation, steps then answer, which is the
+        // order they happened in and the order a reloaded conversation replays
+        // them in. Nothing is added for a continuation that neither called
+        // anything nor said anything - a resume into a refusal has both empty.
+        const continuation = nanoid();
+        if (steps.length > 0 || resumed.output) {
+          // A finished assistant message, which is also what makes the file panel
+          // re-read: `turns` counts those, and a resumed call is usually the one
+          // that was gated - an `execute`, a write - so the workspace beside the
+          // transcript is exactly what changed.
+          addMessage({
+            id: continuation,
+            role: "assistant",
+            content: resumed.output,
+            toolCalls: steps,
+            parts: buildAssistantParts(steps, resumed.output, continuation),
+            timestamp: new Date(),
+            conversationId: conversationId || undefined,
+            // The agent that was answering when the run parked. Without it the
+            // continuation rendered under the generic robot with no name beside it,
+            // so the second half of one turn looked like a different agent had
+            // written it - the same turn, two faces.
+            agentId: turnAgentIdRef.current ?? undefined,
+          });
+        }
         if (parkedAgain.length > 0) {
           setPendingApproval({
             actionRequests: parkedAgain.map((call) => ({
@@ -742,34 +811,11 @@ export function useChat(options: UseChatOptions = {}) {
               allow_edit: false,
             })),
             runId: parked.runId,
-            messageId: parked.messageId,
-          });
-        }
-        // **The answer is shown, not discarded.** `resume_run` runs the agent and
-        // returns what it said, but it returns it *here* - over HTTP, to the caller
-        // - and not over the socket this conversation is streaming. So the reply
-        // used to exist and be thrown away: the panel vanished, a toast said the
-        // run was continuing, and the chat then sat unchanged forever. Reloading
-        // the page showed the finished turn, which is how this looked like an
-        // approval that did nothing.
-        // Truthiness, and it is the right test for this one: an empty answer is
-        // nothing to show, and a run that resumed into a refusal has none.
-        if (resumed.output) {
-          // A finished assistant message, which is also what makes the file panel
-          // re-read: `turns` counts those, and a resumed call is usually the one
-          // that was gated - an `execute`, a write - so the workspace beside the
-          // transcript is exactly what changed.
-          addMessage({
-            id: nanoid(),
-            role: "assistant",
-            content: resumed.output,
-            timestamp: new Date(),
-            conversationId: conversationId || undefined,
-            // The agent that was answering when the run parked. Without it the
-            // continuation rendered under the generic robot with no name beside it,
-            // so the second half of one turn looked like a different agent had
-            // written it - the same turn, two faces.
-            agentId: turnAgentIdRef.current ?? undefined,
+            // The message the new step was just drawn in, not the one that parked
+            // first. Deciding writes the outcome back onto the step it belongs to,
+            // and pointing at the older message meant every decision after the
+            // first landed on a tool call that message does not contain.
+            messageId: continuation,
           });
         }
       } catch (error) {

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -810,6 +810,20 @@ export function useChat(options: UseChatOptions = {}) {
             // The same run as the turn that parked, which is what draws the two as
             // one turn instead of as two agents answering the same question.
             runId: parked.runId,
+            // What the run has cost *in total*, which is what the row carries -
+            // the continuation's own share would read as the price of the whole
+            // answer. Drawn once, under the end of the turn; the figure the
+            // parked segment recorded is superseded rather than added to.
+            usage: {
+              input_tokens: resumed.input_tokens,
+              output_tokens: resumed.output_tokens,
+              cost_usd: Number(resumed.cost_usd),
+              // A resume is not told where the run stands against its budget, and
+              // an invented percentage is worse than a bar that is not drawn.
+              budget_percent: null,
+              agent_budget_percent: null,
+              sandbox: null,
+            },
             // The agent that was answering when the run parked. Without it the
             // continuation rendered under the generic robot with no name beside it,
             // so the second half of one turn looked like a different agent had

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -372,6 +372,12 @@ export function useChat(options: UseChatOptions = {}) {
             for (const request of action_requests) {
               updateToolCallPart(id, request.tool_call_id, { status: "awaiting_approval" });
             }
+            // The only frame that names the run this turn is, and the turn that
+            // parks is the only one that needs it: what somebody approves is
+            // written as further segments of this run, and `MessageList` draws
+            // them as one turn by matching exactly this id. A reloaded
+            // conversation gets it from the stored message instead.
+            updateMessage(id, (msg) => ({ ...msg, runId: run_id }));
           }
           break;
         }
@@ -721,11 +727,21 @@ export function useChat(options: UseChatOptions = {}) {
         // resume ran over HTTP, so their `tool_result` frames went to that response
         // and not to this socket - a step set running when the decision was recorded
         // would spin for the rest of the session waiting for one that cannot arrive.
+        //
+        // With what they returned, which arrives in that same response. The call a
+        // person reviewed was made by the execution that parked, so the resume
+        // produces only its return - it belongs to this step rather than to a new
+        // one, and without it the one call somebody deliberately looked at was the
+        // one that opened onto nothing.
+        const settled = new Map((resumed.settled ?? []).map((call) => [call.tool_call_id, call]));
         if (parked.messageId !== null) {
           const id = parked.messageId;
           for (const [index, request] of parked.actionRequests.entries()) {
             if (decisions[index]?.type === "approve") {
-              updateToolCallPart(id, request.tool_call_id, { status: "completed" });
+              updateToolCallPart(id, request.tool_call_id, {
+                status: "completed",
+                result: settled.get(request.tool_call_id)?.result,
+              });
             }
           }
         }
@@ -791,6 +807,9 @@ export function useChat(options: UseChatOptions = {}) {
             parts: buildAssistantParts(steps, resumed.output, continuation),
             timestamp: new Date(),
             conversationId: conversationId || undefined,
+            // The same run as the turn that parked, which is what draws the two as
+            // one turn instead of as two agents answering the same question.
+            runId: parked.runId,
             // The agent that was answering when the run parked. Without it the
             // continuation rendered under the generic robot with no name beside it,
             // so the second half of one turn looked like a different agent had

--- a/frontend/src/lib/conversation-to-chat.test.ts
+++ b/frontend/src/lib/conversation-to-chat.test.ts
@@ -219,3 +219,17 @@ describe("what a stored message says it cost", () => {
     expect(message).toMatchObject({ agentId: "a-1", agentVersion: 3 });
   });
 });
+
+describe("which run a replayed turn belongs to", () => {
+  it("carries the run through, so a reloaded turn groups as the live one did", () => {
+    // A run that parked on an approval leaves several messages. The list draws
+    // them as one turn by matching this id, and a reload that dropped it would
+    // show three agents where the live chat showed one.
+    expect(conversationMessageToChatMessage(raw({ run_id: "r-9" })).runId).toBe("r-9");
+  });
+
+  it("leaves a turn written outside a run ungrouped", () => {
+    // Null is "not recorded", not "the same run as the one above".
+    expect(conversationMessageToChatMessage(raw({ run_id: null })).runId).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/conversation-to-chat.test.ts
+++ b/frontend/src/lib/conversation-to-chat.test.ts
@@ -233,3 +233,36 @@ describe("which run a replayed turn belongs to", () => {
     expect(conversationMessageToChatMessage(raw({ run_id: null })).runId).toBeUndefined();
   });
 });
+
+describe("a stored tool call that never finished", () => {
+  it("stops looking like it is running", () => {
+    // Nothing on this screen can finish it: the frames that would have are long
+    // gone, and some rows never get an outcome at all - an expired approval, a run
+    // that broke mid-call. Left as `running` the step pulsed forever, in the
+    // present tense, under a conversation that ended days ago.
+    const message = conversationMessageToChatMessage(
+      raw({
+        tool_calls: [
+          { tool_call_id: "tc-1", tool_name: "execute", args: {}, status: "running" },
+          { tool_call_id: "tc-2", tool_name: "execute", args: {}, status: "pending" },
+        ],
+      }),
+    );
+
+    expect(message.toolCalls?.map((call) => call.status)).toEqual(["unfinished", "unfinished"]);
+  });
+
+  it("keeps every status that did record an outcome", () => {
+    // `failed` is this repository's word for what the chat calls `error`.
+    const message = conversationMessageToChatMessage(
+      raw({
+        tool_calls: [
+          { tool_call_id: "tc-1", tool_name: "execute", args: {}, status: "completed" },
+          { tool_call_id: "tc-2", tool_name: "execute", args: {}, status: "failed" },
+        ],
+      }),
+    );
+
+    expect(message.toolCalls?.map((call) => call.status)).toEqual(["completed", "error"]);
+  });
+});

--- a/frontend/src/lib/conversation-to-chat.ts
+++ b/frontend/src/lib/conversation-to-chat.ts
@@ -112,13 +112,32 @@ export function buildAssistantParts(
   return parts;
 }
 
+/**
+ * What a stored tool call's status means once the conversation is being read back.
+ *
+ * `failed` is this repository's word for the state the chat calls `error`.
+ *
+ * A call still marked *running* is the interesting one. Nothing on this screen can
+ * finish it: the frames that would have are long gone, and some rows never get an
+ * outcome at all - an approval that expired, a run that broke while a tool was in
+ * flight. Left as `running` the step pulsed forever under a conversation that ended
+ * days ago, in the present tense, promising a result that was never coming. So a
+ * replayed call in flight is `unfinished`: not an error, not a success, just the
+ * outcome nobody wrote down.
+ */
+function replayedStatus(stored: string): ToolCall["status"] {
+  if (stored === "failed") return "error";
+  if (stored === "running" || stored === "pending") return "unfinished";
+  return stored as ToolCall["status"];
+}
+
 export function conversationMessageToChatMessage(msg: RawMessage): ChatMessage {
   const toolCalls: ToolCall[] | undefined = msg.tool_calls?.map((tc) => ({
     id: tc.tool_call_id,
     name: tc.tool_name,
     args: tc.args,
     result: tc.result,
-    status: (tc.status === "failed" ? "error" : tc.status) as ToolCall["status"],
+    status: replayedStatus(tc.status),
   }));
 
   const parts: MessagePart[] | undefined =

--- a/frontend/src/lib/conversation-to-chat.ts
+++ b/frontend/src/lib/conversation-to-chat.ts
@@ -28,6 +28,8 @@ export interface RawMessage {
   created_at: string;
   /** The configured agent that answered. Null for the general assistant. */
   agent_id?: string | null;
+  /** The run that produced this turn. Null for a turn written outside one. */
+  run_id?: string | null;
   /** The version number of the frozen spec that produced it. */
   agent_version?: number | null;
   tool_calls?: RawToolCall[] | null;
@@ -137,6 +139,7 @@ export function conversationMessageToChatMessage(msg: RawMessage): ChatMessage {
     conversationId: msg.conversation_id,
     agentId: msg.agent_id ?? undefined,
     agentVersion: msg.agent_version ?? undefined,
+    runId: msg.run_id ?? undefined,
     usage: storedUsage(msg) ?? undefined,
     toolCalls,
     parts,

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -40,6 +40,17 @@ export interface ChatMessage {
    *  said by one version of it, and a transcript that named only the agent
    *  attributed old words to today's instructions. */
   agentVersion?: number;
+  /** The run that produced this turn.
+   *
+   *  One run can leave several messages: it parks on an approval, somebody
+   *  decides, it runs again, and each of those segments is written as it happens
+   *  rather than folded back into the message before it. They are one turn and
+   *  are drawn as one - see `MessageList`, which reads exactly this field.
+   *
+   *  Absent means "not recorded", never "its own turn": a turn written outside a
+   *  run has none, and a live turn only learns its run id if something on the
+   *  wire says so. Absent never groups. */
+  runId?: string;
   /** True if message ID is a temporary nanoid, not yet replaced by server ID */
   isTemporaryId?: boolean;
   /** Current user's rating */

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -79,11 +79,18 @@ export interface ToolCall {
   name: string;
   args: Record<string, unknown>;
   result?: unknown;
-  status: "pending" | "running" | "completed" | "error" | "awaiting_approval";
+  status: "pending" | "running" | "completed" | "error" | "awaiting_approval" | "unfinished";
   /**
    * `awaiting_approval` is its own state, not a kind of running. A parked call
    * produces no result *ever* until somebody decides, so a spinner is a lie that
    * never resolves — which is what the card did before.
+   *
+   * `unfinished` is what a *replayed* call in flight becomes. The transcript
+   * stores a call as running until something records its outcome, and some never
+   * get one — an approval that expired, a run that broke mid-call. Read back, that
+   * row animated forever under a conversation that ended days ago, promising a
+   * result nothing was ever going to deliver. It is not an error and not a
+   * success: it is the outcome nobody wrote down.
    */
 }
 

--- a/frontend/src/types/runs.ts
+++ b/frontend/src/types/runs.ts
@@ -193,10 +193,30 @@ export interface ParkedCall {
   tool_args: Record<string, unknown>;
 }
 
+/** One tool call an execution of a run made, and what came back from it. */
+export interface RunStep {
+  tool_call_id: string;
+  tool_name: string;
+  args: Record<string, unknown>;
+  /** Null on the call the run has parked on - it has not run yet. */
+  result: string | null;
+}
+
 export interface ResumedRun {
   run_id: string;
   output: string;
   status: RunStatus;
+  /**
+   * What the continuation called, in order.
+   *
+   * The only account of it there is. A resume executes the agent inside the HTTP
+   * request rather than on the socket this conversation streams, so no `tool_call`
+   * frame arrives for any of it - and a client drawing only `output` showed the
+   * approved call finishing and nothing after it. Approving a command appeared to
+   * do nothing, and the next approval request arrived for a step that had never
+   * been drawn.
+   */
+  steps?: RunStep[];
   /**
    * What the run is waiting on *now*, empty unless it parked again.
    *

--- a/frontend/src/types/runs.ts
+++ b/frontend/src/types/runs.ts
@@ -202,6 +202,12 @@ export interface RunStep {
   result: string | null;
 }
 
+/** What a call the run had already made finally returned. */
+export interface SettledCall {
+  tool_call_id: string;
+  result: string;
+}
+
 export interface ResumedRun {
   run_id: string;
   output: string;
@@ -226,6 +232,15 @@ export interface ResumedRun {
    * calls can come from, and without it the panel closed on a run that was still
    * blocked and could no longer be decided from here.
    */
+  /**
+   * What the calls this execution inherited returned - on a resume, the very call
+   * somebody approved.
+   *
+   * Not in `steps`: it was made by the execution that parked, so the caller has
+   * already drawn its step and this updates it. Drawing it again would put the
+   * same command in the turn twice.
+   */
+  settled?: SettledCall[];
   parked?: ParkedCall[];
   /** Serialised Decimal - never parse into a float for arithmetic. */
   cost_usd: string;


### PR DESCRIPTION
Approving a gated tool call in the chat showed nothing running, then asked for a
second approval for a step that had never been drawn, and eventually answered
about work the transcript did not hold. Three commands ran in a sandbox; one of
them was accounted for anywhere.

## What changed

**The continuation now says what it did.** `POST /runs/{id}/resume` executes the
agent inside the request rather than on the socket the conversation streams, so its
`tool_call` frames go to that response — and the response carried `output`, `status`,
the cost and `parked`, never the calls. `_run` returns a `RunSegment` (output, run,
and what it called), `AgentRunResult` carries them as `steps`, and the chat appends
one assistant turn per continuation: the steps in the order they happened, then the
answer. The call it parked on again is drawn as *waiting for a person*, and the
reopened panel points at **that** message — it pointed at the turn that parked first,
so every decision after the first was written back onto a tool call that message does
not contain.

**A continuation with no answer is recorded.** `TranscriptService.record` wrote the
assistant turn only `if answer:`, and a segment that runs a command and then parks on
a second one has none — so the command, its arguments and its result were never
written. It now writes when there is an answer *or* a call, which is what `_run`'s own
docstring already claimed for a run that failed, parked or was stopped.

**The approval panel belongs to its conversation.** It survived a switch to another
thread and its buttons still worked, so a call could be decided from under a different
agent's transcript, settling a step in messages no longer loaded. Cleared with the
delegation panels, which had this right. A first turn learning its own conversation id
mid-stream is not a switch and keeps its panel.

Docs: `docs/governance.md` (what a resume answers with, and what it records) and
`docs/channels.md` (what a resume draws in chat, and the panel's lifetime).

## How it was verified

- `make test` — 4027 passed, platform layer at 100%
- `make test-frontend-cov` — 100% lines/statements/functions, 97.62% branches
- `make lint`, `python3 scripts/docs_drift.py`

New tests: the transcript writes a parked-again segment's calls; `resume` hands back
what it called; the route serialises it; the chat draws the steps, drops the call it
just decided, marks the newly parked one awaiting a person, and points the panel at
the new message; the panel and the question form clear on a conversation switch and
survive `conversation_created`.

**Not covered by any of that:** the reported sequence end to end, which needs a
sandbox and a real approval. Worth a manual pass before merge.

## Left alone, deliberately

The *result* of the approved call is still recorded nowhere: `tool_calls_in` reads
`new_messages()`, where that call's return arrives without the `ToolCallPart` it
belongs to. Filed as #506 rather than folded in — it needs either completing the
parked row from the resume's returns or widening what a resume records without
reintroducing the duplicate `new_messages()` exists to prevent.

Closes #505
Closes #507
Refs #506

---

## Second pass: one run reads as one turn, and the approved call has an output

Trying the first commit against a real run showed two things it had not fixed —
both visible in one screenshot of one run:

**Three avatars for one run.** A run that parks writes what it had done, and each
continuation is written as it happens rather than folded back into the message
before it; rewriting a turn somebody has already read is worse than appending to
it. So one run leaves several assistant rows, and each drew its own avatar and
agent name — which reads as three agents answering one question.
`MessageList.continuesTurn` now groups *consecutive* assistant messages carrying
the same run into one turn: avatar and name once, at the top, with the gutter kept
empty so the whole turn stays in one column. A person speaking between two
segments restarts the turn, and a message with no run recorded never groups —
absent means "not recorded", not "the same run".

`messages.run_id` was already on the read schema and is now carried to
`ChatMessage.runId`, so a reloaded conversation groups the way the live one did.
Live, the id arrives on the `tool_approval_required` frame — the only frame that
names it, and the only turn that needs it.

**The approved call now records what it returned (#506, which this PR no longer
leaves open).** Its row is written open when the run parks; the resume that finally
runs it produces the return *without* the `ToolCallPart` it belongs to, so
`tool_calls_in` had nothing to hang it on. `settled_calls_in` reads exactly those
orphans, `TranscriptService._settle` closes the row through a new
`get_open_tool_call_in_run`, and the resume answers with them separately from
`steps` — they belong to a step the caller already drew, and adding one would put
the same command in the turn twice. The lookup is scoped by run, not conversation:
a provider's id is unique within a run and a conversation holds many. Integration
tests cover the call this run left open, one that already returned, and another
run's with the same id.

Verified again after both: backend suite 4035 passed with the platform layer at
100%, `make test-frontend-cov` at 100% lines/statements/functions and 97.63%
branches, `make lint` clean.

**Still not covered by tests:** the sequence end to end, which needs a sandbox and
a real approval.

**Found and filed rather than fixed:** #509 — a parked turn stores *"waiting in the
approvals queue"* as the agent's words. It is false the moment somebody approves,
and now that the segments are grouped it sits in the middle of the turn saying so.
Fixing it means persisting what the model actually wrote for a parked turn and
leaving the notice to the socket, which is its own decision.

Closes #506
Refs #509

---

## Third pass: the footer, and a spinner that never stopped

**The turn's cost sat in the middle of the answer.** A run reports what it has spent
when it *parks*, so the figure is recorded on the first segment — and the time, the
tokens and the cost were drawn under the message carrying it, halfway up the turn,
with nothing under the end of it. The footer now renders on the segment that ends the
turn, showing the last figure recorded anywhere in it. Last rather than summed: each
is the run's total as at that point, so adding them would count the first segment
twice. The continuation takes its numbers from the resume's own answer — the run
row's — so a live turn shows the whole run rather than its tail.

**A replayed step animated for ever.** A tool call is stored as running until
something records its outcome, and one ending never does: an expiry runs nothing, so
the step written when the run parked stayed open. Read back it pulsed in the present
tense under a conversation that had ended days earlier. Both halves are fixed:
`_settle_expired_run` closes those steps through the transcript (before `finish_run`,
which clears the state their ids come from), and a replayed call still marked in
flight becomes `unfinished` — past tense, muted, no spinner, no result. Not an error
and not a success; the outcome nobody wrote down.

A *rejected* call needed nothing: `refusal()` hands the model a plain string, so the
resume carries it as a return without its call and `settled_calls_in` already closes
the row with the refusal in it.

Two things worth naming, both found rather than reported:

- `_Sweep` in `test_approval_expiry.py` did not stub `TranscriptService`, so the new
  write failed into `record`'s own exception handler and the tests passed while
  asserting nothing. Stubbed at the same boundary as the repository.
- `turnUsage` ended on a `return` no test can reach — the walk always stops at the
  first segment of a turn. The coverage gate was right to refuse it.

Rows already in a database stay as they are: nothing backfills a call that was never
closed. They no longer animate, because the mapping happens on read.

Verified again: `make test` (4037 passed, platform layer at 100%),
`make test-frontend-cov` (100% lines/statements/functions, 97.63% branches),
`make lint`, `scripts/docs_drift.py`.
