### PR TITLE
chore: cut 0.0.106

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,31 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.106] - 2026-08-11
+
+The seam that puts a chart in a Slack reply is covered, so the line holding it
+there can no longer be deleted with a green suite.
+
+### Fixed
+
+- **A chart could stop reaching a channel reply without a single test
+  noticing.** `drawn_chart` was covered on its own and the runner's hand-back of
+  the tool calls a turn made was covered on its own; nothing joined them. Every
+  test of `ChannelAgentRouter.answer` mocks the runner, so the list of calls
+  stays empty and `image_png` is always `None` — which means `tool_calls=called`
+  could be deleted from either call site in `channels/mentions.py` with a green
+  suite and a 100% coverage gate, and a Slack user would be back to reading
+  "here is the chart" under no chart. Both reply paths now run against a stub
+  runner that fills the list the way the real one does, and assert on the PNG
+  rather than on a mock call; the stub takes the tool calls as a *required*
+  keyword, so a router that stops passing them fails loudly. (#515)
+
+Two things the issue behind this asserted did not survive checking, recorded
+here rather than left open: the line it named was already covered by the pull
+request that exposed it, and CI was never green while the local gate was red —
+the same 99.98% failure was red there for seven runs, so this was not a
+`make check` / CI divergence.
+
 ## [0.0.105] - 2026-08-11
 
 `next build` no longer touches the network, so a CDN nobody in this repository

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.105"
+version = "0.0.106"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.105"
+version = "0.0.106"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.105",
+  "version": "0.0.106",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
The chart-in-a-channel-reply seam, covered (#602, closes #515).

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json`; CHANGELOG updated.