### PR TITLE
chore: cut 0.0.141

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.141] - 2026-08-13
+
+The baked MCP logos were keyed on a domain nothing ever asked for.
+
+### Fixed
+
+- **Every logo in `mcp-logos.generated.ts` was keyed on a brand domain** —
+  `linear.app`, `notion.so` — while `logoDataUri` is always asked with the
+  connection URL's host, `mcp.linear.app`. The intersection was empty, so the MCP
+  badge fell through to Google's live favicon service on every view and the
+  self-contained export phoned home per server instead of rendering offline.
+  (#614)
+
 ## [0.0.140] - 2026-08-13
 
 Polish diacritics swapped typeface mid-word.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.140"
+version = "0.0.141"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.140"
+version = "0.0.141"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.140",
+  "version": "0.0.141",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Key baked logos on the URL host the lookup asks with — #648, closes #614.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than promoted
from `[Unreleased]`, because #648 wrote none.
