### PR TITLE
test(catalog): reach the icon-lookup skip in any directory order

### DIFF
--- a/backend/tests/test_catalog.py
+++ b/backend/tests/test_catalog.py
@@ -60,6 +60,17 @@ class TestCustomIcons:
 
         assert catalog.custom_icon("gamma") == icons_dir / "gamma.svg"
 
+    def test_a_name_matching_no_mark_passes_over_the_ones_present(self, icons_dir: Path):
+        """Whether the test above reaches the skip is the filesystem's decision:
+        `glob` yields `scandir` order, so a directory answering `gamma` first
+        returns on the first iteration and leaves the skip unexecuted - a 99.98%
+        gate on a branch that touched no Python (#625). Asking for a name that
+        matches nothing passes over every candidate in any order."""
+        for stem in ("acme", "beta"):
+            (icons_dir / f"{stem}.svg").write_text("<svg/>")
+
+        assert catalog.custom_icon("ghost") is None
+
     def test_a_missing_icon_resolves_to_none(self, icons_dir: Path):
         assert catalog.custom_icon("ghost") is None
 


### PR DESCRIPTION
## What this fixes

The backend `test` job failed at 99.98% on two branches that touched no Python — #610 (frontend-only) and #623 (a version bump). The missed line was `app/core/catalog/__init__.py:79`, the `continue` in `custom_icon`, reachable only when `glob` happens to yield a non-matching mark first. `Path.glob` order is `scandir` order, which on the runners' ext4 volumes is hash order.

Closes #625

## What changed

`backend/tests/test_catalog.py` — one new test asking for a name that matches no mark in a directory holding two, so every candidate is passed over in any order. The existing order-dependent test stays; "picks the one asked for out of several" is its own claim, it just cannot be what the gate rests on.

## Testing

- `uv run pytest tests/test_catalog.py -q` — 14 passed.
- Measured the new test alone under `coverage run --include=app/core/catalog/*`: line 79 is not in the missing set.
- No product code changed.