### PR TITLE
chore: cut 0.0.135

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.135] - 2026-08-13
+
+The copy guard read a hyphen in the first word as a label separator, so half a
+sentence passed the sweep.
+
+### Fixed
+
+- **`"Sign-in failed"` passed the i18n guard while `"Not authenticated"` was
+  refused.** `NOT_A_SENTENCE` exempts a label built from title case around a
+  separator — `Model / Provider` — and the whitespace on both sides of that
+  separator was optional, so a hyphen *inside* the first word made the whole
+  sentence a label. The separator now needs the whitespace that makes it one.
+  (#656)
+
 ## [0.0.134] - 2026-08-13
 
 A refusal from the BFF reached the toast in English, whatever locale the reader

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.134"
+version = "0.0.135"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.134"
+version = "0.0.135"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.134",
+  "version": "0.0.135",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Read a hyphenated first word as prose, not a label — #677, closes #656.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than promoted
from `[Unreleased]`, because #677 wrote none.
