### PR TITLE
fix(i18n): format timeAgo's date fallback in the active locale

### DIFF
--- a/frontend/src/app/[locale]/(dashboard)/admin/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/admin/page.tsx
@@ -23,7 +23,7 @@ import { apiClient } from "@/lib/api-client";
 import { ROUTES } from "@/lib/constants";
 import { qk } from "@/lib/query-keys";
 import { formatDate, timeAgo } from "@/lib/utils";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 import type { AdminOrganization, AdminStats } from "@/types/admin";
 
@@ -44,6 +44,7 @@ const EVENT_ICON: Record<RecentEvent["type"], LucideIcon> = {
 export default function AdminOverviewPage() {
   const t = useTranslations("pages.admin");
   const tTime = useTranslations("time");
+  const locale = useLocale();
   const statsQuery = useQuery({
     queryKey: ["admin", "stats"],
     queryFn: async (): Promise<AdminStats> => {
@@ -257,7 +258,7 @@ export default function AdminOverviewPage() {
                     <p className="text-muted-foreground truncate text-xs">
                       {e.description}
                       {e.description && " · "}
-                      {timeAgo(e.timestamp, tTime)}
+                      {timeAgo(e.timestamp, tTime, locale)}
                     </p>
                   </div>
                 </li>

--- a/frontend/src/app/[locale]/(dashboard)/dashboard/dashboard.integration.test.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/dashboard/dashboard.integration.test.tsx
@@ -27,6 +27,7 @@ vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
 // Full-key echo, so "dashboard.errors.title" is assertable and unambiguous.
 vi.mock("next-intl", () => ({
+  useLocale: () => "en",
   useTranslations: (namespace?: string) => (key: string) =>
     namespace ? `${namespace}.${key}` : key,
 }));

--- a/frontend/src/components/dashboard/active-sessions.tsx
+++ b/frontend/src/components/dashboard/active-sessions.tsx
@@ -22,7 +22,7 @@ import { apiClient, ApiError } from "@/lib/api-client";
 import { qk } from "@/lib/query-keys";
 import { cn, getErrorMessage, timeAgo } from "@/lib/utils";
 import type { SessionListResponse } from "@/types";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 const PAGE_SIZE = 5;
 
@@ -48,6 +48,7 @@ export function ActiveSessions() {
   const t = useTranslations("dashboard");
   const tc = useTranslations("common");
   const tTime = useTranslations("time");
+  const locale = useLocale();
   const [page, setPage] = useState(0);
   const queryClient = useQueryClient();
 
@@ -180,7 +181,7 @@ export function ActiveSessions() {
                     </p>
                     <p className="text-muted-foreground truncate text-xs">
                       {session.ip_address && `${session.ip_address} · `}
-                      {t("lastActive", { when: timeAgo(session.last_used_at, tTime) })}
+                      {t("lastActive", { when: timeAgo(session.last_used_at, tTime, locale) })}
                     </p>
                   </div>
                 </div>

--- a/frontend/src/components/dashboard/widgets/approvals.tsx
+++ b/frontend/src/components/dashboard/widgets/approvals.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 import { useApprovals } from "@/hooks";
 import { ROUTES } from "@/lib/constants";
@@ -20,6 +20,7 @@ import type { DashboardWidgetProps } from "./types";
 export function ApprovalsWidget({ title, seeAll }: DashboardWidgetProps) {
   const t = useTranslations("dashboard.widgets.approvals");
   const tTime = useTranslations("time");
+  const locale = useLocale();
   const { approvals, total, isLoading, error, refetch } = useApprovals();
 
   return (
@@ -41,7 +42,7 @@ export function ApprovalsWidget({ title, seeAll }: DashboardWidgetProps) {
                   </span>
                   {approval.created_at ? (
                     <span className="text-muted-foreground block text-xs">
-                      {t("waiting", { ago: timeAgo(approval.created_at, tTime) })}
+                      {t("waiting", { ago: timeAgo(approval.created_at, tTime, locale) })}
                     </span>
                   ) : null}
                 </span>

--- a/frontend/src/components/dashboard/widgets/conversations.tsx
+++ b/frontend/src/components/dashboard/widgets/conversations.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 import { useRecentConversations } from "@/hooks";
 import { ROUTES } from "@/lib/constants";
@@ -14,6 +14,7 @@ import type { DashboardWidgetProps } from "./types";
 export function ConversationsWidget({ title, seeAll }: DashboardWidgetProps) {
   const t = useTranslations("dashboard.widgets.conversations");
   const tTime = useTranslations("time");
+  const locale = useLocale();
   const { conversations, isLoading, error, refetch } = useRecentConversations(4);
 
   return (
@@ -33,7 +34,7 @@ export function ConversationsWidget({ title, seeAll }: DashboardWidgetProps) {
                   {conversation.title ?? t("untitled")}
                 </span>
                 <span className="text-muted-foreground block text-xs">
-                  {timeAgo(conversation.updated_at, tTime)}
+                  {timeAgo(conversation.updated_at, tTime, locale)}
                 </span>
               </span>
               <Link

--- a/frontend/src/components/dashboard/widgets/knowledge-freshness.tsx
+++ b/frontend/src/components/dashboard/widgets/knowledge-freshness.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 import { useSyncSources } from "@/hooks";
 import { timeAgo } from "@/lib/utils";
@@ -13,6 +13,7 @@ import type { DashboardWidgetProps } from "./types";
 export function KnowledgeFreshnessWidget({ title, seeAll }: DashboardWidgetProps) {
   const t = useTranslations("dashboard.widgets.knowledge-freshness");
   const tTime = useTranslations("time");
+  const locale = useLocale();
   const { sources, isLoading, error, refetch } = useSyncSources();
 
   return (
@@ -32,7 +33,7 @@ export function KnowledgeFreshnessWidget({ title, seeAll }: DashboardWidgetProps
               sub: failing
                 ? (source.last_error ?? undefined)
                 : source.last_sync_at
-                  ? t("synced", { ago: timeAgo(source.last_sync_at, tTime) })
+                  ? t("synced", { ago: timeAgo(source.last_sync_at, tTime, locale) })
                   : t("neverSynced"),
               pill: failing ? t("failing") : t("fresh"),
               tone: failing ? ("err" as const) : ("ok" as const),

--- a/frontend/src/components/dashboard/widgets/mcp-health.tsx
+++ b/frontend/src/components/dashboard/widgets/mcp-health.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 import { useOrgMcpConnections } from "@/hooks";
 import { timeAgo } from "@/lib/utils";
@@ -17,6 +17,7 @@ import type { DashboardWidgetProps } from "./types";
 export function McpHealthWidget({ title, seeAll }: DashboardWidgetProps) {
   const t = useTranslations("dashboard.widgets.mcp-health");
   const tTime = useTranslations("time");
+  const locale = useLocale();
   const { connections, isLoading, error, refresh } = useOrgMcpConnections();
 
   return (
@@ -39,10 +40,10 @@ export function McpHealthWidget({ title, seeAll }: DashboardWidgetProps) {
               pill:
                 connection.last_status === "error"
                   ? connection.last_checked_at
-                    ? t("downSince", { ago: timeAgo(connection.last_checked_at, tTime) })
+                    ? t("downSince", { ago: timeAgo(connection.last_checked_at, tTime, locale) })
                     : t("down")
                   : connection.last_checked_at
-                    ? t("checked", { ago: timeAgo(connection.last_checked_at, tTime) })
+                    ? t("checked", { ago: timeAgo(connection.last_checked_at, tTime, locale) })
                     : t("unchecked"),
               tone:
                 connection.last_status === "error"

--- a/frontend/src/components/dashboard/widgets/recent-failures.tsx
+++ b/frontend/src/components/dashboard/widgets/recent-failures.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 import { useAgents, useRecentFailures } from "@/hooks";
 import { ROUTES } from "@/lib/constants";
@@ -18,6 +18,7 @@ import type { DashboardWidgetProps } from "./types";
 export function RecentFailuresWidget({ title, seeAll }: DashboardWidgetProps) {
   const t = useTranslations("dashboard.widgets.recent-failures");
   const tTime = useTranslations("time");
+  const locale = useLocale();
   const { failures, isLoading, error, refetch } = useRecentFailures(5);
   const { agents } = useAgents();
   const names = new Map(agents.map((agent) => [agent.id, agent.name]));
@@ -42,7 +43,7 @@ export function RecentFailuresWidget({ title, seeAll }: DashboardWidgetProps) {
                   {run.status === "budget_exceeded"
                     ? t("budgetExceeded")
                     : (run.error ?? t("failed"))}
-                  {run.started_at ? ` · ${timeAgo(run.started_at, tTime)}` : ""}
+                  {run.started_at ? ` · ${timeAgo(run.started_at, tTime, locale)}` : ""}
                 </span>
               </span>
               <Link

--- a/frontend/src/components/dashboard/widgets/top-people.tsx
+++ b/frontend/src/components/dashboard/widgets/top-people.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 import { usePeopleUsage, useUsageStats } from "@/hooks";
 import { timeAgo } from "@/lib/utils";
@@ -25,6 +25,7 @@ const ROWS = 6;
 export function TopPeopleWidget({ title, period, seeAll }: DashboardWidgetProps) {
   const t = useTranslations("dashboard.widgets.top-people");
   const tTime = useTranslations("time");
+  const locale = useLocale();
   const { byUser, isLoading, error, refetch } = usePeopleUsage(
     { from: period.from, to: period.to },
     { limit: ROWS },
@@ -68,7 +69,7 @@ export function TopPeopleWidget({ title, period, seeAll }: DashboardWidgetProps)
                       {formatUsd(Number(person.cost_usd))}
                     </td>
                     <td className="text-muted-foreground py-1.5 text-right">
-                      {timeAgo(person.last_run_at, tTime)}
+                      {timeAgo(person.last_run_at, tTime, locale)}
                     </td>
                   </tr>
                 ))}

--- a/frontend/src/components/files/file-viewer.tsx
+++ b/frontend/src/components/files/file-viewer.tsx
@@ -2,7 +2,7 @@
 
 import { useState, type ReactNode } from "react";
 import { Download } from "lucide-react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 import type { Translate } from "@/lib/agent-step-captions";
 
@@ -84,6 +84,7 @@ interface FileViewerProps {
 export function FileViewer({ file, access, extraTabs = [], onClose }: FileViewerProps) {
   const t = useTranslations("files");
   const tTime = useTranslations("time");
+  const locale = useLocale();
   const kind = resolveFileKind(file.name, file.mimeType);
   const { download, error } = useFileActions(access);
   const [view, setView] = useState("preview");
@@ -142,7 +143,7 @@ export function FileViewer({ file, access, extraTabs = [], onClose }: FileViewer
                 copy in the header plus a copy beside the tabs is one sentence a
                 screen reader reads twice. */}
             <DialogDescription className="truncate text-xs">
-              {describe(file, kind, t, tTime)}
+              {describe(file, kind, t, tTime, locale)}
             </DialogDescription>
           </div>
           {/* Download alone. "Open in new tab" sat beside it doing very nearly the
@@ -200,12 +201,13 @@ function describe(
   kind: FileKind,
   t: (key: string, values?: Record<string, string>) => string,
   tTime: Translate,
+  locale: string,
 ): string {
   const suffix = suffixOf(file.name);
   const parts = [suffix === "" ? t(`kinds.${kind}`) : suffix.toUpperCase()];
   if (file.size != null) parts.push(formatBytes(file.size));
   if (file.modifiedAt != null) {
-    const when = timeAgo(file.modifiedAt, tTime);
+    const when = timeAgo(file.modifiedAt, tTime, locale);
     if (when !== "") parts.push(t("modified", { when }));
   }
   return parts.join(" · ");

--- a/frontend/src/components/rag/sync-source-logs.tsx
+++ b/frontend/src/components/rag/sync-source-logs.tsx
@@ -6,7 +6,7 @@ import { Spinner } from "@/components/ui";
 import type { RAGSyncLog, RAGSyncLogList } from "@/lib/rag-api";
 import { apiClient } from "@/lib/api-client";
 import { cn, timeAgo } from "@/lib/utils";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 interface SyncSourceLogsProps {
   /** API path relative to /api, e.g. /kb/xxx/sync-sources/yyy/logs */
@@ -36,6 +36,7 @@ function duration(log: RAGSyncLog): string {
 function LogRow({ log }: { log: RAGSyncLog }) {
   const t = useTranslations("rag");
   const tTime = useTranslations("time");
+  const locale = useLocale();
   return (
     <div className="border-foreground/8 flex items-start gap-3 border-b py-2.5 last:border-0">
       <div className="mt-0.5 shrink-0">{statusIcon(log.status)}</div>
@@ -46,7 +47,9 @@ function LogRow({ log }: { log: RAGSyncLog }) {
             {log.mode}
           </span>
           {log.started_at && (
-            <span className="text-foreground/45 text-[10px]">{timeAgo(log.started_at, tTime)}</span>
+            <span className="text-foreground/45 text-[10px]">
+              {timeAgo(log.started_at, tTime, locale)}
+            </span>
           )}
           <span className="text-foreground/45 text-[10px]">{duration(log)}</span>
         </div>

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -163,9 +163,9 @@ describe("timeAgo", () => {
   // The real messages, so a broken ICU plural fails here rather than on screen.
   const t = createTranslator({ locale: "en", messages: en, namespace: "time" }) as Translate;
 
-  function at(iso: string): string {
+  function at(iso: string, locale = "en"): string {
     vi.useFakeTimers({ now: NOW });
-    return timeAgo(iso, t);
+    return timeAgo(iso, t, locale);
   }
 
   it("reads the last minute as just now", () => {
@@ -181,6 +181,12 @@ describe("timeAgo", () => {
   it("falls back to a date once a week has passed", () => {
     // "9d ago" tells nobody anything they could act on.
     expect(at("2026-07-01T12:00:00Z")).toBe("Jul 1");
+  });
+
+  it("formats the fallback date in the active locale, not en-US", () => {
+    // Month name and day-month order come from the runtime, so the locale has
+    // to reach the formatter - under `pl` this read "Jul 1" before #621.
+    expect(at("2026-07-01T12:00:00Z", "pl")).toBe("1 lip");
   });
 
   it("says nothing for a date it cannot read or one in the future", () => {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -79,10 +79,11 @@ export function formatBytes(bytes: number): string {
  * keeps the order nor spells the unit the same way. Each unit is an ICU `plural` so a
  * locale that declines its nouns has somewhere to say so.
  *
- * The date it falls back to past a week is still formatted `en-US` - that needs the
- * active locale rather than a translator, and it is #621.
+ * Past a week it falls back to a date, which a translator cannot format - month
+ * names and day-month order come from the runtime - so it also takes the active
+ * locale, from the caller's `useLocale()`.
  */
-export function timeAgo(dateStr: string, t: Translate): string {
+export function timeAgo(dateStr: string, t: Translate, locale: string): string {
   const then = new Date(dateStr).getTime();
   if (Number.isNaN(then)) return "";
   const diff = Math.round((Date.now() - then) / 1000);
@@ -91,7 +92,7 @@ export function timeAgo(dateStr: string, t: Translate): string {
   if (diff < 3600) return t("minutesAgo", { count: Math.floor(diff / 60) });
   if (diff < 86400) return t("hoursAgo", { count: Math.floor(diff / 3600) });
   if (diff < 86400 * 7) return t("daysAgo", { count: Math.floor(diff / 86400) });
-  return new Date(dateStr).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  return new Date(dateStr).toLocaleDateString(locale, { month: "short", day: "numeric" });
 }
 
 export function formatCurrency(


### PR DESCRIPTION
Past the seven-day cutoff `timeAgo` stopped translating and formatted the
date with a hardcoded `"en-US"`, so a nine-day-old run read `Jul 1` — English
month abbreviation, US day-month order — in every locale, at all eleven call
sites (the dashboard widgets, the sessions panel, the sync logs, the file
viewer, the admin event list). The recent-past branches were already localized
through the caller's translator, which made the fallback the one line on the
screen no locale could reach.

A translator cannot fix it — month names and day-month order come from the
runtime — so of the two shapes #621 named, this takes the first: `timeAgo`
takes the active locale as a third argument and every call site passes
`useLocale()`. That keeps the function pure and assertable in
`src/lib/utils.test.ts`, which is where the issue's done-when points; the
`useFormatter` refactor would have moved the assertion into eleven component
tests instead. `FileViewer`'s module-level `describe` helper takes the locale
as a parameter for the same reason `timeAgo` does. The dashboard integration
test's own `next-intl` mock (which shadows the global one) grew the
`useLocale` stub the global mock already had.

**Verified:**

- New assertion in `src/lib/utils.test.ts`: the fallback renders `Jul 1`
  under `en` and `1 lip` under `pl`. Fails with `"en-US"` restored (checked
  by reverting the line and running the file: 1 failed / 39 passed).
- Full frontend suite: 3953 passed. Coverage gate: 100% statements /
  lines / functions, 97.61% branches.
- `make lint-frontend`: eslint, prettier, tsc and the i18n guard all green.

**Left deliberately:** `formatDate`, `formatDateTime` and `formatCurrency` in
the same file still hold `"en-US"` — the issue's "no locale tag left in
`utils.ts`" is met for the `timeAgo` path this issue is about, and the
remaining three are the same defect across ~21 call sites of their own, filed
as #649 rather than folded in here. `formatCurrency` additionally has no
caller outside its own test, noted there.

Closes #621
