### PR TITLE
test(frontend): share one source-tree walker across the sweeps

### DIFF
--- a/frontend/src/app/fonts/fonts.test.ts
+++ b/frontend/src/app/fonts/fonts.test.ts
@@ -3,6 +3,8 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { sourceFiles } from "@/test-utils/source-files";
+
 /**
  * That `next build` asks nothing of a CDN.
  *
@@ -22,14 +24,6 @@ import { describe, expect, it } from "vitest";
 const SRC = join(__dirname, "..", "..");
 const FONTS = __dirname;
 
-function sourceFiles(dir: string): string[] {
-  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-    const path = join(dir, entry.name);
-    if (entry.isDirectory()) return sourceFiles(path);
-    return /\.tsx?$/.test(entry.name) ? [path] : [];
-  });
-}
-
 /**
  * The import statement, not the name. Both this file and `layout.tsx` say what
  * they are avoiding, and a substring match would read those sentences as the
@@ -39,7 +33,7 @@ const GOOGLE_FONT_IMPORT = /from\s+"next\/font\/google"/;
 
 describe("vendored fonts", () => {
   it("no module imports the Google Fonts helper", () => {
-    const offenders = sourceFiles(SRC).filter((path) =>
+    const offenders = sourceFiles(SRC, (name) => /\.tsx?$/.test(name)).filter((path) =>
       GOOGLE_FONT_IMPORT.test(readFileSync(path, "utf8")),
     );
     expect(offenders).toEqual([]);

--- a/frontend/src/components/states/loading-state.test.tsx
+++ b/frontend/src/components/states/loading-state.test.tsx
@@ -1,8 +1,10 @@
-import { readdirSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
+
+import { sourceFiles } from "@/test-utils/source-files";
 
 import { LoadingState } from "./loading-state";
 
@@ -116,19 +118,10 @@ describe("LoadingState", () => {
  */
 describe("no page asks for a shapeless wait", () => {
   const SRC = join(__dirname, "..", "..");
-
-  function sourceFiles(dir: string): string[] {
-    return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-      const path = join(dir, entry.name);
-      if (entry.isDirectory()) return sourceFiles(path);
-      return /\.tsx?$/.test(entry.name) && !entry.name.includes(".test.") ? [path] : [];
-    });
-  }
+  const sources = sourceFiles(SRC, (name) => /\.tsx?$/.test(name) && !name.includes(".test."));
 
   it("mentions dot-pulse nowhere in src/", () => {
-    const offenders = sourceFiles(SRC).filter((file) =>
-      readFileSync(file, "utf8").includes("dot-pulse"),
-    );
+    const offenders = sources.filter((file) => readFileSync(file, "utf8").includes("dot-pulse"));
 
     expect(offenders).toEqual([]);
   });
@@ -138,7 +131,7 @@ describe("no page asks for a shapeless wait", () => {
     // one - the shape is the caller's decision, so it has to be made. Scoped to
     // files that import the shared component: `files/file-content.tsx` reaches for
     // `Skeleton` directly, sized to the body it is standing in for.
-    const offenders = sourceFiles(SRC).filter((file) => {
+    const offenders = sources.filter((file) => {
       const source = readFileSync(file, "utf8");
       const importsShared =
         /import\s*\{[^}]*\bLoadingState\b[^}]*\}\s*from\s*"@\/components\/states"/.test(source);

--- a/frontend/src/lib/platform-proxy.test.ts
+++ b/frontend/src/lib/platform-proxy.test.ts
@@ -23,6 +23,8 @@ import { join } from "node:path";
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { sourceFiles } from "@/test-utils/source-files";
+
 import { platformProxy } from "./platform-proxy";
 
 const BACKEND = "http://localhost:8000";
@@ -208,14 +210,6 @@ describe("platformProxy", () => {
 const SRC = join(process.cwd(), "src");
 const APP_ROOT = join(SRC, "app", "api");
 
-/** Every file under a directory, recursively. */
-function walk(directory: string): string[] {
-  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
-    const path = join(directory, entry.name);
-    return entry.isDirectory() ? walk(path) : [path];
-  });
-}
-
 /**
  * Backend prefixes whose routes resolve the caller's *active* organization
  * rather than reading one out of the URL.
@@ -257,7 +251,7 @@ describe("every org-scoped request carries the organization", () => {
   // answered for the caller's personal organization no matter what the UI was
   // showing. Fixing the two files would have left the next hand-rolled route to
   // make the same omission, which is why this is a sweep and not a unit test.
-  const routeFiles = walk(APP_ROOT).filter((path) => path.endsWith("route.ts"));
+  const routeFiles = sourceFiles(APP_ROOT, (name) => name.endsWith("route.ts"));
 
   it("finds the route files it is supposed to be checking", () => {
     expect(routeFiles.length).toBeGreaterThan(20);
@@ -335,13 +329,10 @@ function isRouted(path: string): boolean {
  */
 function calledPaths(): Set<string> {
   const paths = new Set<string>();
-  const files = walk(SRC).filter(
-    (path) =>
-      (path.endsWith(".ts") || path.endsWith(".tsx")) &&
-      !path.startsWith(APP_ROOT) &&
-      !path.endsWith(".test.ts") &&
-      !path.endsWith(".test.tsx"),
-  );
+  const files = sourceFiles(
+    SRC,
+    (name) => /\.tsx?$/.test(name) && !name.endsWith(".test.ts") && !name.endsWith(".test.tsx"),
+  ).filter((path) => !path.startsWith(APP_ROOT));
   for (const file of files) {
     // `backendFetch` takes a *backend* path, not a BFF one, and there is no
     // route file behind `/api/v1/...` here by design - those calls run on the

--- a/frontend/src/test-utils/source-files.ts
+++ b/frontend/src/test-utils/source-files.ts
@@ -1,0 +1,20 @@
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Every file under `dir`, recursively, whose basename passes `filter`.
+ *
+ * The one walker behind the repository's source sweeps — the tests that read
+ * every file under `src/` and assert a pattern appears nowhere (or everywhere).
+ * Three of them each hand-rolled this and had already drifted apart before the
+ * third landed, which is how a sweep quietly reads fewer files than its author
+ * thinks (#618). Deliberately outside the coverage `include` list in
+ * `vitest.config.ts`, so a test helper does not drag the 100% gate along.
+ */
+export function sourceFiles(dir: string, filter: (name: string) => boolean): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(path, filter);
+    return filter(entry.name) ? [path] : [];
+  });
+}


### PR DESCRIPTION
## What changed

Three frontend tests each hand-rolled the same recursive source-tree walker — the proxy routing sweep (`src/lib/platform-proxy.test.ts`), the loading-state regression net (`src/components/states/loading-state.test.tsx`) and the vendored-fonts guard (`src/app/fonts/fonts.test.ts`) — and they had already drifted before the third landed (#605 fixed a `statSync`-per-entry variant). The next sweep gets written by copying whichever copy its author opened, which is how a filter difference becomes a sweep that quietly reads fewer files than it claims.

One definition now: `src/test-utils/source-files.ts`, `sourceFiles(dir, filter)` taking the caller's own basename predicate. The three filters are unchanged, passed in at each call site; the proxy sweep's `APP_ROOT` exclusion stays at that call site since it is a path condition, not a name one. `src/test-utils/` sits outside the coverage `include` list in `vitest.config.ts` on purpose, so a test helper does not drag the 100% gate along.

## How verified

- The three suites pass: 35 tests, 3 files.
- A planted offence file (a `next/font/google` import, a `dot-pulse` mention, an `/api/*` path with no route behind it) turns exactly the three sweep tests red — the mutations #618 names as proof — then removed.
- `make lint-frontend` green; `make test-frontend-cov` green at 100% statements/functions/lines, 97.61% branches.

Closes #618