### PR TITLE
chore: cut 0.0.97

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.97] - 2026-08-10
+
+Regression coverage that every entry point records a run's transcript.
+
+### Changed
+
+- **Transcript recording is covered for embed, channel and default-agent runs.**
+  `backend/tests/test_surface_transcripts.py` asserts at the repository boundary
+  that a widget run, a channel mention and the default agent each record their
+  turns — role, content, run id, the model and version that actually ran, and
+  tool-call args and results — and that a broken widget run still records what
+  the visitor asked. Closes #205's requirement that the fix ship with a
+  regression test. (#530)
+
 ## [0.0.96] - 2026-08-10
 
 The sync-source wizard is decomposed into one component per step — a structural

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.96"
+version = "0.0.97"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.96"
+version = "0.0.97"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.96",
+  "version": "0.0.97",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
One change since 0.0.96:

- **test(runs): cover embed and channel runs recording a transcript** — regression coverage that widget, channel-mention and default-agent runs each record their full transcript. Closes #205. (#530)

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json`.