### PR TITLE
perf(tests): run the whole-suite targets across worker processes

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -33,9 +33,10 @@ Then, once, before the push:
 ```bash
 make lint               # ruff, ruff format, ty, eslint, prettier, tsc, the two guards,
                         # and codespell over every tracked file
-make test               # backend + the 100% gate on the platform layer
+make test               # backend + the 100% gate; runs across workers (-n auto,
+                        # capped at 4), pytest-cov combines their data
 make test-frontend-cov  # frontend + its gate: 100% lines/stmts/funcs, 97.5% branches
-make test-integration   # only if the change is near the database
+make test-integration   # only if the change is near the database; also parallel
 make check              # every CI job except e2e - lint, test, db-check,
                         # test-frontend-cov, build-frontend, docs-build, audit.
                         # About five minutes.

--- a/Makefile
+++ b/Makefile
@@ -333,16 +333,23 @@ format:
 # in a log nobody reads when it is green. Same run, same gate, either way.
 COV_REPORT ?= term-missing
 
+# `-n auto --maxprocesses 4`: run across worker processes. The integration
+# suite is I/O-bound on one Postgres and roughly halves; the unit suite is
+# import-bound (every worker imports the app once) and gains little past four
+# workers, so `auto` is capped there - on a many-core laptop an uncapped `auto`
+# is slower than serial, all of it worker startup. pytest-cov combines the
+# per-worker data, so the 100% gate holds unchanged. A scoped `pytest <file>`
+# stays serial: worker startup is not worth paying for one file.
 test:
-	uv run --directory backend pytest tests/ -v --cov --cov-report=$(COV_REPORT)
+	uv run --directory backend pytest tests/ -v --cov --cov-report=$(COV_REPORT) -n auto --maxprocesses 4
 
 # Fast loop while writing code — no coverage, no gate.
 test-fast:
-	uv run --directory backend pytest tests/ -q --no-cov
+	uv run --directory backend pytest tests/ -q --no-cov -n auto --maxprocesses 4
 
 # Integration tests only. These talk to a real database; start it with `make docker-db`.
 test-integration:
-	uv run --directory backend pytest tests/integration -v --no-cov
+	uv run --directory backend pytest tests/integration -v --no-cov -n auto --maxprocesses 4
 
 test-cov:
 	uv run --directory backend pytest tests/ --cov --cov-report=html --cov-report=term-missing

--- a/Makefile
+++ b/Makefile
@@ -352,7 +352,7 @@ test-integration:
 	uv run --directory backend pytest tests/integration -v --no-cov -n auto --maxprocesses 4
 
 test-cov:
-	uv run --directory backend pytest tests/ --cov --cov-report=html --cov-report=term-missing
+	uv run --directory backend pytest tests/ --cov --cov-report=html --cov-report=term-missing -n auto --maxprocesses 4
 	@echo "Open backend/htmlcov/index.html"
 
 # Everything, including template-inherited subsystems. Informational: those are

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -98,6 +98,7 @@ dev = [
     "ruff>=0.16.1",
     "ty>=0.0.69",
     "pre-commit>=4.0.0",
+    "pytest-xdist>=3.8.0",
 ]
 # The documentation site. Its own group rather than part of `dev`, because the
 # reference pages import the application to read its docstrings - so this group

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -68,6 +68,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -137,6 +138,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.0.0" },
     { name = "pytest", specifier = ">=9.0.0" },
     { name = "pytest-cov", specifier = ">=6.1.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.16.1" },
     { name = "ty", specifier = ">=0.0.69" },
 ]
@@ -1253,6 +1255,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -4231,6 +4242,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -5598,8 +5622,8 @@ name = "whenever"
 version = "0.10.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
-    { name = "tzlocal", marker = "sys_platform != 'darwin' and sys_platform != 'linux'" },
+    { name = "tzdata", marker = "python_full_version >= '3.13' and sys_platform == 'win32'" },
+    { name = "tzlocal", marker = "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6d/40/94856fe2439c4b8162d1a23b4cf3a48bb00bed0ed7b8d10add40988fa555/whenever-0.10.3.tar.gz", hash = "sha256:af8958c870bd178742f0089c3552d5702241cab1f4b6bdfd3b03111db4bc2150", size = 435946, upload-time = "2026-07-17T07:35:25.734Z" }
 wheels = [

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -21,7 +21,7 @@ Run these from the project root directory.
 | `make run` | Start development server with hot reload |
 | `make run-prod` | Start production server (0.0.0.0:8000) |
 | `make routes` | Show all registered API routes |
-| `make test` | Backend suite plus the 100% gate on the platform layer |
+| `make test` | Backend suite plus the 100% gate on the platform layer. Runs across worker processes (`-n auto --maxprocesses 4`); `pytest-cov` combines their data, so the gate is unchanged |
 | `make test-cov` | Run tests with coverage report (HTML + terminal) |
 | `make format` | Auto-format code — ruff on the backend, prettier on the frontend |
 | `make lint` | Every static check: ruff, ruff format, ty, eslint, prettier, tsc, the backtick and i18n guards, and codespell over the whole tree |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -22,7 +22,7 @@ Run these from the project root directory.
 | `make run-prod` | Start production server (0.0.0.0:8000) |
 | `make routes` | Show all registered API routes |
 | `make test` | Backend suite plus the 100% gate on the platform layer. Runs across worker processes (`-n auto --maxprocesses 4`); `pytest-cov` combines their data, so the gate is unchanged |
-| `make test-cov` | Run tests with coverage report (HTML + terminal) |
+| `make test-cov` | Run tests with coverage report (HTML + terminal). Runs across worker processes like `make test` |
 | `make format` | Auto-format code — ruff on the backend, prettier on the frontend |
 | `make lint` | Every static check: ruff, ruff format, ty, eslint, prettier, tsc, the backtick and i18n guards, and codespell over the whole tree |
 | `make lint-backend` / `make lint-frontend` | One half of the above. CI runs them in two different jobs, so either can be run on its own |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -14,6 +14,15 @@ uv run pytest tests/api/test_workspace_routes.py -x -v     # stop at the first f
 uv run pytest tests/integration -v --no-cov                # the ones needing a database
 ```
 
+These stay **serial** on purpose: spawning worker processes to run one file costs
+more than the file does. The whole-suite targets — `make test`, `make test-fast`,
+`make test-integration` — run across workers (`pytest -n auto --maxprocesses 4`),
+which roughly halves the I/O-bound integration suite; `pytest-cov` combines the
+per-worker data, so the 100% gate is unchanged. The cap is four because the unit
+suite is import-bound — every worker imports the app once — and gains nothing past
+that, while an uncapped `auto` on a many-core laptop is *slower* than serial, all of
+it worker startup (#520).
+
 Once, before pushing — `make check` runs all of it, in this order:
 
 ```bash

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -16,7 +16,7 @@ uv run pytest tests/integration -v --no-cov                # the ones needing a 
 
 These stay **serial** on purpose: spawning worker processes to run one file costs
 more than the file does. The whole-suite targets — `make test`, `make test-fast`,
-`make test-integration` — run across workers (`pytest -n auto --maxprocesses 4`),
+`make test-integration`, `make test-cov` — run across workers (`pytest -n auto --maxprocesses 4`),
 which roughly halves the I/O-bound integration suite; `pytest-cov` combines the
 per-worker data, so the 100% gate is unchanged. The cap is four because the unit
 suite is import-bound — every worker imports the app once — and gains nothing past


### PR DESCRIPTION
## What this fixes

`make test` was serial (~175s), and the integration slice inside it spends almost all
its time waiting on one Postgres — embarrassingly parallel work run one test at a time.
This runs the whole-suite targets across worker processes with `pytest-xdist`.

`Refs #520` — the third lever (parallelism). Orthogonal to and stacking with #535
(schema-once) and #544 (lazy imports).

## What changed

- `backend/pyproject.toml` + `uv.lock` — add `pytest-xdist>=3.8.0` to the `dev` group.
- `Makefile` — `test`, `test-fast`, `test-integration`, `test-cov` gain
  `-n auto --maxprocesses 4`.
- `docs/testing.md`, `docs/commands.md`, `.claude/rules/testing.md` — describe the
  parallel execution and why scoped runs stay serial.

## Why `-n auto --maxprocesses 4`, not bare `-n auto`

The two halves of the suite scale differently, and I measured both:

- **Integration is I/O-bound** on one database. Each worker already gets its own
  per-process `_p<pid>` database — the isolation #189 built extends to xdist workers for
  free — so they parallelise cleanly and saturate around four workers.
- **The unit suite is import-bound**: every worker imports the app once (~2–5s), and
  past four workers that startup grows faster than the parallelism pays back. On a
  ten-core laptop an uncapped `-n auto` (10 workers) ran the suite **slower than
  serial**, all of it worker startup. The cap makes `auto` mean "as many as help": four
  on CI's four-core runner, four on a bigger laptop, fewer on a smaller one.

Scoped runs (`pytest <file>`) stay **serial** — spawning workers to run one file costs
more than the file does, and the write-loop is scoped runs.

## Testing

Measured on `pgvector/pgvector:pg16`, warm, this machine:

| | serial | `-n auto --maxprocesses 4` |
|---|---|---|
| `make test` (unit + integration + gate) | ~175s | **~91s** |
| `make test-integration` | ~124s | **~52s** |
| integration with #535's TRUNCATE + xdist | ~62s | **~31s** |

- **100% platform-coverage gate holds** under xdist — `pytest-cov` combines the
  per-worker data automatically; verified `Required test coverage of 100.0% reached`
  under `-n auto`.
- Full suite green under xdist's load distribution (4299 passed, 6 skipped).
- `tests/test_ci_parity.py` passes — CI calls `make test`, so the internal flag change
  is transparent.
- `make lint-backend` clean. The lock adds `pytest-xdist` + its `execnet` dep, and
  also re-resolves `whenever`'s `tzdata`/`tzlocal` markers to gate them on
  `python_full_version >= '3.13'` — **not** a deliberate change: restoring main's
  lock and running `uv lock` on the pinned toolchain (uv 0.11.2) reproduces exactly
  that marker update with no dependency added, so it is uv catching main up, not
  this PR. Inert for us — pinned to 3.12 on Linux/macOS, where both packages are
  already excluded by their platform markers before and after.

## Noticed, not fixed

- **`pytest-randomly` is documented as on-by-default (CLAUDE.md, `.claude/rules/testing.md`)
  but is not installed and not in the lockfile** — so the suite runs in collection
  order, `-p no:randomly` in the docs is a no-op, and order-independence has never been
  verified by that mechanism. I confirmed the suite *is* order-independent anyway (full
  unit + integration green across two random seeds each with `pytest-randomly`
  temporarily installed, and green under xdist's shuffled distribution here). Filing as
  its own issue; enabling randomly for real is then a low-risk one-liner. Not folded in
  to keep this diff scoped and avoid introducing run-to-run CI order changes unannounced.
- The `#536` Prefect-local test failure is unrelated and pre-existing (CI passes it;
  locally it needs no Prefect server because `backend/.env` points at `localhost:4200`).

