### PR TITLE
docs: sharpen the test-loop guidance and correct its stale numbers

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -18,12 +18,12 @@ Deeper guidance lives in the `backend-tests` skill and `docs/testing.md`.
 ## Running — narrowest first
 
 **Run what covers the change, not the suite.** The suite is the check before a push;
-after an edit it answers the same question thirty times slower.
+after an edit it answers the same question ten to fifty times slower.
 
 | From | Command | About |
 |---|---|---|
-| `backend/` | `uv run pytest tests/test_sandbox_workspace.py -q` | 1s |
-| `backend/` | `uv run pytest tests/api/test_workspace_routes.py -k bytes -x` | 1s |
+| `backend/` | `uv run pytest tests/test_sandbox_workspace.py -q` | ~6s, nearly all importing the app |
+| `backend/` | `uv run pytest tests/api/test_workspace_routes.py -k bytes -x` | ~6s, same |
 | `backend/` | `uv run pytest tests/test_a.py tests/test_b.py -q` | as many files as the change touched |
 | `frontend/` | `bunx vitest run src/components/chat/usage-strip.test.tsx` | 2s |
 | `frontend/` | `bunx vitest run src/components/chat` | a directory |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,10 +149,14 @@ make check                                        # every CI job but e2e — bef
 ## The loop
 
 **Write, run the tests you just wrote, commit, push, and let CI be the wide net.**
-Running every test after every edit is the slowest way to learn the same thing: one
-frontend spec answers in about two seconds against seventy for the suite, one backend
-file in under one against ninety-five for `make test`. CI's jobs run in parallel and
-answer in about seven minutes — from a pushed branch, while you carry on working.
+After an edit, run only the tests that cover the change; the full suites are the
+pre-push gate, not the write-run loop. Running everything after every edit is the
+slowest way to learn the same thing: one frontend spec answers in about two seconds
+against seventy for the suite, one backend file in a few seconds — nearly all of it
+importing the app, since pytest itself clocks the run at a fraction of that — against
+ninety-odd for `make test`. CI's jobs run in parallel and answer in about twelve
+minutes, the backend `test` job the long pole and the one #520 is cutting — from a
+pushed branch, while you carry on working.
 
 Two things about that answer, both since #317. **Pushing again cancels the run in
 flight**, so the answer you were waiting on disappears rather than arriving about a
@@ -261,11 +265,11 @@ Trigger map — what changed → which page:
 |---|---|
 | `app/agents/spec.py` | `docs/reference/spec.md` (via the docstrings) |
 | `app/agents/capabilities/**` | `docs/reference/capabilities.md` |
-| `app/agents/mcp*.py`, `app/services/mcp_*.py`, `catalog/mcp_servers.json` | `docs/mcp.md` |
-| `app/agents/model_resolver.py`, `app/services/model_profile.py`, `model_catalog.py` | `docs/models.md` |
+| `app/agents/mcp*.py`, `app/services/mcp_*.py`, `app/core/catalog/mcp_servers.json` | `docs/mcp.md` |
+| `app/agents/model_resolver.py`, `app/services/model_profile.py`, `app/services/model_catalog.py` | `docs/models.md` |
 | `app/core/vault.py`, `secret_kinds.py`, `app/services/organization_secret.py` | `docs/secrets.md` |
 | `app/core/permissions.py`, `app/services/access.py` | `docs/permissions.md` + `docs/reference/permissions.md` |
-| `app/services/skills.py`, `skill_library.py`, `catalog/skills/**` | `docs/skills.md` |
+| `app/services/skills.py`, `skill_library.py`, `app/core/catalog/skills/**` | `docs/skills.md` |
 | `app/services/spend.py`, `approvals.py`, `notifications.py` | `docs/governance.md` |
 | `app/services/channels/**`, `agent_exposure.py`, `agent_embed.py` | `docs/channels.md` |
 | `app/services/rag/**`, `file_upload.py`, `ingestion_config.py` | `docs/file-processing.md` |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -26,7 +26,8 @@ make docs-build         # mkdocs --strict — a dead link is a failure
 make audit              # the locked dependency set against the advisory database
 ```
 
-About five minutes serial, against CI's seven in parallel. The equality is
+About five minutes serial, against CI's twelve in parallel — the backend `test`
+job the long pole there, which #520 is cutting. The equality is
 maintained rather than asserted: the workflow calls these targets rather than
 repeating their commands, and `tests/test_ci_parity.py` fails if a gating job
 grows a step `make check` does not run. It has drifted four times — see


### PR DESCRIPTION
Closes #522.

## What changed

`CLAUDE.md` is loaded into every session, so a stale line is a mistake repeated on every task. Three honesty fixes plus a correctness sweep.

**Scoped-vs-full is now explicit.** The loop states the rule outright — after an edit run only the tests that cover it; the full suites are the pre-push gate, not the write-run loop — rather than leaving it implied.

**The stale numbers, corrected against measurement** (this machine, Python 3.12.9, no local DB so integration skipped):

| Claim | Was | Measured | Now |
|---|---|---|---|
| CI wall-clock | ~7 min | 11–12 min across 5 recent PR runs, backend `test` the long pole | ~12 min, `#520` cited |
| A scoped backend file | "under one" / `1s` | ~6.5s wall (`uv run` and direct `.venv/bin/pytest` alike); pytest clocks the run itself at 0.2s, the rest is importing the app during collection | "a few seconds" / `~6s` |
| Suite-vs-file ratio | "thirty times slower" | 95s/6s ≈ 16×, 65s/1.3s ≈ 50× | "ten to fifty times slower" |

The same "CI's seven in parallel" claim in `docs/testing.md` was corrected too — one factual claim, two files, and the repo forbids the two disagreeing. Figures that held were left alone: `make test` ~78–118s ("ninety-odd"), the frontend suite ~65s ("seventy"), a frontend spec ~1.3s ("two seconds").

**Correctness sweep** of every command, path and file `CLAUDE.md` names: all `make` targets, all thirteen skills, all rules and docs pages, and the named test files exist. The docs trigger map had moved paths — the catalog now lives at `app/core/catalog/`, so `catalog/mcp_servers.json` and `catalog/skills/**` pointed at a `backend/catalog/` that does not exist, and bare `model_catalog.py` sat beside an `app/agents/` sibling that misdirected the reader; all three qualified.

## Note on #520

This issue depends on the suite-runtime work (#520) for its numbers, and that is still open. Rather than invent revised figures, I corrected to the *current* honest ones and cited #520 in both files so the CI number gets revisited when it lands.

## Verified

`make docs-build` (--strict) and codespell pass. The full CI matrix runs on this branch — not because the diff needs it, but because `scripts/ci_changed_scope.py` exempts only `docs/**`, `mkdocs.yml` and *top-level* `*.md`, and the `.claude/rules/testing.md` edit is none of those, so its timid "anything unrecognised runs everything" rule fires. The jobs pass because `main`'s CI is green.

## Found, not fixed (pre-existing on `main`, out of scope)

`make test` is red *locally* for two reasons unrelated to this change, and both are no-DB / local-env artifacts rather than CI failures (`main`'s CI is green):

- the `agent_runner.py:3387` coverage miss already tracked in **#515** — that line is exercised by an integration test, which runs in CI with a database and skips on a laptop without one, so local coverage lands at 99.49%;
- `tests/test_approval_expiry.py::TestTheScheduledSweep` reaching a *real* Prefect server (`ConnectError`) on my machine instead of the ephemeral one CI uses.

Neither is caused by this branch. Observation, not filed: a `.claude/**`-only change runs the whole ~12-min backend suite for the reason above — deliberate per the script's docstring, but a candidate for the same exemption as `docs/**` if the CI-cost cluster (#317) is revisited.
