### PR TITLE
Validate the role an invite link offers

### DIFF
--- a/backend/app/schemas/organization.py
+++ b/backend/app/schemas/organization.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 from typing import Annotated
 from uuid import UUID
 
-from pydantic import EmailStr, Field, field_validator
+from pydantic import AfterValidator, EmailStr, Field, field_validator
 
 from app.core.permissions import OrgRoleName
 from app.schemas.base import BaseSchema, TimestampSchema
@@ -101,24 +101,28 @@ class OrganizationMemberList(BaseSchema):
     total: int
 
 
+def _invitable_role(v: str) -> str:
+    allowed = {role.value for role in OrgRoleName} - {OrgRoleName.OWNER.value}
+    if v not in allowed:
+        raise ValueError(f"Role must be one of: {', '.join(sorted(allowed))}")
+    return v
+
+
+# An invitation cannot make someone an owner - ownership transfers explicitly.
+# A link takes the same bound: it is built to be shared, so an unvalidated role
+# on it was a mintable owner credential (#551).
+InvitableRole = Annotated[str, AfterValidator(_invitable_role)]
+
+
 class InvitationCreate(BaseSchema):
     email: EmailStr
-    role: str = "member"
-
-    @field_validator("role")
-    @classmethod
-    def role_valid(cls, v: str) -> str:
-        # An invitation cannot make someone an owner - ownership transfers explicitly.
-        allowed = {role.value for role in OrgRoleName} - {OrgRoleName.OWNER.value}
-        if v not in allowed:
-            raise ValueError(f"Role must be one of: {', '.join(sorted(allowed))}")
-        return v
+    role: InvitableRole = "member"
 
 
 class InviteLinkCreate(BaseSchema):
     """A shareable link, as an administrator asks for one."""
 
-    role: str = Field(default="member", max_length=20)
+    role: InvitableRole = "member"
     max_uses: int | None = Field(
         default=None,
         ge=1,

--- a/backend/tests/test_invite_links.py
+++ b/backend/tests/test_invite_links.py
@@ -16,9 +16,11 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from app.core.exceptions import AuthenticationError, AuthorizationError, BadRequestError
 from app.db.models.organization import InvitationStatus, OrgRole
+from app.schemas.organization import InvitationCreate, InviteLinkCreate
 from app.services.invitation import InvitationService
 
 MODULE = "app.services.invitation"
@@ -117,6 +119,30 @@ class TestMinting:
             )
 
         assert create.call_args.kwargs["email_domain"] == "acme.com"
+
+
+class TestRoleOffered:
+    """Both create schemas refuse a role an invitation may not grant (#551).
+
+    The service's only ceiling is on Admins, so an Owner's request reaches the
+    membership row unchecked - the schema is where "no owner links, no made-up
+    roles" holds for every requester.
+    """
+
+    @pytest.mark.parametrize("role", ["owner", "ceo"])
+    def test_a_link_offering_an_ungrantable_role_is_refused(self, role):
+        with pytest.raises(ValidationError):
+            InviteLinkCreate(role=role)
+
+    @pytest.mark.parametrize("role", ["owner", "ceo"])
+    def test_an_email_invitation_offering_an_ungrantable_role_is_refused(self, role):
+        with pytest.raises(ValidationError):
+            InvitationCreate(email="new@acme.com", role=role)
+
+    @pytest.mark.parametrize("role", ["admin", "member", "viewer"])
+    def test_a_grantable_role_passes_both_schemas(self, role):
+        assert InviteLinkCreate(role=role).role == role
+        assert InvitationCreate(email="new@acme.com", role=role).role == role
 
 
 class TestAccepting:


### PR DESCRIPTION
## What this fixes

`InviteLinkCreate.role` carried no validator while its sibling `InvitationCreate` refused `owner` and unknown roles. An Owner could mint a **shareable link that grants owner** — co-ownership via a pasted URL, the exact thing the email invitation path forbids — or an invented role string that `role_has` cannot reason about, which then flowed unvalidated onto the accepter's membership row.

Closes #551

## What changed

- `backend/app/schemas/organization.py:104` — one `InvitableRole` annotated type: every role from the catalog **except** `owner`, refused at validation.
- `backend/app/schemas/organization.py:117` — `InvitationCreate.role` uses it, replacing its own `field_validator` (same rule, one definition).
- `backend/app/schemas/organization.py:124` — `InviteLinkCreate.role` uses it; the old `max_length=20` is subsumed by set membership.

## How it failed before

`POST` a link with `role: "owner"` and the schema accepted it; so did `role: "wizard"`. The service's only ceiling is on Admins, so an Owner hit neither guard. The email path refused both.

## Testing

- `backend/tests/test_invite_links.py` — refuses `owner` and an unknown role on **both** schemas, accepts `admin`/`member`/`viewer`. The pre-fix run failed on the link half exactly; 18 tests pass here.
- `make lint-backend` and `make test` green (4382 passed, 100% gate holds).

## Noticed, not fixed

`change_role` accepts `owner` for a non-owner target, so an Owner can mint a second owner past `transfer_ownership`. Same family, different call path — filed separately rather than widened into this diff.
