### PR TITLE
chore: cut 0.0.127

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.127] - 2026-08-13
+
+An invitation nobody clicked stayed pending for ever, and one clicked too late
+was recorded as withdrawn.
+
+### Added
+
+- **An hourly `invitation-expiry-sweep`**, the same shape as the approval sweep.
+  `InvitationStatus.EXPIRED` was unreachable — `invitation_repo.expire_stale` had
+  no caller — so the pending list kept offering invitations that had timed out.
+  Registered hourly rather than more often, because the TTL is measured in days.
+  (#456)
+
+### Fixed
+
+- **Accepting a stale invitation marked it `revoked`**, which records a withdrawal
+  somebody made when what actually happened is that it ran out. (#456)
+
 ## [0.0.126] - 2026-08-13
 
 A shareable invite link could grant ownership, or a role that does not exist.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.126"
+version = "0.0.127"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.126"
+version = "0.0.127"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.126",
+  "version": "0.0.127",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Expire a stale invitation instead of leaving it pending — #667, closes #456.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than promoted
from `[Unreleased]`, because #667 wrote none.
