### PR TITLE
chore: cut 0.0.88

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.88] - 2026-08-10
+
+Two grouped dependency updates, nothing else. The lockfile resolves cleanly with
+both applied (`uv lock --check`), and CI is green on the combination.
+
+### Changed
+
+- **Agent-framework dependencies** — `pydantic-ai-slim` to 2.26.0 (including its
+  `mcp` extra), `logfire` to 4.40.0, and `genai-prices` to 0.1.1. (#523)
+- **The rest of the backend** — `uvicorn[standard]` to 0.52.1, `alembic` to
+  1.19.0, `pymupdf` to 1.28.2, `liteparse` to 2.11.1, `google-auth` to 2.56.3,
+  `boto3` to 1.43.66, and the `ty` type checker to 0.0.69. (#524)
+
 ## [0.0.87] - 2026-08-10
 
 Mattermost is a channel you can register and talk to, and the gaps that stopped

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.87"
+version = "0.0.88"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.87"
+version = "0.0.88"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.87",
+  "version": "0.0.88",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release for #523 and #524 — two grouped Dependabot updates and nothing else.

Bumps the version in `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json`, and adds the 0.0.88 CHANGELOG entry. `SPEC_VERSION` stays at 8.

Both dependency PRs already merged to main; `uv lock --check` confirms the combined lockfile is a valid, up-to-date resolution. This PR's full CI is the integration check on the combination.