### PR TITLE
chore: cut 0.0.91

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.91] - 2026-08-10
+
+The integration test suite builds its schema once per process instead of before
+every test, halving it.
+
+### Changed
+
+- **Integration tests build the schema once, not before every test.** The
+  per-test `drop_all` + `create_all` (~0.4s of DDL each, very nearly the whole
+  runtime of a suite whose assertions are microseconds of Postgres work) is
+  replaced by a session-scoped build plus a `TRUNCATE ... RESTART IDENTITY
+  CASCADE` reset between tests. The integration slice drops from ~125s to ~53s,
+  and the per-process `_p<pid>` database isolation is untouched, so two runs on
+  one machine stay safe. `TRUNCATE`, not a rollback: the API-flow tests commit
+  through the real session, so their rows would outlive a rollback. Closes #215.
+  Refs #520. (#535)
+
 ## [0.0.90] - 2026-08-10
 
 Importing the application stops dragging in two SDKs it never uses on the

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.90"
+version = "0.0.91"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.90"
+version = "0.0.91"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.90",
+  "version": "0.0.91",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
One change since 0.0.90:

- **perf(tests): build the integration schema once, not before every test** — session-scoped `create_all` plus a `TRUNCATE` reset between tests replaces the per-test `drop_all`/`create_all`; the integration slice drops ~125s → ~53s with the per-process DB isolation untouched. Closes #215. (#535, refs #520)

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json`.