### PR TITLE
perf(tests): build the integration schema once, not before every test

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -117,8 +117,8 @@ name meant two runs on one machine dropping each other's tables mid-test (#189).
 drops it at the end, even when the suite fails, so **two concurrent runs are safe and
 nothing has to be passed to make them so**. It still skips when no database is
 reachable (a laptop without Docker) and still refuses any database whose name contains
-neither `test` nor `ci`, or that is not a plain identifier — it calls `drop_all`
-unconditionally and drops the database itself afterwards.
+neither `test` nor `ci`, or that is not a plain identifier — it empties every table
+unconditionally between tests and drops the database itself afterwards.
 
 A run killed outright (`SIGKILL`) leaks its database; the next run with that pid drops
 it before creating its own. Anything else named `agenticos_*` on a shared Postgres was

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -6,12 +6,16 @@ unique index actually prevents a second default. Those are the guarantees the
 schema is supposed to provide, and the only way to know is to ask Postgres.
 
 The database belongs to this pytest process alone: it is created here and
-dropped again when the session ends. `drop_all` below is unconditional, so a
-shared name meant two runs on one machine demolishing each other's tables
-mid-test - deadlocks between one run's `DROP TABLE` and another's `CREATE
-INDEX`, a column that "does not exist" on a database that had it, and two runs
-of the same commit reporting different failures (#189). `tests/conftest.py`
-derives the per-process name; this module owns its lifecycle.
+dropped again when the session ends. The per-process name is what keeps two
+runs on one machine off each other's tables - without it a shared name once had
+them demolishing each other mid-test, back when each test rebuilt the schema
+with `drop_all` + `create_all` and the collision was a deadlock between one
+run's `DROP TABLE` and another's `CREATE INDEX`, a column that "does not exist"
+on a database that had it, and two runs of the same commit reporting different
+failures (#189). The schema is built once now and the reset between tests is
+`TRUNCATE` (#215), so that DDL deadlock can no longer happen - but the
+per-process name still earns its place. `tests/conftest.py` derives it; this
+module owns its lifecycle.
 
 The whole module is skipped when no database is reachable, so `make test` on a
 laptop without Docker still runs everything else.
@@ -99,12 +103,12 @@ _PLAIN_IDENTIFIER = re.compile(r"[A-Za-z0-9_]+")
 def _refuse_a_real_database(name: str) -> None:
     """Refuse to run against a database that is not obviously a test one.
 
-    `drop_all` here is unconditional and this module drops the database itself
-    afterwards, so pointing the suite at a development database destroys it.
-    Nothing in the fixture can tell the difference once it has happened; the only
-    moment it can be caught is before the first drop. The per-process suffix is
-    appended before this runs, so what is checked is the name that will actually
-    be dropped.
+    The reset between tests `TRUNCATE`s every table unconditionally and this
+    module drops the database itself afterwards, so pointing the suite at a
+    development database destroys it. Nothing in the fixture can tell the
+    difference once it has happened; the only moment it can be caught is before
+    the first of those runs. The per-process suffix is appended before this runs,
+    so what is checked is the name that will actually be dropped.
     """
     if not _PLAIN_IDENTIFIER.fullmatch(name):
         raise RuntimeError(

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -25,6 +25,7 @@ import re
 from collections.abc import AsyncGenerator, Iterator
 
 import pytest
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -162,24 +163,82 @@ def database_url() -> Iterator[str]:
         asyncio.run(_outside_a_transaction(maintenance, drop))
 
 
-@pytest.fixture
-async def engine(database_url: str) -> AsyncGenerator[AsyncEngine, None]:
-    """An engine on that database, with the schema freshly built from the models.
+async def _create_schema(url: str) -> None:
+    """Build the schema from the models, once, on a loop of its own."""
+    engine = create_async_engine(url)
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(Base.metadata.create_all)
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture(scope="session")
+def schema_url(database_url: str) -> str:
+    """The suite's database URL, with the schema built from the models once.
 
     The schema is created from the models rather than by running migrations:
     these tests assert what the *code* believes the schema is. Whether the
     migrations arrive at the same place is a separate question, answered by
     `make test-migrations`.
 
-    Function-scoped rather than session-scoped: anyio's backend fixture is
-    per-function, and a session-scoped async fixture cannot depend on it.
-    Recreating the schema costs a fraction of a second and buys complete
-    isolation between tests.
+    Session-scoped and synchronous for the same reason `database_url` is: a
+    session-scoped *async* fixture cannot depend on anyio's per-function backend
+    fixture, and `asyncio.run` gives the build a loop of its own. `create_all`
+    with no `drop_all` before it is enough because `database_url` hands over a
+    database that was just created - there is nothing to drop.
+
+    This is the whole of #215: the schema used to be rebuilt in the
+    function-scoped `engine` fixture below (`drop_all` + `create_all` before
+    *every* test), ~0.4s of DDL that was very nearly the entire runtime of a
+    suite whose assertions are microseconds of Postgres work. Built once here,
+    the `engine` fixture only has to empty the data between tests.
     """
-    engine = create_async_engine(database_url)
+    asyncio.run(_create_schema(database_url))
+    return database_url
+
+
+async def _reset(engine: AsyncEngine) -> None:
+    """Return the database to the modelled schema with every table empty.
+
+    `TRUNCATE ... RESTART IDENTITY CASCADE` over every model table empties them
+    in one statement, no DDL and no ordering to get right. Unlike rolling back a
+    transaction it also clears rows a test committed through the real
+    `get_db_session` - which the API-flow tests in `test_platform_flows.py` and
+    the dispatch-ordering tests do by design, so a rollback-only reset would not
+    be enough on its own.
+
+    A test may also create a table *outside* the models - a runtime
+    `rag_<collection>`, one of the ordering probes. Those are dropped first, so
+    each test starts from the modelled schema and nothing else regardless of the
+    order the suite ran in.
+    """
     async with engine.begin() as connection:
-        await connection.run_sync(Base.metadata.drop_all)
-        await connection.run_sync(Base.metadata.create_all)
+        present = await connection.execute(
+            text("SELECT tablename FROM pg_tables WHERE schemaname = 'public'")
+        )
+        modelled = set(Base.metadata.tables)
+        # `name` is a live identifier from `pg_tables` and each table name below
+        # comes from `Base.metadata` - both are developer-controlled identifiers,
+        # not user input, and neither DROP nor TRUNCATE can bind them as
+        # parameters, so they are quoted and interpolated.
+        for name in (row[0] for row in present if row[0] not in modelled):
+            await connection.execute(text(f'DROP TABLE IF EXISTS "{name}" CASCADE'))
+        tables = ", ".join(f'"{table.name}"' for table in Base.metadata.sorted_tables)
+        await connection.execute(text(f"TRUNCATE TABLE {tables} RESTART IDENTITY CASCADE"))
+
+
+@pytest.fixture
+async def engine(schema_url: str) -> AsyncGenerator[AsyncEngine, None]:
+    """An engine on the suite's database, with every table emptied first.
+
+    Function-scoped because anyio's backend fixture is: the reset has to run on
+    the same per-function event loop the test does. The schema itself is built
+    once by `schema_url`; here each test is handed a clean slate cheaply, by
+    emptying the data rather than rebuilding the schema (#215).
+    """
+    engine = create_async_engine(schema_url)
+    await _reset(engine)
     yield engine
     await engine.dispose()
 

--- a/backend/tests/integration/test_commit_before_response.py
+++ b/backend/tests/integration/test_commit_before_response.py
@@ -53,7 +53,8 @@ async def probe_table(engine: AsyncEngine) -> AsyncGenerator[AsyncEngine, None]:
     Not one of the product's own tables on purpose: this asserts a property of
     the request lifecycle, and it should not start failing because a model grew
     a `NOT NULL` column. The cost of being outside the metadata is that the
-    `engine` fixture's `drop_all` does not reach it, so it is dropped here.
+    `engine` fixture's per-test reset only empties model tables, so it is
+    dropped here rather than left for the reset to find.
     """
     async with engine.begin() as connection:
         await connection.execute(text(_DROP))

--- a/backend/tests/integration/test_flow_starts_after_commit.py
+++ b/backend/tests/integration/test_flow_starts_after_commit.py
@@ -68,8 +68,9 @@ async def probe_table(engine: AsyncEngine) -> AsyncGenerator[AsyncEngine, None]:
 
     Deliberately not one of the product's own tables: this asserts a property of
     dispatch, and must not start failing because a model grew a `NOT NULL`
-    column. Outside the metadata means the `engine` fixture's `drop_all` does
-    not reach it, so it is dropped here.
+    column. Outside the metadata means the `engine` fixture's per-test reset
+    only empties model tables, so it is dropped here rather than left for the
+    reset to find.
     """
     async with engine.begin() as connection:
         await connection.execute(text(_DROP))

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -226,16 +226,28 @@ Everything under `tests/integration/` is the exception, and it asks for the `db`
 fixture from `tests/integration/conftest.py` rather than building an engine of its
 own — that fixture is what puts the schema in place.
 
+**The schema is built once for the whole process, and the data reset between tests.**
+The `schema_url` fixture runs `create_all` a single time; the function-scoped `engine`
+fixture then hands each test an empty database by `TRUNCATE`-ing every model table
+(and dropping any table a test created outside the models — a runtime
+`rag_<collection>`, an ordering probe) rather than rebuilding the schema. It used to
+`drop_all` + `create_all` before *every* test, ~0.4s of DDL that was very nearly the
+entire runtime of a suite whose assertions are microseconds of Postgres work; building
+it once cut `tests/integration` from ~125s to ~50s
+([#215](https://github.com/vstorm-co/agenticos/issues/215)). `TRUNCATE` rather than a
+transaction rollback because the API-flow tests commit through the real
+`get_db_session`, so their rows outlive a rollback.
+
 **The database it uses belongs to the pytest process that asked for it**:
 `<POSTGRES_DB>_p<pid>`, created when the session starts and dropped when it ends,
 failure included. That is what makes two runs at once safe — two worktrees, or a
 worktree and a `make test`, against the one Postgres container — and it needs nothing
 passed on the command line. The name was constant until [#189](https://github.com/vstorm-co/agenticos/issues/189),
-and since the fixture rebuilds the schema before every test, two runs spent their time
-dropping each other's tables and reporting failures that belonged to neither branch.
-The suite still refuses any database whose name does not contain `test` or `ci`: it
-drops tables unconditionally, so the guard is the only thing between it and a
-development database.
+and because each test dropped and recreated the schema on that shared database, two
+runs spent their time dropping each other's tables and reporting failures that belonged
+to neither branch. The suite still refuses any database whose name does not contain
+`test` or `ci`: it drops tables unconditionally, so the guard is the only thing between
+it and a development database.
 
 **The credential is resolved once, in `tests/conftest.py`, and everything reads it
 back off the settings object.** Two engines reach that database — the fixture's, and


### PR DESCRIPTION
## What this fixes

The integration suite rebuilt the whole schema from the models before **every**
test — `drop_all` + `create_all` in a function-scoped fixture, ~0.4s of DDL each.
On a suite whose assertions are microseconds of Postgres work, that DDL was very
nearly the entire runtime. This builds the schema **once per process** and resets
the *data* between tests instead.

`Closes #215`. `Refs #520` (the first, and biggest, committed lever of the
test-speed work — the finding for all three suites is below).

## What changed

- `backend/tests/integration/conftest.py`
  - New session-scoped, synchronous `schema_url` fixture — `create_all` once, via
    `asyncio.run` (the pattern `database_url` already uses; a session-scoped *async*
    fixture cannot depend on anyio's per-function backend).
  - `engine` (function-scoped) now calls `_reset`: `TRUNCATE … RESTART IDENTITY
    CASCADE` over every model table, plus a `DROP` of any table a test created
    outside the models (a runtime `rag_<collection>`, an ordering probe). No DDL for
    the schema itself, ever, after the first build.
- `test_commit_before_response.py`, `test_flow_starts_after_commit.py` — docstrings
  on the two ordering-probe fixtures updated (they referenced the old `drop_all`).
- `backend/tests/integration/conftest.py` — the module docstring and
  `_refuse_a_real_database` docstring reworded off the old per-test `drop_all`
  onto the `TRUNCATE`/schema-once reset (review follow-up, 6db994b8).
- `docs/testing.md`, `.claude/rules/testing.md` — the fixture description updated to
  the build-once mechanism.

`TRUNCATE`, not a transaction rollback: the API-flow tests in `test_platform_flows.py`
and the dispatch-ordering tests commit through the real `get_db_session` by design, so
their rows outlive a rollback — rollback-only isolation would leak between tests.

## How it failed before

Not a failure, a cost. `pytest tests/integration --no-cov`: **400 tests in ~125s**,
almost all of it in the `setup` phase (~0.3–0.5s each), which is the schema DDL.

## Testing

Measured on `pgvector/pgvector:pg16`, warm, this machine:

| | Before | After |
|---|---|---|
| `pytest tests/integration --no-cov` (ordered) | ~125s | **~53s** |
| same, verified order-independent (two `--randomly-seed`s, #571) | — | ~57s |
| full `make test` (unit + integration + 100% gate) | ~175s | **~103s** |

- 400 integration tests pass ordered (`-p no:randomly`) **and** in random order.
- Two runs concurrently: both green (154/154 on an overlapping subset) — the
  per-process `_p<pid>` database from #189 is untouched, so the property it bought
  survives.
- `ruff`, `ruff format`, `ty` clean on the changed files; pre-commit green;
  `scripts/docs_drift.py` clean.

## The #520 finding — where the time goes, per suite

Numbers from this machine, same container.

**Backend `make test` — the CI long pole (~103s after this PR).**
- *Integration slice* — was the whole story: ~125s, essentially all schema DDL. **This
  PR: ~53s.** The remaining per-test cost is `create_async_engine` + one `pg_tables`
  scan + one `TRUNCATE` + dispose — bounded by anyio giving each test its own event
  loop, so the engine cannot be shared session-wide (the "Future attached to a
  different loop" trap the probe fixtures already document).
- *Unit slice* — ~32–44s `--no-cov`, no single hotspot; it is app-import + per-test
  fixtures across ~3,900 tests. Runs **single-process** — `pytest-xdist` is the next
  lever and unclaimed.
- *Coverage instrumentation* — real but modest, ~15–20% on top. Not the dominant cost;
  the dominant cost was the DDL, now gone.

**Frontend `make test-frontend-cov` — ~53s, not the bottleneck.** `test:run` ~45s,
`test:coverage` ~53s (coverage ~+18%). vitest already runs fully parallel across cores
(~850% CPU). Sharding would only help CI split across machines, not a local run.

## Noticed, not fixed

Filed as follow-ups under #520, not folded into this diff:

- **`pytest-xdist` for the backend unit slice** — the largest remaining local lever,
  and it interacts with the per-process `_p<pid>` DB naming (each xdist worker needs its
  own database). Real design work, its own PR.
- **Run the coverage gate once at the end**, not on every scoped run — the issue's
  "coverage instrumentation can run once" idea. Tooling change, separate.
- **`tests/test_approval_expiry.py::TestTheScheduledSweep::test_the_flow_answers_with_what_it_expired`
  fails locally without a live Prefect API at `localhost:4200`** — pre-existing (fails
  identically on `main`), environmental, unrelated to this change. Directly relevant to
  #520's "too hard to run locally" theme, so worth a guard/skip; filing separately.

