### PR TITLE
ci: guard route helpers, banner comments and dead code

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -143,3 +143,25 @@ Rules:
 - Use `status_code=status.HTTP_201_CREATED` for POST, `HTTP_204_NO_CONTENT` for DELETE
 - DELETE endpoints: `response_model=None`
 - Pagination: `skip: int = Query(0, ge=0)`, `limit: int = Query(50, ge=1, le=100)`
+
+### A route module holds routers, not helpers
+
+The HTTP layer validates, delegates and returns; the logic it delegates to lives
+in a service, and the dependencies it needs live in `api/deps.py`. A plain helper
+that lands in a route file — a loader, a parser, a formatter — is business logic in
+the one place the architecture says holds none, and it arrives quietly because
+nothing complains.
+
+`scripts/check_routes.py` is that complaint, run by `make lint`. In an **endpoint
+module**, a top-level function must be a route handler (`@router.get(...)` &c.) or a
+router factory (annotated `-> APIRouter`, like `build_sharing_router`). Anything
+else is reported, and the fix is to **move it**: a parser or loader to the service
+that owns the domain (`RunStatus.parse_csv` left `runs.py` this way), a dependency
+to `deps.py`, and anything genuinely route-adjacent to a `_`-prefixed helper module
+beside the endpoints — `_workspace_bytes.py`, `_sharing_loaders.py`. Those `_*.py`
+modules are skipped by the guard; they are the sanctioned home for route-adjacent
+code that is not an endpoint.
+
+There is a last resort — `# routes-helper: <reason>` on or above the `def`, the same
+bargain as `i18n-exempt` — but it is for a helper that genuinely cannot move, not
+for dodging the move. Reach for it last; the default is to move the code out.

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -58,6 +58,52 @@ from app.core.exceptions import NotFoundError
 from app.schemas.user import UserCreate, UserRead
 ```
 
+## Comments
+
+Comments are scarce and earn their place. **The default is no comment.** The
+reference docs are generated from docstrings, so what reasoning a piece of code
+needs lives in a docstring, not in a running commentary of `#` lines.
+
+The bar for a comment is one question: **would a competent reader make a mistake,
+or be genuinely misled, without it?** If not, delete it. Clear names and small
+functions carry the meaning; a comment is for the thing the code cannot say.
+
+Delete a comment that:
+
+- **Restates what the code does.** `# increment i`, `# loop over users`.
+- **Labels a section.** `# the owner's side`, `# sending`, `# internals`,
+  `# what the agent may ask` — the class, the method and their names already mark
+  the structure. (ASCII-banner form — `# --- sending ---` — is rejected outright
+  by `scripts/check_comments.py`; the plain-label form is the same slop without
+  the dashes, so it goes too.)
+- **Narrates an optimisation or a mechanism a reader already sees.** "In one
+  query rather than an `EXISTS` per row." "Skipped when the page is empty —
+  nothing to do." "Two queries, deduplicated on ids." The code says this; the
+  comment is a second, staler copy.
+- **Grows into a paragraph.** A multi-line essay is a docstring in the wrong
+  place — move it, or cut it to the single clause that carries the *why*, or drop
+  it. Most drop.
+
+Keep a comment only when it prevents a real mistake: a footgun, a non-obvious
+constraint, a security or correctness invariant that the code cannot express, or
+a decision that looks wrong until you know the reason — ideally with the issue
+number (`# … (#417)`). One tight sentence, not a paragraph.
+
+**No commented-out code.** Git remembers it; delete it.
+
+When in doubt, delete. A comment removed is cheap to bring back; a wall of
+comments is what makes real code hard to find.
+
+## Dead code
+
+- No unused function, parameter, branch or import. `make lint` runs `vulture` as
+  a gate on what it is certain of (unused variables, parameters); `make dead-code`
+  is the deeper, human-read scan for unused functions and methods — noisier,
+  because the codebase is registry-driven, so read each finding before deleting.
+- False positives that are genuinely reachable (a dynamic dispatch vulture cannot
+  follow) go in `ignore_names` under `[tool.vulture]` in `backend/pyproject.toml`,
+  each with a comment saying what uses it.
+
 ## Other Conventions
 
 - `datetime.now(UTC)` not `datetime.utcnow()`

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -31,8 +31,8 @@ after an edit it answers the same question ten to fifty times slower.
 Then, once, before the push:
 
 ```bash
-make lint               # ruff, ruff format, ty, eslint, prettier, tsc, the two guards,
-                        # and codespell over every tracked file
+make lint               # ruff, ruff format, ty, vulture, eslint, prettier, tsc, the guard
+                        # scripts, and codespell over every tracked file
 make test               # backend + the 100% gate; runs across workers (-n auto,
                         # capped at 4), pytest-cov combines their data
 make test-frontend-cov  # frontend + its gate: 100% lines/stmts/funcs, 97.5% branches

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,6 +103,30 @@ repos:
         language: system
         types: [python]
         pass_filenames: false
+      # Dead code, at the confidence set in `[tool.vulture]` - a gate on what
+      # vulture is sure of (unused variables, parameters). The deeper,
+      # false-positive-prone function scan is `make dead-code`, not this.
+      - id: vulture
+        name: vulture
+        entry: uv run --no-sync --directory backend vulture
+        language: system
+        types: [python]
+        pass_filenames: false
+      # A route module holds routers, not helpers. Anything else needs a
+      # `# routes-helper: <reason>` marker.
+      - id: check-routes
+        name: routes hold only routers
+        entry: python3 scripts/check_routes.py
+        language: system
+        types: [python]
+        pass_filenames: false
+      # No ASCII banner comments (`# ---- foo ----`).
+      - id: check-comments
+        name: no banner comments
+        entry: python3 scripts/check_comments.py
+        language: system
+        types_or: [python, ts, tsx, yaml]
+        pass_filenames: false
       # Double backticks are reStructuredText; Markdown renders them literally,
       # and so do editor hovers over a docstring.
       - id: check-backticks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,8 +44,15 @@ changes" is. Concretely, in this repo:
   an exception, never add a fallback that papers over a bug.
 - **No dead weight.** No speculative abstraction, unused parameter, commented-out code
   or "just in case" branch. If a branch cannot be reached, delete it; if it can, test it.
-- **Reasoning lives in docstrings.** The reference docs are generated from them, so a
-  decision explained in a commit message is a decision nobody will find.
+  `make lint` runs `vulture` as a gate on what it is sure of; `make dead-code` is the
+  deeper, human-read scan for unused functions (`docs/branching.md`, `code-style.md`).
+- **Comments are scarce; the default is none.** Reasoning lives in docstrings (the
+  reference docs are generated from them). The bar for a `#`/`//` comment is one
+  question — *would a competent reader make a mistake without it?* If not, delete it. No
+  restating what the code says, no section labels (`# the owner's side`), no narrating an
+  optimisation a reader already sees (`# one query rather than an EXISTS per row`), no
+  ASCII banners (a guard rejects those). Keep only a footgun, a non-obvious constraint or
+  an invariant — one sentence, ideally with an issue number. See `code-style.md`.
 - **Scoped diffs.** Fix what was asked. Propose follow-ups instead of taking them.
 - **Tests are part of the change.** New behaviour ships with a test; a bug ships with a
   regression test that fails without the fix.
@@ -132,8 +139,9 @@ make check                                        # every CI job but e2e — bef
 
 | | |
 |---|---|
-| `make lint` / `make format` | ruff + ty + eslint + prettier + tsc + the two guards + codespell |
+| `make lint` / `make format` | ruff + ty + vulture + eslint + prettier + tsc + the guard scripts + codespell |
 | `make lint-backend` / `make lint-frontend` | one half of it — CI runs them in two jobs |
+| `make dead-code` | vulture + knip, unused functions — a report to read, not a gate |
 | `make test-fast` | no coverage — the write-run-write loop |
 | `make test` | backend + the 100% gate on the platform layer |
 | `make test-integration` | only the tests needing a real database |

--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,7 @@ deps-upgrade-all:
 # change can run `lint-backend` and skip a minute of eslint.
 #
 # The frontend half was missing entirely until #143: `make lint` ran ruff, ty and
-# the two guard scripts, while CI additionally ran eslint, prettier and tsc - so
+# the guard scripts, while CI additionally ran eslint, prettier and tsc - so
 # `make lint` passed on a branch with a type error in a `.tsx`, and CLAUDE.md's
 # "ruff + ty + eslint + tsc" described a command that ran half of that.
 lint: lint-backend lint-frontend lint-spelling
@@ -291,8 +291,28 @@ lint-backend:
 	uv run --directory backend ruff check . ../scripts
 	uv run --directory backend ruff format . ../scripts --check
 	uv run --directory backend ty check
+	uv run --directory backend vulture
 	python3 scripts/check_backticks.py
 	python3 scripts/check_i18n.py
+	python3 scripts/check_routes.py
+	python3 scripts/check_comments.py
+
+# Unused functions and methods, reported rather than gated. `make lint` runs
+# vulture at a confidence high enough to be a gate (unused variables and
+# parameters, near-zero false positives); this lowers it to reach unused
+# functions too, which on a registry-driven codebase come with false positives -
+# a CLI command, a capability hook, a route handler - that a human reads before
+# deleting. The same role dependency-freshness plays for dependencies. See
+# [tool.vulture] in backend/pyproject.toml.
+#
+# The frontend half is knip, also a report rather than a gate: on a
+# design-system codebase it flags the whole UI-primitive barrel and every
+# exported type it cannot trace a use for, so `frontend/knip.json` narrows it to
+# what is worth reading and the rest is read by eye. `bunx` fetches knip on
+# demand - it is not a project dependency, because nothing gating runs it.
+dead-code:
+	uv run --directory backend vulture --min-confidence 60
+	cd frontend && bunx knip@5 --no-progress
 
 lint-frontend:
 	cd frontend && bun run lint

--- a/backend/app/agents/capabilities/knowledge/_search.py
+++ b/backend/app/agents/capabilities/knowledge/_search.py
@@ -1,4 +1,3 @@
-# TODO refactor it
 """RAG tool for agent knowledge base search."""
 
 import contextvars

--- a/backend/app/agents/capabilities/web_research/_search.py
+++ b/backend/app/agents/capabilities/web_research/_search.py
@@ -1,5 +1,3 @@
-# TODO refactor it
-
 """Searching the public web, through whichever service the agent was given.
 
 Four providers behind one payload. The payload is the point: every provider

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -282,7 +282,6 @@ async def get_current_user(
     if payload is None:
         raise AuthenticationError(message="Invalid or expired token")
 
-    # Ensure this is an access token, not a refresh token
     if payload.get("type") != "access":
         raise AuthenticationError(message="Invalid token type")
 

--- a/backend/app/api/routes/v1/_sharing_loaders.py
+++ b/backend/app/api/routes/v1/_sharing_loaders.py
@@ -1,0 +1,48 @@
+"""Per-resource row loaders for the sharing routers.
+
+Loading a row is the only thing that differs between sharing an agent, a
+collection, a skill and a vault secret, so each loader is injected into
+`build_sharing_router`. They live here - beside the factory, not in an endpoint
+module and not in `SharingService`, which stays agnostic about what it is
+sharing.
+"""
+
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import NotFoundError
+from app.db.models.agent import Agent
+from app.db.models.knowledge_base import KnowledgeBase
+from app.db.models.organization_secret import OrganizationSecret
+from app.db.models.skill import Skill
+
+
+async def load_agent(db: AsyncSession, agent_id: UUID, organization_id: UUID) -> Agent:
+    agent = await db.get(Agent, agent_id)
+    if agent is None or agent.organization_id != organization_id:
+        raise NotFoundError(message="Agent not found", details={"agent_id": str(agent_id)})
+    return agent
+
+
+async def load_collection(db: AsyncSession, kb_id: UUID, organization_id: UUID) -> KnowledgeBase:
+    collection = await db.get(KnowledgeBase, kb_id)
+    if collection is None or collection.organization_id != organization_id:
+        raise NotFoundError(message="Collection not found", details={"kb_id": str(kb_id)})
+    return collection
+
+
+async def load_skill(db: AsyncSession, skill_id: UUID, organization_id: UUID) -> Skill:
+    skill = await db.get(Skill, skill_id)
+    if skill is None or skill.organization_id != organization_id:
+        raise NotFoundError(message="Skill not found", details={"skill_id": str(skill_id)})
+    return skill
+
+
+async def load_secret(
+    db: AsyncSession, secret_id: UUID, organization_id: UUID
+) -> OrganizationSecret:
+    secret = await db.get(OrganizationSecret, secret_id)
+    if secret is None or secret.organization_id != organization_id:
+        raise NotFoundError(message="Secret not found", details={"secret_id": str(secret_id)})
+    return secret

--- a/backend/app/api/routes/v1/runs.py
+++ b/backend/app/api/routes/v1/runs.py
@@ -12,7 +12,6 @@ from fastapi import APIRouter, Depends, Query
 
 from app.api.deps import AgentRunnerSvc, ApprovalSvc, Auth, RunExportSvc, require
 from app.api.responses import csv_response
-from app.core.exceptions import ValidationError
 from app.core.permissions import Perm
 from app.db.models.agent_run import (
     ApprovalStatus,
@@ -110,7 +109,7 @@ async def list_runs(
         parent_run_id=parent_run_id,
         include_delegations=include_delegations,
         filters=RunFilters(
-            statuses=_parse_statuses(status),
+            statuses=RunStatus.parse_csv(status),
             surface=None if surface is None else surface.value,
             user_id=user_id,
             started_from=started_from,
@@ -126,9 +125,6 @@ async def list_runs(
         skip=skip,
         limit=limit,
     )
-    # Which of this page's runs earned a 👎, in one query rather than an EXISTS
-    # per row. Skipped when the page is empty - there is nothing to mark, and
-    # nothing to ask the database about.
     down_rated = (
         await service.down_rated_run_ids(ctx, [run.id for run in items]) if items else set()
     )
@@ -139,20 +135,6 @@ async def list_runs(
         ],
         total=total,
     )
-
-
-def _parse_statuses(raw: str | None) -> list[str] | None:
-    if raw is None:
-        return None
-    values = [part.strip() for part in raw.split(",") if part.strip()]
-    known = {member.value for member in RunStatus}
-    unknown = sorted(set(values) - known)
-    if unknown:
-        raise ValidationError(
-            message="Unknown run status",
-            details={"unknown": unknown, "expected": sorted(known)},
-        )
-    return values or None
 
 
 @router.get(
@@ -192,7 +174,7 @@ async def export_runs(
         parent_run_id=parent_run_id,
         include_delegations=include_delegations,
         filters=RunFilters(
-            statuses=_parse_statuses(status),
+            statuses=RunStatus.parse_csv(status),
             surface=None if surface is None else surface.value,
             user_id=user_id,
             started_from=started_from,

--- a/backend/app/api/routes/v1/sharing.py
+++ b/backend/app/api/routes/v1/sharing.py
@@ -1,55 +1,20 @@
 """Sharing endpoints for every shareable resource.
 
 Agents, collections, skills and vault secrets each get the same four routes,
-generated from one definition. The resource loaders live here because loading a row is the only
-thing that differs between them - and they are deliberately *not* in the sharing
-service, which stays agnostic about what it is sharing.
+generated from one definition in `_sharing_routes.build_sharing_router`, wired to
+the per-resource loader from `_sharing_loaders`.
 """
 
-from uuid import UUID
-
-from sqlalchemy.ext.asyncio import AsyncSession
-
+from app.api.routes.v1._sharing_loaders import (
+    load_agent,
+    load_collection,
+    load_secret,
+    load_skill,
+)
 from app.api.routes.v1._sharing_routes import build_sharing_router
-from app.core.exceptions import NotFoundError
-from app.db.models.agent import Agent
-from app.db.models.knowledge_base import KnowledgeBase
-from app.db.models.organization_secret import OrganizationSecret
-from app.db.models.skill import Skill
 from app.services.access import AGENT, COLLECTION, SECRET, SKILL
 
-
-async def _load_agent(db: AsyncSession, agent_id: UUID, organization_id: UUID) -> Agent:
-    agent = await db.get(Agent, agent_id)
-    if agent is None or agent.organization_id != organization_id:
-        raise NotFoundError(message="Agent not found", details={"agent_id": str(agent_id)})
-    return agent
-
-
-async def _load_collection(db: AsyncSession, kb_id: UUID, organization_id: UUID) -> KnowledgeBase:
-    collection = await db.get(KnowledgeBase, kb_id)
-    if collection is None or collection.organization_id != organization_id:
-        raise NotFoundError(message="Collection not found", details={"kb_id": str(kb_id)})
-    return collection
-
-
-async def _load_skill(db: AsyncSession, skill_id: UUID, organization_id: UUID) -> Skill:
-    skill = await db.get(Skill, skill_id)
-    if skill is None or skill.organization_id != organization_id:
-        raise NotFoundError(message="Skill not found", details={"skill_id": str(skill_id)})
-    return skill
-
-
-async def _load_secret(
-    db: AsyncSession, secret_id: UUID, organization_id: UUID
-) -> OrganizationSecret:
-    secret = await db.get(OrganizationSecret, secret_id)
-    if secret is None or secret.organization_id != organization_id:
-        raise NotFoundError(message="Secret not found", details={"secret_id": str(secret_id)})
-    return secret
-
-
-agent_sharing_router = build_sharing_router(resource_type=AGENT, load=_load_agent)
-collection_sharing_router = build_sharing_router(resource_type=COLLECTION, load=_load_collection)
-skill_sharing_router = build_sharing_router(resource_type=SKILL, load=_load_skill)
-secret_sharing_router = build_sharing_router(resource_type=SECRET, load=_load_secret)
+agent_sharing_router = build_sharing_router(resource_type=AGENT, load=load_agent)
+collection_sharing_router = build_sharing_router(resource_type=COLLECTION, load=load_collection)
+skill_sharing_router = build_sharing_router(resource_type=SKILL, load=load_skill)
+secret_sharing_router = build_sharing_router(resource_type=SECRET, load=load_secret)

--- a/backend/app/api/versioning.py
+++ b/backend/app/api/versioning.py
@@ -81,14 +81,12 @@ class VersionDeprecationMiddleware(BaseHTTPMiddleware):
         response.headers["Deprecation"] = "true"
 
         if sunset := info.get("sunset"):
-            # Convert to HTTP date format
             sunset_date = datetime.fromisoformat(sunset)
             response.headers["Sunset"] = sunset_date.strftime("%a, %d %b %Y %H:%M:%S GMT")
 
         if link := info.get("link"):
             response.headers["Link"] = f'<{link}>; rel="deprecation"'
 
-        # Custom warning header
         message = info.get("message", f"API {version} is deprecated")
         response.headers["X-API-Deprecation-Warning"] = message
 

--- a/backend/app/commands/rag.py
+++ b/backend/app/commands/rag.py
@@ -174,14 +174,12 @@ async def ingest_path_async(
         for filepath in pbar:
             pbar.set_postfix_str(filepath.name[:30], refresh=True)
 
-            # Sync mode checks
             source_path = str(filepath.resolve())
             if sync_mode in ("new_only", "update_only"):
                 existing_id: str | None = await ingestion.find_existing(collection, source_path)
 
                 if sync_mode == "new_only":
                     if existing_id:
-                        # File exists - check if content changed via hash
                         file_hash: str = hashlib.sha256(filepath.read_bytes()).hexdigest()
                         existing_hash: str | None = await ingestion.get_existing_hash(
                             collection, source_path
@@ -189,11 +187,9 @@ async def ingest_path_async(
                         if existing_hash and file_hash == existing_hash:
                             skipped_count += 1
                             continue
-                        # Hash changed - will re-ingest below
 
                 elif sync_mode == "update_only":
                     if not existing_id:
-                        # Not in collection - skip (update_only ignores new files)
                         skipped_count += 1
                         continue
                     file_hash = hashlib.sha256(filepath.read_bytes()).hexdigest()

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -37,7 +37,7 @@ class Settings(BaseSettings):
     TIMEZONE: str = "UTC"  # IANA timezone (e.g. "UTC", "Europe/Warsaw", "America/New_York")
     MODELS_CACHE_DIR: Path = Path("./models_cache")
     MEDIA_DIR: Path = Path("./media")
-    MAX_UPLOAD_SIZE_MB: int = 50  # Max file upload size in MB
+    MAX_UPLOAD_SIZE_MB: int = 50
     STORAGE_SOFT_LIMIT_BYTES: int = 5 * 1024 * 1024 * 1024
 
     # Seconds the event loop may stop turning before the worker kills itself so
@@ -107,7 +107,7 @@ class Settings(BaseSettings):
             )
         return v
 
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30  # 30 minutes
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
     REFRESH_TOKEN_EXPIRE_MINUTES: int = 60 * 24 * 7  # 7 days
     # How long a parked tool call waits before the sweep denies it by timeout.
     # Three days spans a weekend, which is the gap an approval most often falls
@@ -155,7 +155,7 @@ class Settings(BaseSettings):
         return f"redis://{self.REDIS_HOST}:{self.REDIS_PORT}/{self.REDIS_DB}"
 
     RATE_LIMIT_REQUESTS: int = 100
-    RATE_LIMIT_PERIOD: int = 60  # seconds
+    RATE_LIMIT_PERIOD: int = 60
 
     PREFECT_API_URL: str = "http://localhost:4200/api"
     PREFECT_API_KEY: str | None = None

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -69,6 +69,5 @@ class PiiRedactionFilter(logging.Filter):
 def setup_logging() -> None:
     """Configure root logger with PII redaction filter."""
     root_logger = logging.getLogger()
-    # Avoid adding duplicate filters
     if not any(isinstance(f, PiiRedactionFilter) for f in root_logger.filters):
         root_logger.addFilter(PiiRedactionFilter())

--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -33,7 +33,6 @@ class Perm(StrEnum):
     recombine the values listed here.
     """
 
-    # Resource permissions - always carry a Scope.
     AGENTS_VIEW = "agents:view"
     AGENTS_EDIT = "agents:edit"
     AGENTS_PUBLISH = "agents:publish"
@@ -49,7 +48,6 @@ class Perm(StrEnum):
     SECRETS_VIEW = "secrets:view"
     SECRETS_EDIT = "secrets:edit"
 
-    # Global permissions - binary, org-wide.
     APPROVALS_DECIDE = "approvals:decide"
     # Watching a host and managing one are separate authorities. Reading a
     # connection's session list, its activity log and the ceilings its service

--- a/backend/app/core/sanitize.py
+++ b/backend/app/core/sanitize.py
@@ -1,15 +1,10 @@
 """Input sanitization utilities.
 
-This module provides security-focused input sanitization functions:
-- Filename sanitization to prevent path traversal and unsafe characters
-- Webhook URL validation to prevent SSRF attacks
+Webhook URL validation to prevent SSRF attacks.
 """
 
 import ipaddress
-import os
-import re
 import socket
-import unicodedata
 from urllib.parse import urlparse
 
 WEBHOOK_ALLOWED_SCHEMES = frozenset({"http", "https"})
@@ -27,43 +22,6 @@ class SSRFBlockedError(ValueError):
     Dedicated exception type to avoid fragile string matching when
     distinguishing SSRF blocks from other ValueErrors.
     """
-
-
-def sanitize_filename(filename: str, allow_unicode: bool = False) -> str:
-    """Sanitize a filename to prevent path traversal and unsafe characters.
-
-    Args:
-        filename: The filename to sanitize.
-        allow_unicode: Whether to allow unicode characters.
-
-    Returns:
-        A safe filename string.
-
-    Example:
-        >>> sanitize_filename("../../../etc/passwd")
-        "etc_passwd"
-        >>> sanitize_filename("hello world.txt")
-        "hello_world.txt"
-    """
-    if not filename:
-        return ""
-
-    if allow_unicode:
-        filename = unicodedata.normalize("NFKC", filename)
-    else:
-        filename = unicodedata.normalize("NFKD", filename).encode("ascii", "ignore").decode("ascii")
-
-    filename = os.path.basename(filename)
-    filename = filename.replace("\x00", "")
-
-    filename = re.sub(r"[/\\:*?\"<>|]", "_", filename)
-    filename = re.sub(r"[\s_]+", "_", filename)
-    filename = filename.strip("._")
-
-    if not filename:
-        return "unnamed"
-
-    return filename
 
 
 def _is_ip_blocked(ip_str: str) -> bool:

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -5,8 +5,6 @@ from datetime import datetime
 from sqlalchemy import DateTime, MetaData, func
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
-# Naming convention for database constraints and indexes
-# This ensures consistent naming across all migrations
 NAMING_CONVENTION = {
     "ix": "%(column_0_label)s_idx",
     "uq": "%(table_name)s_%(column_0_name)s_key",

--- a/backend/app/db/models/agent_run.py
+++ b/backend/app/db/models/agent_run.py
@@ -31,6 +31,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
+from app.core.exceptions import ValidationError
 from app.db.base import Base, TimestampMixin
 
 
@@ -50,6 +51,26 @@ class RunStatus(enum.StrEnum):
     CANCELLED = "cancelled"
     AWAITING_APPROVAL = "awaiting_approval"
     BUDGET_EXCEEDED = "budget_exceeded"
+
+    @classmethod
+    def parse_csv(cls, raw: str | None) -> list[str] | None:
+        """A comma-separated status filter, validated against the known values.
+
+        An unknown value is refused by name rather than ignored: a filter that
+        silently matches nothing looks exactly like an organization with nothing
+        wrong.
+        """
+        if raw is None:
+            return None
+        values = [part.strip() for part in raw.split(",") if part.strip()]
+        known = {member.value for member in cls}
+        unknown = sorted(set(values) - known)
+        if unknown:
+            raise ValidationError(
+                message="Unknown run status",
+                details={"unknown": unknown, "expected": sorted(known)},
+            )
+        return values or None
 
 
 class RunSurface(enum.StrEnum):

--- a/backend/app/db/models/conversation.py
+++ b/backend/app/db/models/conversation.py
@@ -79,7 +79,7 @@ class Message(Base, TimestampMixin):
         nullable=False,
         index=True,
     )
-    role: Mapped[str] = mapped_column(String(20), nullable=False)  # user, assistant, system
+    role: Mapped[str] = mapped_column(String(20), nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
     thinking: Mapped[str | None] = mapped_column(Text, nullable=True)
     model_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
@@ -201,9 +201,7 @@ class ToolCall(Base):
     tool_name: Mapped[str] = mapped_column(String(100), nullable=False)
     args: Mapped[dict[str, object]] = mapped_column(JSONB, nullable=False, default=dict)
     result: Mapped[str | None] = mapped_column(Text, nullable=True)
-    status: Mapped[str] = mapped_column(
-        String(20), nullable=False, default="pending"
-    )  # pending, running, completed, failed
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="pending")
     started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)

--- a/backend/app/db/models/mcp_connection.py
+++ b/backend/app/db/models/mcp_connection.py
@@ -135,7 +135,6 @@ class McpConnection(Base, TimestampMixin):
     allowed_tools: Mapped[list[str] | None] = mapped_column(JSONB, nullable=True)
     is_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
 
-    # "bearer" (static token in auth_token) or "oauth" (authorization-code flow).
     auth_type: Mapped[str] = mapped_column(String(16), nullable=False, default="bearer")
     # CSRF token for an in-flight OAuth authorization redirect; NULL once done.
     oauth_state: Mapped[str | None] = mapped_column(String(128), nullable=True, index=True)

--- a/backend/app/db/models/rag_document.py
+++ b/backend/app/db/models/rag_document.py
@@ -28,8 +28,6 @@ class RAGDocument(TimestampMixin, Base):
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
     vector_document_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
     chunk_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    # -- how this document, specifically, was read ------------------------
-    #
     # A collection's configuration changes; a document does not get re-parsed
     # when it does. Without these columns "why is this one chunked differently"
     # has no answer, and a per-upload override would be invisible the moment the

--- a/backend/app/repositories/agent_run.py
+++ b/backend/app/repositories/agent_run.py
@@ -763,8 +763,6 @@ async def spend_by_key(
     return [(row[0], row[1], Decimal(row[2]), row[3]) for row in result.all()]
 
 
-# -- window aggregates, for GET /stats/usage ----------------------------------
-#
 # All of these read the same half-open window [start, end) on `started_at` -
 # the column the org+started index serves and the one the spend queries already
 # filter on. `user_id` narrows to one person's runs, which is the whole of

--- a/backend/app/repositories/channel_session.py
+++ b/backend/app/repositories/channel_session.py
@@ -94,7 +94,6 @@ async def create(
     platform_chat_id: str,
     chat_type: str = "private",
     conversation_id: UUID | None = None,
-    project_id: UUID | None = None,
 ) -> ChannelSession:
     """Create a new channel session."""
     session = ChannelSession(

--- a/backend/app/repositories/skill.py
+++ b/backend/app/repositories/skill.py
@@ -16,7 +16,6 @@ from app.db.models.resource_grant import Visibility
 from app.db.models.skill import Skill, SkillResource
 from app.repositories._search import contains_ci
 
-# How a listing may be ordered: by name, or by when a skill last changed.
 SkillSort = Literal["name", "updated"]
 
 
@@ -129,8 +128,6 @@ async def list_visible(
             )
         )
     if categories:
-        # Several shelves at once: the filter is a multi-select, and a row
-        # matches any of the picked categories.
         where.append(Skill.category.in_(categories))
 
     order_by = (

--- a/backend/app/services/admin.py
+++ b/backend/app/services/admin.py
@@ -49,7 +49,6 @@ class AdminService:
         except Exception:
             logger.exception("admin_stats_active_users_query_failed")
 
-        # Conversations + messages totals - 0 when AI/chat is disabled
         total_conversations = (
             await self.db.execute(select(func.count(Conversation.id)))
         ).scalar_one()

--- a/backend/app/services/agent_embed.py
+++ b/backend/app/services/agent_embed.py
@@ -83,8 +83,6 @@ class AgentEmbedService:
         self.db = db
         self.agents = AgentRegistryService(db)
 
-    # --- the owner's side --------------------------------------------------
-
     async def list_for_agent(self, ctx: AuthContext, agent_id: UUID) -> list[EmbedRead]:
         """Every widget publishing one agent.
 
@@ -204,8 +202,6 @@ class AgentEmbedService:
             details={"embed_id": str(embed_id)},
         )
 
-    # --- the visitor's side ------------------------------------------------
-
     async def admit(
         self, public_key: str, *, origin: str | None, token: str | None
     ) -> tuple[AgentEmbed, str | None]:
@@ -258,8 +254,6 @@ class AgentEmbedService:
             requires_token=embed.auth_mode == "jwt",
             agent_name=agent.name if agent else "Assistant",
         )
-
-    # --- internals ---------------------------------------------------------
 
     def _origin_allowed(self, embed: AgentEmbed, origin: str | None) -> bool:
         """Whether the page the widget is on may use it.

--- a/backend/app/services/agent_registry.py
+++ b/backend/app/services/agent_registry.py
@@ -388,8 +388,6 @@ class AgentRegistryService:
     def __init__(self, db: AsyncSession) -> None:
         self.db = db
 
-    # -- reading --------------------------------------------------------
-
     async def get(
         self, ctx: AuthContext, agent_id: UUID, *, perm: Perm = Perm.AGENTS_VIEW
     ) -> Agent:
@@ -489,8 +487,6 @@ class AgentRegistryService:
             for agent in agents
         ]
         return rows, total
-
-    # -- writing --------------------------------------------------------
 
     async def create(self, ctx: AuthContext, spec: AgentSpec) -> Agent:
         """Create an agent in draft.
@@ -905,8 +901,6 @@ class AgentRegistryService:
                 f"'{secret.name}' holds a {secret.kind}"
             ]
         return []
-
-    # -- delegation -----------------------------------------------------
 
     async def _delegation_problems(
         self, ctx: AuthContext, spec: AgentSpec, *, agent_id: UUID | None

--- a/backend/app/services/agent_session.py
+++ b/backend/app/services/agent_session.py
@@ -262,7 +262,6 @@ class AgentSession:
             model_label = turn.model_label
             agent_version_id = turn.agent_version_id
 
-            # Update in-memory history only after a complete agent run
             self.conversation_history.append({"role": "user", "content": user_message})
             self.conversation_history.append({"role": "assistant", "content": output})
             assistant_msg_id: str | None = None

--- a/backend/app/services/channel_bot.py
+++ b/backend/app/services/channel_bot.py
@@ -390,10 +390,6 @@ class ChannelBotService:
             if value is not None and hasattr(value, "model_dump"):
                 update_data[field] = value.model_dump()
         updated = await channel_bot_repo.update(self.db, db_bot=bot, update_data=update_data)
-        # Unconditionally, rather than on the fields a stream reads. A token, a
-        # server address and the delivery mode all change what the connection
-        # is, and a rule listing them is a rule the next column forgets - while
-        # reopening a stream nobody changed costs one reconnect.
         self._reopen_stream(updated)
         return updated
 

--- a/backend/app/services/channel_link.py
+++ b/backend/app/services/channel_link.py
@@ -187,8 +187,6 @@ class ChannelLinkService:
         by_identity = await channel_session_repo.bots_by_identity(
             self.db, identity_ids=[identity.id for identity in identities]
         )
-        # One membership lookup per organization rather than per bot: a person
-        # with six bots in one organization is one query, not six.
         contexts: dict[UUID, AuthContext | None] = {}
         places: dict[UUID, list[LinkedPlace]] = {}
         for identity_id, bots in by_identity.items():

--- a/backend/app/services/channels/base.py
+++ b/backend/app/services/channels/base.py
@@ -200,7 +200,6 @@ class ChannelAdapter(ABC):
         """
         raise NotImplementedError(f"{self.platform} attachments cannot be downloaded yet")
 
-    # --- what the agent may ask about the channel it is in -------------------
     #
     # The implementation half of `app.agents.capabilities.channel_tools`: the
     # capability declares one shape for all three platforms so an agent does not

--- a/backend/app/services/channels/mattermost.py
+++ b/backend/app/services/channels/mattermost.py
@@ -116,8 +116,6 @@ class MattermostAdapter(ChannelAdapter):
         """Record which Mattermost server a bot belongs to."""
         self._base_urls[bot_id] = api_base_url.rstrip("/")
 
-    # --- sending -----------------------------------------------------------
-
     async def send_message(self, bot_token: str, msg: OutgoingMessage) -> None:
         """Post a reply.
 
@@ -141,9 +139,6 @@ class MattermostAdapter(ChannelAdapter):
         headers = {"Authorization": f"Bearer {bot_token}"}
 
         async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
-            # One upload for the chart and the attachments together: Mattermost
-            # attaches files to a post by id, so both halves are the same call and
-            # a post referencing them follows.
             uploads: list[tuple[str, tuple[str, bytes, str]]] = []
             if msg.image_png is not None:
                 uploads.append(("files", (msg.image_filename, msg.image_png, "image/png")))
@@ -173,8 +168,6 @@ class MattermostAdapter(ChannelAdapter):
 
             response = await client.post(f"{base_url}/api/v4/posts", headers=headers, json=body)
             response.raise_for_status()
-
-    # --- an answer somebody can watch arrive -------------------------------
 
     async def begin_reply(self, bot_token: str, msg: OutgoingMessage) -> str | None:
         """Post the message that will become the answer, and return its id."""
@@ -250,7 +243,6 @@ class MattermostAdapter(ChannelAdapter):
         self._seq[bot_id] = self._seq.get(bot_id, 1) + 1
         return self._seq[bot_id]
 
-    # --- what the agent may ask about the channel --------------------------
     #
     # Every call here needs `read_channel` on the channel, which a bot holds by
     # being a member of it. That is the permission boundary, it is Mattermost's
@@ -468,8 +460,6 @@ class MattermostAdapter(ChannelAdapter):
             for post_id in order
         ]
 
-    # --- receiving, over the socket ---------------------------------------
-
     async def start_polling(self, bot_id: str, bot_token: str) -> None:
         """Open the event stream for one bot."""
         existing = self._socket_tasks.get(bot_id)
@@ -585,8 +575,6 @@ class MattermostAdapter(ChannelAdapter):
         async with get_db_context() as db:
             await router.route(incoming, db)
 
-    # --- receiving, over a webhook ----------------------------------------
-
     async def register_webhook(self, bot_token: str, url: str, secret: str | None) -> bool:
         """Mattermost has no API for this: outgoing webhooks are created in its
         own integrations page. Logged so the URL can be pasted there."""
@@ -616,8 +604,6 @@ class MattermostAdapter(ChannelAdapter):
         payload = decode_webhook_body(body)
         token = str(payload.get("token", ""))
         return bool(token) and secrets.compare_digest(token, secret)
-
-    # --- normalising -------------------------------------------------------
 
     def parse_incoming(self, raw_payload: dict[str, Any], bot_id: str) -> IncomingMessage | None:
         """Normalise a `posted` event or an outgoing-webhook body.

--- a/backend/app/services/channels/router.py
+++ b/backend/app/services/channels/router.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 # key format: "{bot_id}:{identity_id}", value = (count, window_start_ts)
 _rate_buckets: dict[str, tuple[int, float]] = {}
 
-_DEFAULT_RPM = 10  # requests per minute
+_DEFAULT_RPM = 10
 
 # In group chats multiple users can message simultaneously. Without a lock the router
 # would race: duplicate ChannelSession creation, interleaved agent calls, rate-limit races.
@@ -616,7 +616,6 @@ class ChannelMessageRouter:
                     raise BadRequestError(message="Rate limit exceeded. Please slow down.")
                 _rate_buckets[key] = (count + 1, window_start)
             else:
-                # Window expired - reset
                 _rate_buckets[key] = (1, now)
         else:
             _rate_buckets[key] = (1, now)

--- a/backend/app/services/channels/slack.py
+++ b/backend/app/services/channels/slack.py
@@ -83,7 +83,6 @@ class SlackAdapter(ChannelAdapter):
 
         client = AsyncWebClient(token=bot_token)
 
-        # If platform_chat_id contains ":" it includes a thread_ts
         channel, _, thread_ts = msg.platform_chat_id.partition(":")
 
         kwargs: dict[str, Any] = {
@@ -125,7 +124,6 @@ class SlackAdapter(ChannelAdapter):
 
         await client.chat_postMessage(**kwargs)
 
-    # --- what the agent may ask about the channel --------------------------
     #
     # `channels:read`, `groups:read` and `channels:history` on the Slack app -
     # scopes an admin grants when they install it. The bot sees what the app was
@@ -404,7 +402,6 @@ class SlackAdapter(ChannelAdapter):
         if event_type != "message" and event_type != "app_mention":
             return None
 
-        # Ignore bot messages and edits
         if event.get("bot_id") or event.get("subtype"):
             return None
 
@@ -433,7 +430,7 @@ class SlackAdapter(ChannelAdapter):
             chat_type=chat_type,
             text=text,
             raw=raw_payload,
-            platform_username=None,  # resolved later if needed
+            platform_username=None,
             platform_display_name=None,
             message_id=message_ts,
             attachments=attachments,

--- a/backend/app/services/channels/telegram.py
+++ b/backend/app/services/channels/telegram.py
@@ -109,7 +109,6 @@ class TelegramAdapter(ChannelAdapter):
                     reply_to_message_id=reply_to,
                 )
             except TelegramBadRequest:
-                # Markdown parsing failed - send as plain text
                 await bot.send_message(
                     chat_id=msg.platform_chat_id,
                     text=msg.text,
@@ -153,7 +152,6 @@ class TelegramAdapter(ChannelAdapter):
                 reply_to_message_id=reply_to,
             )
 
-    # --- what the agent may ask about the chat -----------------------------
     #
     # Two of the four, and that is the whole of what Telegram gives a bot.
     # `search_channels` and `channel_history` are inherited from the base class,
@@ -297,7 +295,6 @@ class TelegramAdapter(ChannelAdapter):
         but accepted for interface compatibility with ChannelAdapter.
         """
         received = headers.get("x-telegram-bot-api-secret-token", "")
-        # Use hmac.compare_digest for constant-time comparison
         return hmac.compare_digest(received.encode(), secret.encode())
 
     def parse_incoming(self, raw_payload: dict[str, Any], bot_id: str) -> IncomingMessage | None:

--- a/backend/app/services/collection_access.py
+++ b/backend/app/services/collection_access.py
@@ -114,8 +114,6 @@ class CollectionAccessService:
     def __init__(self, db: AsyncSession) -> None:
         self.db = db
 
-    # -- collections ----------------------------------------------------
-
     async def _first_readable(self, ctx: AuthContext, name: str) -> KnowledgeBase | None:
         """The first knowledge base claiming this name that the caller may read.
 
@@ -227,8 +225,6 @@ class CollectionAccessService:
                     details={"collection": name},
                 )
 
-    # -- documents ------------------------------------------------------
-
     async def _document(self, doc_id: str) -> RAGDocument:
         parsed = _as_uuid(doc_id)
         doc = None if parsed is None else await rag_document_repo.get_by_id(self.db, parsed)
@@ -254,8 +250,6 @@ class CollectionAccessService:
         if await self._first_writable(ctx, doc.collection_name) is None:
             raise _no_document(doc_id)
         return doc
-
-    # -- sync ------------------------------------------------------------
 
     async def sync_source(self, ctx: AuthContext, source_id: str) -> SyncSource:
         """The integration with this id inside the caller's organization.

--- a/backend/app/services/conversation.py
+++ b/backend/app/services/conversation.py
@@ -93,7 +93,6 @@ class ConversationService:
             and conversation.user_id is not None
             and str(conversation.user_id) != str(user_id)
         ):
-            # Not the owner - check if user has a share granting access
             share = await conversation_share_repo.get_share(self.db, conversation_id, user_id)
             if not share:
                 raise NotFoundError(

--- a/backend/app/services/conversation_share.py
+++ b/backend/app/services/conversation_share.py
@@ -107,7 +107,6 @@ class ConversationShareService:
         if not share:
             raise NotFoundError(message="Share not found", details={"share_id": str(share_id)})
 
-        # Owner or the recipient can revoke
         if share.shared_by != user_id and share.shared_with != user_id:
             raise AuthorizationError(message="Not authorized to revoke this share")
 

--- a/backend/app/services/file_storage.py
+++ b/backend/app/services/file_storage.py
@@ -47,10 +47,10 @@ SPREADSHEET_MIME_TYPES = {
 
 IMAGE_MIME_TYPES = {"image/jpeg", "image/png", "image/gif", "image/webp"}
 
-MAX_UPLOAD_SIZE = 10 * 1024 * 1024  # 10MB
+MAX_UPLOAD_SIZE = 10 * 1024 * 1024
 # Avatars are decoration rendered at 40px; the limit is what stops someone
 # storing a 40MB photograph to be scaled down on every page load.
-MAX_AVATAR_SIZE = 2 * 1024 * 1024  # 2MB
+MAX_AVATAR_SIZE = 2 * 1024 * 1024
 
 
 def classify_file(mime_type: str, filename: str) -> str:

--- a/backend/app/services/mcp_connection.py
+++ b/backend/app/services/mcp_connection.py
@@ -589,8 +589,6 @@ class McpConnectionService:
             )
         return db_connection
 
-    # -- organization-scoped connections --------------------------------
-
     async def list_for_org(self, ctx: AuthContext) -> tuple[list[McpConnection], int]:
         return await mcp_connection_repo.list_org_scoped(
             self.db, organization_id=ctx.organization_id

--- a/backend/app/services/member.py
+++ b/backend/app/services/member.py
@@ -12,7 +12,6 @@ from app.repositories import member_repo, user_repo
 
 logger = logging.getLogger(__name__)
 
-# Roles Admin is allowed to assign (cannot grant/revoke Owner via Admin)
 # Roles an admin may hand out. Deliberately excludes owner and admin: promoting
 # a peer to your own level is an ownership decision, not a management one.
 _ADMIN_ASSIGNABLE_ROLES = {

--- a/backend/app/services/model_profile.py
+++ b/backend/app/services/model_profile.py
@@ -119,8 +119,6 @@ class ModelProfileService:
     def __init__(self, db: AsyncSession) -> None:
         self.db = db
 
-    # -- credentials ----------------------------------------------------
-
     async def list_profiles(self, ctx: AuthContext) -> list[ModelProfile]:
         return await credential_repo.list_profiles(self.db, organization_id=ctx.organization_id)
 
@@ -257,8 +255,6 @@ class ModelProfileService:
             target_type="model_profile",
             target_id=str(profile_id),
         )
-
-    # -- resolution -----------------------------------------------------
 
     async def _resolve_credential(
         self, organization_id: UUID, profile: ModelProfile

--- a/backend/app/services/rag/config.py
+++ b/backend/app/services/rag/config.py
@@ -62,7 +62,6 @@ LITEPARSE_IMAGE_FORMATS: set[str] = {
 # Mirrors OFFICE_EXTENSIONS + PRESENTATION_EXTENSIONS + SPREADSHEET_EXTENSIONS
 # in liteparse's `conversion.rs`. Kept in that order so the two can be diffed.
 LITEPARSE_OFFICE_FORMATS: set[str] = {
-    # Word processing
     ".doc",
     ".docx",
     ".docm",
@@ -73,7 +72,6 @@ LITEPARSE_OFFICE_FORMATS: set[str] = {
     ".ott",
     ".rtf",
     ".pages",
-    # Presentations
     ".ppt",
     ".pptx",
     ".pptm",
@@ -83,7 +81,6 @@ LITEPARSE_OFFICE_FORMATS: set[str] = {
     ".odp",
     ".otp",
     ".key",
-    # Spreadsheets
     ".xls",
     ".xlsx",
     ".xlsm",
@@ -140,8 +137,6 @@ def get_supported_formats(parser_name: str = "pymupdf") -> set[str]:
     return PARSER_FORMATS.get(parser_name, PYMUPDF_FORMATS)
 
 
-# Known embedding models and their output dimensions.
-# Used to auto-set vector store dimension from model name.
 EMBEDDING_DIMENSIONS: dict[str, int] = {
     "text-embedding-3-small": 1536,
     "text-embedding-3-large": 3072,

--- a/backend/app/services/rag/connectors/__init__.py
+++ b/backend/app/services/rag/connectors/__init__.py
@@ -72,7 +72,6 @@ class BaseSyncConnector(ABC):
         return True, None
 
 
-# Registry of available connectors - import conditionally to avoid missing deps
 CONNECTOR_REGISTRY: dict[str, type[BaseSyncConnector]] = {}
 from app.services.rag.connectors.google_drive import GoogleDriveConnector
 

--- a/backend/app/services/rag/connectors/google_drive.py
+++ b/backend/app/services/rag/connectors/google_drive.py
@@ -150,7 +150,6 @@ class GoogleDriveConnector(BaseSyncConnector):
             for f in response.get("files", []):
                 mime = f.get("mimeType", "")
 
-                # Handle folders - recurse if enabled, otherwise skip
                 if mime == "application/vnd.google-apps.folder":
                     if include_subfolders:
                         files.extend(self._list_folder(service, f["id"], include_subfolders))
@@ -158,7 +157,6 @@ class GoogleDriveConnector(BaseSyncConnector):
 
                 name = f.get("name", "")
 
-                # Map Google Apps MIME types to exportable formats
                 if mime in GOOGLE_DOCS_EXPORT:
                     export_mime, ext = GOOGLE_DOCS_EXPORT[mime]
                     if not name.endswith(ext):

--- a/backend/app/services/rag/documents.py
+++ b/backend/app/services/rag/documents.py
@@ -592,7 +592,6 @@ class DocumentProcessor:
         self.settings = settings
         self.splitter = self._create_splitter(settings)
 
-        # Always use Python native parser for plain text
         self.text_parser = TextDocumentParser()
         self.docx_parser = DocxDocumentParser()
         self.image_describer = image_describer
@@ -608,7 +607,6 @@ class DocumentProcessor:
         strategy = settings.chunking_strategy
 
         if strategy == "markdown":
-            # Split by markdown headers, then by size
             return MarkdownHeaderTextSplitter(
                 headers_to_split_on=[
                     ("#", "h1"),
@@ -619,7 +617,6 @@ class DocumentProcessor:
             )
 
         if strategy == "fixed":
-            # Simple fixed-size chunks with no smart splitting
             return RecursiveCharacterTextSplitter(
                 chunk_size=settings.chunk_size,
                 chunk_overlap=settings.chunk_overlap,
@@ -627,7 +624,6 @@ class DocumentProcessor:
                 separators=["\n"],
             )
 
-        # Default: recursive (smart splitting by paragraphs, sentences, words)
         return RecursiveCharacterTextSplitter(
             chunk_size=settings.chunk_size,
             chunk_overlap=settings.chunk_overlap,
@@ -681,7 +677,6 @@ class DocumentProcessor:
                 f"Unsupported file type: {suffix}. "
                 f"{type(self.pdf_parser).__name__} reads {', '.join(self.pdf_parser.allowed)}"
             )
-        # Describe images using LLM vision before chunking
         await self._describe_images(document)
 
         pages = document.pages
@@ -716,6 +711,5 @@ class DocumentProcessor:
                 f"with OCR {'on' if self.settings.enable_ocr else 'off'}."
             )
 
-        # Add chunked pages to original document
         document.chunked_pages = chunked_pages
         return document

--- a/backend/app/services/rag/ingestion.py
+++ b/backend/app/services/rag/ingestion.py
@@ -58,8 +58,6 @@ class IngestionService:
                 meta = doc.additional_info or {}
                 if meta.get("source_path") == source_path:
                     return doc.document_id
-                # Also check top-level metadata fields
-                # (source_path is stored in metadata dict per chunk)
             for doc in docs:
                 if doc.filename and doc.filename == Path(source_path).name:
                     return doc.document_id
@@ -111,7 +109,6 @@ class IngestionService:
                     existing_id = await self._find_existing_by_source(
                         collection_name, document.metadata.source_path
                     )
-                # Check by content hash when path lookup missed (exact duplicate detection)
                 if not existing_id and document.metadata.content_hash:
                     existing_id = await self._find_existing_by_hash(
                         collection_name, document.metadata.content_hash

--- a/backend/app/services/rag/sources/base.py
+++ b/backend/app/services/rag/sources/base.py
@@ -106,7 +106,6 @@ class BaseDocumentSource(ABC):
             for source_file in files:
                 try:
                     local_path = await self.download_file(source_file.id, dest)
-                    # Pass source-specific path for deduplication
                     source_uri = f"{source_file.path or source_file.id}"
                     ingest_result = await ingestion_service.ingest_file(
                         filepath=local_path,

--- a/backend/app/services/rag/sources/s3.py
+++ b/backend/app/services/rag/sources/s3.py
@@ -57,7 +57,7 @@ class S3Source(BaseDocumentSource):
             for obj in page.get("Contents", []):
                 key = obj["Key"]
                 if key.endswith("/"):
-                    continue  # skip directories
+                    continue
 
                 name = Path(key).name
                 ext = Path(name).suffix.lower()

--- a/backend/app/services/rag/vectorstore.py
+++ b/backend/app/services/rag/vectorstore.py
@@ -116,9 +116,6 @@ class BaseVectorStore(ABC):
     def _build_chunk_metadata(
         self, chunk: "DocumentPageChunk", document: Document
     ) -> dict[str, Any]:
-        # `document.metadata.model_dump()` is spread last so it can override per-chunk
-        # defaults. `getattr` with defaults is used for optional image fields that may
-        # not be present on all chunk types.
         return {
             "page_num": chunk.page_num,
             "chunk_num": chunk.chunk_num,
@@ -132,10 +129,6 @@ class BaseVectorStore(ABC):
         return document_id.replace('"', "").replace("\\", "")
 
     def _group_documents(self, results: list[dict[str, Any]]) -> list[DocumentInfo]:
-        # Iterates results twice: first to record the initial occurrence of each
-        # parent_doc_id (capturing filename/filesize/filetype and merging source_path,
-        # content_hash, and any extra dict into additional_info), then to increment
-        # chunk_count for every row belonging to that document.
         doc_map: dict[str, dict[str, Any]] = {}
         for item in results:
             doc_id = item.get("parent_doc_id")

--- a/backend/app/services/rate_limit/rules.py
+++ b/backend/app/services/rate_limit/rules.py
@@ -41,7 +41,6 @@ class RateLimitCategory:
     WEBHOOK = "webhook"
 
 
-# Default fallback limits (used when plan features don't define limits)
 DEFAULT_RATE_LIMITS: dict[str, RateLimitRule] = {
     RateLimitCategory.AGENT_INVOCATION: RateLimitRule(per_user=10, period_seconds=86400),
     RateLimitCategory.RAG_UPLOAD: RateLimitRule(per_user=5, period_seconds=86400),

--- a/backend/app/services/rate_limit/service.py
+++ b/backend/app/services/rate_limit/service.py
@@ -60,7 +60,6 @@ async def check_rate_limit(
     storage = _get_storage()
     ip = request.client.host if request.client else "unknown"
 
-    # Resolve rule: plan features > defaults
     rule: RateLimitRule | None = None
     if plan_features:
         rl = plan_features.get("rate_limits", {})
@@ -131,7 +130,6 @@ def make_rate_limit_dep(category: str):
 
     async def _dep(request: Request, user: CurrentUser, active_org: ActiveOrg) -> None:
         plan_features: dict | None = None
-        # Try to load plan features from org subscription (best-effort)
         try:
             if hasattr(active_org, "subscription") and active_org.subscription:
                 sub = active_org.subscription

--- a/backend/app/services/sandbox_connection.py
+++ b/backend/app/services/sandbox_connection.py
@@ -112,8 +112,6 @@ class SandboxConnectionService:
         self.db = db
         self.secrets = OrganizationSecretService(db)
 
-    # -- operator-facing ------------------------------------------------
-
     async def list_connections(self, ctx: AuthContext) -> list[SandboxConnectionRead]:
         rows = await sandbox_connection_repo.list_for_organization(
             self.db, organization_id=ctx.organization_id
@@ -219,8 +217,6 @@ class SandboxConnectionService:
             target_id=str(connection_id),
             details={"name": row.name},
         )
-
-    # -- what this deployment can already see ---------------------------
 
     @staticmethod
     def runtime_catalog() -> list[dict[str, Any]]:
@@ -414,8 +410,6 @@ class SandboxConnectionService:
                 message="A container connection needs the address its sandbox service answers on",
                 details={"field": "base_url"},
             )
-
-    # -- run-facing ----------------------------------------------------
 
     async def resolve(self, ctx: AuthContext, connection_id: UUID | None) -> ResolvedConnection:
         """The connection an agent should use, with its credential unsealed.

--- a/backend/app/services/skill_proposal.py
+++ b/backend/app/services/skill_proposal.py
@@ -43,8 +43,6 @@ class SkillProposalService:
         self.db = db
         self.skills = SkillService(db)
 
-    # -- written by a run ------------------------------------------------
-
     async def record(
         self,
         ctx: AuthContext,
@@ -103,8 +101,6 @@ class SkillProposalService:
                 details={"skills": [proposal.name for proposal in recorded]},
             )
         return recorded
-
-    # -- decided by a person ---------------------------------------------
 
     async def list_proposals(
         self, ctx: AuthContext, *, status: str | None = None

--- a/backend/app/services/skills.py
+++ b/backend/app/services/skills.py
@@ -436,8 +436,6 @@ class SkillService:
         )
         return skill
 
-    # -- resources -------------------------------------------------------
-
     async def add_resource(
         self,
         ctx: AuthContext,

--- a/backend/app/services/sync_source.py
+++ b/backend/app/services/sync_source.py
@@ -288,7 +288,7 @@ class SyncSourceService:
         Raises:
             NotFoundError: If sync source does not exist.
         """
-        await self.get_source(source_id)  # verify exists
+        await self.get_source(source_id)
         await sync_source_repo.delete(self.db, UUID(source_id))
 
     async def trigger_sync(self, source_id: str) -> object:

--- a/backend/app/worker/prefect_app.py
+++ b/backend/app/worker/prefect_app.py
@@ -45,11 +45,9 @@ logger = logging.getLogger(__name__)
 async def main() -> None:
     """Register all deployments and serve them."""
     deployments = []
-    # On-demand: triggered from API on file upload
     deployments.append(await ingest_document_flow.ato_deployment(name="ingest-document"))
     deployments.append(await sync_single_source_flow.ato_deployment(name="sync-single-source"))
     deployments.append(await sync_collection_flow.ato_deployment(name="sync-collection"))
-    # Scheduled: check connector sources every minute
     deployments.append(
         await check_scheduled_syncs_flow.ato_deployment(
             name="rag-sync-check",

--- a/backend/app/worker/tasks/rag_tasks.py
+++ b/backend/app/worker/tasks/rag_tasks.py
@@ -389,7 +389,6 @@ async def _run_sync(
 
             if mode == "new_only":
                 if existing_id:
-                    # File exists - check if content changed via hash
                     file_hash = hashlib.sha256(filepath.read_bytes()).hexdigest()
                     existing_hash = await ingestion_service.get_existing_hash(
                         collection_name, source_path
@@ -397,7 +396,6 @@ async def _run_sync(
                     if existing_hash and file_hash == existing_hash:
                         skipped += 1
                         continue
-                    # Hash changed - will re-ingest below
 
             elif mode == "update_only":
                 if not existing_id:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -99,6 +99,7 @@ dev = [
     "ty>=0.0.69",
     "pre-commit>=4.0.0",
     "pytest-xdist>=3.8.0",
+    "vulture>=2.14",
 ]
 # The documentation site. Its own group rather than part of `dev`, because the
 # reference pages import the application to read its docstrings - so this group
@@ -118,6 +119,37 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["app", "cli"]
+
+# Dead-code detection. Two modes share this config:
+#   `make lint` runs `vulture` at the default confidence below - a blocking gate,
+#   but only on what vulture is sure of (unused variables, parameters, imports).
+#   Unused *functions and methods* sit at 60% confidence here because the
+#   codebase is registry-driven: FastAPI route handlers, Pydantic validators and
+#   capability-protocol methods are all called by name from a framework vulture
+#   cannot see, so a blocking function-level gate would be false positives all
+#   the way down. `make dead-code` lowers the confidence to 60 for a periodic,
+#   human-read scan instead - the same role `dependency-freshness` plays.
+# `ignore_decorators` removes the framework false positives from both modes;
+# `ignore_names` is the allowlist for anything left that is reachable in a way
+# vulture cannot follow - add `name  # why` when a real false positive appears.
+[tool.vulture]
+paths = ["app"]
+min_confidence = 80
+ignore_decorators = [
+    "@field_validator",
+    "@model_validator",
+    "@field_serializer",
+    "@model_serializer",
+    "@computed_field",
+    "@router.*",
+    "@*.get",
+    "@*.post",
+    "@*.put",
+    "@*.patch",
+    "@*.delete",
+    "@*.websocket",
+]
+ignore_names = []
 
 [tool.ruff]
 target-version = "py312"
@@ -402,6 +434,7 @@ include = [
     "app/repositories/organization_secret.py",
     "app/repositories/resource_grant.py",
     "app/api/routes/v1/_sharing_routes.py",
+    "app/api/routes/v1/_sharing_loaders.py",
     "app/api/routes/v1/secrets.py",
     "app/api/routes/v1/agent_environments.py",
     "app/api/routes/v1/agent_exposures.py",
@@ -559,6 +592,7 @@ include = [
     "app/repositories/organization_secret.py",
     "app/repositories/resource_grant.py",
     "app/api/routes/v1/_sharing_routes.py",
+    "app/api/routes/v1/_sharing_loaders.py",
     "app/api/routes/v1/secrets.py",
     "app/api/routes/v1/agent_environments.py",
     "app/api/routes/v1/agent_exposures.py",

--- a/backend/tests/test_sharing_routes.py
+++ b/backend/tests/test_sharing_routes.py
@@ -14,11 +14,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.api.routes.v1._sharing_loaders import (
+    load_agent,
+    load_collection,
+    load_secret,
+    load_skill,
+)
 from app.api.routes.v1.sharing import (
-    _load_agent,
-    _load_collection,
-    _load_secret,
-    _load_skill,
     agent_sharing_router,
     collection_sharing_router,
     secret_sharing_router,
@@ -35,10 +37,10 @@ ROUTERS = (
 )
 
 LOADERS = (
-    ("agent", _load_agent, "Agent not found", "agent_id"),
-    ("collection", _load_collection, "Collection not found", "kb_id"),
-    ("skill", _load_skill, "Skill not found", "skill_id"),
-    ("secret", _load_secret, "Secret not found", "secret_id"),
+    ("agent", load_agent, "Agent not found", "agent_id"),
+    ("collection", load_collection, "Collection not found", "kb_id"),
+    ("skill", load_skill, "Skill not found", "skill_id"),
+    ("secret", load_secret, "Secret not found", "secret_id"),
 )
 
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -71,6 +71,7 @@ dev = [
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "ty" },
+    { name = "vulture" },
 ]
 docs = [
     { name = "mkdocs" },
@@ -141,6 +142,7 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.16.1" },
     { name = "ty", specifier = ">=0.0.69" },
+    { name = "vulture", specifier = ">=2.14" },
 ]
 docs = [
     { name = "mkdocs", specifier = ">=1.6.0" },
@@ -5416,6 +5418,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fe/25/e367a7229b0914772ca8d81b41fde012d9feda68523b52644a571bb21ce8/virtualenv-21.7.0.tar.gz", hash = "sha256:7f9519b9432ff11b6e1a3e94061664efc2ff99ea21780e3cf4f6bd0a5da8b37c", size = 5527510, upload-time = "2026-07-21T13:12:14.109Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/7a/ae29312b1e88a22e81f5d21fc11526d2a114089776c2550d2b205b6c2a47/virtualenv-21.7.0-py3-none-any.whl", hash = "sha256:a8370c1c5530fbabf955e40b8fbbc68a431648b10f9433faa587db30a06e51dd", size = 5507078, upload-time = "2026-07-21T13:12:12.136Z" },
+]
+
+[[package]]
+name = "vulture"
+version = "2.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/3e/4d08c5903b2c0c70cad583c170cc4a663fc6a61e2ad00b711fcda61358cd/vulture-2.16.tar.gz", hash = "sha256:f8d9f6e2af03011664a3c6c240c9765b3f392917d3135fddca6d6a68d359f717", size = 52680, upload-time = "2026-03-25T14:41:27.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/be/f935130312330614811dae2ea9df3f395f6d63889eb6c2e68c14507152ee/vulture-2.16-py3-none-any.whl", hash = "sha256:6e0f1c312cef1c87856957e5c2ca9608834a7c794c2180477f30bf0e4cc58eee", size = 26993, upload-time = "2026-03-25T14:41:26.21Z" },
 ]
 
 [[package]]

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -26,6 +26,7 @@ cost a second place for every change to sit, so it was removed.
 | No force push, no deletion | Ruleset |
 | No commit made while standing on `main` | `no-commit-to-branch` in `.pre-commit-config.yaml` |
 | Spelling, across every tracked file | codespell — as a hook on the files a commit touches, and as `make lint-spelling` in CI's `lint` job over the whole tree |
+| Routes hold only routers, no banner comments, no dead code | `check_routes.py`, `check_comments.py` and `vulture` — hooks in `.pre-commit-config.yaml` (each scans the whole tree, `pass_filenames: false`) and steps of `make lint-backend` in CI's `lint` job |
 
 A hook only ever reads what a commit touches, which makes it a poor gate on its
 own: a misspelling that merges with its file sits there until somebody edits that

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -24,8 +24,9 @@ Run these from the project root directory.
 | `make test` | Backend suite plus the 100% gate on the platform layer. Runs across worker processes (`-n auto --maxprocesses 4`); `pytest-cov` combines their data, so the gate is unchanged |
 | `make test-cov` | Run tests with coverage report (HTML + terminal). Runs across worker processes like `make test` |
 | `make format` | Auto-format code — ruff on the backend, prettier on the frontend |
-| `make lint` | Every static check: ruff, ruff format, ty, eslint, prettier, tsc, the backtick and i18n guards, and codespell over the whole tree |
+| `make lint` | Every static check: ruff, ruff format, ty, vulture, eslint, prettier, tsc, the guard scripts (backtick, i18n, routes, banner comments), and codespell over the whole tree |
 | `make lint-backend` / `make lint-frontend` | One half of the above. CI runs them in two different jobs, so either can be run on its own |
+| `make dead-code` | Unused functions and methods — vulture at a lower confidence than the `lint` gate, plus knip on the frontend. A report to read, not a gate: on a registry-driven codebase it comes with false positives (a CLI command, a capability hook), so read each before deleting. The same role `dependency-freshness` plays for dependencies |
 | `make lint-spelling` | codespell over every tracked file. The pre-commit hook reads only the files a commit touches, so a misspelling that lands with its file waits there to refuse somebody else's unrelated commit |
 | `make build-frontend` | `next build`. Type-checks the route tree and fails on a server component that cannot render — which neither tsc nor vitest sees |
 | `make audit` | Audit the locked dependency set for known vulnerabilities (needs the network) |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -26,7 +26,7 @@ it worker startup (#520).
 Once, before pushing — `make check` runs all of it, in this order:
 
 ```bash
-make lint               # ruff, ruff format, ty, eslint, prettier, tsc, and the two guards
+make lint               # ruff, ruff format, ty, vulture, eslint, prettier, tsc, the guards
 make test               # the suite plus the 100% gate on the platform layer
 make db-check           # alembic check — a model change with no migration fails here
 make test-frontend-cov  # the frontend suite plus its own gate

--- a/frontend/e2e/delegation.spec.ts
+++ b/frontend/e2e/delegation.spec.ts
@@ -79,7 +79,7 @@ test("an agent delegates to another, and both runs are recorded", async ({ page 
   const parentToken = `PONG-PARENT-${stamp}`;
   const delegateToken = `PONG-CHILD-${stamp}`;
 
-  // ------------------------------------------------------- 1. the delegate
+  // 1. the delegate
   const delegateId = await createAgent(page, delegateName);
   expect(
     new URL(page.url()).pathname,
@@ -98,7 +98,7 @@ test("an agent delegates to another, and both runs are recorded", async ({ page 
     "the delegate has run before it was ever delegated to",
   ).toBe(0);
 
-  // --------------------------------------------------------- 2. the parent
+  // 2. the parent
   const parentId = await createAgent(page, parentName);
   await instruct(
     page,
@@ -111,7 +111,7 @@ test("an agent delegates to another, and both runs are recorded", async ({ page 
   );
   await useSavedModel(page, modelLabel);
 
-  // ------------------------------------------------- 3. binding the delegate
+  // 3. binding the delegate
   await openBuilderTab(page, "Toolbox");
   const grant = page.getByRole("switch", { name: "Give this agent Delegation", exact: true });
   await expect(
@@ -143,7 +143,7 @@ test("an agent delegates to another, and both runs are recorded", async ({ page 
 
   await publish(page);
 
-  // ------------------------------------------------------- 4. running it
+  // 4. running it
   await page.getByRole("button", { name: "Open in chat" }).click();
   await expect(page).toHaveURL(/\/chat$/, { timeout: 30_000 });
   await expect(page.getByRole("button", { name: /^Agent:/ })).toContainText(parentName);
@@ -158,7 +158,7 @@ test("an agent delegates to another, and both runs are recorded", async ({ page 
   // was typed into it.
   await expect(composer).toHaveValue("");
 
-  // ---------------------------------------------- 5. the nested panel
+  // 5. the nested panel
   // Found by the delegate's handle, which the platform put there: the panel is
   // built from `subagent_start`, whose `subagent` is the name the parent's spec
   // pinned. A panel with a name in it is a delegation that was resolved, begun
@@ -190,7 +190,7 @@ test("an agent delegates to another, and both runs are recorded", async ({ page 
     "the panel is open but holds nothing the delegate generated",
   ).toBeVisible();
 
-  // ------------------------------------------- 6. two runs, attributed apart
+  // 6. two runs, attributed apart
   // The delegate's history, which was empty before this turn. One row on it is a
   // run row created for the delegate's *own* agent id - the fact that separates
   // real delegation from a parent that did the work and narrated it.
@@ -222,7 +222,7 @@ test("an agent delegates to another, and both runs are recorded", async ({ page 
   await page.getByRole("tab", { name: "Runs", exact: true }).click();
   await expect(page.getByRole("row").filter({ hasText: modelLabel })).toHaveCount(1);
 
-  // ----------------------------------------------------------- 7. cleaning up
+  // 7. cleaning up
   // Through the API, in dependency order - the parent pins the delegate, both
   // name the profile - because this spec runs on every push and an organization
   // that grows two agents and a model per run stops resembling the seed the other

--- a/frontend/e2e/journey.spec.ts
+++ b/frontend/e2e/journey.spec.ts
@@ -59,7 +59,7 @@ test("an agent goes from a stored key to a run with a cost", async ({ page }) =>
   const agentName = `E2E Journey ${stamp}`;
   const answerToken = `PONG-${stamp}`;
 
-  // ---------------------------------------------------------------- 1. a key
+  // 1. a key
   await page.goto("/vault");
   await expect(pageHeading(page, "Vault")).toBeVisible();
 
@@ -93,7 +93,7 @@ test("an agent goes from a stored key to a run with a cost", async ({ page }) =>
   // on the second.
   await expect(page.getByRole("main").getByText(keyLabel)).toBeVisible();
 
-  // ------------------------------------------------------------- 2. an agent
+  // 2. an agent
   await page.goto("/agents");
   await expect(pageHeading(page, "Agents")).toBeVisible();
 
@@ -115,7 +115,7 @@ test("an agent goes from a stored key to a run with a cost", async ({ page }) =>
   await expect(pageHeading(page, new RegExp(agentName))).toBeVisible();
   const agentId = new URL(page.url()).pathname.split("/").pop() ?? "";
 
-  // ----------------------------------------------- 3. instructions and a model
+  // 3. instructions and a model
   const build = page.getByRole("tabpanel");
   await build
     .getByPlaceholder(/^You are Support Copilot/)
@@ -159,7 +159,7 @@ test("an agent goes from a stored key to a run with a cost", async ({ page }) =>
     page.getByRole("group", { name: "Current model" }).getByText(modelLabel),
   ).toBeVisible();
 
-  // ---------------------------------------------------------- 4. a capability
+  // 4. a capability
   // Capabilities live in Toolbox, not Build. This used to look for them in the
   // Build panel and find none, so the step below skipped itself with "the
   // capability catalog is empty" against a deployment whose catalog was fine -
@@ -189,7 +189,7 @@ test("an agent goes from a stored key to a run with a cost", async ({ page }) =>
     await page.getByRole("option", { name: "Never ask" }).click();
   }
 
-  // ------------------------------------------------------------ 5. publishing
+  // 5. publishing
   const publish = page.getByRole("button", { name: "Publish" });
   if (!(await publish.isVisible())) {
     test.skip(true, "this user cannot publish agents");
@@ -202,7 +202,7 @@ test("an agent goes from a stored key to a run with a cost", async ({ page }) =>
   await expect(pageHeading(page)).toContainText("published", { timeout: 30_000 });
   await expect(page.getByText("This agent cannot be published yet")).toHaveCount(0);
 
-  // ------------------------------------------------------------ 6. running it
+  // 6. running it
   // The Builder hands the agent to the chat, which is where this product runs
   // one. That the chat is addressed to *this* agent rather than the general
   // assistant is what the next assertion turns on: the assistant would answer
@@ -226,7 +226,7 @@ test("an agent goes from a stored key to a run with a cost", async ({ page }) =>
   await expect(composer).toHaveValue("");
   await expect(page.getByRole("main").getByText(answerToken)).toBeVisible({ timeout: 120_000 });
 
-  // -------------------------------------------------- 7. the run in Activity
+  // 7. the run in Activity
   await page.goto("/runs");
   await expect(pageHeading(page, "Activity")).toBeVisible();
   await page.getByRole("tab", { name: "Runs", exact: true }).click();
@@ -238,7 +238,7 @@ test("an agent goes from a stored key to a run with a cost", async ({ page }) =>
   await expect(row).toBeVisible();
   await expect(row).toContainText(/\$\d+\.\d{4}/);
 
-  // ----------------------------------------------------------- 8. cleaning up
+  // 8. cleaning up
   // This is the one spec that creates a whole agent, and it runs on every push -
   // so without this the organization grows an agent, a model and a key per run,
   // and the counts other specs take start describing the history of CI rather

--- a/frontend/knip.json
+++ b/frontend/knip.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://unpkg.com/knip@5/schema.json",
+  "entry": ["e2e/*.setup.ts", "e2e/stub-model-server.ts", "e2e/screenshot.ts"],
+  "project": ["src/**/*.{ts,tsx}", "e2e/**/*.ts"],
+  "ignore": ["src/components/ui/**"],
+  "ignoreDependencies": ["date-fns", "eslint-config-prettier"]
+}

--- a/frontend/src/components/layout/mobile-tab-bar.tsx
+++ b/frontend/src/components/layout/mobile-tab-bar.tsx
@@ -38,7 +38,6 @@ export function MobileTabBar() {
       label: t("search"),
       icon: Search,
       onClick: () => {
-        // Trigger global ⌘K command palette via synthetic keyboard event.
         const event = new KeyboardEvent("keydown", {
           key: "k",
           metaKey: true,

--- a/frontend/src/components/legal/cookie-banner.tsx
+++ b/frontend/src/components/legal/cookie-banner.tsx
@@ -11,7 +11,7 @@ import { useTranslations } from "next-intl";
 const STORAGE_KEY = "cookie.consent";
 
 interface CookieConsent {
-  essential: true; // always required
+  essential: true;
   analytics: boolean;
   functional: boolean;
   decided_at: string;

--- a/frontend/src/components/rag/sync-source-wizard.tsx
+++ b/frontend/src/components/rag/sync-source-wizard.tsx
@@ -104,7 +104,6 @@ export function SyncSourceWizard({
   const enabledConnectors = connectors.filter((c) => c.enabled);
   const hasOrgIntegrations = orgIntegrations.length > 0;
 
-  // --- clone mode ---
   const selectedIntegration = orgIntegrations.find((i) => i.id === cloneSourceId);
 
   const handleCloneSubmit = async () => {
@@ -116,7 +115,6 @@ export function SyncSourceWizard({
     );
   };
 
-  // --- new mode canAdvance ---
   const canAdvance = (() => {
     if (mode === "clone") {
       return Boolean(cloneSourceId) && Boolean(defaultCollection);

--- a/frontend/src/components/theme/theme-provider.tsx
+++ b/frontend/src/components/theme/theme-provider.tsx
@@ -21,7 +21,6 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     root.style.colorScheme = resolvedTheme;
   }, [theme]);
 
-  // Listen for system theme changes when using "system" theme
   useEffect(() => {
     if (theme !== "system") return;
 

--- a/frontend/src/components/ui/button.test.tsx
+++ b/frontend/src/components/ui/button.test.tsx
@@ -25,7 +25,6 @@ describe("Button component", () => {
   it("should apply size classes", () => {
     render(<Button size="lg">Large Button</Button>);
     const button = screen.getByRole("button");
-    // Check that the button has appropriate size styling
     expect(button).toBeInTheDocument();
   });
 

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -160,12 +160,10 @@ export function useChat(options: UseChatOptions = {}) {
 
       switch (wsEvent.type) {
         case "conversation_created": {
-          // Handle new conversation created by backend
           const { conversation_id } = wsEvent.data as { conversation_id: string };
           setCurrentConversationId(conversation_id);
           // Reflect the new ID in the URL so the page is refreshable + shareable.
           setUrlParam("id", conversation_id);
-          // Update all messages that don't have a conversationId yet
           const { updateMessagesWhere } = useChatStore.getState();
           updateMessagesWhere(
             (msg) => !msg.conversationId,
@@ -176,10 +174,8 @@ export function useChat(options: UseChatOptions = {}) {
         }
 
         case "message_saved": {
-          // Assistant message was saved to database, update local ID to real database ID
           const { message_id } = wsEvent.data as { message_id: string };
           if (currentMessageIdRef.current) {
-            // Update the current streaming message's ID to the real database ID
             updateMessage(currentMessageIdRef.current, (msg) => ({
               ...msg,
               id: message_id,
@@ -192,7 +188,6 @@ export function useChat(options: UseChatOptions = {}) {
             // to nothing, so it appeared only after a reload fetched it from the row.
             setCurrentMessageId(message_id);
           } else {
-            // Fallback: find the last assistant message with a temp ID
             // This handles cases where currentMessageId was already cleared
             const messages = useChatStore.getState().messages;
             const lastTemp = [...messages]
@@ -258,7 +253,6 @@ export function useChat(options: UseChatOptions = {}) {
         }
 
         case "tool_call": {
-          // Add tool call to current message
           if (currentMessageIdRef.current) {
             const { tool_name, args, tool_call_id } = wsEvent.data as {
               tool_name: string;
@@ -277,7 +271,6 @@ export function useChat(options: UseChatOptions = {}) {
         }
 
         case "tool_result": {
-          // Update tool call with result
           if (currentMessageIdRef.current) {
             const { tool_call_id, content } = wsEvent.data as {
               tool_call_id: string;
@@ -292,7 +285,6 @@ export function useChat(options: UseChatOptions = {}) {
         }
 
         case "final_result": {
-          // Finalize message
           if (currentMessageIdRef.current) {
             const { output } = wsEvent.data as { output: string };
             // If the model returned text only via final_result (no streamed
@@ -330,7 +322,6 @@ export function useChat(options: UseChatOptions = {}) {
         }
 
         case "error": {
-          // Handle error
           if (currentMessageIdRef.current) {
             const id = currentMessageIdRef.current;
             const { message } = wsEvent.data as { message: string };
@@ -945,7 +936,6 @@ export function useChat(options: UseChatOptions = {}) {
     setThinkingEffort: (effort: "low" | "medium" | "high" | null) => {
       thinkingEffortRef.current = effort;
     },
-    // Human-in-the-Loop support
     pendingApproval,
     sendResumeDecisions,
     pendingQuestions,

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -116,7 +116,6 @@ class ApiClient {
   private async request<T>(endpoint: string, options: RequestOptions = {}): Promise<T> {
     const response = await this.send(endpoint, options);
 
-    // Handle empty responses
     const text = await response.text();
     if (!text) {
       return null as T;

--- a/frontend/src/lib/server-api.ts
+++ b/frontend/src/lib/server-api.ts
@@ -64,7 +64,6 @@ export async function backendFetch<T>(endpoint: string, options: RequestOptions 
     throw new BackendApiError(response.status, response.statusText, errorData);
   }
 
-  // Handle empty responses
   const text = await response.text();
   if (!text) {
     return null as T;

--- a/frontend/src/stores/auth-store.test.ts
+++ b/frontend/src/stores/auth-store.test.ts
@@ -12,7 +12,6 @@ const createMockUser = (overrides?: Partial<User>): User => ({
 
 describe("Auth Store", () => {
   beforeEach(() => {
-    // Reset store before each test
     useAuthStore.setState({
       user: null,
       isAuthenticated: false,
@@ -38,10 +37,8 @@ describe("Auth Store", () => {
   });
 
   it("should clear user on logout", () => {
-    // First set a user
     useAuthStore.getState().setUser(createMockUser());
 
-    // Then logout
     useAuthStore.getState().logout();
 
     const state = useAuthStore.getState();

--- a/scripts/check_comments.py
+++ b/scripts/check_comments.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Ban ASCII banner comments.
+
+A comment that is a horizontal rule - `# --- sending ---------`,
+`// ==== internals ====` - is decoration, not information. It signposts a
+section that the code's own structure (a class, a function, a well-named module)
+should already mark, it drifts out of date the moment the section moves, and the
+format itself reads as machine-generated. Plain "why" comments are welcome; a
+rule drawn in dashes is not.
+
+Detected: a line whose first non-whitespace is a comment marker (`#` or `//`)
+followed by a run of three or more rule characters (`- = ~ *`). Anchoring to a
+line-leading marker is what keeps a dashed string literal from tripping it - a
+banner always sits on its own line.
+
+The fix is to delete the line. If a section genuinely needs a heading, a short
+plain comment (`# Sending`) says the same thing without the rule.
+
+Usage::
+
+    python scripts/check_comments.py            # report, exit 1 if any found
+
+Exits 1 when a banner is found, 0 when clean.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+SUFFIXES = {".py", ".ts", ".tsx", ".js", ".jsx", ".yml", ".yaml"}
+
+SKIP_DIRS = {
+    ".git",
+    ".next",
+    ".venv",
+    "__pycache__",
+    "node_modules",
+    "htmlcov",
+    "dist",
+    "build",
+    "site",
+    ".claude",
+}
+
+# A line-leading comment marker, then optional space, then a rule of one repeated
+# character (`---`, `====`, `~~~`, `***`). `\1{2,}` ties the run to a single
+# character, so `-*-` (a coding cookie) and prose with a lone dash do not match.
+BANNER = re.compile(r"^\s*(?:#|//)\s*([-=~*])\1{2,}")
+
+
+def _iter_files(root: Path) -> Iterator[Path]:
+    for path in root.rglob("*"):
+        if path.is_dir():
+            continue
+        # Parts relative to the root, so a checkout that itself lives under a
+        # skipped name (a worktree under `.claude/`) is not skipped wholesale.
+        if any(part in SKIP_DIRS for part in path.relative_to(root).parts):
+            continue
+        if path.suffix in SUFFIXES:
+            yield path
+
+
+def main() -> int:
+    found = False
+    for path in sorted(_iter_files(REPO_ROOT)):
+        for lineno, line in enumerate(path.read_text(errors="ignore").splitlines(), 1):
+            if BANNER.match(line):
+                found = True
+                rel = path.relative_to(REPO_ROOT)
+                print(f"{rel}:{lineno}: banner comment - delete the rule. {line.strip()[:60]}")
+    return 1 if found else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_routes.py
+++ b/scripts/check_routes.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Keep `app/api/routes/**` to routers, not helpers.
+
+A route module is the HTTP layer: request in, delegate to a service, response
+out. A plain helper that lands here - a parser, a loader, a formatter - is
+business logic in the one place the architecture says holds none, and it gets
+there quietly because nothing complains. This is that complaint.
+
+Only endpoint modules are checked - a file whose name starts with `_` is a
+dedicated helper module (`_workspace_bytes.py`, `_sharing_routes.py`), which is
+the sanctioned place to put route-adjacent code that is not an endpoint, so it is
+skipped.
+
+In an endpoint module, a module-level function is allowed only when it is one of:
+
+- a **route handler** - decorated `@router.get(...)`, `@router.post(...)` and so
+  on (any `<router>.<http-method>` decorator);
+- a **router factory** - annotated `-> APIRouter`, the pattern that builds a set
+  of endpoints from one definition (e.g. `build_sharing_router`);
+- **declared on purpose** with `# routes-helper: <reason>` on the `def` line or
+  the line above it. The reason is required, the same bargain as `i18n-exempt`
+  and `ty: ignore`, and it is for the rare helper that genuinely cannot move -
+  a callback the routing itself injects, not a parser or a loader that a service
+  should own.
+
+Everything else is reported. The fix is almost always to move it: a loader or a
+validator belongs in a service, a dependency in `api/deps.py`, and anything else
+route-adjacent in a `_`-prefixed module beside the endpoints. Reach for the
+marker last, not first.
+
+Usage::
+
+    python scripts/check_routes.py            # report, exit 1 if any found
+
+Exits 1 when an undeclared helper is found, 0 when clean.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+# `websocket` and `api_route` are FastAPI route decorators too; a handler wears
+# one of these as `<router>.<name>(...)`.
+HTTP_METHODS = frozenset(
+    {"get", "post", "put", "patch", "delete", "head", "options", "trace", "websocket", "api_route"}
+)
+
+MARKER = "# routes-helper:"
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ROUTES_DIR = REPO_ROOT / "backend" / "app" / "api" / "routes"
+
+
+def _is_route_handler(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    for dec in node.decorator_list:
+        call = dec.func if isinstance(dec, ast.Call) else dec
+        if isinstance(call, ast.Attribute) and call.attr in HTTP_METHODS:
+            return True
+    return False
+
+
+def _is_router_factory(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    ret = node.returns
+    if isinstance(ret, ast.Name):
+        return ret.id == "APIRouter"
+    if isinstance(ret, ast.Attribute):
+        return ret.attr == "APIRouter"
+    return False
+
+
+def _reason_after(line: str) -> bool:
+    idx = line.find(MARKER)
+    return idx != -1 and bool(line[idx + len(MARKER) :].strip())
+
+
+def _has_marker(lines: list[str], node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    # The `def` line itself (a trailing marker), or anywhere in the contiguous
+    # block of comment lines directly above it - so a multi-line note carries.
+    if 1 <= node.lineno <= len(lines) and _reason_after(lines[node.lineno - 1]):
+        return True
+    i = node.lineno - 2
+    while i >= 0 and lines[i].lstrip().startswith("#"):
+        if _reason_after(lines[i]):
+            return True
+        i -= 1
+    return False
+
+
+def _findings(path: Path) -> list[tuple[int, str]]:
+    source = path.read_text()
+    lines = source.splitlines()
+    tree = ast.parse(source, str(path))
+    out: list[tuple[int, str]] = []
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        if _is_route_handler(node) or _is_router_factory(node) or _has_marker(lines, node):
+            continue
+        out.append((node.lineno, node.name))
+    return out
+
+
+def main() -> int:
+    if not ROUTES_DIR.is_dir():
+        print(f"routes directory not found: {ROUTES_DIR}", file=sys.stderr)
+        return 1
+    found = False
+    for path in sorted(ROUTES_DIR.rglob("*.py")):
+        if path.name.startswith("_"):
+            continue
+        for lineno, name in _findings(path):
+            found = True
+            rel = path.relative_to(REPO_ROOT)
+            print(
+                f"{rel}:{lineno}: helper '{name}' in a route module. Move it to a "
+                f"service or api/deps.py, or mark it `{MARKER} <reason>`."
+            )
+    if found:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What this is

Re-opens the work from #584, which GitHub auto-closed when #579 merged (the
squash deleted `chore/strip-dead-weight`, this PR's old base). Same content,
rebuilt on top of current `main` and re-verified — now a clean, single-commit
diff against `main`.

Enforces three standards CLAUDE.md states but nothing checked, applies them, and
does the tree-wide comment cleanup you asked for.

## The three guards (in `make lint` + pre-commit)

1. **Routes hold only routers** — `scripts/check_routes.py`. A top-level function
   in an endpoint module must be a route handler or a `-> APIRouter` factory;
   anything else moves out (a `_*.py` helper module beside the endpoints is the
   sanctioned home and is skipped). The runs status parser became
   `RunStatus.parse_csv` — now shared by the list route and `main`'s new
   `runs/export` route — and the sharing loaders moved to `_sharing_loaders.py`.
2. **No banner comments** — `scripts/check_comments.py`. Rejects `# --- x ---`.
3. **Dead code** — vulture. Blocking at confidence 80 (unused vars/params);
   `make dead-code` is the advisory function-level scan (+ knip for the
   frontend), because a blocking function gate on a registry-driven codebase is
   false positives all the way down.

## The gate paid for itself, twice

- It caught two dead items #579's manual sweep missed: `sanitize_filename`
  (orphaned when `validate_safe_path` went) and a dead `project_id` param on
  `channel_session.create`.
- Rebuilding on current `main` surfaced that `main`'s new `runs/export` feature
  carries the **`# … one query rather than an EXISTS per row …`** comment you
  flagged — the exact optimisation-narration the policy targets. Removed here.

## Comment cleanup

~140 lines of genuine slop removed across backend and frontend — section labels
(`# -- documents --`), restatements (`# 10MB`), and mechanism-narration — via a
delete-only sweep that **keeps** the load-bearing `#issue`/footgun/invariant
comments and the docstrings, per the standard. CLAUDE.md and `code-style.md` now
state the bar plainly: *default is no comment; would a competent reader make a
mistake without it?*

The honest finding: past the banners/labels/narration this codebase is not
broadly over-commented — most `#`/`//` comments are the "why" kind CLAUDE.md
values. So the sweep is targeted, not a purge.

## Testing

- `make lint` (ruff, ty, vulture, the four guards, eslint, prettier, tsc,
  codespell) — green.
- `make test` — **coverage 100%**, 4378 passed, 6 skipped. The one red backend
  test is the pre-existing `test_approval_expiry` (needs a Prefect API at
  `localhost:4200`); unrelated, and it passes in CI.
- `make test-frontend-cov` — green.

## Not touched, on purpose

Docstrings (the sanctioned home for reasoning) and a handful of borderline glosses
(cookie-lifetime `// 15 minutes` decodes, QueryClient tuning notes) — say the word
for a stricter pass on either.


Closes #521
