### PR TITLE
fix(rag): await the OCR describer instead of nesting an event loop

### DIFF
--- a/backend/app/services/rag/documents.py
+++ b/backend/app/services/rag/documents.py
@@ -178,7 +178,7 @@ class PyMuPDFParser(BaseDocumentParser):
     # routed them, and saying so here keeps `is_extension_allowed` honest.
     allowed = sorted(PYMUPDF_PDF_FORMATS)
 
-    def __init__(self, enable_ocr: bool = False, image_describer: Any = None):
+    def __init__(self, enable_ocr: bool = False, image_describer: BaseImageDescriber | None = None):
         self.enable_ocr = enable_ocr
         self._image_describer = image_describer
 
@@ -225,23 +225,22 @@ class PyMuPDFParser(BaseDocumentParser):
         except Exception:
             return ""
 
-    def _ocr_page(self, page: Any, image_describer: Any = None) -> str:
-        """OCR a scanned page by rendering it as image and sending to LLM vision."""
+    async def _ocr_page(self, page: Any, image_describer: BaseImageDescriber | None = None) -> str:
+        """OCR a scanned page by rendering it as an image and sending it to LLM vision.
+
+        Awaited on the caller's loop: a second loop via `run_until_complete`
+        raised `RuntimeError` inside an already-running loop, so every
+        scanned page OCR'd to `""` and the document indexed empty (#550).
+        """
         if not image_describer:
             return ""
         try:
             pix = page.get_pixmap(dpi=200)
             image_bytes = pix.tobytes("png")
-            loop = asyncio.new_event_loop()
-            try:
-                return str(
-                    loop.run_until_complete(image_describer.describe(image_bytes, "image/png"))
-                )
-            finally:
-                loop.close()
         except Exception as e:
-            logger.warning("LLM OCR failed for page %d: %s", page.number + 1, e)
+            logger.warning("Rendering page %d as an image for OCR failed: %s", page.number + 1, e)
             return ""
+        return await image_describer.describe(image_bytes, "image/png")
 
     def _extract_images(self, doc: Any, page: Any) -> list["DocumentImage"]:
         """Extract images from page for LLM description."""
@@ -267,7 +266,7 @@ class PyMuPDFParser(BaseDocumentParser):
                 logger.warning("Skipping an unreadable image on page %d", page.number + 1)
         return images
 
-    def _parse_pdf_file(self, filepath: Path) -> Document:
+    async def _parse_pdf_file(self, filepath: Path) -> Document:
         """Parse PDF with smart extraction pipeline."""
         doc: Any = pymupdf.open(filepath)  # type: ignore[no-untyped-call]
 
@@ -285,7 +284,7 @@ class PyMuPDFParser(BaseDocumentParser):
                 text = text + "\n\n" + tables_md if text.strip() else tables_md
 
             if self.enable_ocr and len(text.strip()) < self.MIN_TEXT_LENGTH:
-                ocr_text = self._ocr_page(page, self._image_describer)
+                ocr_text = await self._ocr_page(page, self._image_describer)
                 if len(ocr_text.strip()) > len(text.strip()):
                     text = ocr_text
                     logger.info("OCR fallback used for page %d", page.number + 1)
@@ -318,7 +317,7 @@ class PyMuPDFParser(BaseDocumentParser):
     async def parse(self, filepath: Path) -> Document:
         if not self.is_extension_allowed(filepath):
             raise ValueError(f"Extension {filepath.suffix} not supported by PyMuPDFParser")
-        return self._parse_pdf_file(filepath)
+        return await self._parse_pdf_file(filepath)
 
 
 class LlamaParseParser(BaseDocumentParser):

--- a/backend/tests/test_pymupdf_ocr.py
+++ b/backend/tests/test_pymupdf_ocr.py
@@ -1,0 +1,77 @@
+"""The PyMuPDF OCR fallback and the loop it runs on (#550).
+
+`_ocr_page` used to drive the image describer through a second event loop
+(`asyncio.new_event_loop().run_until_complete`) while `parse` was already
+awaiting on the running one. The nested loop raised `RuntimeError`, a broad
+`except` logged it as "LLM OCR failed", and every scanned page OCR'd to
+`""` - the document indexed empty, indistinguishable from a PDF that
+genuinely had no text.
+"""
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import pymupdf
+import pytest
+
+from app.services.rag.documents import PyMuPDFParser
+from app.services.rag.image_describer import BaseImageDescriber
+
+pytestmark = pytest.mark.anyio
+
+
+class LoopRecordingDescriber(BaseImageDescriber):
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.loops: list[asyncio.AbstractEventLoop] = []
+
+    async def describe(self, image_bytes: bytes, mime_type: str = "image/png") -> str:
+        self.loops.append(asyncio.get_running_loop())
+        return self.text
+
+
+def _scanned_pdf(path: Path) -> Path:
+    doc = pymupdf.open()
+    doc.new_page()
+    doc.save(str(path))
+    doc.close()
+    return path
+
+
+async def test_a_scanned_page_indexes_with_its_ocr_text(tmp_path: Path) -> None:
+    describer = LoopRecordingDescriber("Text the vision model recovered from the scan.")
+    parser = PyMuPDFParser(enable_ocr=True, image_describer=describer)
+
+    document = await parser.parse(_scanned_pdf(tmp_path / "scan.pdf"))
+
+    assert document.pages[0].content == describer.text
+
+
+async def test_ocr_runs_on_the_callers_loop_not_a_nested_one(tmp_path: Path) -> None:
+    describer = LoopRecordingDescriber("Recovered text long enough to beat the empty page.")
+    parser = PyMuPDFParser(enable_ocr=True, image_describer=describer)
+
+    await parser.parse(_scanned_pdf(tmp_path / "scan.pdf"))
+
+    assert describer.loops == [asyncio.get_running_loop()]
+
+
+async def test_a_page_that_cannot_render_skips_ocr_without_failing_the_parse() -> None:
+    describer = LoopRecordingDescriber("never reached")
+    parser = PyMuPDFParser(enable_ocr=True, image_describer=describer)
+    page = SimpleNamespace(
+        number=0,
+        get_pixmap=lambda dpi: (_ for _ in ()).throw(RuntimeError("render failed")),
+    )
+
+    assert await parser._ocr_page(page, describer) == ""
+    assert describer.loops == []
+
+
+async def test_ocr_without_a_describer_returns_nothing(tmp_path: Path) -> None:
+    parser = PyMuPDFParser(enable_ocr=True)
+
+    document = await parser.parse(_scanned_pdf(tmp_path / "scan.pdf"))
+
+    assert document.pages[0].content == ""


### PR DESCRIPTION
## What this fixes

Closes #550. A scanned PDF ingested through the PyMuPDF parser with OCR
enabled indexed near-empty: the OCR fallback produced nothing, silently,
and the result was indistinguishable from a PDF that genuinely had no
text.

## What changed

- `PyMuPDFParser._ocr_page` and `_parse_pdf_file` are now `async`; the
  image describer is awaited on the caller's event loop instead of being
  driven through `asyncio.new_event_loop().run_until_complete(...)`.
- The `except` in `_ocr_page` is narrowed to the pixmap-rendering step,
  so an infrastructure error is no longer reported as "LLM OCR failed".
  Describer failures are already handled inside
  `PydanticAIImageDescriber.describe` (logged, returns `""`).
- `image_describer` is typed `BaseImageDescriber | None` instead of
  `Any` on the two signatures the fix touches.

## How it failed before

`parse` awaited `_parse_pdf_file` directly on the running loop, so
`run_until_complete` inside `_ocr_page` executed while that loop was
already running: `RuntimeError: Cannot run the event loop while another
loop is running`, caught by the broad `except`, logged as a warning, and
`""` returned for every scanned page. Silent data loss, gated on
`enable_ocr` plus a configured vision describer.

## Testing

New `backend/tests/test_pymupdf_ocr.py`, verified to fail on the
pre-fix code:

- a scanned (image-only) PDF indexes with the describer's text;
- OCR runs on the caller's loop, not a nested one;
- a page that cannot render skips OCR without failing the parse;
- OCR with no describer configured still returns nothing.

`make lint` and `make test` green locally (4379 passed, platform layer
at 100%). Not verified against a real worker run with a live vision
model — the issue asked for that confirmation; the unit tests cover the
loop mechanics end to end through `parse`.

## Noticed, not fixed

- The PyMuPDF parse still runs its CPU-bound work (text extraction,
  table detection, pixmap rendering) on the event loop, unlike the
  LiteParse path which goes through `asyncio.to_thread`. Same class as
  #25; recorded there rather than filed twice.
