### PR TITLE
chore: cut 0.0.134

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,25 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.134] - 2026-08-13
+
+A refusal from the BFF reached the toast in English, whatever locale the reader
+was in.
+
+### Fixed
+
+- **The route handlers under `src/app/api/**` write a wire payload, not copy**, and
+  the toast that renders it was showing that payload verbatim. A refusal now
+  travels as a code the client resolves in the active locale, and
+  `getErrorMessage` takes the caller's translator — it moved from `@/lib/utils` to
+  `@/lib/api-error` in the process, because a function that needs a translator is
+  not a utility. Step details take the same route. (#603)
+- **The copy guard reads a `.ts` file by the same rules as a `.tsx` one**, so a
+  hook's toast and a module table of labels are copy too. `src/app/api/**` is
+  skipped by the offence sweep — a route handler sits outside the `[locale]`
+  segment and has no translator to reach — and read by the catalog rules, which is
+  what reports a `detail` that duplicates a message. (#603)
+
 ## [0.0.133] - 2026-08-13
 
 The banner guard walked every worktree on the machine before deciding to ignore

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.133"
+version = "0.0.134"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.133"
+version = "0.0.134"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.133",
+  "version": "0.0.134",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Resolve BFF refusal codes and step details in the locale — #654, closes #603.

The merge with main kept `modelDetail` and the `selected` prop it added beside
this branch's move of `getErrorMessage`, and gave the `use-embeds` call site main
added the translator the new signature wants.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than promoted
from `[Unreleased]`, because #654 wrote none.
