### PR TITLE
chore: cut 0.0.133

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.133] - 2026-08-13
+
+The banner guard walked every worktree on the machine before deciding to ignore
+them.
+
+### Fixed
+
+- **`scripts/check_comments.py` filtered after walking rather than pruning.**
+  `Path.rglob("*")` descended into `.git`, `.venv`, `node_modules` and every
+  checkout under `.claude/worktrees/`, and `SKIP_DIRS` only decided what was
+  *reported*. On a machine with 68 worktrees that was about 3.9M paths and roughly
+  seven minutes per commit, because pre-commit runs the hook with
+  `pass_filenames: false`. It is now `os.walk` with in-place pruning. (#635)
+
 ## [0.0.132] - 2026-08-13
 
 The spend page said nothing could not be priced, above three breakdowns that had

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.132"
+version = "0.0.133"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.132"
+version = "0.0.133"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.132",
+  "version": "0.0.133",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Prune the banner guard's walk instead of filtering it — #647, closes #635.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than promoted
from `[Unreleased]`, because #647 wrote none.
