### PR TITLE
test(channels): cover the seam that puts a chart in a channel reply

### DIFF
--- a/backend/tests/test_channel_charts.py
+++ b/backend/tests/test_channel_charts.py
@@ -9,13 +9,16 @@ for a chart on a channel answered "here is the chart" with no chart, which is th
 worst shape a bug can take: the sentence is confident and the evidence is absent.
 """
 
-from unittest.mock import patch
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from app.agents.capabilities.charts._spec import ChartSpec
+from app.core.permissions import OrgRoleName
 from app.services.channels.chart_png import render_chart_png
-from app.services.channels.mentions import drawn_chart
+from app.services.channels.mentions import ChannelAgentRouter, drawn_chart
 from app.services.transcript import RecordedToolCall
 
 ROWS = [{"x": "Jan", "revenue": 120}, {"x": "Feb", "revenue": 150}, {"x": "Mar", "revenue": 90}]
@@ -171,3 +174,83 @@ class TestChoosingWhatToSend:
             "app.services.channels.mentions.render_chart_png", side_effect=RuntimeError("boom")
         ):
             assert drawn_chart([_call(_spec().model_dump_json())]) is None
+
+
+def _runner_that_draws() -> AsyncMock:
+    """A runner whose turn calls `create_chart`.
+
+    It fills the list it was handed the way `AgentRunnerService.execute` does,
+    and takes `tool_calls` as a required keyword: a router that stops passing
+    one fails here with a `TypeError` rather than quietly replying without the
+    picture.
+    """
+
+    async def execute(
+        *_args: Any, tool_calls: list[RecordedToolCall], **_kwargs: Any
+    ) -> tuple[str, MagicMock]:
+        tool_calls.append(_call(_spec().model_dump_json()))
+        return "here is the chart", MagicMock()
+
+    return AsyncMock(side_effect=execute)
+
+
+class TestTheReplyAChannelTurnBuilds:
+    """The seam between the two halves above: `drawn_chart` reads what the run
+    called, and the run only has somewhere to put it because the router passes a
+    list into `execute` (#205).
+
+    Both halves are covered on their own, so deleting `tool_calls=called` from
+    either call site leaves the suite green, the coverage gate at 100%, and Slack
+    back to "here is the chart" with no chart - which is the #157 shape this
+    module exists to keep dead (#515).
+    """
+
+    @pytest.mark.anyio
+    async def test_a_mention_that_drew_a_chart_answers_with_the_picture(self):
+        with (
+            patch("app.services.channels.mentions.member_repo") as members,
+            patch("app.services.channels.mentions.agent_repo") as agents,
+            patch("app.services.channels.mentions.agent_exposure_repo") as exposures,
+            patch("app.services.channels.mentions.AgentRunnerService") as runner_cls,
+        ):
+            members.get = AsyncMock(return_value=MagicMock(role=OrgRoleName.MEMBER))
+            agents.get_by_slug = AsyncMock(return_value=MagicMock(id=uuid.uuid4()))
+            exposures.get_for_bot = AsyncMock(return_value=MagicMock(is_active=True))
+            runner_cls.return_value.execute = _runner_that_draws()
+
+            answered = await ChannelAgentRouter(MagicMock()).answer(
+                "@support chart my revenue",
+                platform="slack",
+                organization_id=uuid.uuid4(),
+                bot_id=uuid.uuid4(),
+                user_id=uuid.uuid4(),
+            )
+
+        assert answered.image_png is not None
+        assert answered.image_png.startswith(b"\x89PNG")
+
+    @pytest.mark.anyio
+    async def test_a_message_naming_no_handle_answers_with_the_picture_too(self):
+        """`answer_default` is the ordinary path on a direct-message bot, and it
+        passes its own list - a fix applied to `answer` alone leaves it out."""
+        with (
+            patch("app.services.channels.mentions.member_repo") as members,
+            patch("app.services.channels.mentions.agent_exposure_repo") as exposures,
+            patch("app.services.channels.mentions.AgentRunnerService") as runner_cls,
+        ):
+            members.get = AsyncMock(return_value=MagicMock(role=OrgRoleName.MEMBER))
+            exposures.list_active_for_bot = AsyncMock(
+                return_value=[(MagicMock(), MagicMock(id=uuid.uuid4(), slug="support"))]
+            )
+            runner_cls.return_value.execute = _runner_that_draws()
+
+            answered = await ChannelAgentRouter(MagicMock()).answer_default(
+                "chart my revenue",
+                platform="slack",
+                organization_id=uuid.uuid4(),
+                bot_id=uuid.uuid4(),
+                user_id=uuid.uuid4(),
+            )
+
+        assert answered.image_png is not None
+        assert answered.image_png.startswith(b"\x89PNG")

--- a/backend/tests/test_channel_charts.py
+++ b/backend/tests/test_channel_charts.py
@@ -17,6 +17,7 @@ import pytest
 
 from app.agents.capabilities.charts._spec import ChartSpec
 from app.core.permissions import OrgRoleName
+from app.services.channels.base import OutgoingAttachment
 from app.services.channels.chart_png import render_chart_png
 from app.services.channels.mentions import ChannelAgentRouter, drawn_chart
 from app.services.transcript import RecordedToolCall
@@ -177,18 +178,24 @@ class TestChoosingWhatToSend:
 
 
 def _runner_that_draws() -> AsyncMock:
-    """A runner whose turn calls `create_chart`.
+    """A runner whose turn draws a chart, writes a file, and drops one.
 
-    It fills the list it was handed the way `AgentRunnerService.execute` does,
-    and takes `tool_calls` as a required keyword: a router that stops passing
+    It fills all three lists it was handed the way `AgentRunnerService.execute`
+    does, and takes all three as required keywords: a router that stops passing
     one fails here with a `TypeError` rather than quietly replying without the
-    picture.
+    picture, without the file, or without saying a file was dropped.
     """
 
     async def execute(
-        *_args: Any, tool_calls: list[RecordedToolCall], **_kwargs: Any
+        *_args: Any,
+        tool_calls: list[RecordedToolCall],
+        outbound: list[OutgoingAttachment],
+        outbound_refused: list[str],
+        **_kwargs: Any,
     ) -> tuple[str, MagicMock]:
         tool_calls.append(_call(_spec().model_dump_json()))
+        outbound.append(OutgoingAttachment(filename="revenue.csv", content=b"x,revenue\n"))
+        outbound_refused.append("/too-big.csv")
         return "here is the chart", MagicMock()
 
     return AsyncMock(side_effect=execute)
@@ -203,6 +210,13 @@ class TestTheReplyAChannelTurnBuilds:
     either call site leaves the suite green, the coverage gate at 100%, and Slack
     back to "here is the chart" with no chart - which is the #157 shape this
     module exists to keep dead (#515).
+
+    `outbound` and `outbound_refused` are the same seam under different names -
+    a list the router builds, hands to `execute` and reads back into
+    `AnsweredTurn` - and each was equally undefended: deleting either from
+    `answer` left the whole suite green (4381 passed), so a reply could say
+    "here is your file" and carry none. All three are asserted here for that
+    reason, rather than the one the issue happened to name.
     """
 
     @pytest.mark.anyio
@@ -228,11 +242,13 @@ class TestTheReplyAChannelTurnBuilds:
 
         assert answered.image_png is not None
         assert answered.image_png.startswith(b"\x89PNG")
+        assert [a.filename for a in answered.attachments] == ["revenue.csv"]
+        assert answered.refused == ["/too-big.csv"]
 
     @pytest.mark.anyio
     async def test_a_message_naming_no_handle_answers_with_the_picture_too(self):
         """`answer_default` is the ordinary path on a direct-message bot, and it
-        passes its own list - a fix applied to `answer` alone leaves it out."""
+        passes its own lists - a fix applied to `answer` alone leaves it out."""
         with (
             patch("app.services.channels.mentions.member_repo") as members,
             patch("app.services.channels.mentions.agent_exposure_repo") as exposures,
@@ -254,3 +270,5 @@ class TestTheReplyAChannelTurnBuilds:
 
         assert answered.image_png is not None
         assert answered.image_png.startswith(b"\x89PNG")
+        assert [a.filename for a in answered.attachments] == ["revenue.csv"]
+        assert answered.refused == ["/too-big.csv"]


### PR DESCRIPTION
## What this fixes

Closes #515 — but not the way the issue expected, so the reasoning is below rather than in a commit nobody re-reads.

Two of the issue's three claims no longer hold, and the third is real and is what this branch covers.

## The gate is already green

`make test` on a clean `main` (1f40a588), with Postgres up so the integration suite ran rather than skipping:

```
TOTAL    8314      0   1810      0   100%
Required test coverage of 100.0% reached. Total coverage: 100.00%
4379 passed, 6 skipped in 750.01s
```

The line #515 named — `agent_runner.py`'s `tool_calls.extend(segment.tool_calls)` — was covered inside the very pull request that exposed it. #513 added `tests/test_agent_runner.py::TestFilesAcrossOneTurn::test_the_tool_calls_a_turn_made_reach_the_caller`, which is the test the issue's "how you would know it was fixed" asks for, in the shape it asks for it.

## CI was not green

The issue asks why a gate that failed locally passed in CI, and flags it as a possible `make check` / CI divergence of the kind #143 found four of. There is no divergence: CI ran `make test COV_REPORT=xml`, which is the same command, and it **failed**.

[Run 31329489467](https://github.com/vstorm-co/agenticos/actions/runs/31329489467) at `61ab8fe7` — the exact commit the issue reproduced against — has a red `test` job on the identical figure:

```
FAIL Required test coverage of 100.0% not reached. Total coverage: 99.98%
app/services/agent_runner.py    652    1    128    1    99%   2693
```

Seven of the branch's runs were red before `a01b2df7` went green. So `tests/test_ci_parity.py` needs no new case, and nothing here is a hole in the ruleset.

## What did survive, and what changed

The gap behind the issue is real, and coverage was never going to show it.

`drawn_chart` is covered on its own (`test_channel_charts.py`) and `execute`'s hand-back is covered on its own (`test_agent_runner.py`). Nothing joined them. Every test of `ChannelAgentRouter.answer` mocks `AgentRunnerService`, so the list stays empty and `image_png` is always `None` — meaning `tool_calls=called` could be deleted from **either** call site in `mentions.py` with a green suite and a 100% gate, and a Slack user would be back to reading "here is the chart" under no chart (#157).

- `backend/tests/test_channel_charts.py` — `TestTheReplyAChannelTurnBuilds`, two tests. `answer` and `answer_default` each run against a stub runner that fills the list the way `execute` does, and the assertion is on `AnsweredTurn.image_png` being a PNG, not on a mock call.
- The stub takes `tool_calls` as a **required** keyword, so a router that stops passing one fails with a `TypeError` rather than quietly answering without the picture.

## Testing

- `uv run pytest tests/test_channel_charts.py -q` — 26 passed.
- Verified the tests catch what they claim: with `tool_calls=called` removed from both call sites in `app/services/channels/mentions.py`, both new tests fail; restored, both pass.
- `make lint` — clean (`ty`'s 65 warnings are pre-existing on `main` and non-gating).
- `make test` — the full gate on this branch, with a local Postgres: `4381 passed, 6 skipped`, `Total coverage: 100.00%`.

## Noticed, not fixed

Nothing new. The issue's own "found reviewing" trail is now closed out above rather than left as an open question.
