### PR TITLE
chore: cut 0.0.125

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.125] - 2026-08-13
+
+A plain role change could mint a second owner and walk around ownership transfer.
+
+### Fixed
+
+- **`PATCH /orgs/{org_id}/members/{user_id}` accepted `{"role": "owner"}`** against
+  any non-owner member. It succeeded, left the organization with two owners, and
+  wrote an audit entry reading `member.role_changed` rather than saying ownership
+  had moved — so `transfer_ownership`, the one path that demotes the outgoing owner
+  in the same breath, could be walked around with a PATCH. Both halves are closed,
+  because either alone leaves the hole open somewhere: `OrganizationMemberUpdate`
+  subtracts `owner` from the roles it admits, the way `InvitationCreate` already
+  did, and the service now caps the role being *assigned* rather than only
+  inspecting the target. (#672)
+
 ## [0.0.124] - 2026-08-13
 
 A Mattermost bot reached through an outgoing webhook answered every post in a

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.124"
+version = "0.0.125"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.124"
+version = "0.0.125"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.124",
+  "version": "0.0.125",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Stop `change_role` handing out the owner role — #697, closes #672.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than promoted
from `[Unreleased]`, because #697 wrote none.
