### PR TITLE
chore: cut 0.0.136

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.136] - 2026-08-13
+
+DOM key constants were sitting in the message catalog and read back through the
+translator.
+
+### Fixed
+
+- **`e.key === t("enter2")` compared a keyboard event against a translation.**
+  `Enter`, `Escape`, `Tab`, `ArrowUp` and `ArrowDown` were parked in `en.json` and
+  read back in the chat composer, the command palette, conversation rename, the
+  share dialog, the sources panel and the question prompt. `src/i18n.ts` merges
+  `en.json` under every locale, so this worked only while `pl.json` omitted those
+  keys — the first translator to render one would have broken every shortcut on
+  that screen. They are literals in the source again, and
+  `messages/catalog.test.ts` refuses a catalog value that is a DOM key constant.
+  Six of them had in the meantime been translated into `pl.json`, which is the
+  failure arriving; they are deleted. (#549)
+
 ## [0.0.135] - 2026-08-13
 
 The copy guard read a hyphen in the first word as a label separator, so half a

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.135"
+version = "0.0.136"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.135"
+version = "0.0.136"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.135",
+  "version": "0.0.136",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Compare DOM key literals, not catalog values — #669, closes #549.

The merged suite failed on the defect the branch is about: `ArrowDown`, `ArrowUp`,
two `Enter`s, `skills.enter` and `skills.escape` had been translated into
`pl.json` while the branch was open. Deleted, and the new catalog rule is what
would have stopped them.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than promoted
from `[Unreleased]`, because #669 wrote none.
