### PR TITLE
fix(chat): keep a parked run saying it waits after a reload

### DIFF
--- a/backend/app/api/routes/v1/runs.py
+++ b/backend/app/api/routes/v1/runs.py
@@ -21,7 +21,7 @@ from app.db.models.agent_run import (
     RunSurface,
 )
 from app.repositories.agent_run import ApprovalFilters, RunFilters
-from app.schemas.agent import AgentRunResult, RunStep, SettledCall
+from app.schemas.agent import AgentRunResult, ParkedCall, RunStep, SettledCall
 from app.schemas.agent_run import (
     AgentRunList,
     AgentRunRead,
@@ -241,6 +241,29 @@ async def get_run_transcript(
         ],
         total=total,
     )
+
+
+@router.get(
+    "/runs/{run_id}/parked",
+    response_model=list[ParkedCall],
+    dependencies=[Depends(require(Perm.APPROVALS_DECIDE))],
+)
+async def get_parked_calls(run_id: UUID, service: AgentRunnerSvc, ctx: Auth) -> Any:
+    """What this run is waiting on a decision for, right now.
+
+    The same rows `POST /runs/{run_id}/resume` returns in `parked`, readable
+    without resuming anything. A live surface is handed them as a
+    `tool_approval_required` frame the moment the run parks, but that frame
+    exists only for whoever was watching: reloading the conversation lost the
+    panel, and the only way to finish the run was the approvals queue on another
+    page (#601). Empty for a run that is not parked - including one whose calls
+    were all decided and which is now waiting to be resumed.
+
+    Gated on `approvals:decide` like the resume and the queue, because the rows
+    are offered here to be decided.
+    """
+    run = await service.get_run(ctx, run_id)
+    return await service.parked_calls(ctx, run)
 
 
 @router.post(

--- a/backend/app/db/models/conversation.py
+++ b/backend/app/db/models/conversation.py
@@ -182,7 +182,9 @@ class ToolCall(Base):
         tool_name: Name of the tool that was called
         args: JSON arguments passed to the tool
         result: Result returned by the tool
-        status: Current status (pending, running, completed, failed)
+        status: Current status (pending, running, completed, failed,
+            awaiting_approval - the run parked on this call and a person has
+            not decided yet)
         started_at: When the tool call started
         completed_at: When the tool call completed
         duration_ms: Execution time in milliseconds

--- a/backend/app/repositories/conversation.py
+++ b/backend/app/repositories/conversation.py
@@ -611,15 +611,23 @@ async def create_tool_call(
     tool_name: str,
     args: dict[str, Any],
     started_at: datetime,
+    status: str = "running",
 ) -> ToolCall:
-    """Create a new tool call record."""
+    """Create a new tool call record.
+
+    `status` is `awaiting_approval` for a call the run parked on: the parked
+    state otherwise lives only on `agent_runs` and the `approvals` rows, so a
+    reloaded conversation read the one call somebody has to decide about as a
+    step that ran (#601). `complete_tool_call` closes the row whichever way the
+    call ends - a resume, a rejection replayed, or an expiry.
+    """
     tool_call = ToolCall(
         message_id=message_id,
         tool_call_id=tool_call_id,
         tool_name=tool_name,
         args=args,
         started_at=started_at,
-        status="running",
+        status=status,
     )
     db.add(tool_call)
     await db.flush()

--- a/backend/app/schemas/conversation.py
+++ b/backend/app/schemas/conversation.py
@@ -84,7 +84,7 @@ class ToolCallRead(ToolCallBase):
     id: UUID
     message_id: UUID
     result: str | None = None
-    status: Literal["pending", "running", "completed", "failed"] = "pending"
+    status: Literal["pending", "running", "completed", "failed", "awaiting_approval"] = "pending"
     started_at: datetime
     completed_at: datetime | None = None
     duration_ms: int | None = None

--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -11,6 +11,7 @@ Framework-specific concerns (multimodal input, streaming events) stay in the rou
 
 import json
 import logging
+from collections.abc import Collection
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
@@ -286,6 +287,7 @@ async def persist_assistant_turn(
     agent_version_id: UUID | None = None,
     usage: UsageReport | None = None,
     run_id: UUID | None = None,
+    parked_tool_call_ids: Collection[str] = (),
 ) -> str | None:
     """Persist the assistant message and any tool calls. Returns the saved message id.
 
@@ -318,6 +320,13 @@ async def persist_assistant_turn(
     persisted before the run is built. It is passed beside `data` rather than
     inside it: `MessageCreate` is bound from a request body elsewhere, and a run
     id a caller could set is one they could aim at another organization's run.
+
+    `parked_tool_call_ids` names the calls the turn stopped on, so their rows are
+    stored `awaiting_approval` rather than `running` - the parked state otherwise
+    lives only on `agent_runs` and the `approvals` rows, and a reloaded
+    conversation read the one call somebody has to decide about as a step that
+    ran (#601). The resume settles the row through the transcript service, and an
+    expiry settles it with the timeout notice.
     """
     try:
         async with get_db_context() as db:
@@ -353,6 +362,7 @@ async def persist_assistant_turn(
                             args=normalize_tool_args(tc.get("args")),
                             started_at=datetime.now(UTC),
                         ),
+                        parked=tc["tool_call_id"] in parked_tool_call_ids,
                     )
                     if tc.get("result"):
                         await conv_service.complete_tool_call(

--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -3204,6 +3204,9 @@ class AgentRunnerService:
                 answer=output,
                 tool_calls=called,
                 settled=settled,
+                # So the step the run stopped on reads "awaiting approval" when
+                # the conversation is read back, not as a call that ran (#601).
+                parked=frozenset(paused.tool_call_ids.values()) if paused else frozenset(),
                 model_label=prepared.built.model_label,
             )
             # Committed here rather than left to the session context: that exit

--- a/backend/app/services/agent_session.py
+++ b/backend/app/services/agent_session.py
@@ -289,6 +289,10 @@ class AgentSession:
                     agent_version_id=agent_version_id,
                     usage=turn.usage,
                     run_id=turn.run_id,
+                    # Stored as `awaiting_approval`, so reloading the page keeps
+                    # saying the step is waiting on a person (#601). The frame
+                    # below carries the same calls to whoever is watching live.
+                    parked_tool_call_ids={parked.tool_call_id for parked in turn.parked},
                 )
                 # Written, so the `finally` below has nothing left to save. It
                 # cannot read `turn` to work that out - the whole point of it is

--- a/backend/app/services/conversation.py
+++ b/backend/app/services/conversation.py
@@ -491,7 +491,16 @@ class ConversationService:
         self,
         message_id: UUID,
         data: ToolCallCreate,
+        *,
+        parked: bool = False,
     ) -> ToolCall:
+        """Write one tool call under a message.
+
+        `parked` is a keyword rather than a field on `ToolCallCreate` for the
+        reason `MessageCreate` carries no `run_id`: the schema is bindable from
+        a request body, and whether a call is awaiting a person is the runner's
+        fact, not a caller's claim.
+        """
         await self.get_message(message_id)
         return await conversation_repo.create_tool_call(
             self.db,
@@ -500,6 +509,7 @@ class ConversationService:
             tool_name=data.tool_name,
             args=data.args,
             started_at=data.started_at or datetime.now(UTC),
+            status="awaiting_approval" if parked else "running",
         )
 
     async def complete_tool_call(

--- a/backend/app/services/transcript.py
+++ b/backend/app/services/transcript.py
@@ -25,7 +25,7 @@ must not make the run inside it unaccountable.
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping, Sequence
+from collections.abc import Collection, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
@@ -146,6 +146,7 @@ class TranscriptService:
         answer: str,
         tool_calls: Sequence[RecordedToolCall] = (),
         settled: Mapping[str, str] | None = None,
+        parked: Collection[str] = (),
         model_label: str | None = None,
     ) -> None:
         """Write whatever this run produced, and never fail the run for it.
@@ -170,6 +171,14 @@ class TranscriptService:
         the call it belongs to (:func:`settled_calls_in`). So the one call somebody
         deliberately reviewed used to be the one call the transcript showed
         finishing with nothing under it.
+
+        `parked` names the calls this run just stopped on, and their rows are
+        written `awaiting_approval` rather than `running`. The parked state
+        otherwise lives only on `agent_runs` and the `approvals` rows, so a
+        reloaded conversation read the one call somebody has to decide about as
+        a step that ran (#601). The row is not left that way for ever: a resume
+        settles it with what the call returned, and an expiry settles it with
+        the timeout notice (:meth:`ApprovalService._settle_expired_run`).
 
         Never raises, and never poisons the session it shares with the caller.
         The answer has already been produced and the money already spent; losing
@@ -205,6 +214,7 @@ class TranscriptService:
                         run,
                         answer=answer,
                         tool_calls=tool_calls,
+                        parked=parked,
                         model_label=model_label,
                     )
         except Exception:
@@ -242,6 +252,7 @@ class TranscriptService:
         *,
         answer: str,
         tool_calls: Sequence[RecordedToolCall],
+        parked: Collection[str],
         model_label: str | None,
     ) -> None:
         """The assistant turn and the calls it made, attributed to the version.
@@ -269,6 +280,7 @@ class TranscriptService:
                 tool_name=call.tool_name,
                 args=call.args,
                 started_at=now,
+                status="awaiting_approval" if call.tool_call_id in parked else "running",
             )
             if call.result is not None:
                 await conversation_repo.complete_tool_call(

--- a/backend/tests/api/test_platform_routes.py
+++ b/backend/tests/api/test_platform_routes.py
@@ -38,6 +38,7 @@ from app.core.exceptions import NotFoundError, RunExecutionError
 from app.core.permissions import ROLE_PERMS, AuthContext, OrgRoleName, Perm, Scope
 from app.db.models.resource_grant import Visibility
 from app.main import app
+from app.schemas.agent import ParkedCall
 from app.services.agent_runner import RunSegment
 from app.services.sharing import SharingService
 from app.services.stats import StatsService
@@ -237,6 +238,7 @@ CALLS: tuple[Call, ...] = (
         query="?started_from=2020-01-01T00:00:00&started_to=2020-01-02T00:00:00",
     ),
     Call("GET", "/runs/{run_id}", Perm.RUNS_VIEW),
+    Call("GET", "/runs/{run_id}/parked", Perm.APPROVALS_DECIDE),
     Call("POST", "/runs/{run_id}/resume", Perm.APPROVALS_DECIDE),
     Call("GET", "/approvals", Perm.APPROVALS_DECIDE),
     Call(
@@ -885,6 +887,67 @@ class TestSharingRoutesRefuseWithoutAGrant:
         # Reading reports the row as missing rather than forbidden, so ids
         # cannot be probed; changing it is an outright refusal.
         assert response.status_code == (404 if method == "GET" else 403)
+
+
+class TestReadingWhatARunIsParkedOn:
+    """`GET /runs/{run_id}/parked` hands a reloaded surface what the live frame had.
+
+    The `tool_approval_required` frame exists only for whoever was watching the
+    run park; reloading the conversation lost the panel and the only way to
+    finish the run was the approvals queue on another page (#601). This is the
+    same payload, read back off the rows.
+    """
+
+    async def test_the_parked_calls_come_back_with_the_approval_to_decide(
+        self, as_role: ClientFactory, synthetic_roles: None
+    ) -> None:
+        run = MagicMock(id=uuid4())
+        approval_id = uuid4()
+
+        class _Parked:
+            async def get_run(self, *args: Any, **kwargs: Any) -> Any:
+                return run
+
+            async def parked_calls(self, *args: Any, **kwargs: Any) -> list[ParkedCall]:
+                return [
+                    ParkedCall(
+                        id=approval_id,
+                        tool_call_id="call-1",
+                        tool_name="send_email",
+                        tool_args={"to": "ada@example.com"},
+                    )
+                ]
+
+        overrides = {deps.get_agent_runner_service: lambda: _Parked()}
+        async with as_role(only(Perm.APPROVALS_DECIDE), overrides) as client:
+            response = await client.get(_url(f"/runs/{run.id}/parked"))
+
+        assert response.status_code == 200
+        assert response.json() == [
+            {
+                "id": str(approval_id),
+                "tool_call_id": "call-1",
+                "tool_name": "send_email",
+                "tool_args": {"to": "ada@example.com"},
+            }
+        ]
+
+    async def test_a_run_in_another_organization_reads_as_absent(
+        self, as_role: ClientFactory, synthetic_roles: None
+    ) -> None:
+        """The service resolves the run against the caller's organization before
+        anything is read off it, so a foreign id answers the same 404 an unknown
+        one does - the response cannot be used to learn that a run exists."""
+
+        class _Elsewhere:
+            async def get_run(self, *args: Any, **kwargs: Any) -> Any:
+                raise NotFoundError(message="Run not found", details={})
+
+        overrides = {deps.get_agent_runner_service: lambda: _Elsewhere()}
+        async with as_role(only(Perm.APPROVALS_DECIDE), overrides) as client:
+            response = await client.get(_url(f"/runs/{uuid4()}/parked"))
+
+        assert response.status_code == 404
 
 
 class TestResumeConveysAFailedContinuation:

--- a/backend/tests/test_agent_runner.py
+++ b/backend/tests/test_agent_runner.py
@@ -1028,6 +1028,7 @@ class TestWhatANonStreamingRunRecords:
         assert [(call.tool_name, call.args, call.result) for call in written["tool_calls"]] == [
             ("send_email", {"to": "ada@example.com"}, "ok")
         ]
+        assert written["parked"] == frozenset()
 
     @pytest.mark.anyio
     async def test_a_run_that_broke_still_records_what_was_asked(self):
@@ -1299,6 +1300,29 @@ class TestParking:
             # here, one whose agent binds no delegation at all (agenticos#175).
             "dynamic_specialists": [],
         }
+
+    @pytest.mark.anyio
+    async def test_a_parked_runs_transcript_marks_the_call_that_is_waiting(self):
+        """The transcript rows are the only account of the turn a reload has, and
+        they used to say `running` for the very call somebody has to decide about -
+        so a reopened conversation showed the step as ran and said nothing about
+        waiting (#601)."""
+        service = AgentRunnerService(_db())
+        prepared = _prepared(conversation_id=uuid.uuid4())
+        prepared.approvals.parked = {"approval-1": "call-1"}
+        result = MagicMock(output=DeferredToolRequests())
+        result.all_messages = MagicMock(return_value=[])
+        result.new_messages = MagicMock(return_value=[])
+        prepared.built.agent.run = AsyncMock(return_value=result)
+
+        with (
+            patch.object(service, "prepare", new=AsyncMock(return_value=prepared)),
+            patch("app.services.agent_runner.agent_run_repo.finish_run", new=AsyncMock()),
+            patch.object(service.transcript, "record", new=AsyncMock()) as record,
+        ):
+            await service.execute(_ctx(), uuid.uuid4(), "email the customer")
+
+        assert record.await_args.kwargs["parked"] == frozenset({"call-1"})
 
     @pytest.mark.anyio
     async def test_the_delegation_tree_is_folded_in_without_the_surface_supplying_it(self):

--- a/backend/tests/test_agent_session.py
+++ b/backend/tests/test_agent_session.py
@@ -531,6 +531,19 @@ class TestATurnThatFinished:
             },
         )
 
+    async def test_a_parked_turn_stores_which_calls_are_waiting(self):
+        """The panel above is live state; the stored turn is what a reload gets.
+        Without the parked ids the row is written `running`, which replays as a
+        step that ran - so the page said nothing about waiting and the only way
+        to find the decision was the approvals queue on another page (#601)."""
+        session = _session()
+        turn = _finished_turn(output="", parked=_parked_call())
+
+        with _chat(AsyncMock(return_value=turn)) as chat:
+            await session.process_message(_message())
+
+        assert chat.answer.await_args.kwargs["parked_tool_call_ids"] == {"call-1"}
+
     async def test_a_parked_turn_stores_no_notice_in_the_agents_own_voice(self):
         """Whatever this turn ends with becomes the assistant message's `content`,
         so a sentence about the approvals queue is stored as something the agent

--- a/backend/tests/test_services_conversation.py
+++ b/backend/tests/test_services_conversation.py
@@ -862,6 +862,31 @@ class TestConversationServiceToolCalls:
 
             assert result.tool_name == "search"
             mock_repo.create_tool_call.assert_called_once()
+            assert mock_repo.create_tool_call.call_args.kwargs["status"] == "running"
+
+    @pytest.mark.anyio
+    async def test_a_parked_tool_call_is_stored_awaiting_approval(
+        self, service: ConversationService
+    ):
+        """The status is what a reloaded conversation reads: written `running`,
+        the one call somebody has to decide about replayed as a step that ran and
+        the page said nothing about waiting (#601)."""
+        msg_id = uuid4()
+        mock_data = MagicMock()
+        mock_data.tool_call_id = str(uuid4())
+        mock_data.tool_name = "send_email"
+        mock_data.args = {"to": "ada@example.com"}
+        mock_data.started_at = None
+
+        with patch("app.services.conversation.conversation_repo") as mock_repo:
+            mock_repo.get_message_by_id = AsyncMock(return_value=MockMessage(id=msg_id))
+            mock_repo.create_tool_call = AsyncMock(
+                return_value=MockToolCall(message_id=msg_id, tool_name="send_email")
+            )
+
+            await service.start_tool_call(msg_id, mock_data, parked=True)
+
+            assert mock_repo.create_tool_call.call_args.kwargs["status"] == "awaiting_approval"
 
     @pytest.mark.anyio
     async def test_start_tool_call_verifies_message_exists(self, service: ConversationService):

--- a/backend/tests/test_transcript.py
+++ b/backend/tests/test_transcript.py
@@ -270,6 +270,46 @@ class TestWritingTheTranscript:
         conversations.create_tool_call.assert_awaited_once()
         conversations.complete_tool_call.assert_not_awaited()
 
+    async def test_a_parked_call_is_written_awaiting_approval_not_running(self, conversations):
+        """The parked state lives on `agent_runs` and the `approvals` rows, so the
+        transcript row was the one place a reloaded conversation could not see it:
+        the one call somebody has to decide about read as a step that ran (#601)."""
+        await TranscriptService(_session()).record(
+            _run(),
+            prompt="email ada",
+            answer="",
+            tool_calls=[
+                RecordedToolCall(
+                    tool_call_id="c1", tool_name="search", args={"q": "ada"}, result="1 hit"
+                ),
+                RecordedToolCall(
+                    tool_call_id="c2", tool_name="send_email", args={"to": "ada@example.com"}
+                ),
+            ],
+            parked=frozenset({"c2"}),
+        )
+
+        statuses = {
+            call.kwargs["tool_call_id"]: call.kwargs["status"]
+            for call in conversations.create_tool_call.await_args_list
+        }
+        assert statuses == {"c1": "running", "c2": "awaiting_approval"}
+
+    async def test_a_call_that_merely_never_returned_is_not_marked_as_waiting(self, conversations):
+        """A run that broke or was stopped mid-call also leaves a call with no
+        result, and nobody can approve it into finishing - `awaiting_approval` is
+        only for the calls the run parked on."""
+        await TranscriptService(_session()).record(
+            _run(),
+            prompt="charge it",
+            answer="",
+            tool_calls=[
+                RecordedToolCall(tool_call_id="c1", tool_name="charge_card", args={"amount": 500})
+            ],
+        )
+
+        assert conversations.create_tool_call.await_args.kwargs["status"] == "running"
+
     async def test_a_resumed_run_writes_no_user_turn(self, conversations):
         """It picks up at the tool call it stopped on. There is no new question,
         and inventing one would put words in somebody's mouth."""

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -580,6 +580,17 @@ Four properties worth knowing:
 
 - **A parked run is resumable.** Its message history is stored, so the decision is
   applied to the conversation it belongs to rather than starting again.
+- **A parked run survives a reload saying so.** The transcript stores the call the
+  run stopped on as `awaiting_approval` rather than `running`, so reopening the
+  conversation still shows the step waiting — and `GET /runs/{id}/parked` answers
+  with the pending calls (the approval to decide, the tool, its arguments), which
+  is how the chat rebuilds the approval panel the live
+  `tool_approval_required` frame gave to whoever was watching. It answers empty
+  for a run that is not parked, and it is gated on `approvals:decide` like the
+  queue, because its rows are offered to be decided
+  ([#601](https://github.com/vstorm-co/agenticos/issues/601)). The step does not
+  read as waiting for ever: a resume settles it with what the call returned, an
+  expiry settles it with the timeout notice.
 - **A continuation says what it did.** `POST /runs/{id}/resume` answers with the
   tool calls the continuation made, in order, each with what came back — and the
   transcript records them whether or not it reached an answer. Both halves used to

--- a/frontend/src/components/chat/chat-container.integration.test.tsx
+++ b/frontend/src/components/chat/chat-container.integration.test.tsx
@@ -98,7 +98,16 @@ beforeEach(() => {
   get.mockImplementation((url: string) =>
     url.startsWith("/auth/me")
       ? Promise.resolve({ ...SIGNED_IN, access_token: "t-1" })
-      : Promise.resolve({ items: [], total: 0 }),
+      : url === "/me/permissions"
+        ? // A real shape, not the list fallback: `usePermissions` reads
+          // `data.permissions` off whatever this answers.
+          Promise.resolve({
+            organization_id: "org-1",
+            role: "member",
+            is_app_admin: false,
+            permissions: [],
+          })
+        : Promise.resolve({ items: [], total: 0 }),
   );
   useAuthStore.setState({
     accessToken: "t-1",

--- a/frontend/src/hooks/use-chat.test.tsx
+++ b/frontend/src/hooks/use-chat.test.tsx
@@ -20,8 +20,8 @@ import {
 // A decision on a parked call goes to the same REST endpoints the approvals queue
 // uses. It used to be a WebSocket `resume` frame the server silently discarded, so
 // asserting on the frame is exactly what let that pass.
-const { post } = vi.hoisted(() => ({ post: vi.fn() }));
-vi.mock("@/lib/api-client", () => ({ apiClient: { post } }));
+const { post, get } = vi.hoisted(() => ({ post: vi.fn(), get: vi.fn() }));
+vi.mock("@/lib/api-client", () => ({ apiClient: { post, get } }));
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
 const { sent, socket, connect, disconnect } = vi.hoisted(() => ({
@@ -40,18 +40,32 @@ const { sent, socket, connect, disconnect } = vi.hoisted(() => ({
 /**
  * `useChat` resolves the tenant through the organizations query, so it needs a
  * client - it clears a queued message when the organization moves, and a
- * message queued in one organization must not be sent as another.
+ * message queued in one organization must not be sent as another. It reads the
+ * caller's permissions the same way, for whether a reloaded parked run may have
+ * its approval panel rebuilt.
  */
-function wrapper({ children }: { children: ReactNode }) {
-  const client = new QueryClient({
-    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
-  });
-  // Seeded rather than fetched: these tests count requests, and an
-  // organizations query going out for the tenant would be a request none of
-  // them made.
-  client.setQueryData(qk.organizations.list(), []);
-  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+function makeWrapper(permissions: string[] = []) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    // Seeded rather than fetched: these tests count requests, and an
+    // organizations or permissions query going out would be a request none of
+    // them made.
+    client.setQueryData(qk.organizations.list(), []);
+    client.setQueryData(qk.organizations.permissions("current"), {
+      organization_id: "org-1",
+      role: "member",
+      is_app_admin: false,
+      permissions: permissions.map((permission) => ({ permission, scope: "all" })),
+    });
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
 }
+
+const wrapper = makeWrapper();
+/** The same wrapper for a caller who may decide approvals. */
+const decider = makeWrapper(["approvals:decide"]);
 
 vi.mock("./use-websocket", () => ({
   useWebSocket: (options: {
@@ -94,6 +108,19 @@ function frame(nth = 0): Record<string, unknown> {
 /** The assistant message being streamed. */
 function streaming() {
   return useChatStore.getState().messages.find((message) => message.role === "assistant");
+}
+
+/** A stored assistant turn whose run is parked - what a reloaded conversation holds. */
+function parkedTurn() {
+  return {
+    id: "m-1",
+    role: "assistant" as const,
+    content: "",
+    timestamp: new Date(),
+    conversationId: "c-1",
+    runId: "r-1",
+    toolCalls: [{ id: "tc-1", name: "send_email", args: {}, status: "awaiting_approval" as const }],
+  };
 }
 
 beforeEach(() => {
@@ -1055,6 +1082,121 @@ describe("useChat - approvals and questions", () => {
     });
 
     expect(result.current.pendingApproval).toBeNull();
+  });
+
+  it("puts the approval panel back when a reloaded conversation is still parked", async () => {
+    // The live `tool_approval_required` frame exists only for whoever was watching
+    // when the run parked. The stored step says "waiting for approval" after a
+    // reload, but the panel with the decision was gone, so the only way to finish
+    // the run was the approvals queue on another page (#601).
+    get.mockResolvedValue([
+      { id: "ar-1", tool_call_id: "tc-1", tool_name: "send_email", tool_args: { to: "a@b.c" } },
+      // A run parked before the tool-call mapping was stored has no id to
+      // resolve a card with; the decision is still offered.
+      { id: "ar-2", tool_call_id: null, tool_name: "execute", tool_args: {} },
+    ]);
+    useConversationStore.getState().setCurrentConversationId("c-1");
+    useChatStore.getState().addMessage(parkedTurn());
+
+    const { result } = renderHook(() => useChat(), { wrapper: decider });
+    await act(async () => {});
+
+    expect(get.mock.calls).toEqual([["/runs/r-1/parked"]]);
+    expect(result.current.pendingApproval).toEqual({
+      actionRequests: [
+        { id: "ar-1", tool_call_id: "tc-1", tool_name: "send_email", args: { to: "a@b.c" } },
+        { id: "ar-2", tool_call_id: "", tool_name: "execute", args: {} },
+      ],
+      reviewConfigs: [
+        { tool_name: "send_email", allow_edit: false },
+        { tool_name: "execute", allow_edit: false },
+      ],
+      runId: "r-1",
+      messageId: "m-1",
+    });
+  });
+
+  it("asks nothing without approvals:decide", async () => {
+    // The endpoint is gated on the permission deciding takes, so a caller
+    // without it would 403 on every reopened conversation. The stored step
+    // still says the run is waiting; there is just no decision to offer.
+    useConversationStore.getState().setCurrentConversationId("c-1");
+    useChatStore.getState().addMessage(parkedTurn());
+
+    const { result } = renderHook(() => useChat(), { wrapper });
+    await act(async () => {});
+
+    expect(get).not.toHaveBeenCalled();
+    expect(result.current.pendingApproval).toBeNull();
+  });
+
+  it("asks about a run once, not on every store update", async () => {
+    get.mockResolvedValue([]);
+    useConversationStore.getState().setCurrentConversationId("c-1");
+    useChatStore.getState().addMessage(parkedTurn());
+    const { result } = renderHook(() => useChat(), { wrapper: decider });
+    await act(async () => {});
+    expect(result.current.pendingApproval).toBeNull();
+
+    act(() => {
+      useChatStore.getState().addMessage({
+        id: "m-2",
+        role: "user",
+        content: "hello?",
+        timestamp: new Date(),
+      });
+    });
+    await act(async () => {});
+
+    // Once for the run - and an answer of "nothing pending" leaves the panel
+    // down rather than inventing one: the calls were decided somewhere else.
+    expect(get).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves a parked step from before runs were stamped on messages alone", async () => {
+    // The step still reads "waiting for approval", but there is no run on the
+    // message to ask about.
+    useConversationStore.getState().setCurrentConversationId("c-1");
+    useChatStore.getState().addMessage({ ...parkedTurn(), runId: undefined });
+
+    const { result } = renderHook(() => useChat(), { wrapper: decider });
+    await act(async () => {});
+
+    expect(get).not.toHaveBeenCalled();
+    expect(result.current.pendingApproval).toBeNull();
+  });
+
+  it("stays quiet when the parked rows cannot be read", async () => {
+    // The approvals queue holds the same rows, so a panel that could not be
+    // rebuilt is not worth an error over the transcript somebody is reading.
+    get.mockRejectedValue(new Error("offline"));
+    useConversationStore.getState().setCurrentConversationId("c-1");
+    useChatStore.getState().addMessage(parkedTurn());
+
+    const { result } = renderHook(() => useChat(), { wrapper: decider });
+    await act(async () => {});
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(result.current.pendingApproval).toBeNull();
+  });
+
+  it("waits for the turn in flight before asking", async () => {
+    // While a turn is processing the parked state on screen is the live one,
+    // and the live frame is what will carry the panel.
+    get.mockResolvedValue([]);
+    useConversationStore.getState().setCurrentConversationId("c-1");
+    const { result } = renderHook(() => useChat(), { wrapper: decider });
+    act(() => result.current.sendMessage("do it"));
+    act(() => {
+      useChatStore.getState().addMessage(parkedTurn());
+    });
+    await act(async () => {});
+    expect(get).not.toHaveBeenCalled();
+
+    receive("complete", {});
+    await act(async () => {});
+
+    expect(get).toHaveBeenCalledTimes(1);
   });
 
   it("takes a pending question off screen when another conversation is opened", () => {

--- a/frontend/src/hooks/use-chat.test.tsx
+++ b/frontend/src/hooks/use-chat.test.tsx
@@ -1180,6 +1180,36 @@ describe("useChat - approvals and questions", () => {
     expect(result.current.pendingApproval).toBeNull();
   });
 
+  it("drops an answer that lands after another conversation was opened", async () => {
+    // The fetch can resolve on the far side of a conversation switch, and a
+    // panel drawn under another transcript is the stale, actionable state the
+    // switch effect exists to prevent - Approve would decide a call the person
+    // is no longer looking at.
+    let resolveParked!: (rows: unknown) => void;
+    get.mockReturnValue(
+      new Promise((resolve) => {
+        resolveParked = resolve;
+      }),
+    );
+    useConversationStore.getState().setCurrentConversationId("c-1");
+    useChatStore.getState().addMessage(parkedTurn());
+    const { result } = renderHook(() => useChat(), { wrapper: decider });
+    await act(async () => {});
+    expect(get).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      useConversationStore.getState().setCurrentConversationId("c-2");
+      // What the container does on a switch - the messages on screen are the
+      // new conversation's.
+      useChatStore.getState().clearMessages();
+    });
+    await act(async () => {
+      resolveParked([{ id: "ar-1", tool_call_id: "tc-1", tool_name: "send_email", tool_args: {} }]);
+    });
+
+    expect(result.current.pendingApproval).toBeNull();
+  });
+
   it("waits for the turn in flight before asking", async () => {
     // While a turn is processing the parked state on screen is the live one,
     // and the live frame is what will carry the panel.

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -4,9 +4,11 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { nanoid } from "nanoid";
 import { useTranslations } from "next-intl";
 import { useWebSocket } from "./use-websocket";
+import { usePermissions } from "./use-permissions";
 import { useChatStore, useAuthStore, useOrgStore } from "@/stores";
 import { useTenantId } from "@/hooks/use-organizations";
 import { useAgentSelectionStore } from "@/stores";
+import { Perm } from "@/types/permissions";
 import type {
   ActionRequest,
   AskUserAnswer,
@@ -21,7 +23,7 @@ import type {
   TurnUsage,
   WSEvent,
 } from "@/types";
-import type { ResumedRun } from "@/types/runs";
+import type { ParkedCall, ResumedRun } from "@/types/runs";
 import {
   applyDelegationFrame,
   closeOpenDelegations,
@@ -117,6 +119,12 @@ export function useChat(options: UseChatOptions = {}) {
   const activeConversationId = currentConversationIdFromStore || conversationId || null;
 
   const [pendingApproval, setPendingApproval] = useState<PendingApproval | null>(null);
+  // Runs this hook has already put an approval panel up for, live or restored.
+  // What keeps the restore effect below from re-opening a panel somebody is in
+  // the middle of deciding: `sendResumeDecisions` clears the panel before the
+  // steps stop reading `awaiting_approval`, which is exactly the state the
+  // effect reads as "a reloaded parked run".
+  const approvalOfferedForRef = useRef<Set<string>>(new Set());
   const [pendingQuestions, setPendingQuestions] = useState<AskUserQuestion[] | null>(null);
   // The delegations of the turn on screen, keyed by their own `task_id` and held
   // *outside* the assistant message on purpose.
@@ -351,6 +359,7 @@ export function useChat(options: UseChatOptions = {}) {
             review_configs: ReviewConfig[];
             run_id: string;
           };
+          approvalOfferedForRef.current.add(run_id);
           setPendingApproval({
             actionRequests: action_requests,
             reviewConfigs: review_configs,
@@ -616,6 +625,7 @@ export function useChat(options: UseChatOptions = {}) {
     clearQueued();
     setPendingApproval(null);
     setPendingQuestions(null);
+    approvalOfferedForRef.current = new Set();
     // A delegation belongs to a run in one organization, and to one conversation
     // inside it - the effect below is the other half of that sentence. Left on
     // screen it would show the previous tenant's specialist names and prompts to
@@ -646,8 +656,11 @@ export function useChat(options: UseChatOptions = {}) {
   // panels that are already open and `applyDelegationFrame` would drop every frame
   // after it as naming a task it holds no panel for - a silent loss of the last thing
   // a specialist said, which is the failure this whole design exists to avoid. The
-  // panels are live state that no reload restores, so keeping them for a conversation
-  // somebody may return to would also disagree with what that reload shows.
+  // delegation and question panels are live state that no reload restores, so keeping
+  // them for a conversation somebody may return to would also disagree with what that
+  // reload shows; the approval panel is the one the restore effect below rebuilds
+  // from the rows, which is why its guard is reset here - coming back to a still
+  // parked conversation must offer the decision again.
   //
   // A layout effect for the reason the one above is one: before the paint, so no
   // frame of the previous conversation's panels is shown under this one's transcript.
@@ -663,7 +676,66 @@ export function useChat(options: UseChatOptions = {}) {
     setDelegations([]);
     setPendingApproval(null);
     setPendingQuestions(null);
+    approvalOfferedForRef.current = new Set();
   }, [activeConversationId]);
+
+  // The caller's permissions, for the restore effect below: rebuilding the
+  // approval panel reads an endpoint gated on `approvals:decide`, so a caller
+  // without it is not asked to 403 on every reopened conversation.
+  const { can } = usePermissions();
+  const canDecide = can(Perm.approvalsDecide);
+
+  // The other direction of `tool_approval_required`: that frame exists only for
+  // whoever was watching when the run parked. A reloaded conversation carries
+  // the parked state on its steps - the transcript stores them
+  // `awaiting_approval` - but the panel with the decision was gone, so the only
+  // way to finish the run was the approvals queue on another page (#601). This
+  // asks the backend what the run is still waiting on and puts the panel back.
+  //
+  // Guarded per run so it never reopens a panel mid-decision:
+  // `sendResumeDecisions` clears the panel before the steps stop reading
+  // `awaiting_approval`, which is exactly the state this effect would otherwise
+  // read as a reloaded parked run. Empty rows are left alone - a run decided
+  // elsewhere but not yet resumed has nothing left to offer - and a fetch that
+  // failed is left alone too: the approvals queue holds the same rows, and an
+  // error toast over a transcript somebody is reading buys nothing.
+  useEffect(() => {
+    if (pendingApproval !== null || isProcessing || !canDecide) return;
+    const parkedMessage = [...messages]
+      .reverse()
+      .find(
+        (message) =>
+          message.role === "assistant" &&
+          (message.toolCalls ?? []).some((call) => call.status === "awaiting_approval"),
+      );
+    // No `runId` is a turn stored before runs were stamped on messages: its
+    // step still says it is waiting, but there is no run to ask about.
+    if (parkedMessage === undefined || parkedMessage.runId === undefined) return;
+    const runId = parkedMessage.runId;
+    if (approvalOfferedForRef.current.has(runId)) return;
+    approvalOfferedForRef.current.add(runId);
+    void (async () => {
+      try {
+        const parked = await apiClient.get<ParkedCall[]>(`/runs/${runId}/parked`);
+        if (parked.length === 0) return;
+        setPendingApproval({
+          actionRequests: parked.map((call) => ({
+            id: call.id,
+            tool_call_id: call.tool_call_id ?? "",
+            tool_name: call.tool_name,
+            args: call.tool_args,
+          })),
+          // The same shape the live frame carries: editing a parked call is not
+          // offered, because the arguments were recorded on the row being decided.
+          reviewConfigs: parked.map((call) => ({ tool_name: call.tool_name, allow_edit: false })),
+          runId,
+          messageId: parkedMessage.id,
+        });
+      } catch {
+        // Deliberately quiet - see above.
+      }
+    })();
+  }, [messages, pendingApproval, isProcessing, canDecide]);
 
   /** Record one decision on the `approvals` row it belongs to. */
   const decideApproval = useCallback(

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -714,10 +714,15 @@ export function useChat(options: UseChatOptions = {}) {
     const runId = parkedMessage.runId;
     if (approvalOfferedForRef.current.has(runId)) return;
     approvalOfferedForRef.current.add(runId);
+    const conversation = activeConversationId;
     void (async () => {
       try {
         const parked = await apiClient.get<ParkedCall[]>(`/runs/${runId}/parked`);
-        if (parked.length === 0) return;
+        // An answer that lands after the reader has moved on is dropped: a
+        // panel drawn under another conversation's transcript is the stale,
+        // actionable state the conversation-switch effect above exists to
+        // prevent, and this fetch can resolve on the far side of that switch.
+        if (parked.length === 0 || panelsBelongTo.current !== conversation) return;
         setPendingApproval({
           actionRequests: parked.map((call) => ({
             id: call.id,
@@ -735,7 +740,7 @@ export function useChat(options: UseChatOptions = {}) {
         // Deliberately quiet - see above.
       }
     })();
-  }, [messages, pendingApproval, isProcessing, canDecide]);
+  }, [messages, pendingApproval, isProcessing, canDecide, activeConversationId]);
 
   /** Record one decision on the `approvals` row it belongs to. */
   const decideApproval = useCallback(

--- a/frontend/src/lib/conversation-to-chat.test.ts
+++ b/frontend/src/lib/conversation-to-chat.test.ts
@@ -265,4 +265,20 @@ describe("a stored tool call that never finished", () => {
 
     expect(message.toolCalls?.map((call) => call.status)).toEqual(["completed", "error"]);
   });
+
+  it("keeps a parked call saying it waits for approval", () => {
+    // Not an unwritten outcome: the run parked on this call and a person can
+    // still decide it. Mapped to `unfinished` the one step somebody has to act
+    // on read as a step that ran, and the reloaded page said nothing about
+    // waiting (#601).
+    const message = conversationMessageToChatMessage(
+      raw({
+        tool_calls: [
+          { tool_call_id: "tc-1", tool_name: "send_email", args: {}, status: "awaiting_approval" },
+        ],
+      }),
+    );
+
+    expect(message.toolCalls?.map((call) => call.status)).toEqual(["awaiting_approval"]);
+  });
 });

--- a/frontend/src/lib/conversation-to-chat.ts
+++ b/frontend/src/lib/conversation-to-chat.ts
@@ -119,11 +119,16 @@ export function buildAssistantParts(
  *
  * A call still marked *running* is the interesting one. Nothing on this screen can
  * finish it: the frames that would have are long gone, and some rows never get an
- * outcome at all - an approval that expired, a run that broke while a tool was in
- * flight. Left as `running` the step pulsed forever under a conversation that ended
- * days ago, in the present tense, promising a result that was never coming. So a
- * replayed call in flight is `unfinished`: not an error, not a success, just the
- * outcome nobody wrote down.
+ * outcome at all - a run that broke while a tool was in flight. Left as `running`
+ * the step pulsed forever under a conversation that ended days ago, in the present
+ * tense, promising a result that was never coming. So a replayed call in flight is
+ * `unfinished`: not an error, not a success, just the outcome nobody wrote down.
+ *
+ * A stored *awaiting_approval* passes through unchanged, and must (#601): the run
+ * parked on that call and a person can still decide it, so it is a present-tense
+ * state rather than an unwritten outcome. It does not outlive the run either way -
+ * a resume settles the row with what the call returned, an expiry settles it with
+ * the timeout notice.
  */
 function replayedStatus(stored: string): ToolCall["status"] {
   if (stored === "failed") return "error";


### PR DESCRIPTION
Reload a conversation whose run is parked on an approval and nothing on the screen said so: the step the run stopped on rendered as though it ran, and the approval panel never came back — the only way to finish the run was the approvals queue on another page. #509 removed the stored notice that had been covering for both halves, which is what made the gap visible; it had always been true of every non-streaming surface.

## What changed

Both halves the issue names, at both ends:

- **The step.** The transcript now stores the calls a run parks on with `status="awaiting_approval"` instead of `running`. `TranscriptService.record` takes the parked ids off the runner's paused state (every non-streaming surface), and the web chat hands them to `persist_assistant_turn` from `turn.parked`. On replay the status passes through unchanged, and `tool-call-card` already renders it as its own state. The row does not read "waiting" for ever: a resume settles it with what the call returned (`_settle`), an expiry settles it with the timeout notice (`_settle_expired_run`) — both paths already existed.
- **The panel.** New `GET /runs/{run_id}/parked` answers the run's pending calls (the approval row to decide, the tool call id, the tool, its arguments) — the same payload the live `tool_approval_required` frame carries and `POST /runs/{id}/resume` returns in `parked`, gated on `approvals:decide` like both of them. `use-chat` asks it when a reloaded conversation's parked step still reads `awaiting_approval` and rebuilds `pendingApproval`: once per run, so a panel somebody is mid-decision on is never reopened; not without the permission, so a viewer is not asked to 403 on every reopened thread; and quietly on a failed read, since the approvals queue holds the same rows. An empty answer (decided elsewhere, not yet resumed) leaves the panel down.

`ToolCallRead.status` gains the `awaiting_approval` literal (without it the stored row would fail response serialization), and `docs/governance.md` documents the reload behaviour under the approval properties.

## How it was verified

- `backend/tests/test_transcript.py` — a parked call is written `awaiting_approval`, a call that merely never returned stays `running`.
- `backend/tests/test_agent_runner.py` / `test_agent_session.py` / `test_services_conversation.py` — the parked ids reach the transcript from both surfaces, and a finished run passes none.
- `backend/tests/api/test_platform_routes.py` — the new route in the permission-gate registry, the payload shape, and the cross-tenant 404.
- `frontend/src/lib/conversation-to-chat.test.ts` — a stored `awaiting_approval` replays as itself (pinned as a regression guard: the passthrough existed but was unreachable, because nothing ever stored that status).
- `frontend/src/hooks/use-chat.test.tsx` — the panel is rebuilt from the rows (including a null `tool_call_id` from a run parked before the mapping was stored); no fetch without `approvals:decide`; once per run; quiet on failure; waits out a turn in flight.

`make lint`, `make test` (backend, 100% coverage gate) and `make test-frontend-cov` (3959 tests, gate met) all pass locally.

Closes #601

