### PR TITLE
chore: cut 0.0.99

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.99] - 2026-08-10
+
+Run history can be filtered by rating, and a down-rated run says so — with the
+comment readable on the run itself.
+
+### Added
+
+- **Filter run history by rating, and flag a down-rated run.** A `rated=down`
+  filter on run history, and a `down_rated_run_ids` marker on list rows —
+  tenant-bound, `distinct`, and the same `rating < 0` definition the filter uses,
+  so a marked row is exactly a row the filter returns. In the run detail, the
+  most recent down rating's comment is read off the transcript
+  (`RunTranscriptMessage.rating_comment`, from
+  `get_down_rating_comments_for_messages`, batched newest-first), so "what people
+  said was wrong" is readable where the run is read rather than only in the
+  app-admin export. Permission-gated on `runs:view`. Completes the run side of
+  #209. (#538)
+
 ## [0.0.98] - 2026-08-10
 
 Runs, approvals and spend export as CSV — exactly the rows the list would show.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.98"
+version = "0.0.99"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.98"
+version = "0.0.99"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.98",
+  "version": "0.0.99",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
One change since 0.0.98:

- **feat(runs): filter run history by rating and flag it on the run** — a `rated=down` filter and a tenant-bound `down_rated_run_ids` marker on list rows, plus the latest down rating's comment read on the run detail (`rating_comment` off the transcript). Completes the run side of #209. (#538)

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json`.