### PR TITLE
chore: cut 0.0.103

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.103] - 2026-08-11
+
+The Builder says when the agent people are talking to is not the one on screen,
+and Publish says what it will move before it moves it.
+
 ### Added
 
 - **Publish says what it will move before it moves it.** The confirmation dialog

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.102"
+version = "0.0.103"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.102"
+version = "0.0.103"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.102",
+  "version": "0.0.103",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release cut for #598 — the Builder's unpublished-state badge and the publish confirmation dialog, plus the environments-cache invalidation that ships beside them. Closes #519.

## What changed

- `backend/pyproject.toml`, `backend/uv.lock`, `frontend/package.json` — 0.0.102 → 0.0.103.
- `CHANGELOG.md` — the `Unreleased` entries move under `## [0.0.103] - 2026-08-11` with a one-line summary above them. No link reference, matching every cut since 0.0.33.

## Verified

- `uv lock --check` — resolved, no drift from the bumped version.
- Pre-commit on the staged paths (toml, json, codespell, backticks) — clean.
- Only the four files a cut touches. The release content was verified on #598: `e2e` green on the head SHA, `test-frontend` with its coverage gate, `lint`, and the failing MCP-publishing spec passing for the right reason.

The tag and the GitHub release follow the merge, as with 0.0.102.