### PR TITLE
test: run the backend suite in a random order

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -58,9 +58,12 @@ Traps, each of which has cost a red job here:
 
 - **The order is shuffled every run** (`pytest-randomly`, on by default since #571), so
   a test that passed yesterday and fails today may have been depending on what ran
-  before it. The header prints `Using --randomly-seed=<n>`; pass that seed back to
-  reproduce the failure, and `-p no:randomly` to pin collection order while bisecting.
-  The controller's seed reaches every xdist worker, so `-n auto` collects one order.
+  before it. The header prints `Using --randomly-seed=<n>`; replay that seed to get the
+  same order back, and `-p no:randomly` to pin collection order while bisecting. The
+  seed fixes the order, not which worker runs what - `--dist load` decides that on
+  timing - so a failure that depended on what shared a worker only reproduces without
+  `-n`. The plugin also reseeds `random` identically before every test: anything using
+  it for uniqueness is unique within a test and repeats across them.
 - **`bun run test:run` measures no coverage.** The frontend gate is a separate command
   and CI runs it (`bun run test:coverage`); 168 green files still failed the job.
 - **Frontend commands run from `frontend/`.** At the repository root vitest finds no

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -56,6 +56,11 @@ job always has one.
 
 Traps, each of which has cost a red job here:
 
+- **The order is shuffled every run** (`pytest-randomly`, on by default since #571), so
+  a test that passed yesterday and fails today may have been depending on what ran
+  before it. The header prints `Using --randomly-seed=<n>`; pass that seed back to
+  reproduce the failure, and `-p no:randomly` to pin collection order while bisecting.
+  The controller's seed reaches every xdist worker, so `-n auto` collects one order.
 - **`bun run test:run` measures no coverage.** The frontend gate is a separate command
   and CI runs it (`bun run test:coverage`); 168 green files still failed the job.
 - **Frontend commands run from `frontend/`.** At the repository root vitest finds no

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -99,6 +99,12 @@ dev = [
     "ty>=0.0.69",
     "pre-commit>=4.0.0",
     "pytest-xdist>=3.8.0",
+    # Shuffles the suite every run and prints the seed, so an order-dependent
+    # test fails here rather than months later in an unrelated pull request.
+    # It carries its own xdist support (the controller's seed is handed to each
+    # worker through `workerinput`), without which the workers would collect in
+    # four different orders and `-n auto` would abort on the mismatch.
+    "pytest-randomly>=4.1.0",
     "vulture>=2.14",
 ]
 # The documentation site. Its own group rather than part of `dev`, because the

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -39,6 +39,7 @@ from sqlalchemy.ext.asyncio import (
 
 from app.core.config import settings
 from app.db.base import Base
+from app.db.session import engine as app_engine
 
 # Where to connect to issue `CREATE DATABASE` / `DROP DATABASE`, neither of
 # which can run from inside the database it names. Every Postgres image this
@@ -240,7 +241,18 @@ async def engine(schema_url: str) -> AsyncGenerator[AsyncEngine, None]:
     the same per-function event loop the test does. The schema itself is built
     once by `schema_url`; here each test is handed a clean slate cheaply, by
     emptying the data rather than rebuilding the schema (#215).
+
+    The application's own engine is disposed first. It is a module-level object,
+    so its pool outlives the test that filled it, while anyio gives each test an
+    event loop of its own - and a connection created on a loop that has since
+    closed answers the next statement issued through it with `InterfaceError:
+    another operation is in progress`, from whichever unlucky test checked it
+    out. The tests that drive the real `get_db_session` used to each dispose it
+    on the way out, which only covers the pair of them; disposing on the way *in*
+    covers every test that could be handed one, whatever ran before it in this
+    worker. Disposing an empty pool costs nothing, which is the common case.
     """
+    await app_engine.dispose()
     engine = create_async_engine(schema_url)
     await _reset(engine)
     yield engine

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -251,8 +251,13 @@ async def engine(schema_url: str) -> AsyncGenerator[AsyncEngine, None]:
     on the way out, which only covers the pair of them; disposing on the way *in*
     covers every test that could be handed one, whatever ran before it in this
     worker. Disposing an empty pool costs nothing, which is the common case.
+
+    `close=False` because those connections belong to loops that are already
+    closed: closing one from the loop running now is an operation that cannot
+    succeed, and SQLAlchemy answers a failing close by logging it at ERROR and
+    carrying on. De-referencing the pool is what is actually meant.
     """
-    await app_engine.dispose()
+    await app_engine.dispose(close=False)
     engine = create_async_engine(schema_url)
     await _reset(engine)
     yield engine

--- a/backend/tests/integration/test_commit_before_response.py
+++ b/backend/tests/integration/test_commit_before_response.py
@@ -33,7 +33,6 @@ from app.api.deps import DBSession
 from app.api.exception_handlers import register_exception_handlers
 from app.core.exceptions import NotFoundError
 from app.core.middleware import RequestIDMiddleware
-from app.db.session import engine as app_engine
 
 pytestmark = pytest.mark.anyio
 
@@ -62,12 +61,6 @@ async def probe_table(engine: AsyncEngine) -> AsyncGenerator[AsyncEngine, None]:
     yield engine
     async with engine.begin() as connection:
         await connection.execute(text(_DROP))
-    # The routes below go through the real `get_db_session`, which draws from
-    # the module-level engine's pool. anyio gives each test its own event loop,
-    # so a connection left in that pool by this test is one the next test finds
-    # attached to a loop that no longer exists ("got Future attached to a
-    # different loop"). Returned here, on the loop that opened them.
-    await app_engine.dispose()
 
 
 def _app() -> FastAPI:

--- a/backend/tests/integration/test_flow_starts_after_commit.py
+++ b/backend/tests/integration/test_flow_starts_after_commit.py
@@ -41,7 +41,6 @@ from app.api.exception_handlers import register_exception_handlers
 from app.core.background import spawn, spawn_after_commit
 from app.core.exceptions import NotFoundError
 from app.core.middleware import RequestIDMiddleware
-from app.db.session import engine as app_engine
 
 pytestmark = pytest.mark.anyio
 
@@ -78,10 +77,6 @@ async def probe_table(engine: AsyncEngine) -> AsyncGenerator[AsyncEngine, None]:
     yield engine
     async with engine.begin() as connection:
         await connection.execute(text(_DROP))
-    # The route below goes through the real `get_db_session` and its pool. anyio
-    # gives each test its own event loop, so a connection left in that pool is
-    # one the next test finds attached to a loop that no longer exists.
-    await app_engine.dispose()
 
 
 async def _committed(engine: AsyncEngine, row_id: UUID) -> bool:

--- a/backend/tests/test_random_order.py
+++ b/backend/tests/test_random_order.py
@@ -1,0 +1,33 @@
+"""A guard on the plugin that shuffles this suite.
+
+`pytest-randomly` is the only thing standing between an order-dependent test and
+a green build, and its absence is silent: without it the suite runs in collection
+order, `-p no:randomly` becomes a no-op, and nothing anywhere says so. That is
+not hypothetical. Both `docs/testing.md` and `.claude/rules/testing.md` described
+it as on by default while it was in neither the dependency group nor the
+lockfile, so the order-independence the docs called verified had never once been
+exercised (#571).
+
+The declaration is what makes the shuffle true for everybody who runs `uv sync`,
+so that is what is asserted - deliberately not that the shuffle is active in this
+process. Pinning collection order with `-p no:randomly` is the documented move
+while bisecting an order-dependent failure, and a guard that turned it red would
+be telling people to stop using it.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+PYPROJECT = Path(__file__).resolve().parents[1] / "pyproject.toml"
+
+
+def test_the_suite_is_shuffled_because_the_docs_say_it_is() -> None:
+    config = tomllib.loads(PYPROJECT.read_text())
+    dev_group: list[str] = config["dependency-groups"]["dev"]
+    assert any(spec.startswith("pytest-randomly") for spec in dev_group), (
+        "pytest-randomly is gone from the dev dependency group, so the suite now runs "
+        "in collection order. Either put it back or correct docs/testing.md and "
+        ".claude/rules/testing.md, which both promise a shuffled run and a live seed."
+    )

--- a/backend/tests/test_random_order.py
+++ b/backend/tests/test_random_order.py
@@ -8,26 +8,41 @@ it as on by default while it was in neither the dependency group nor the
 lockfile, so the order-independence the docs called verified had never once been
 exercised (#571).
 
-The declaration is what makes the shuffle true for everybody who runs `uv sync`,
-so that is what is asserted - deliberately not that the shuffle is active in this
-process. Pinning collection order with `-p no:randomly` is the documented move
-while bisecting an order-dependent failure, and a guard that turned it red would
-be telling people to stop using it.
+Two halves, because #571 was both: declared nowhere *and* installed nowhere. The
+declaration is what makes the shuffle true for everybody who runs `uv sync`; the
+import is what makes it true for the interpreter running this test, which a stale
+virtualenv or a `pytest` invoked from outside `uv run` can disagree about.
+
+Neither asserts that the shuffle is *active* in this process, deliberately.
+Pinning collection order with `-p no:randomly` is the documented move while
+bisecting an order-dependent failure - it deactivates the plugin without
+uninstalling it, so both assertions below still hold - and a guard that turned it
+red would be telling people to stop using it.
 """
 
 from __future__ import annotations
 
 import tomllib
+from importlib.util import find_spec
 from pathlib import Path
 
 PYPROJECT = Path(__file__).resolve().parents[1] / "pyproject.toml"
 
 
-def test_the_suite_is_shuffled_because_the_docs_say_it_is() -> None:
-    config = tomllib.loads(PYPROJECT.read_text())
+def test_the_dev_group_declares_the_plugin_that_shuffles_the_suite() -> None:
+    with PYPROJECT.open("rb") as handle:
+        config = tomllib.load(handle)
     dev_group: list[str] = config["dependency-groups"]["dev"]
     assert any(spec.startswith("pytest-randomly") for spec in dev_group), (
         "pytest-randomly is gone from the dev dependency group, so the suite now runs "
         "in collection order. Either put it back or correct docs/testing.md and "
         ".claude/rules/testing.md, which both promise a shuffled run and a live seed."
+    )
+
+
+def test_the_plugin_that_shuffles_the_suite_is_installed() -> None:
+    assert find_spec("pytest_randomly") is not None, (
+        "pytest-randomly is declared but not importable, so this run is in collection "
+        "order whatever pyproject.toml says. Re-sync the environment with `uv sync`, "
+        "and run the suite through `uv run` so it is the one that gets used."
     )

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -68,6 +68,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-randomly" },
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "ty" },
@@ -139,6 +140,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.0.0" },
     { name = "pytest", specifier = ">=9.0.0" },
     { name = "pytest-cov", specifier = ">=6.1.0" },
+    { name = "pytest-randomly", specifier = ">=4.1.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.16.1" },
     { name = "ty", specifier = ">=0.0.69" },
@@ -4241,6 +4243,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-randomly"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/b3/36192dacc0f470ac2cc516f73e01739c9a48a8224f76beada4f85e1c8a89/pytest_randomly-4.1.0.tar.gz", hash = "sha256:47f1d9746c3bc3efabd53ae1ebfb8bb385cf3d4df4b505b6d58d9c97a3dfe70f", size = 14302, upload-time = "2026-04-20T13:01:51.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/db/2df9a1fca597a273f957a559c20c2d95d629928384507b2afa43ba6909d1/pytest_randomly-4.1.0-py3-none-any.whl", hash = "sha256:f55e89e53367b090c0c053697d7f9d77595543d0e0516c93978b50c0f6b252f9", size = 8353, upload-time = "2026-04-20T13:01:50.382Z" },
 ]
 
 [[package]]

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -23,6 +23,22 @@ suite is import-bound — every worker imports the app once — and gains nothin
 that, while an uncapped `auto` on a many-core laptop is *slower* than serial, all of
 it worker startup (#520).
 
+**Every run is shuffled**, by `pytest-randomly`, and the header says with what:
+`Using --randomly-seed=1697040112`. An order-dependent test — one that passes only
+because something before it left state behind — is the classic "green on my laptop,
+red in CI", and a suite that always runs in collection order never asks the question.
+CI asks it in a fresh order every run.
+
+```bash
+uv run pytest tests/ -q --randomly-seed=1697040112   # reproduce a red run exactly
+uv run pytest tests/ -q -p no:randomly               # collection order, while bisecting
+```
+
+The seed is chosen once by the controller and handed to each xdist worker, so `-n auto`
+collects one order rather than four. Until #571 the plugin was documented but not
+installed, `-p no:randomly` was a silent no-op, and nothing had ever exercised the
+claim.
+
 Once, before pushing — `make check` runs all of it, in this order:
 
 ```bash

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -30,14 +30,20 @@ red in CI", and a suite that always runs in collection order never asks the ques
 CI asks it in a fresh order every run.
 
 ```bash
-uv run pytest tests/ -q --randomly-seed=1697040112   # reproduce a red run exactly
+uv run pytest tests/ -q --randomly-seed=1697040112   # that order again, serially
 uv run pytest tests/ -q -p no:randomly               # collection order, while bisecting
 ```
 
 The seed is chosen once by the controller and handed to each xdist worker, so `-n auto`
-collects one order rather than four. Until #571 the plugin was documented but not
-installed, `-p no:randomly` was a silent no-op, and nothing had ever exercised the
-claim.
+collects one order rather than four. It does not fix which worker runs what: `make test`
+leaves xdist on its default `--dist load`, which hands each test to whichever worker is
+free. So a failure that depended on what shared a worker — the `InterfaceError` #571
+found is one — comes back by replaying the seed *serially*, as above, and not by
+re-running `make test`. The plugin also reseeds `random` identically before every test,
+so anything using it for uniqueness is unique within a test and repeats across them.
+
+Until #571 the plugin was documented but not installed, `-p no:randomly` was a silent
+no-op, and nothing had ever exercised the claim.
 
 Once, before pushing — `make check` runs all of it, in this order:
 


### PR DESCRIPTION
## What this fixes

`pytest-randomly` was described as on by default in `docs/testing.md` and
`.claude/rules/testing.md` while being in neither `backend/pyproject.toml` nor the
lockfile — so the suite ran in collection order, the documented `-p no:randomly` was a
silent no-op, and the order-independence those pages called verified had never been
exercised by that mechanism. #579 removed the false claim; this installs the plugin and
makes the claim true instead.

It then immediately earned its keep: the first shuffled run went red on a pre-existing
connection-pool defect in the integration harness, fixed in the second commit here.

Closes #571.

## What changed

**Enabling the shuffle**

- `backend/pyproject.toml` — `pytest-randomly>=4.1.0` in `[dependency-groups] dev`, with
  a note on why the plugin's own xdist support is load-bearing here
- `backend/uv.lock` — the resolved package and nothing else
- `backend/tests/test_random_order.py` — a guard: the dev group must declare it, so
  removing it fails a test instead of silently un-shuffling the suite. It asserts the
  *declaration*, not that the shuffle is active in this process — `-p no:randomly` is the
  documented move while bisecting, and a guard that turned it red would be telling people
  to stop using it
- `docs/testing.md` — the shuffle, the seed in the header, reproducing a red run, pinning
  the order while bisecting
- `.claude/rules/testing.md` — the same as a trap: a test that passed yesterday and fails
  today may have been depending on what ran before it

**What the shuffle found** (`fix(tests): dispose the app engine before each integration test`)

- `backend/tests/integration/conftest.py:255` — the `engine` fixture disposes
  `app.db.session.engine` on the way *in*
- `test_commit_before_response.py`, `test_flow_starts_after_commit.py` — their per-file
  disposes removed, leaving one explanation instead of three

## How it failed before

```
$ uv run pytest tests/ -p randomly
ImportError: Error importing plugin "randomly": No module named 'randomly'
```

And once it was installed:

```
sqlalchemy.exc.InterfaceError: (asyncpg.exceptions._base.InterfaceError)
cannot perform operation: another operation is in progress
[SQL: INSERT INTO dispatch_ordering_probe (id) VALUES ($1)]
```

`app.db.session.engine` is a module-level object, so its pool outlives the test that
filled it, while anyio gives every test its own event loop. A connection created on a loop
that has since closed answers the next statement issued through it that way, in whichever
test checked it out. The two files that drive the real `get_db_session` each disposed the
engine on the way *out*, which only covers the pair of them — anything else sharing the
xdist worker can leave a connection in that pool.

**Found by this branch, not caused by it:** which tests share a worker was already decided
at run time by xdist's `--dist load`. The shuffle changes the adjacencies and made it
surface.

## Testing

Locally against a live pgvector Postgres, so `tests/integration/` ran rather than skipping:

| What | Result |
|---|---|
| baseline on `main`, collection order | 4379 passed, 6 skipped |
| `--randomly-seed=12345 -n auto --maxprocesses 4` | 4380 passed, 6 skipped |
| full suite, fresh shuffle each run, **before** the pool fix | **red on run 6 of 8** |
| the two engine-driving integration files alone, 25 shuffled runs | 25 green — not those two on their own |
| full suite, fresh shuffle each run, **after** the pool fix | green ×12 |
| CI `test` job **before** the pool fix | red, same `InterfaceError`, first attempt |
| CI `test` job **after** | pass, 100% coverage gate held |

The header now prints `Using --randomly-seed=<n>`, and the controller's seed reaches every
xdist worker through `workerinput`, so `-n auto` collects one order rather than four —
without that the workers would abort on a collection mismatch.

`tests/test_migrations.py` was the other place order-dependence looked likely — an
`upgrade head` test beside a `downgrade base` one — and each test upgrades for itself
first, so the shuffle is safe there.

## Noticed, not fixed

`docs/testing.md` says the suite "takes a minute and a half". With a database up it is one
to three minutes here depending on load; the minute and a half is the unit layer with
`tests/integration/` skipping itself. Separate claim, worth its own measurement rather than
a guess in this diff.
