### PR TITLE
chore: cut 0.0.121

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.121] - 2026-08-13
+
+A message's attachments were downloaded and stored twice, and the run was handed
+the second copy.
+
+### Fixed
+
+- **Each path fetched the files for itself.** A mention that names nobody of ours
+  falls through to the default assistant, and both halves called `_receive_files`
+  — so an ordinary message with a spreadsheet on it was downloaded from the
+  platform twice, stored twice, and run with the second set. The first row stayed
+  against the sender with nothing pointing at it, which on `chat_files` means
+  scoped by `user_id` alone and collected by nothing. The fetch now happens once,
+  above both paths, and is passed down. (#683)
+
 ## [0.0.120] - 2026-08-13
 
 Reloading a conversation whose run is parked on an approval showed nothing to

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.120"
+version = "0.0.121"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.120"
+version = "0.0.121"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.120",
+  "version": "0.0.121",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Fetch a message's attachments once, not per path — #684, closes #683.

The double fetch survived #634 in a worse shape: `_answer_mention` still received
files at its top and the default path received them again, and the first copy
leaked on `UnaddressedMessage`, which returns `False` without discarding. The
hoist stands — one fetch above both paths — while #634's lazy placeholder and
`admit_unlinked` are kept as they are.

The helper that routes a message through now stubs `count_messages`, which #634
added under `_load_history`.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than promoted
from `[Unreleased]`, because #684 wrote none.
