### PR TITLE
chore: cut 0.0.140

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.140] - 2026-08-13
+
+Polish diacritics swapped typeface mid-word.
+
+### Fixed
+
+- **The vendored woff2 files were the latin subsets**, and eight of the nine
+  Polish pairs — `ą ć ę ł ń ś ź ż` — live in latin-ext, so per-glyph fallback
+  rendered them in the system font. Worst on Bricolage Grotesque headings at
+  700–800, where a word could change typeface halfway through. The latin-ext
+  subset of all three families is vendored beside the latin one, at the same
+  Google Fonts versions, about 119 KB together. (#606)
+
 ## [0.0.139] - 2026-08-13
 
 `timeAgo` fell back to an English date once a timestamp was old enough.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.139"
+version = "0.0.140"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.139"
+version = "0.0.140"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.139",
+  "version": "0.0.140",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Render Polish diacritics in the brand fonts — #652, closes #606.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than promoted
from `[Unreleased]`, because #652 wrote none.
