### PR TITLE
chore: cut 0.0.132

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.132] - 2026-08-13
+
+The spend page said nothing could not be priced, above three breakdowns that had
+priced nothing.
+
+### Fixed
+
+- **`GET /runs/spend` counted its "could not be priced" caveat over *top-level*
+  rows only.** By provider and By key price every row in the window through a
+  subquery that is deliberately not windowed, so a parent that started before the
+  window and delegated inside it put its delegate's spend into the breakdowns while
+  the caveat above them read `0` — a page saying the numbers are complete when they
+  are not. The caveat now counts what the breakdowns count. (#620)
+
 ## [0.0.131] - 2026-08-13
 
 Two RAG document lookups disagreed about which document they were looking at, and

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.131"
+version = "0.0.132"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.131"
+version = "0.0.132"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.131",
+  "version": "0.0.132",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Count an unpriced tree that straddles the window start — #650, closes #620.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than promoted
from `[Unreleased]`, because #650 wrote none.
