### PR TITLE
fix(mcp): stop OAuth refusals quoting the upstream client

### DIFF
--- a/backend/app/agents/mcp_oauth.py
+++ b/backend/app/agents/mcp_oauth.py
@@ -61,6 +61,26 @@ class OAuthError(Exception):
     """A recoverable failure in the OAuth flow (surfaced to the user)."""
 
 
+def _flow_failed(exc: Exception, *, summary: str, advice: str) -> str:
+    """The sentence a failed OAuth step may show, for an exception it may not.
+
+    Three of these refusals used to be built by interpolating whatever raised.
+    `httpx` puts the failing request in its message, and the requests this flow
+    makes are a token grant and a client registration - so that message carries
+    the token endpoint, and a token endpoint is reached with credentials in the
+    body. A pydantic `ValidationError` over the token payload is worse again:
+    its `str()` echoes the input it rejected, and that input is the tokens. All
+    three reach the browser, as a toast since #657 (#686).
+
+    So the exception's own text stays in the `logger.exception` beside the raise
+    and goes no further, and what is shown names the step that gave up, what
+    class of thing raised, and what the reader can do. The class still goes out:
+    it separates a server we could not reach from one that refused us, and a
+    class name has never carried an endpoint or a key.
+    """
+    return f"{summary} ({type(exc).__name__}) - {advice}. The server log has the full error."
+
+
 async def _send(client: httpx.AsyncClient, request: httpx.Request) -> httpx.Response:
     """Send *request*, SSRF-checking every hop, redirects included.
 
@@ -243,7 +263,14 @@ async def register_client(server: DiscoveredServer, redirect_uri: str) -> tuple[
         try:
             info = await handle_registration_response(await _send(client, request))
         except httpx.HTTPError as exc:
-            raise OAuthError(f"Dynamic client registration failed: {exc}") from exc
+            logger.exception("MCP dynamic client registration failed at %s", request.url)
+            raise OAuthError(
+                _flow_failed(
+                    exc,
+                    summary="Client registration with this server did not complete",
+                    advice="check the server URL, then try again",
+                )
+            ) from exc
         except OAuthFlowError as exc:
             # The SDK puts the server's response body in the message - keep it
             # in the log, hand the user a fixed string.
@@ -344,7 +371,14 @@ async def _token_request(token_endpoint: str, data: dict[str, str]) -> OAuthToke
                 ),
             )
         except httpx.HTTPError as exc:
-            raise OAuthError(f"Token request failed: {exc}") from exc
+            logger.exception("MCP token request to %s failed", token_endpoint)
+            raise OAuthError(
+                _flow_failed(
+                    exc,
+                    summary="The token request did not complete",
+                    advice="start the connection again",
+                )
+            ) from exc
     if response.status_code != 200:
         # The body is whatever the endpoint chose to return, and this message
         # ends up in the user's browser - log the detail, show the status.
@@ -358,4 +392,13 @@ async def _token_request(token_endpoint: str, data: dict[str, str]) -> OAuthToke
     try:
         return OAuthToken.model_validate_json(response.content)
     except ValueError as exc:
-        raise OAuthError(f"Invalid token response: {exc}") from exc
+        logger.exception(
+            "MCP token endpoint %s returned an unreadable token response", token_endpoint
+        )
+        raise OAuthError(
+            _flow_failed(
+                exc,
+                summary="This server's token response could not be read",
+                advice="check that it implements OAuth 2.1",
+            )
+        ) from exc

--- a/backend/tests/test_mcp_connections.py
+++ b/backend/tests/test_mcp_connections.py
@@ -1,13 +1,15 @@
 """Tests for MCP connections: agents/mcp toolset building + the service layer."""
 
 import contextlib
+import logging
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import httpx
 import pytest
-from mcp.shared.auth import OAuthToken
+from mcp.shared.auth import OAuthMetadata, OAuthToken
+from pydantic import AnyUrl
 from sqlalchemy.exc import IntegrityError
 
 from app.agents import mcp_oauth
@@ -1874,6 +1876,104 @@ class TestOAuthRequestSafety:
 
         assert "redis" not in str(exc_info.value)
         assert "500" in str(exc_info.value)
+
+
+class TestOAuthRefusalsDoNotQuoteTheServer:
+    """An OAuth refusal reaches the browser - as a toast since #657 - so what it
+    may say is written here rather than by whatever raised.
+
+    `httpx` puts the failing request in its message, and the two requests this
+    flow makes are a token grant and a client registration: a URL in that
+    message is an endpoint reached with credentials. The vendor's text is not
+    deleted, it moves to the log beside the raise (#686).
+    """
+
+    _LEAKY_URL = "https://auth.example.com/token?client_secret=shh-9f2c"
+
+    @staticmethod
+    def _discovered() -> mcp_oauth.DiscoveredServer:
+        metadata = OAuthMetadata(
+            issuer=AnyUrl("https://auth.example.com"),
+            authorization_endpoint=AnyUrl("https://auth.example.com/authorize"),
+            token_endpoint=AnyUrl("https://auth.example.com/token"),
+            registration_endpoint=AnyUrl("https://auth.example.com/register"),
+            response_types_supported=["code"],
+        )
+        return mcp_oauth.DiscoveredServer(
+            authorization_endpoint=str(metadata.authorization_endpoint),
+            token_endpoint=str(metadata.token_endpoint),
+            registration_endpoint=str(metadata.registration_endpoint),
+            resource="https://mcp.example.com/",
+            scope=None,
+            metadata=metadata,
+        )
+
+    @pytest.mark.anyio
+    async def test_an_unreachable_token_endpoint_is_named_by_its_class(self, monkeypatch, caplog):
+        vendor_text = f"[Errno 61] Connection refused for {self._LEAKY_URL}"
+
+        async def fake_send(client, request):
+            raise httpx.ConnectError(vendor_text)
+
+        monkeypatch.setattr(mcp_oauth, "_send", fake_send)
+        with (
+            caplog.at_level(logging.ERROR, logger="app.agents.mcp_oauth"),
+            pytest.raises(mcp_oauth.OAuthError) as exc_info,
+        ):
+            await mcp_oauth._token_request(
+                "https://auth.example.com/token", {"grant_type": "refresh_token"}
+            )
+
+        shown = str(exc_info.value)
+        assert "client_secret" not in shown
+        assert self._LEAKY_URL not in shown
+        assert "ConnectError" in shown
+        assert vendor_text in caplog.text
+
+    @pytest.mark.anyio
+    async def test_a_failed_registration_is_named_by_its_class(self, monkeypatch, caplog):
+        vendor_text = f"Server disconnected without sending a response: {self._LEAKY_URL}"
+
+        async def fake_send(client, request):
+            raise httpx.ReadError(vendor_text)
+
+        monkeypatch.setattr(mcp_oauth, "_send", fake_send)
+        with (
+            caplog.at_level(logging.ERROR, logger="app.agents.mcp_oauth"),
+            pytest.raises(mcp_oauth.OAuthError) as exc_info,
+        ):
+            await mcp_oauth.register_client(
+                self._discovered(), "https://app.example.com/oauth/callback"
+            )
+
+        shown = str(exc_info.value)
+        assert "client_secret" not in shown
+        assert self._LEAKY_URL not in shown
+        assert "ReadError" in shown
+        assert vendor_text in caplog.text
+
+    @pytest.mark.anyio
+    async def test_an_unreadable_token_response_does_not_echo_its_input(self, monkeypatch, caplog):
+        """A pydantic `ValidationError` echoes the input it rejected, and here
+        that input is the token payload - so a server that names the field
+        wrongly used to have its own tokens read back to the browser."""
+
+        async def fake_send(client, request):
+            return httpx.Response(200, json={"token": "at-secret-9f2c"}, request=request)
+
+        monkeypatch.setattr(mcp_oauth, "_send", fake_send)
+        with (
+            caplog.at_level(logging.ERROR, logger="app.agents.mcp_oauth"),
+            pytest.raises(mcp_oauth.OAuthError) as exc_info,
+        ):
+            await mcp_oauth._token_request(
+                "https://auth.example.com/token", {"grant_type": "authorization_code"}
+            )
+
+        shown = str(exc_info.value)
+        assert "at-secret-9f2c" not in shown
+        assert "ValidationError" in shown
+        assert "at-secret-9f2c" in caplog.text
 
 
 class TestReadSchema:

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -79,6 +79,14 @@ Every URL reached in that flow is SSRF-checked, not just the one somebody typed:
 discovery means the *remote server* chooses most of the addresses we call, and
 those deserve the same policy as a webhook.
 
+A step that fails says **which step gave up and what class of thing raised**,
+never what the upstream client wrote. `httpx` puts the failing request in its
+message and the two requests here are a client registration and a token grant,
+so quoting it would carry a token endpoint — reached with credentials — into the
+browser; a pydantic error over an unreadable token response echoes the payload it
+rejected, which is the tokens. Both stay in the server log, which is where an
+operator already looks.
+
 !!! warning "An organization's OAuth connection is still someone's grant"
 
     `POST /mcp-connections/oauth/start` produces a connection the organization


### PR DESCRIPTION
## What this fixes

Closes #686. Three refusals in the MCP OAuth flow were built by interpolating
whatever raised, and `str()` of an `OAuthError` reaches the browser — rendered
as a toast since #657, via `McpOAuthCallbackResult(ok=False, error=str(exc))`.

## How it failed before

- `backend/app/agents/mcp_oauth.py:246` (`register_client`) and `:347`
  (`_token_request`) interpolated an `httpx` error. httpx puts the failing
  request in its message, and the two requests this flow makes are a client
  registration and a token grant — so the URL it carried is an endpoint we reach
  with credentials.
- `:361` parsed the token response with `OAuthToken.model_validate_json` and
  interpolated the `ValidationError`. Pydantic echoes the input it rejected, and
  that input is the token payload: a server answering `{"token": "at-secret-9f2c"}`
  put that string in the callback's `error` field verbatim. That one is new
  information — the issue expected the failing field's input, and it is worse.

## What changed

- A module-private `_flow_failed(exc, *, summary, advice)` builds the sentence
  each of the three raises: which step gave up, the class that raised, and what
  the reader can do. The exception's own text moves to a `logger.exception`
  beside the raise, and goes no further. The class still goes out — it separates
  a server we could not reach from one that refused us, and a class name has
  never carried an endpoint or a key.
- Same shape as `app/services/rag/failures.py` (#423) and the `_turn_failed`
  helper in #675 / #659.
- `docs/mcp.md` — one paragraph under Authentication saying what a failed step is
  allowed to report, next to the SSRF paragraph it belongs with.

The five sibling refusals in the same file already said what happened without
quoting the client; they are untouched.

## Testing

`TestOAuthRefusalsDoNotQuoteTheServer` in
`backend/tests/test_mcp_connections.py` — three tests, each failing on the
previous code, each asserting both halves (the URL or the token is absent from
the refusal and present in the log):

- an unreachable token endpoint (`httpx.ConnectError` whose message holds
  `?client_secret=…`);
- a failed dynamic client registration (`httpx.ReadError`, same);
- an unreadable token response, asserting the token string is in the log and not
  in the refusal.

`make lint-backend` green. `make test` green — 4378 passed, 6 skipped, 100% on
the gated layer. `mcp_oauth.py` is deliberately outside the coverage gate
(documented in `backend/pyproject.toml`), so these tests pin the observable
contract rather than the module's lines.

Based on `origin/main` — the code being fixed is on main, not on a feature
branch.

## Noticed, not fixed

- `app/api/routes/v1/me_mcp_connections.py:100` still answers `error=str(exc)`,
  and `:86` raises `HTTPException(detail=str(exc))`. Both are now safe because
  every `OAuthError` message is written in this repository, which is the fix the
  issue asked for; making the route carry a code rather than English is #654 and
  stays there.
- `_token_request` logs `response.text[:200]` on a non-200 (pre-existing, line
  351). That is the sanctioned home for it — noting it only so a reader knows it
  was seen.
