### PR TITLE
Wait on the dispatched task instead of a 250ms grace

### DIFF
--- a/backend/tests/integration/test_flow_starts_after_commit.py
+++ b/backend/tests/integration/test_flow_starts_after_commit.py
@@ -15,13 +15,14 @@ visible to anyone but the request. Under `READ COMMITTED` that answer is a fact
 about the ordering, not a bet on timing. The third is the failure path: a
 request that raises dispatches nothing at all.
 
-What makes it deterministic in both directions is the wait in the route: after
-handing the work over, the route pauses for a moment for the flow to take its
-reading. `spawn` fills that pause - the task exists, so the loop runs it, and it
-reads an uncommitted database every time. `spawn_after_commit` leaves it empty:
-there is no task to run until the commit, so the wait times out, the route
-returns, the session commits, and only then does the flow read. One route, two
-handoffs, opposite answers.
+What makes it deterministic in both directions is what the route does after
+handing the work over: it awaits whatever tasks the handoff created, and nothing
+else. `spawn` creates one, so the flow takes its reading inside the request and
+finds an uncommitted database every time. `spawn_after_commit` creates none, so
+there is nothing to await, the route returns, the session commits, and only then
+does the flow read. One route, two handoffs, opposite answers - and neither of
+them a bet on the loop scheduling a task inside a fixed grace, which is what made
+this file flake under `make test`'s four workers and coverage (#680).
 """
 
 import asyncio
@@ -51,11 +52,9 @@ _DROP = "DROP TABLE IF EXISTS dispatch_ordering_probe"
 _INSERT = "INSERT INTO dispatch_ordering_probe (id) VALUES (:id)"
 _SELECT = "SELECT 1 FROM dispatch_ordering_probe WHERE id = :id"
 
-# How long the route holds after handing the work over, and how long the test
-# waits afterwards for a flow that has not run yet. The first is paid once by
-# the deferred case, where nothing fills it; the second is only ever reached by
-# a failure.
-_GRACE = 0.25
+# The only clock left in this file, and a passing run never spends it: every
+# wait below is on a task or an event that has already been created, so the
+# deadline is a guard against hanging rather than a window to fit inside.
 _PATIENCE = 5.0
 
 Handoff = Callable[[AsyncSession, Coroutine[Any, Any, None]], None]
@@ -94,6 +93,27 @@ def _spawn_now(session: AsyncSession, coro: Coroutine[Any, Any, None]) -> None:
 def _spawn_deferred(session: AsyncSession, coro: Coroutine[Any, Any, None]) -> None:
     """The handoff this file exists to pin."""
     spawn_after_commit(session, coro, name="probe-flow")
+
+
+@contextlib.asynccontextmanager
+async def _awaiting_whatever_it_starts() -> AsyncGenerator[None, None]:
+    """Let the tasks created inside the block run to completion before going on.
+
+    This is the ordering probe itself. Which tasks to wait for is settled by
+    diffing the loop's own set across the block rather than by taking the
+    handoff's word for it, so a `spawn_after_commit` that began spawning
+    immediately is waited for here and caught, instead of being agreed with.
+
+    It replaces a fixed 250ms grace, which was a bet that the loop would
+    schedule the task inside it. Under `make test` - four xdist workers and
+    coverage instrumentation on one machine - that bet loses often enough to
+    turn the ordering property red for reasons that are not the diff (#680).
+    """
+    before = asyncio.all_tasks()
+    yield
+    started = asyncio.all_tasks() - before
+    if started:
+        await asyncio.wait(started, timeout=_PATIENCE)
 
 
 async def _drive(app: FastAPI) -> int:
@@ -156,12 +176,10 @@ async def _dispatch(handoff: Handoff, engine: AsyncEngine) -> bool:
 
     async def dispatch(db: DBSession) -> Response:
         await db.execute(text(_INSERT), {"id": row_id})
-        handoff(db, flow())
         # Standing in for the several suspension points a real endpoint has
-        # left before its commit, and bounded so the correct handoff - which
-        # cannot fill it - does not hang here.
-        with contextlib.suppress(TimeoutError):
-            await asyncio.wait_for(read.wait(), _GRACE)
+        # left before its commit.
+        async with _awaiting_whatever_it_starts():
+            handoff(db, flow())
         return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     answered = await _drive(_application(dispatch))
@@ -217,9 +235,9 @@ async def test_a_request_that_fails_dispatches_nothing(probe_table: AsyncEngine,
         spawn_after_commit(db, flow(), name="probe-flow")
         raise NotFoundError(message="decided after the write", details={"row_id": row_id})
 
-    with caplog.at_level(logging.WARNING, logger="app.core.background"):
-        answered = await _drive(_application(dispatch))
-    await asyncio.sleep(_GRACE)
+    async with _awaiting_whatever_it_starts():
+        with caplog.at_level(logging.WARNING, logger="app.core.background"):
+            answered = await _drive(_application(dispatch))
 
     assert answered == status.HTTP_404_NOT_FOUND
     assert not started.is_set(), "a flow ran for a row the database threw away"


### PR DESCRIPTION
## What this fixes

Closes #680.

`tests/integration/test_flow_starts_after_commit.py::test_spawning_inside_the_request_starts_before_the_row_exists`
failed once under `make test` and passed on a clean re-run and in CI. The route
handed the work over with `spawn` and then held for a fixed `_GRACE = 0.25`
seconds so the spawned flow could take its reading of the still-uncommitted row;
the assertion was that the reading happened inside that window. Under `make test`
— four xdist workers plus coverage instrumentation on one machine — 250ms
guarantees nothing, and when the loop did not get round to the task the test
reported the ordering property as broken.

## What changed

One test file. The grace is now a wait on the work itself.

`_awaiting_whatever_it_starts()` diffs `asyncio.all_tasks()` across the handoff
and awaits whatever the handoff created:

- `spawn` creates a task, so the flow completes its read inside the request,
  before the session commits — `seen` is `False` by construction, not by timing.
- `spawn_after_commit` creates none, so there is nothing to await, the route
  returns, the session commits and only then does the flow read.

The tasks are found by diffing the loop rather than taken from the handoff's
return value **on purpose**: a `spawn_after_commit` that started spawning
immediately is then waited for and caught, where trusting the handoff to say what
it did would quietly agree with the regression.

The same wait replaces the `await asyncio.sleep(_GRACE)` in the rolled-back case,
which was proving an absence with a clock for the same reason. `_GRACE` is gone;
`_PATIENCE = 5.0` is the only clock left in the file and a passing run never
spends it — it is a hang guard, not a window to fit inside.

No production code changed.

## Why a bigger timeout was not the fix

Raising 250ms to 2s would move the failure rate, not remove it. The shape is
wrong: "did A happen before B" was being answered by "did A fit inside a fixed
budget", and any fixed budget is a bet against a loaded machine. The ordering is
observable directly — the task either exists at handoff time or it does not — so
the test now observes it instead of sampling it. As a side effect the file is
also ~800ms faster, because it no longer pays the grace twice.

## Testing

**It still catches #417, in both directions.** Verified by breaking the
production code and watching it go red, then restoring it:

- `app/core/background.py` patched so `spawn_after_commit` spawns immediately →
  `test_a_dispatched_flow_can_read_the_row_that_dispatched_it` fails with the
  #417 message, and `test_a_request_that_fails_dispatches_nothing` fails with
  "a flow ran for a row the database threw away". 2 failed, 1 passed.
- the immediate handoff patched to defer →
  `test_spawning_inside_the_request_starts_before_the_row_exists` fails with
  "spawning inside the request no longer outruns the commit". 1 failed, 2 passed.

**And the old shape really was a timing bet.** On the pre-change file, deleting
the 250ms wait (emulating a loop that never got round to the task inside it)
makes the spawn test fail with exactly the message #680 reports. Shrinking the
grace to 0.5ms was *not* enough to reproduce it, which is consistent with how
rarely it fires.

**Repeatedly, under load.** 25 consecutive runs of the file with eight CPU-bound
processes hogging the machine: 25/25 green, 0 failures. A 25-run baseline of the
unchanged file under sixteen hogs did not reproduce the flake either — a bare run
is not `make test`, which is why the emulation above is the real evidence rather
than the loop.

**Gates.** `make lint-backend` exit 0. `make test` green on five consecutive
runs (4375 passed, 6 skipped, 100% on the platform layer); the integration suite
ran in all five. `python3 scripts/docs_drift.py` — nothing owed, this is
test-only.

**CI is green**, including `e2e` (4m44s) and `test` (7m26s) on the first attempt.
`test-frontend` and `docker` skipped on changed paths, which is a pass.

## Noticed, not fixed

Nothing. The two neighbouring assertions in the file were the same timing shape
and are fixed here rather than filed, since they live in the same helper and the
same diff.
