### PR TITLE
chore: cut 0.0.123

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.123] - 2026-08-13
+
+The embed session — one visitor's turn on a public URL — was the last surface
+outside the coverage and type gates.
+
+### Changed
+
+- **`app/services/embed_session.py` is held to 100% coverage and to `ty`.** It
+  decides who a visitor's turn runs as, how often they may ask, and what the page
+  is allowed to put in front of the model — every one of which is a refusal a
+  stranger can reach — and an unreachable `except BudgetExceeded` sat in it for as
+  long as it was ungated, which is the kind of thing the gate exists to name. The
+  module was at 93%: the missing 13 lines and 8 partial branches were the frame
+  guards in `handle` (a frame that is not a message, an empty one, one past the
+  character cap, a visitor past their rate limit), the two endings that produce no
+  words, and `_files`. All are covered. (#663)
+
 ## [0.0.122] - 2026-08-13
 
 A platform's second way in built its own idea of what a message is, and the two

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.122"
+version = "0.0.123"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.122"
+version = "0.0.123"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.122",
+  "version": "0.0.123",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Hold the embed session to the 100% coverage and ty gate — #674, closes #663.

The branch's test file was written against the constructor #634 replaced — `db=`
and a `member_repo` patch, where the module now takes a session factory and asks
`access.publisher_context` — so it is rewritten rather than merged. The
unreachable `except BudgetExceeded` this branch removed is already gone from
main, which leaves the gate itself as the change.

Main's own tests left the module at 93%. The gap is covered here, and both
`include` lists in `backend/pyproject.toml` now hold it.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than promoted
from `[Unreleased]`, because #674 wrote none.
