### PR TITLE
perf(imports): defer aiogram and prefect out of app import

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,11 +33,8 @@ from app.services.rag.vectorstore import BaseVectorStore
 from app.repositories.channel_bot import get_active_polling_bots
 from app.services.channel_bot import unseal_bot_token, unseal_slack_app_token
 from app.services.channels import register_adapter
-from app.services.channels.supervisor import open_inbound_stream
-from app.services.channels.telegram import TelegramAdapter
 from app.services.channels import register_adapter as _slack_register
-from app.services.channels.mattermost import MattermostAdapter
-from app.services.channels.slack import SlackAdapter
+from app.services.channels.supervisor import open_inbound_stream
 from app.core.rate_limit import limiter
 
 logger = logging.getLogger(__name__)
@@ -112,6 +109,15 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[LifespanState, None]:
             state["vector_store"] = vector_store
         except Exception as e:
             logger.error("pgvector connection failed: %s. Vector store will not be available.", e)
+
+    # Imported here rather than at module top so that importing `app.main` does
+    # not pull in the channel SDKs (aiogram, the Slack client) - ~1.2s of import
+    # that the API and the test suite pay for on every process start and never
+    # use. The adapters are only ever needed from this point on: registered at
+    # startup, and stopped after the yield below (#520).
+    from app.services.channels.mattermost import MattermostAdapter
+    from app.services.channels.slack import SlackAdapter
+    from app.services.channels.telegram import TelegramAdapter
 
     _telegram_adapter = TelegramAdapter()
     register_adapter(_telegram_adapter)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,7 +33,6 @@ from app.services.rag.vectorstore import BaseVectorStore
 from app.repositories.channel_bot import get_active_polling_bots
 from app.services.channel_bot import unseal_bot_token, unseal_slack_app_token
 from app.services.channels import register_adapter
-from app.services.channels import register_adapter as _slack_register
 from app.services.channels.supervisor import open_inbound_stream
 from app.core.rate_limit import limiter
 
@@ -134,7 +133,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[LifespanState, None]:
         logger.error("Mattermost: failed to start the event stream: %s", _mm_exc)
 
     _slack_adapter = SlackAdapter()
-    _slack_register(_slack_adapter)
+    register_adapter(_slack_adapter)
     try:
         await _start_channel_polling("slack")
     except (OSError, ValueError, RuntimeError) as _slack_exc:

--- a/backend/app/services/channels/telegram.py
+++ b/backend/app/services/channels/telegram.py
@@ -6,7 +6,7 @@ import hmac
 import logging
 from typing import Any
 
-from aiogram import Bot, Dispatcher, Router
+from aiogram import Bot, Dispatcher
 from aiogram.client.default import DefaultBotProperties
 from aiogram.enums import ParseMode
 from aiogram.exceptions import TelegramBadRequest
@@ -23,8 +23,6 @@ from app.services.channels.base import (
 from app.services.channels.router import ChannelMessageRouter
 
 logger = logging.getLogger(__name__)
-
-_telegram_router = Router()
 
 
 # Every field Telegram puts a file in, with a name and a type for the kinds that

--- a/backend/app/services/rag_sync.py
+++ b/backend/app/services/rag_sync.py
@@ -9,7 +9,6 @@ from app.core.exceptions import BadRequestError, NotFoundError
 from app.db.models.sync_log import SyncLog
 from app.repositories import sync_log_repo
 from app.schemas.rag import RAGSyncLogItem, RAGSyncLogList
-from app.worker.tasks.rag_tasks import sync_collection_flow
 
 
 def _as_item(log: SyncLog) -> RAGSyncLogItem:
@@ -102,6 +101,12 @@ class RAGSyncService:
             mode=mode,
         )
         from app.core.background import spawn_after_commit
+
+        # Imported here rather than at module top so that importing this service
+        # does not pull in Prefect (~1.4s), which the API and the test suite pay
+        # for and never use - the flow only runs in the worker. The same reason
+        # `rag_document.py` and `sync_source.py` import their flows locally (#520).
+        from app.worker.tasks.rag_tasks import sync_collection_flow
 
         # The flow reads this sync log by id on its own session, so it starts
         # after the commit rather than after this line (#417).

--- a/backend/tests/test_flow_dispatch.py
+++ b/backend/tests/test_flow_dispatch.py
@@ -29,7 +29,6 @@ from app.core.permissions import AuthContext
 from app.repositories import rag_document_repo
 from app.repositories import sync_log as sync_log_repo
 from app.repositories import sync_source as sync_source_repo
-from app.services import rag_sync
 from app.services.ingestion_config import IngestionConfig, IngestionConfigService
 from app.services.rag_document import RAGDocumentService
 from app.services.rag_sync import RAGSyncService
@@ -80,7 +79,7 @@ async def test_a_local_sync_starts_after_its_log_row_is_committed(session, monke
     async def flow(*, sync_log_id: str, **_: Any) -> None:
         dispatched.append(sync_log_id)
 
-    monkeypatch.setattr(rag_sync, "sync_collection_flow", flow)
+    monkeypatch.setattr(rag_tasks, "sync_collection_flow", flow)
 
     await RAGSyncService(session).start_local_sync(
         collection_name="handbooks", mode="full", path="/srv/docs"

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,0 +1,41 @@
+"""`import app.main` stays cheap - the channel SDKs and Prefect are not pulled in.
+
+#520. `aiogram` (Telegram) and `prefect` together are the better part of three
+seconds of import that the API pays once per process and the unit suite pays
+once per worker, and neither the request path nor the tests touch them: the
+adapters are imported inside `lifespan`, which `ASGITransport` never runs, and
+the sync flows are imported by the dispatcher method that queues them, not at
+module top. Add back a single top-level `from ...channels.telegram import
+TelegramAdapter` or `from ...worker.tasks.rag_tasks import sync_collection_flow`
+and that cost returns with no other signal - so this is the signal.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_importing_the_app_does_not_pull_in_the_channel_sdks_or_prefect() -> None:
+    """A subprocess so the import is genuinely cold, not one a fixture warmed.
+
+    `python -c` puts the working directory first on `sys.path`, so `import app`
+    resolves from `backend/` the way the sibling reloader probe relies on it.
+    """
+    probe = "import app.main, sys; print('aiogram' in sys.modules, 'prefect' in sys.modules)"
+    loaded = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=REPO_ROOT / "backend",
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert loaded.stdout.strip() == "False False", (
+        "importing `app.main` pulled in a channel SDK or Prefect - a top-level "
+        "adapter or flow import has crept back and restored the import cost this "
+        f"defends (#520). stdout={loaded.stdout!r} stderr={loaded.stderr!r}"
+    )


### PR DESCRIPTION
## What this fixes

Importing `app.main` took **~5.5s** warm, ~2.3s of which was two libraries the API
and the test suite never touch: **`aiogram`** (the Telegram SDK) and **`prefect`**.
Every scoped `pytest <file>` pays that fixed cost once before a single test runs, and
`tests/conftest.py` imports `app.main`, so all ~3,900 unit tests inherit it — the
exact "a few seconds, nearly all of it importing the app" cost the loop docs describe.

`Refs #520` — the second lever of the test-speed work, orthogonal to #535 (integration
schema-once): this one cuts the *per-invocation* import, #535 cut the *integration
per-test* DDL.

## What changed

- `app/main.py` — `TelegramAdapter` / `SlackAdapter` / `MattermostAdapter` were imported
  at module top but are only instantiated inside `lifespan` (registered at startup,
  stopped after the yield). Moved the three imports into `lifespan`. Production is
  identical (startup imports them anyway); the test suite drives the app over
  ASGITransport and **never runs `lifespan`**, so it stops importing aiogram + the Slack
  client entirely.
- `app/services/rag_sync.py` — imported `sync_collection_flow` at module top, the only
  top-level worker-task import in the services layer. Moved it into the dispatching
  method, matching `rag_document.py:279` and `sync_source.py:316`, which already do this.
  The flow only runs in the worker; nothing in the API path needs Prefect at import.
- `app/services/channels/telegram.py` — removed a dead `_telegram_router = Router()`
  module global that instantiated aiogram at import and is referenced nowhere.
- `tests/test_flow_dispatch.py` — the regression test patched
  `rag_sync.sync_collection_flow`; with the import moved it patches
  `rag_tasks.sync_collection_flow` (the source module), the same way its sibling
  assertions already patch the other two flows.

## How it failed before

Not a failure — a cost. `import app.main` eagerly loaded aiogram (~1.2s) and prefect
(~1.4s) plus their transitive deps, on every process start and every scoped test run.

## Testing

Measured warm, on this machine:

| | Before | After |
|---|---|---|
| `import app.main` | ~5.5s | **~2.3s** |

- `python -c "import app.main, sys; print('aiogram' in sys.modules, 'prefect' in sys.modules)"`
  → `False False` (both confirmed absent after the import).
- `tests/test_main.py::test_importing_the_app_does_not_pull_in_the_channel_sdks_or_prefect`
  guards it in a subprocess (cold import), so a re-added top-level adapter/flow
  import fails rather than silently restoring the cost (review follow-up).
- Full unit suite green in random order (3,899 passed).
- Integration suite green (400 passed).
- 100% platform-coverage gate holds — the moved lines run in `lifespan` and
  `start_local_sync`, both covered.
- `make lint-backend` clean; ty diagnostic count unchanged vs base (66 → 66, all
  pre-existing in template-inherited files).

## Noticed, not fixed

- The `import app.main` residual is still ~2.3s (sqlalchemy + pydantic-ai + the app
  graph). A `pytest-xdist` PR (next #520 lever) amortizes the full-suite cost; a warm
  test daemon would attack the single-invocation cost but carries real caveats here
  (our capability registry and Prefect `@flow` registration would need reload
  patch-points) — evaluated separately, not pursued yet.
- The `register_adapter` / `_slack_register` alias in `main.py` is removed
  (review follow-up, 3696fc59) — one name for one thing.

