### PR TITLE
Format an absolute date in the active locale

### DIFF
--- a/frontend/src/app/[locale]/(dashboard)/admin/conversations/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/admin/conversations/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { ChevronLeft, ChevronRight, ExternalLink, Search } from "lucide-react";
 
 import {
@@ -66,6 +66,7 @@ function UserAvatar({
 export default function AdminConversationsPage() {
   const t = useTranslations("admin");
   const tc = useTranslations("common");
+  const locale = useLocale();
   const {
     conversations,
     conversationsTotal,
@@ -223,7 +224,7 @@ export default function AdminConversationsPage() {
           </SortButton>
         ),
         cell: (conv) => (
-          <span className="text-muted-foreground">{formatDate(conv.created_at)}</span>
+          <span className="text-muted-foreground">{formatDate(conv.created_at, locale)}</span>
         ),
       },
       {

--- a/frontend/src/app/[locale]/(dashboard)/admin/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/admin/page.tsx
@@ -23,7 +23,7 @@ import { apiClient } from "@/lib/api-client";
 import { ROUTES } from "@/lib/constants";
 import { qk } from "@/lib/query-keys";
 import { formatDate, timeAgo } from "@/lib/utils";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 import type { AdminOrganization, AdminStats } from "@/types/admin";
 
@@ -44,6 +44,7 @@ const EVENT_ICON: Record<RecentEvent["type"], LucideIcon> = {
 export default function AdminOverviewPage() {
   const t = useTranslations("pages.admin");
   const tTime = useTranslations("time");
+  const locale = useLocale();
   const statsQuery = useQuery({
     queryKey: ["admin", "stats"],
     queryFn: async (): Promise<AdminStats> => {
@@ -220,7 +221,7 @@ export default function AdminOverviewPage() {
                     <td className="px-3 py-3 text-right tabular-nums">{org.member_count}</td>
                     <td className="px-3 py-3 text-right tabular-nums">{org.agent_count}</td>
                     <td className="text-muted-foreground px-5 py-3 text-right text-xs">
-                      {formatDate(org.created_at)}
+                      {formatDate(org.created_at, locale)}
                     </td>
                   </tr>
                 ))}

--- a/frontend/src/app/[locale]/(dashboard)/admin/ratings/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/admin/ratings/page.tsx
@@ -37,13 +37,14 @@ import { ErrorState } from "@/components/states";
 import { ROUTES } from "@/lib/constants";
 import { formatDate } from "@/lib/utils";
 import type { MessageRatingListResponse, MessageRatingWithDetails, RatingSummary } from "@/types";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 const PAGE_SIZE = 50;
 type RatingFilter = "all" | "positive" | "negative";
 
 export default function AdminRatingsPage() {
   const t = useTranslations("pages.admin");
+  const locale = useLocale();
   const [filter, setFilter] = useState<RatingFilter>("all");
   const [commentsOnly, setCommentsOnly] = useState(false);
   const [page, setPage] = useState(0);
@@ -105,7 +106,7 @@ export default function AdminRatingsPage() {
       className: "whitespace-nowrap",
       cell: (r) => (
         <span className="text-muted-foreground font-mono text-xs tabular-nums">
-          {formatDate(r.created_at)}
+          {formatDate(r.created_at, locale)}
         </span>
       ),
     },

--- a/frontend/src/app/[locale]/(dashboard)/admin/users/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/admin/users/page.tsx
@@ -30,7 +30,7 @@ import type { AdminUser } from "@/types";
 import { cn, formatDate } from "@/lib/utils";
 import { useChanged } from "@/hooks/use-changed";
 
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 const PAGE_SIZE_OPTIONS = [25, 50, 100] as const;
 type SortDir = "asc" | "desc";
 // Keys the backend can sort on (route → service → repo).
@@ -48,6 +48,7 @@ function getInitials(nameOrEmail: string): string {
 export default function AdminUsersPage() {
   const t = useTranslations("pages.admin");
   const tc = useTranslations("common");
+  const locale = useLocale();
   const { users, total, isLoading, fetchUsers, updateUser, deleteUser, impersonateUser } =
     useAdminUsers();
   const [search, setSearch] = useState("");
@@ -192,7 +193,7 @@ export default function AdminUsersPage() {
           </SortHeader>
         ),
         cell: (u) => (
-          <span className="text-muted-foreground text-sm">{formatDate(u.created_at)}</span>
+          <span className="text-muted-foreground text-sm">{formatDate(u.created_at, locale)}</span>
         ),
       },
       {

--- a/frontend/src/app/[locale]/(dashboard)/orgs/[id]/members/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/orgs/[id]/members/page.tsx
@@ -49,7 +49,7 @@ interface PageProps {
   params: Promise<{ id: string }>;
 }
 
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 const ROLE_VARIANT: Record<OrgRole, "default" | "secondary" | "outline"> = {
   owner: "default",
   admin: "secondary",
@@ -71,6 +71,7 @@ function getInitials(nameOrEmail: string): string {
 export default function OrgMembersPage({ params }: PageProps) {
   const t = useTranslations("pages.orgs");
   const tc = useTranslations("common");
+  const locale = useLocale();
   const { id } = use(params);
   const { user } = useAuth();
   const { members, total, isLoading, fetchMembers, changeRole, removeMember } = useMembers(id);
@@ -203,7 +204,7 @@ export default function OrgMembersPage({ params }: PageProps) {
         key: "joined",
         header: t("joined"),
         cell: (m) => (
-          <span className="text-muted-foreground text-sm">{formatDate(m.joined_at)}</span>
+          <span className="text-muted-foreground text-sm">{formatDate(m.joined_at, locale)}</span>
         ),
       },
     ];
@@ -403,10 +404,10 @@ export default function OrgMembersPage({ params }: PageProps) {
                         )}
                       </>
                     ) : (
-                      <>{t("invitedOn", { date: formatDate(inv.created_at) })}</>
+                      <>{t("invitedOn", { date: formatDate(inv.created_at, locale) })}</>
                     )}
                     {inv.expires_at && (
-                      <> · {t("expiresOn", { date: formatDate(inv.expires_at) })}</>
+                      <> · {t("expiresOn", { date: formatDate(inv.expires_at, locale) })}</>
                     )}
                   </p>
                 </div>

--- a/frontend/src/app/[locale]/(dashboard)/rag/[id]/kb-detail-sections.integration.test.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/rag/[id]/kb-detail-sections.integration.test.tsx
@@ -28,6 +28,7 @@ vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 // `t.rich is not a function` inside a render, several files from the assertion.
 const translators = new Map<string, (key: string) => string>();
 vi.mock("next-intl", () => ({
+  useLocale: () => "en",
   useTranslations: (ns: string) => {
     const cached = translators.get(ns);
     if (cached !== undefined) return cached;

--- a/frontend/src/app/[locale]/(dashboard)/settings/profile/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/settings/profile/page.tsx
@@ -15,10 +15,11 @@ import { formatDate, getErrorMessage, isAppAdmin, MAX_AVATAR_SIZE_BYTES } from "
 import { useAuthStore } from "@/stores";
 import type { User } from "@/types";
 import { useChanged } from "@/hooks/use-changed";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 export default function ProfileSettingsPage() {
   const t = useTranslations("pages.settings");
+  const locale = useLocale();
   const { user } = useAuth();
   const { setUser, bumpAvatarVersion, avatarVersion } = useAuthStore();
 
@@ -141,7 +142,7 @@ export default function ProfileSettingsPage() {
             </Button>
             <p className="text-muted-foreground mt-2 text-xs">
               {isAppAdmin(user) ? t("admin") : ""}
-              {t("memberSince", { date: formatDate(user.created_at) })}
+              {t("memberSince", { date: formatDate(user.created_at, locale) })}
             </p>
           </div>
         </div>

--- a/frontend/src/app/[locale]/shared/[token]/page.tsx
+++ b/frontend/src/app/[locale]/shared/[token]/page.tsx
@@ -20,7 +20,7 @@ async function fetchSharedConversation(token: string) {
 
 export default async function SharedConversationPage({ params }: SharedConversationPageProps) {
   const t = await getTranslations("pages.root");
-  const { token } = await params;
+  const { token, locale } = await params;
   const data = await fetchSharedConversation(token);
 
   if (!data || !data.conversation) {
@@ -63,7 +63,7 @@ export default async function SharedConversationPage({ params }: SharedConversat
               }`}
             >
               <p className="text-sm whitespace-pre-wrap">{msg.content}</p>
-              <p className="mt-1 text-xs opacity-60">{formatDateTime(msg.created_at)}</p>
+              <p className="mt-1 text-xs opacity-60">{formatDateTime(msg.created_at, locale)}</p>
             </div>
           </div>
         ))}

--- a/frontend/src/components/admin/user-detail-drawer.tsx
+++ b/frontend/src/components/admin/user-detail-drawer.tsx
@@ -28,7 +28,7 @@ import { apiClient } from "@/lib/api-client";
 import { ROUTES } from "@/lib/constants";
 import { formatDateTime, getErrorMessage } from "@/lib/utils";
 import { qk } from "@/lib/query-keys";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 interface UserDetailDrawerProps {
   user: AdminUser | null;
@@ -55,6 +55,7 @@ export function UserDetailDrawer({
   onImpersonate,
 }: UserDetailDrawerProps) {
   const t = useTranslations("admin");
+  const locale = useLocale();
   // Server data through the query layer, which is where `.claude/rules/frontend.md`
   // says it lives. It was three pieces of state and an effect: a list, a loading
   // flag, and a reset when the drawer closed - all of which `useQuery` already
@@ -153,7 +154,7 @@ export function UserDetailDrawer({
             <KV label={t("userId")} value={subject.id} mono onCopy={handleCopyId} />
             <KV label={t("email")} value={subject.email} mono />
             {subject.full_name && <KV label={t("displayName")} value={subject.full_name} />}
-            <KV label={t("joined")} value={formatDateTime(subject.created_at)} />
+            <KV label={t("joined")} value={formatDateTime(subject.created_at, locale)} />
           </dl>
 
           <section className="mt-7">
@@ -183,7 +184,7 @@ export function UserDetailDrawer({
                         {c.title || t("untitled")}
                       </p>
                       <p className="text-foreground/45 truncate font-mono text-[10px] tracking-wider uppercase">
-                        {formatDateTime(c.created_at)}
+                        {formatDateTime(c.created_at, locale)}
                         {typeof c.message_count === "number" &&
                           ` · ${t("messageCountShort", { count: c.message_count })}`}
                       </p>

--- a/frontend/src/components/agents/agent-card.tsx
+++ b/frontend/src/components/agents/agent-card.tsx
@@ -27,7 +27,7 @@ import {
 import { ROUTES } from "@/lib/constants";
 import { cn, formatDate } from "@/lib/utils";
 import type { Agent } from "@/types/agents";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 /** Chip labels for the surfaces an agent answers on. Unknown values pass through. */
 const CHANNEL_LABEL: Record<string, string> = {
@@ -81,6 +81,7 @@ export function AgentCard({
 }) {
   const t = useTranslations("agents");
   const tc = useTranslations("common");
+  const locale = useLocale();
   const archived = agent.status === "archived";
 
   return (
@@ -125,7 +126,7 @@ export function AgentCard({
       <div className="relative mt-3 flex items-center justify-between gap-2 border-t pt-3">
         <span className="text-muted-foreground pointer-events-none text-xs">
           {agent.updated_at
-            ? t("editedWhen", { when: formatDate(agent.updated_at) })
+            ? t("editedWhen", { when: formatDate(agent.updated_at, locale) })
             : t("neverEdited")}
         </span>
 

--- a/frontend/src/components/agents/run-summary.tsx
+++ b/frontend/src/components/agents/run-summary.tsx
@@ -7,7 +7,7 @@ import { RunStatusBadge } from "@/components/agents/status-badge";
 import { ROUTES } from "@/lib/constants";
 import { formatDate } from "@/lib/utils";
 import type { AgentRun } from "@/types/runs";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 interface RunSummaryProps {
   agentId: string;
@@ -59,6 +59,7 @@ function tally(runs: AgentRun[]): Tally {
  */
 export function RunSummary({ agentId, runs }: RunSummaryProps) {
   const t = useTranslations("agents");
+  const locale = useLocale();
   const stats = tally(runs);
   const activityHref = `${ROUTES.RUNS}?agent=${agentId}`;
 
@@ -96,7 +97,7 @@ export function RunSummary({ agentId, runs }: RunSummaryProps) {
           <li key={run.id} className="flex flex-wrap items-center gap-x-3 gap-y-1 p-3 text-sm">
             <RunStatusBadge status={run.status} />
             <span className="text-muted-foreground text-xs">
-              {run.started_at ? formatDate(run.started_at) : t("notStarted")}
+              {run.started_at ? formatDate(run.started_at, locale) : t("notStarted")}
             </span>
             <span className="text-muted-foreground text-xs">{run.surface}</span>
             <span className="ml-auto font-mono text-xs">{run.model_label ?? "-"}</span>

--- a/frontend/src/components/agents/version-history.tsx
+++ b/frontend/src/components/agents/version-history.tsx
@@ -18,7 +18,7 @@ import { useAgentVersion } from "@/hooks";
 import { collapseUnchanged, diffLines, diffStat } from "@/lib/diff";
 import { cn, formatDate } from "@/lib/utils";
 import type { AgentEnvironment, AgentSpec, AgentVersion } from "@/types/agents";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 interface VersionHistoryProps {
   agentId: string;
@@ -106,6 +106,7 @@ export function VersionHistory({
   promoting,
 }: VersionHistoryProps) {
   const t = useTranslations("agents");
+  const locale = useLocale();
   // Newest against the one before it: the comparison somebody opening a history
   // almost always wants, and the one that needs no explaining.
   const [rightId, setRightId] = useState<string>(DRAFT);
@@ -145,7 +146,7 @@ export function VersionHistory({
               </p>
               <p className="text-muted-foreground mt-0.5 text-xs">
                 {version.published_by_email ?? t("unknownAuthor")}
-                {version.created_at ? ` · ${formatDate(version.created_at)}` : ""}
+                {version.created_at ? ` · ${formatDate(version.created_at, locale)}` : ""}
               </p>
             </div>
             {/* Which environments serve this exact version - the fact that

--- a/frontend/src/components/rag/sync-source-row.tsx
+++ b/frontend/src/components/rag/sync-source-row.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Plug, RotateCw, Trash2 } from "lucide-react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 import { Button } from "@/components/ui";
 import { BrandIcon, connectorBrand } from "@/components/icons/brand-icon";
@@ -24,7 +24,8 @@ export function SyncSourceRow({
   onDelete?: () => void;
 }) {
   const t = useTranslations("pages.kb");
-  const lastSync = source.last_sync_at ? formatDateTime(source.last_sync_at) : t("never");
+  const locale = useLocale();
+  const lastSync = source.last_sync_at ? formatDateTime(source.last_sync_at, locale) : t("never");
   const brand = connectorBrand(source.connector_type);
   return (
     <li className="overflow-hidden">

--- a/frontend/src/components/runs/approvals-tab.tsx
+++ b/frontend/src/components/runs/approvals-tab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { CheckCircle2, XCircle } from "lucide-react";
 
 import { ApprovalDelegate } from "@/components/runs/approval-delegate";
@@ -30,6 +30,7 @@ import { formatDate, getErrorMessage } from "@/lib/utils";
  */
 export function ApprovalsTab() {
   const t = useTranslations("pages.runs");
+  const locale = useLocale();
   const { approvals, total, isLoading, error, decide, refetch } = useApprovals();
 
   return (
@@ -72,7 +73,7 @@ export function ApprovalsTab() {
                     <ApprovalDelegate approval={approval} />
                   </div>
                   <span className="text-muted-foreground shrink-0 text-xs">
-                    {approval.created_at ? formatDate(approval.created_at) : ""}
+                    {approval.created_at ? formatDate(approval.created_at, locale) : ""}
                   </span>
                 </div>
                 <pre className="bg-muted/40 overflow-x-auto rounded p-3 text-xs">

--- a/frontend/src/components/runs/run-table.tsx
+++ b/frontend/src/components/runs/run-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { ThumbsDown } from "lucide-react";
 
 import { RunStatusBadge } from "@/components/agents/status-badge";
@@ -43,6 +43,7 @@ export function RunTable({
   onSort?: (key: RunSortKey) => void;
 }) {
   const t = useTranslations("pages.runs");
+  const locale = useLocale();
   const sortable = sort !== undefined && onSort !== undefined;
   return (
     <div className="overflow-x-auto">
@@ -136,7 +137,7 @@ export function RunTable({
                 {formatRunDuration(run.started_at, run.ended_at)}
               </td>
               <td className="text-muted-foreground px-3 py-2 text-xs">
-                {run.started_at === null ? "-" : formatDate(run.started_at)}
+                {run.started_at === null ? "-" : formatDate(run.started_at, locale)}
               </td>
             </tr>
           ))}

--- a/frontend/src/components/runs/spend-tab.tsx
+++ b/frontend/src/components/runs/spend-tab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 import { ErrorState, LoadingState } from "@/components/states";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
@@ -22,15 +22,16 @@ import type { CostSummary } from "@/types/runs";
 function windowLabel(
   spend: CostSummary | undefined,
   t: ReturnType<typeof useTranslations<"pages.runs">>,
+  locale: string,
 ): string {
   if (spend?.period_days != null) return t("lastDays", { days: spend.period_days });
-  const from = formatDate(spend?.from_date);
+  const from = formatDate(spend?.from_date, locale);
   // Null means "up to now", which is a word rather than a date - and rendering
   // it through `formatDate` would put a bare dash where the end of the window
   // should be.
   return spend?.to_date == null
     ? t("fromDateToNow", { from })
-    : t("fromDateToDate", { from, to: formatDate(spend.to_date) });
+    : t("fromDateToDate", { from, to: formatDate(spend.to_date, locale) });
 }
 
 /**
@@ -48,6 +49,7 @@ function windowLabel(
  */
 export function SpendTab() {
   const t = useTranslations("pages.runs");
+  const locale = useLocale();
   const { spend, isLoading, error, refetch } = useSpend(30);
 
   if (isLoading) return <LoadingState variant="stats" rows={2} />;
@@ -106,7 +108,7 @@ export function SpendTab() {
               sent - `runs.py` refuses to answer "30 days" and a range at once -
               and a default in its place renders "Last 30 days" over a range that
               is nothing of the sort. Silently, which is what a fallback buys. */}
-          <CardDescription>{windowLabel(spend, t)}</CardDescription>
+          <CardDescription>{windowLabel(spend, t, locale)}</CardDescription>
         </CardHeader>
         <CardContent className="space-y-2">
           {!spend || spend.by_agent.length === 0 ? (

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -7,7 +7,6 @@ import {
   cn,
   EMAIL_RE,
   formatBytes,
-  formatCurrency,
   formatDate,
   formatDateTime,
   formatRunDuration,
@@ -191,40 +190,35 @@ describe("timeAgo", () => {
   });
 });
 
-describe("formatCurrency", () => {
-  it("reads cents as the currency amount they are", () => {
-    expect(formatCurrency(1999)).toBe("$19.99");
-    expect(formatCurrency(2000)).toBe("$20");
-  });
-
-  it("keeps the cents on a round amount when asked", () => {
-    expect(formatCurrency(2000, "USD", 2)).toBe("$20.00");
-  });
-
-  it("takes a currency in either case", () => {
-    expect(formatCurrency(1000, "eur", 2)).toBe("€10.00");
-  });
-});
-
 describe("formatDate", () => {
   it("reads a date, from a string or a Date", () => {
-    expect(formatDate("2026-07-31T12:00:00Z")).toBe("Jul 31, 2026");
-    expect(formatDate(new Date("2026-07-31T12:00:00Z"))).toBe("Jul 31, 2026");
+    expect(formatDate("2026-07-31T12:00:00Z", "en")).toBe("Jul 31, 2026");
+    expect(formatDate(new Date("2026-07-31T12:00:00Z"), "en")).toBe("Jul 31, 2026");
+  });
+
+  it("formats in the active locale, not en-US", () => {
+    // Month name and day-month order come from the runtime, so the locale has
+    // to reach the formatter - under `pl` this read "Jul 31, 2026" before #649.
+    expect(formatDate("2026-07-31T12:00:00Z", "pl")).toBe("31 lip 2026");
   });
 
   it("says nothing rather than 'Invalid Date' for what it cannot read", () => {
     // Which is what a listing shows for a row whose timestamp the API omitted.
-    expect(formatDate(null)).toBe("-");
-    expect(formatDate(undefined)).toBe("-");
-    expect(formatDate("")).toBe("-");
-    expect(formatDate("not a date")).toBe("-");
+    expect(formatDate(null, "en")).toBe("-");
+    expect(formatDate(undefined, "en")).toBe("-");
+    expect(formatDate("", "en")).toBe("-");
+    expect(formatDate("not a date", "en")).toBe("-");
   });
 });
 
 describe("formatDateTime", () => {
   it("reads a timestamp down to the minute", () => {
-    expect(formatDateTime("2026-07-31T12:34:00Z")).toMatch(/Jul 31, 2026/);
-    expect(formatDateTime(new Date("2026-07-31T12:34:00Z"))).toMatch(/Jul 31, 2026/);
+    expect(formatDateTime("2026-07-31T12:34:00Z", "en")).toMatch(/Jul 31, 2026/);
+    expect(formatDateTime(new Date("2026-07-31T12:34:00Z"), "en")).toMatch(/Jul 31, 2026/);
+  });
+
+  it("formats in the active locale, not en-US", () => {
+    expect(formatDateTime("2026-07-31T12:34:00Z", "pl")).toMatch(/31 lip 2026/);
   });
 });
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -94,32 +94,28 @@ export function timeAgo(dateStr: string, t: Translate): string {
   return new Date(dateStr).toLocaleDateString("en-US", { month: "short", day: "numeric" });
 }
 
-export function formatCurrency(
-  amountCents: number,
-  currency = "USD",
-  minimumFractionDigits = 0,
-): string {
-  return (amountCents / 100).toLocaleString("en-US", {
-    style: "currency",
-    currency: currency.toUpperCase(),
-    minimumFractionDigits,
-  });
-}
-
-export function formatDate(date: Date | string | null | undefined): string {
+/**
+ * An absolute date, in the active locale.
+ *
+ * Month names and day-month order come from the runtime, not a translator, so it
+ * takes the locale from the caller's `useLocale()` - hardcoding `en-US` here put
+ * "Jul 31, 2026" on every locale's screen (#649).
+ */
+export function formatDate(date: Date | string | null | undefined, locale: string): string {
   if (!date) return "-";
   const d = typeof date === "string" ? new Date(date) : date;
   if (Number.isNaN(d.getTime())) return "-";
-  return d.toLocaleDateString("en-US", {
+  return d.toLocaleDateString(locale, {
     year: "numeric",
     month: "short",
     day: "numeric",
   });
 }
 
-export function formatDateTime(date: Date | string): string {
+/** `formatDate` down to the minute; takes the locale for the same reason (#649). */
+export function formatDateTime(date: Date | string, locale: string): string {
   const d = typeof date === "string" ? new Date(date) : date;
-  return d.toLocaleString("en-US", {
+  return d.toLocaleString(locale, {
     year: "numeric",
     month: "short",
     day: "numeric",


### PR DESCRIPTION
## What this fixes

`formatDate` and `formatDateTime` passed a hardcoded `"en-US"` to `toLocaleDateString`/`toLocaleString`, so month name and day-month order came from English on every locale — a Polish reader saw `Jul 31, 2026` where the runtime would have given `31 lip 2026`. None of it is copy a translator can reach, since the strings come from `Intl` rather than the catalog, so `pl.json` could never have fixed it.

Closes #649

## What changed

- `frontend/src/lib/utils.ts:104` — `formatDate(date, locale)` formats in the locale it is given.
- `frontend/src/lib/utils.ts:116` — `formatDateTime(date, locale)`, same.
- `frontend/src/lib/utils.ts` — **`formatCurrency` deleted**, not localized. See below.
- Sixteen call sites across nine components and pages now pass a locale: client components from `useLocale()`, and `shared/[token]/page.tsx` — the one server component that formats a date — from the `locale` already in its route params.
- `frontend/src/app/[locale]/(dashboard)/rag/[id]/kb-detail-sections.integration.test.tsx` — its wholesale `next-intl` stub gained `useLocale`, without which `SyncSourceRow` throws on render.

### Why `formatCurrency` is deleted rather than fixed

It has **no caller anywhere in `src`** — on `main`, the only references are its own three tests. Giving it a locale parameter would have been work for nobody, and the repo's rule is that what nothing reaches goes rather than gets covered. A future caller is better served by a function written against the locale from the start than by a dead one carrying the right signature.

## How it failed before

`formatDate("2026-07-31T12:00:00Z", "pl")` returned `Jul 31, 2026`: the argument was accepted and then ignored, because the function had no locale parameter at all and `"en-US"` was baked into the call. Every dashboard listing, the admin tables, agent cards, version history and the public shared-conversation page rendered English dates under `pl`.

## Testing

- `frontend/src/lib/utils.test.ts` — two new assertions, one per function, that `"pl"` yields `31 lip 2026`. Both fail against the pre-fix implementation, which formatted as en-US whatever it was handed; 38 tests in the file pass here.
- **`tsc` is what proves the sweep complete** — the added parameter is required, so a missed call site is a type error, not a silently English date. It reported seven remaining sites after the first pass; all are fixed and `tsc --noEmit` is clean.
- `make lint-frontend` green (including `check:i18n` — "No hardcoded copy in frontend/src").
- `make test-frontend-cov` green — 260 files, 3951 tests, gate satisfied.

## Noticed, not fixed

- `timeAgo` still hardcodes `en-US` in its older-than-a-week fallback (`utils.ts:94`). That is #621's scope and its PR (#651) is open; touching it here would have collided.
- Ten other test files stub `next-intl` wholesale without `useLocale`. None currently render a component that reads the locale, so all ten still pass — but each is a trap for the next component that starts to. Not worth a fix in this diff; worth knowing.
