### PR TITLE
chore: cut 0.0.139

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.139] - 2026-08-13
+
+`timeAgo` fell back to an English date once a timestamp was old enough.
+
+### Fixed
+
+- **The date `timeAgo` answers with past its relative window** was built with a
+  hardcoded locale, so a Polish reader watching a list of runs saw Polish for
+  anything recent and English the moment a row aged out of "2 days ago". It takes
+  the active locale now, like the absolute formatters beside it. (#621)
+
 ## [0.0.138] - 2026-08-13
 
 An absolute date was formatted in English on every locale.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.138"
+version = "0.0.139"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.138"
+version = "0.0.139"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.138",
+  "version": "0.0.139",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Format `timeAgo`'s date fallback in the active locale — #651, closes #621.

The other half of #673, released in 0.0.138: that fixed the absolute formatters,
this fixes the one the relative formatter falls back to.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than promoted
from `[Unreleased]`, because #651 wrote none.
