### PR TITLE
chore: cut 0.0.122

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,25 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.122] - 2026-08-13
+
+A platform's second way in built its own idea of what a message is, and the two
+disagreed about files.
+
+### Fixed
+
+- **Each adapter now has exactly one parser.** Every platform has two ways in — a
+  webhook and a stream, or long-polling — and the second one built its own
+  normalised message: Telegram's polling loop read text and nothing else, and the
+  Mattermost outgoing webhook read no `file_ids` at all. So somebody dropping a
+  spreadsheet on a bot had it silently discarded, depending only on which
+  transport that deployment happened to run — and long-polling is what a
+  self-hosted install uses. Both now put the update back into the shape the
+  platform sends and hand it to the same `parse_incoming`, so what counts as a
+  message is decided once. What each transport is *handed* still differs, and that
+  is the platform's doing: Telegram's polling loop subscribes to new messages
+  only, so an edit reaches the webhook receiver and never the poller. (#672)
+
 ## [0.0.121] - 2026-08-13
 
 A message's attachments were downloaded and stored twice, and the run was handed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.121"
+version = "0.0.122"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.121"
+version = "0.0.122"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.121",
+  "version": "0.0.122",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Parse every inbound transport with one parser — #698, closes #672.

The conflicting docs section was the old linking paragraph, which #634 rewrote
into the direct-message / channel split; main's wins whole, and this branch's own
paragraph about the parsers sits beside it.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than promoted
from `[Unreleased]`, because #698 wrote none.
