### PR TITLE
fix(api): answer a refusal with the backend's reason, not a generic

### DIFF
--- a/docs/plans/frontend-coverage.md
+++ b/docs/plans/frontend-coverage.md
@@ -93,19 +93,13 @@ between them dropped it. Fixed, and `admin-routes.test.ts` now pins each paramet
 the screen can send.
 
 
-Thirty-eight of the generated routes under `src/app/api` answer a refusal with
-`detail: error.message`. That is `BackendApiError`'s own string - `"Backend API
-error: 400 Bad Request"` - not the backend's `detail`, which is sitting right
-there in `error.data`. The routes written by hand for this platform
-(`login`, `register`, `oauth-callback`) read the envelope properly; the
-template's do not.
-
-The symptom is a user-visible one: an expired magic link, a stale password-reset
-token and a duplicate invitation all report a status code instead of the sentence
-that says what to do. The fix is one helper and thirty-eight call sites, so it
-wants its own change rather than riding along with the tests -
-`session-routes.test.ts` asserts the current behaviour with a comment naming it,
-because a test claiming the better sentence would be a test of nothing.
+The generated routes under `src/app/api` used to answer a refusal with
+`detail: error.message` - `BackendApiError`'s own string, `"Backend API error:
+400 Bad Request"` - while the backend's sentence sat unread in `error.data`.
+Fixed by #546: `backendErrorDetail` in `server-api.ts` reads the envelope, all
+fifty-five call sites go through it, and the refusal tests in
+`cookie-routes.test.ts`, `admin-routes.test.ts` and `session-routes.test.ts`
+assert the sentence as well as the status.
 
 ## Backend
 

--- a/frontend/src/app/api/admin/admin-routes.test.ts
+++ b/frontend/src/app/api/admin/admin-routes.test.ts
@@ -143,11 +143,16 @@ describe("the admin gate", () => {
   });
 
   it.each(GUARDED)("passes the backend's own refusal of %s through", async (_name, call) => {
-    vi.mocked(backendFetch).mockRejectedValue(new BackendApiError(409, "Conflict", null));
+    // Sentence included - `error.message` is the constructor's generic
+    // string, and answering with it was #546.
+    vi.mocked(backendFetch).mockRejectedValue(
+      new BackendApiError(409, "Conflict", { detail: "User already deactivated" }),
+    );
 
     const response = await call();
 
     expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({ detail: "User already deactivated" });
   });
 });
 

--- a/frontend/src/app/api/admin/conversations/[id]/route.ts
+++ b/frontend/src/app/api/admin/conversations/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { backendFetch, BackendApiError } from "@/lib/server-api";
+import { backendFetch, BackendApiError, backendErrorDetail } from "@/lib/server-api";
 import { requireAdmin } from "@/lib/admin-auth";
 
 interface RouteParams {
@@ -19,10 +19,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json(
-        { detail: error.message || "Failed to fetch conversation" },
-        { status: error.status },
-      );
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }

--- a/frontend/src/app/api/admin/conversations/route.ts
+++ b/frontend/src/app/api/admin/conversations/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { backendFetch, BackendApiError } from "@/lib/server-api";
+import { backendFetch, BackendApiError, backendErrorDetail } from "@/lib/server-api";
 import { requireAdmin } from "@/lib/admin-auth";
 
 export async function GET(request: NextRequest) {
@@ -46,10 +46,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json(
-        { detail: error.message || "Failed to fetch conversations" },
-        { status: error.status },
-      );
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }

--- a/frontend/src/app/api/admin/organizations/route.ts
+++ b/frontend/src/app/api/admin/organizations/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { requireAdmin } from "@/lib/admin-auth";
-import { BackendApiError, backendFetch } from "@/lib/server-api";
+import { BackendApiError, backendFetch, backendErrorDetail } from "@/lib/server-api";
 
 export async function GET(request: NextRequest) {
   try {
@@ -16,7 +16,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }

--- a/frontend/src/app/api/admin/ratings/export/route.ts
+++ b/frontend/src/app/api/admin/ratings/export/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { backendFetch, BackendApiError } from "@/lib/server-api";
+import { backendFetch, BackendApiError, backendErrorDetail } from "@/lib/server-api";
 import { requireAdmin } from "@/lib/admin-auth";
 
 export async function GET(request: NextRequest) {
@@ -43,10 +43,7 @@ export async function GET(request: NextRequest) {
     });
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json(
-        { detail: error.message || "Failed to export ratings" },
-        { status: error.status },
-      );
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }

--- a/frontend/src/app/api/admin/ratings/route.ts
+++ b/frontend/src/app/api/admin/ratings/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { backendFetch, BackendApiError } from "@/lib/server-api";
+import { backendFetch, BackendApiError, backendErrorDetail } from "@/lib/server-api";
 import { requireAdmin } from "@/lib/admin-auth";
 
 export async function GET(request: NextRequest) {
@@ -27,10 +27,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json(
-        { detail: error.message || "Failed to fetch ratings" },
-        { status: error.status },
-      );
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }

--- a/frontend/src/app/api/admin/ratings/summary/route.ts
+++ b/frontend/src/app/api/admin/ratings/summary/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { backendFetch, BackendApiError } from "@/lib/server-api";
+import { backendFetch, BackendApiError, backendErrorDetail } from "@/lib/server-api";
 import { requireAdmin } from "@/lib/admin-auth";
 
 export async function GET(request: NextRequest) {
@@ -26,10 +26,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json(
-        { detail: error.message || "Failed to fetch ratings summary" },
-        { status: error.status },
-      );
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }

--- a/frontend/src/app/api/admin/stats/route.ts
+++ b/frontend/src/app/api/admin/stats/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { requireAdmin } from "@/lib/admin-auth";
-import { BackendApiError, backendFetch } from "@/lib/server-api";
+import { BackendApiError, backendFetch, backendErrorDetail } from "@/lib/server-api";
 
 export async function GET(request: NextRequest) {
   try {
@@ -15,7 +15,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }

--- a/frontend/src/app/api/admin/system/route.ts
+++ b/frontend/src/app/api/admin/system/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { requireAdmin } from "@/lib/admin-auth";
-import { BackendApiError, backendFetch } from "@/lib/server-api";
+import { BackendApiError, backendFetch, backendErrorDetail } from "@/lib/server-api";
 
 /**
  * Per-service health for the admin system page.
@@ -23,7 +23,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }

--- a/frontend/src/app/api/admin/users/[userId]/impersonate/route.ts
+++ b/frontend/src/app/api/admin/users/[userId]/impersonate/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { backendFetch, BackendApiError } from "@/lib/server-api";
+import { backendFetch, BackendApiError, backendErrorDetail } from "@/lib/server-api";
 import { requireAdmin } from "@/lib/admin-auth";
 
 interface RouteParams {
@@ -20,7 +20,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }

--- a/frontend/src/app/api/admin/users/[userId]/route.ts
+++ b/frontend/src/app/api/admin/users/[userId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { backendFetch, BackendApiError } from "@/lib/server-api";
+import { backendFetch, BackendApiError, backendErrorDetail } from "@/lib/server-api";
 import { requireAdmin } from "@/lib/admin-auth";
 
 interface RouteParams {
@@ -19,7 +19,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
@@ -45,7 +45,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
@@ -65,7 +65,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     return new NextResponse(null, { status: 204 });
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }

--- a/frontend/src/app/api/admin/users/route.ts
+++ b/frontend/src/app/api/admin/users/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { backendFetch, BackendApiError } from "@/lib/server-api";
+import { backendFetch, BackendApiError, backendErrorDetail } from "@/lib/server-api";
 import { requireAdmin } from "@/lib/admin-auth";
 
 export async function GET(request: NextRequest) {
@@ -30,10 +30,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json(
-        { detail: error.message || "Failed to fetch users" },
-        { status: error.status },
-      );
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }

--- a/frontend/src/app/api/auth/magic-link/request/route.ts
+++ b/frontend/src/app/api/auth/magic-link/request/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 
-import { BackendApiError, backendFetch } from "@/lib/server-api";
+import { BackendApiError, backendFetch, backendErrorDetail } from "@/lib/server-api";
 
 export async function POST(request: NextRequest) {
   try {
@@ -12,7 +12,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }

--- a/frontend/src/app/api/auth/magic-link/verify/route.ts
+++ b/frontend/src/app/api/auth/magic-link/verify/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 
-import { BackendApiError, backendFetch } from "@/lib/server-api";
+import { BackendApiError, backendFetch, backendErrorDetail } from "@/lib/server-api";
 
 interface TokenResponse {
   access_token: string;
@@ -44,7 +44,7 @@ export async function POST(request: NextRequest) {
     return response;
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }

--- a/frontend/src/app/api/auth/password-reset/confirm/route.ts
+++ b/frontend/src/app/api/auth/password-reset/confirm/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 
-import { BackendApiError, backendFetch } from "@/lib/server-api";
+import { BackendApiError, backendFetch, backendErrorDetail } from "@/lib/server-api";
 
 export async function POST(request: NextRequest) {
   try {
@@ -12,7 +12,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }

--- a/frontend/src/app/api/auth/password-reset/request/route.ts
+++ b/frontend/src/app/api/auth/password-reset/request/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 
-import { BackendApiError, backendFetch } from "@/lib/server-api";
+import { BackendApiError, backendFetch, backendErrorDetail } from "@/lib/server-api";
 
 export async function POST(request: NextRequest) {
   try {
@@ -12,7 +12,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }

--- a/frontend/src/app/api/auth/session-routes.test.ts
+++ b/frontend/src/app/api/auth/session-routes.test.ts
@@ -394,12 +394,10 @@ describe("signing in without a password", () => {
   });
 
   it("refuses a link that did not verify, without a session", async () => {
-    // The status survives; the *sentence* does not. This route reports
-    // `error.message`, which is `BackendApiError`'s own generic string, so an
-    // expired link reads as "Backend API error: 400 Bad Request" rather than
-    // "This link has expired". Thirty-eight generated routes do the same thing -
-    // see `docs/plans/frontend-coverage.md`. Asserted as it behaves, not as it
-    // should: a test that claimed the better sentence would be a test of nothing.
+    // The status and the sentence both survive. This route used to report
+    // `error.message`, `BackendApiError`'s own generic string, so an expired
+    // link read as "Backend API error: 400 Bad Request" rather than the
+    // reason the backend gave (#546).
     vi.mocked(backendFetch).mockRejectedValue(
       new BackendApiError(400, "Bad Request", { detail: "This link has expired" }),
     );
@@ -407,9 +405,7 @@ describe("signing in without a password", () => {
     const response = await magicLinkVerify(request({}, { token: "stale" }));
 
     expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toEqual({
-      detail: "Backend API error: 400 Bad Request",
-    });
+    await expect(response.json()).resolves.toEqual({ detail: "This link has expired" });
     expect(cookie(response, "access_token")).toBeUndefined();
   });
 

--- a/frontend/src/app/api/cookie-routes.test.ts
+++ b/frontend/src/app/api/cookie-routes.test.ts
@@ -381,11 +381,20 @@ describe("the routes that read the session cookie", () => {
   });
 
   it.each(COOKIE_GATED)("passes the backend's refusal of %s through", async (_name, call) => {
-    vi.mocked(backendFetch).mockRejectedValue(new BackendApiError(403, "Forbidden", null));
+    // Status and sentence both. These routes used to answer with
+    // `BackendApiError`'s own constructor string, so every refusal on this
+    // surface read "Backend API error: 403 Forbidden" instead of the reason
+    // sitting in the body (#546).
+    vi.mocked(backendFetch).mockRejectedValue(
+      new BackendApiError(403, "Forbidden", { detail: "Only Owner or Admin can manage members" }),
+    );
 
     const response = await call(true);
 
     expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      detail: "Only Owner or Admin can manage members",
+    });
   });
 
   it.each(COOKIE_GATED)("answers 500 when %s could not be forwarded", async (_name, call) => {

--- a/frontend/src/app/api/invitations/[token]/route.ts
+++ b/frontend/src/app/api/invitations/[token]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { backendFetch, BackendApiError } from "@/lib/server-api";
+import { backendFetch, BackendApiError, backendErrorDetail } from "@/lib/server-api";
 
 interface RouteParams {
   params: Promise<{ token: string }>;
@@ -17,7 +17,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError)
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
 }
@@ -34,7 +34,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     return new NextResponse(null, { status: 204 });
   } catch (error) {
     if (error instanceof BackendApiError)
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
 }

--- a/frontend/src/app/api/me/channel-link/[token]/route.ts
+++ b/frontend/src/app/api/me/channel-link/[token]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 
-import { BackendApiError, backendFetch } from "@/lib/server-api";
+import { BackendApiError, backendFetch, backendErrorDetail } from "@/lib/server-api";
 
 /**
  * The chat account a link URL is about, and the confirmation that claims it.
@@ -24,7 +24,7 @@ export async function GET(request: NextRequest, context: { params: Promise<{ tok
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
@@ -44,7 +44,7 @@ export async function POST(request: NextRequest, context: { params: Promise<{ to
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
@@ -74,7 +74,7 @@ export async function DELETE(
     return new NextResponse(null, { status: 204 });
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }

--- a/frontend/src/app/api/me/channel-link/route.ts
+++ b/frontend/src/app/api/me/channel-link/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 
-import { BackendApiError, backendFetch } from "@/lib/server-api";
+import { BackendApiError, backendFetch, backendErrorDetail } from "@/lib/server-api";
 
 /**
  * The chat accounts the signed-in person has connected.
@@ -21,7 +21,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }

--- a/frontend/src/app/api/me/mcp-connections/[id]/route.ts
+++ b/frontend/src/app/api/me/mcp-connections/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 
-import { BackendApiError, backendFetch } from "@/lib/server-api";
+import { BackendApiError, backendFetch, backendErrorDetail } from "@/lib/server-api";
 
 export async function PATCH(request: NextRequest, context: { params: Promise<{ id: string }> }) {
   const accessToken = request.cookies.get("access_token")?.value;
@@ -18,7 +18,7 @@ export async function PATCH(request: NextRequest, context: { params: Promise<{ i
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
@@ -38,7 +38,7 @@ export async function DELETE(request: NextRequest, context: { params: Promise<{ 
     return new NextResponse(null, { status: 204 });
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }

--- a/frontend/src/app/api/me/mcp-connections/[id]/test/route.ts
+++ b/frontend/src/app/api/me/mcp-connections/[id]/test/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 
-import { BackendApiError, backendFetch } from "@/lib/server-api";
+import { BackendApiError, backendFetch, backendErrorDetail } from "@/lib/server-api";
 
 export async function POST(request: NextRequest, context: { params: Promise<{ id: string }> }) {
   const accessToken = request.cookies.get("access_token")?.value;
@@ -16,7 +16,7 @@ export async function POST(request: NextRequest, context: { params: Promise<{ id
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }

--- a/frontend/src/app/api/me/mcp-connections/oauth/start/route.ts
+++ b/frontend/src/app/api/me/mcp-connections/oauth/start/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 
-import { BackendApiError, backendFetch } from "@/lib/server-api";
+import { BackendApiError, backendFetch, backendErrorDetail } from "@/lib/server-api";
 
 export async function POST(request: NextRequest) {
   const accessToken = request.cookies.get("access_token")?.value;
@@ -17,7 +17,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }

--- a/frontend/src/app/api/me/mcp-connections/route.ts
+++ b/frontend/src/app/api/me/mcp-connections/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 
-import { BackendApiError, backendFetch } from "@/lib/server-api";
+import { BackendApiError, backendFetch, backendErrorDetail } from "@/lib/server-api";
 
 export async function GET(request: NextRequest) {
   const accessToken = request.cookies.get("access_token")?.value;
@@ -15,7 +15,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
@@ -36,7 +36,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(data, { status: 201 });
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }

--- a/frontend/src/app/api/me/slash-commands/[id]/route.ts
+++ b/frontend/src/app/api/me/slash-commands/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 
-import { BackendApiError, backendFetch } from "@/lib/server-api";
+import { BackendApiError, backendFetch, backendErrorDetail } from "@/lib/server-api";
 
 export async function PATCH(request: NextRequest, context: { params: Promise<{ id: string }> }) {
   const accessToken = request.cookies.get("access_token")?.value;
@@ -18,7 +18,7 @@ export async function PATCH(request: NextRequest, context: { params: Promise<{ i
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
@@ -38,7 +38,7 @@ export async function DELETE(request: NextRequest, context: { params: Promise<{ 
     return new NextResponse(null, { status: 204 });
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }

--- a/frontend/src/app/api/me/slash-commands/builtin/route.ts
+++ b/frontend/src/app/api/me/slash-commands/builtin/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 
-import { BackendApiError, backendFetch } from "@/lib/server-api";
+import { BackendApiError, backendFetch, backendErrorDetail } from "@/lib/server-api";
 
 export async function PUT(request: NextRequest) {
   const accessToken = request.cookies.get("access_token")?.value;
@@ -17,7 +17,7 @@ export async function PUT(request: NextRequest) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }

--- a/frontend/src/app/api/me/slash-commands/custom/route.ts
+++ b/frontend/src/app/api/me/slash-commands/custom/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 
-import { BackendApiError, backendFetch } from "@/lib/server-api";
+import { BackendApiError, backendFetch, backendErrorDetail } from "@/lib/server-api";
 
 export async function POST(request: NextRequest) {
   const accessToken = request.cookies.get("access_token")?.value;
@@ -17,7 +17,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(data, { status: 201 });
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }

--- a/frontend/src/app/api/me/slash-commands/route.ts
+++ b/frontend/src/app/api/me/slash-commands/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 
-import { BackendApiError, backendFetch } from "@/lib/server-api";
+import { BackendApiError, backendFetch, backendErrorDetail } from "@/lib/server-api";
 
 export async function GET(request: NextRequest) {
   const accessToken = request.cookies.get("access_token")?.value;
@@ -15,7 +15,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError) {
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     }
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }

--- a/frontend/src/app/api/orgs/[id]/integrations/[sourceId]/route.ts
+++ b/frontend/src/app/api/orgs/[id]/integrations/[sourceId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 
-import { BackendApiError, backendFetch } from "@/lib/server-api";
+import { BackendApiError, backendFetch, backendErrorDetail } from "@/lib/server-api";
 
 interface RouteParams {
   params: Promise<{ id: string; sourceId: string }>;
@@ -21,7 +21,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     return new NextResponse(null, { status: 204 });
   } catch (error) {
     if (error instanceof BackendApiError)
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
 }

--- a/frontend/src/app/api/orgs/[id]/integrations/[sourceId]/trigger/route.ts
+++ b/frontend/src/app/api/orgs/[id]/integrations/[sourceId]/trigger/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 
-import { BackendApiError, backendFetch } from "@/lib/server-api";
+import { BackendApiError, backendFetch, backendErrorDetail } from "@/lib/server-api";
 
 interface RouteParams {
   params: Promise<{ id: string; sourceId: string }>;
@@ -21,7 +21,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError)
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
 }

--- a/frontend/src/app/api/orgs/[id]/integrations/connectors/route.ts
+++ b/frontend/src/app/api/orgs/[id]/integrations/connectors/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 
-import { BackendApiError, backendFetch } from "@/lib/server-api";
+import { BackendApiError, backendFetch, backendErrorDetail } from "@/lib/server-api";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -20,7 +20,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError)
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
 }

--- a/frontend/src/app/api/orgs/[id]/integrations/route.ts
+++ b/frontend/src/app/api/orgs/[id]/integrations/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 
-import { BackendApiError, backendFetch } from "@/lib/server-api";
+import { BackendApiError, backendFetch, backendErrorDetail } from "@/lib/server-api";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -20,7 +20,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError)
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
 }
@@ -43,7 +43,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json(data, { status: 201 });
   } catch (error) {
     if (error instanceof BackendApiError)
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
 }

--- a/frontend/src/app/api/orgs/[id]/invitations/[invitationId]/route.ts
+++ b/frontend/src/app/api/orgs/[id]/invitations/[invitationId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { backendFetch, BackendApiError } from "@/lib/server-api";
+import { backendFetch, BackendApiError, backendErrorDetail } from "@/lib/server-api";
 
 interface RouteParams {
   params: Promise<{ id: string; invitationId: string }>;
@@ -25,7 +25,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     return new NextResponse(null, { status: 204 });
   } catch (error) {
     if (error instanceof BackendApiError)
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
 }

--- a/frontend/src/app/api/orgs/[id]/invitations/route.ts
+++ b/frontend/src/app/api/orgs/[id]/invitations/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { backendFetch, BackendApiError } from "@/lib/server-api";
+import { backendFetch, BackendApiError, backendErrorDetail } from "@/lib/server-api";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -16,7 +16,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError)
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
 }
@@ -35,7 +35,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json(data, { status: 201 });
   } catch (error) {
     if (error instanceof BackendApiError)
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
 }

--- a/frontend/src/app/api/orgs/[id]/members/[userId]/route.ts
+++ b/frontend/src/app/api/orgs/[id]/members/[userId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { backendFetch, BackendApiError } from "@/lib/server-api";
+import { backendFetch, BackendApiError, backendErrorDetail } from "@/lib/server-api";
 
 interface RouteParams {
   params: Promise<{ id: string; userId: string }>;
@@ -19,7 +19,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError)
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
 }
@@ -36,7 +36,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     return new NextResponse(null, { status: 204 });
   } catch (error) {
     if (error instanceof BackendApiError)
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
 }

--- a/frontend/src/app/api/orgs/[id]/members/route.ts
+++ b/frontend/src/app/api/orgs/[id]/members/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { backendFetch, BackendApiError } from "@/lib/server-api";
+import { backendFetch, BackendApiError, backendErrorDetail } from "@/lib/server-api";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -16,7 +16,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError)
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
 }

--- a/frontend/src/app/api/orgs/[id]/route.ts
+++ b/frontend/src/app/api/orgs/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { backendFetch, BackendApiError } from "@/lib/server-api";
+import { backendFetch, BackendApiError, backendErrorDetail } from "@/lib/server-api";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -16,7 +16,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError)
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
 }
@@ -35,7 +35,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError)
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
 }
@@ -52,7 +52,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     return new NextResponse(null, { status: 204 });
   } catch (error) {
     if (error instanceof BackendApiError)
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
 }

--- a/frontend/src/app/api/orgs/route.ts
+++ b/frontend/src/app/api/orgs/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { backendFetch, BackendApiError } from "@/lib/server-api";
+import { backendFetch, BackendApiError, backendErrorDetail } from "@/lib/server-api";
 
 export async function GET(request: NextRequest) {
   try {
@@ -12,7 +12,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError)
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
 }
@@ -31,7 +31,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(data, { status: 201 });
   } catch (error) {
     if (error instanceof BackendApiError)
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
 }

--- a/frontend/src/app/api/sessions/[id]/route.ts
+++ b/frontend/src/app/api/sessions/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { backendFetch, BackendApiError } from "@/lib/server-api";
+import { backendFetch, BackendApiError, backendErrorDetail } from "@/lib/server-api";
 
 export async function DELETE(
   request: NextRequest,
@@ -16,7 +16,7 @@ export async function DELETE(
     return new NextResponse(null, { status: 204 });
   } catch (error) {
     if (error instanceof BackendApiError)
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
 }

--- a/frontend/src/app/api/sessions/route.ts
+++ b/frontend/src/app/api/sessions/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { backendFetch, BackendApiError } from "@/lib/server-api";
+import { backendFetch, BackendApiError, backendErrorDetail } from "@/lib/server-api";
 
 export async function GET(request: NextRequest) {
   try {
@@ -19,7 +19,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError)
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
 }
@@ -35,7 +35,7 @@ export async function DELETE(request: NextRequest) {
     return new NextResponse(null, { status: 204 });
   } catch (error) {
     if (error instanceof BackendApiError)
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
 }

--- a/frontend/src/app/api/users/me/route.ts
+++ b/frontend/src/app/api/users/me/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { backendFetch, BackendApiError } from "@/lib/server-api";
+import { backendFetch, BackendApiError, backendErrorDetail } from "@/lib/server-api";
 
 export async function GET(request: NextRequest) {
   try {
@@ -11,7 +11,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError)
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
 }
@@ -29,7 +29,7 @@ export async function PATCH(request: NextRequest) {
     return NextResponse.json(data);
   } catch (error) {
     if (error instanceof BackendApiError)
-      return NextResponse.json({ detail: error.message }, { status: error.status });
+      return NextResponse.json({ detail: backendErrorDetail(error) }, { status: error.status });
     return NextResponse.json({ detail: "Internal server error" }, { status: 500 });
   }
 }

--- a/frontend/src/lib/server-api.test.ts
+++ b/frontend/src/lib/server-api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { BackendApiError, backendFetch, getAuthHeaders } from "./server-api";
+import { BackendApiError, backendErrorDetail, backendFetch, getAuthHeaders } from "./server-api";
 
 /**
  * The server-side half of every proxy route.
@@ -110,6 +110,30 @@ describe("backendFetch", () => {
     const failure = await backendFetch("/api/v1/agents").catch((error: unknown) => error);
 
     expect(failure).toMatchObject({ status: 502, data: null });
+  });
+});
+
+describe("backendErrorDetail", () => {
+  it("surfaces the backend's own sentence, not the constructor's generic one", () => {
+    const error = new BackendApiError(403, "Forbidden", {
+      detail: "Only Owner or Admin can manage members",
+    });
+
+    expect(backendErrorDetail(error)).toBe("Only Owner or Admin can manage members");
+  });
+
+  it("falls back to the generic message when the refusal had no readable body", () => {
+    const error = new BackendApiError(502, "Bad Gateway", null);
+
+    expect(backendErrorDetail(error)).toBe("Backend API error: 502 Bad Gateway");
+  });
+
+  it("falls back when detail is a validation list rather than a sentence", () => {
+    const error = new BackendApiError(422, "Unprocessable Entity", {
+      detail: [{ loc: ["body", "email"], msg: "field required" }],
+    });
+
+    expect(backendErrorDetail(error)).toBe("Backend API error: 422 Unprocessable Entity");
   });
 });
 

--- a/frontend/src/lib/server-api.ts
+++ b/frontend/src/lib/server-api.ts
@@ -18,6 +18,18 @@ export class BackendApiError extends Error {
   }
 }
 
+/**
+ * The backend's refusal reason, for a route handler answering an error.
+ *
+ * FastAPI puts the sentence in the body's `detail`; a validation error puts a
+ * list there, which is no sentence to show anybody, so anything but a string
+ * falls back to the error's own generic message.
+ */
+export function backendErrorDetail(error: BackendApiError): string {
+  const detail = (error.data as { detail?: unknown } | null)?.detail;
+  return typeof detail === "string" ? detail : error.message;
+}
+
 interface RequestOptions extends RequestInit {
   params?: Record<string, string>;
   /** Return raw text instead of parsing as JSON */


### PR DESCRIPTION
> **This body was wrong and is being corrected.** It held PR #667's text verbatim —
> invitation expiry, `Closes #456` — on a diff that changes ~40 frontend proxy route
> handlers. The footer is fixed below so a merge cannot close the wrong issue; the
> narrative still needs writing by whoever finishes the branch. Found in the #683 map
> rebuild.

## What this fixes

The hand-rolled `backendFetch` route handlers under `frontend/src/app/api/**` discard
the backend's refusal reason and answer with a generic `Backend API error`, so a
refusal a person could act on ("that name is already taken", "you may not write that
collection") reaches the toast as a sentence that says nothing. That is #546.

## What changed

`gh pr diff 668 --name-only` is the list: the admin, auth, invitations, orgs, files,
me/* and rag route families, plus `admin-routes.test.ts`, `session-routes.test.ts`,
`cookie-routes.test.ts` and `docs/plans/frontend-coverage.md`.

## Still owed on this branch

- A written account of what changed and how it was verified, at the bar `CLAUDE.md`
  sets for a body — the failure prevented, concretely; how it was verified and how far
  that reaches; what was seen and deliberately not fixed.
- Whether this supersedes or only overlaps **#564** (collapse the `backendFetch`
  forwarder family into `platformProxy`), which is the structural version of the same
  change, and **#553** (the same family omitting `no-store`). If this touches all forty
  handlers anyway, doing it as #564 rather than as a per-file patch is the cheaper end
  state.

Closes #546
