### PR TITLE
chore: cut 0.0.118

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,25 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.118] - 2026-08-13
+
+A crashed turn told the chat panel whatever the provider's SDK had put in its
+exception.
+
+### Fixed
+
+- **The `error` frame carried `str(exc)` of whatever came out of the run.** A
+  provider SDK puts the failing request in its message, so that routinely meant an
+  endpoint, an internal host, or a URL with a key still in its query string —
+  reaching a member's chat panel and their browser console rather than an HTTP
+  body, which is where #342 fixed the same leak. The exception's text now stays in
+  the `logger.exception` beside the send, and the frame names only what the reader
+  can act on. The class still goes out, because it separates an upstream that
+  timed out from one that refused a credential and a class name has never carried
+  a URL. Our own refusals do not come through here at all — an `AppException` and
+  a `BudgetExceeded` are caught above and passed through whole, since their
+  messages are written in this repository. (#659)
+
 ## [0.0.117] - 2026-08-13
 
 A failed run stored the provider's own error text in a column that run history

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.117"
+version = "0.0.118"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.117"
+version = "0.0.118"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.117",
+  "version": "0.0.118",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Stop sending a provider's own text to the chat panel — #675, closes #659.

The `error` frame on the dashboard socket carried `str(exc)`, so a failing model
request reached a member's browser as the URL it failed on. Same rule as #342 in
an HTTP body and #676 in the run row, on the surface a person is watching while
it happens.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than promoted
from `[Unreleased]`, because #675 wrote none.
