### PR TITLE
docs(budgets): say which breakdown the pricing caveat measures

### DIFF
--- a/backend/app/api/routes/v1/runs.py
+++ b/backend/app/api/routes/v1/runs.py
@@ -420,15 +420,8 @@ async def get_spend(
         # How much of everything below is a fact. Summed from the per-agent rows
         # rather than queried again, so this figure and `by_agent` cannot
         # disagree about which runs could not be priced - they count the same
-        # top-level rows.
-        #
-        # It marks the two breakdowns underneath as well without measuring them.
-        # Those sum every row's own spend, delegated rows included, so an
-        # unpriced *delegate* makes a vendor and a key a floor while this counts
-        # trees: one parent with three unpriced delegates reads 1. The marker
-        # still fires, because a tree shares one spend ledger and the parent's
-        # row is therefore a floor too - which is why the figure is never 0
-        # while a figure below it is one.
+        # top-level rows. It marks the two breakdowns below without measuring
+        # them; see `CostSummary.partial_run_count`.
         partial_run_count=sum(row.partial_run_count for row in agents),
         by_agent=[
             CostByAgent(

--- a/backend/app/api/routes/v1/runs.py
+++ b/backend/app/api/routes/v1/runs.py
@@ -418,8 +418,17 @@ async def get_spend(
         to_date=to_date,
         month_to_date_usd=await service.monthly_spend(ctx),
         # How much of everything below is a fact. Summed from the per-agent rows
-        # rather than queried again, so the figure and its breakdown cannot
-        # disagree about which runs could not be priced.
+        # rather than queried again, so this figure and `by_agent` cannot
+        # disagree about which runs could not be priced - they count the same
+        # top-level rows.
+        #
+        # It marks the two breakdowns underneath as well without measuring them.
+        # Those sum every row's own spend, delegated rows included, so an
+        # unpriced *delegate* makes a vendor and a key a floor while this counts
+        # trees: one parent with three unpriced delegates reads 1. The marker
+        # still fires, because a tree shares one spend ledger and the parent's
+        # row is therefore a floor too - which is why the figure is never 0
+        # while a figure below it is one.
         partial_run_count=sum(row.partial_run_count for row in agents),
         by_agent=[
             CostByAgent(

--- a/backend/app/repositories/agent_run.py
+++ b/backend/app/repositories/agent_run.py
@@ -554,10 +554,12 @@ class AgentSpendRow:
             the column sums to the total printed above it. A delegate's tokens
             are already inside its parent's row.
         run_count: Runs behind that figure.
-        partial_run_count: How many of them had a model with no price. The
-            figure is a floor by exactly that much, and saying "3 of 40 runs
-            could not be priced" is the difference between a number a reader
-            can act on and one they have to take on trust.
+        partial_run_count: How many of them could not be fully priced - some
+            model in the run had no price, its delegates' included, because a
+            tree shares one ledger. The figure is a floor by exactly that many
+            runs, and saying "3 of 40 runs could not be priced" is the
+            difference between a number a reader can act on and one they have
+            to take on trust.
         month_to_date_usd: This agent's **own** month, delegated rows included -
             because that is the spend its cap is a cap on, and a delegate's rows
             are the only record of what it itself did. It does not sum to the

--- a/backend/app/schemas/agent_run.py
+++ b/backend/app/schemas/agent_run.py
@@ -279,10 +279,11 @@ class CostByAgent(BaseSchema):
     partial_run_count: int = Field(
         default=0,
         description=(
-            "How many of those runs had a model with no price. The cost is a "
-            "floor by exactly that much, and '3 of 40 runs could not be priced' "
-            "is the difference between a figure a reader can act on and one "
-            "they have to take on trust"
+            "How many of those runs could not be fully priced - some model in "
+            "the run had no price, its delegates' included, because a tree "
+            "shares one ledger. The cost is a floor by exactly that many runs, "
+            "and '3 of 40 runs could not be priced' is the difference between a "
+            "figure a reader can act on and one they have to take on trust"
         ),
     )
     month_to_date_usd: Decimal | None = Field(
@@ -350,8 +351,15 @@ class CostSummary(BaseSchema):
     partial_run_count: int = Field(
         default=0,
         description=(
-            "Runs in the window whose cost is a floor because some model in "
-            "them had no price. How much of everything below is a fact"
+            "Top-level runs in the window whose cost is a floor because some "
+            "model in the run had no price - the run's own or any it delegated "
+            "to, which share one spend ledger. How much of everything below is "
+            "a fact: it is never 0 while a figure below it is a floor, because "
+            "an unpriced delegate is in its parent's ledger too. It counts "
+            "*trees* rather than the rows `by_provider` and `by_key` sum, so "
+            "one parent with three unpriced delegates reads 1 - it marks those "
+            "two breakdowns without measuring them, and measures `by_agent`, "
+            "which counts the same top-level rows"
         ),
     )
     by_agent: list[CostByAgent]

--- a/backend/app/schemas/agent_run.py
+++ b/backend/app/schemas/agent_run.py
@@ -354,12 +354,15 @@ class CostSummary(BaseSchema):
             "Top-level runs in the window whose cost is a floor because some "
             "model in the run had no price - the run's own or any it delegated "
             "to, which share one spend ledger. How much of everything below is "
-            "a fact: it is never 0 while a figure below it is a floor, because "
-            "an unpriced delegate is in its parent's ledger too. It counts "
-            "*trees* rather than the rows `by_provider` and `by_key` sum, so "
-            "one parent with three unpriced delegates reads 1 - it marks those "
-            "two breakdowns without measuring them, and measures `by_agent`, "
-            "which counts the same top-level rows"
+            "a fact: an unpriced delegate is in its parent's ledger too, so a "
+            "floor under `by_provider` or `by_key` is marked here even though "
+            "neither is measured here. It counts *trees* rather than the rows "
+            "those two sum, so one parent with three unpriced delegates reads "
+            "1, and it measures `by_agent`, which counts the same top-level "
+            "rows. A tree that straddles the start of the window is the one "
+            "case it misses: the delegate's row is inside the window and its "
+            "parent's is not, so the splits are a floor and this reads 0 "
+            "(agenticos#620)"
         ),
     )
     by_agent: list[CostByAgent]

--- a/backend/tests/integration/test_delegated_run_spend.py
+++ b/backend/tests/integration/test_delegated_run_spend.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 
 import pytest
@@ -87,6 +87,7 @@ async def _run(
     cost: Decimal,
     secret: OrganizationSecret | None = None,
     partial: bool = False,
+    started_at: datetime | None = None,
 ) -> AgentRun:
     """A run somebody started, opened and finished the way every surface does.
 
@@ -97,6 +98,9 @@ async def _run(
     `partial` is what the run's ledger answered about pricing, which is a question
     about the whole tree: a delegate on a model with no price makes this row a
     floor too, because parent and delegate book into one ledger.
+
+    `started_at` is the column every spend window filters on, so it is what puts a
+    run inside or outside the one being asked about.
     """
     run = await agent_run_repo.create_run(
         db,
@@ -109,7 +113,7 @@ async def _run(
         model_label="gpt-4.1",
         provider="openai",
         secret_id=None if secret is None else secret.id,
-        started_at=datetime.now(UTC),
+        started_at=datetime.now(UTC) if started_at is None else started_at,
     )
     return await agent_run_repo.finish_run(
         db,
@@ -134,6 +138,7 @@ async def _delegated(
     task_id: str = "4f2a1b8c",
     secret: OrganizationSecret | None = None,
     partial: bool = False,
+    started_at: datetime | None = None,
 ) -> AgentRun:
     """A delegation, written the way `finish` writes one: complete, in one insert.
 
@@ -141,7 +146,7 @@ async def _delegated(
     while the run was still going - and the foreign key is the thing this proves:
     the parent's row has to exist by the time these are written.
     """
-    moment = datetime.now(UTC)
+    moment = datetime.now(UTC) if started_at is None else started_at
     return await agent_run_repo.record_delegated_run(
         db,
         run_id=uuid.uuid4(),
@@ -496,13 +501,14 @@ class TestTheCostScreen:
 
         The caveat counts top-level runs; By provider and By key sum every row's
         own spend, delegated rows included (#194). So an unpriced *delegate* makes
-        those two a floor through a row the caveat never looks at, and the figure
-        would read 0 above them if the delegation's row were the only one carrying
-        that unpriced request.
+        those two a floor through a row the caveat never looks at, and what keeps
+        the figure non-zero above the vendor it marks is the parent's row being
+        written a floor as well (#597).
 
-        It is not. A tree shares one spend ledger, so the request is in the
-        parent's ledger too and the parent's row is written a floor as well -
-        which is what keeps the count non-zero above the vendor it marks (#597).
+        Both rows are written partial here, which is the state that shared ledger
+        produces rather than a proof of it - `tests/test_delegation_seams.py` is
+        where the parent inherits its delegate's unpriced request. What this pins
+        is the arithmetic downstream of it.
         """
         org = await _org(db)
         orchestrator = await _agent(db, org, slug="orchestrator")
@@ -531,6 +537,55 @@ class TestTheCostScreen:
         assert sum(row.partial_run_count for row in by_agent) == 1
         # And the figure it is a caveat about: Anthropic's share is the delegate's
         # own spend, so that row is the floor the count above it is announcing.
+        assert {provider: cost for provider, cost, _runs in by_provider}["anthropic"] == Decimal(
+            "0.40"
+        )
+
+    async def test_a_tree_that_straddles_the_start_of_the_window_is_marked_nowhere(self, db):
+        """The one floor this page still shows with no figure over it saying so.
+
+        The caveat counts top-level runs *in the window*; the two splits price
+        every row in it through a subquery that is deliberately not windowed
+        (:func:`_own_cost`). A parent that started before the window and delegated
+        inside it therefore puts its delegate's own spend under a vendor and a key
+        and puts nothing at all under the count above them.
+
+        Pinned rather than fixed, and asserted as `0` on purpose: the shared ledger
+        closes the other route to a false zero, this one is a `WHERE` that no
+        longer matches the rows underneath it (agenticos#620). Inverting the first
+        assertion is how the fix will announce itself.
+        """
+        org = await _org(db)
+        orchestrator = await _agent(db, org, slug="orchestrator")
+        researcher = await _agent(db, org, slug="researcher")
+        since = datetime.now(UTC) - timedelta(hours=1)
+        parent = await _run(
+            db,
+            org=org,
+            agent=orchestrator,
+            cost=Decimal("1.00"),
+            partial=True,
+            started_at=since - timedelta(hours=2),
+        )
+        await _delegated(
+            db,
+            org=org,
+            agent=researcher,
+            version=await _version(db, researcher),
+            parent=parent,
+            cost=Decimal("0.40"),
+            partial=True,
+            started_at=since + timedelta(minutes=30),
+        )
+        service = AgentRunnerService(db)
+        ctx = AuthContext(user_id=None, organization_id=org.id, role=OrgRoleName.OWNER)
+
+        by_agent = await service.spend_by_agent(ctx, since=since)
+        by_provider = await service.spend_by_provider(ctx, since=since)
+
+        assert sum(row.partial_run_count for row in by_agent) == 0
+        # The floor nothing on the page announces: the delegate's own spend, at
+        # the vendor it was spent with, from a row written `cost_is_partial`.
         assert {provider: cost for provider, cost, _runs in by_provider}["anthropic"] == Decimal(
             "0.40"
         )

--- a/backend/tests/integration/test_delegated_run_spend.py
+++ b/backend/tests/integration/test_delegated_run_spend.py
@@ -86,12 +86,17 @@ async def _run(
     agent: Agent,
     cost: Decimal,
     secret: OrganizationSecret | None = None,
+    partial: bool = False,
 ) -> AgentRun:
     """A run somebody started, opened and finished the way every surface does.
 
     On OpenAI, because the delegate below runs on Anthropic: the provider split is
     where double-counting is least visible - the same money appears under two
     vendors at once, and each looks plausible on its own.
+
+    `partial` is what the run's ledger answered about pricing, which is a question
+    about the whole tree: a delegate on a model with no price makes this row a
+    floor too, because parent and delegate book into one ledger.
     """
     run = await agent_run_repo.create_run(
         db,
@@ -113,7 +118,7 @@ async def _run(
         input_tokens=1000,
         output_tokens=100,
         cost_usd=cost,
-        cost_is_partial=False,
+        cost_is_partial=partial,
         ended_at=datetime.now(UTC),
     )
 
@@ -128,6 +133,7 @@ async def _delegated(
     cost: Decimal,
     task_id: str = "4f2a1b8c",
     secret: OrganizationSecret | None = None,
+    partial: bool = False,
 ) -> AgentRun:
     """A delegation, written the way `finish` writes one: complete, in one insert.
 
@@ -155,7 +161,9 @@ async def _delegated(
         input_tokens=500,
         output_tokens=50,
         cost_usd=cost,
-        cost_is_partial=False,
+        # This delegation's own requests, not the run's - the parent carries the
+        # tree's answer, and both are written from the one terminal write.
+        cost_is_partial=partial,
         started_at=moment,
         ended_at=moment,
     )
@@ -482,6 +490,83 @@ class TestTheCostScreen:
         assert sum(row.cost_usd for row in by_agent) == month_to_date
         assert sum(row[1] for row in by_provider) == month_to_date
         assert sum(row[2] for row in by_key) == month_to_date
+
+    async def test_an_unpriced_delegate_is_marked_above_the_splits_it_makes_a_floor(self, db):
+        """No breakdown on this page is a floor without a figure on it saying so.
+
+        The caveat counts top-level runs; By provider and By key sum every row's
+        own spend, delegated rows included (#194). So an unpriced *delegate* makes
+        those two a floor through a row the caveat never looks at, and the figure
+        would read 0 above them if the delegation's row were the only one carrying
+        that unpriced request.
+
+        It is not. A tree shares one spend ledger, so the request is in the
+        parent's ledger too and the parent's row is written a floor as well -
+        which is what keeps the count non-zero above the vendor it marks (#597).
+        """
+        org = await _org(db)
+        orchestrator = await _agent(db, org, slug="orchestrator")
+        researcher = await _agent(db, org, slug="researcher")
+        key = await _secret(db, org, name="Shared key")
+        parent = await _run(
+            db, org=org, agent=orchestrator, cost=Decimal("1.00"), secret=key, partial=True
+        )
+        await _delegated(
+            db,
+            org=org,
+            agent=researcher,
+            version=await _version(db, researcher),
+            parent=parent,
+            cost=Decimal("0.40"),
+            secret=key,
+            partial=True,
+        )
+        service = AgentRunnerService(db)
+        ctx = AuthContext(user_id=None, organization_id=org.id, role=OrgRoleName.OWNER)
+
+        by_agent = await service.spend_by_agent(ctx, since=month_start())
+        by_provider = await service.spend_by_provider(ctx, since=month_start())
+
+        # The sum the route renders above all three breakdowns.
+        assert sum(row.partial_run_count for row in by_agent) == 1
+        # And the figure it is a caveat about: Anthropic's share is the delegate's
+        # own spend, so that row is the floor the count above it is announcing.
+        assert {provider: cost for provider, cost, _runs in by_provider}["anthropic"] == Decimal(
+            "0.40"
+        )
+
+    async def test_the_caveat_counts_trees_rather_than_the_rows_the_splits_sum(self, db):
+        """One parent, two unpriced delegates, and the figure reads 1.
+
+        Its magnitude is top-level runs - which is what "3 of 40 runs" is counted
+        out of - so it marks By provider and By key without measuring them. The
+        delegate's own row is counted nowhere: its agent's `partial_run_count` is
+        the top-level runs *it* started, and it started none.
+        """
+        org = await _org(db)
+        orchestrator = await _agent(db, org, slug="orchestrator")
+        researcher = await _agent(db, org, slug="researcher")
+        version = await _version(db, researcher)
+        parent = await _run(db, org=org, agent=orchestrator, cost=Decimal("1.00"), partial=True)
+        for cost, task_id in ((Decimal("0.40"), "4f2a1b8c"), (Decimal("0.30"), "9c1d2e3f")):
+            await _delegated(
+                db,
+                org=org,
+                agent=researcher,
+                version=version,
+                parent=parent,
+                cost=cost,
+                task_id=task_id,
+                partial=True,
+            )
+        ctx = AuthContext(user_id=None, organization_id=org.id, role=OrgRoleName.OWNER)
+
+        by_agent = await AgentRunnerService(db).spend_by_agent(ctx, since=month_start())
+
+        assert {row.agent_name: row.partial_run_count for row in by_agent} == {
+            "Orchestrator": 1,
+            "Researcher": 0,
+        }
 
     async def test_the_delegates_own_month_is_still_its_own_spend(self, db):
         """The same service, the other question: what a budget alert on the

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -332,11 +332,18 @@ a figure wearing a plus sign is not.
 A run counts when any model in its tree had no price, **its delegates' included** —
 the tree shares one spend ledger, so an unpriced delegate makes the parent's row a
 floor as well. That is what lets one figure govern all three breakdowns: By
-provider and By key sum every row's own spend, delegated rows included, and the
-count is never `0` while one of their figures is a floor. It measures By agent,
-which counts the same top-level rows, and only **marks** the other two — it counts
-trees, so one parent with three unpriced delegates reads `1` while three figures
-below it are a floor.
+provider and By key sum every row's own spend, delegated rows included, and a floor
+in either of them is marked by a count that never looked at the row causing it. It
+**measures** By agent, which counts the same top-level rows, and only **marks** the
+other two — it counts trees, so one parent with three unpriced delegates reads `1`
+while three figures below it are a floor.
+
+A tree that **straddles the start of the window** is the one case the marker misses:
+the delegate's row is inside the window and its parent's row is not, so By provider
+and By key are a floor and the count above them reads `0`. Rare — it needs a
+delegation that outlives the window's edge — and it is the only remaining way this
+page shows a floor with nothing over it saying so
+([#620](https://github.com/vstorm-co/agenticos/issues/620)).
 
 A row is **one per agent**, with `agent_name` on it. It used to be one per agent
 *and model*, carrying only `model_label` — so the tab listed model names where a

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -324,10 +324,19 @@ this page's rule throughout:
 | `cost_usd` | Its share of the window, **top-level runs only**, so the column sums to the total above it |
 | `month_to_date_usd` | Its **own** calendar month, delegated rows **included** — the spend its `monthly_cap_usd` is a cap on. It does not sum to the organization's month and is not drawn as if it did |
 
-`partial_run_count` says how much of any of it is a fact: how many runs in the
-window had a model with no price, so the cost is a floor by exactly that many.
-*"3 of 40 runs could not be priced"* is something a reader can act on; a figure
-wearing a plus sign is not.
+`partial_run_count` says how much of any of it is a fact: how many **top-level
+runs** in the window could not be fully priced, so the cost is a floor by exactly
+that many. *"3 of 40 runs could not be priced"* is something a reader can act on;
+a figure wearing a plus sign is not.
+
+A run counts when any model in its tree had no price, **its delegates' included** —
+the tree shares one spend ledger, so an unpriced delegate makes the parent's row a
+floor as well. That is what lets one figure govern all three breakdowns: By
+provider and By key sum every row's own spend, delegated rows included, and the
+count is never `0` while one of their figures is a floor. It measures By agent,
+which counts the same top-level rows, and only **marks** the other two — it counts
+trees, so one parent with three unpriced delegates reads `1` while three figures
+below it are a floor.
 
 A row is **one per agent**, with `agent_name` on it. It used to be one per agent
 *and model*, carrying only `model_label` — so the tab listed model names where a

--- a/frontend/src/components/runs/spend-tab.tsx
+++ b/frontend/src/components/runs/spend-tab.tsx
@@ -63,10 +63,14 @@ export function SpendTab() {
   return (
     <div className="space-y-4">
       {/* The one caveat that governs every figure below: how many of the
-          window's runs ran on a model with no price. The breakdowns are a floor
-          by exactly that many, and saying so once at the top is what stops a
-          reader treating the totals as exact. Summed server-side from the same
-          rows, so the caveat and the breakdown cannot disagree about the count. */}
+          window's top-level runs could not be fully priced. A delegate on a
+          model with no price makes its parent's row a floor too - a tree shares
+          one spend ledger - so this is non-zero whenever By provider or By key
+          is a floor, which is what stops a reader treating the totals as exact.
+          It counts trees rather than the rows those two sum, so it marks them
+          without measuring them; By agent counts the same top-level rows and is
+          summed server-side from them, so the caveat and that breakdown cannot
+          disagree about the count. */}
       {spend != null && spend.partial_run_count > 0 && (
         <p className="text-muted-foreground text-sm" role="note">
           {t("someRunsCouldNotBePriced", { count: spend.partial_run_count })}

--- a/frontend/src/components/runs/spend-tab.tsx
+++ b/frontend/src/components/runs/spend-tab.tsx
@@ -63,14 +63,10 @@ export function SpendTab() {
   return (
     <div className="space-y-4">
       {/* The one caveat that governs every figure below: how many of the
-          window's top-level runs could not be fully priced. A delegate on a
-          model with no price makes its parent's row a floor too - a tree shares
-          one spend ledger - so this is non-zero whenever By provider or By key
-          is a floor, which is what stops a reader treating the totals as exact.
-          It counts trees rather than the rows those two sum, so it marks them
-          without measuring them; By agent counts the same top-level rows and is
-          summed server-side from them, so the caveat and that breakdown cannot
-          disagree about the count. */}
+          window's top-level runs could not be fully priced. Saying it once at
+          the top is what stops a reader treating the totals as exact. It marks
+          By provider and By key without measuring them, and measures By agent -
+          see `CostSummary.partial_run_count` for which is which. */}
       {spend != null && spend.partial_run_count > 0 && (
         <p className="text-muted-foreground text-sm" role="note">
           {t("someRunsCouldNotBePriced", { count: spend.partial_run_count })}


### PR DESCRIPTION
## What this fixes

`GET /api/v1/runs/spend` prints one "some runs could not be priced" caveat above
three breakdowns, and three places described it as measuring all three. It
measures one — `by_agent`, which counts the same top-level rows — and only
*marks* By provider and By key, which sum every row's own spend, delegated rows
included (#194). So one parent with three unpriced delegates reads `1` while
three figures below it are a floor.

The marker itself is sound, which is not what #597's body claims. Its sequence —
an unpriced delegate, `partial_run_count: 0`, "the page says nothing" — is not
reachable: a run tree shares one spend ledger (`BudgetGuard.for_delegate` passes
`ledger=self.ledger`), `SpendLedger.has_unpriced_models` is asked of every entry
in it, and the top-level row is written `cost_is_partial=ledger.has_unpriced_models`.
An unpriced delegate therefore flags its parent, `filter(top_level, cost_is_partial)`
counts it, and the caveat renders. That leaves a wording defect in a description
and a comment, which is what this changes — plus the invariant, which nothing was
pinning.

Closes #597.

## What changed

- `backend/app/schemas/agent_run.py:351` — `CostSummary.partial_run_count` says
  what it counts (top-level runs, one per tree), why it is never `0` while a
  figure below it is a floor, and which breakdown it measures versus marks
- `backend/app/schemas/agent_run.py:279` — `CostByAgent.partial_run_count`: "had
  a model with no price" was the run's own model; a delegate's counts too
- `backend/app/api/routes/v1/runs.py:420` — the comment claiming the figure and
  "its breakdown" cannot disagree, which is true of `by_agent` and overclaims for
  the two below it
- `frontend/src/components/runs/spend-tab.tsx:65` — same overclaim on the
  rendering side ("the breakdowns are a floor by exactly that many")
- `docs/governance.md:327` — the same sentence on the page
- `backend/tests/integration/test_delegated_run_spend.py` — two tests, below

No behaviour change: descriptions, comments and tests only.

## Testing

- `tests/integration/test_delegated_run_spend.py::TestTheCostScreen::test_an_unpriced_delegate_is_marked_above_the_splits_it_makes_a_floor`
  — a priced parent with an unpriced delegate: the figure the route sums reads
  `1` above an Anthropic split that is the delegate's own $0.40. This is the
  invariant #597 asked for — no breakdown is a floor without a figure on the
  same page saying so — and it was untested end to end
- `…::test_the_caveat_counts_trees_rather_than_the_rows_the_splits_sum`
  — one parent, two unpriced delegates, figure reads `1`; the delegate's own row
  is counted nowhere. Pins the magnitude the descriptions now state
- The other two links in the chain were already covered and still pass:
  `tests/test_delegation_seams.py` (an unpriced delegation makes the whole
  ledger a floor) and `tests/test_agent_runner.py::test_partial_pricing_is_flagged_on_the_run`
  (the ledger's answer is what `finish_run` is given)
- `make check` — green

## Noticed, not fixed

- The user-facing string is unchanged: `someRunsCouldNotBePriced` reads "N runs
  in this window could not be priced, so the figures below are a floor", which is
  true as written — N *runs* are a floor, and so is everything below. A reader
  could still infer that N rows of By provider are affected. Changing it is copy
  in two locales for no accuracy gain, so it stayed out of this diff.
- `.claude/worktrees/` is not in `.gitignore`, so a worktree in the main checkout
  shows up as untracked files — an easy way to stage something that should never
  be committed. Unrelated to this change; worth a one-line follow-up.


---

## Update after review — `1f84b15f`

The first commit's wording was itself an overclaim. *"It is never `0` while a
figure below it is a floor"* holds against the delegate route and not against
the window: `spend_by_agent` counts partials over `top_level` rows **inside**
the window, while `by_provider` and `by_key` price every row in it through an
unwindowed `_own_cost()` subquery. A parent that started before `since` and
delegated after it contributes its child's own spend to both splits and nothing
to the count. Against Postgres:

```
parent   started_at = since - 2h   cost_is_partial = True
delegate started_at = since + 30m  cost_is_partial = True, anthropic, $0.40

partial_run_count -> 0
by_provider       -> [('anthropic', 0.40, 1)]
```

Which is #597's step 3 reached through the window instead of the ledger — and
`_own_cost()`'s docstring already named the asymmetry, so shipping the absolute
would have left two docstrings in the repository disagreeing about whether the
case exists. Filed as **#620**; every copy of the claim now names it as the
exception.

- `schemas/agent_run.py` — the claim is bounded and names the case
- `repositories/agent_run.py` — `AgentSpendRow.partial_run_count` still carried
  the sentence this branch corrected on `CostByAgent`, and it is the row the
  schema copies the value off. Fourth copy of one drifting fact
- `runs.py`, `spend-tab.tsx` — both comments restated the schema description
  sentence for sentence; cut to what each call site needs plus a pointer to the
  canonical copy
- `docs/governance.md` — the same bound, with the straddling case spelled out
- `test_a_tree_that_straddles_the_start_of_the_window_is_marked_nowhere` —
  asserts `0` deliberately; inverting it is how #620's fix announces itself
- the docstring on `…_is_marked_above_the_splits_it_makes_a_floor` claimed the
  test proved the ledger link. Both its rows are written partial by hand, so it
  now says what it pins and points at `test_delegation_seams.py` for the link

Refs #620.
