### PR TITLE
chore: cut 0.0.129

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.129] - 2026-08-13
+
+An MCP OAuth failure put the token endpoint, and whatever its query string held,
+into a toast in the browser.
+
+### Fixed
+
+- **Three refusals in the MCP OAuth flow interpolated whatever raised.** `httpx`
+  puts the failing request in its message, and the two requests this flow makes
+  are a client registration and a token grant — so a broken provider reached the
+  member's screen as the endpoint it failed on, rendered as a toast since #657 via
+  `McpOAuthCallbackResult(ok=False, error=str(exc))`. Each refusal now names the
+  stage it failed at and what the reader can do about it; the client's own text
+  stays in the `logger.exception` beside the raise. (#686)
+
 ## [0.0.128] - 2026-08-13
 
 A test that proved `spawn_after_commit` was needed proved it on a 250ms

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.128"
+version = "0.0.129"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.128"
+version = "0.0.129"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.128",
+  "version": "0.0.129",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Stop OAuth refusals quoting the upstream client — #693, closes #686.

The same rule as #342 in an HTTP body, #423 in the ingestion columns, #659 in the
chat frame and #676 in the run row, on the one path where the string is rendered
as a toast.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than promoted
from `[Unreleased]`, because #693 wrote none.
