### PR TITLE
chore: cut 0.0.124

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,27 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.124] - 2026-08-13
+
+A Mattermost bot reached through an outgoing webhook answered every post in a
+channel it was merely invited to.
+
+### Fixed
+
+- **The outgoing-webhook path left `addressed` unset**, and the router reads unset
+  as "the platform did not say" and answers. So the transport put the bot back in
+  the position the event stream's rule took it out of: replying to colleagues
+  talking to each other. The body carries no mention list — Mattermost sends the
+  post, not who it notified — so what is read instead is `trigger_word`, the
+  platform's own record that the post was for this integration. Empty means the
+  webhook fired on its channel filter alone, which delivers every post exactly as
+  the socket does, so it is `False` for the same reason a `posted` event with no
+  mentions is. Worth knowing before choosing this transport: `@the-bot` is not
+  readable here, because nothing in the body says which account the bot is — set
+  the trigger word to the bot's handle if that is how people should reach it. An
+  `@agent-slug` needs nothing, since the router reads a slug out of the text.
+  (#662)
+
 ## [0.0.123] - 2026-08-13
 
 The embed session — one visitor's turn on a public URL — was the last surface

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.123"
+version = "0.0.124"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.123"
+version = "0.0.124"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.123",
+  "version": "0.0.124",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Gate a Mattermost webhook post the way the stream is — #718, closes #662.

Replaces #685, which GitHub closed automatically when its base branch
`feat/agent-surfaces` was deleted on merge; its diff was replayed onto `main`
rather than the stale branch rebased, because that branch carried a pre-squash
copy of all of #634 and conflicted in 35 files.

Two of its hunks were deliberately dropped, both because main is newer: the
`@channel` / `@all` / `@here` paragraph, where c900eaa4 decided those are never a
mention and #685 said the opposite, and the e2e publish locators, which main
already anchors.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`.
