### PR TITLE
chore: cut 0.0.143

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.143] - 2026-08-13
+
+Three sweeps walked the source tree three different ways.
+
+### Changed
+
+- **One source-tree walker, shared.** `fonts.test.ts`, `loading-state.test.tsx`
+  and `platform-proxy.test.ts` each carried their own recursive read of
+  `frontend/src`, with their own idea of what to skip — so a directory one of them
+  learned to ignore stayed invisible only to that one. They now share
+  `src/test-utils/source-files.ts`. (#618)
+
 ## [0.0.142] - 2026-08-13
 
 Every page declared itself English, Polish ones included.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.142"
+version = "0.0.143"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.142"
+version = "0.0.143"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.142",
+  "version": "0.0.143",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Share one source-tree walker across the sweeps — #645, closes #618.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than promoted
from `[Unreleased]`, because #645 wrote none.
