### PR TITLE
fix(permissions): stop change_role handing out the owner role

### DIFF
--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -263,6 +263,37 @@ def role_has(role: str, permission: Perm) -> bool:
     return ROLE_PERMS.get(role, {}).get(permission, Scope.NONE) is not Scope.NONE
 
 
+def _reaches(holder: dict[Perm, Scope], offered: dict[Perm, Scope]) -> bool:
+    """Whether `holder` holds everything `offered` does, at least as widely."""
+    return all(holder.get(perm, Scope.NONE) >= scope for perm, scope in offered.items())
+
+
+def assignable_roles(role: str) -> frozenset[str]:
+    """The roles a member holding `role` may hand out.
+
+    A role may only assign one whose authority it *strictly* exceeds: every
+    permission the offered role holds, held at least as widely by the assigner,
+    and something the assigner holds that the offered role does not. So nobody
+    assigns their own level - promoting a peer to it is an ownership decision,
+    not a management one - and nobody at all assigns `owner`, since no role
+    outranks it. Ownership moves through
+    :meth:`app.services.member.MemberService.transfer_ownership`, which demotes
+    the outgoing owner in the same breath.
+
+    Derived from the catalog rather than from a role name, which is the whole
+    point: the ceiling this replaced compared against the literal `"admin"`, so
+    a custom role (Phase 2) holding `roles:manage` passed it unseen and could
+    mint a second owner (#672). An unknown role holds nothing and so may assign
+    nothing.
+    """
+    held = ROLE_PERMS.get(role, {})
+    return frozenset(
+        name
+        for name, perms in ROLE_PERMS.items()
+        if _reaches(held, perms) and not _reaches(perms, held)
+    )
+
+
 # The role an anonymous context carries. Deliberately not a member of
 # :class:`OrgRoleName` and deliberately not a key of `ROLE_PERMS`, so it
 # cannot pick up permissions from a later edit to either.

--- a/backend/app/schemas/organization.py
+++ b/backend/app/schemas/organization.py
@@ -90,7 +90,9 @@ class OrganizationMemberUpdate(BaseSchema):
     @field_validator("role")
     @classmethod
     def role_valid(cls, v: str) -> str:
-        allowed = {role.value for role in OrgRoleName}
+        # A role change cannot make a second owner - ownership transfers
+        # explicitly, and transfer-ownership demotes the outgoing owner (#672).
+        allowed = {role.value for role in OrgRoleName} - {OrgRoleName.OWNER.value}
         if v not in allowed:
             raise ValueError(f"Role must be one of: {', '.join(sorted(allowed))}")
         return v

--- a/backend/app/services/member.py
+++ b/backend/app/services/member.py
@@ -6,20 +6,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.audit import record_audit
 from app.core.exceptions import AuthorizationError, BadRequestError, NotFoundError
-from app.core.permissions import OrgRoleName, Perm, role_has
+from app.core.permissions import Perm, assignable_roles, role_has
 from app.db.models.organization import OrganizationMember, OrgRole
 from app.repositories import member_repo, user_repo
 
 logger = logging.getLogger(__name__)
-
-# Roles an admin may hand out. Deliberately excludes owner and admin: promoting
-# a peer to your own level is an ownership decision, not a management one.
-_ADMIN_ASSIGNABLE_ROLES = {
-    OrgRoleName.BUILDER.value,
-    OrgRoleName.OPERATOR.value,
-    OrgRoleName.MEMBER.value,
-    OrgRoleName.VIEWER.value,
-}
 
 
 class MemberService:
@@ -57,8 +48,10 @@ class MemberService:
         """Change a member's role.
 
         Rules:
-        - Only OWNER or ADMIN may change roles.
-        - ADMIN can only assign/change to MEMBER or VIEWER (cannot promote to ADMIN/OWNER).
+        - The requester needs `roles:manage`.
+        - They may only assign a role their own strictly outranks, which is
+          :func:`app.core.permissions.assignable_roles` - so no requester can
+          hand out `owner`, and none can promote a peer to their own level.
         - OWNER cannot be demoted via this method (use transfer_ownership).
         """
         requester = await member_repo.get(
@@ -83,8 +76,11 @@ class MemberService:
         if target.role == OrgRole.OWNER.value:
             raise BadRequestError(message="Use transfer-ownership to change the Owner role")
 
-        if requester.role == OrgRole.ADMIN.value and new_role not in _ADMIN_ASSIGNABLE_ROLES:
-            raise AuthorizationError(message="Admin can only assign Member or Viewer roles")
+        if new_role not in assignable_roles(requester.role):
+            raise AuthorizationError(
+                message="You cannot assign a role your own does not outrank",
+                details={"role": new_role},
+            )
 
         previous_role = target.role
         updated = await member_repo.update_role(self.db, target, role=new_role)

--- a/backend/tests/test_permissions.py
+++ b/backend/tests/test_permissions.py
@@ -21,6 +21,7 @@ from app.core.permissions import (
     OrgRoleName,
     Perm,
     Scope,
+    assignable_roles,
 )
 
 
@@ -141,6 +142,63 @@ class TestAuthContext:
     def test_app_admin_holds_everything_regardless_of_role(self):
         ctx = _ctx(OrgRoleName.VIEWER, is_app_admin=True)
         assert all(ctx.has(perm) for perm in Perm)
+
+
+class TestAssignableRoles:
+    """Which roles a role may hand out, derived from the catalog (#672).
+
+    The rule is "strictly weaker than mine", so the interesting cases are the
+    two it refuses: a role cannot clone itself, and no role at all can assign
+    `owner` - ownership moves through transfer-ownership, which demotes the
+    outgoing owner in the same breath.
+    """
+
+    def test_no_role_can_assign_owner(self):
+        assert not any(
+            OrgRoleName.OWNER.value in assignable_roles(role.value) for role in OrgRoleName
+        )
+
+    @pytest.mark.parametrize("role", list(OrgRoleName))
+    def test_no_role_can_assign_its_own(self, role: OrgRoleName):
+        assert role.value not in assignable_roles(role.value)
+
+    def test_an_owner_may_assign_every_role_below_them(self):
+        assert assignable_roles(OrgRoleName.OWNER.value) == {
+            OrgRoleName.ADMIN.value,
+            OrgRoleName.BUILDER.value,
+            OrgRoleName.OPERATOR.value,
+            OrgRoleName.MEMBER.value,
+            OrgRoleName.VIEWER.value,
+        }
+
+    def test_an_admin_may_not_assign_admin(self):
+        assert assignable_roles(OrgRoleName.ADMIN.value) == {
+            OrgRoleName.BUILDER.value,
+            OrgRoleName.OPERATOR.value,
+            OrgRoleName.MEMBER.value,
+            OrgRoleName.VIEWER.value,
+        }
+
+    def test_a_role_cannot_hand_out_a_permission_it_lacks(self):
+        """An operator holds `approvals:decide` at ALL; a builder does not."""
+        assert OrgRoleName.OPERATOR.value not in assignable_roles(OrgRoleName.BUILDER.value)
+
+    def test_a_wider_scope_is_not_assignable_from_a_narrower_one(self):
+        """A member edits their own agents; a builder edits every shared one."""
+        assert OrgRoleName.BUILDER.value not in assignable_roles(OrgRoleName.MEMBER.value)
+
+    def test_a_custom_role_is_bounded_by_what_it_actually_holds(self, monkeypatch):
+        """The reason this is not keyed on a role name.
+
+        A custom role (Phase 2) holding `roles:manage` is exactly what a check
+        written against the literal `admin` cannot see, and it is the path by
+        which `owner` would have been mintable.
+        """
+        monkeypatch.setitem(ROLE_PERMS, "test:role-admin", {Perm.ROLES_MANAGE: Scope.ALL})
+        assert assignable_roles("test:role-admin") == frozenset()
+
+    def test_an_unknown_role_may_assign_nothing(self):
+        assert assignable_roles("nonexistent") == frozenset()
 
 
 class TestRequireDependency:

--- a/backend/tests/test_services_members.py
+++ b/backend/tests/test_services_members.py
@@ -287,9 +287,10 @@ class TestMemberService:
 class TestRoleAssigned:
     """The request schema refuses a role a role change may not grant (#672).
 
-    The membership half of what `InvitationCreate` and `InviteLinkCreate` hold
-    for invitations: the service's ceiling depends on who is asking, so the
-    schema is where "no owner by PATCH, no made-up roles" holds for everyone.
+    The membership half of what `InvitationCreate` holds for invitations - and
+    of what `InviteLinkCreate` is still missing on this base, which is #551.
+    The service's ceiling depends on who is asking, so the schema is where "no
+    owner by PATCH, no made-up roles" holds for every requester alike.
     """
 
     @pytest.mark.parametrize("role", ["owner", "ceo"])

--- a/backend/tests/test_services_members.py
+++ b/backend/tests/test_services_members.py
@@ -4,6 +4,7 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from app.core.exceptions import (
     AlreadyExistsError,
@@ -11,6 +12,7 @@ from app.core.exceptions import (
     BadRequestError,
     NotFoundError,
 )
+from app.schemas.organization import OrganizationMemberUpdate
 from app.services.invitation import InvitationService
 from app.services.member import MemberService
 
@@ -123,6 +125,93 @@ class TestMemberService:
             )
 
     @pytest.mark.anyio
+    @pytest.mark.parametrize("requester_role", ["owner", "admin"])
+    async def test_change_role_cannot_mint_an_owner(self, service, requester_role):
+        """Nobody promotes to Owner through this route (#672).
+
+        `transfer_ownership` demotes the outgoing Owner in the same breath, so
+        a PATCH that only promotes leaves the organization with two - and an
+        audit trail that says `member.role_changed` rather than that ownership
+        moved.
+        """
+        requester = MagicMock(role=requester_role)
+        target = MagicMock(role="member")
+        update_role = AsyncMock()
+
+        with (
+            patch(
+                "app.services.member.member_repo.get",
+                new=AsyncMock(side_effect=[requester, target]),
+            ),
+            patch("app.services.member.member_repo.update_role", new=update_role),
+            pytest.raises(AuthorizationError),
+        ):
+            await service.change_role(
+                uuid.uuid4(), uuid.uuid4(), "owner", requester_id=uuid.uuid4()
+            )
+
+        update_role.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_a_custom_role_holding_roles_manage_cannot_mint_an_owner(
+        self, service, monkeypatch
+    ):
+        """The ceiling is what the requester holds, not whether they are `admin`.
+
+        Keyed on the literal role name, the check that stops an Admin promoting
+        someone could not see a custom role (Phase 2) at all - and `roles:manage`
+        is deliberately written to admit one.
+        """
+        from app.core.permissions import ROLE_PERMS, Perm, Scope
+
+        monkeypatch.setitem(ROLE_PERMS, "test:role-admin", {Perm.ROLES_MANAGE: Scope.ALL})
+        requester = MagicMock(role="test:role-admin")
+        target = MagicMock(role="member")
+        update_role = AsyncMock()
+
+        with (
+            patch(
+                "app.services.member.member_repo.get",
+                new=AsyncMock(side_effect=[requester, target]),
+            ),
+            patch("app.services.member.member_repo.update_role", new=update_role),
+            pytest.raises(AuthorizationError),
+        ):
+            await service.change_role(
+                uuid.uuid4(), uuid.uuid4(), "owner", requester_id=uuid.uuid4()
+            )
+
+        update_role.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_an_owner_still_promotes_a_member_to_admin(self, service):
+        """The ceiling bounds the assignment; it does not remove it."""
+        requester = MagicMock(role="owner")
+        target = MagicMock(role="member")
+        promoted = MagicMock(role="admin", user_id=uuid.uuid4())
+
+        with (
+            patch(
+                "app.services.member.member_repo.get",
+                new=AsyncMock(side_effect=[requester, target]),
+            ),
+            patch(
+                "app.services.member.member_repo.update_role",
+                new=AsyncMock(return_value=promoted),
+            ),
+            patch("app.services.member.record_audit", new=AsyncMock()),
+            patch(
+                "app.services.member.user_repo.get_by_id",
+                new=AsyncMock(return_value=MagicMock(email="a@example.com")),
+            ),
+        ):
+            member, _, _, _ = await service.change_role(
+                uuid.uuid4(), uuid.uuid4(), "admin", requester_id=uuid.uuid4()
+            )
+
+        assert member.role == "admin"
+
+    @pytest.mark.anyio
     async def test_remove_raises_if_not_authorized(self, service):
         mock_member = MagicMock()
         mock_member.role = "viewer"
@@ -193,6 +282,24 @@ class TestMemberService:
             pytest.raises(BadRequestError),
         ):
             await service.transfer_ownership(uuid.uuid4(), uid, requester_id=uid)
+
+
+class TestRoleAssigned:
+    """The request schema refuses a role a role change may not grant (#672).
+
+    The membership half of what `InvitationCreate` and `InviteLinkCreate` hold
+    for invitations: the service's ceiling depends on who is asking, so the
+    schema is where "no owner by PATCH, no made-up roles" holds for everyone.
+    """
+
+    @pytest.mark.parametrize("role", ["owner", "ceo"])
+    def test_an_ungrantable_role_is_refused(self, role):
+        with pytest.raises(ValidationError):
+            OrganizationMemberUpdate(role=role)
+
+    @pytest.mark.parametrize("role", ["admin", "builder", "operator", "member", "viewer"])
+    def test_a_grantable_role_passes(self, role):
+        assert OrganizationMemberUpdate(role=role).role == role
 
 
 class TestInvitationService:

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -124,6 +124,26 @@ keeps an invented role out is a validator on the member and invitation schemas,
 and if one ever got through, an unknown role resolves to no permissions rather
 than to somebody else's.
 
+### Who may hand out which role
+
+Holding `roles:manage` says a member may change roles; it does not say *which*.
+`assignable_roles` answers that from the catalog: a role may assign one whose
+authority it strictly exceeds - every permission the offered role holds, held at
+least as widely by the assigner, plus something the assigner holds that it does
+not. Two consequences, and both are the point:
+
+- **Nobody assigns `owner`**, because no role outranks it. Ownership moves
+  through `POST /orgs/{id}/transfer-ownership`, which demotes the outgoing owner
+  in the same breath; a role change that only promotes would leave two owners
+  and an audit entry reading `member.role_changed` (#672).
+- **Nobody assigns their own level.** An Admin may make a Builder or a Viewer,
+  never a second Admin - promoting a peer to your own level is an ownership
+  decision.
+
+Derived from the catalog rather than from a role name, so a custom role (Phase
+2) is bounded by what it actually holds. The ceiling this replaced compared
+against the literal `"admin"` and could not see one at all.
+
 Custom roles are Phase 2 and may only ever recombine the permissions above;
 clients cannot invent new ones.
 


### PR DESCRIPTION
## What this fixes

Closes #672. `PATCH /orgs/{org_id}/members/{target_user_id}` with `{"role": "owner"}`
succeeded against any non-owner member, leaving the organization with two owners and an
audit entry reading `member.role_changed` rather than saying ownership had moved.
`transfer_ownership` — the one path that demotes the outgoing owner in the same breath —
could be walked around with a plain PATCH.

## What changed

Two halves, because either alone leaves the hole open somewhere.

**The schema.** `OrganizationMemberUpdate.role` was the only schema in
`backend/app/schemas/organization.py` still admitting the full catalog including `owner`.
It now subtracts it, the way `InvitationCreate` already does.

**The service ceiling.** `backend/app/services/member.py` only inspected the *target*
("is this already an owner"), never `new_role`, and what capped an assignment compared
against the literal string `admin`. That is replaced by `assignable_roles` in
`app/core/permissions.py`: **a role may hand out one whose authority it strictly
exceeds**, computed from `ROLE_PERMS` — every permission the offered role holds, held at
least as widely by the assigner, plus something the assigner holds that it does not.

Two consequences fall out of the catalog rather than being spelled:

- no role outranks `owner`, so nobody assigns it;
- no role outranks itself, so an Admin still cannot mint a second Admin — the behaviour
  the `admin` literal was reaching for.

## How it failed before

Today the caller must already be an Owner, so this was a policy bypass rather than an
escalation. The role-name literal is what made it dangerous later: `roles:manage` at
`member.py:72` is deliberately written to admit a custom role (Phase 2), and a check
keyed on `"admin"` cannot see one. Such a role would have minted an Owner with the
ceiling looking straight past it. `assignable_roles` bounds it by what it actually holds,
which for a bare `roles:manage` role is nothing.

The frontend already excluded `owner` from the role picker (`useAssignableRoles`), so
this makes the backend keep a promise the UI was already making — no frontend change is
needed.

## Testing

Regression tests written first and watched fail, then green:

- `tests/test_services_members.py` — `change_role(..., new_role="owner")` refused for an
  Owner requester **and** for a synthetic custom role holding only `roles:manage`; the
  repository write asserted not to have happened, not just the raise.
- `tests/test_services_members.py::TestRoleAssigned` — `OrganizationMemberUpdate(role="owner")`
  and a made-up role fail validation; the five grantable roles pass. Mirrors
  `TestRoleOffered` that #671 adds for the invitation schemas.
- `tests/test_permissions.py::TestAssignableRoles` — the catalog rule itself: no role
  assigns `owner`, no role assigns its own, an Owner reaches every role below, an Admin
  does not reach Admin, a narrower scope cannot hand out a wider one, an unknown role
  assigns nothing.
- The positive path is covered too — an Owner promoting a Member to Admin still works, so
  the ceiling is a bound and not a blanket refusal.

`make lint-backend` clean, `make test` green (4399 passed, platform layer at 100%),
`make docs-build --strict` clean, `scripts/docs_drift.py` satisfied. Frontend untouched.

`docs/permissions.md` gains "Who may hand out which role"; `docs/reference/permissions.md`
regenerates from the new docstring.

## Overlaps

**PR #671 (open, #551) touches the same file** — `backend/app/schemas/organization.py` —
and is not merged, so `InvitableRole` does not exist on this base and is deliberately not
imported here. The two edits sit in different regions of the file (`OrganizationMemberUpdate`
vs. the invitation schemas), so they should merge cleanly, but afterwards the file holds
two spellings of one predicate: `_invitable_role` and this validator both mean "any catalog
role except owner". **They want reconciling into one shared annotated type once #671
lands** — whichever merges second is the natural place to do it, and the substance is
identical either way.

## Noticed, not fixed

Reviewing my own diff (the automated reviewer is off, #311) turned up three things, all
pre-existing and all out of scope for #672. Two are filed; the third already is.

- **#696** — `app/services/invitation.py:25` (`_ADMIN_INVITABLE_ROLES`, used at `:50` and
  `:132`) holds exactly the same `admin`-keyed ceiling for invitations that this PR
  removes from `change_role`, so a custom role holding `members:manage` could invite at
  Admin level unseen.
- **#700** — `change_role` bounds what may be *offered* but never inspects the target
  below the `owner` check, so an Admin may demote a peer Admin to Viewer — the same
  authority that `remove` at `member.py:138` explicitly refuses to take.
- **#551 / PR #671** — `InviteLinkCreate.role` carries no validator on this base, so an
  invite link can still offer `owner`. That is the other open half of this cluster, not
  something new; the second commit here corrects a test docstring that had wrongly
  claimed the bound was already in place.

Also seen and not filed: `useAssignableRoles` filters only `owner`, so an Admin is still
offered `admin` in the picker and gets a 403 — a frontend refinement that is now cheap,
since `assignable_roles` gives a per-caller answer where before there was only a role
list. Worth folding into whichever of the above touches the picker.

The map issue #168 has the cluster written up.
