### PR TITLE
chore: cut 0.0.120

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,30 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.120] - 2026-08-13
+
+Reloading a conversation whose run is parked on an approval showed nothing to
+say so, at either end.
+
+### Added
+
+- **`GET /runs/{run_id}/parked`** answers a run's pending calls — the approval row
+  to decide, the tool call id, the tool and its arguments — the same payload the
+  live `tool_approval_required` frame carries. Gated on `approvals:decide`. (#601)
+
+### Fixed
+
+- **The step a run parked on rendered as though it had run.** The transcript now
+  stores those calls with `status="awaiting_approval"` rather than `running`, taken
+  off the runner's paused state for every non-streaming surface and off
+  `turn.parked` in web chat. The row does not read "waiting" for ever: a resume
+  settles it with what the call returned, an expiry with the timeout notice, and
+  both paths already existed. (#601)
+- **The approval panel never came back after a reload**, so the only way to finish
+  a parked run was the approvals queue on another page. This had always been true
+  of every non-streaming surface; #509 removed the stored notice that had been
+  covering for both halves, which is what made it visible. (#601)
+
 ## [0.0.119] - 2026-08-13
 
 A channel turn refused before it ran left the files it had already stored behind,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.119"
+version = "0.0.120"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.119"
+version = "0.0.120"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.119",
+  "version": "0.0.120",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Keep a parked run saying it waits after a reload — #653, closes #601.

Both halves the issue names, at both ends: the transcript records the parked
calls with their own status, and a new `parked` route lets the panel come back
without the live frame that first announced it.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than promoted
from `[Unreleased]`, because #653 wrote none.
