### PR TITLE
chore: cut 0.0.100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.100] - 2026-08-10
+
+Dead weight removed across the backend and frontend, and one dead method turned
+into a real contract.
+
+### Changed
+
+- **Stripped unreferenced code across the tree.** Repository helpers, service
+  methods, sanitizers and frontend exports with no surviving caller are deleted
+  (each traced first), and four frontend `export`s narrowed to module-internal.
+  Net −892/+53. Not only deletion: the vector store's dead `aclose()` becomes an
+  abstract contract the application lifespan shuts down through, so teardown no
+  longer reaches past the interface into `.engine` behind a `# type: ignore`.
+  (#579)
+
 ## [0.0.99] - 2026-08-10
 
 Run history can be filtered by rating, and a down-rated run says so — with the

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.99"
+version = "0.0.100"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.99"
+version = "0.0.100"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.99",
+  "version": "0.0.100",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
One change since 0.0.99:

- **refactor: strip dead weight across backend and frontend** — delete unreferenced repo helpers, service methods, sanitizers and frontend exports (each traced to no surviving caller), and turn the vector store's dead `aclose()` into an abstract contract the lifespan shuts down through. Net −892/+53. (#579)

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json`.