### PR TITLE
fix(budgets): count an unpriced tree that straddles the window start

### DIFF
--- a/backend/app/api/routes/v1/runs.py
+++ b/backend/app/api/routes/v1/runs.py
@@ -420,8 +420,8 @@ async def get_spend(
         # How much of everything below is a fact. Summed from the per-agent rows
         # rather than queried again, so this figure and `by_agent` cannot
         # disagree about which runs could not be priced - they count the same
-        # top-level rows. It marks the two breakdowns below without measuring
-        # them; see `CostSummary.partial_run_count`.
+        # rows. It marks the two breakdowns below without measuring them; see
+        # `CostSummary.partial_run_count`.
         partial_run_count=sum(row.partial_run_count for row in agents),
         by_agent=[
             CostByAgent(

--- a/backend/app/repositories/agent_run.py
+++ b/backend/app/repositories/agent_run.py
@@ -559,7 +559,11 @@ class AgentSpendRow:
             tree shares one ledger. The figure is a floor by exactly that many
             runs, and saying "3 of 40 runs could not be priced" is the
             difference between a number a reader can act on and one they have
-            to take on trust.
+            to take on trust. It can exceed `run_count`: an unpriced tree that
+            straddles the start of the window counts here on the agent its
+            delegate ran as, whose top-level runs the delegation is not among,
+            because the parent's row is outside the window and nothing else
+            can carry the mark (#620).
         month_to_date_usd: This agent's **own** month, delegated rows included -
             because that is the spend its cap is a cap on, and a delegate's rows
             are the only record of what it itself did. It does not sum to the
@@ -607,11 +611,28 @@ async def spend_by_agent(
     their own spend and no one else's, and the narrowing is a `WHERE` here rather
     than a filter applied after the sums - so both windows and the counts describe
     the same person's rows.
+
+    The unpriced count reaches one set of rows the top-level filter cannot: an
+    unpriced delegation whose parent started before the window. The delegate's
+    own spend is inside `spend_by_provider` and `spend_by_key` - their per-row
+    sums are deliberately not windowed backwards (:func:`_own_cost`) - so those
+    splits are a floor, and the tree's own mark sits on a parent row outside
+    every aggregate here. Counted by distinct parent, the same trees-not-rows
+    rule the top-level count follows, and gated on the parent being outside the
+    window so a tree wholly inside it is never counted twice (#620).
     """
     window = [AgentRun.started_at >= since]
     if until is not None:
         window.append(AgentRun.started_at <= until)
     top_level = and_(*window, AgentRun.parent_run_id.is_(None))
+    parent = aliased(AgentRun)
+    straddling = and_(
+        *window,
+        AgentRun.cost_is_partial,
+        select(parent.id)
+        .where(parent.id == AgentRun.parent_run_id, parent.started_at < since)
+        .exists(),
+    )
     cap = AgentVersion.spec["budget"]["monthly_usd"]
     rows = await db.execute(
         select(
@@ -619,7 +640,8 @@ async def spend_by_agent(
             Agent.name,
             func.coalesce(func.sum(AgentRun.cost_usd).filter(top_level), 0),
             func.count(AgentRun.id).filter(top_level),
-            func.count(AgentRun.id).filter(top_level, AgentRun.cost_is_partial),
+            func.count(AgentRun.id).filter(top_level, AgentRun.cost_is_partial)
+            + func.count(AgentRun.parent_run_id.distinct()).filter(straddling),
             func.coalesce(
                 func.sum(AgentRun.cost_usd).filter(AgentRun.started_at >= month_since), 0
             ),

--- a/backend/app/schemas/agent_run.py
+++ b/backend/app/schemas/agent_run.py
@@ -283,7 +283,11 @@ class CostByAgent(BaseSchema):
             "the run had no price, its delegates' included, because a tree "
             "shares one ledger. The cost is a floor by exactly that many runs, "
             "and '3 of 40 runs could not be priced' is the difference between a "
-            "figure a reader can act on and one they have to take on trust"
+            "figure a reader can act on and one they have to take on trust. It "
+            "can exceed `run_count`: an unpriced tree that straddles the start "
+            "of the window counts on the agent its delegate ran as, whose "
+            "top-level runs the delegation is not among, because the parent's "
+            "row is outside the window (agenticos#620)"
         ),
     )
     month_to_date_usd: Decimal | None = Field(
@@ -358,11 +362,12 @@ class CostSummary(BaseSchema):
             "floor under `by_provider` or `by_key` is marked here even though "
             "neither is measured here. It counts *trees* rather than the rows "
             "those two sum, so one parent with three unpriced delegates reads "
-            "1, and it measures `by_agent`, which counts the same top-level "
-            "rows. A tree that straddles the start of the window is the one "
-            "case it misses: the delegate's row is inside the window and its "
-            "parent's is not, so the splits are a floor and this reads 0 "
-            "(agenticos#620)"
+            "1, and it measures `by_agent`, which counts the same rows. A tree "
+            "that straddles the start of the window - the delegate's row inside "
+            "it, its parent's before it - is counted through the delegate's "
+            "agent, once per straddling tree, because the parent row that would "
+            "otherwise carry the mark is outside every window here while the "
+            "delegate's own spend is inside both splits (agenticos#620)"
         ),
     )
     by_agent: list[CostByAgent]

--- a/backend/tests/integration/test_delegated_run_spend.py
+++ b/backend/tests/integration/test_delegated_run_spend.py
@@ -541,19 +541,18 @@ class TestTheCostScreen:
             "0.40"
         )
 
-    async def test_a_tree_that_straddles_the_start_of_the_window_is_marked_nowhere(self, db):
-        """The one floor this page still shows with no figure over it saying so.
+    async def test_a_tree_that_straddles_the_start_of_the_window_is_still_marked(self, db):
+        """No breakdown is a floor without a figure on the same page saying so,
+        and a window boundary inside the tree does not suspend that.
 
-        The caveat counts top-level runs *in the window*; the two splits price
-        every row in it through a subquery that is deliberately not windowed
-        (:func:`_own_cost`). A parent that started before the window and delegated
-        inside it therefore puts its delegate's own spend under a vendor and a key
-        and puts nothing at all under the count above them.
-
-        Pinned rather than fixed, and asserted as `0` on purpose: the shared ledger
-        closes the other route to a false zero, this one is a `WHERE` that no
-        longer matches the rows underneath it (agenticos#620). Inverting the first
-        assertion is how the fix will announce itself.
+        The caveat's top-level count carries the window, so a parent that started
+        before the window and delegated inside it used to put its delegate's own
+        spend under a vendor and a key - the two splits price every row in the
+        window through a subquery that is deliberately not windowed
+        (:func:`_own_cost`) - and nothing at all under the count above them
+        (agenticos#620). The count now reaches the delegate's row: it carries the
+        mark on the agent it ran as, because the parent row that would otherwise
+        carry it is outside every aggregate on the page.
         """
         org = await _org(db)
         orchestrator = await _agent(db, org, slug="orchestrator")
@@ -583,12 +582,83 @@ class TestTheCostScreen:
         by_agent = await service.spend_by_agent(ctx, since=since)
         by_provider = await service.spend_by_provider(ctx, since=since)
 
-        assert sum(row.partial_run_count for row in by_agent) == 0
-        # The floor nothing on the page announces: the delegate's own spend, at
-        # the vendor it was spent with, from a row written `cost_is_partial`.
+        assert sum(row.partial_run_count for row in by_agent) == 1
+        # On the agent the delegate ran as - the only row of the tree the window
+        # can see - not on the orchestrator, whose run is outside the window.
+        counts = {row.agent_name: row.partial_run_count for row in by_agent}
+        assert counts["Researcher"] == 1
+        # The floor that count announces: the delegate's own spend, at the vendor
+        # it was spent with, from a row written `cost_is_partial`.
         assert {provider: cost for provider, cost, _runs in by_provider}["anthropic"] == Decimal(
             "0.40"
         )
+
+    async def test_a_straddling_tree_counts_once_however_many_delegations_crossed(self, db):
+        """The trees-not-rows rule holds across the window's edge: one parent
+        outside it, two unpriced delegations inside it, and the figure reads 1 -
+        distinct parents, not delegated rows."""
+        org = await _org(db)
+        orchestrator = await _agent(db, org, slug="orchestrator")
+        researcher = await _agent(db, org, slug="researcher")
+        version = await _version(db, researcher)
+        since = datetime.now(UTC) - timedelta(hours=1)
+        parent = await _run(
+            db,
+            org=org,
+            agent=orchestrator,
+            cost=Decimal("1.00"),
+            partial=True,
+            started_at=since - timedelta(hours=2),
+        )
+        for cost, task_id in ((Decimal("0.40"), "4f2a1b8c"), (Decimal("0.30"), "9c1d2e3f")):
+            await _delegated(
+                db,
+                org=org,
+                agent=researcher,
+                version=version,
+                parent=parent,
+                cost=cost,
+                task_id=task_id,
+                partial=True,
+                started_at=since + timedelta(minutes=30),
+            )
+        ctx = AuthContext(user_id=None, organization_id=org.id, role=OrgRoleName.OWNER)
+
+        by_agent = await AgentRunnerService(db).spend_by_agent(ctx, since=since)
+
+        assert sum(row.partial_run_count for row in by_agent) == 1
+
+    async def test_a_priced_delegation_across_the_edge_raises_no_caveat(self, db):
+        """The parent's unpriced spend is outside the window, and the delegate's
+        own spend - the only money of the tree the splits sum - is fully priced.
+        The window's figures are exact, so a caveat here would mark a floor that
+        is not one."""
+        org = await _org(db)
+        orchestrator = await _agent(db, org, slug="orchestrator")
+        researcher = await _agent(db, org, slug="researcher")
+        since = datetime.now(UTC) - timedelta(hours=1)
+        parent = await _run(
+            db,
+            org=org,
+            agent=orchestrator,
+            cost=Decimal("1.00"),
+            partial=True,
+            started_at=since - timedelta(hours=2),
+        )
+        await _delegated(
+            db,
+            org=org,
+            agent=researcher,
+            version=await _version(db, researcher),
+            parent=parent,
+            cost=Decimal("0.40"),
+            started_at=since + timedelta(minutes=30),
+        )
+        ctx = AuthContext(user_id=None, organization_id=org.id, role=OrgRoleName.OWNER)
+
+        by_agent = await AgentRunnerService(db).spend_by_agent(ctx, since=since)
+
+        assert sum(row.partial_run_count for row in by_agent) == 0
 
     async def test_the_caveat_counts_trees_rather_than_the_rows_the_splits_sum(self, db):
         """One parent, two unpriced delegates, and the figure reads 1.

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -338,12 +338,14 @@ in either of them is marked by a count that never looked at the row causing it. 
 other two — it counts trees, so one parent with three unpriced delegates reads `1`
 while three figures below it are a floor.
 
-A tree that **straddles the start of the window** is the one case the marker misses:
-the delegate's row is inside the window and its parent's row is not, so By provider
-and By key are a floor and the count above them reads `0`. Rare — it needs a
-delegation that outlives the window's edge — and it is the only remaining way this
-page shows a floor with nothing over it saying so
-([#620](https://github.com/vstorm-co/agenticos/issues/620)).
+A tree that **straddles the start of the window** — the delegate's row inside it,
+its parent's row before it — is counted through the delegate: the parent row that
+would otherwise carry the mark is outside every aggregate on the page, while the
+delegate's own spend is inside both splits. It lands on the agent the delegate ran
+as, once per straddling tree however many delegations crossed the edge, and only
+when the delegate's own requests went unpriced — a priced delegation under an
+unpriced out-of-window parent raises no caveat, because the window's own money is
+exact ([#620](https://github.com/vstorm-co/agenticos/issues/620)).
 
 A row is **one per agent**, with `agent_name` on it. It used to be one per agent
 *and model*, carrying only `model_label` — so the tab listed model names where a

--- a/frontend/src/components/runs/spend-tab.tsx
+++ b/frontend/src/components/runs/spend-tab.tsx
@@ -63,7 +63,7 @@ export function SpendTab() {
   return (
     <div className="space-y-4">
       {/* The one caveat that governs every figure below: how many of the
-          window's top-level runs could not be fully priced. Saying it once at
+          window's run trees could not be fully priced. Saying it once at
           the top is what stops a reader treating the totals as exact. It marks
           By provider and By key without measuring them, and measures By agent -
           see `CostSummary.partial_run_count` for which is which. */}


### PR DESCRIPTION
## What changed and why

`GET /api/v1/runs/spend` printed one "could not be priced" caveat above three breakdowns, and the count read `0` when the only unpriced row in the window belonged to a tree that started before the window did. The caveat's aggregate carried the window on **top-level** rows, while By provider and By key price every row in the window through a subquery that is deliberately not windowed (`_own_cost`) — so a parent that started before the window and delegated inside it put its delegate's own spend under a vendor and a key with nothing on the page saying the figures were a floor (#620).

The fix is the `WHERE` the issue asked for: `spend_by_agent` adds a second filtered aggregate over unpriced delegated rows in the window whose parent started before it, counted by **distinct parent** so one straddling tree reads `1` however many delegations crossed the edge — the same trees-not-rows rule the top-level count already follows. The mark lands on the agent the delegate ran as, the only row of the tree any aggregate on the page can see, so per-agent `partial_run_count` can now exceed `run_count`; the schema descriptions and `docs/governance.md` say so plainly instead of naming the case as a blind spot. The parent-outside-the-window gate keeps a tree wholly inside the window counted once, on its top-level row, exactly as before.

Deliberately **not** a caveat: a priced delegation under an unpriced out-of-window parent. The parent's unpriced spend is outside the window and the delegate's own spend — the only money of the tree the splits sum — is exact.

## How it was verified

- `tests/integration/test_delegated_run_spend.py` against Postgres: the pinned test is inverted (asserts `1`, and asserts the mark sits on the delegate's agent, plus the `$0.40` floor it announces); without the fix it fails `0 == 1` (checked by stashing the repository change). Two new tests cover the trees-not-rows rule across the edge and the no-false-caveat refusal.
- The pre-existing `test_an_unpriced_delegate_is_marked_above_the_splits_it_makes_a_floor` and `test_the_caveat_counts_trees_rather_than_the_rows_the_splits_sum` still pass, which is what pins the no-double-count property for in-window trees.
- `make lint-backend` green; `make test` green — 4377 passed, platform-layer coverage gate holds at 100%.
- `python3 scripts/docs_drift.py` satisfied: `docs/governance.md` moved with the behaviour.

The frontend change is one comment line in `spend-tab.tsx` that described the caveat as counting "top-level runs"; no behaviour or copy changed there.

Closes #620
