### PR TITLE
chore: cut 0.0.116

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,26 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.116] - 2026-08-13
+
+A failing tool named a search provider's endpoint, with the key still in the
+query string, to everyone watching the run.
+
+### Fixed
+
+- **A `tool_result` frame carried whatever the tool that raised had put in its
+  `ModelRetry`.** `web_search` builds one out of the `httpx` or SDK exception it
+  caught, so a broken key put `401 Unauthorized for url
+  'https://api.tavily.com/search?…'` — an endpoint, a host and whatever the query
+  string held — into the chat panel and the browser console of everyone watching.
+  An MCP tool's retry is a third party's string entirely, which is why the frame
+  is trimmed where it is sent rather than at each raise. The frame still names the
+  tool, because a card that resolves saying which step failed is the difference
+  from one that spins for ever, and the tool's own text goes to the log beside the
+  send. The model reads the retry whole either way — Pydantic AI puts the part
+  into the next request itself. Applied in `run_stream.py`, so the widget, a
+  hosted page and a channel are covered by the same sentence web chat is. (#681)
+
 ## [0.0.115] - 2026-08-13
 
 A file link that fails no longer takes the transcript of a paid run with it.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.115"
+version = "0.0.116"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.115"
+version = "0.0.116"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.115",
+  "version": "0.0.116",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Name the tool that failed, not the search provider's error — #694, closes #681.

A `tool_result` frame carried `str(part.content)` from a `RetryPromptPart`, and
that content is written by whichever tool raised. `web_search` turns a provider's
failure into a `ModelRetry` built out of the exception it caught, so a broken key
reached the chat panel as the failing URL with its query string.

Landed in `app/services/run_stream.py` rather than `agent_session.py`, because
#634 moved the streaming loop there and every surface now goes through it — so
the widget, the hosted page and channels get the same trimmed frame instead of
web chat alone.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than promoted
from `[Unreleased]`, because #694 wrote none.
