### PR TITLE
chore: cut 0.0.131

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.131] - 2026-08-13
+
+Two RAG document lookups disagreed about which document they were looking at, and
+heap order decided.
+
+### Fixed
+
+- **`IngestionService.find_existing` and `get_existing_hash` used different
+  precedence.** The first checked every document for a `source_path` match before
+  falling back to `filename`; the second interleaved the two in one pass, where a
+  filename hit blocked any later source-path match — so a re-sync could answer with
+  a different document depending on which helper asked. (#548)
+- **`PgVectorStore.get_documents` selected with no `ORDER BY`**, so heap order
+  decided which document a lookup answered with, and re-running the same query
+  could give a different one. (#548)
+
 ## [0.0.130] - 2026-08-13
 
 A scanned PDF ingested with OCR enabled indexed near-empty, silently.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.130"
+version = "0.0.131"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.130"
+version = "0.0.131"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.130",
+  "version": "0.0.131",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Give RAG document lookup one precedence and a stable order — #670, closes #548.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than promoted
from `[Unreleased]`, because #670 wrote none.
