### PR TITLE
chore: cut 0.0.138

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.138] - 2026-08-13
+
+An absolute date was formatted in English on every locale.
+
+### Fixed
+
+- **`formatDate` and `formatDateTime` passed a hardcoded `"en-US"`** to
+  `toLocaleDateString` / `toLocaleString`, so the month name and the day-month
+  order came from English everywhere — a Polish reader saw `Jul 31, 2026` where
+  the runtime would have given `31 lip 2026`. None of it is copy a translator can
+  reach, because the strings come from `Intl` rather than the catalog, so no
+  amount of `pl.json` would have fixed it. (#621)
+
 ## [0.0.137] - 2026-08-13
 
 An MCP consent that was refused landed on the servers page looking exactly like

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.137"
+version = "0.0.138"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.137"
+version = "0.0.138"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.137",
+  "version": "0.0.138",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Format an absolute date in the active locale — #673, refs #621.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than promoted
from `[Unreleased]`, because #673 wrote none.
