### PR TITLE
fix(channels): gate a Mattermost webhook post the way the stream is

### DIFF
--- a/backend/app/services/channels/mattermost.py
+++ b/backend/app/services/channels/mattermost.py
@@ -766,6 +766,29 @@ class MattermostAdapter(ChannelAdapter):
         return response.content
 
     def _from_webhook(self, payload: dict[str, Any], bot_id: str) -> IncomingMessage | None:
+        """Normalise one outgoing-webhook body.
+
+        The addressing rule is the socket's, read off what this payload actually
+        carries. An outgoing-webhook body has no mention list - Mattermost sends
+        the post, not who it notified - so the bot's own account cannot be looked
+        for in it, and this path left `addressed` unset. The router reads unset as
+        "the platform did not say" and answers, which put the bot back in the
+        position the socket's rule took it out of: replying to colleagues talking
+        to each other in a channel it was merely invited to (#662).
+
+        What the payload does say is `trigger_word` - the word an operator
+        configured *this integration* to fire on, which is Mattermost's own record
+        that the post was for us. Empty means the webhook fired on its channel
+        filter alone, and a channel filter delivers every post exactly as the
+        socket does, so it is `False` for the same reason a `posted` event with no
+        mentions is.
+
+        The consequence worth knowing before choosing this transport: `@the-bot`
+        is not readable here, because nothing in the body says which account the
+        bot is. Set the trigger word to the bot's handle if that is how people
+        should reach it; an `@agent-slug` needs nothing, since the router reads a
+        slug out of the text.
+        """
         text = str(payload.get("text") or "").strip()
         if not text:
             return None
@@ -790,4 +813,5 @@ class MattermostAdapter(ChannelAdapter):
             platform_username=str(payload.get("user_name") or "") or None,
             platform_display_name=str(payload.get("user_name") or "") or None,
             message_id=str(payload.get("post_id") or "") or None,
+            addressed=bool(str(payload.get("trigger_word") or "").strip()),
         )

--- a/backend/tests/test_channel_addressing.py
+++ b/backend/tests/test_channel_addressing.py
@@ -21,6 +21,11 @@ regression, and the quietest to ship.
 *Silence where the platform did not say.* Slack and Telegram deliver on their own
 subscription rules, so reading "no mention data" as "ignore" would take a working
 bot on either of them off the air.
+
+And the rule belongs to the *bot*, not to one way of reaching it: Mattermost's
+outgoing webhook hands over a watched channel's posts the same way the socket
+does, and answered all of them for as long as it said nothing about who they
+named (#662).
 """
 
 from __future__ import annotations
@@ -165,3 +170,56 @@ class TestReadingMattermostsOwnMentionList:
 
         assert adapter._addressed({"mentions": "not json"}, "bot-1") is False
         assert adapter._addressed({"mentions": json.dumps({"id": "bot-user"})}, "bot-1") is False
+
+
+class TestTheOutgoingWebhookTransportObeysTheSameRule:
+    """The rule was the socket's alone, so the other half of the same adapter
+    answered everything it was handed (#662). An outgoing-webhook body carries no
+    mention list, so what stands in for one is `trigger_word`: the word an operator
+    told *this integration* to fire on. Empty means the webhook fired on its
+    channel filter, which delivers every post exactly as the socket does.
+    """
+
+    @staticmethod
+    def _delivered(**payload: str) -> IncomingMessage:
+        body = {
+            "token": "t",
+            "user_id": "u1",
+            "user_name": "kacper",
+            "channel_id": "c1",
+            "channel_name": "town-square",
+            "post_id": "p1",
+            "text": "standup at 10 then",
+            **payload,
+        }
+        incoming = MattermostAdapter().parse_incoming(body, "bot-1")
+        assert incoming is not None
+        return incoming
+
+    def test_a_channel_post_that_fired_no_trigger_word_is_overheard(self) -> None:
+        """The defect: Mattermost hands over every post in a watched channel and
+        the bot answered each one, having said nothing about whether it was named."""
+        delivered = self._delivered()
+
+        assert delivered.addressed is False
+        assert ChannelMessageRouter._is_overheard(delivered) is True
+
+    def test_a_trigger_word_is_mattermosts_own_record_that_the_post_was_for_us(self) -> None:
+        delivered = self._delivered(trigger_word="@ops", text="@ops standup at 10 then")
+
+        assert delivered.addressed is True
+        assert ChannelMessageRouter._is_overheard(delivered) is False
+
+    def test_an_agent_handle_reaches_the_bot_without_one(self) -> None:
+        """A slug is a name in this product, not a trigger word somebody had to
+        configure, so it is read out of the text on either transport."""
+        delivered = self._delivered(text="@sales what is the refund window")
+
+        assert delivered.addressed is False
+        assert ChannelMessageRouter._is_overheard(delivered) is False
+
+    def test_a_direct_message_is_answered_without_one(self) -> None:
+        """There is nobody else in the room, and no trigger word to type."""
+        delivered = self._delivered(channel_name="u1__u2")
+
+        assert ChannelMessageRouter._is_overheard(delivered) is False

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -612,25 +612,40 @@ Two ways in; pick by whether your Mattermost can reach this deployment.
 
 **Every** post, which is the thing to know about this transport: the socket is not
 a subscription to messages aimed at the bot, it is the channel. So the rule is the
-one a colleague follows:
+one a colleague follows — and it belongs to the bot rather than to one way of
+reaching it, so the outgoing webhook below obeys the same table:
 
 | Where | When it answers |
 |---|---|
 | **A direct message** | Always. There is nobody else in the room, so requiring a mention would be asking somebody to address the only participant |
 | **A channel** | Only when it is named — `@the-bot`, or `@agent-slug` for one of the agents exposed on it |
 
-The bot resolves its own account once per stream session and reads Mattermost's
-own mention list off each event, rather than matching text: `@ada` is somebody
-whose display name the bot cannot resolve, and a bot called `bot` should not answer
-the word "robot". An `@agent-slug` is the exception that has to be read from the
-text — a slug is a name in *this* product, so it is never in a mention list. A
-handle that turns out to name neither the bot nor one of its agents is answered in
-a direct message and passed over in a channel, because there it was somebody's
-colleague.
+*How* it knows it was named is the transport's, because the two payloads say
+different things:
 
-If the bot's own account cannot be resolved, it answers everything, as it did
-before this rule existed: going quiet on a server that would not say who we are is
-the worse of the two failures.
+| Transport | What it reads |
+|---|---|
+| **Event stream** | Mattermost's own mention list on each `posted` event, against the account the bot resolves once per session |
+| **Outgoing webhook** | The `trigger_word` the integration fired on. The body carries no mention list, so `@the-bot` cannot be read here — set the trigger word to the bot's handle if that is how people should reach it |
+
+An `@agent-slug` needs neither and works on both: it is read out of the text,
+because a slug is a name in *this* product and so is never in a mention list.
+
+The stream reads the list rather than matching text for the same reason: `@ada` is
+somebody whose display name the bot cannot resolve, and a bot called `bot` should
+not answer the word "robot". A handle that turns out to name neither the bot nor
+one of its agents is answered in a direct message and passed over in a channel,
+because there it was somebody's colleague. A broadcast — `@channel`, `@all`,
+`@here` — is answered wherever Mattermost lists the bot among the notified, which
+is what such a post asks for; the list is the platform's own answer to "who was
+this for", and a second notion of it here would disagree with the one everybody
+else in the channel was shown.
+
+If the bot's own account cannot be resolved, the stream answers everything, as it
+did before this rule existed: going quiet on a server that would not say who we
+are is the worse of the two failures. The webhook has no such fallback and does
+not need one — an integration with no trigger word is a channel filter, and a
+channel filter says nothing about who a post was for.
 
 **Outgoing webhook.** For a Mattermost that can reach this API.
 
@@ -638,7 +653,9 @@ the worse of the two failures.
 2. *System Console → Integrations → Outgoing Webhooks → Add*, with the callback
    URL `https://your-api.example.com/api/v1/mattermost/BOT_ID/webhook` — the bot
    id is on the row once it is registered, and `channel-webhook-register` prints
-   the whole URL.
+   the whole URL. Its **trigger words** are what addresses the bot on this
+   transport, per the table above; leave them empty and only an `@agent-slug`
+   reaches it in a channel.
 3. Mattermost shows a **token** when the webhook is saved. Paste that into the
    bot's **Webhook token** field here.
 

--- a/frontend/e2e/surfaces.spec.ts
+++ b/frontend/e2e/surfaces.spec.ts
@@ -34,7 +34,9 @@ async function openAvailability(page: Page, agent: string): Promise<Locator> {
 
 /** Publish a hosted page, and answer with the link it produced. */
 async function publishPage(page: Page, panel: Locator): Promise<string> {
-  const publish = panel.getByRole("button", { name: /Hosted page/ }).first();
+  // Anchored: a name is matched as a substring, and every row already published
+  // carries the same words on its own controls - "Edit Hosted page".
+  const publish = panel.getByRole("button", { name: /^Hosted page/ }).first();
   // Wait for the panel's query to resolve before deciding the button is absent:
   // isVisible() is immediate, so a slow embeds fetch would skip the spec as
   // "cannot publish" on a machine that was merely slow rather than unpermitted.
@@ -44,7 +46,10 @@ async function publishPage(page: Page, panel: Locator): Promise<string> {
     test.skip(true, "this user cannot publish an embed");
   }
   await publish.click();
-  const submit = panel.getByRole("button", { name: "Publish" });
+  // Exact, for the same reason: the picker's Public API card ends "Nothing to
+  // publish here.", so a substring match on this name never reaches zero once
+  // the form has unmounted and the picker is back.
+  const submit = panel.getByRole("button", { name: "Publish", exact: true });
   await submit.click();
   // The picker form unmounts on success, so the write has landed once the submit
   // is gone. Reloading before that races the mutation - .click() resolves on the


### PR DESCRIPTION
## What this fixes

Closes #662 — the Mattermost outgoing-webhook transport answered every post it
was handed, while the event stream had already stopped doing that.

## Stacked, deliberately — base is `feat/agent-surfaces` (#634), not `main`

Not an accident, and worth checking before merging. The addressing rule this
defect is *about* exists only on that branch:

| Symbol | On `main`? |
|---|---|
| `IncomingMessage.addressed` | No |
| `ChannelMessageRouter._is_overheard` / `_names_the_bot` | No |
| `MattermostAdapter._addressed` / `_own_ids` / `_own_user_id` | No |
| `tests/test_channel_addressing.py` | No |

`main`'s router has no addressing gate on *either* transport — it answers every
channel message on both — so there is nothing on `main` to fix, and a regression
test written there would assert behaviour that does not exist. Same shape as #658
finding the triggers feature only on PR #537.

**Consequence for the merge:** this is a stacked PR, so `gh pr merge --admin`
will refuse it. Land #634 first and this retargets to `main` cleanly; or merge
`main` into the base and de-stack.

## What changed

- `backend/app/services/channels/mattermost.py` — `_from_webhook` now sets
  `addressed`. An outgoing-webhook body carries no mention list, so what stands
  in for one is `trigger_word`: the word an operator told *this integration* to
  fire on, which is Mattermost's own record that the post was for us. Empty means
  the webhook fired on its channel filter, which delivers every post exactly as
  the socket does — `False`, for the same reason a `posted` event with no
  mentions is. The reasoning is in the docstring.
- `backend/tests/test_channel_addressing.py` — four cases for the webhook
  transport, asserting `_is_overheard` and not only the field.
- `docs/channels.md` — the addressing table now says it is the bot's rule and
  both transports obey it, with a second table for *how* each one reads "named".
  The trigger-word consequence is repeated once in the webhook setup steps,
  where an operator is standing when they choose them.

A direct message and an `@agent-slug` are untouched: both are decided before the
flag is read, so `@sales what is the refund window` still works over a
channel-filtered webhook and a DM still answers everything.

The cost, and it is documented: `@the-bot` is not readable on this transport,
because nothing in the body says which account the bot is. An operator who wants
that sets the trigger word to the bot's handle.

## How it failed before

`_from_webhook` left `addressed` at its default `None`. The router reads `None`
as "the platform did not say" — deliberately, so Slack and Telegram keep working
— and answers. So a bot on a channel-watched outgoing webhook replied to
colleagues talking to each other, and posted its unknown-handle refusals
("@ada is not available on this bot") out loud in a channel it was never
addressed in.

## Testing

The three new field assertions fail against the old parser with
`AssertionError: assert None is False` and pass with the fix; the overheard
assertion fails with them.

- `uv run pytest tests/test_channel_addressing.py tests/test_mattermost_channel.py tests/test_channel_mentions.py -q` → 85 passed
- `make lint-backend` → clean
- `make test` → 4622 passed, 7 skipped, coverage 100%
- `make docs-build` → clean

## CI is not fully green, and the red is not mine

`lint`, `docs`, `Security Scan` and `test` (the backend suite plus the 100% gate)
pass. `test-frontend` and `docker` skip — backend-and-docs-only paths, and a
skipped required check is a pass.

**`e2e` fails: 4 failed, 97 passed.** All four are `e2e/surfaces.spec.ts`, all
four are the same assertion in the `publishPage` helper —
`expect(submit).toHaveCount(0)` timing out at 15s with the Publish button still
on screen:

- `:64` A published surface › is editable after it exists, and the change survives a reload
- `:96` A published surface › takes a picture of its own once it exists
- `:128` What the page offers a visitor › starts a fresh thread without losing the link
- `:170` What the page offers a visitor › offers dictation only where the operator turned it on

Confirmed already red on the base ref rather than assumed. Run
[31692218637](https://github.com/vstorm-co/agenticos/actions/runs/31692218637)
on `feat/agent-surfaces` at sha `3f58155` — the head this branch was cut from —
reports `4 failed, 96 passed`: the same four specs, the same assertion. Mine has
one more pass, which is this branch's own added coverage.

The spec does not exist on `main` (`git ls-tree origin/main
frontend/e2e/surfaces.spec.ts` is empty) and nothing in this diff reaches a
hosted surface — the whole change is a Mattermost webhook parser's return value,
its docstring, tests and docs. Not touched here; it belongs to #634.

## Overlaps

#660 (a non-mention channel message with attachments stores every file twice)
and #661 (a channel turn refused before the run orphans its ChatFile rows) are
open against neighbouring code — `ChannelMessageRouter._receive_files` and its
two call sites — and are being worked in parallel. **Merge order matters.**

This branch does not touch either: the whole diff is `_from_webhook`'s return
value, its docstring, tests and docs. Nothing here needs what #660 or #661 owns.

## Noticed, not fixed

`@channel` / `@all` / `@here` on the **stream** transport. The bot answers a
broadcast wherever Mattermost lists it among the notified. #662 raised that as an
open question; this PR answers it by writing it down in `docs/channels.md` as
intended — a private notion of "who was this for" here would disagree with the
one the whole channel was shown. Nobody has checked a real server to see when
Mattermost actually puts a bot in that list, so if it turns out to be noisy in
practice that is a new issue rather than a silent filter added on a guess.

