### PR TITLE
chore: cut 0.0.112

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.112] - 2026-08-12
+
+The copy guard reads the frontend with a TypeScript parser instead of five
+regexes, and the 137 English strings it can now see are in the catalog.
+
 ### Changed
 
 - **The i18n guard parses instead of grepping, and the copy it found is in the

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.111"
+version = "0.0.112"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.111"
+version = "0.0.112"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.111",
+  "version": "0.0.112",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
The i18n guard as a parser, and the backlog it found (#610, closes #395 and #141).

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json`; the Unreleased entry #610 wrote becomes the 0.0.112 section.