### PR TITLE
ci(lint): prune the banner guard's walk instead of filtering it

### DIFF
--- a/backend/tests/test_check_comments.py
+++ b/backend/tests/test_check_comments.py
@@ -1,0 +1,97 @@
+"""Where the banner guard walks, which is what #635 was about.
+
+`scripts/check_comments.py` gates every commit through pre-commit and `make lint`,
+and it used to walk with `Path.rglob("*")` and filter afterwards - so `SKIP_DIRS`
+only decided what was *reported*, never where the walk went. On a machine with a
+populated `.claude/worktrees/` (a full checkout each, `node_modules` and `.venv`
+included) that was millions of paths and about seven minutes per commit. The walk
+is `os.walk` with in-place pruning now, the `check_backticks.walk` shape, and
+these tests hold the pruning shut from both sides: skipped names are never
+descended into, and the files of this branch are still read.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = REPO_ROOT / "scripts" / "check_comments.py"
+_spec = importlib.util.spec_from_file_location("check_comments_under_test", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+check_comments = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(check_comments)
+
+# Built rather than written out - a literal banner line in this file would itself
+# be a finding when the guard reads its own tests.
+RULE = "-" * 12
+BANNER_LINE = f"#  {RULE} sending {RULE}\n"
+
+
+def _walked(root: Path) -> set[str]:
+    return {str(path.relative_to(root)) for path in check_comments._iter_files(root)}
+
+
+def test_a_banner_comment_line_is_matched() -> None:
+    """The half that has to keep working, or the walk tests guard a no-op."""
+    assert check_comments.BANNER.match(BANNER_LINE)
+
+
+def test_files_on_this_branch_are_walked(tmp_path: Path) -> None:
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "conf.py").write_text(BANNER_LINE)
+
+    assert "docs/conf.py" in _walked(tmp_path)
+
+
+def test_a_nested_checkout_is_not_walked(tmp_path: Path) -> None:
+    """A worktree's files belong to another branch, wherever the worktree sits.
+
+    `.claude` in `SKIP_DIRS` covers the usual home; this covers a
+    `git worktree add` pointed anywhere else.
+    """
+    worktree = tmp_path / "other-branch"
+    worktree.mkdir()
+    # What `git worktree add` leaves behind: a file, not a directory.
+    (worktree / ".git").write_text("gitdir: /somewhere/.git/worktrees/other-branch\n")
+    (worktree / "module.py").write_text(BANNER_LINE)
+
+    assert not [path for path in _walked(tmp_path) if "other-branch" in path]
+
+
+def test_a_skipped_directory_is_pruned_not_filtered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The defect itself. Filtering after `rglob` yields the same files, so the
+    proof is one level down: descending is a `scandir` per directory, and none
+    may happen under a skipped name (#635)."""
+    dependency = tmp_path / ".claude" / "worktrees" / "wt" / "frontend" / "node_modules" / "dep"
+    dependency.mkdir(parents=True)
+    (dependency / "index.js").write_text("// fine\n")
+    (tmp_path / "module.py").write_text(BANNER_LINE)
+
+    real_scandir = os.scandir
+    scanned: list[str] = []
+
+    def recording_scandir(path: str | os.PathLike[str] = ".") -> object:
+        scanned.append(str(path))
+        return real_scandir(path)
+
+    monkeypatch.setattr(os, "scandir", recording_scandir)
+    walked = _walked(tmp_path)
+
+    assert "module.py" in walked
+    assert not [entry for entry in scanned if ".claude" in Path(entry).parts]
+
+
+def test_a_root_that_itself_lives_under_a_skipped_name_is_walked(tmp_path: Path) -> None:
+    """The guard runs inside worktrees too - this one included. Only the root's
+    subdirectories are judged against `SKIP_DIRS`, never the root's own path."""
+    root = tmp_path / ".claude" / "worktrees" / "this-branch"
+    root.mkdir(parents=True)
+    (root / "module.py").write_text(BANNER_LINE)
+
+    assert "module.py" in _walked(root)

--- a/scripts/check_comments.py
+++ b/scripts/check_comments.py
@@ -25,6 +25,7 @@ Exits 1 when a banner is found, 0 when clean.
 
 from __future__ import annotations
 
+import os
 import re
 from collections.abc import Iterator
 from pathlib import Path
@@ -52,16 +53,30 @@ SKIP_DIRS = {
 BANNER = re.compile(r"^\s*(?:#|//)\s*([-=~*])\1{2,}")
 
 
+def _is_nested_checkout(directory: Path) -> bool:
+    """Another checkout — a worktree holds a `.git` file, a clone a `.git` directory.
+
+    Detected rather than named, for the reasons `check_backticks.is_nested_checkout`
+    spells out: a worktree can be placed anywhere, and a directory merely called
+    `worktrees` is part of this branch.
+    """
+    return (directory / ".git").exists()
+
+
 def _iter_files(root: Path) -> Iterator[Path]:
-    for path in root.rglob("*"):
-        if path.is_dir():
-            continue
-        # Parts relative to the root, so a checkout that itself lives under a
-        # skipped name (a worktree under `.claude/`) is not skipped wholesale.
-        if any(part in SKIP_DIRS for part in path.relative_to(root).parts):
-            continue
-        if path.suffix in SUFFIXES:
-            yield path
+    for directory, subdirectories, filenames in os.walk(root):
+        here = Path(directory)
+        # Pruned in place, which is what `os.walk` reads to decide where to descend -
+        # `rglob` filtered after descending, ~7 minutes on a tree with worktrees (#635).
+        subdirectories[:] = [
+            name
+            for name in subdirectories
+            if name not in SKIP_DIRS and not _is_nested_checkout(here / name)
+        ]
+        for name in sorted(filenames):
+            path = here / name
+            if path.suffix in SUFFIXES:
+                yield path
 
 
 def main() -> int:


### PR DESCRIPTION
## What changed and why

`scripts/check_comments.py` walked the repository with `Path.rglob("*")` and filtered afterwards, so `SKIP_DIRS` only decided what was *reported* — the walk still descended into `.git`, `.venv`, `node_modules` and every checkout under `.claude/worktrees/`. On a machine with 68 worktrees that was ~3.9M paths and about seven minutes per commit, since pre-commit runs the hook with `pass_filenames: false` (#635).

The walk is `os.walk` with in-place pruning now — the shape `check_backticks.walk` already has since #343, nested-checkout detection included, so a worktree placed outside `.claude/` is skipped too while a directory merely named like one is still read. What the guard reports is unchanged; only where the walk goes.

Checked the siblings the issue asked about: `check_routes.py` globs only the bounded routes directory and `docs_drift.py` walks nothing, so neither shares the defect and neither was touched.

## How verified

- `backend/tests/test_check_comments.py` (new): the two walk tests — a nested checkout is not walked, a skipped directory is pruned rather than filtered (asserted at the `scandir` level) — **fail against the old `rglob` walker and pass against this one**; the banner match itself is still asserted, plus the root-under-a-skipped-name case the guard's own worktree runs depend on.
- Timed in a worktree holding only a 747M `backend/.venv` (no populated `.claude/worktrees/` to reproduce the seven minutes against): **4.4s before, 0.36s after**, same zero findings.
- `make lint-backend` green; `python3 scripts/docs_drift.py` reports nothing owed (behaviour a page describes is unchanged).

Closes #635
