### PR TITLE
chore: cut 0.0.142

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.142] - 2026-08-13
+
+Every page declared itself English, Polish ones included.
+
+### Fixed
+
+- **`<html lang="en">` was hard-coded** from `defaultLocale` in the one layout that
+  renders `<html>`, so a screen reader on `/pl/agents` announced Polish copy with
+  English pronunciation rules and a crawler read the page as English. It now comes
+  from the active locale. More visible since #604, because before that the UI
+  mostly reverted to English anyway. (#619)
+
 ## [0.0.141] - 2026-08-13
 
 The baked MCP logos were keyed on a domain nothing ever asked for.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.141"
+version = "0.0.142"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.141"
+version = "0.0.142"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.141",
+  "version": "0.0.142",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Declare `<html lang>` from the active locale — #646, closes #619.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than promoted
from `[Unreleased]`, because #646 wrote none.
