### PR TITLE
chore: cut 0.0.92

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.92] - 2026-08-10
+
+The whole-suite test targets run across worker processes, roughly halving them.
+
+### Changed
+
+- **`make test` and the other whole-suite targets run across workers.** `pytest
+  -n auto --maxprocesses 4` on `test`, `test-fast`, `test-integration` and
+  `test-cov`; `pytest-cov` combines the per-worker data so the 100% platform gate
+  is unchanged, and scoped `pytest <file>` runs stay serial (spawning workers for
+  one file costs more than the file). The cap is four because the unit slice is
+  import-bound — every worker imports the app once — and an uncapped `-n auto` on
+  a many-core machine runs *slower* than serial, all of it worker startup. Adds
+  `pytest-xdist` to the dev group. Refs #520. (#570)
+
 ## [0.0.91] - 2026-08-10
 
 The integration test suite builds its schema once per process instead of before

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.91"
+version = "0.0.92"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.91"
+version = "0.0.92"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.91",
+  "version": "0.0.92",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
One change since 0.0.91:

- **perf(tests): run the whole-suite targets across worker processes** — `pytest -n auto --maxprocesses 4` on `test`, `test-fast`, `test-integration` and `test-cov`; `pytest-cov` combines per-worker data so the 100% gate holds, scoped runs stay serial. Adds `pytest-xdist` to the dev group. (#570, refs #520)

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json`.