### PR TITLE
Expire a stale invitation instead of leaving it pending

### DIFF
--- a/backend/app/repositories/invitation.py
+++ b/backend/app/repositories/invitation.py
@@ -100,6 +100,13 @@ async def revoke(db: AsyncSession, invite: Invitation) -> Invitation:
     return invite
 
 
+async def expire(db: AsyncSession, invite: Invitation) -> Invitation:
+    invite.status = InvitationStatus.EXPIRED.value
+    await db.flush()
+    await db.refresh(invite)
+    return invite
+
+
 async def expire_stale(db: AsyncSession) -> int:
     """Mark all PENDING invitations past their expiry as EXPIRED. Returns count updated."""
     result = await db.execute(

--- a/backend/app/services/invitation.py
+++ b/backend/app/services/invitation.py
@@ -182,7 +182,9 @@ class InvitationService:
             )
 
         if invite.expires_at and invite.expires_at < datetime.now(UTC):
-            await invitation_repo.revoke(self.db, invite)
+            # Expired, not revoked: `revoked` records a withdrawal somebody
+            # made, and this row timed out with nobody acting on it (#456).
+            await invitation_repo.expire(self.db, invite)
             raise BadRequestError(message="Invitation has expired")
 
         accepting_user = await user_repo.get_by_id(self.db, accepting_user_id)
@@ -244,6 +246,21 @@ class InvitationService:
             invite.organization_id,
         )
         return invite
+
+    async def expire_stale(self) -> int:
+        """Mark every PENDING invitation past its expiry as EXPIRED.
+
+        An invitation ordinarily times out by nobody clicking it, so no request
+        path can be relied on to write `EXPIRED` - without a schedule the row
+        stays `pending` for ever and the pending list keeps offering it. The
+        sweep reads across every organization because a schedule has no tenant
+        to be scoped to; all it writes is a status the row already promised.
+
+        Returns:
+            How many invitations were expired. Zero on the ordinary sweep,
+            which is why the flow logs only when it is not.
+        """
+        return await invitation_repo.expire_stale(self.db)
 
     async def revoke_by_id(
         self, organization_id: UUID, invitation_id: UUID, requester_id: UUID

--- a/backend/app/worker/prefect_app.py
+++ b/backend/app/worker/prefect_app.py
@@ -27,6 +27,7 @@ from prefect.client.schemas.schedules import IntervalSchedule
 
 from app.core.config import settings
 from app.worker.tasks.approval_tasks import approval_expiry_sweep_flow
+from app.worker.tasks.invitation_tasks import invitation_expiry_sweep_flow
 from app.worker.tasks.mcp_tasks import mcp_connection_sweep_flow
 from app.worker.tasks.rag_tasks import (
     check_scheduled_syncs_flow,
@@ -70,6 +71,14 @@ async def main() -> None:
     deployments.append(
         await approval_expiry_sweep_flow.ato_deployment(
             name="approval-expiry-sweep",
+            schedules=[IntervalSchedule(interval=3600)],
+        )
+    )
+    # Hourly for the same reason as the approval sweep: the invitation TTL is
+    # measured in days, so an invitation expiring 40 minutes late costs nothing.
+    deployments.append(
+        await invitation_expiry_sweep_flow.ato_deployment(
+            name="invitation-expiry-sweep",
             schedules=[IntervalSchedule(interval=3600)],
         )
     )

--- a/backend/app/worker/tasks/invitation_tasks.py
+++ b/backend/app/worker/tasks/invitation_tasks.py
@@ -1,0 +1,32 @@
+"""Scheduled upkeep for organization invitations.
+
+One flow, for rows that otherwise never reach their promised state. An
+invitation nobody clicks is exactly the one no request path ever touches, so
+`EXPIRED` can only be written on a schedule - the same reasoning as the
+approval sweep. Until this ran, a stale invitation sat `pending` for ever and
+the pending list kept offering it.
+"""
+
+import logging
+
+from prefect import flow
+
+from app.db.session import get_db_context
+from app.services.invitation import InvitationService
+
+logger = logging.getLogger(__name__)
+
+
+@flow(name="invitation-expiry-sweep")
+async def invitation_expiry_sweep_flow() -> int:
+    """Mark every PENDING invitation past `expires_at` as EXPIRED.
+
+    Returns how many invitations were expired, so a flow run's result says
+    what it found without anybody reading the logs.
+    """
+    async with get_db_context() as db:
+        expired = await InvitationService(db).expire_stale()
+
+    if expired:
+        logger.info("Invitation sweep: %d invitation(s) expired unaccepted", expired)
+    return expired

--- a/backend/tests/integration/test_invitation_expiry.py
+++ b/backend/tests/integration/test_invitation_expiry.py
@@ -1,0 +1,69 @@
+"""The invitation sweep against a real database.
+
+A mock can pin who calls the sweep; only Postgres can say which rows the
+UPDATE actually touches. What matters is the boundary: a pending invitation
+past its expiry flips to `expired`, and nothing else moves - not the one
+still within its window, and not the one an administrator already revoked,
+whose status records a decision the sweep must not write over (#456).
+"""
+
+from __future__ import annotations
+
+import secrets
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.db.models.organization import Invitation, InvitationStatus, Organization
+from app.db.models.user import User
+from app.repositories import invitation_repo
+
+pytestmark = pytest.mark.anyio
+
+
+async def _invitation(db, *, status: str, expires_at: datetime) -> Invitation:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"{uuid.uuid4().hex}@example.com",
+        hashed_password="x",
+        is_active=True,
+    )
+    db.add(user)
+    await db.flush()
+    org = Organization(
+        id=uuid.uuid4(),
+        name="Acme",
+        slug=f"acme-{uuid.uuid4().hex[:8]}",
+        created_by_user_id=user.id,
+    )
+    db.add(org)
+    await db.flush()
+    invite = Invitation(
+        id=uuid.uuid4(),
+        organization_id=org.id,
+        email=f"{uuid.uuid4().hex}@example.com",
+        invited_by_user_id=user.id,
+        token=secrets.token_urlsafe(32),
+        status=status,
+        expires_at=expires_at,
+    )
+    db.add(invite)
+    await db.flush()
+    return invite
+
+
+async def test_the_sweep_expires_exactly_the_stale_pending_rows(db):
+    hour_ago = datetime.now(UTC) - timedelta(hours=1)
+    next_week = datetime.now(UTC) + timedelta(days=7)
+    stale = await _invitation(db, status=InvitationStatus.PENDING.value, expires_at=hour_ago)
+    fresh = await _invitation(db, status=InvitationStatus.PENDING.value, expires_at=next_week)
+    revoked = await _invitation(db, status=InvitationStatus.REVOKED.value, expires_at=hour_ago)
+
+    assert await invitation_repo.expire_stale(db) == 1
+
+    for invite in (stale, fresh, revoked):
+        await db.refresh(invite)
+    assert stale.status == InvitationStatus.EXPIRED.value
+    assert fresh.status == InvitationStatus.PENDING.value
+    assert revoked.status == InvitationStatus.REVOKED.value

--- a/backend/tests/test_invitation_expiry.py
+++ b/backend/tests/test_invitation_expiry.py
@@ -1,0 +1,84 @@
+"""Tests for expiring an invitation nobody accepted in time.
+
+An invitation times out by clock, and the ordinary way it does is that nobody
+ever clicks it - so no request path can be relied on to write `EXPIRED`, and
+the ceiling has to be a schedule, the same reasoning as the approval sweep.
+The one request-path case, a click arriving past the expiry, must record a
+timeout rather than a withdrawal: `revoked` says somebody took the invitation
+back, which is a different fact from the one that happened (#456).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.exceptions import BadRequestError
+from app.db.models.organization import InvitationStatus, OrgRole
+from app.services.invitation import InvitationService
+from app.worker.tasks.invitation_tasks import invitation_expiry_sweep_flow
+
+pytestmark = pytest.mark.anyio
+
+MODULE = "app.services.invitation"
+
+
+def _stale_invite() -> MagicMock:
+    invite = MagicMock()
+    invite.id = uuid.uuid4()
+    invite.organization_id = uuid.uuid4()
+    invite.email = "invited@acme.test"
+    invite.role = OrgRole.MEMBER.value
+    invite.status = InvitationStatus.PENDING.value
+    invite.expires_at = datetime.now(UTC) - timedelta(days=1)
+    return invite
+
+
+class TestAClickPastExpiry:
+    async def test_a_timed_out_invitation_is_marked_expired_not_revoked(self):
+        """What an admin reads off the members list. `revoked` claims somebody
+        withdrew the invitation; the row timed out, and the status must say so."""
+        invite = _stale_invite()
+        with (
+            patch(f"{MODULE}.invitation_repo.get_by_token", new=AsyncMock(return_value=invite)),
+            patch(f"{MODULE}.invitation_repo.expire", new=AsyncMock()) as expire,
+            patch(f"{MODULE}.invitation_repo.revoke", new=AsyncMock()) as revoke,
+            pytest.raises(BadRequestError, match="expired"),
+        ):
+            await InvitationService(MagicMock()).accept("tok", uuid.uuid4())
+
+        expire.assert_awaited_once()
+        assert expire.await_args.args[1] is invite
+        revoke.assert_not_awaited()
+
+
+class TestTheScheduledSweep:
+    """The flow around the service. Thin on purpose - what it must not do is
+    swallow the count, since that is all a Prefect run reports."""
+
+    async def test_the_flow_answers_with_what_it_expired(self):
+        with (
+            patch("app.worker.tasks.invitation_tasks.get_db_context") as db_context,
+            patch(
+                "app.worker.tasks.invitation_tasks.InvitationService",
+                return_value=MagicMock(expire_stale=AsyncMock(return_value=2)),
+            ),
+        ):
+            db_context.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+            db_context.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            assert await invitation_expiry_sweep_flow() == 2
+
+    async def test_the_service_sweep_is_the_repository_sweep(self):
+        """One UPDATE, cross-tenant by construction - a schedule has no tenant
+        to be scoped to. The service adds nothing on purpose, and this pins
+        that the count is handed through rather than swallowed."""
+        with patch(
+            f"{MODULE}.invitation_repo.expire_stale", new=AsyncMock(return_value=3)
+        ) as sweep:
+            assert await InvitationService(MagicMock()).expire_stale() == 3
+
+        sweep.assert_awaited_once()

--- a/backend/tests/test_invite_links.py
+++ b/backend/tests/test_invite_links.py
@@ -206,7 +206,7 @@ class TestAccepting:
         invite = _link(expires_at=datetime.now(UTC) - timedelta(days=1))
         with (
             patch(f"{MODULE}.invitation_repo.get_by_token", new=AsyncMock(return_value=invite)),
-            patch(f"{MODULE}.invitation_repo.revoke", new=AsyncMock()),
+            patch(f"{MODULE}.invitation_repo.expire", new=AsyncMock()),
             pytest.raises(BadRequestError, match="expired"),
         ):
             await InvitationService(MagicMock()).accept("tok", uuid.uuid4())

--- a/backend/tests/test_prefect_app.py
+++ b/backend/tests/test_prefect_app.py
@@ -80,6 +80,7 @@ async def test_every_deployment_is_registered_before_the_runner_starts(
         "rag-sync-check",
         "mcp-connection-sweep",
         "approval-expiry-sweep",
+        "invitation-expiry-sweep",
         "weekly-usage-report",
         "monthly-usage-report",
     }


### PR DESCRIPTION
## What this fixes

Closes #456. `InvitationStatus.EXPIRED` was unreachable: `invitation_repo.expire_stale` had no caller, so an invitation nobody clicks stayed `pending` for ever and the pending list kept offering it. And when one *was* clicked past its expiry, the accept path marked it `revoked` — recording a withdrawal somebody made, when what happened is that it timed out.

## What changed

- `backend/app/worker/tasks/invitation_tasks.py` (new) — `invitation-expiry-sweep` flow, the same shape as the approval sweep (#457).
- `backend/app/worker/prefect_app.py:77` — registers the sweep hourly; the TTL is measured in days, so precision buys nothing.
- `backend/app/services/invitation.py:249` — `InvitationService.expire_stale`, the service boundary the flow calls; hands through the repository sweep that already existed.
- `backend/app/services/invitation.py:187` — `accept` now writes `EXPIRED` instead of `REVOKED` on a click past `expires_at`.
- `backend/app/repositories/invitation.py:103` — new `expire(db, invite)`, mirroring `revoke`.
- `backend/tests/test_prefect_app.py:83` — the registration set names the new deployment.
- `backend/tests/test_invite_links.py:209` — the expired-link test patches `expire` instead of `revoke`.

## How it failed before

1. Invite someone; `expires_at` set, status `pending`.
2. Wait past it. Nothing runs, nothing changes — the row stays `pending`, the pending list still offers it.
3. Have them click the link: correctly refused, but the row becomes `revoked` rather than `expired` — the wrong fact for an admin reading the list.

## Testing

- `tests/test_invitation_expiry.py::TestAClickPastExpiry::test_a_timed_out_invitation_is_marked_expired_not_revoked` — fails on `main` (`revoke` awaited, `expire` does not exist).
- `tests/test_invitation_expiry.py::TestTheScheduledSweep` — the flow answers with the count, and the service hands it through.
- `tests/integration/test_invitation_expiry.py` — against a real Postgres, the sweep flips exactly the stale pending row: not the one still within its window, and not the one already revoked.
- `make lint-backend` and `make test` (4379 passed, 100% gate) green locally.

No frontend change owed: the members page filters invitations to `status === "pending"`, so an expired row drops off the list, which is the point.

## Noticed, not fixed

- `InvitationService.invite` refuses a re-invite while a stale `pending` invitation waits for the sweep — at an hourly interval that window is under an hour, where before this change it was for ever. Not worth an in-request expiry check on the invite path for now.
- `InvitationStatus.REJECTED` is also defined and never assigned, but nothing presents it as having happened, so it is dead weight rather than a wrong fact on a row.
