### PR TITLE
chore: cut 0.0.93

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.93] - 2026-08-10
+
+A run's transcript is readable by authorization, not only by whoever owns the
+run.
+
+### Added
+
+- **`GET /api/v1/runs/{run_id}/transcript`** — returns a run's messages
+  (paginated) to any colleague in the same organization holding `runs:view`; a
+  run is read by authorization, not by ownership. A caller from another tenant is
+  refused exactly as a run that does not exist is, so existence never leaks. The
+  response's `conversation_id` is `null` when the run has no transcript, distinct
+  from an empty `items`. `AgentRunnerService.get_run_transcript` resolves the run
+  org-scoped (404 before the permission is read), then checks `runs:view` (403).
+  Closes #490. (#525)
+
 ## [0.0.92] - 2026-08-10
 
 The whole-suite test targets run across worker processes, roughly halving them.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.92"
+version = "0.0.93"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.92"
+version = "0.0.93"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.92",
+  "version": "0.0.93",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
One change since 0.0.92:

- **feat(api): read a run's transcript, authorized not owned** — `GET /api/v1/runs/{run_id}/transcript` returns a run's messages to any colleague holding `runs:view`; another tenant is refused as a missing run, so existence never leaks. Closes #490. (#525)

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json`.