### PR TITLE
chore: cut 0.0.126

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.126] - 2026-08-13
+
+A shareable invite link could grant ownership, or a role that does not exist.
+
+### Fixed
+
+- **`InviteLinkCreate.role` carried no validator** while its sibling
+  `InvitationCreate` refused `owner` and unknown roles. An Owner could mint a link
+  that grants owner — co-ownership through a pasted URL, the exact thing the email
+  invitation path forbids — or an invented role string that `role_has` cannot
+  reason about, which then flowed unvalidated onto the accepter's membership row.
+  Both schemas now share one `InvitableRole`: every role in the catalog except
+  `owner`, refused at validation. (#551)
+
 ## [0.0.125] - 2026-08-13
 
 A plain role change could mint a second owner and walk around ownership transfer.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.125"
+version = "0.0.126"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.125"
+version = "0.0.126"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.125",
+  "version": "0.0.126",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Validate the role an invite link offers — #671, closes #551.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than promoted
from `[Unreleased]`, because #671 wrote none.
