### PR TITLE
fix(chat): stop storing the approval notice as the agent's words

### DIFF
--- a/backend/app/services/agent_chat.py
+++ b/backend/app/services/agent_chat.py
@@ -371,8 +371,8 @@ class ChatAgentRunner:
                 )
                 status = RunStatus.AWAITING_APPROVAL
             else:
+                output = result.output
                 status = RunStatus.COMPLETED
-            output = display_output(result.output)
         except asyncio.CancelledError:
             # The user pressed stop, or the socket went away mid-run. Cancelled
             # is not failed, and the tokens spent up to here were still spent.

--- a/backend/app/services/agent_chat.py
+++ b/backend/app/services/agent_chat.py
@@ -69,14 +69,6 @@ type ChatStream = Callable[[AgentRun[AgentDeps, str | DeferredToolRequests]], Aw
 # role implies.
 _NOT_A_MEMBER = "You are no longer a member of this organization."
 
-# What the person is told when the run stopped on an approval instead of an
-# answer. Silence would read as the agent ignoring them, and the run does not
-# continue in this conversation - it continues when somebody decides, from the
-# approvals queue.
-_AWAITING_APPROVAL = (
-    "This run needs approval before it can go further - it is waiting in the approvals queue."
-)
-
 
 def requested_agent_id(frame: Mapping[str, Any]) -> UUID | None:
     """Which published agent a chat frame is addressed to, if any.
@@ -152,8 +144,18 @@ def display_output(output: str | DeferredToolRequests) -> str:
     side-effecting call, Pydantic AI ends the run with the calls waiting on a
     human. There is no model text to show then, and the object itself is not
     something a client can render.
+
+    Empty, then - and deliberately not a sentence about the queue. This value
+    becomes the assistant message's `content`, so a notice put here is stored as
+    the agent's words: false the moment somebody approves, and false for good, in
+    the middle of a turn that plainly did go further (#509). That a run is parked
+    is state, and it is already carried by things that stop carrying it when the
+    decision is made - the step the run stopped on, and the approval panel put in
+    front of whoever is looking. Every surface that does not stream records an
+    empty answer here too (:meth:`AgentRunnerService._run`), so this is the whole
+    platform's answer rather than this one's.
     """
-    return output if isinstance(output, str) else _AWAITING_APPROVAL
+    return output if isinstance(output, str) else ""
 
 
 @dataclass(frozen=True)
@@ -182,6 +184,10 @@ class ChatTurn:
     """What one published-agent turn produced, for the surface to persist."""
 
     output: str
+    """The answer, or empty for a turn that parked on an approval - see
+    :func:`display_output`. A surface that streamed the turn holds what the model
+    said before it stopped; this carries only what the run *ended* with."""
+
     model_label: str
     agent_id: UUID
     agent_version_id: UUID | None
@@ -289,8 +295,8 @@ class ChatAgentRunner:
 
         Returns:
             The answer to show and persist, and the model that produced it. A
-            run parked on an approval returns the queue's explanation instead of
-            an answer - it did not fail, and it has not finished either.
+            run parked on an approval returns no answer at all - it did not fail,
+            and it has not finished either - and `parked` is what says so.
 
         Raises:
             AuthorizationError: If the user is not a member of this organization.

--- a/backend/app/services/agent_session.py
+++ b/backend/app/services/agent_session.py
@@ -200,11 +200,12 @@ class AgentSession:
         # stored, so a reloaded conversation is the one somebody watched rather
         # than a reconstruction of it; see `chat_timeline.TurnTimeline`.
         #
-        # It also holds what the model has said so far, for the turn that does not
-        # finish. On the success path `turn.output` is the answer and `.text` is
-        # never read; nothing can tell in advance which path a turn is on, and the
-        # alternative is throwing away a half-written answer on exactly the runs
-        # somebody opens afterwards.
+        # It also holds what the model has said so far, for every turn that does
+        # not end with an answer: one that failed, was stopped or lost its socket,
+        # and one that parked on an approval. `turn.output` is the answer where
+        # there is one and empty where there is not; nothing can tell in advance
+        # which path a turn is on, and the alternative is throwing away a
+        # half-written answer on exactly the runs somebody opens afterwards.
         timeline = TurnTimeline()
         # The run row, as soon as `prepare` opens one. A list because the
         # callback is `list.append` and a turn opens at most one run - it is
@@ -258,12 +259,23 @@ class AgentSession:
                     model_profile_id=requested_model_profile_id(data),
                     environment_id=requested_environment_id(data),
                 )
-            output = turn.output
+            # What the model actually wrote. `turn.output` is what the run ended
+            # with, and a turn that parked on an approval ended with nothing - so
+            # what it said before it stopped is on the timeline, exactly as it is
+            # for a turn that failed. The notice that used to stand in for the
+            # answer was stored as the agent's words and stayed there after the
+            # decision, saying a turn was waiting inside a turn that went on
+            # (#509); the step and the approval panel say it instead, and stop.
+            output = turn.output or timeline.text
             model_label = turn.model_label
             agent_version_id = turn.agent_version_id
 
             self.conversation_history.append({"role": "user", "content": user_message})
-            self.conversation_history.append({"role": "assistant", "content": output})
+            # Only when there was something to say. A parked turn is the ordinary
+            # way to reach this with nothing, and an empty assistant turn in the
+            # history is a `TextPart` with no content on the next request.
+            if output:
+                self.conversation_history.append({"role": "assistant", "content": output})
             assistant_msg_id: str | None = None
             if self.current_conversation_id:
                 assistant_msg_id = await persist_assistant_turn(

--- a/backend/app/services/agent_session.py
+++ b/backend/app/services/agent_session.py
@@ -259,21 +259,20 @@ class AgentSession:
                     model_profile_id=requested_model_profile_id(data),
                     environment_id=requested_environment_id(data),
                 )
-            # What the model actually wrote. `turn.output` is what the run ended
-            # with, and a turn that parked on an approval ended with nothing - so
-            # what it said before it stopped is on the timeline, exactly as it is
-            # for a turn that failed. The notice that used to stand in for the
-            # answer was stored as the agent's words and stayed there after the
-            # decision, saying a turn was waiting inside a turn that went on
-            # (#509); the step and the approval panel say it instead, and stop.
+            # `turn.output` is what the run *ended* with; a turn that parked ended
+            # with nothing, so its words are on the timeline (#509).
             output = turn.output or timeline.text
             model_label = turn.model_label
             agent_version_id = turn.agent_version_id
 
             self.conversation_history.append({"role": "user", "content": user_message})
-            # Only when there was something to say. A parked turn is the ordinary
-            # way to reach this with nothing, and an empty assistant turn in the
-            # history is a `TextPart` with no content on the next request.
+            # Only when there was something to say - tidiness, not a broken
+            # request being fixed. Skipping the assistant entry can leave two
+            # `user` entries in a row (park with no text, decide, type again),
+            # and `_agent_graph._clean_message_history` merges those into one
+            # `ModelRequest` before every model call; the empty `TextPart` this
+            # avoids was harmless too, dropped by the Anthropic adapter and sent
+            # as `content: ""` by the OpenAI one.
             if output:
                 self.conversation_history.append({"role": "assistant", "content": output})
             assistant_msg_id: str | None = None

--- a/backend/tests/test_agent_chat.py
+++ b/backend/tests/test_agent_chat.py
@@ -329,11 +329,13 @@ class TestWhatTheClientIsShown:
     def test_an_answer_is_shown_as_the_model_wrote_it(self):
         assert display_output("42 days") == "42 days"
 
-    def test_a_parked_run_says_so_instead_of_showing_nothing(self):
-        """A blank turn reads as the agent ignoring you; it is waiting on a person."""
-        shown = display_output(DeferredToolRequests())
-
-        assert "approval" in shown.lower()
+    def test_a_parked_run_produces_no_text_of_its_own(self):
+        """This value is stored as the assistant message's `content`, so a notice
+        about the queue put here is stored as the agent's words - and stays there,
+        false, once somebody approves and the run goes on (#509). Parked is state:
+        the step it stopped on and the approval panel carry it, and stop carrying
+        it when the decision is made."""
+        assert display_output(DeferredToolRequests()) == ""
 
 
 class TestWhoTheRunBelongsTo:
@@ -727,7 +729,9 @@ class TestPausingMidRun:
         finished = runner.finish.call_args.kwargs
         assert finished["status"] is RunStatus.AWAITING_APPROVAL
         assert finished["paused_state"].tool_call_ids == {"approval-1": "call-1"}
-        assert "approval" in turn.output.lower()
+        # And no answer, because it produced none. What it is waiting on is on the
+        # row and in `parked`, not in a sentence stored as the agent's words.
+        assert turn.output == ""
 
 
 class TestAttachmentsAreRoutedHereAndNotBySurfaces:

--- a/backend/tests/test_agent_session.py
+++ b/backend/tests/test_agent_session.py
@@ -148,6 +148,18 @@ def _finished_turn(
     )
 
 
+def _parked_call() -> tuple[ParkedApproval, ...]:
+    """One gated call waiting on a person - what makes a turn a parked one."""
+    return (
+        ParkedApproval(
+            approval_id=uuid4(),
+            tool_call_id="call-1",
+            tool_name="send_email",
+            tool_args={"to": "ops@example.com"},
+        ),
+    )
+
+
 @contextmanager
 def _chat(
     run: AsyncMock,
@@ -518,6 +530,52 @@ class TestATurnThatFinished:
                 "review_configs": [{"tool_name": "send_email", "allow_edit": False}],
             },
         )
+
+    async def test_a_parked_turn_stores_no_notice_in_the_agents_own_voice(self):
+        """Whatever this turn ends with becomes the assistant message's `content`,
+        so a sentence about the approvals queue is stored as something the agent
+        said - and it is still there, in the middle of the turn, once somebody
+        approves and the run visibly goes on (#509). The step that parked and the
+        panel below it already say it, and they stop saying it when it stops being
+        true."""
+        session = _session()
+        turn = _finished_turn(output="", parked=_parked_call())
+
+        with _chat(AsyncMock(return_value=turn)) as chat:
+            await session.process_message(_message())
+
+        assert chat.answer.await_args.args[1] == ""
+
+    async def test_a_parked_turn_keeps_what_the_model_wrote_before_it_stopped(self):
+        """`turn.output` is what the run *ended* with, and a parked run ended with
+        nothing - so the words are read off the timeline, the route a turn that
+        failed already takes. Without it a model that explained itself and then
+        asked for a gated call is written down as having said nothing at all.
+
+        Driven over a real `Agent.iter` so the text travels the way the client's
+        `text_delta` frames do: what is stored is what its reader saw."""
+        session = _session()
+
+        async def stopped_on_an_approval(**kwargs: Any) -> ChatTurn:
+            async with _answering_agent().iter("how many are open?") as agent_run:
+                await kwargs["stream"](agent_run)
+            return _finished_turn(output="", parked=_parked_call())
+
+        with _chat(AsyncMock(side_effect=stopped_on_an_approval)) as chat:
+            await session.process_message(_message())
+
+        assert chat.answer.await_args.args[1] == "Two are open."
+
+    async def test_a_turn_that_answered_nothing_leaves_no_empty_reply_in_the_history(self):
+        """The history is replayed as `ModelResponse` parts on the next request,
+        and an assistant turn with no content is a `TextPart` carrying nothing. A
+        parked turn is the ordinary way to reach this."""
+        session = _session()
+
+        with _chat(AsyncMock(return_value=_finished_turn(output="", parked=_parked_call()))):
+            await session.process_message(_message("how many are open?"))
+
+        assert session.conversation_history == [{"role": "user", "content": "how many are open?"}]
 
 
 class TestATurnThatDidNotFinish:


### PR DESCRIPTION
## What this fixes

A chat turn that parked on an approval stored *"This run needs approval before it can
go further - it is waiting in the approvals queue."* as the assistant message's
`content`. The moment somebody approved, that sentence was false — and it stayed in
the transcript for good, attributed to the agent, in the middle of a turn that plainly
did go further. Since #505 draws the segments of one run as one turn, the reader sees
it between two steps that both ran.

It was never the model's text. It was UI state written into the one field that keeps
things forever.

Closes #509.

## What changed

- `backend/app/services/agent_chat.py` — `display_output` answers `""` for a run that
  ended on `DeferredToolRequests`, and `_AWAITING_APPROVAL` is gone. This is what every
  surface that does not stream already records (`AgentRunnerService._run` sets
  `output = ""` and hands that to `TranscriptService.record`), so web chat was the one
  place inventing a sentence.
- `backend/app/services/agent_session.py` — a parked turn persists what the model wrote
  before it stopped (`timeline.text`), the same route a turn that failed, was stopped or
  lost its socket already takes. Usually empty; not always, and a model that explained
  itself before asking for a gated call was previously overwritten by the notice.
- `backend/app/services/agent_session.py` — the in-memory history no longer gets an
  assistant entry when the turn said nothing. `build_message_history` turns each one into
  a `ModelResponse` holding a single `TextPart`, and an empty one is a part with nothing
  in it on the next request. The notice used to keep that field non-empty by accident.

That a run is parked is still said, by the two things that stop saying it when the
decision is made: the step it stopped on renders `awaiting_approval` ("waiting for
approval", amber, paused icon), and the `tool_approval_required` frame puts the panel in
front of whoever is looking. No frontend change — the client already appends nothing for
`final_result` with an empty `output`, and a message with tool-call parts and no text
renders its steps without an empty bubble.

## Testing

- `tests/test_agent_chat.py::TestWhatTheClientIsShown::test_a_parked_run_produces_no_text_of_its_own`
- `tests/test_agent_chat.py::TestPausingMidRun::test_a_parked_tool_call_leaves_the_run_resumable` — asserted the notice, now asserts no answer
- `tests/test_agent_session.py::TestATurnThatFinished` — three new: the parked turn stores
  no notice; it keeps what the model wrote (driven over a real `Agent.iter`, so the text
  travels the route the client's `text_delta` frames do); and a turn that answered nothing
  leaves no empty reply in the history
- `make lint` and `make test` clean, including the 100% gate — both files are in the
  platform layer

## Noticed, not fixed

**A still-parked run says nothing about waiting once the page is reloaded**, and this
change removes the sentence that was accidentally covering for it. The stored tool-call
row for a parked call keeps `status="running"`, which `replayedStatus` maps to
`unfinished` and `tool-call-card` draws as a finished step; and `pendingApproval` is only
ever set from a live socket frame, so the panel does not come back either. Every
non-streaming surface has always looked like this — the fix aligns web chat with them
rather than causing it — but it is worth its own issue, filed as #601.
