### PR TITLE
chore: cut 0.0.115

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.115] - 2026-08-13
+
+A file link that fails no longer takes the transcript of a paid run with it.
+
+### Fixed
+
+- **The write linking a channel turn's files to its message shared the
+  transcript's SAVEPOINT**, so an exception from it rolled back the user turn,
+  the settled tool calls and the assistant message — for a run that had already
+  spent money, over a file. It now has a savepoint of its own inside that one:
+  it is the only write there touching rows the conversation does not own, and a
+  failure costs the link alone. Web chat has always made this trade for the same
+  write, in `persist_user_turn`. The savepoint is skipped outright when nothing
+  was attached, because opening and releasing one on every turn in the deployment
+  is a real cost for a list that is almost always empty. (#690)
+
 ## [0.0.114] - 2026-08-13
 
 The security page described an authorization model that was deleted three

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.114"
+version = "0.0.115"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.114"
+version = "0.0.115"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.114",
+  "version": "0.0.115",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
The file link a channel turn writes gets a SAVEPOINT of its own — #703, refs #690.

#634 landed the linking itself. What was left, and what this releases, is the
transaction it rides: the link was written inside the SAVEPOINT the whole
transcript shares, so an exception from it rolled back the user turn, the settled
calls and the assistant message with its tool calls — for a run that had already
spent money, over a file.

It also adds the test #690 actually asked for: one that reads the column back off
a real database rather than asserting at the repository boundary.
`link_to_message` was never the broken part; that no surface but web chat called
it was.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than promoted
from `[Unreleased]`, because #703 wrote none.
