### PR TITLE
chore: cut 0.0.130

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.130] - 2026-08-13
+
+A scanned PDF ingested with OCR enabled indexed near-empty, silently.
+
+### Fixed
+
+- **The OCR fallback drove the image describer through
+  `asyncio.new_event_loop().run_until_complete(...)`** from inside a running loop,
+  which produced nothing — and the result was indistinguishable from a PDF that
+  genuinely had no text. `PyMuPDFParser._ocr_page` and `_parse_pdf_file` are now
+  `async` and await the describer on the caller's loop. (#550)
+
 ## [0.0.129] - 2026-08-13
 
 An MCP OAuth failure put the token endpoint, and whatever its query string held,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.129"
+version = "0.0.130"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.129"
+version = "0.0.130"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.129",
+  "version": "0.0.130",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Await the OCR describer instead of nesting an event loop — #666, closes #550.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than promoted
from `[Unreleased]`, because #666 wrote none.
