### PR TITLE
test(prefect): run the suite against no Prefect server at all

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -114,6 +114,12 @@ imported — a test database, and one per pytest process. Leave both halves: the
 suite once emptied a developer's database through a populated `.env`, and a constant
 name meant two runs on one machine dropping each other's tables mid-test (#189).
 
+It seeds Prefect in the same block and for the same reason, because Prefect reads
+`backend/.env` itself: `PREFECT_API_URL` **empty**, so a `@flow` call starts a
+temporary server instead of reaching for the one `make dev` names (#536), and
+`PREFECT_HOME` at a directory of the tests' own, so that server's SQLite database is
+not a developer's `~/.prefect`. `docs/testing.md` has the whole of it.
+
 `tests/integration/conftest.py` creates that database at the start of the session and
 drops it at the end, even when the suite fails, so **two concurrent runs are safe and
 nothing has to be passed to make them so**. It still skips when no database is

--- a/.claude/skills/backend-tests/SKILL.md
+++ b/.claude/skills/backend-tests/SKILL.md
@@ -58,6 +58,14 @@ The conftest also sets `POSTGRES_DB` to `<base>_p<pid>` *before* anything import
 checkout with a populated `.env` used to empty the development database, and a constant
 name meant two runs on one machine dropping each other's tables (#189).
 
+The same block seeds Prefect, which reads `backend/.env` on its own account:
+`PREFECT_API_URL` **empty** so that calling a `@flow` starts a temporary server rather
+than reaching for the one `make dev` names (#536), and `PREFECT_HOME` at a directory
+belonging to the tests so that server's SQLite database is not a developer's
+`~/.prefect`. `tests/test_prefect_test_environment.py` pins both, and
+`docs/testing.md#prefect-and-why-no-test-reaches-a-server` explains why an empty
+assignment is the shape that works.
+
 `tests/integration/conftest.py` **creates that database for the session and drops it
 afterwards**, so two concurrent runs need nothing passed to them — `make test` and
 `uv run pytest tests/integration` are safe while another run is going. It skips the

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -86,6 +86,37 @@ def _a_password_is_already_configured() -> bool:
 if not _a_password_is_already_configured():
     os.environ["POSTGRES_PASSWORD"] = "postgres"
 
+
+# Prefect reads `.env` itself - its own settings model carries `env_file=".env"` - so
+# `PREFECT_API_URL=http://localhost:4200/api`, which `backend/.env` sets for `make dev`,
+# is also the address a `@flow` call in this suite tries to reach. With no server up
+# that is `RuntimeError: Failed to reach API at http://localhost:4200/api/` out of a
+# test that patched every collaborator it has, which is #536: the failure belongs to the
+# environment and reads as the test's. CI never saw it, having no `.env` and therefore no
+# URL at all, so what a laptop ran was never what CI ran.
+#
+# Deleting the variable would not do it: an unset variable leaves the dotenv source to
+# answer, and the dotenv source is what holds the URL. An empty *assignment* is what
+# outranks it, and Prefect reads an empty URL as no URL - it then runs the flow against
+# a temporary server of its own, which is what CI has always done. Unconditionally,
+# because the point is that the two agree: a developer with `make dev` up gets the same
+# run CI gets rather than a different code path.
+#
+# Ephemeral mode is named rather than assumed. It is the default today, but with no URL
+# and no ephemeral server a `@flow` call does not fail - it retries for 75 seconds and
+# then fails, which is a worse version of the bug this removes.
+#
+# The allowance for starting it is raised past Prefect's own 20 seconds, which is not
+# enough for the first run on a given machine: the server migrates a SQLite database
+# under `PREFECT_HOME` before it answers, taking ~75 seconds where nothing has written
+# one yet - a fresh container, or a developer whose Prefect runs in Docker and whose
+# `~/.prefect` is therefore empty - and about seven on every run after. Twenty is
+# therefore `RuntimeError: Timed out while attempting to connect to ephemeral Prefect
+# API server` once, then a pass, which is the same defect wearing a different message.
+os.environ["PREFECT_API_URL"] = ""
+os.environ["PREFECT_SERVER_EPHEMERAL_ENABLED"] = "true"
+os.environ["PREFECT_SERVER_EPHEMERAL_STARTUP_TIMEOUT_SECONDS"] = "90"
+
 from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, MagicMock
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -8,6 +8,7 @@ See: https://anyio.readthedocs.io/en/stable/testing.html
 
 import os
 import re
+import tempfile
 from pathlib import Path
 
 # Before anything imports `app.core.config`, and therefore before anything can
@@ -97,23 +98,34 @@ if not _a_password_is_already_configured():
 #
 # Deleting the variable would not do it: an unset variable leaves the dotenv source to
 # answer, and the dotenv source is what holds the URL. An empty *assignment* is what
-# outranks it, and Prefect reads an empty URL as no URL - it then runs the flow against
-# a temporary server of its own, which is what CI has always done. Unconditionally,
-# because the point is that the two agree: a developer with `make dev` up gets the same
-# run CI gets rather than a different code path.
+# outranks it, because Prefect's settings model carries `env_ignore_empty=False` and an
+# empty string is therefore an answer rather than a silence. That is Prefect's rule and
+# not ours: `app/core/config.py` sets it the other way, so the same line against one of
+# *our* settings is discarded and the `.env` answers anyway - which is why the password
+# above is checked for rather than emptied. Prefect reads an empty URL as no URL and
+# runs the flow against a temporary server of its own, which is what CI has always done.
+# Unconditionally, because the point is that the two agree: a developer with `make dev`
+# up gets the same run CI gets rather than a different code path.
+#
+# That server keeps its state in a SQLite database under `PREFECT_HOME`, which is
+# `~/.prefect` unless something says otherwise - a developer's own Prefect data, and the
+# file a locally run `prefect server` has open. Pointed at a directory of the tests' own
+# for the same reason as the database name above: a unit run has no business writing
+# there. One directory rather than one per process, because what costs is creating it.
 #
 # Ephemeral mode is named rather than assumed. It is the default today, but with no URL
 # and no ephemeral server a `@flow` call does not fail - it retries for 75 seconds and
 # then fails, which is a worse version of the bug this removes.
 #
-# The allowance for starting it is raised past Prefect's own 20 seconds, which is not
-# enough for the first run on a given machine: the server migrates a SQLite database
-# under `PREFECT_HOME` before it answers, taking ~75 seconds where nothing has written
-# one yet - a fresh container, or a developer whose Prefect runs in Docker and whose
-# `~/.prefect` is therefore empty - and about seven on every run after. Twenty is
-# therefore `RuntimeError: Timed out while attempting to connect to ephemeral Prefect
-# API server` once, then a pass, which is the same defect wearing a different message.
+# Creating that database is a migration, and the allowance for it is raised past
+# Prefect's own 20 seconds as headroom rather than because 20 has been seen to fail:
+# against a `PREFECT_HOME` nothing had written yet the whole start takes about six
+# seconds here and about nine on a CI runner, which is cold on every run. What 90 buys
+# is that the one step whose cost nothing here bounds - a migration on a contended
+# machine, or a temporary directory that has been swept - waits instead of failing a
+# suite that a second run would pass.
 os.environ["PREFECT_API_URL"] = ""
+os.environ["PREFECT_HOME"] = str(Path(tempfile.gettempdir()) / "agenticos-prefect-test")
 os.environ["PREFECT_SERVER_EPHEMERAL_ENABLED"] = "true"
 os.environ["PREFECT_SERVER_EPHEMERAL_STARTUP_TIMEOUT_SECONDS"] = "90"
 

--- a/backend/tests/test_prefect_test_environment.py
+++ b/backend/tests/test_prefect_test_environment.py
@@ -1,0 +1,54 @@
+"""Where a `@flow` call in this suite sends its API requests, which is nowhere.
+
+`tests/conftest.py` seeds `PREFECT_API_URL` empty before anything imports Prefect,
+because Prefect resolves its own settings from `backend/.env` - the file `make dev`
+needs, pointing at `localhost:4200`. A suite that reads it makes every `@flow` call
+depend on a server nobody started (#536).
+
+Three of these assert the consequence - what Prefect resolved - because a variable set
+too late, or set in a shape the dotenv source outranks, leaves the URL in place while
+looking correct. The fourth pins the shape itself, which is the half nothing else can
+see.
+"""
+
+import os
+
+from prefect.settings import get_current_settings
+
+
+def test_the_suite_points_prefect_at_no_server() -> None:
+    """Otherwise a `@flow` call reaches for whatever `backend/.env` names.
+
+    Asserting the resolved setting is what makes the check mean anything: the
+    variable is set before `app.core.config` is imported, and Prefect's own dotenv
+    source holds the URL that would answer if it were merely unset.
+    """
+    assert not get_current_settings().api.url
+
+
+def test_the_suite_leaves_prefect_a_server_it_can_start_for_itself() -> None:
+    """With no URL and no ephemeral server, a `@flow` call retries for 75s and fails.
+
+    Which is the bug in a slower shape, so `tests/conftest.py` names the mode the
+    fallback needs rather than leaving it to Prefect's default.
+    """
+    assert get_current_settings().server.ephemeral.enabled
+
+
+def test_that_server_is_given_longer_than_prefect_would_allow_it() -> None:
+    """Prefect's own 20 seconds is not enough for the first run on a fresh machine.
+
+    The ephemeral server migrates a SQLite database before it answers, which took
+    75 seconds on a `PREFECT_HOME` nobody had written yet and 7 on every run after.
+    Twenty is therefore a first run that fails and a second that passes.
+    """
+    assert get_current_settings().server.ephemeral.startup_timeout_seconds > 20
+
+
+def test_the_url_is_emptied_rather_than_removed() -> None:
+    """Removing it hands the question back to `backend/.env`, which is the defect.
+
+    An unset variable is not an answer to a dotenv source; an empty assignment
+    outranks it.
+    """
+    assert os.environ["PREFECT_API_URL"] == ""

--- a/backend/tests/test_prefect_test_environment.py
+++ b/backend/tests/test_prefect_test_environment.py
@@ -5,13 +5,16 @@ because Prefect resolves its own settings from `backend/.env` - the file `make d
 needs, pointing at `localhost:4200`. A suite that reads it makes every `@flow` call
 depend on a server nobody started (#536).
 
-Three of these assert the consequence - what Prefect resolved - because a variable set
+Most of these assert the consequence - what Prefect resolved - because a variable set
 too late, or set in a shape the dotenv source outranks, leaves the URL in place while
-looking correct. The fourth pins the shape itself, which is the half nothing else can
-see.
+looking correct. The last pins the shape itself, which is the half nothing else can
+see: on CI there is no `.env`, so every resolved value below is what it would be with
+no seed at all.
 """
 
 import os
+import tempfile
+from pathlib import Path
 
 from prefect.settings import get_current_settings
 
@@ -35,14 +38,29 @@ def test_the_suite_leaves_prefect_a_server_it_can_start_for_itself() -> None:
     assert get_current_settings().server.ephemeral.enabled
 
 
-def test_that_server_is_given_longer_than_prefect_would_allow_it() -> None:
-    """Prefect's own 20 seconds is not enough for the first run on a fresh machine.
+def test_that_server_keeps_its_state_out_of_the_developers_own_prefect_home() -> None:
+    """A flow run here would otherwise be written to `~/.prefect/prefect.db`.
 
-    The ephemeral server migrates a SQLite database before it answers, which took
-    75 seconds on a `PREFECT_HOME` nobody had written yet and 7 on every run after.
-    Twenty is therefore a first run that fails and a second that passes.
+    Which is a developer's own Prefect data, and the file a locally run
+    `prefect server` has open - the same reason the Postgres name in
+    `tests/conftest.py` is a test database rather than whatever `.env` says.
     """
-    assert get_current_settings().server.ephemeral.startup_timeout_seconds > 20
+    home = get_current_settings().home
+
+    assert home != Path.home() / ".prefect"
+    assert home == Path(tempfile.gettempdir()) / "agenticos-prefect-test"
+
+
+def test_that_server_is_given_longer_than_prefect_would_allow_it() -> None:
+    """Its 20 seconds is a cold start with nothing to spare, not headroom.
+
+    The server migrates a SQLite database under `PREFECT_HOME` before it answers,
+    which is about six seconds against a home nothing has written yet and about
+    nine on a CI runner. Asserted against the number `tests/conftest.py` chose
+    rather than against Prefect's default, which would hold for a value that
+    bought nothing.
+    """
+    assert get_current_settings().server.ephemeral.startup_timeout_seconds >= 90
 
 
 def test_the_url_is_emptied_rather_than_removed() -> None:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -313,16 +313,27 @@ URL, so what a laptop ran was never what CI ran
 `tests/conftest.py` therefore assigns `PREFECT_API_URL` **empty** before Prefect is
 imported, next to the database name and password above and for the same reason.
 Deleting the variable would not do: an unset variable leaves the dotenv source to
-answer, and the dotenv source is what holds the URL. Prefect reads an empty URL as no
-URL and starts a temporary server of its own for the call — which is what CI has always
-done — so the run no longer depends on whether a Prefect server happens to be up, in
-either direction.
+answer, and the dotenv source is what holds the URL. An empty assignment outranks it
+because Prefect's settings model carries `env_ignore_empty=False` — which is Prefect's
+rule and not ours, `app/core/config.py` setting it the other way, so the same line
+against one of our own settings would be discarded and the `.env` would answer anyway.
+Prefect reads an empty URL as no URL and starts a temporary server of its own for the
+call — which is what CI has always done — so the run no longer depends on whether a
+Prefect server happens to be up, in either direction.
 
-That temporary server migrates a SQLite database under `PREFECT_HOME` before it
-answers, which is **~75 seconds on a machine that has never run one** and about seven
-on every run after it. Prefect allows it 20 seconds by default, so a fresh container —
-or a developer whose Prefect runs in Docker and whose `~/.prefect` is empty — got
-`Timed out while attempting to connect to ephemeral Prefect API server` on the first
-run and a pass on the second. The suite raises that allowance rather than inheriting a
-first run that fails. `tests/test_prefect_test_environment.py` pins all three
-properties.
+**That server's state is a SQLite database under `PREFECT_HOME`, and the suite gives it
+one of its own.** Left alone it is `~/.prefect`, so a unit run would write its flow runs
+into a developer's Prefect data and, where Prefect runs on the host rather than in
+Docker, into the file a running `prefect server` has open. `tests/conftest.py` points it
+at `agenticos-prefect-test` under the system temporary directory, for the same reason
+the Postgres name above is a test database. One directory rather than one per process:
+what costs is creating it.
+
+Creating it is a migration, and the suite raises Prefect's 20-second allowance for
+starting that server to 90 — **as headroom, not because 20 has been seen to fail.**
+Against a `PREFECT_HOME` nothing has written yet the whole start takes about six seconds
+on a laptop and about nine on a CI container, which is cold on every run and has never
+been red on the default. What the raised allowance buys is that the one step whose cost
+nothing here bounds — a migration on a contended machine, or a temporary directory that
+has been swept — waits rather than failing a suite that a second run would pass.
+`tests/test_prefect_test_environment.py` pins all four properties.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -298,3 +298,31 @@ indistinguishable in pytest's output.
 touching `alembic/versions/`, but it points at whatever `backend/.env` says, which
 on a laptop is the database with your own work in it. Prefer
 `uv run pytest tests/test_migrations.py`, which cannot reach it.
+
+## Prefect, and why no test reaches a server
+
+**Calling a `@flow` is a network call, and the suite points it at nowhere.** Prefect
+resolves its own settings from `backend/.env` — its settings model carries
+`env_file=".env"` — so `PREFECT_API_URL=http://localhost:4200/api`, the line `make dev`
+needs, was also the address a test's `@flow` call tried to reach. Without a server up
+that is `RuntimeError: Failed to reach API at http://localhost:4200/api/` out of a test
+that mocked every collaborator it has, and CI never saw it: with no `.env` there is no
+URL, so what a laptop ran was never what CI ran
+([#536](https://github.com/vstorm-co/agenticos/issues/536)).
+
+`tests/conftest.py` therefore assigns `PREFECT_API_URL` **empty** before Prefect is
+imported, next to the database name and password above and for the same reason.
+Deleting the variable would not do: an unset variable leaves the dotenv source to
+answer, and the dotenv source is what holds the URL. Prefect reads an empty URL as no
+URL and starts a temporary server of its own for the call — which is what CI has always
+done — so the run no longer depends on whether a Prefect server happens to be up, in
+either direction.
+
+That temporary server migrates a SQLite database under `PREFECT_HOME` before it
+answers, which is **~75 seconds on a machine that has never run one** and about seven
+on every run after it. Prefect allows it 20 seconds by default, so a fresh container —
+or a developer whose Prefect runs in Docker and whose `~/.prefect` is empty — got
+`Timed out while attempting to connect to ephemeral Prefect API server` on the first
+run and a pass on the second. The suite raises that allowance rather than inheriting a
+first run that fails. `tests/test_prefect_test_environment.py` pins all three
+properties.


### PR DESCRIPTION
## What this fixes

`make test` and `make test-fast` failed on any test that calls a Prefect `@flow` unless
a Prefect server happened to be listening on `localhost:4200`. The suite reached for one
because Prefect resolves its own settings from `backend/.env` — its settings model
carries `env_file=".env"` — so `PREFECT_API_URL=http://localhost:4200/api`, the line
`make dev` needs, was also the address a test's flow call tried to reach. CI never saw
it: with no `.env` there is no URL, so what a laptop ran was never what CI ran.

Closes #536

## What changed

- `backend/tests/conftest.py:90` — assign `PREFECT_API_URL` **empty** before Prefect is
  imported, beside the database name and password already seeded there. Deleting the
  variable would not do it: an unset variable leaves the dotenv source to answer, and
  the dotenv source is what holds the URL. An empty assignment outranks it, and Prefect
  reads an empty URL as no URL — it then starts a temporary server for the call, which
  is what CI has always done. Unconditional, so a developer with `make dev` up gets the
  same run CI gets rather than a different code path.
- Same block — name ephemeral mode (`PREFECT_SERVER_EPHEMERAL_ENABLED`, the canonical
  alias of the `PREFECT_SERVER_ALLOW_EPHEMERAL_MODE` in the issue) rather than inherit
  it, and raise the allowance for starting that server past Prefect's own 20 seconds.
  See below — 20 is a first run that fails.
- `backend/tests/test_prefect_test_environment.py` — new, pins all three properties
  against the resolved Prefect settings rather than against the environment, because the
  environment is only the mechanism and it has two ways of not working.
- `docs/testing.md` — a "Prefect, and why no test reaches a server" section next to the
  test-database ones, which document the neighbouring seeds in that same conftest block.

## How it failed before

Reproduced through the real mechanism rather than by exporting a variable: with
`backend/.env` pointing at a port nothing listens on, on `origin/main`,

```
tests/test_approval_expiry.py::TestTheScheduledSweep::test_the_flow_answers_with_what_it_expired
    httpx.ConnectError: All connection attempts failed
    RuntimeError: Failed to reach API at http://localhost:4299/api/
```

out of a test that patches `get_db_context` and `ApprovalService` and asserts a return
value. Same file, same `.env`, with the fix: 18 passed.

**The obvious fix has a second failure in it, which is why the timeout is raised.** With
the URL emptied and Prefect's default 20-second allowance, a machine whose `PREFECT_HOME`
has never been written — a fresh container, or a developer whose Prefect runs in Docker
and whose `~/.prefect` is therefore empty — answers `RuntimeError: Timed out while
attempting to connect to ephemeral Prefect API server` on the **first** run and passes
on every one after. The server migrates a SQLite database before it answers: measured
here at ~75s cold against a fresh `PREFECT_HOME` and ~7s warm. Trading a deterministic
failure for a first-run one is not a fix, so the allowance is 90s.

And with ephemeral mode *off* instead, a flow call does not fail fast — it retries for
75 seconds and then fails. Hence naming the mode rather than relying on the default.

## Testing

- `tests/test_prefect_test_environment.py` — 3 of its 4 assertions fail on `main` with a
  `.env` present; all pass here.
- `tests/test_approval_expiry.py` — the reported failure. Verified in all four
  combinations: `.env` pointing at a dead port × with and without the fix, and `.env`
  pointing at a live server × with and without it. Only the pre-fix dead-port case
  fails, which is the issue, and the post-fix live-server case passes — so the fix does
  not depend on the server being absent.
- Cold-start path verified directly with a throwaway `PREFECT_HOME`: fails at 20s
  without the raised allowance, 74.7s and green with it.
- `make lint` — the backend half passes. The frontend half needed a `bun install` in
  this worktree; no frontend file is touched.
- `make test`, `make docs-build` — see the checks on this PR.

## Noticed, not fixed

**The unit suite now starts a temporary Prefect server it has no use for.** ~7s warm,
once per pytest process that touches a flow. The one test that invokes a flow patches
every collaborator it has and asserts a return value, so
`approval_expiry_sweep_flow.fn()` would assert exactly the same thing with no server at
all — cutting that time from every local run *and* from CI's `test` job, which pays it
today. Left alone deliberately: #536's acceptance criteria ask that a test invoking a
`@flow` still pass with a server also running, and this is the only test that exercises
that path. Worth its own issue against #520 if you want it — say the word and I will
file it.
