### PR TITLE
chore: cut 0.0.114

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,30 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.114] - 2026-08-13
+
+The security page described an authorization model that was deleted three
+months ago.
+
+### Fixed
+
+- **`SECURITY.md` documented `RoleChecker` and `UserRole.USER` / `UserRole.ADMIN`
+  as the authorization model.** The `users.role` column went in migration `0066`;
+  authority inside an organization is a membership row plus the permission
+  catalog, and has been since. A security page is read by somebody deciding
+  whether to trust a deployment, so being three months stale there costs more
+  than elsewhere. It now describes the three layers and points at
+  `docs/permissions.md`.
+- **The hardening checklist named no rate limits at all**, which left an operator
+  no way to know the public surfaces have them. It now lists the per-surface
+  limits — the embed widget's per-visitor cap and each channel bot's
+  `rate_limit_rpm` — and says plainly that the console's own routes are not
+  metered.
+- **The audit-log entry named a table that does not exist.**
+  `app_admin_audit_log` is `app_admin_audit_logs`, and organization-level actions
+  carry a trail of their own gated by `audit:read`, which the page did not
+  mention. (`docs/governance.md`)
+
 ## [0.0.113] - 2026-08-13
 
 Every surface — web chat, the embed widget, a channel bot, and the hosted page

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.113"
+version = "0.0.114"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.113"
+version = "0.0.114"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.113",
+  "version": "0.0.114",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
`SECURITY.md` and `docs/governance.md` brought back in line with the code — #665.

The page described `RoleChecker` and `UserRole.USER` / `UserRole.ADMIN` as the authorization model. That column was dropped in migration `0066`; authority inside an organization is a membership row plus the permission catalog. It also named `app_admin_audit_log` (the table is `app_admin_audit_logs`) and listed no rate limits in the hardening checklist.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json`. The CHANGELOG entry is written here rather than promoted from `[Unreleased]`, because #665 wrote none.
