### PR TITLE
fix(i18n): declare <html lang> from the active locale

### DIFF
--- a/frontend/src/app/layout.test.tsx
+++ b/frontend/src/app/layout.test.tsx
@@ -1,0 +1,47 @@
+import { getLocale } from "next-intl/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import RootLayout from "./layout";
+
+vi.mock("next-intl/server", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("next-intl/server")>()),
+  getLocale: vi.fn(),
+}));
+
+vi.mock("next/font/local", () => ({
+  default: () => ({ variable: "", className: "" }),
+}));
+
+vi.mock("./globals.css", () => ({}));
+
+/**
+ * `<html lang>` follows the active locale (#619).
+ *
+ * The root layout is the only layout that renders `<html>`, and it used to
+ * hard-code `lang="en"` - so a screen reader on a Polish page announced Polish
+ * copy with an English voice, and a crawler read the page as English. An async
+ * server component cannot mount under Testing Library, so the layout is called
+ * as the function it is and the returned element inspected.
+ */
+describe("RootLayout", () => {
+  beforeEach(() => {
+    vi.mocked(getLocale).mockReset();
+  });
+
+  it("declares a Polish page as Polish", async () => {
+    vi.mocked(getLocale).mockResolvedValue("pl");
+
+    const element = await RootLayout({ children: null });
+
+    expect(element.type).toBe("html");
+    expect(element.props.lang).toBe("pl");
+  });
+
+  it("declares an English page as English", async () => {
+    vi.mocked(getLocale).mockResolvedValue("en");
+
+    const element = await RootLayout({ children: null });
+
+    expect(element.props.lang).toBe("en");
+  });
+});

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata, Viewport } from "next";
+import { getLocale } from "next-intl/server";
 import localFont from "next/font/local";
 import "./globals.css";
-import { defaultLocale } from "@/i18n";
 import { SITE } from "@/lib/seo";
 
 // Vendored, not `next/font/google`: that helper resolves a family against
@@ -84,14 +84,16 @@ export const viewport: Viewport = {
   ],
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const locale = await getLocale();
+
   return (
     <html
-      lang={defaultLocale}
+      lang={locale}
       suppressHydrationWarning
       className={`${display.variable} ${body.variable} ${mono.variable}`}
     >


### PR DESCRIPTION
## What changed

Every page shipped `<html lang="en">`, Polish ones included — `frontend/src/app/layout.tsx` is the only layout that renders `<html>` and it hard-coded the attribute from `defaultLocale`. A screen reader on `/pl/agents` announced Polish copy with English pronunciation rules, and a crawler read the page as English. More visible since #604: before it the UI mostly reverted to English anyway, so the wrong `lang` usually matched what was on screen.

The root layout is now async and reads `getLocale()` from `next-intl/server`, so `lang` follows the active locale. The request config in `src/i18n.ts` already falls back to `defaultLocale` when no locale is resolvable, so `not-found.tsx` keeps rendering outside the locale segment, and `global-error.tsx` keeps its own `<html lang="en">` — it replaces the root layout entirely and has no request to read.

## How verified

- New `frontend/src/app/layout.test.tsx` asserts the attribute for both locales. It fails against the old layout (`expected 'en' to be 'pl'`) and passes with the fix.
- `make lint-frontend`, `make test-frontend-cov` (100% stmts/lines/funcs, 97.61% branches) and `make build-frontend` all green.

Closes #619
