### PR TITLE
fix(i18n): keep the chosen locale across navigations

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -83,6 +83,16 @@ There is no `(marketing)` route group.
   renders English instead of the key. A module-level table of labels cannot call a
   translator, so it holds *keys* and the component translates at the point of use;
   a pure helper either answers with a key or takes `t`.
+- **The locale lives in a cookie, and a switch goes through `@/lib/locale-navigation`.**
+  `localePrefix: "as-needed"` means an unprefixed path *is* English, and 49 files import
+  a plain `next/link` - so a switch that only rewrites the URL survives exactly one
+  navigation (#285). `useRouter().push(pathname, { locale })` from
+  `@/lib/locale-navigation` writes `NEXT_LOCALE` as well as prefixing the path, and
+  `src/middleware.ts` restores that prefix from the cookie on the way in - and records
+  the cookie for a path that names a locale, which next-intl does only when
+  `accept-language` disagrees. Never switch locale through `next/navigation`, and keep
+  prefix parsing in `src/lib/locale-routing.ts`: next-intl matches a prefix
+  case-insensitively, and a second parser that does not turns `/PL/agents` into a 404.
 - Keep components under ~100 lines; extract when they grow.
 - **A response with no `Cache-Control` is not a response nobody caches.**
   `platform-proxy.ts` stamps `no-store` on anything the backend left unmarked: every

--- a/frontend/src/components/language-switcher.test.tsx
+++ b/frontend/src/components/language-switcher.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { LanguageSwitcherIcon } from "@/components/language-switcher";
+import { LOCALE_COOKIE_NAME } from "@/lib/locale-routing";
+import middleware from "@/middleware";
+
+describe("LanguageSwitcherIcon", () => {
+  beforeEach(() => {
+    document.cookie = `${LOCALE_COOKIE_NAME}=; max-age=0; path=/`;
+  });
+
+  it("makes a chosen locale survive the next navigation", async () => {
+    // The two halves of #285 in one test, because either alone still reverts:
+    // the switch has to record the choice, and the middleware has to act on it
+    // when a link arrives without a prefix - which most of them do.
+    const user = userEvent.setup();
+    render(
+      <NextIntlClientProvider locale="en" messages={{}}>
+        <LanguageSwitcherIcon />
+      </NextIntlClientProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Language" }));
+    await user.click(await screen.findByText("Polski"));
+
+    expect(document.cookie).toContain(`${LOCALE_COOKIE_NAME}=pl`);
+
+    const nextPage = new NextRequest(new URL("https://agenticos.test/orgs"), {
+      headers: new Headers({ cookie: document.cookie }),
+    });
+    expect(middleware(nextPage).headers.get("location")).toBe("https://agenticos.test/pl/orgs");
+  });
+});

--- a/frontend/src/components/language-switcher.tsx
+++ b/frontend/src/components/language-switcher.tsx
@@ -2,7 +2,6 @@
 
 import { Check, Globe } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
-import { useRouter, usePathname } from "next/navigation";
 
 import {
   DropdownMenu,
@@ -10,25 +9,9 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { locales, defaultLocale, type Locale, getLocaleLabel, getLocaleFlag } from "@/i18n";
+import { locales, type Locale, getLocaleLabel, getLocaleFlag } from "@/i18n";
+import { usePathname, useRouter } from "@/lib/locale-navigation";
 import { cn } from "@/lib/utils";
-
-/**
- * Build a path for the given locale, preserving the rest of the route.
- * Handles `localePrefix: "as-needed"` - default locale has no prefix.
- */
-function buildLocalizedPath(pathname: string, newLocale: Locale): string {
-  const segments = pathname.split("/").filter(Boolean);
-  const first = segments[0];
-  if (first && (locales as readonly string[]).includes(first)) {
-    segments.shift();
-  }
-  const rest = segments.join("/");
-  if (newLocale === defaultLocale) {
-    return rest ? `/${rest}` : "/";
-  }
-  return rest ? `/${newLocale}/${rest}` : `/${newLocale}`;
-}
 
 /**
  * Icon-button language switcher - globe icon trigger + Radix dropdown.
@@ -44,7 +27,7 @@ export function LanguageSwitcherIcon() {
   const pathname = usePathname();
 
   const handleChange = (newLocale: Locale) => {
-    router.push(buildLocalizedPath(pathname, newLocale));
+    router.push(pathname, { locale: newLocale });
   };
 
   return (

--- a/frontend/src/components/layout/active-org-guard.integration.test.tsx
+++ b/frontend/src/components/layout/active-org-guard.integration.test.tsx
@@ -9,7 +9,13 @@ import { apiClient } from "@/lib/api-client";
 import { ApiError } from "@/lib/api-error";
 import { useOrgStore } from "@/stores";
 
-vi.mock("next/navigation", () => ({ usePathname: () => "/dashboard" }));
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/dashboard",
+  // Wrapped at module scope by the language switcher's locale-aware navigation,
+  // which this tree imports; without them the file fails to import at all.
+  redirect: vi.fn(),
+  permanentRedirect: vi.fn(),
+}));
 vi.mock("next-intl", () => ({ useTranslations: () => (key: string) => key }));
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 vi.mock("@/lib/api-client", async () => {

--- a/frontend/src/components/layout/active-org-guard.integration.test.tsx
+++ b/frontend/src/components/layout/active-org-guard.integration.test.tsx
@@ -11,8 +11,7 @@ import { useOrgStore } from "@/stores";
 
 vi.mock("next/navigation", () => ({
   usePathname: () => "/dashboard",
-  // Wrapped at module scope by the language switcher's locale-aware navigation,
-  // which this tree imports; without them the file fails to import at all.
+  // next-intl's createNavigation wraps these at module scope; see `vitest.setup.ts`.
   redirect: vi.fn(),
   permanentRedirect: vi.fn(),
 }));

--- a/frontend/src/components/layout/app-sidebar.test.tsx
+++ b/frontend/src/components/layout/app-sidebar.test.tsx
@@ -7,7 +7,13 @@ const can = vi.fn<(permission: string) => boolean>();
 const currentPath = vi.fn<() => string>(() => "/dashboard");
 const currentUser = vi.fn<() => { is_app_admin?: boolean } | null>(() => ({}));
 
-vi.mock("next/navigation", () => ({ usePathname: () => currentPath() }));
+vi.mock("next/navigation", () => ({
+  usePathname: () => currentPath(),
+  // Wrapped at module scope by the language switcher's locale-aware navigation,
+  // which this tree imports; without them the file fails to import at all.
+  redirect: vi.fn(),
+  permanentRedirect: vi.fn(),
+}));
 vi.mock("next-intl", () => ({ useTranslations: () => (key: string) => key }));
 vi.mock("@/hooks/use-permissions", () => ({ usePermissions: () => ({ can }) }));
 vi.mock("@/stores", () => ({ useAuthStore: () => ({ user: currentUser() }) }));

--- a/frontend/src/components/layout/app-sidebar.test.tsx
+++ b/frontend/src/components/layout/app-sidebar.test.tsx
@@ -9,8 +9,7 @@ const currentUser = vi.fn<() => { is_app_admin?: boolean } | null>(() => ({}));
 
 vi.mock("next/navigation", () => ({
   usePathname: () => currentPath(),
-  // Wrapped at module scope by the language switcher's locale-aware navigation,
-  // which this tree imports; without them the file fails to import at all.
+  // next-intl's createNavigation wraps these at module scope; see `vitest.setup.ts`.
   redirect: vi.fn(),
   permanentRedirect: vi.fn(),
 }));

--- a/frontend/src/components/layout/command-palette.test.tsx
+++ b/frontend/src/components/layout/command-palette.test.tsx
@@ -19,8 +19,7 @@ const push = vi.fn();
 vi.mock("next-intl", () => ({ useTranslations: () => (key: string) => key }));
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push }),
-  // Wrapped at module scope by the language switcher's locale-aware navigation,
-  // which this tree imports; without them the file fails to import at all.
+  // next-intl's createNavigation wraps these at module scope; see `vitest.setup.ts`.
   redirect: vi.fn(),
   permanentRedirect: vi.fn(),
 }));

--- a/frontend/src/components/layout/command-palette.test.tsx
+++ b/frontend/src/components/layout/command-palette.test.tsx
@@ -17,7 +17,13 @@ const currentUser = vi.fn<() => { is_app_admin?: boolean } | null>(() => ({
 const push = vi.fn();
 
 vi.mock("next-intl", () => ({ useTranslations: () => (key: string) => key }));
-vi.mock("next/navigation", () => ({ useRouter: () => ({ push }) }));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+  // Wrapped at module scope by the language switcher's locale-aware navigation,
+  // which this tree imports; without them the file fails to import at all.
+  redirect: vi.fn(),
+  permanentRedirect: vi.fn(),
+}));
 vi.mock("@/hooks/use-permissions", () => ({ usePermissions: () => ({ can }) }));
 vi.mock("@/hooks", () => ({ useAuth: () => ({ user: currentUser(), logout: vi.fn() }) }));
 vi.mock("@/lib/api-client", () => ({ apiClient: { get: vi.fn() } }));

--- a/frontend/src/lib/locale-navigation.ts
+++ b/frontend/src/lib/locale-navigation.ts
@@ -1,0 +1,17 @@
+import { createNavigation } from "next-intl/navigation";
+
+import { routing } from "@/lib/locale-routing";
+
+/**
+ * Locale-aware navigation, built from the one routing config.
+ *
+ * `router.push(pathname, { locale })` does the two things a language switch needs
+ * and that `next/navigation` cannot: it prefixes the path for the target locale,
+ * and it writes the locale cookie the middleware reads. Pushing a hand-built path
+ * did only the first, so the choice survived exactly until a link dropped the
+ * prefix (#285).
+ *
+ * `usePathname` is next-intl's, which answers without the locale prefix - which is
+ * what `push` expects.
+ */
+export const { usePathname, useRouter } = createNavigation(routing);

--- a/frontend/src/lib/locale-routing.test.ts
+++ b/frontend/src/lib/locale-routing.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { LOCALE_COOKIE_NAME, localePrefixOf, routing } from "@/lib/locale-routing";
+
+describe("localePrefixOf", () => {
+  it("names the locale a prefixed path carries", () => {
+    expect(localePrefixOf("/pl/agents")).toBe("pl");
+    expect(localePrefixOf("/pl")).toBe("pl");
+    expect(localePrefixOf("/en/agents")).toBe("en");
+  });
+
+  it("answers null for a path that carries none", () => {
+    expect(localePrefixOf("/agents")).toBeNull();
+    expect(localePrefixOf("/")).toBeNull();
+    expect(localePrefixOf("")).toBeNull();
+  });
+
+  it("does not mistake a route whose first segment merely starts with a locale", () => {
+    expect(localePrefixOf("/plans")).toBeNull();
+    expect(localePrefixOf("/environments")).toBeNull();
+  });
+});
+
+describe("routing", () => {
+  it("writes the cookie the middleware reads", () => {
+    // The switch persists nothing if these two names drift apart, and the
+    // symptom is silent: the URL prefix carries the locale for the current page.
+    expect(routing.localeCookie).toMatchObject({ name: LOCALE_COOKIE_NAME });
+  });
+
+  it("keeps the locale beyond the browser session", () => {
+    expect(routing.localeCookie).toMatchObject({ maxAge: 60 * 60 * 24 * 365 });
+  });
+
+  it("leaves accept-language sniffing off", () => {
+    expect(routing.localeDetection).toBe(false);
+    expect(routing.localePrefix).toBe("as-needed");
+  });
+});

--- a/frontend/src/lib/locale-routing.test.ts
+++ b/frontend/src/lib/locale-routing.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { LOCALE_COOKIE_NAME, localePrefixOf, routing } from "@/lib/locale-routing";
+import { LOCALE_COOKIE_NAME, localePrefixOf, pickedLocale, routing } from "@/lib/locale-routing";
 
 describe("localePrefixOf", () => {
   it("names the locale a prefixed path carries", () => {
@@ -18,6 +18,30 @@ describe("localePrefixOf", () => {
   it("does not mistake a route whose first segment merely starts with a locale", () => {
     expect(localePrefixOf("/plans")).toBeNull();
     expect(localePrefixOf("/environments")).toBeNull();
+  });
+
+  it("names it whatever case the path wrote it in", () => {
+    // next-intl matches a prefix case-insensitively, so a path it treats as Polish
+    // must be treated as Polish here too - see `middleware.test.ts` for what a
+    // disagreement costs.
+    expect(localePrefixOf("/PL/agents")).toBe("pl");
+    expect(localePrefixOf("/En")).toBe("en");
+  });
+});
+
+describe("pickedLocale", () => {
+  it("names a locale this deployment serves", () => {
+    expect(pickedLocale("pl")).toBe("pl");
+  });
+
+  it("answers null for the default, which needs no prefix", () => {
+    expect(pickedLocale("en")).toBeNull();
+  });
+
+  it("answers null for nothing, for empty, and for a locale we do not serve", () => {
+    expect(pickedLocale(undefined)).toBeNull();
+    expect(pickedLocale("")).toBeNull();
+    expect(pickedLocale("de")).toBeNull();
   });
 });
 

--- a/frontend/src/lib/locale-routing.ts
+++ b/frontend/src/lib/locale-routing.ts
@@ -1,0 +1,43 @@
+import { defineRouting } from "next-intl/routing";
+
+import { locales, defaultLocale, type Locale } from "@/i18n";
+
+/**
+ * The cookie holding the locale the visitor picked.
+ *
+ * `NEXT_LOCALE` is next-intl's own default name, written client-side by the
+ * navigation APIs below and read back by `src/middleware.ts`. It is named here
+ * rather than left to the default so that the write and the read are the same
+ * constant: a divergence between them is invisible - the switch appears to work,
+ * because the URL prefix carries the locale for exactly as long as the current
+ * page lasts.
+ */
+export const LOCALE_COOKIE_NAME = "NEXT_LOCALE";
+
+/** A year. The choice is a preference, not a session. */
+const LOCALE_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
+
+/**
+ * One routing configuration, shared by the middleware and the navigation APIs.
+ *
+ * `localePrefix: "as-needed"` - English, the default, has no prefix; Polish lives
+ * under `/pl/...`.
+ *
+ * `localeDetection: false` because it gates the `accept-language` header as well
+ * as the cookie, and a visitor with a Polish browser must still be served English
+ * at the root until they ask for Polish. The cookie half is therefore read by hand
+ * in `src/middleware.ts`; see the note there.
+ */
+export const routing = defineRouting({
+  locales,
+  defaultLocale,
+  localePrefix: "as-needed",
+  localeDetection: false,
+  localeCookie: { name: LOCALE_COOKIE_NAME, maxAge: LOCALE_COOKIE_MAX_AGE },
+});
+
+/** The locale a path names in its first segment, or `null` when it names none. */
+export function localePrefixOf(pathname: string): Locale | null {
+  const segment = pathname.split("/")[1];
+  return segment && (locales as readonly string[]).includes(segment) ? (segment as Locale) : null;
+}

--- a/frontend/src/lib/locale-routing.ts
+++ b/frontend/src/lib/locale-routing.ts
@@ -6,16 +6,17 @@ import { locales, defaultLocale, type Locale } from "@/i18n";
  * The cookie holding the locale the visitor picked.
  *
  * `NEXT_LOCALE` is next-intl's own default name, written client-side by the
- * navigation APIs below and read back by `src/middleware.ts`. It is named here
- * rather than left to the default so that the write and the read are the same
- * constant: a divergence between them is invisible - the switch appears to work,
+ * navigation APIs below, and read back - and written, for a path that names a
+ * locale - by `src/middleware.ts`. It is named here rather than left to the
+ * default so that every write and the read are the same constant: a divergence
+ * between them is invisible - the switch appears to work,
  * because the URL prefix carries the locale for exactly as long as the current
  * page lasts.
  */
 export const LOCALE_COOKIE_NAME = "NEXT_LOCALE";
 
 /** A year. The choice is a preference, not a session. */
-const LOCALE_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
+export const LOCALE_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
 
 /**
  * One routing configuration, shared by the middleware and the navigation APIs.
@@ -25,8 +26,8 @@ const LOCALE_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
  *
  * `localeDetection: false` because it gates the `accept-language` header as well
  * as the cookie, and a visitor with a Polish browser must still be served English
- * at the root until they ask for Polish. The cookie half is therefore read by hand
- * in `src/middleware.ts`; see the note there.
+ * at the root until they ask for Polish. The cookie half is therefore kept by hand
+ * in `src/middleware.ts`; see the notes there.
  */
 export const routing = defineRouting({
   locales,
@@ -36,8 +37,22 @@ export const routing = defineRouting({
   localeCookie: { name: LOCALE_COOKIE_NAME, maxAge: LOCALE_COOKIE_MAX_AGE },
 });
 
-/** The locale a path names in its first segment, or `null` when it names none. */
+/**
+ * The locale a path names in its first segment, or `null` when it names none.
+ *
+ * Matched case-insensitively, because next-intl's own prefix matching is:
+ * `/PL/agents` is a Polish path to it, redirected to the canonical `/pl/agents`.
+ * Reading it as unprefixed here would put a second prefix on the front of a path
+ * that already has one - `/pl/PL/agents`, which no route serves.
+ */
 export function localePrefixOf(pathname: string): Locale | null {
-  const segment = pathname.split("/")[1];
+  const segment = pathname.split("/")[1]?.toLowerCase();
   return segment && (locales as readonly string[]).includes(segment) ? (segment as Locale) : null;
+}
+
+/** The locale the visitor picked, when this deployment serves it and it is not the default. */
+export function pickedLocale(value: string | undefined): Locale | null {
+  return value && value !== defaultLocale && (locales as readonly string[]).includes(value)
+    ? (value as Locale)
+    : null;
 }

--- a/frontend/src/middleware.test.ts
+++ b/frontend/src/middleware.test.ts
@@ -1,0 +1,64 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it } from "vitest";
+
+import middleware from "@/middleware";
+import { LOCALE_COOKIE_NAME } from "@/lib/locale-routing";
+
+function request(path: string, init?: { locale?: string; acceptLanguage?: string }): NextRequest {
+  const headers = new Headers({ "sec-fetch-dest": "document" });
+  if (init?.acceptLanguage) headers.set("accept-language", init.acceptLanguage);
+  if (init?.locale) headers.set("cookie", `${LOCALE_COOKIE_NAME}=${init.locale}`);
+  return new NextRequest(new URL(path, "https://agenticos.test"), { headers });
+}
+
+/** Where a response sends the browser next, or `null` when it sends it nowhere. */
+function redirectedTo(response: Response): string | null {
+  const location = response.headers.get("location");
+  return location ? new URL(location).pathname + new URL(location).search : null;
+}
+
+describe("the locale a visitor picked", () => {
+  it("still holds on a path that carries no prefix", () => {
+    // The whole of #285: `router.push("/orgs")` and any plain `<Link>` drop the
+    // prefix, and with it - before this - the language.
+    expect(redirectedTo(middleware(request("/orgs", { locale: "pl" })))).toBe("/pl/orgs");
+  });
+
+  it("still holds at the root", () => {
+    expect(redirectedTo(middleware(request("/", { locale: "pl" })))).toBe("/pl");
+  });
+
+  it("keeps the query string it was carrying", () => {
+    expect(redirectedTo(middleware(request("/orgs?create=1", { locale: "pl" })))).toBe(
+      "/pl/orgs?create=1",
+    );
+  });
+
+  it("does not redirect a path that already names it", () => {
+    expect(redirectedTo(middleware(request("/pl/orgs", { locale: "pl" })))).toBeNull();
+  });
+
+  it("loses to the path when the two disagree, so a shared URL means what it says", () => {
+    expect(redirectedTo(middleware(request("/pl/orgs", { locale: "en" })))).toBeNull();
+    expect(redirectedTo(middleware(request("/orgs", { locale: "en" })))).toBeNull();
+  });
+});
+
+describe("a visitor who picked nothing", () => {
+  it("is served the default locale, unprefixed", () => {
+    expect(redirectedTo(middleware(request("/orgs")))).toBeNull();
+  });
+
+  it("is served English even from a Polish browser", () => {
+    // `localeDetection: false` is deliberate - Polish is opted into, never sniffed.
+    // Reading the cookie by hand is what must not quietly reintroduce the header.
+    expect(
+      redirectedTo(middleware(request("/orgs", { acceptLanguage: "pl-PL,pl;q=0.9" }))),
+    ).toBeNull();
+  });
+
+  it("is unaffected by a cookie naming a locale this deployment does not have", () => {
+    expect(redirectedTo(middleware(request("/orgs", { locale: "de" })))).toBeNull();
+    expect(redirectedTo(middleware(request("/orgs", { locale: "" })))).toBeNull();
+  });
+});

--- a/frontend/src/middleware.test.ts
+++ b/frontend/src/middleware.test.ts
@@ -1,11 +1,14 @@
-import { NextRequest } from "next/server";
+import { NextRequest, type NextResponse } from "next/server";
 import { describe, expect, it } from "vitest";
 
 import middleware from "@/middleware";
 import { LOCALE_COOKIE_NAME } from "@/lib/locale-routing";
 
-function request(path: string, init?: { locale?: string; acceptLanguage?: string }): NextRequest {
-  const headers = new Headers({ "sec-fetch-dest": "document" });
+function request(
+  path: string,
+  init?: { locale?: string; acceptLanguage?: string; dest?: string },
+): NextRequest {
+  const headers = new Headers({ "sec-fetch-dest": init?.dest ?? "document" });
   if (init?.acceptLanguage) headers.set("accept-language", init.acceptLanguage);
   if (init?.locale) headers.set("cookie", `${LOCALE_COOKIE_NAME}=${init.locale}`);
   return new NextRequest(new URL(path, "https://agenticos.test"), { headers });
@@ -15,6 +18,11 @@ function request(path: string, init?: { locale?: string; acceptLanguage?: string
 function redirectedTo(response: Response): string | null {
   const location = response.headers.get("location");
   return location ? new URL(location).pathname + new URL(location).search : null;
+}
+
+/** The locale a response asks the browser to remember, or `null` when it asks nothing. */
+function cookieSetTo(response: NextResponse): string | null {
+  return response.cookies.get(LOCALE_COOKIE_NAME)?.value ?? null;
 }
 
 describe("the locale a visitor picked", () => {
@@ -36,6 +44,13 @@ describe("the locale a visitor picked", () => {
 
   it("does not redirect a path that already names it", () => {
     expect(redirectedTo(middleware(request("/pl/orgs", { locale: "pl" })))).toBeNull();
+  });
+
+  it("does not prefix a path whose prefix is merely in the wrong case", () => {
+    // next-intl matches a prefix case-insensitively and canonicalises `/PL/orgs`
+    // to `/pl/orgs`. Reading it as unprefixed here made that `/pl/PL/orgs` - a 404
+    // on a URL that worked before the cookie existed.
+    expect(redirectedTo(middleware(request("/PL/orgs", { locale: "pl" })))).toBe("/pl/orgs");
   });
 
   it("loses to the path when the two disagree, so a shared URL means what it says", () => {
@@ -60,5 +75,29 @@ describe("a visitor who picked nothing", () => {
   it("is unaffected by a cookie naming a locale this deployment does not have", () => {
     expect(redirectedTo(middleware(request("/orgs", { locale: "de" })))).toBeNull();
     expect(redirectedTo(middleware(request("/orgs", { locale: "" })))).toBeNull();
+  });
+});
+
+describe("a path that names a locale", () => {
+  it("is remembered, so the next unprefixed link keeps it", () => {
+    // next-intl writes the cookie itself only when `accept-language` disagrees with
+    // the locale it resolved, so a Polish browser opening a shared `/pl/...` link
+    // persisted nothing and reverted to English on the next plain `<Link>`.
+    const response = middleware(request("/pl/orgs", { acceptLanguage: "pl-PL,pl;q=0.9" }));
+    expect(cookieSetTo(response)).toBe("pl");
+  });
+
+  it("is remembered for a browser that asked for nothing in particular", () => {
+    expect(cookieSetTo(middleware(request("/pl/orgs")))).toBe("pl");
+  });
+
+  it("says nothing when the cookie already agrees", () => {
+    expect(cookieSetTo(middleware(request("/pl/orgs", { locale: "pl" })))).toBeNull();
+  });
+
+  it("leaves a background request alone", () => {
+    // The router revalidates routes of the locale just switched away from; writing
+    // the cookie from one of those would undo the switch that has just been made.
+    expect(cookieSetTo(middleware(request("/pl/orgs", { dest: "empty" })))).toBeNull();
   });
 });

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,8 +1,13 @@
 import createMiddleware from "next-intl/middleware";
 import { NextResponse, type NextRequest } from "next/server";
 
-import { locales, defaultLocale } from "./i18n";
-import { LOCALE_COOKIE_NAME, localePrefixOf, routing } from "./lib/locale-routing";
+import {
+  LOCALE_COOKIE_MAX_AGE,
+  LOCALE_COOKIE_NAME,
+  localePrefixOf,
+  pickedLocale,
+  routing,
+} from "./lib/locale-routing";
 
 const handleI18nRouting = createMiddleware(routing);
 
@@ -24,18 +29,48 @@ function restorePickedLocale(request: NextRequest): NextResponse | null {
   const { pathname } = request.nextUrl;
   if (localePrefixOf(pathname)) return null;
 
-  const picked = request.cookies.get(LOCALE_COOKIE_NAME)?.value;
-  if (!picked || picked === defaultLocale || !(locales as readonly string[]).includes(picked)) {
-    return null;
-  }
+  const picked = pickedLocale(request.cookies.get(LOCALE_COOKIE_NAME)?.value);
+  if (!picked) return null;
 
   const url = request.nextUrl.clone();
   url.pathname = `/${picked}${pathname === "/" ? "" : pathname}`;
   return NextResponse.redirect(url);
 }
 
+/**
+ * Record the locale a prefixed path names, so it outlives that path.
+ *
+ * next-intl writes the cookie itself only when the request carries none *and*
+ * `accept-language` disagrees with the locale it resolved. So a Polish browser
+ * opening a shared `/pl/agents` persists nothing, and its next ordinary `<Link>`
+ * is English again - #285 arriving by URL rather than by the switcher, for the
+ * visitors most likely to want Polish.
+ *
+ * Document requests only. A background request is how the router revalidates a
+ * route of the locale the visitor has just left, so writing from one would undo
+ * the switch they have just made; next-intl's `syncCookie` reads the same header
+ * for the same reason.
+ */
+function rememberPrefixedLocale(request: NextRequest, response: NextResponse): void {
+  if ((request.headers.get("sec-fetch-dest") ?? "document") !== "document") return;
+
+  const named = localePrefixOf(request.nextUrl.pathname);
+  if (!named || request.cookies.get(LOCALE_COOKIE_NAME)?.value === named) return;
+
+  response.cookies.set(LOCALE_COOKIE_NAME, named, {
+    path: "/",
+    maxAge: LOCALE_COOKIE_MAX_AGE,
+    sameSite: "lax",
+  });
+}
+
 export default function middleware(request: NextRequest): NextResponse {
-  return restorePickedLocale(request) ?? handleI18nRouting(request);
+  const restored = restorePickedLocale(request);
+  if (restored) return restored;
+
+  const response = handleI18nRouting(request);
+  rememberPrefixedLocale(request, response);
+  return response;
 }
 
 export const config = {

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,16 +1,42 @@
 import createMiddleware from "next-intl/middleware";
+import { NextResponse, type NextRequest } from "next/server";
+
 import { locales, defaultLocale } from "./i18n";
+import { LOCALE_COOKIE_NAME, localePrefixOf, routing } from "./lib/locale-routing";
 
-export default createMiddleware({
-  locales,
-  defaultLocale,
-  // Don't prefix the default locale (e.g., /about instead of /en/about)
-  localePrefix: "as-needed",
+const handleI18nRouting = createMiddleware(routing);
 
-  // Always serve `defaultLocale` (en) at root, regardless of the visitor's
-  // Accept-Language header. The user opts into Polish via the language switcher.
-  localeDetection: false,
-});
+/**
+ * Send a request whose URL carries no locale to the one the visitor picked.
+ *
+ * With `localePrefix: "as-needed"` the prefix is the whole of the locale: a path
+ * without one resolves to `defaultLocale`. So an ordinary `<Link href="/agents">`
+ * or `router.push("/orgs")` - and there are dozens, none of them locale-aware -
+ * silently switched the UI back to English, which is what #285 saw as the choice
+ * "reverting" on the next navigation.
+ *
+ * next-intl reads the cookie itself, but only under `localeDetection`, which also
+ * turns on `accept-language` sniffing - and a Polish browser must still be served
+ * English until somebody asks for Polish. So the cookie is read here and the header
+ * is not.
+ */
+function restorePickedLocale(request: NextRequest): NextResponse | null {
+  const { pathname } = request.nextUrl;
+  if (localePrefixOf(pathname)) return null;
+
+  const picked = request.cookies.get(LOCALE_COOKIE_NAME)?.value;
+  if (!picked || picked === defaultLocale || !(locales as readonly string[]).includes(picked)) {
+    return null;
+  }
+
+  const url = request.nextUrl.clone();
+  url.pathname = `/${picked}${pathname === "/" ? "" : pathname}`;
+  return NextResponse.redirect(url);
+}
+
+export default function middleware(request: NextRequest): NextResponse {
+  return restorePickedLocale(request) ?? handleI18nRouting(request);
+}
 
 export const config = {
   matcher: [

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -10,6 +10,16 @@ export default defineConfig({
     setupFiles: ["./vitest.setup.ts"],
     include: ["**/*.{test,spec}.{ts,tsx}"],
     exclude: ["node_modules", ".next", "e2e"],
+    server: {
+      deps: {
+        // `next-intl/middleware` imports `next/server` bare, which Node's ESM
+        // resolver cannot answer for an externalized dependency ("did you mean
+        // next/server.js"). Transformed by Vite instead, the import resolves and
+        // `src/middleware.test.ts` can drive the real middleware rather than a
+        // stand-in for it.
+        inline: ["next-intl"],
+      },
+    },
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -31,6 +31,12 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => new URLSearchParams(),
   usePathname: () => "/",
   useParams: () => ({}),
+  // next-intl's `createNavigation` wraps these at module scope, so a component
+  // reaching for locale-aware navigation fails to import at all without them -
+  // "No 'redirect' export is defined on the 'next/navigation' mock", from a file
+  // that never mentions redirects.
+  redirect: vi.fn(),
+  permanentRedirect: vi.fn(),
 }));
 
 // Node 22+ ships a built-in localStorage that is disabled (undefined) without


### PR DESCRIPTION
## What this fixes

Picking Polish redrew the current page and nothing more: the next link took the UI
back to English. Closes #285.

The locale's entire persistence was the `/pl` URL prefix. `localePrefix: "as-needed"`
means a path without a prefix *is* the default locale, and the switcher pushed a
hand-built path with `next/navigation` — so every ordinary `<Link href="/agents">`
and `router.push("/orgs")` in the app dropped the prefix and, with it, the language.
next-intl reads a `NEXT_LOCALE` cookie itself, but only under `localeDetection`,
which also turns on `accept-language` sniffing — and this deployment deliberately
serves English at the root whatever the browser asks for. So nothing wrote the
cookie and nothing read it.

## What changed

- `frontend/src/lib/locale-routing.ts` — new. One routing config for the middleware
  and the navigation APIs, naming the cookie explicitly (a drift between the write
  and the read is invisible: the switch still appears to work for one page) and
  giving it a year's `maxAge`, so the choice is a preference rather than a session.
- `frontend/src/lib/locale-navigation.ts` — new. `createNavigation(routing)`, so
  `router.push(pathname, { locale })` both prefixes the path and writes the cookie.
- `frontend/src/middleware.ts:23` — reads that cookie by hand and redirects an
  unprefixed path to the picked locale, leaving `localeDetection: false` in place so
  `accept-language` is still ignored. A path that names a locale always wins, so a
  shared `/pl/...` URL still means what it says.
- `frontend/src/components/language-switcher.tsx:30` — `router.push(pathname, { locale })`
  in place of `router.push(buildLocalizedPath(...))`; the hand-rolled path builder is gone.
- `frontend/vitest.config.ts` — inline `next-intl` so `next-intl/middleware`'s bare
  `next/server` import resolves under Vite; without it the middleware cannot be
  imported by a test at all.
- `frontend/vitest.setup.ts` — `redirect` / `permanentRedirect` added to the
  `next/navigation` mock. `createNavigation` wraps them at module scope, so a
  component reaching for locale-aware navigation otherwise fails to import.
- Three layout test files shadow that shared mock with a one-line override and
  render a tree that now imports the switcher, so they needed the same two
  exports. Found by the coverage gate, second commit.

## How it failed before

Switch to Polish on `/pl/dashboard`, then click anything that navigates with an
absolute path — `router.push("/orgs")` in `components/teams/org-switcher.tsx:43` is
one of dozens — and the middleware resolves `/orgs` to `en` because there is no
prefix, no cookie and no detection. English again, and a reload never brought Polish
back either.

## Testing

- `src/middleware.test.ts` — 8 tests. The three that matter fail on `main`
  (verified by stubbing the new call out): an unprefixed path with `NEXT_LOCALE=pl`
  redirects to the prefixed one, at the root too, query string intact. The rest are
  the refusals: a path that names a locale is left alone, an unknown or empty cookie
  changes nothing, and a Polish `accept-language` with no cookie still gets English —
  that last one guards the `localeDetection: false` decision against exactly the
  shortcut this change could have taken.
- `src/components/language-switcher.test.tsx` — the round trip, because either half
  alone still reverts: click Polski, then feed the cookie the component actually
  wrote to the real middleware and assert it redirects `/orgs` → `/pl/orgs`.
- `src/lib/locale-routing.test.ts` — `localePrefixOf`, plus the config assertions
  that keep the cookie name and lifetime honest.
- Locally: `make test-frontend-cov` green — 256 files, 3875 tests, 100%
  lines/statements/functions, 97.65% branches. `make build-frontend` compiles.
  `scripts/check_i18n.py` clean, and pre-commit ran eslint, prettier and tsc on
  both commits.
- Not written: an E2E spec. The switcher test already drives the real middleware,
  and `frontend/e2e` needs a seeded backend for a journey these three cover.

## Noticed, not fixed

- **The switch drops the query string.** `usePathname` carries no search params, so
  switching language on `/orgs?create=1` lands on `/orgs`. True before this change
  too, and unchanged by it.
- **The redirect costs a hop.** An unprefixed navigation under a non-default locale
  now round-trips through a 307. Routing every internal `<Link>` and `useRouter`
  through next-intl's locale-aware equivalents would avoid it — 49 files import
  `next/link` and 27 use `useRouter`, so that is its own change, and the cookie is
  needed regardless for a reload or a pasted URL.


## Review round (f3a57b3e)

Three findings from reviewing the branch, two of them defects:

- **`localePrefixOf` disagreed with next-intl about case.** next-intl's
  `getPathnameMatch` lowercases both sides, so `/PL/agents` is a Polish path to it and
  was an unprefixed one here — with a `pl` cookie the middleware prefixed it again and
  redirected to `/pl/PL/agents`, a 404 on a URL that worked before the cookie existed.
  Fixed, and asserted from both sides.
- **A shared `/pl/...` link persisted nothing for a Polish browser.** next-intl's
  `syncCookie` writes `NEXT_LOCALE` only when the request carries no cookie *and*
  `accept-language` disagrees with the resolved locale — so exactly the visitors most
  likely to want Polish got no cookie, and their next ordinary `<Link>` was English
  again. That is #285 arriving by URL rather than by the switcher, and it is why the
  middleware now records the locale a prefixed path names. Document requests only: the
  router revalidates routes of the locale just switched away from, and writing from one
  of those would undo the switch.
- **The cookie value is validated by `pickedLocale`**, beside the other locale parsing,
  so the middleware no longer reaches around the routing module back to `./i18n`.
  `.claude/rules/frontend.md` gains the invariant, because nothing recorded that a
  switch must go through `@/lib/locale-navigation`.

The `<html lang="en">` bug the review turned up is pre-existing and out of scope here —
filed as #619.
