### PR TITLE
fix(i18n): read a hyphenated first word as prose, not a label

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -49,7 +49,11 @@ There is no `(marketing)` route group.
   there are no thresholds left to fall between: a node the formatter broke over three
   lines is one node, a type argument list is not JsxText at all, and a comment is
   invisible rather than blanked. The four shapes patched into the old regexes - #199,
-  #246, #249, #314 - each keep a spec, and so does #141's plain multi-line node.
+  #246, #249, #314 - each keep a spec, and so does #141's plain multi-line node. What a
+  *string literal* holds is the one rule still deciding by pattern, and #656 is what that
+  costs: a hyphen inside the first word read as the separator in `Foo / Bar`, so
+  `Sign-in failed` was a label and no sentence opening on a hyphenated word was ever
+  reported.
 - **It reads a `.ts` file as well as a `.tsx` one, and by the same rules.** A parser
   reads one by construction: there is no bracket to anchor on and so nothing to gate on
   the suffix, and a file with no JSX in it simply yields no phrases. That matters because

--- a/frontend/scripts/check-i18n.test.ts
+++ b/frontend/scripts/check-i18n.test.ts
@@ -389,6 +389,22 @@ describe("a string literal", () => {
     expect(said(source)).toEqual(["string 'Escape a \\\\ and a \\' in one sentence'"]);
   });
 
+  it("refuses prose whose first word is hyphenated (#656)", () => {
+    // The hyphen inside `Sign-in` read as the separator in `Foo / Bar`, so the whole
+    // sentence was a label and left the sweep silently. `Sign-in failed` and `Sign-in
+    // successful` survived #603's sweep of the BFF handlers that way, and it was review
+    // that found them (#654), not the guard.
+    expect(saidTs('const x = "Sign-in failed";\n')).toEqual(["string 'Sign-in failed'"]);
+    expect(saidTs('const x = "Auto-refresh is on";\n')).toEqual(["string 'Auto-refresh is on'"]);
+  });
+
+  it("passes a label built from title case around a separator", () => {
+    // What that exemption is for, and the bound on the tightening above: the separator
+    // joins two capitalised tokens, which is the one thing prose does not do.
+    expect(saidTs('const x = "Model / Provider";\n')).toEqual([]);
+    expect(saidTs('const x = "Agent - Settings";\n')).toEqual([]);
+  });
+
   it("passes a two-token label, an icon name and an import", () => {
     expect(said('import { Button } from "@/components/ui/button";\n')).toEqual([]);
     expect(said('const icon = "chevron-right";\n')).toEqual([]);

--- a/frontend/scripts/check-i18n.ts
+++ b/frontend/scripts/check-i18n.ts
@@ -202,9 +202,16 @@ const MACHINE_WORD = /^[A-Z0-9_]+$/;
 /**
  * What `NOT_A_SENTENCE` kept out of the string-literal rule: a label built from title
  * case around a separator, a leading acronym, a CSS measurement.
+ *
+ * The separator joins *two capitalised tokens* - `Model / Provider`, `Agent - Settings`
+ * - and the `[A-Z]` after it is the whole of #656. Without it a hyphen inside the first
+ * word was the separator, so `Sign-in failed` read as a label and every sentence whose
+ * first word is hyphenated left the sweep silently: two of them survived #603 in the BFF
+ * handlers and were found by review rather than by this (#654). Prose after a hyphen
+ * carries on in lower case, which is the one thing a two-token label never does.
  */
 const NOT_A_SENTENCE =
-  /^(?:[A-Z][a-z]+(?:\s[A-Z][a-z]+)*\s?[-/]\s?|[A-Z]{2,}\s|.*\b(?:px|rem|vh|vw|deg)\b)/;
+  /^(?:[A-Z][a-z]+(?:\s[A-Z][a-z]+)*\s?[-/]\s?[A-Z]|[A-Z]{2,}\s|.*\b(?:px|rem|vh|vw|deg)\b)/;
 
 export interface Offence {
   line: number;

--- a/frontend/src/app/[locale]/auth/callback/page.tsx
+++ b/frontend/src/app/[locale]/auth/callback/page.tsx
@@ -19,6 +19,8 @@ export default function AuthCallbackPage() {
   // a flag - keeping the message here means neither is written from an effect
   // synchronously, and the URL case is shown a render earlier than it was.
   const [exchangeFailed, setExchangeFailed] = useState(false);
+  // i18n-exempt: a sentinel nothing renders - what the branch below shows is
+  // `t("signInFailedRedirecting")`, and the provider's own code is discarded the same way.
   const error = searchParams.get("error") ?? (exchangeFailed ? "Sign-in failed" : null);
 
   const adoptSession = useAdoptSession();

--- a/frontend/src/lib/seo.ts
+++ b/frontend/src/lib/seo.ts
@@ -25,6 +25,7 @@ export const SITE = {
   tagline: "The operating system for your company's AI agents",
   /** One-paragraph default description (≤160 chars for SERP truncation). */
   description:
+    // i18n-exempt: the tagline's reason, one line up - metadata read above `[locale]`.
     "Self-hosted, open source, and yours: agents are configuration you own, running on your infrastructure, against your keys.",
   /** Canonical absolute origin. NO trailing slash. */
   url:


### PR DESCRIPTION
## What this fixes

Closes #656. The i18n guard did not report prose whose first word is hyphenated, so
`"Sign-in failed"` passed the sweep while `"Not authenticated"` was refused.

`NOT_A_SENTENCE` exempts a label built from title case around a separator —
`Model / Provider` — and the whitespace on both sides of that separator was optional.
A hyphen *inside* the first word was therefore the separator too, which made the whole
sentence a label: `Sign-in failed`, `Auto-refresh is on`, `Re-run the agent now`. Two
strings survived the #603 sweep in `app/api/auth/oauth-callback/route.ts` and
`magic-link/verify/route.ts` that way, and it was review that removed them (#654), not
the guard.

## What changed

* **`frontend/scripts/check-i18n.ts`** — the separator must now introduce a second
  capitalised token. That is what a two-token label does and what prose never does:
  prose carries on in lower case after a hyphen.
* **`frontend/scripts/check-i18n.test.ts`** — two specs, both halves of the rule. The
  hyphenated sentence is reported (`Sign-in failed`, `Auto-refresh is on`); the label it
  is being separated from (`Model / Provider`, `Agent - Settings`) still is not, so the
  tightening is bounded rather than open-ended.
* **`.claude/rules/frontend.md`** — one clause saying that the string-literal rule is
  the one still deciding by pattern, and what that cost here.

## The offences it surfaced — 2, neither of them a message

A tightened guard finds strings that were invisible before. Both take an
`i18n-exempt` with a reason; neither is copy for the catalog.

| | |
|---|---|
| `src/lib/seo.ts:28` | The site description. Its sibling one line up, `tagline`, already carries this exemption for the same reason: both are read by the root layout and the OG image route, which sit above the `[locale]` segment and have no locale to translate against. |
| `src/app/[locale]/auth/callback/page.tsx:22` | A sentinel nothing renders. The branch it gates shows `t("signInFailedRedirecting")`, and the provider's own error code is discarded the same way. |

A third string the change reaches — `DEFAULT_EMBED_THEME.greeting` in
`src/types/embeds.ts`, `"Hi - what can I help you with?"` — needed nothing: the
exemption on the statement already covers it.

## Testing

* `bunx vitest run scripts/check-i18n.test.ts` — 70 passed. The new spec fails on
  `origin/main` (`expected [] to deeply equal [ "string 'Sign-in failed'" ]`).
* `bun run check:i18n` — green on the real tree, 3201 messages.
* `make lint-frontend` — eslint, prettier, tsc, the guard.
* `make test-frontend-cov` — 260 files, 3954 tests, coverage gate met.

## Noticed, not fixed

`NOT_A_SENTENCE`'s second alternative, `[A-Z]{2,}\s`, has the same shape of hole:
`"API keys are stored in the vault"` and `"MCP servers appear here once connected"`
are both unreported today. Nothing in the tree is currently hidden by it beyond an SEO
keyword, and it is a different alternative from the one #656 names, so it is filed
rather than folded in.
