### PR TITLE
chore: cut 0.0.137

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,29 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.137] - 2026-08-13
+
+An MCP consent that was refused landed on the servers page looking exactly like
+one that was accepted.
+
+### Fixed
+
+- **Nothing read the outcome the OAuth callback redirected with.** The provider
+  sends the browser to a route that has no way to answer the person — a JSON body
+  on a page nobody navigated to is a dead end — so every outcome ends as a redirect
+  carrying its result in the query. That contract was written in the route handler
+  and consumed by no page. The MCP servers page now announces it, and the redirect
+  lands there rather than on `/settings/integrations`, which is itself a redirect.
+  (#657)
+- **A refusal of ours and a refusal from somewhere else travel separately.** The
+  callback takes no session by design — the `state` token authenticates the
+  exchange — so anybody can put a browser on that address with a refusal of their
+  choosing, and that query is now rendered. Ours goes under `mcp_oauth_failure` and
+  is looked up in a fixed table, so a stranger cannot spell one and have the
+  product say it in its own voice; anything else is stripped of control
+  characters, capped at 200 characters and shown quoted after a sentence this
+  repository wrote. (#657)
+
 ## [0.0.136] - 2026-08-13
 
 DOM key constants were sitting in the message catalog and read back through the

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.136"
+version = "0.0.137"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.136"
+version = "0.0.137"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.136",
+  "version": "0.0.137",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Announce the MCP OAuth outcome after the provider redirect — #682, closes #657.

#654 wrote the emitting half while this branch was open, collapsing both kinds of
refusal into one `reason=`. This branch's two-parameter scheme wins, and the
merge commit says why: the address takes no session, so the distinction is what
stops a stranger's sentence being spoken in the product's voice.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than promoted
from `[Unreleased]`, because #682 wrote none.
