### PR TITLE
Give RAG document lookup one precedence and a stable order

### DIFF
--- a/backend/app/services/rag/ingestion.py
+++ b/backend/app/services/rag/ingestion.py
@@ -9,7 +9,7 @@ from app.services.embedding_resolution import embeddings_for_collection
 from app.services.rag.documents import DocumentProcessor
 from app.services.rag.embeddings import EmbeddingService
 from app.services.rag.failures import IngestionStage, failure_summary
-from app.services.rag.models import Document, IngestionResult, IngestionStatus
+from app.services.rag.models import Document, DocumentInfo, IngestionResult, IngestionStatus
 from app.services.rag.vectorstore import BaseVectorStore
 from app.services.rag.vectorstore import PgVectorStore as VectorStore
 
@@ -51,19 +51,34 @@ class IngestionService:
             except Exception as e:
                 logger.warning("Webhook event dispatch failed: %s", e)
 
-    async def _find_existing_by_source(self, collection_name: str, source_path: str) -> str | None:
+    async def _existing_by_source(
+        self, collection_name: str, source_path: str
+    ) -> tuple[str | None, str | None]:
+        """The stored document `source_path` refers to, as `(document_id, content_hash)`.
+
+        One precedence for both answers: a `source_path` match anywhere in the
+        collection beats a `filename` match anywhere in it. The id lookup and
+        the hash lookup used to walk the documents with different rules, so the
+        sync modes compared a live file's hash against a different document's
+        `content_hash` than the one they were about to replace (#548).
+        """
         try:
             docs = await self.store.get_documents(collection_name)
-            for doc in docs:
-                meta = doc.additional_info or {}
-                if meta.get("source_path") == source_path:
-                    return doc.document_id
-            for doc in docs:
-                if doc.filename and doc.filename == Path(source_path).name:
-                    return doc.document_id
         except Exception as exc:
             logger.warning("Could not check for existing document: %s", exc, exc_info=True)
-        return None
+            return None, None
+        filename = Path(source_path).name
+        fallback: DocumentInfo | None = None
+        for doc in docs:
+            meta = doc.additional_info or {}
+            if meta.get("source_path") == source_path:
+                return doc.document_id, meta.get("content_hash") or None
+            if fallback is None and doc.filename and doc.filename == filename:
+                fallback = doc
+        if fallback is None:
+            return None, None
+        meta = fallback.additional_info or {}
+        return fallback.document_id, meta.get("content_hash") or None
 
     async def _find_existing_by_hash(self, collection_name: str, content_hash: str) -> str | None:
         """Find an existing document by content hash (exact duplicate check)."""
@@ -106,7 +121,7 @@ class IngestionService:
             existing_id = None
             if replace:
                 if document.metadata.source_path:
-                    existing_id = await self._find_existing_by_source(
+                    existing_id, _ = await self._existing_by_source(
                         collection_name, document.metadata.source_path
                     )
                 if not existing_id and document.metadata.content_hash:
@@ -165,27 +180,12 @@ class IngestionService:
         )
 
     async def find_existing(self, collection_name: str, source_path: str) -> str | None:
-        return await self._find_existing_by_source(collection_name, source_path)
+        document_id, _ = await self._existing_by_source(collection_name, source_path)
+        return document_id
 
     async def get_existing_hash(self, collection_name: str, source_path: str) -> str | None:
-        try:
-            docs = await self.store.get_documents(collection_name)
-            doc_id: str | None = None
-            content_hash: str | None = None
-            for doc in docs:
-                meta = doc.additional_info or {}
-                if doc_id is None:
-                    if meta.get("source_path") == source_path:
-                        doc_id = doc.document_id
-                        content_hash = meta.get("content_hash")
-                        break
-                    if doc.filename and doc.filename == Path(source_path).name:
-                        doc_id = doc.document_id
-                        content_hash = meta.get("content_hash")
-            return content_hash
-        except Exception as exc:
-            logger.warning("Could not retrieve existing hash: %s", exc, exc_info=True)
-        return None
+        _, content_hash = await self._existing_by_source(collection_name, source_path)
+        return content_hash
 
     async def remove_document(self, collection_name: str, document_id: str) -> bool:
         """Wipes all traces of a document from the vector store."""

--- a/backend/app/services/rag/vectorstore.py
+++ b/backend/app/services/rag/vectorstore.py
@@ -471,7 +471,11 @@ class PgVectorStore(BaseVectorStore):
             return []
         table = self._table(collection_name)
         async with self.async_session() as session:
-            result = await session.execute(text(f"SELECT parent_doc_id, metadata FROM {table}"))
+            # Ordered so a lookup that falls back to a filename match does not
+            # depend on heap order (#548).
+            result = await session.execute(
+                text(f"SELECT parent_doc_id, metadata FROM {table} ORDER BY parent_doc_id, id")
+            )
             rows = result.fetchall()
         results = [
             {

--- a/backend/tests/test_rag_document_lookup.py
+++ b/backend/tests/test_rag_document_lookup.py
@@ -1,0 +1,122 @@
+"""One precedence for "which stored document is this source_path" (#548).
+
+`find_existing` and `get_existing_hash` used to walk the collection with
+different rules: the id lookup checked every document for a `source_path`
+match before falling back to `filename`, while the hash lookup interleaved
+the two and let a filename hit block a later source-path match. Row order
+decided which document each answered with — `get_documents` had no ORDER BY —
+so the sync modes in `rag_tasks.py` compared a live file's hash against a
+different document's `content_hash` than the one they were about to replace:
+an unchanged file re-embedded on every sync, or a changed one skipped as
+already current.
+
+This module is template-inherited and outside the coverage gate, which is why
+the precedence is pinned by name rather than trusted to a percentage.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.rag.ingestion import IngestionService
+from app.services.rag.models import DocumentInfo
+from app.services.rag.vectorstore import PgVectorStore
+
+pytestmark = pytest.mark.anyio
+
+
+def _service(docs: list[DocumentInfo]) -> IngestionService:
+    store = MagicMock(get_documents=AsyncMock(return_value=docs))
+    return IngestionService(processor=MagicMock(), vector_store=store)
+
+
+def _doc(
+    document_id: str, *, filename: str, source_path: str = "", content_hash: str = ""
+) -> DocumentInfo:
+    return DocumentInfo(
+        document_id=document_id,
+        filename=filename,
+        additional_info={"source_path": source_path, "content_hash": content_hash},
+    )
+
+
+class TestOnePrecedenceForBothAnswers:
+    async def test_the_id_and_the_hash_name_the_same_document(self):
+        """A filename match ordered before the source-path match must not split the answer."""
+        service = _service(
+            [
+                _doc(
+                    "doc-a",
+                    filename="handbook.pdf",
+                    source_path="/old/handbook.pdf",
+                    content_hash="hash-a",
+                ),
+                _doc(
+                    "doc-b",
+                    filename="handbook.pdf",
+                    source_path="/srv/sync/handbook.pdf",
+                    content_hash="hash-b",
+                ),
+            ]
+        )
+
+        assert await service.find_existing("kb", "/srv/sync/handbook.pdf") == "doc-b"
+        assert await service.get_existing_hash("kb", "/srv/sync/handbook.pdf") == "hash-b"
+
+    async def test_a_filename_match_answers_when_no_source_path_does(self):
+        service = _service(
+            [
+                _doc("doc-a", filename="other.pdf", content_hash="hash-a"),
+                _doc("doc-b", filename="handbook.pdf", content_hash="hash-b"),
+            ]
+        )
+
+        assert await service.find_existing("kb", "/srv/sync/handbook.pdf") == "doc-b"
+        assert await service.get_existing_hash("kb", "/srv/sync/handbook.pdf") == "hash-b"
+
+    async def test_no_match_answers_none_on_both_paths(self):
+        service = _service([_doc("doc-a", filename="other.pdf", content_hash="hash-a")])
+
+        assert await service.find_existing("kb", "/srv/sync/handbook.pdf") is None
+        assert await service.get_existing_hash("kb", "/srv/sync/handbook.pdf") is None
+
+    async def test_a_store_failure_answers_no_match_on_both_paths(self):
+        store = MagicMock(get_documents=AsyncMock(side_effect=RuntimeError("connection refused")))
+        service = IngestionService(processor=MagicMock(), vector_store=store)
+
+        assert await service.find_existing("kb", "/srv/sync/handbook.pdf") is None
+        assert await service.get_existing_hash("kb", "/srv/sync/handbook.pdf") is None
+
+    async def test_a_document_without_a_stored_hash_answers_none_not_empty(self):
+        """`_group_documents` fills an absent hash with "" — callers gate on truthiness."""
+        service = _service(
+            [_doc("doc-a", filename="handbook.pdf", source_path="/srv/sync/handbook.pdf")]
+        )
+
+        assert await service.get_existing_hash("kb", "/srv/sync/handbook.pdf") is None
+
+
+class TestGetDocumentsIsDeterministic:
+    async def test_the_document_listing_carries_an_order_by(self):
+        """The defence half of #548: arbitrary heap order is what let the two
+        old lookups disagree, so the listing pins its own order. Asserted on
+        the statement — the real consequence needs a populated Postgres, and a
+        heap that happens to be ordered would pass a behavioural check falsely.
+        """
+        session = MagicMock()
+        session.execute = AsyncMock(return_value=MagicMock(fetchall=MagicMock(return_value=[])))
+        session_ctx = MagicMock()
+        session_ctx.__aenter__ = AsyncMock(return_value=session)
+        session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        store = PgVectorStore.__new__(PgVectorStore)
+        store.async_session = MagicMock(return_value=session_ctx)
+        store._collection_exists = AsyncMock(return_value=True)  # type: ignore[method-assign]
+        store._table = MagicMock(return_value="collection_kb")  # type: ignore[method-assign]
+
+        await store.get_documents("kb")
+
+        statement = str(session.execute.await_args.args[0])
+        assert "ORDER BY parent_doc_id, id" in statement


### PR DESCRIPTION
## What this fixes

Closes #548 — the two RAG document-lookup helpers disagreed on precedence, and `get_documents` had no `ORDER BY`.

`IngestionService.find_existing` checked every document for a `source_path` match before falling back to `filename`; `get_existing_hash` interleaved the two in one pass, where a filename hit blocked any later source-path match. `PgVectorStore.get_documents` selected with no `ORDER BY`, so heap order decided which document each helper answered with. The `new_only`/`update_only` sync modes in `rag_tasks.py` call both, so they could compare a live file's hash against a *different* document's `content_hash` than the one `replace` was about to overwrite — an unchanged file re-embedded on every sync (needless embedding spend), or a changed file skipped as already current (stale index).

## What changed

- `app/services/rag/ingestion.py`: one private helper, `_existing_by_source`, returns `(document_id, content_hash)` under a single precedence — a `source_path` match anywhere in the collection beats a `filename` match anywhere in it. `find_existing`, `get_existing_hash` and `ingest_file`'s replace-dedupe all route through it.
- `app/services/rag/vectorstore.py`: `get_documents` orders by `(parent_doc_id, id)`, so the filename fallback no longer depends on heap order.
- An absent `content_hash` now comes back as `None` rather than `""` (the `_group_documents` filler). Every caller gates on truthiness, so behaviour is unchanged; the test pins it.

## How it failed before

Two documents where a filename-only match precedes the source-path match in row order: `find_existing` answered doc B (source match), `get_existing_hash` answered doc A's hash.

## Testing

- `backend/tests/test_rag_document_lookup.py` — new. Fails on the previous code on three counts (split answer, `""` hash passthrough, missing `ORDER BY`); passes on this branch. The ORDER BY is asserted on the statement text deliberately: a heap that happened to be ordered would pass a behavioural check falsely.
- `make lint-backend` green; `make test` green with the 100% platform gate; `make test-integration` ran against a real pgvector Postgres, 422 passed.
- No docs owed: `docs/file-processing.md` describes the sync modes at behaviour level ("unchanged skipped, changed updated") — this fix restores that described behaviour rather than changing it.

## Noticed, not fixed

- Each `find_existing` + `get_existing_hash` pair in `rag_tasks.py` / `commands/rag.py` still fetches the whole collection twice per file (O(N) per lookup) — that is #566's scope, and the shared helper makes collapsing the pair into one call trivial there.
