### PR TITLE
fix(channels): gate a Mattermost webhook post the way the stream is

### DIFF
--- a/backend/app/services/channels/mattermost.py
+++ b/backend/app/services/channels/mattermost.py
@@ -775,6 +775,29 @@ class MattermostAdapter(ChannelAdapter):
         return response.content
 
     def _from_webhook(self, payload: dict[str, Any], bot_id: str) -> IncomingMessage | None:
+        """Normalise one outgoing-webhook body.
+
+        The addressing rule is the socket's, read off what this payload actually
+        carries. An outgoing-webhook body has no mention list - Mattermost sends
+        the post, not who it notified - so the bot's own account cannot be looked
+        for in it, and this path left `addressed` unset. The router reads unset as
+        "the platform did not say" and answers, which put the bot back in the
+        position the socket's rule took it out of: replying to colleagues talking
+        to each other in a channel it was merely invited to (#662).
+
+        What the payload does say is `trigger_word` - the word an operator
+        configured *this integration* to fire on, which is Mattermost's own record
+        that the post was for us. Empty means the webhook fired on its channel
+        filter alone, and a channel filter delivers every post exactly as the
+        socket does, so it is `False` for the same reason a `posted` event with no
+        mentions is.
+
+        The consequence worth knowing before choosing this transport: `@the-bot`
+        is not readable here, because nothing in the body says which account the
+        bot is. Set the trigger word to the bot's handle if that is how people
+        should reach it; an `@agent-slug` needs nothing, since the router reads a
+        slug out of the text.
+        """
         # Mattermost sends the bot's own posts to an outgoing webhook only when
         # explicitly configured to, but a loop is expensive enough to check for.
         if payload.get("user_name") in {"", None} or str(payload.get("user_id") or "") == "":
@@ -802,4 +825,5 @@ class MattermostAdapter(ChannelAdapter):
             platform_display_name=str(payload.get("user_name") or "") or None,
             message_id=str(payload.get("post_id") or "") or None,
             attachments=attachments,
+            addressed=bool(str(payload.get("trigger_word") or "").strip()),
         )

--- a/backend/tests/test_channel_addressing.py
+++ b/backend/tests/test_channel_addressing.py
@@ -21,6 +21,11 @@ regression, and the quietest to ship.
 *Silence where the platform did not say.* Slack and Telegram deliver on their own
 subscription rules, so reading "no mention data" as "ignore" would take a working
 bot on either of them off the air.
+
+And the rule belongs to the *bot*, not to one way of reaching it: Mattermost's
+outgoing webhook hands over a watched channel's posts the same way the socket
+does, and answered all of them for as long as it said nothing about who they
+named (#662).
 """
 
 from __future__ import annotations
@@ -165,3 +170,56 @@ class TestReadingMattermostsOwnMentionList:
 
         assert adapter._addressed({"mentions": "not json"}, "bot-1") is False
         assert adapter._addressed({"mentions": json.dumps({"id": "bot-user"})}, "bot-1") is False
+
+
+class TestTheOutgoingWebhookTransportObeysTheSameRule:
+    """The rule was the socket's alone, so the other half of the same adapter
+    answered everything it was handed (#662). An outgoing-webhook body carries no
+    mention list, so what stands in for one is `trigger_word`: the word an operator
+    told *this integration* to fire on. Empty means the webhook fired on its
+    channel filter, which delivers every post exactly as the socket does.
+    """
+
+    @staticmethod
+    def _delivered(**payload: str) -> IncomingMessage:
+        body = {
+            "token": "t",
+            "user_id": "u1",
+            "user_name": "kacper",
+            "channel_id": "c1",
+            "channel_name": "town-square",
+            "post_id": "p1",
+            "text": "standup at 10 then",
+            **payload,
+        }
+        incoming = MattermostAdapter().parse_incoming(body, "bot-1")
+        assert incoming is not None
+        return incoming
+
+    def test_a_channel_post_that_fired_no_trigger_word_is_overheard(self) -> None:
+        """The defect: Mattermost hands over every post in a watched channel and
+        the bot answered each one, having said nothing about whether it was named."""
+        delivered = self._delivered()
+
+        assert delivered.addressed is False
+        assert ChannelMessageRouter._is_overheard(delivered) is True
+
+    def test_a_trigger_word_is_mattermosts_own_record_that_the_post_was_for_us(self) -> None:
+        delivered = self._delivered(trigger_word="@ops", text="@ops standup at 10 then")
+
+        assert delivered.addressed is True
+        assert ChannelMessageRouter._is_overheard(delivered) is False
+
+    def test_an_agent_handle_reaches_the_bot_without_one(self) -> None:
+        """A slug is a name in this product, not a trigger word somebody had to
+        configure, so it is read out of the text on either transport."""
+        delivered = self._delivered(text="@sales what is the refund window")
+
+        assert delivered.addressed is False
+        assert ChannelMessageRouter._is_overheard(delivered) is False
+
+    def test_a_direct_message_is_answered_without_one(self) -> None:
+        """There is nobody else in the room, and no trigger word to type."""
+        delivered = self._delivered(channel_name="u1__u2")
+
+        assert ChannelMessageRouter._is_overheard(delivered) is False

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -633,21 +633,30 @@ Two ways in; pick by whether your Mattermost can reach this deployment.
 
 **Every** post, which is the thing to know about this transport: the socket is not
 a subscription to messages aimed at the bot, it is the channel. So the rule is the
-one a colleague follows:
+one a colleague follows — and it belongs to the bot rather than to one way of
+reaching it, so the outgoing webhook below obeys the same table:
 
 | Where | When it answers |
 |---|---|
 | **A direct message** | Always. There is nobody else in the room, so requiring a mention would be asking somebody to address the only participant |
 | **A channel** | Only when it is named — `@the-bot`, or `@agent-slug` for one of the agents exposed on it |
 
-The bot resolves its own account once per stream session and reads Mattermost's
-own mention list off each event, rather than matching text: `@ada` is somebody
-whose display name the bot cannot resolve, and a bot called `bot` should not answer
-the word "robot". An `@agent-slug` is the exception that has to be read from the
-text — a slug is a name in *this* product, so it is never in a mention list. A
-handle that turns out to name neither the bot nor one of its agents is answered in
-a direct message and passed over in a channel, because there it was somebody's
-colleague.
+*How* it knows it was named is the transport's, because the two payloads say
+different things:
+
+| Transport | What it reads |
+|---|---|
+| **Event stream** | Mattermost's own mention list on each `posted` event, against the account the bot resolves once per session |
+| **Outgoing webhook** | The `trigger_word` the integration fired on. The body carries no mention list, so `@the-bot` cannot be read here — set the trigger word to the bot's handle if that is how people should reach it |
+
+An `@agent-slug` needs neither and works on both: it is read out of the text,
+because a slug is a name in *this* product and so is never in a mention list.
+
+The stream reads the list rather than matching text for the same reason: `@ada` is
+somebody whose display name the bot cannot resolve, and a bot called `bot` should
+not answer the word "robot". A handle that turns out to name neither the bot nor
+one of its agents is answered in a direct message and passed over in a channel,
+because there it was somebody's colleague.
 
 **`@channel`, `@all`, `@here` and `@everyone` address the room, not an agent.**
 They have the shape of a slug, and a channel-wide mention puts every member of the
@@ -656,9 +665,11 @@ read as a message naming an agent nobody has. Those four handles are never a
 mention here, and an agent named after one gets `-agent` on the end of its handle so
 it stays reachable.
 
-If the bot's own account cannot be resolved, it answers everything, as it did
-before this rule existed: going quiet on a server that would not say who we are is
-the worse of the two failures.
+If the bot's own account cannot be resolved, the stream answers everything, as it
+did before this rule existed: going quiet on a server that would not say who we
+are is the worse of the two failures. The webhook has no such fallback and does
+not need one — an integration with no trigger word is a channel filter, and a
+channel filter says nothing about who a post was for.
 
 **Outgoing webhook.** For a Mattermost that can reach this API.
 
@@ -666,7 +677,9 @@ the worse of the two failures.
 2. *System Console → Integrations → Outgoing Webhooks → Add*, with the callback
    URL `https://your-api.example.com/api/v1/mattermost/BOT_ID/webhook` — the bot
    id is on the row once it is registered, and `channel-webhook-register` prints
-   the whole URL.
+   the whole URL. Its **trigger words** are what addresses the bot on this
+   transport, per the table above; leave them empty and only an `@agent-slug`
+   reaches it in a channel.
 3. Mattermost shows a **token** when the webhook is saved. Paste that into the
    bot's **Webhook token** field here.
 


### PR DESCRIPTION
Reopens #685, which GitHub closed automatically when its base branch `feat/agent-surfaces` was deleted on merge. Its own diff is replayed onto `main` rather than the stale branch rebased — that branch carries a pre-squash copy of all of #634 and conflicted in 35 files.

An outgoing-webhook body carries no mention list, so the path left `addressed` unset and the router answered every post in a channel the bot was merely invited to. `trigger_word` is the payload's own record that the post was for this integration.

**Two of #685's hunks are deliberately dropped**, both because main is newer:

- the `@channel` / `@all` / `@here` paragraph — c900eaa4 decided those are *never* a mention, and #685 said the opposite;
- the e2e publish locators — main already anchors them and drops the `.first()` #685 kept.

Verified: `test_channel_addressing.py`, `test_channel_adapter_attachments.py` and `test_channel_mentions.py`, 109 passed.

Refs #662