### PR TITLE
chore: cut 0.0.119

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.119] - 2026-08-13
+
+A channel turn refused before it ran left the files it had already stored behind,
+owned by nothing.
+
+### Fixed
+
+- **The bytes are stored before the agent is resolved, so whatever refuses in its
+  place has to give them back.** A turn that never produced a run left `chat_files`
+  rows nothing points at — and that table carries no organization, so an unlinked
+  row is scoped by `user_id` alone and no sweep collects it. Both refusal paths now
+  discard what the turn stored: the one that stores first and refuses second, and
+  the one where a handle names no agent of ours. A file that cannot be deleted
+  costs neither the other files nor the reply, because a cleanup that raised would
+  replace a refusal somebody can act on with a bot that answered nothing at all.
+  (#661, #690)
+
 ## [0.0.118] - 2026-08-13
 
 A crashed turn told the chat panel whatever the provider's SDK had put in its

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.118"
+version = "0.0.119"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.118"
+version = "0.0.119"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.118",
+  "version": "0.0.119",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Delete the files a refused channel turn stored — #689, closes #661.

Merged over #634, whose mention gate decides whether an `AppException` is posted
or only logged; the discard happens either way, before that decision. Two tests
that hand `_route_inner` a mock session now stub `_load_history`, because #634
added a `count_messages` call those tests reach — what they assert on is the file
rows.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than promoted
from `[Unreleased]`, because #689 wrote none.
