### PR TITLE
ci(changes): let a version-only bump skip the expensive suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,9 +129,17 @@ jobs:
           set -euo pipefail
           gh api --paginate \
             "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" \
-            --jq '.[] | .filename, (.previous_filename // empty)' \
-            > "$RUNNER_TEMP/changed.txt"
-          python3 scripts/ci_changed_scope.py "$RUNNER_TEMP/changed.txt" >> "$GITHUB_OUTPUT"
+            > "$RUNNER_TEMP/files.json"
+          jq -r '.[] | .filename, (.previous_filename // empty)' \
+            < "$RUNNER_TEMP/files.json" > "$RUNNER_TEMP/changed.txt"
+          # The same answer, kept whole: `patch` is what lets a version-only bump
+          # skip the matrix, and it has to be the diff rather than the path,
+          # because those three files also hold the dependency and coverage lists.
+          # `--paginate` concatenates pages as separate arrays, so they are
+          # flattened into one.
+          jq -s 'add // []' < "$RUNNER_TEMP/files.json" > "$RUNNER_TEMP/patches.json"
+          python3 scripts/ci_changed_scope.py \
+            "$RUNNER_TEMP/changed.txt" "$RUNNER_TEMP/patches.json" >> "$GITHUB_OUTPUT"
 
   lint:
     # Never gated. It is one billed minute, `make lint-spelling` reads every

--- a/backend/tests/test_ci_changed_scope.py
+++ b/backend/tests/test_ci_changed_scope.py
@@ -52,6 +52,24 @@ def workflow() -> dict[str, Any]:
     return loaded
 
 
+_CUT_PATHS = [
+    "CHANGELOG.md",
+    "backend/pyproject.toml",
+    "backend/uv.lock",
+    "frontend/package.json",
+]
+"""Exactly what `chore: cut 0.0.x` touches."""
+
+_CUT_PATCHES = {
+    "backend/pyproject.toml": '@@ -1,7 +1,7 @@\n-version = "0.0.126"\n+version = "0.0.127"\n',
+    "backend/uv.lock": '@@ -10,7 +10,7 @@\n-version = "0.0.126"\n+version = "0.0.127"\n',
+    "frontend/package.json": (
+        '@@ -1,5 +1,5 @@\n-  "version": "0.0.126",\n+  "version": "0.0.127",\n'
+    ),
+}
+"""The diffs of that cut, in the shape `pulls/{n}/files` reports them."""
+
+
 class TestNothingUnrecognisedIsEverSkipped:
     """The direction that matters. A path nobody classified must run everything."""
 
@@ -131,22 +149,92 @@ class TestWhatMayBeSkipped:
         assert ci_changed_scope.scope(["backend/app/main.py"])["e2e"] is True
         assert ci_changed_scope.scope(["frontend/src/app/page.tsx"])["e2e"] is True
 
-    def test_a_release_bump_runs_everything(self) -> None:
-        """Worth stating: `chore: cut 0.0.x` touches both halves, so it skips nothing.
+    def test_a_release_bump_with_no_patches_still_runs_everything(self) -> None:
+        """The paths alone prove nothing, and this is the direction that is safe.
 
-        #317 originally claimed a release pull request would stop paying for the
-        whole matrix. It does not - the version lives in `backend/pyproject.toml`,
-        `backend/uv.lock` and `frontend/package.json`, so every filter matches.
+        Those three files carry the version *and* the dependency lists, the
+        coverage `include` lists and the ruff and ty configuration. Without the
+        diff there is nothing to tell one from the other, so the answer is the
+        expensive one - which is also what a push to `main` gets, where the
+        classifier does not run at all.
         """
-        decided = ci_changed_scope.scope(
-            [
-                "CHANGELOG.md",
-                "backend/pyproject.toml",
-                "backend/uv.lock",
-                "frontend/package.json",
-            ]
-        )
+        decided = ci_changed_scope.scope(_CUT_PATHS)
+
         assert decided == {"backend": True, "frontend": True, "e2e": True}
+
+    def test_a_release_bump_whose_diff_is_only_the_version_skips_all_three(self) -> None:
+        """What #317 claimed a release pull request would do, and did not.
+
+        A CHANGELOG entry is already exempt for being a top-level `*.md`, so once
+        the three version strings are proved to be version strings there is nothing
+        left in the change set that any suite can observe.
+        """
+        decided = ci_changed_scope.scope(_CUT_PATHS, _CUT_PATCHES)
+
+        assert decided == {"backend": False, "frontend": False, "e2e": False}
+
+    def test_a_dependency_added_beside_the_bump_runs_everything(self) -> None:
+        """One unrecognised line in the diff is enough, which is the whole point:
+        the exemption is about what changed, not about which file it changed in."""
+        patches = {
+            **_CUT_PATCHES,
+            "backend/pyproject.toml": (
+                '@@ -1,7 +1,8 @@\n-version = "0.0.126"\n+version = "0.0.127"\n+    "httpx>=0.28",\n'
+            ),
+        }
+
+        assert ci_changed_scope.scope(_CUT_PATHS, patches)["backend"] is True
+
+    def test_a_coverage_include_list_edited_beside_the_bump_runs_everything(self) -> None:
+        """The 100% gate is configured in the same file the version lives in, and
+        adding a module to it is exactly a change the backend suite decides."""
+        patches = {
+            **_CUT_PATCHES,
+            "backend/pyproject.toml": (
+                '@@ -1,7 +1,8 @@\n-version = "0.0.126"\n+version = "0.0.127"\n'
+                '+    "app/services/embed_session.py",\n'
+            ),
+        }
+
+        assert ci_changed_scope.scope(_CUT_PATHS, patches)["backend"] is True
+
+    def test_a_version_file_with_no_patch_of_its_own_runs_everything(self) -> None:
+        """GitHub omits `patch` for a file too large to inline, and an absent proof
+        is not a proof."""
+        patches = {path: text for path, text in _CUT_PATCHES.items() if path != "backend/uv.lock"}
+
+        assert ci_changed_scope.scope(_CUT_PATHS, patches)["backend"] is True
+
+    def test_a_patch_that_changes_nothing_is_not_a_version_bump(self) -> None:
+        """A diff of context lines alone would otherwise vacuously pass `all()`,
+        which is the same `all()`-over-nothing trap the empty change set has."""
+        patches = {**_CUT_PATCHES, "frontend/package.json": '@@ -1,3 +1,3 @@\n   "name": "x",\n'}
+
+        assert ci_changed_scope.scope(_CUT_PATHS, patches)["frontend"] is True
+
+    def test_a_source_file_beside_a_version_bump_still_runs_its_suite(self) -> None:
+        """The exemption is per path and the proof is over all of them, so a cut
+        that smuggled a module in with it is not a cut."""
+        decided = ci_changed_scope.scope(
+            [*_CUT_PATHS, "backend/app/services/agent_runner.py"], _CUT_PATCHES
+        )
+
+        assert decided == {"backend": True, "frontend": False, "e2e": True}
+
+    def test_a_dependency_pinned_to_a_version_is_not_a_version_line(self) -> None:
+        """`_VERSION_LINE` is anchored end to end, so a lockfile entry naming some
+        other package's version does not read as this package's own."""
+        patches = {
+            **_CUT_PATCHES,
+            "backend/uv.lock": (
+                '@@ -1,4 +1,4 @@\n-name = "fastapi"\n+name = "fastapi"\n'
+                '-version = "0.115.0"\n+version = "0.116.0"\n'
+            ),
+        }
+
+        # The version *line* matches - it is the same spelling - but the `name`
+        # lines beside it do not, and one unrecognised line is enough.
+        assert ci_changed_scope.scope(_CUT_PATHS, patches)["backend"] is True
 
     def test_a_nested_markdown_file_is_not_documentation(self) -> None:
         """Only a *top-level* `*.md` is exempt; `backend/app/README.md` is not."""

--- a/scripts/ci_changed_scope.py
+++ b/scripts/ci_changed_scope.py
@@ -29,6 +29,24 @@ Which is why the exemptions are only these, each true because it was checked:
     skipped on the change it guards is the gate reading green because the thing
     is not in it, which is the mistake above.
 
+`backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json` **when the
+only thing their diff changes is the version string**
+:   The one exemption here that reads a diff rather than a path, and the only one
+    that could be: those three files carry the version *and* the dependency lists,
+    the coverage `include` lists and the ruff and ty configuration, so the path
+    alone proves nothing. A `chore: cut 0.0.x` is three version strings and a
+    CHANGELOG entry - which is already exempt, being a top-level `*.md` - and it
+    ran the whole 18-minute matrix against a change no suite can observe. #317
+    claimed a release would stop paying for it; it did not, and this is what
+    that claim needs to be true.
+
+    Timid in the same direction as everything else: a patch that is absent,
+    unreadable, or holds one line this does not recognise runs everything. It is
+    keyed on the diff rather than on the branch name or the commit subject
+    precisely because those are a claim anybody can make - a gate you pass by
+    naming your branch `chore/cut-` is the gate reading green because the thing is
+    not in it.
+
 Everything else runs everything, `.github/**` and `Makefile` emphatically
 included: `tests/test_ci_parity.py` reads both, so a workflow edit is a change
 the backend suite has an opinion about - this very file's arrival among them.
@@ -43,17 +61,30 @@ because nothing here can detect its absence.
 
 Usage, from the `changes` job:
 
-    python3 scripts/ci_changed_scope.py changed-files.txt >> "$GITHUB_OUTPUT"
+    python3 scripts/ci_changed_scope.py changed-files.txt [patches.json] >> "$GITHUB_OUTPUT"
 """
 
 from __future__ import annotations
 
+import json
+import re
 import sys
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from pathlib import Path
 
 # The jobs this decides for, in the order the workflow declares them.
 JOBS = ("backend", "frontend", "e2e")
+
+VERSIONED = ("backend/pyproject.toml", "backend/uv.lock", "frontend/package.json")
+"""The three files a release cut edits besides the CHANGELOG."""
+
+_VERSION_LINE = re.compile(r'^\s*(?:version\s*=|"version":)\s*"\d+\.\d+\.\d+"\s*,?\s*$')
+"""One version assignment, in either the TOML or the JSON spelling.
+
+Anchored end to end on purpose. A dependency pinned to a version in the same file
+is `name = "fastapi"` on its own line, so it does not match; a line that both
+sets the version and does something else does not match either.
+"""
 
 
 def _is_documentation(path: str) -> bool:
@@ -63,8 +94,31 @@ def _is_documentation(path: str) -> bool:
     return "/" not in path and path.endswith(".md")
 
 
-def _irrelevant_to(job: str, path: str) -> bool:
+def _is_version_only(patch: str | None) -> bool:
+    """Whether this file's diff changes the version string and nothing else.
+
+    `None` - the caller passed no patches, or GitHub omitted one, which it does
+    for a file too large to inline - is not a proof, so it is `False`.
+
+    A rewrite counts every changed line: a diff that raises the version *and*
+    adds a dependency has one line this does not recognise, and one is enough.
+    """
+    if not patch:
+        return False
+    changed = [
+        line
+        for line in patch.splitlines()
+        if line[:1] in {"+", "-"} and not line.startswith(("+++", "---"))
+    ]
+    if not changed:
+        return False
+    return all(_VERSION_LINE.match(line[1:]) for line in changed)
+
+
+def _irrelevant_to(job: str, path: str, patches: Mapping[str, str]) -> bool:
     if _is_documentation(path):
+        return True
+    if path in VERSIONED and _is_version_only(patches.get(path)):
         return True
     if job == "backend":
         # The BFF proxies are the exception: the backend suite reads them.
@@ -75,7 +129,7 @@ def _irrelevant_to(job: str, path: str) -> bool:
     return False
 
 
-def scope(paths: Iterable[str]) -> dict[str, bool]:
+def scope(paths: Iterable[str], patches: Mapping[str, str] | None = None) -> dict[str, bool]:
     """Map each job to whether this change set requires it to run.
 
     An empty change set runs everything. That is not a case worth optimising -
@@ -85,16 +139,38 @@ def scope(paths: Iterable[str]) -> dict[str, bool]:
     changed = [path for path in paths if path]
     if not changed:
         return dict.fromkeys(JOBS, True)
-    return {job: not all(_irrelevant_to(job, path) for path in changed) for job in JOBS}
+    seen = patches or {}
+    return {job: not all(_irrelevant_to(job, path, seen) for path in changed) for job in JOBS}
+
+
+def _patches_from(path: Path) -> dict[str, str]:
+    """The `filename` → `patch` map from what `pulls/{n}/files` answered.
+
+    Unreadable or malformed answers with an empty map rather than raising, which
+    is the timid direction: no patch is no proof, and every version file then
+    runs everything.
+    """
+    try:
+        listed = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(listed, list):
+        return {}
+    return {
+        entry["filename"]: entry["patch"]
+        for entry in listed
+        if isinstance(entry, dict) and isinstance(entry.get("patch"), str)
+    }
 
 
 def main(argv: list[str]) -> int:
-    if len(argv) != 2:
-        print(f"usage: {argv[0]} <file-of-changed-paths>", file=sys.stderr)
+    if len(argv) not in {2, 3}:
+        print(f"usage: {argv[0]} <file-of-changed-paths> [file-of-patches]", file=sys.stderr)
         return 2
 
     paths = Path(argv[1]).read_text().splitlines()
-    decided = scope(paths)
+    patches = _patches_from(Path(argv[2])) if len(argv) == 3 else {}
+    decided = scope(paths, patches)
     for job, required in decided.items():
         print(f"{job}={'true' if required else 'false'}")
 


### PR DESCRIPTION
A `chore: cut 0.0.x` is three version strings and a CHANGELOG entry, and it paid for the whole 18-minute matrix — `test`, `test-frontend` and `e2e` — against a change no suite can observe. #317 claimed a release pull request would stop doing that; it never did, and `test_a_release_bump_runs_everything` recorded the shortfall rather than defending it.

## Why the diff and not the path

Those three files also hold the dependency lists, the coverage `include` lists and the ruff and ty configuration, so `backend/pyproject.toml` changed proves nothing on its own. And keying it on the branch name or the commit subject would be worse: a gate you pass by naming your branch `chore/cut-` is the gate reading green because the thing is not in it.

`pulls/{n}/files` already answers with `patch`. The `changes` job was throwing that away and now hands it through, so the decision is made on what actually changed.

## Timid in the same direction as the rest of the file

Runs everything when: no patches are passed at all (a push to `main`, or the old call shape), GitHub omitted a `patch` because the file was too large to inline, the diff holds only context lines, or one changed line is not a version assignment. `_VERSION_LINE` is anchored end to end, so a dependency pinned to a version does not match.

Seven tests cover those, including a dependency added beside the bump and a coverage `include` entry added beside it.

## Verified

`tests/test_ci_changed_scope.py` and `tests/test_ci_parity.py`, 55 passed. Smoke-tested the script end to end against a real cut's file list: with patches it skips all three, without them it skips nothing.

**This pull request is itself the counter-example** — it touches `.github/**` and `scripts/**`, so it runs the whole matrix.

Refs #317