### PR TITLE
chore: cut 0.0.89

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,29 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.89] - 2026-08-10
+
+Run history gains the duration controls the dashboard's p95 needs rows behind,
+and the contributor guidance has its test-loop numbers corrected.
+
+### Added
+
+- **Sort and filter run history by duration** — a sortable `Took` column, a
+  "slow runs" canned view, and a dashboard p95 deep-link that seeds the sort and
+  the time window. The sort is server-side over the whole narrowed set, not one
+  page; the backend query landed with #202 and is reused unchanged. Closes #210.
+  (#528)
+
+### Changed
+
+- **Contributor guidance** — `CLAUDE.md` now states the scoped-vs-full test rule
+  outright and its runtime figures are corrected against measurement: CI answers
+  in about twelve minutes rather than seven, and a scoped backend file takes a
+  few seconds rather than "under one" (the wait is importing the app, not the
+  run). The same stale CI figure in `docs/testing.md` and three moved
+  `app/core/catalog/` paths in the docs trigger map went with it. Closes #522.
+  (#534)
+
 ## [0.0.88] - 2026-08-10
 
 Two grouped dependency updates, nothing else. The lockfile resolves cleanly with

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.88"
+version = "0.0.89"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.88"
+version = "0.0.89"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.88",
+  "version": "0.0.89",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Two changes since 0.0.88:

- **feat(runs): sort and filter run history by duration in the UI** — a sortable `Took` column, a "slow runs" canned view, and a dashboard p95 deep-link into the sorted list. (#528, closes #210)
- **docs: sharpen the test-loop guidance and correct its stale numbers** — CLAUDE.md's scoped-vs-full rule stated outright and its runtime figures corrected against measurement (CI ~12 min not ~7, a scoped backend file ~6s not "under one"), plus the same stale figure in `docs/testing.md` and three moved `app/core/catalog/` paths. (#534, closes #522)

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json`; `uv lock --check` resolves cleanly.