### PR TITLE
feat(governance): reconcile per-person spend with an unattributed bucket

### DIFF
--- a/backend/app/repositories/agent_run.py
+++ b/backend/app/repositories/agent_run.py
@@ -1069,6 +1069,42 @@ async def usage_by_user(
     return [(row[0], row[1], row[2], row[3], Decimal(row[4]), row[5]) for row in result.all()]
 
 
+async def unattributed_usage(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    start: datetime,
+    end: datetime,
+) -> tuple[int, Decimal, datetime] | None:
+    """The window's runs with no user behind them, gathered into one bucket.
+
+    The counterpart to :func:`usage_by_user`'s inner JOIN, which drops a run
+    whose `user_id` is null - a deleted user (the foreign key SET-NULLs) or an
+    account-less channel or widget run. Collected here rather than dropped so
+    the per-person spend card reconciles with the by-agent total, which counts
+    these runs under their agent. Returns None when the window holds no such
+    run, so the card shows the bucket only when it has something to account for.
+
+    Top-level only, like every window aggregate: a delegated child copies its
+    parent's null `user_id`, and its cost already sits inside the parent's row.
+    """
+    conditions = _window_conditions(
+        organization_id=organization_id, start=start, end=end, user_id=None
+    )
+    conditions.append(AgentRun.user_id.is_(None))
+    result = await db.execute(
+        select(
+            func.count(AgentRun.id),
+            func.coalesce(func.sum(AgentRun.cost_usd), 0),
+            func.max(AgentRun.started_at),
+        ).where(*conditions)
+    )
+    runs, cost, last_run_at = result.one()
+    if not runs:
+        return None
+    return (int(runs), Decimal(cost), last_run_at)
+
+
 async def count_pending_approval_runs(
     db: AsyncSession,
     *,

--- a/backend/app/schemas/stats.py
+++ b/backend/app/schemas/stats.py
@@ -153,12 +153,13 @@ class VersionUsageRow(BaseSchema):
 class PersonUsageRow(BaseSchema):
     """One person's share of the window - the who-is-using-it card's row.
 
-    Runs with no user behind them are excluded rather than collected into an
-    "unattributed" row: a channel message from somebody with no account, and a
-    run whose user was deleted (the foreign key SET-NULLs), both land in that
-    bucket, and neither is a person this card can name. That exclusion is also
-    what keeps the card consistent with the `active_users` count it sits
-    under, which counts distinct non-null users over the same rows.
+    Runs with no user behind them are not named here: a channel message from
+    somebody with no account, and a run whose user was deleted (the foreign key
+    SET-NULLs), neither is a person this card can name. Keeping them out of
+    these rows is what keeps the card consistent with the `active_users` count
+    it sits under, which counts distinct non-null users over the same rows;
+    their runs and cost are gathered into `UnattributedUsage` instead, so the
+    per-person total still reconciles with the by-agent card.
 
     Ordered by `runs`, deliberately not by cost - the same rows sorted by
     spend read as a league table, and the question the card answers is
@@ -169,6 +170,22 @@ class PersonUsageRow(BaseSchema):
     user_id: UUID
     email: str
     full_name: str | None
+    runs: int
+    cost_usd: Decimal
+    last_run_at: datetime
+
+
+class UnattributedUsage(BaseSchema):
+    """The window's runs with no user behind them, as one muted bucket.
+
+    A run whose `user_id` is null - a deleted user (the foreign key SET-NULLs)
+    or an account-less channel or widget run - is dropped from `by_user`'s
+    named rows. It names nobody, so it cannot be a `PersonUsageRow`; it is
+    collected here so the per-person spend card reconciles with the by-agent
+    total, which counts these runs. `scope=org` only: a `scope=own` request is
+    already one person's own rows, none of which are unattributed.
+    """
+
     runs: int
     cost_usd: Decimal
     last_run_at: datetime
@@ -204,3 +221,4 @@ class UsageStats(BaseSchema):
     agent_id: UUID | None = None
     by_version: list[VersionUsageRow] | None = None
     by_user: list[PersonUsageRow] | None = None
+    unattributed_usage: UnattributedUsage | None = None

--- a/backend/app/services/stats.py
+++ b/backend/app/services/stats.py
@@ -37,6 +37,7 @@ from app.schemas.stats import (
     ScopedRatingSummary,
     StatusCount,
     SurfaceCount,
+    UnattributedUsage,
     UsageStats,
     VersionUsageRow,
 )
@@ -350,6 +351,18 @@ class StatsService:
             user_id=user_id,
             limit=limit,
         )
+        # Only org scope carries the bucket: a scope=own answer is already one
+        # person's own rows, none of which are unattributed.
+        unattributed = (
+            await agent_run_repo.unattributed_usage(
+                self.db,
+                organization_id=ctx.organization_id,
+                start=window.start,
+                end=window.end,
+            )
+            if scope == "org"
+            else None
+        )
         return UsageStats(
             from_date=window.from_date,
             to_date=window.to_date,
@@ -365,6 +378,13 @@ class StatsService:
                 )
                 for row_user_id, email, full_name, runs, cost, last_run_at in rows
             ],
+            unattributed_usage=(
+                UnattributedUsage(
+                    runs=unattributed[0], cost_usd=unattributed[1], last_run_at=unattributed[2]
+                )
+                if unattributed is not None
+                else None
+            ),
         )
 
     async def ratings_summary(

--- a/backend/tests/integration/test_usage_stats_sql.py
+++ b/backend/tests/integration/test_usage_stats_sql.py
@@ -801,6 +801,79 @@ class TestPersonRows:
         assert [(row.user_id, row.runs) for row in result.by_user] == [(owner.id, 1)]
         assert result.total_runs is None
 
+    async def test_the_unattributed_bucket_reconciles_by_person_with_by_agent(self, db) -> None:
+        """A deleted user's priced runs, and account-less ones, are gathered
+        into the bucket rather than dropped, so the per-person total lines up
+        with the by-agent total, which still counts them under their agent."""
+        organization, owner = await _org_with_owner(db, "Reconcile")
+        agent = await _agent(db, organization, owner)
+        named = await _user(db)
+        leaver = await _user(db)
+        await _run(
+            db,
+            organization=organization,
+            agent=agent,
+            started_at=START,
+            user_id=named.id,
+            cost=Decimal("2.00"),
+        )
+        await _run(
+            db,
+            organization=organization,
+            agent=agent,
+            started_at=START + timedelta(days=1),
+            user_id=leaver.id,
+            cost=Decimal("3.00"),
+        )
+        # A channel or widget run that never had an account behind it.
+        await _run(
+            db,
+            organization=organization,
+            agent=agent,
+            started_at=START,
+            user_id=None,
+            cost=Decimal("0.50"),
+        )
+        # The user leaves the organization: ondelete=SET NULL nulls their run.
+        await db.delete(leaver)
+        await db.flush()
+
+        named_rows = await agent_run_repo.usage_by_user(
+            db, organization_id=organization.id, start=START, end=END, limit=10
+        )
+        bucket = await agent_run_repo.unattributed_usage(
+            db, organization_id=organization.id, start=START, end=END
+        )
+        total_runs = await agent_run_repo.count_runs(
+            db, organization_id=organization.id, start=START, end=END
+        )
+        total_cost = await agent_run_repo.sum_cost_window(
+            db, organization_id=organization.id, start=START, end=END
+        )
+
+        # The leaver has dropped out of the named rows; the account-less run
+        # never was one. Both land in the bucket.
+        assert [row[0] for row in named_rows] == [named.id]
+        assert bucket is not None
+        bucket_runs, bucket_cost, _last = bucket
+        assert (bucket_runs, bucket_cost) == (2, Decimal("3.50"))
+        # Named rows plus the bucket reconcile with the by-agent totals.
+        assert sum(row[3] for row in named_rows) + bucket_runs == total_runs
+        assert sum(row[4] for row in named_rows) + bucket_cost == total_cost
+
+    async def test_a_window_with_every_run_named_has_no_bucket(self, db) -> None:
+        organization, owner = await _org_with_owner(db, "AllNamed")
+        agent = await _agent(db, organization, owner)
+        person = await _user(db)
+        await _run(db, organization=organization, agent=agent, started_at=START, user_id=person.id)
+
+        assert (
+            await agent_run_repo.unattributed_usage(
+                db, organization_id=organization.id, start=START, end=END
+            )
+            is None
+        )
+
 
 class TestDelegationsAndDoubleCounting:
     """Which side of `include_delegations` each dashboard aggregate takes.

--- a/backend/tests/integration/test_usage_stats_sql.py
+++ b/backend/tests/integration/test_usage_stats_sql.py
@@ -874,6 +874,45 @@ class TestPersonRows:
             is None
         )
 
+    async def test_another_organizations_unattributed_runs_never_enter_the_bucket(self, db) -> None:
+        """A null-user run in another organization stays out of this one's bucket.
+
+        `unattributed_usage` takes its organization id from the caller and gathers
+        the window's account-less runs, so it needs the same tenant bound the named
+        rows carry: without it a widget or channel run in a stranger's organization
+        would inflate a reconciliation total that is supposed to be the caller's
+        alone. The bound bites at exactly the query that reads an id from the caller,
+        which is where a borrowed id would."""
+        mine, my_owner = await _org_with_owner(db, "MineBucket")
+        theirs, their_owner = await _org_with_owner(db, "TheirsBucket")
+        my_agent = await _agent(db, mine, my_owner)
+        their_agent = await _agent(db, theirs, their_owner)
+        await _run(
+            db,
+            organization=mine,
+            agent=my_agent,
+            started_at=START,
+            user_id=None,
+            cost=Decimal("0.50"),
+        )
+        for _ in range(9):
+            await _run(
+                db,
+                organization=theirs,
+                agent=their_agent,
+                started_at=START,
+                user_id=None,
+                cost=Decimal("1.00"),
+            )
+
+        bucket = await agent_run_repo.unattributed_usage(
+            db, organization_id=mine.id, start=START, end=END
+        )
+
+        assert bucket is not None
+        bucket_runs, bucket_cost, _last = bucket
+        assert (bucket_runs, bucket_cost) == (1, Decimal("0.50"))
+
 
 class TestDelegationsAndDoubleCounting:
     """Which side of `include_delegations` each dashboard aggregate takes.

--- a/backend/tests/test_stats.py
+++ b/backend/tests/test_stats.py
@@ -47,6 +47,7 @@ def repos(monkeypatch: pytest.MonkeyPatch) -> dict[str, AsyncMock]:
         ("count_pending_approval_runs", 0),
         ("usage_by_version", []),
         ("usage_by_user", []),
+        ("unattributed_usage", None),
     ):
         mock = AsyncMock(return_value=value)
         monkeypatch.setattr(f"app.services.stats.agent_run_repo.{name}", mock)
@@ -351,6 +352,30 @@ class TestPersonGrouping:
             await StatsService(MagicMock()).usage_by_user(
                 _ctx(role=OrgRoleName.MEMBER.value), scope="org", limit=10
             )
+
+    async def test_org_scope_gathers_the_unattributed_bucket(self, repos) -> None:
+        """Null-user runs come back as a bucket so the card reconciles with By agent."""
+        repos["unattributed_usage"].return_value = (7, Decimal("4.20"), _AT)
+
+        result = await StatsService(MagicMock()).usage_by_user(_ctx(), scope="org", limit=10)
+
+        assert result.unattributed_usage is not None
+        bucket = result.unattributed_usage
+        assert (bucket.runs, bucket.cost_usd, bucket.last_run_at) == (7, Decimal("4.20"), _AT)
+
+    async def test_no_unattributed_runs_leaves_the_bucket_off(self, repos) -> None:
+        result = await StatsService(MagicMock()).usage_by_user(_ctx(), scope="org", limit=10)
+
+        assert result.unattributed_usage is None
+
+    async def test_own_scope_never_asks_for_an_unattributed_bucket(self, repos) -> None:
+        """A caller's own rows are never unattributed, so the query is skipped."""
+        ctx = _ctx(role=OrgRoleName.MEMBER.value)
+
+        result = await StatsService(MagicMock()).usage_by_user(ctx, scope="own", limit=10)
+
+        assert result.unattributed_usage is None
+        repos["unattributed_usage"].assert_not_called()
 
 
 class TestRatingsSummary:

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -320,6 +320,16 @@ stewards, and it says so in its own copy. A caller without `runs:view` does not 
 it — the card is absent, and its question is never asked, rather than a request that
 comes back refused.
 
+A run with **nobody behind it** — a member whose account was deleted, whose runs the
+foreign key SET-NULLs, or an account-less channel or widget run — would fall out of a
+per-person breakdown built on an inner join, and the tab would read as if that spend
+had vanished. It does not: those runs are gathered into a single **unattributed**
+bucket shown beside the named rows, over the same window, so the people total
+reconciles with By agent — which still counts them under the agent that ran them. The
+bucket appears only when the window holds such a run, and like every window aggregate
+it is top-level only, so a delegation's null `user_id` is not counted a second time
+outside its parent.
+
 ### Narrowing the approvals queue
 
 `GET /approvals` serves two views of the same rows. Pending only by default, which

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -309,6 +309,17 @@ reader expects an agent, and split one agent across two rows for having answered
 two models. The per-model shape survives where it is the question being asked: the
 usage email still groups that way.
 
+**Who spent it is a fourth breakdown**, beneath By provider, By key and By agent —
+the one that answers with people rather than vendors or agents. It reads the same
+`group_by=user` rows the dashboard's adoption table does — top-level runs only,
+busiest first — so a delegate's cost lands once, inside the run that started it, and
+it covers the window the rest of the tab shows rather than a rolling default of its
+own. Naming the organization's people is the same call the dashboard card makes, so
+it takes the same gate: `runs:view`, held by builder and operator as well as the two
+stewards, and it says so in its own copy. A caller without `runs:view` does not see
+it — the card is absent, and its question is never asked, rather than a request that
+comes back refused.
+
 ### Narrowing the approvals queue
 
 `GET /approvals` serves two views of the same rows. Pending only by default, which

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2370,6 +2370,7 @@
       "argumentsAreShownFull": "The arguments are shown in full. Approving a tool name without seeing what it will do is a rubber stamp, not approval.",
       "askedBy": "Asked by {name}",
       "byKey": "By key",
+      "byPerson": "By person",
       "byProvider": "By provider",
       "calendarMonthSoReconciles": "Calendar month, so it reconciles against an invoice.",
       "cost": "Cost",
@@ -2393,12 +2394,14 @@
       "narrowedToOneRun": "Narrowed to one run and what it delegated.",
       "noRunsYet": "No runs yet",
       "noSuchRun": "No such run",
+      "nobodyHasRunAnything": "Nobody has run anything yet.",
       "notRecorded": "Not recorded",
       "nothingHasRun": "Nothing has run.",
       "nothingSpentYet": "Nothing spent yet.",
       "nothingSpentYet2": "Nothing spent yet.",
       "nothingWaiting": "Nothing waiting",
       "openTheRunItCame": "Open the run it came from",
+      "perPersonDisclosure": "Everyone holding runs:view sees this - builders and operators as well as owners and admins.",
       "queueCouldNotBeRead": "The approvals queue could not be read",
       "reject": "Reject",
       "runCouldNotBeRead": "That run could not be read",
@@ -2431,7 +2434,9 @@
       "waitingPerson": "Waiting on a person",
       "whatEachVendorWas": "What each vendor was paid - this is the number an invoice is checked against.",
       "whatYourAgentsDid2": "What your agents did, what it cost, and what is waiting on a person.",
-      "whichStoredCredentialWas": "Which stored credential it was spent through. A key you do not recognise here is one to rotate."
+      "whichStoredCredentialWas": "Which stored credential it was spent through. A key you do not recognise here is one to rotate.",
+      "whoIsSpendingCouldNotBeRead": "Who is spending could not be read.",
+      "whoRanAgentsAndWhatItCost": "Who ran agents in this window, and what it cost - busiest first."
     },
     "sandboxes": {
       "addConnection": "Add connection",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2420,6 +2420,8 @@
       "spendByAgent": "Spend by agent",
       "spendCouldNotBeRead": "Spend could not be read",
       "spendMonth": "Spend this month",
+      "spendUnattributed": "Deleted users and anonymous runs",
+      "spendWindowNote": "Figures cover the selected window, bucketed by UTC day, so the total can differ slightly from By agent at the edges.",
       "started": "Started",
       "status": "Status",
       "surface": "Surface",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2401,6 +2401,7 @@
       "nothingSpentYet2": "Nothing spent yet.",
       "nothingWaiting": "Nothing waiting",
       "openTheRunItCame": "Open the run it came from",
+      "othersRanAgents": "{count, plural, =1 {1 more person ran at least one agent} other {# more people ran at least one agent}}",
       "perPersonDisclosure": "Everyone holding runs:view sees this - builders and operators as well as owners and admins.",
       "queueCouldNotBeRead": "The approvals queue could not be read",
       "reject": "Reject",

--- a/frontend/src/components/runs/spend-by-person.integration.test.tsx
+++ b/frontend/src/components/runs/spend-by-person.integration.test.tsx
@@ -1,0 +1,149 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SpendByPerson } from "./spend-by-person";
+import { apiClient } from "@/lib/api-client";
+import type { Permission } from "@/types/permissions";
+import type { PersonUsageRow } from "@/types/stats";
+
+/**
+ * Who is spending, on the Spend tab.
+ *
+ * The load-bearing case is the refusal: this breakdown names the organization's
+ * people, so a caller without `runs:view` must not see it - and not by a request
+ * that 403s after the card is on screen, but by the card never rendering and its
+ * question never being asked. The rest proves it obeys the tab's window, and that
+ * a failed request reads as a failure rather than as "nobody spent anything".
+ */
+
+vi.mock("@/lib/api-client", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api-client")>("@/lib/api-client");
+  return { ...actual, apiClient: { ...actual.apiClient, get: vi.fn() } };
+});
+
+// Full-key echo, so a chrome string is assertable and unambiguous.
+vi.mock("next-intl", () => ({
+  useTranslations: (namespace?: string) => (key: string) =>
+    namespace ? `${namespace}.${key}` : key,
+}));
+
+const auth = {
+  can: (_permission: Permission) => true,
+  canAll: () => true,
+  scopeOf: () => "all" as const,
+  role: "owner",
+  isAppAdmin: false,
+  isLoading: false,
+  error: null,
+};
+vi.mock("@/hooks/use-permissions", () => ({ usePermissions: () => auth }));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+function holds(...held: Permission[]) {
+  return (permission: Permission) => held.includes(permission);
+}
+
+const PEOPLE: PersonUsageRow[] = [
+  {
+    user_id: "u1",
+    email: "k.nowak@example.com",
+    full_name: "Katarzyna Nowak",
+    runs: 24,
+    cost_usd: "1.1000",
+    last_run_at: "2026-08-04T09:30:00Z",
+  },
+  {
+    user_id: "u2",
+    email: "j.wisniewski@example.com",
+    full_name: null,
+    runs: 16,
+    cost_usd: "0.5400",
+    last_run_at: "2026-08-03T17:05:00Z",
+  },
+];
+
+function serve(byUser: PersonUsageRow[] | null) {
+  vi.mocked(apiClient.get).mockResolvedValue({ by_user: byUser });
+}
+
+function usageCalls() {
+  return vi.mocked(apiClient.get).mock.calls.filter(([path]) => path === "/stats/usage");
+}
+
+beforeEach(() => {
+  vi.mocked(apiClient.get).mockReset();
+  auth.can = () => true;
+});
+
+describe("the per-person spend breakdown", () => {
+  it("names the people who spent, and what their runs cost", async () => {
+    serve(PEOPLE);
+
+    render(<SpendByPerson from="2026-07-08" to="2026-08-07" />, { wrapper });
+
+    // Data-borne, not chrome: the names and figures came from the response.
+    expect(await screen.findByText("Katarzyna Nowak")).toBeVisible();
+    expect(screen.getByText("$1.1000")).toBeVisible();
+    // No display name stored - the email identifies the person instead.
+    expect(screen.getByText("j.wisniewski@example.com")).toBeVisible();
+    expect(screen.getByText("pages.runs.perPersonDisclosure")).toBeVisible();
+  });
+
+  it("asks /stats/usage for the org's people over the window it was handed", async () => {
+    serve(PEOPLE);
+
+    render(<SpendByPerson from="2026-07-08" to="2026-08-07" />, { wrapper });
+
+    await waitFor(() => expect(usageCalls().length).toBeGreaterThan(0));
+    const [, options] = usageCalls()[0]!;
+    const params = (options as { params: Record<string, string> }).params;
+    expect(params.group_by).toBe("user");
+    expect(params.scope).toBe("org");
+    expect(params.from).toBe("2026-07-08");
+    expect(params.to).toBe("2026-08-07");
+  });
+
+  it("is absent for a caller without runs:view, and never asks who spent", async () => {
+    // The refusal that is the point: not disabled, not a 403 after the fact - the
+    // card is not rendered and the question is never put to the server.
+    auth.can = holds("agents:view", "agents:run");
+    serve(PEOPLE);
+
+    const { container } = render(<SpendByPerson from="2026-07-08" to="2026-08-07" />, { wrapper });
+
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText("Katarzyna Nowak")).toBeNull();
+    expect(usageCalls()).toHaveLength(0);
+  });
+
+  it("says the request failed rather than that nobody spent anything", async () => {
+    // The empty-state trap on a page about money: a 502 and a quiet month are the
+    // same pixels unless the card keeps them apart.
+    vi.mocked(apiClient.get).mockRejectedValue(new Error("502"));
+
+    render(<SpendByPerson from="2026-07-08" to="2026-08-07" />, { wrapper });
+
+    expect(await screen.findByText("pages.runs.whoIsSpendingCouldNotBeRead")).toBeVisible();
+    expect(screen.queryByText("pages.runs.nobodyHasRunAnything")).toBeNull();
+
+    // Retry re-asks rather than sitting on the stale failure.
+    await userEvent.click(screen.getByRole("button", { name: "pages.runs.tryAgain" }));
+    await waitFor(() => expect(usageCalls().length).toBeGreaterThan(1));
+  });
+
+  it("says nobody has run anything when the window is genuinely empty", async () => {
+    serve([]);
+
+    render(<SpendByPerson from="2026-07-08" to="2026-08-07" />, { wrapper });
+
+    expect(await screen.findByText("pages.runs.nobodyHasRunAnything")).toBeVisible();
+    expect(screen.queryByText("pages.runs.whoIsSpendingCouldNotBeRead")).toBeNull();
+  });
+});

--- a/frontend/src/components/runs/spend-by-person.integration.test.tsx
+++ b/frontend/src/components/runs/spend-by-person.integration.test.tsx
@@ -69,8 +69,14 @@ const PEOPLE: PersonUsageRow[] = [
   },
 ];
 
-function serve(byUser: PersonUsageRow[] | null) {
-  vi.mocked(apiClient.get).mockResolvedValue({ by_user: byUser });
+function serve(byUser: PersonUsageRow[] | null, active: number | null = null) {
+  vi.mocked(apiClient.get).mockImplementation((_path: string, options?: unknown) => {
+    const params = (options as { params?: Record<string, string> } | undefined)?.params;
+    if (params?.group_by === "user") return Promise.resolve({ by_user: byUser });
+    return Promise.resolve({
+      active_users: active === null ? null : { active, total_members: active },
+    });
+  });
 }
 
 function usageCalls() {
@@ -96,13 +102,34 @@ describe("the per-person spend breakdown", () => {
     expect(screen.getByText("pages.runs.perPersonDisclosure")).toBeVisible();
   });
 
+  it("says how many people the top rows leave unnamed", async () => {
+    // A card is not a directory: the org has more active people than it lists, and
+    // it says so rather than reading as the whole organization.
+    serve(PEOPLE, 5);
+
+    render(<SpendByPerson from="2026-07-08" to="2026-08-07" />, { wrapper });
+
+    expect(await screen.findByText("pages.runs.othersRanAgents")).toBeVisible();
+  });
+
+  it("claims no others when the rows already name everyone active", async () => {
+    serve(PEOPLE, 2);
+
+    render(<SpendByPerson from="2026-07-08" to="2026-08-07" />, { wrapper });
+
+    expect(await screen.findByText("Katarzyna Nowak")).toBeVisible();
+    expect(screen.queryByText("pages.runs.othersRanAgents")).toBeNull();
+  });
+
   it("asks /stats/usage for the org's people over the window it was handed", async () => {
     serve(PEOPLE);
 
     render(<SpendByPerson from="2026-07-08" to="2026-08-07" />, { wrapper });
 
     await waitFor(() => expect(usageCalls().length).toBeGreaterThan(0));
-    const [, options] = usageCalls()[0]!;
+    const [, options] = usageCalls().find(
+      ([, opts]) => (opts as { params?: Record<string, string> }).params?.group_by === "user",
+    )!;
     const params = (options as { params: Record<string, string> }).params;
     expect(params.group_by).toBe("user");
     expect(params.scope).toBe("org");
@@ -134,8 +161,9 @@ describe("the per-person spend breakdown", () => {
     expect(screen.queryByText("pages.runs.nobodyHasRunAnything")).toBeNull();
 
     // Retry re-asks rather than sitting on the stale failure.
+    const before = usageCalls().length;
     await userEvent.click(screen.getByRole("button", { name: "pages.runs.tryAgain" }));
-    await waitFor(() => expect(usageCalls().length).toBeGreaterThan(1));
+    await waitFor(() => expect(usageCalls().length).toBeGreaterThan(before));
   });
 
   it("says nobody has run anything when the window is genuinely empty", async () => {

--- a/frontend/src/components/runs/spend-by-person.integration.test.tsx
+++ b/frontend/src/components/runs/spend-by-person.integration.test.tsx
@@ -7,7 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SpendByPerson } from "./spend-by-person";
 import { apiClient } from "@/lib/api-client";
 import type { Permission } from "@/types/permissions";
-import type { PersonUsageRow } from "@/types/stats";
+import type { PersonUsageRow, UnattributedUsage } from "@/types/stats";
 
 /**
  * Who is spending, on the Spend tab.
@@ -69,10 +69,15 @@ const PEOPLE: PersonUsageRow[] = [
   },
 ];
 
-function serve(byUser: PersonUsageRow[] | null, active: number | null = null) {
+function serve(
+  byUser: PersonUsageRow[] | null,
+  active: number | null = null,
+  unattributed: UnattributedUsage | null = null,
+) {
   vi.mocked(apiClient.get).mockImplementation((_path: string, options?: unknown) => {
     const params = (options as { params?: Record<string, string> } | undefined)?.params;
-    if (params?.group_by === "user") return Promise.resolve({ by_user: byUser });
+    if (params?.group_by === "user")
+      return Promise.resolve({ by_user: byUser, unattributed_usage: unattributed });
     return Promise.resolve({
       active_users: active === null ? null : { active, total_members: active },
     });
@@ -119,6 +124,26 @@ describe("the per-person spend breakdown", () => {
 
     expect(await screen.findByText("Katarzyna Nowak")).toBeVisible();
     expect(screen.queryByText("pages.runs.othersRanAgents")).toBeNull();
+  });
+
+  it("shows an unattributed bucket so the total reconciles with by agent", async () => {
+    // A deleted user's runs and account-less runs are counted by the by-agent
+    // card; the bucket keeps them visible here rather than silently dropped.
+    serve(PEOPLE, 2, { runs: 5, cost_usd: "0.9000", last_run_at: "2026-08-05T12:00:00Z" });
+
+    render(<SpendByPerson from="2026-07-08" to="2026-08-07" />, { wrapper });
+
+    expect(await screen.findByText("pages.runs.spendUnattributed")).toBeVisible();
+    expect(screen.getByText("$0.9000")).toBeVisible();
+  });
+
+  it("omits the unattributed bucket when every run has a named user", async () => {
+    serve(PEOPLE, 2, null);
+
+    render(<SpendByPerson from="2026-07-08" to="2026-08-07" />, { wrapper });
+
+    expect(await screen.findByText("Katarzyna Nowak")).toBeVisible();
+    expect(screen.queryByText("pages.runs.spendUnattributed")).toBeNull();
   });
 
   it("asks /stats/usage for the org's people over the window it was handed", async () => {

--- a/frontend/src/components/runs/spend-by-person.tsx
+++ b/frontend/src/components/runs/spend-by-person.tsx
@@ -24,12 +24,17 @@ const ROWS = 10;
  * failed request says so here rather than reporting that nobody spent anything.
  * The rows exclude delegated runs, the same as every other figure on the page, so
  * a delegate's cost is counted once inside the run that started it.
+ *
+ * Runs with no named user - a deleted account, or an account-less channel run -
+ * are the figure the by-agent card counts and a per-person list cannot name; they
+ * are shown as one muted bucket row so the two cards reconcile rather than silently
+ * disagree.
  */
 export function SpendByPerson({ from, to }: { from: string; to: string }) {
   const t = useTranslations("pages.runs");
   const { can } = usePermissions();
   const maySee = can(Perm.runsView);
-  const { byUser, isLoading, error, refetch } = usePeopleUsage(
+  const { byUser, unattributed, isLoading, error, refetch } = usePeopleUsage(
     { from, to },
     { scope: "org", limit: ROWS, enabled: maySee },
   );
@@ -74,12 +79,20 @@ export function SpendByPerson({ from, to }: { from: string; to: string }) {
                 <span className="font-mono">${Number(person.cost_usd).toFixed(4)}</span>
               </div>
             ))}
+            {unattributed && unattributed.runs > 0 ? (
+              <div className="text-muted-foreground flex items-center justify-between gap-3 rounded-md border border-dashed p-3 text-sm">
+                <span className="min-w-0 flex-1 truncate italic">{t("spendUnattributed")}</span>
+                <span className="text-xs">{t("runCount", { count: unattributed.runs })}</span>
+                <span className="font-mono">${Number(unattributed.cost_usd).toFixed(4)}</span>
+              </div>
+            ) : null}
             {others > 0 ? (
               <p className="text-muted-foreground text-xs">
                 {t("othersRanAgents", { count: others })}
               </p>
             ) : null}
             <p className="text-muted-foreground text-xs">{t("perPersonDisclosure")}</p>
+            <p className="text-muted-foreground text-xs">{t("spendWindowNote")}</p>
           </>
         )}
       </CardContent>

--- a/frontend/src/components/runs/spend-by-person.tsx
+++ b/frontend/src/components/runs/spend-by-person.tsx
@@ -4,7 +4,7 @@ import { useTranslations } from "next-intl";
 
 import { LoadingState } from "@/components/states";
 import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
-import { usePeopleUsage, usePermissions } from "@/hooks";
+import { usePeopleUsage, usePermissions, useUsageStats } from "@/hooks";
 import { Perm } from "@/types/permissions";
 
 /** A card, not a directory: the busiest few, with the disclosure under them. */
@@ -33,6 +33,10 @@ export function SpendByPerson({ from, to }: { from: string; to: string }) {
     { from, to },
     { scope: "org", limit: ROWS, enabled: maySee },
   );
+  // The org headcount rides the composed usage answer for the same window, so a
+  // top-N list can say how many people it leaves unnamed without a second request.
+  const { usage } = useUsageStats({ from, to }, { scope: "org", enabled: maySee });
+  const others = Math.max((usage?.active_users?.active ?? 0) - byUser.length, 0);
 
   if (!maySee) return null;
 
@@ -70,6 +74,11 @@ export function SpendByPerson({ from, to }: { from: string; to: string }) {
                 <span className="font-mono">${Number(person.cost_usd).toFixed(4)}</span>
               </div>
             ))}
+            {others > 0 ? (
+              <p className="text-muted-foreground text-xs">
+                {t("othersRanAgents", { count: others })}
+              </p>
+            ) : null}
             <p className="text-muted-foreground text-xs">{t("perPersonDisclosure")}</p>
           </>
         )}

--- a/frontend/src/components/runs/spend-by-person.tsx
+++ b/frontend/src/components/runs/spend-by-person.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+import { LoadingState } from "@/components/states";
+import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
+import { usePeopleUsage, usePermissions } from "@/hooks";
+import { Perm } from "@/types/permissions";
+
+/** A card, not a directory: the busiest few, with the disclosure under them. */
+const ROWS = 10;
+
+/**
+ * Who spent the money, over the window the rest of the tab already shows.
+ *
+ * The one breakdown on this page that answers with people rather than vendors or
+ * agents, so it carries its own audience note: the gate is `runs:view`, which
+ * builder and operator hold as well as the two stewards, and somebody named here
+ * deserves to know how far the list reaches. Absent entirely - never disabled or
+ * refused after the fact - for a caller without it, and its request is not made.
+ *
+ * Its own query against `/stats/usage?group_by=user`, so it fails on its own card
+ * rather than taking the vendor and key breakdowns down with it - which is why a
+ * failed request says so here rather than reporting that nobody spent anything.
+ * The rows exclude delegated runs, the same as every other figure on the page, so
+ * a delegate's cost is counted once inside the run that started it.
+ */
+export function SpendByPerson({ from, to }: { from: string; to: string }) {
+  const t = useTranslations("pages.runs");
+  const { can } = usePermissions();
+  const maySee = can(Perm.runsView);
+  const { byUser, isLoading, error, refetch } = usePeopleUsage(
+    { from, to },
+    { scope: "org", limit: ROWS, enabled: maySee },
+  );
+
+  if (!maySee) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("byPerson")}</CardTitle>
+        <CardDescription>{t("whoRanAgentsAndWhatItCost")}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {isLoading ? (
+          <LoadingState variant="skeleton-panel" rows={3} />
+        ) : error ? (
+          <div className="space-y-2">
+            <p className="text-muted-foreground text-sm">{t("whoIsSpendingCouldNotBeRead")}</p>
+            <Button variant="outline" size="sm" onClick={() => void refetch()}>
+              {t("tryAgain")}
+            </Button>
+          </div>
+        ) : byUser.length === 0 ? (
+          <p className="text-muted-foreground text-sm">{t("nobodyHasRunAnything")}</p>
+        ) : (
+          <>
+            {byUser.map((person) => (
+              <div
+                key={person.user_id}
+                className="flex items-center justify-between gap-3 rounded-md border p-3 text-sm"
+              >
+                <span className="min-w-0 flex-1 truncate font-medium">
+                  {person.full_name ?? person.email}
+                </span>
+                <span className="text-muted-foreground text-xs">
+                  {t("runCount", { count: person.runs })}
+                </span>
+                <span className="font-mono">${Number(person.cost_usd).toFixed(4)}</span>
+              </div>
+            ))}
+            <p className="text-muted-foreground text-xs">{t("perPersonDisclosure")}</p>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/runs/spend-tab.tsx
+++ b/frontend/src/components/runs/spend-tab.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { ErrorState, LoadingState } from "@/components/states";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
 import { SpendBreakdown } from "@/components/runs/spend-breakdown";
+import { SpendByPerson } from "@/components/runs/spend-by-person";
 import { useSpend } from "@/hooks";
 import { formatDate, getErrorMessage } from "@/lib/utils";
 import type { CostSummary } from "@/types/runs";
@@ -134,6 +135,19 @@ export function SpendTab() {
           )}
         </CardContent>
       </Card>
+
+      {/* Who spent it, over the same window the breakdowns above read. The
+          people rows come from `/stats/usage?group_by=user` rather than `/spend`,
+          so the window is handed over as the range this tab resolved to: the
+          `from`/`to` the caption already reflects, with an open-ended window read
+          as "up to now". Gated on runs:view inside the card, so it is absent for
+          a caller without it rather than a refused request. */}
+      {spend?.from_date != null && (
+        <SpendByPerson
+          from={spend.from_date.slice(0, 10)}
+          to={(spend.to_date ?? new Date().toISOString()).slice(0, 10)}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/hooks/use-usage-stats.ts
+++ b/frontend/src/hooks/use-usage-stats.ts
@@ -91,7 +91,13 @@ export function usePeopleUsage(
     enabled: options?.enabled ?? true,
     ...DASHBOARD_FRESHNESS,
   });
-  return { byUser: data?.by_user ?? [], isLoading, error, refetch };
+  return {
+    byUser: data?.by_user ?? [],
+    unattributed: data?.unattributed_usage ?? null,
+    isLoading,
+    error,
+    refetch,
+  };
 }
 
 /** Answer quality for the window: the thumbs split and its per-day series. */

--- a/frontend/src/types/stats.ts
+++ b/frontend/src/types/stats.ts
@@ -84,6 +84,13 @@ export interface PersonUsageRow {
   last_run_at: string;
 }
 
+export interface UnattributedUsage {
+  runs: number;
+  /** Serialised Decimal - never parse into a float for arithmetic. */
+  cost_usd: string;
+  last_run_at: string;
+}
+
 export interface UsageStats {
   from: string;
   to: string;
@@ -106,6 +113,8 @@ export interface UsageStats {
   by_version: VersionUsageRow[] | null;
   /** group_by=user only, capped by the request's limit. */
   by_user: PersonUsageRow[] | null;
+  /** group_by=user, scope=org only: runs with no named user, as one bucket. */
+  unattributed_usage: UnattributedUsage | null;
 }
 
 export interface RatingsByDay {


### PR DESCRIPTION
## Summary

The Spend tab's **By person** card could under-count against the **By agent** card above it — the disagreement #214 warned against ("a breakdown that disagrees with the number above it is worse than no breakdown"). `usage_by_user` inner-joins `User`, so a priced run whose user was deleted (the FK SET-NULLs) or an account-less channel run was dropped from By person while By agent still counted it. This gathers those runs into an unattributed bucket so the two cards reconcile.

## Related Issue

Closes #539.

## Added

- `unattributed_usage` (`app/repositories/agent_run.py`) — the window's `user_id IS NULL` runs as one bucket (runs, cost, last run), top-level only. `UnattributedUsage` schema plus an `unattributed_usage` field on `UsageStats`.
- A muted bucket row ("Deleted users and anonymous runs") with its cost on `spend-by-person.tsx`, and a note naming the window basis.

## Changed

- `StatsService.usage_by_user` composes the bucket for `scope=org` only — a caller's own rows are never unattributed. `PersonUsageRow`'s docstring updated: null-user runs are gathered into the bucket rather than silently dropped, and `by_user`'s named rows are left untouched, so they stay consistent with `active_users`.
- `usePeopleUsage` exposes `unattributed`.

## Checks

- [x] Tests cover the new behaviour, and would fail without the change
- [ ] `make check` passes (lint, format, types)
- [x] Platform-layer coverage is still 100%
- [x] If a capability was added or changed, its `README.md` says why
- [x] If a migration was added, `alembic downgrade base && alembic upgrade head` works

## Notes for Reviewers

- **Stacked on #527** (`feat/per-person-usage`): this PR is based on that branch, so the diff shows only the reconciliation change and not #527's card. Once #527 merges, GitHub auto-retargets this to `main`, and `Closes #539` fires when it lands there.
- **The window is not aligned, by design.** By agent (`/spend`) ends at a precise `now`; By person (`/stats/usage`) truncates to whole UTC days — aligning would move every dashboard card. The bucket closes the structural gap; the card's window note names the residual edge difference so the two are never silently summed.
- **Verified against a real database:** a deleted user's priced runs and account-less runs land in the bucket, and the named rows plus the bucket sum to the by-agent totals (`test_usage_stats_sql.py`, 31 passed against pgvector). Plus service unit tests (org present/absent, own skips the query), frontend bucket present/absent, and `ty` / `ruff` / `check_i18n` / `catalog` / `tsc` all clean. `make check` left unticked above — CI is the wide net.
