### PR TITLE
chore: cut 0.0.90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.90] - 2026-08-10
+
+Importing the application stops dragging in two SDKs it never uses on the
+request path, so every process start and scoped test run is a couple of seconds
+shorter.
+
+### Changed
+
+- **`import app.main` no longer pulls in `aiogram` and `prefect`.** The Telegram,
+  Slack and Mattermost adapters are imported inside `lifespan` (which the test
+  client never runs) and the sync flows inside their dispatcher, so a cold app
+  import drops from ~5.5s to ~2.3s — a cost every scoped `pytest` run and every
+  process start paid for libraries neither the API nor the tests touch. A
+  subprocess guard test keeps them out of `sys.modules`, and a dead
+  `_slack_register` alias went with it. Runtime behaviour is unchanged; startup
+  imports them as before. Refs #520. (#544)
+
 ## [0.0.89] - 2026-08-10
 
 Run history gains the duration controls the dashboard's p95 needs rows behind,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.89"
+version = "0.0.90"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.89"
+version = "0.0.90"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.89",
+  "version": "0.0.90",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
One change since 0.0.89:

- **perf(imports): defer aiogram and prefect out of app import** — the channel adapters move into `lifespan` and the sync flows into their dispatcher, so a cold `import app.main` drops ~5.5s → ~2.3s; every scoped `pytest` run and process start pays that much less for SDKs neither the API nor the tests touch. A subprocess guard test keeps them out. (#544, refs #520)

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json`; the `agenticos` lock entry bumped by hand (no re-resolve), matching how prior cuts were done.