### PR TITLE
chore: cut 0.0.96

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.96] - 2026-08-10
+
+The sync-source wizard is decomposed into one component per step — a structural
+refactor, no behaviour change.
+
+### Changed
+
+- **Sync-source wizard split into per-step components.** The 761-line
+  `sync-source-wizard.tsx` becomes a ~320-line shell (cross-step flow, the shared
+  form, the header and step indicator, and the `connectorsFailed` /
+  `orgIntegrationsFailed` flags it hands down) plus one component per step —
+  `sync-source-{connector,configure,schedule,clone}-step.tsx` — following the
+  pattern #221 set in `components/rag/`. A folded-in fix routes the empty-config
+  note through `next-intl`. Closes #461, #540. (#529)
+
 ## [0.0.95] - 2026-08-10
 
 The Activity tab's spend view breaks down who spent what.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.95"
+version = "0.0.96"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.95"
+version = "0.0.96"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.95",
+  "version": "0.0.96",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
One change since 0.0.95:

- **refactor(rag): split sync source wizard into per-step components** — the 761-line wizard becomes a ~320-line shell plus one component per step; no behaviour change, with a folded-in next-intl fix. Closes #461, #540. (#529)

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json`.