### PR TITLE
chore: cut 0.0.94

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.94] - 2026-08-10
+
+The Activity tab gains a per-version summary that cannot disagree with the
+dashboard's completed-share figure.
+
+### Added
+
+- **A version strip on the Activity tab.** When narrowed to one agent, a card per
+  version sits above the run table — runs, completed share, cost per run, p95 and
+  the current-version marker. Its "completed share" and the dashboard's Outcomes
+  donut both compute through one shared helper (`src/lib/run-outcomes.ts`), with
+  `cancelled` and `budget_exceeded` in the denominator on both sides, so the two
+  figures cannot drift. Closes #489. (#526)
+
 ## [0.0.93] - 2026-08-10
 
 A run's transcript is readable by authorization, not only by whoever owns the

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.93"
+version = "0.0.94"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.93"
+version = "0.0.94"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.93",
+  "version": "0.0.94",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
One change since 0.0.93:

- **feat(activity): add version strip sharing the donut's completed share** — a per-version summary above the Activity run table (runs, completed share, cost/run, p95), reusing the dashboard Outcomes donut's exact completed-share computation so the two cannot drift. Closes #489. (#526)

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json`.