### PR TITLE
chore: cut 0.0.102

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.102] - 2026-08-11
+
+The copy guard reads a `.ts` file, and the 381 English strings it had never been
+pointed at are in the catalog.
+
 ### Fixed
 
 - **`check_i18n.py` never read a `.ts` file, so every hook toast was invisible to

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.101"
+version = "0.0.102"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.101"
+version = "0.0.102"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.101",
+  "version": "0.0.102",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release cut for #609, which read a `.ts` file in the i18n offence sweep and migrated the 381 English strings that had been invisible to it since the guard was written. Closes #446.

## What changed

- `backend/pyproject.toml`, `backend/uv.lock`, `frontend/package.json` — 0.0.101 → 0.0.102.
- `CHANGELOG.md` — the `Unreleased` entries move under `## [0.0.102] - 2026-08-11`, with a one-line summary above them. No link reference, matching every cut since 0.0.33.

## Verified

- `uv lock --check` — resolved, no drift from the bumped version.
- `python3 scripts/check_backticks.py`, pre-commit on the staged paths — clean.
- Nothing but the four files a cut touches; the release content itself was verified on #609 (`make check` green, `e2e` green on re-run).

The tag and the GitHub release follow the merge, as with 0.0.101.