### PR TITLE
feat(channels): confirm channel membership before a thread is shown

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -36,6 +36,7 @@ from app.services.channel_bot import unseal_bot_token, unseal_slack_app_token
 from app.services.channels import register_adapter
 from app.services import rate_limit
 from app.services.channels import dedupe as channel_dedupe
+from app.services.channels import membership as channel_membership
 from app.services.channels.supervisor import open_inbound_stream
 
 logger = logging.getLogger(__name__)
@@ -101,6 +102,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[LifespanState, None]:
     # outside any request the limiter could read `request.state` from, and a
     # count kept in this process would be off by the worker count (#39).
     rate_limit.configure(redis_client)
+    # And the membership check behind the participant model, which the
+    # conversation service consults from inside a request but caches in the
+    # Redis every worker shares (#641).
+    channel_membership.configure(redis_client)
     embedder: EmbeddingService | None = None
     try:
         embedder = EmbeddingService(settings=settings.rag)
@@ -168,6 +173,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[LifespanState, None]:
         await _mattermost_adapter.stop_polling(_mbid)
     channel_dedupe.configure(None)
     rate_limit.configure(None)
+    channel_membership.configure(None)
     if "redis" in state:
         await state["redis"].close()
 

--- a/backend/app/repositories/channel_bot.py
+++ b/backend/app/repositories/channel_bot.py
@@ -19,6 +19,20 @@ async def get_for_inbound(db: AsyncSession, bot_id: UUID) -> ChannelBot | None:
     return await db.get(ChannelBot, bot_id)
 
 
+async def get_by_ids(db: AsyncSession, bot_ids: set[UUID]) -> dict[UUID, ChannelBot]:
+    """The bots behind a batch of participation claims, keyed by id.
+
+    Deliberately unscoped for the same reason :func:`get_for_inbound` is: the
+    caller holds session rows, and the bot row is where each one's organization
+    comes from. A bot deleted since the claim was recorded is simply absent, and
+    the claim it anchored goes unconfirmed.
+    """
+    if not bot_ids:
+        return {}
+    result = await db.execute(select(ChannelBot).where(ChannelBot.id.in_(bot_ids)))
+    return {bot.id: bot for bot in result.scalars().all()}
+
+
 async def get_for_org(
     db: AsyncSession,
     bot_id: UUID,

--- a/backend/app/repositories/conversation.py
+++ b/backend/app/repositories/conversation.py
@@ -1,8 +1,9 @@
 """Conversation repository."""
 
+from collections.abc import Collection
 from datetime import datetime
 from decimal import Decimal
-from typing import Any
+from typing import Any, NamedTuple
 from uuid import UUID
 
 from sqlalchemy import ColumnElement, distinct, func, or_, select
@@ -13,6 +14,7 @@ from sqlalchemy.orm import selectinload
 from app.db.models.agent import Agent
 from app.db.models.agent_run import AgentRun
 from app.db.models.channel_identity import ChannelIdentity
+from app.db.models.channel_session import ChannelSession
 from app.db.models.conversation import Conversation, Message, ToolCall
 from app.db.models.user import User
 from app.repositories._search import contains_ci
@@ -241,56 +243,83 @@ async def authors_of(db: AsyncSession, identity_ids: list[UUID]) -> dict[UUID, C
     return {identity.id: identity for identity in result.scalars().all()}
 
 
-def _reachable_by(user_id: UUID) -> ColumnElement[bool]:
+def _reachable_by(user_id: UUID, participant_ids: Collection[UUID]) -> ColumnElement[bool]:
     """Whose conversation list a thread appears in.
 
-    Theirs if they own it, and theirs if a chat account of theirs has spoken in
-    it - which is what puts a channel thread in front of everybody who was in the
-    room rather than only whoever happened to speak first. A channel thread has no
-    owner at all when the first speaker had linked no account, so ownership alone
-    left it invisible to everybody (#639).
+    Theirs if they own it, and theirs if they are a *confirmed* participant of
+    the room it came from. Participation used to be a correlated `EXISTS` over
+    `messages.channel_identity_id` - who spoke - and speaking once kept the
+    thread readable after the platform removed them from the channel (#641). So
+    the ids arrive vetted instead: the caller runs :func:`participation_claims`
+    through `app.services.channels.membership`, which asks the platform, and
+    hands over only the threads whose membership held up.
 
-    **This is who spoke, not who may read.** Participation is never re-checked
-    against the platform, so somebody removed from the channel keeps the thread in
-    their list - deliberately, and #641 is what it would take to change. Nothing
-    may use this as an authorization check without asking the platform first.
-
-    The same correlation care as :func:`_list_filters`: only `conversations` may be
-    correlated, or the subquery loses its FROM clause and raises.
+    The default is therefore the narrow one. A caller that passes nothing gets
+    owner-only, which fails safe - forgetting the participation step hides a
+    thread rather than showing it to somebody who was removed.
     """
-    spoke_in_it = (
-        select(Message.id)
-        .select_from(Message)
-        .join(ChannelIdentity, ChannelIdentity.id == Message.channel_identity_id)
-        .where(
-            Message.conversation_id == Conversation.id,
-            ChannelIdentity.user_id == user_id,
-        )
-        .correlate(Conversation)
-        .exists()
-    )
-    return or_(Conversation.user_id == user_id, spoke_in_it)
+    if not participant_ids:
+        return Conversation.user_id == user_id
+    return or_(Conversation.user_id == user_id, Conversation.id.in_(participant_ids))
 
 
-async def spoke_in(db: AsyncSession, conversation_id: UUID, user_id: UUID) -> bool:
-    """Whether a chat account of this user's has spoken in this conversation.
+class ParticipationClaim(NamedTuple):
+    """One "I spoke there" fact, addressed well enough to check it.
 
-    The read-side counterpart of `_reachable_by`'s `spoke_in_it`: a channel
-    thread appears in the list of everyone who was in the room, so opening it has
-    to be allowed for the same set - otherwise a participant sees the thread and
-    gets a 404 opening it. The same #641 caveat carries over: this is who spoke,
-    not a live check against the platform's current membership.
+    The conversation a chat account of the user's wrote in, and the bot and
+    platform chat the thread belongs to - which is what
+    `app.services.channels.membership` needs to ask the platform whether the
+    account is *still* in that channel. A claim is who spoke, never who may
+    read (#641); nothing may treat one as access without that check.
     """
-    result = await db.execute(
-        select(Message.id)
-        .join(ChannelIdentity, ChannelIdentity.id == Message.channel_identity_id)
-        .where(
-            Message.conversation_id == conversation_id,
-            ChannelIdentity.user_id == user_id,
+
+    conversation_id: UUID
+    platform_user_id: str
+    bot_id: UUID
+    platform_chat_id: str
+
+
+async def participation_claims(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    organization_id: UUID | None = None,
+    conversation_id: UUID | None = None,
+) -> list[ParticipationClaim]:
+    """Every channel this user's chat accounts have spoken in, by conversation.
+
+    One query for the whole listing: messages joined to the identity that wrote
+    them, to the session that names the room, distinct over the four scalars -
+    scalars because `channel_bots` carries `json` columns, which have no
+    equality operator, so a `DISTINCT` over the row itself is a 500 on a real
+    database (see :func:`app.repositories.channel_session.bots_by_identity`).
+
+    The join to `channel_sessions` is inner on purpose. A thread the session no
+    longer points at - `/new` re-points `conversation_id` at a fresh row - has
+    no channel anybody can ask about, and a claim that cannot be checked is
+    refused rather than trusted (#641). The owner and an explicit share still
+    reach such a thread; participation alone does not.
+    """
+    query = (
+        select(
+            Message.conversation_id,
+            ChannelIdentity.platform_user_id,
+            ChannelSession.bot_id,
+            ChannelSession.platform_chat_id,
         )
-        .limit(1)
+        .join(ChannelIdentity, ChannelIdentity.id == Message.channel_identity_id)
+        .join(ChannelSession, ChannelSession.conversation_id == Message.conversation_id)
+        .where(ChannelIdentity.user_id == user_id)
+        .distinct()
     )
-    return result.first() is not None
+    if organization_id is not None:
+        query = query.join(Conversation, Conversation.id == Message.conversation_id).where(
+            Conversation.organization_id == organization_id
+        )
+    if conversation_id is not None:
+        query = query.where(Message.conversation_id == conversation_id)
+    result = await db.execute(query)
+    return [ParticipationClaim(*row) for row in result.all()]
 
 
 def _sort_columns() -> dict[str, Any]:
@@ -333,6 +362,7 @@ async def get_conversations_by_user(
     archived_only: bool = False,
     sort_by: str = "updated_at",
     sort_dir: str = "desc",
+    participant_conversation_ids: Collection[UUID] = frozenset(),
 ) -> list[Conversation]:
     """Get one organization's conversations, optionally narrowed to one user.
 
@@ -340,10 +370,14 @@ async def get_conversations_by_user(
     the tenant would return every tenant's rows, and that mistake must not look
     like an ordinary call. The narrowing arguments after it are shared with the
     admin listing - see :func:`_list_filters` for what each one means.
+
+    `participant_conversation_ids` widens a user's list to channel threads whose
+    membership the caller has already confirmed against the platform - see
+    :func:`_reachable_by` for why they arrive vetted rather than derived here.
     """
     query = select(Conversation).where(Conversation.organization_id == organization_id)
     if user_id:
-        query = query.where(_reachable_by(user_id))
+        query = query.where(_reachable_by(user_id, participant_conversation_ids))
     for condition in _list_filters(
         search=search,
         agent_id=agent_id,
@@ -421,18 +455,20 @@ async def count_conversations(
     agent_id: UUID | None = None,
     include_archived: bool = False,
     archived_only: bool = False,
+    participant_conversation_ids: Collection[UUID] = frozenset(),
 ) -> int:
     """Count one organization's conversations, optionally narrowed to one user.
 
     Takes the same narrowing as :func:`get_conversations_by_user` because it
     answers a question about that page: a total counted without the filters the
-    page was fetched with is a number that contradicts the rows under it.
+    page was fetched with is a number that contradicts the rows under it -
+    which includes the vetted participation set.
     """
     query = select(func.count(Conversation.id)).where(
         Conversation.organization_id == organization_id
     )
     if user_id:
-        query = query.where(_reachable_by(user_id))
+        query = query.where(_reachable_by(user_id, participant_conversation_ids))
     for condition in _list_filters(
         search=search,
         agent_id=agent_id,

--- a/backend/app/services/channels/base.py
+++ b/backend/app/services/channels/base.py
@@ -256,6 +256,25 @@ class ChannelAdapter(ABC):
         """
         raise ChannelDirectoryUnsupported(f"{self.platform} cannot list a channel's members.")
 
+    async def is_channel_member(
+        self, bot_token: str, channel_id: str, platform_user_id: str, *, api_base_url: str | None
+    ) -> bool:
+        """Whether one platform account is currently in one channel.
+
+        Asked per account rather than read off :meth:`channel_members`, because
+        that list cannot carry the answer: on Telegram it is only the
+        administrators, and on the other two it stops at `limit` - so an
+        ordinary member of a large room would read as absent. This is the
+        question `/chat`'s participant model puts to the platform before a
+        thread is shown (#641).
+
+        Raises:
+            ChannelDirectoryUnsupported: If this platform does not tell a bot.
+        """
+        raise ChannelDirectoryUnsupported(
+            f"{self.platform} cannot say whether an account is in a channel."
+        )
+
     async def search_channels(
         self, bot_token: str, channel_id: str, *, api_base_url: str | None, query: str, limit: int
     ) -> list[ChannelSummary]:

--- a/backend/app/services/channels/base.py
+++ b/backend/app/services/channels/base.py
@@ -58,6 +58,24 @@ DEFAULT_ACCESS_POLICY_JSON: str = (
 )
 
 
+def channel_key(platform_chat_id: str) -> str:
+    """The chat a message arrived in, with any thread stripped.
+
+    Slack folds `thread_ts` into `platform_chat_id` as `channel:thread_ts` and
+    Mattermost folds `root_id` in the same way, so the raw id identifies a
+    *thread*. Anything scoped to the channel - a workspace shared across its
+    threads, an API call about the channel itself - has to key on what is stable
+    across them, which is the part before the colon. Every other platform's id
+    is already the chat.
+
+    Here rather than in `mentions`, where it started: `channels.membership`
+    asks the platform about the channel too and must not drag the agent runtime
+    in with the import - and two implementations of "which channel is this" is
+    how one of them ends up asking Mattermost about a thread id.
+    """
+    return platform_chat_id.partition(":")[0]
+
+
 @dataclass(frozen=True)
 class IncomingAttachment:
     """A file somebody sent a bot, before it has been fetched.

--- a/backend/app/services/channels/mattermost.py
+++ b/backend/app/services/channels/mattermost.py
@@ -372,6 +372,27 @@ class MattermostAdapter(ChannelAdapter):
             for user in users.json()
         ]
 
+    async def is_channel_member(
+        self, bot_token: str, channel_id: str, platform_user_id: str, *, api_base_url: str | None
+    ) -> bool:
+        """`GET /channels/{id}/members/{user_id}` - Mattermost answers per account.
+
+        A 404 is the platform saying "not in this channel", which is an answer
+        rather than a failure. Anything else unexpected - a 403 because the bot
+        itself was removed, a server error - raises, and the participant model
+        treats a question it could not ask as a refusal.
+        """
+        base_url = self._server(api_base_url)
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+            found = await client.get(
+                f"{base_url}/api/v4/channels/{channel_id}/members/{platform_user_id}",
+                headers={"Authorization": f"Bearer {bot_token}"},
+            )
+        if found.status_code == 404:
+            return False
+        found.raise_for_status()
+        return True
+
     async def search_channels(
         self, bot_token: str, channel_id: str, *, api_base_url: str | None, query: str, limit: int
     ) -> list[ChannelSummary]:

--- a/backend/app/services/channels/membership.py
+++ b/backend/app/services/channels/membership.py
@@ -1,0 +1,186 @@
+"""Whether a channel thread's participant is still in the channel.
+
+`/chat` shows a channel thread to everybody whose linked chat account has
+written in it. That record - `messages.channel_identity_id` - says who *spoke*,
+and speaking once used to keep the thread readable after the platform removed
+them from the channel: a second access path to channel content that outlived
+the access the platform grants (#641). This module is the check that closes it:
+every participation claim is confirmed against the platform's current
+membership before the listing shows the thread or the read opens it.
+
+The confirmation is one `adapter.is_channel_member` call per (bot, chat,
+account), behind a short shared-Redis cache so a listing does not become an API
+call per channel per page. It **fails closed, loudly**: a platform that cannot
+answer (`ChannelDirectoryUnsupported`), a bot or adapter that is gone, and a
+call that errors all read as "not a member", each with a log line. Refusing a
+participant for a cache's TTL is the acceptable cost; showing a removed one the
+room's transcript is the defect this exists to prevent. The owner of a thread
+and anybody it was explicitly shared with are not this module's business - both
+ways in survive a refusal here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.clients.redis import RedisClient
+from app.db.models.channel_bot import ChannelBot
+from app.repositories import channel_bot as channel_bot_repo
+from app.repositories import conversation as conversation_repo
+from app.services.channel_bot import unseal_bot_token
+from app.services.channels import get_adapter
+from app.services.channels.base import ChannelDirectoryUnsupported
+
+logger = logging.getLogger(__name__)
+
+MEMBERSHIP_TTL_SECONDS = 60
+"""How long one membership answer is trusted.
+
+Short on purpose: it is the window in which somebody removed from a channel
+can still open its thread, so it is a minute rather than the fifteen the
+dedupe claim gets. Refusals are cached for the same window - a platform that
+is down would otherwise be asked again, with a timeout, on every listing.
+"""
+
+_redis: RedisClient | None = None
+
+
+def configure(redis: RedisClient | None) -> None:
+    """Hand over the shared Redis client, or withdraw it with `None`.
+
+    Called by the lifespan next to where the client is created, the same
+    contract as `dedupe.configure`. Unconfigured is not unsafe here, only
+    slow: every check goes to the platform.
+    """
+    global _redis
+    _redis = redis
+
+
+def _key(bot_id: UUID, platform_chat_id: str, platform_user_id: str) -> str:
+    return f"channel:member:{bot_id}:{platform_chat_id}:{platform_user_id}"
+
+
+async def _cached(key: str) -> bool | None:
+    """The remembered answer, or None for both "no entry" and "no Redis"."""
+    if _redis is None:
+        return None
+    try:
+        value = await _redis.get(key)
+    except Exception:
+        logger.warning("channel_membership_cache_unavailable", exc_info=True)
+        return None
+    if value is None:
+        return None
+    return value == "1"
+
+
+async def _remember(key: str, member: bool) -> None:
+    if _redis is None:
+        return
+    try:
+        await _redis.set(key, "1" if member else "0", ttl=MEMBERSHIP_TTL_SECONDS)
+    except Exception:
+        logger.warning("channel_membership_cache_unavailable", exc_info=True)
+
+
+async def is_still_member(bot: ChannelBot, platform_chat_id: str, platform_user_id: str) -> bool:
+    """Whether this account is in this channel right now, as far as we can know.
+
+    False means "could not be confirmed", not always "was removed": a platform
+    that will not tell a bot, an adapter that is not registered, a token that
+    fails to unseal and a call that errors all refuse, because an access check
+    that fails open is not one. Each cause is logged; the answer - either
+    answer - is cached for :data:`MEMBERSHIP_TTL_SECONDS`.
+    """
+    key = _key(bot.id, platform_chat_id, platform_user_id)
+    cached = await _cached(key)
+    if cached is not None:
+        return cached
+    try:
+        adapter = get_adapter(bot.platform)
+        member = await adapter.is_channel_member(
+            unseal_bot_token(bot),
+            platform_chat_id,
+            platform_user_id,
+            api_base_url=bot.api_base_url,
+        )
+    except ChannelDirectoryUnsupported as exc:
+        logger.info(
+            "Channel membership not confirmable, refusing: bot=%s chat=%s - %s",
+            bot.id,
+            platform_chat_id,
+            exc,
+        )
+        member = False
+    except Exception:
+        logger.warning(
+            "Channel membership check failed, refusing: bot=%s chat=%s",
+            bot.id,
+            platform_chat_id,
+            exc_info=True,
+        )
+        member = False
+    await _remember(key, member)
+    return member
+
+
+async def _confirmed(
+    db: AsyncSession, claims: list[conversation_repo.ParticipationClaim]
+) -> set[UUID]:
+    """The conversations whose claims held up against the platform.
+
+    One membership question per distinct (bot, chat, account) however many
+    threads hang off it, asked concurrently - on a cold cache each is a network
+    round trip, and a listing is waiting.
+    """
+    if not claims:
+        return set()
+    bots = await channel_bot_repo.get_by_ids(db, {claim.bot_id for claim in claims})
+    questions = {
+        (claim.bot_id, claim.platform_chat_id, claim.platform_user_id)
+        for claim in claims
+        if claim.bot_id in bots
+    }
+    ordered = sorted(questions, key=str)
+    answers = await asyncio.gather(
+        *(is_still_member(bots[bot_id], chat, account) for bot_id, chat, account in ordered)
+    )
+    confirmed = {question for question, answer in zip(ordered, answers, strict=True) if answer}
+    return {
+        claim.conversation_id
+        for claim in claims
+        if (claim.bot_id, claim.platform_chat_id, claim.platform_user_id) in confirmed
+    }
+
+
+async def confirmed_participant_threads(
+    db: AsyncSession, *, user_id: UUID, organization_id: UUID
+) -> set[UUID]:
+    """The channel threads this user may currently be shown, listing-side.
+
+    Everything a chat account of theirs spoke in, kept only where the platform
+    confirms the account is still in the channel. This is what
+    `ConversationService.list_conversations` hands the repository as the vetted
+    participation set.
+    """
+    claims = await conversation_repo.participation_claims(
+        db, user_id=user_id, organization_id=organization_id
+    )
+    return await _confirmed(db, claims)
+
+
+async def confirms_participation(db: AsyncSession, *, conversation_id: UUID, user_id: UUID) -> bool:
+    """The read-side of the same rule: may participation open *this* thread.
+
+    The same claims, narrowed to one conversation, so the list and the read
+    cannot disagree - a thread the listing refuses is a thread the read
+    refuses, and the other way around.
+    """
+    claims = await conversation_repo.participation_claims(
+        db, user_id=user_id, conversation_id=conversation_id
+    )
+    return conversation_id in await _confirmed(db, claims)

--- a/backend/app/services/channels/membership.py
+++ b/backend/app/services/channels/membership.py
@@ -33,7 +33,7 @@ from app.repositories import channel_bot as channel_bot_repo
 from app.repositories import conversation as conversation_repo
 from app.services.channel_bot import unseal_bot_token
 from app.services.channels import get_adapter
-from app.services.channels.base import ChannelDirectoryUnsupported
+from app.services.channels.base import ChannelDirectoryUnsupported, channel_key
 
 logger = logging.getLogger(__name__)
 
@@ -135,13 +135,17 @@ async def _confirmed(
 
     One membership question per distinct (bot, chat, account) however many
     threads hang off it, asked concurrently - on a cold cache each is a network
-    round trip, and a listing is waiting.
+    round trip, and a listing is waiting. The chat is the *channel*: Slack and
+    Mattermost fold a thread id into `platform_chat_id`, and handed that
+    composite the platform answers `channel_not_found` - so every thread
+    participant would be refused while still in the room. `channel_key` strips
+    it, which also makes a channel's many threads one question.
     """
     if not claims:
         return set()
     bots = await channel_bot_repo.get_by_ids(db, {claim.bot_id for claim in claims})
     questions = {
-        (claim.bot_id, claim.platform_chat_id, claim.platform_user_id)
+        (claim.bot_id, channel_key(claim.platform_chat_id), claim.platform_user_id)
         for claim in claims
         if claim.bot_id in bots
     }
@@ -153,7 +157,7 @@ async def _confirmed(
     return {
         claim.conversation_id
         for claim in claims
-        if (claim.bot_id, claim.platform_chat_id, claim.platform_user_id) in confirmed
+        if (claim.bot_id, channel_key(claim.platform_chat_id), claim.platform_user_id) in confirmed
     }
 
 

--- a/backend/app/services/channels/mentions.py
+++ b/backend/app/services/channels/mentions.py
@@ -58,7 +58,7 @@ from app.db.models.organization import Organization
 from app.repositories import agent_exposure_repo, agent_repo, member_repo
 from app.services.access import publisher_context
 from app.services.agent_runner import AgentRunnerService, RunStream
-from app.services.channels.base import ROOM_HANDLES, OutgoingAttachment
+from app.services.channels.base import ROOM_HANDLES, OutgoingAttachment, channel_key
 from app.services.channels.chart_png import render_chart_png
 from app.services.transcript import RecordedToolCall
 from app.services.usage_report import (
@@ -169,23 +169,6 @@ def parse_mention(text: str) -> Mention | None:
     if not prompt or slug in ROOM_HANDLES:
         return None
     return Mention(slug=slug, prompt=prompt)
-
-
-def channel_key(platform_chat_id: str) -> str:
-    """The chat a message arrived in, with any thread stripped.
-
-    Slack folds `thread_ts` into `platform_chat_id` as `channel:thread_ts` and
-    Mattermost folds `root_id` in the same way, so the raw id identifies a
-    *thread*. Anything scoped to the channel - a workspace shared across its
-    threads, an API call about the channel itself - has to key on what is stable
-    across them, which is the part before the colon. Every other platform's id
-    is already the chat.
-
-    Module-level rather than a method: the channel bindings this feeds are built
-    where the bot row is, and two implementations of "which channel is this" is
-    how one of them ends up asking Mattermost about a thread id.
-    """
-    return platform_chat_id.partition(":")[0]
 
 
 class UnaddressedMessage(Exception):

--- a/backend/app/services/channels/router.py
+++ b/backend/app/services/channels/router.py
@@ -22,14 +22,18 @@ from app.services.channel_bot import unseal_bot_token
 from app.services.channel_link import ChannelLinkService
 from app.services.channels import get_adapter
 from app.services.channels.attachments import ChannelAttachmentService
-from app.services.channels.base import IncomingMessage, OutgoingAttachment, OutgoingMessage
+from app.services.channels.base import (
+    IncomingMessage,
+    OutgoingAttachment,
+    OutgoingMessage,
+    channel_key,
+)
 from app.services.channels.dedupe import claim_delivery, release_delivery
 from app.services.channels.directory import BoundChannelDirectory
 from app.services.channels.live_reply import WORKING, LiveReply, channel_stream
 from app.services.channels.mentions import (
     ChannelAgentRouter,
     UnaddressedMessage,
-    channel_key,
     parse_mention,
 )
 

--- a/backend/app/services/channels/slack.py
+++ b/backend/app/services/channels/slack.py
@@ -35,6 +35,13 @@ from app.services.channels.router import ChannelMessageRouter
 
 logger = logging.getLogger(__name__)
 
+_MEMBERSHIP_PAGES = 50
+"""How far `is_channel_member` will walk `conversations.members`.
+
+At Slack's 1000 ids per page this covers a fifty-thousand-member channel,
+which is a bound on a runaway cursor rather than on any real room.
+"""
+
 
 class SlackAdapter(ChannelAdapter):
     """Concrete Slack adapter using slack-sdk."""
@@ -197,6 +204,39 @@ class SlackAdapter(ChannelAdapter):
                 )
             )
         return members
+
+    async def is_channel_member(
+        self, bot_token: str, channel_id: str, platform_user_id: str, *, api_base_url: str | None
+    ) -> bool:
+        """`conversations.members`, paged until the account is found or the list ends.
+
+        Slack has no per-account membership call for a bot token, so the page
+        walk is the question - full pages of ids only, never the `users.info`
+        fan-out `channel_members` does, because nobody here needs a name. The
+        page cap exists so a pathological cursor cannot loop forever; a channel
+        bigger than it answers "not a member", logged, which is the participant
+        model's safe default rather than a claim about the room.
+        """
+        from slack_sdk.web.async_client import AsyncWebClient
+
+        client = AsyncWebClient(token=bot_token)
+        cursor: str | None = None
+        for _ in range(_MEMBERSHIP_PAGES):
+            response = await client.conversations_members(
+                channel=channel_id, limit=1000, cursor=cursor
+            )
+            if platform_user_id in {str(found) for found in (response.get("members") or [])}:
+                return True
+            cursor = str((response.get("response_metadata") or {}).get("next_cursor") or "") or None
+            if cursor is None:
+                return False
+        logger.warning(
+            "Slack channel %s exceeded %d membership pages; treating %s as not a member",
+            channel_id,
+            _MEMBERSHIP_PAGES,
+            platform_user_id,
+        )
+        return False
 
     async def search_channels(
         self, bot_token: str, channel_id: str, *, api_base_url: str | None, query: str, limit: int

--- a/backend/app/services/channels/telegram.py
+++ b/backend/app/services/channels/telegram.py
@@ -212,6 +212,32 @@ class TelegramAdapter(ChannelAdapter):
             for entry in administrators[:limit]
         ]
 
+    async def is_channel_member(
+        self, bot_token: str, channel_id: str, platform_user_id: str, *, api_base_url: str | None
+    ) -> bool:
+        """`getChatMember`, read for its status.
+
+        The one membership question Telegram does answer per account, where
+        enumerating ordinary members is refused outright. `left` and `kicked`
+        are Telegram's words for "was here, is not"; every other status - down
+        to `restricted`, which is a member who may not speak - is still in the
+        room. An account Telegram cannot place in the chat at all raises
+        `TelegramBadRequest`, which is the same answer as `left` for the
+        question being asked.
+        """
+        try:
+            member_id = int(platform_user_id)
+        except ValueError:
+            return False
+        bot = Bot(token=bot_token)
+        try:
+            found = await bot.get_chat_member(chat_id=channel_id, user_id=member_id)
+        except TelegramBadRequest:
+            return False
+        finally:
+            await bot.session.close()
+        return found.status not in ("left", "kicked")
+
     async def start_polling(self, bot_id: str, bot_token: str) -> None:
         """Start a supervised polling loop for this bot."""
         if bot_id in self._polling_tasks and not self._polling_tasks[bot_id].done():

--- a/backend/app/services/conversation.py
+++ b/backend/app/services/conversation.py
@@ -34,6 +34,7 @@ from app.schemas.conversation import (
     ToolCallCreate,
 )
 from app.schemas.conversation_share import AdminConversationList, AdminConversationRead
+from app.services.channels import membership as channel_membership
 
 logger = logging.getLogger(__name__)
 
@@ -124,19 +125,21 @@ class ConversationService:
 
         Three ways in, and a channel thread needs all three: the owner, whoever
         it was explicitly shared with, and - for a thread that came out of a room
-        - anyone a chat account of whose spoke in it, the same set `_reachable_by`
-        puts the thread in front of in the list. Ownership alone left the list and
-        the read disagreeing: a participant saw the thread and got a 404 opening
-        it, and a thread whose first speaker linked no account has no owner at all,
-        so the whole organization could read it while the list showed it only to
-        the people who were there.
+        - a participant the platform confirms is *still in the channel*, the same
+        set `_reachable_by` puts the thread in front of in the list. Having
+        spoken is not enough on its own: participation that stopped at the
+        `messages` table outlived the access the platform grants, so somebody
+        removed from the channel kept reading everything said after they left
+        (#641). `channels.membership` is the check, and it fails closed.
         """
         owner = getattr(conversation, "user_id", None)
         if owner is not None and str(owner) == str(user_id):
             return True
         if await conversation_share_repo.get_share(self.db, conversation.id, user_id):
             return True
-        return await conversation_repo.spoke_in(self.db, conversation.id, user_id)
+        return await channel_membership.confirms_participation(
+            self.db, conversation_id=conversation.id, user_id=user_id
+        )
 
     async def _may_write(self, conversation: Conversation, user_id: UUID) -> bool:
         """Whether this reader may change or delete this conversation.
@@ -198,7 +201,19 @@ class ConversationService:
         The total is counted with the same narrowing as the page, so a caller
         rendering "showing 30 of N" is describing the list it was handed rather
         than the deployment.
+
+        A user's page includes the channel threads they participate in, and the
+        participation set is vetted here - against the platform's current
+        membership, through `channels.membership` - before the repository sees
+        it, so the query never widens on who merely spoke (#641).
         """
+        participant_ids: set[UUID] = (
+            await channel_membership.confirmed_participant_threads(
+                self.db, user_id=user_id, organization_id=organization_id
+            )
+            if user_id is not None
+            else set()
+        )
         items = await conversation_repo.get_conversations_by_user(
             self.db,
             user_id=user_id,
@@ -211,6 +226,7 @@ class ConversationService:
             archived_only=archived_only,
             sort_by=sort_by,
             sort_dir=sort_dir,
+            participant_conversation_ids=participant_ids,
         )
         total = await conversation_repo.count_conversations(
             self.db,
@@ -220,6 +236,7 @@ class ConversationService:
             agent_id=agent_id,
             include_archived=include_archived,
             archived_only=archived_only,
+            participant_conversation_ids=participant_ids,
         )
         await self._attach_agents(items)
         return items, total

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -422,6 +422,7 @@ include = [
     "app/services/skill_workspace.py",
     "app/services/channels/attachments.py",
     "app/services/channels/dedupe.py",
+    "app/services/channels/membership.py",
     "app/services/channels/mentions.py",
     "app/services/collection_access.py",
     "app/services/embed_session.py",
@@ -579,6 +580,7 @@ include = [
     "app/services/skill_workspace.py",
     "app/services/channels/attachments.py",
     "app/services/channels/dedupe.py",
+    "app/services/channels/membership.py",
     "app/services/channels/mentions.py",
     "app/services/collection_access.py",
     # One visitor's turn on a public widget: who it runs as, how often they may

--- a/backend/tests/integration/test_channel_thread_participants.py
+++ b/backend/tests/integration/test_channel_thread_participants.py
@@ -94,6 +94,9 @@ async def _channel(
 
     Without this row the thread has no channel anybody can ask about, and a
     participation claim on it is refused - which one test below pins on purpose.
+    The chat id carries a folded thread root (`:root-1`), the shape Mattermost
+    and Slack store - the membership question must name the channel in front of
+    the colon, and the assertion on `asked_chat` pins that on real rows.
     """
     bot = ChannelBot(
         id=uuid.uuid4(),
@@ -110,7 +113,7 @@ async def _channel(
         bot_id=bot.id,
         identity_id=identity.id,
         conversation_id=conversation.id,
-        platform_chat_id="town-square",
+        platform_chat_id="town-square:root-1",
         chat_type="group",
     )
     db.add(session)

--- a/backend/tests/integration/test_channel_thread_participants.py
+++ b/backend/tests/integration/test_channel_thread_participants.py
@@ -4,30 +4,32 @@ A room is one conversation with several people in it, and until #639 it belonged
 to whoever spoke first - or, once an unlinked sender could be answered at all, to
 nobody, which left it invisible to everybody including the people who were in it.
 
-Participation is now a `DISTINCT` over `messages.channel_identity_id`, and what
-has to be true of it is exactly what a statement test cannot show: the correlated
-`EXISTS` lands on real rows, the same predicate reaches the count as well as the
-page, and a thread somebody never spoke in stays out of their list.
-
-**It says who spoke, not who may read** (#641). The test that pins the good half
-of that - a thread reaching somebody the moment they link - is also the test that
-pins the cost: nothing here consults the platform, so nothing here can know they
-have since been removed from the channel.
+Participation starts from `messages.channel_identity_id` - who *spoke* - and
+since #641 speaking is a claim, not access: every claim is checked against the
+platform's current membership before the listing shows the thread or the read
+opens it. These tests stub exactly that boundary - `membership.is_still_member`,
+the one call that would leave the process - and let everything under it run on
+real rows: the claims query, the session and bot joins, the same predicate
+reaching the count as well as the page.
 """
 
 from __future__ import annotations
 
 import uuid
+from unittest.mock import AsyncMock
 
 import pytest
 
 from app.core.exceptions import NotFoundError
+from app.db.models.channel_bot import ChannelBot
 from app.db.models.channel_identity import ChannelIdentity
+from app.db.models.channel_session import ChannelSession
 from app.db.models.conversation import Conversation, Message
 from app.db.models.organization import Organization
 from app.db.models.user import User
 from app.repositories import conversation as conversation_repo
 from app.schemas.conversation import MessageCreate
+from app.services.channels import membership
 from app.services.conversation import ConversationService
 
 pytestmark = pytest.mark.anyio
@@ -85,6 +87,37 @@ async def _room_thread(db, organization: Organization) -> Conversation:
     return conversation
 
 
+async def _channel(
+    db, organization: Organization, conversation: Conversation, identity: ChannelIdentity
+) -> ChannelSession:
+    """The room the thread came from: a bot of the organization's, one session.
+
+    Without this row the thread has no channel anybody can ask about, and a
+    participation claim on it is refused - which one test below pins on purpose.
+    """
+    bot = ChannelBot(
+        id=uuid.uuid4(),
+        organization_id=organization.id,
+        platform="mattermost",
+        name="Support",
+        token_encrypted="sealed-elsewhere",
+        api_base_url="https://mattermost.acme.com",
+    )
+    db.add(bot)
+    await db.flush()
+    session = ChannelSession(
+        id=uuid.uuid4(),
+        bot_id=bot.id,
+        identity_id=identity.id,
+        conversation_id=conversation.id,
+        platform_chat_id="town-square",
+        chat_type="group",
+    )
+    db.add(session)
+    await db.flush()
+    return session
+
+
 async def _said(db, conversation: Conversation, identity: ChannelIdentity | None) -> None:
     db.add(
         Message(
@@ -98,33 +131,83 @@ async def _said(db, conversation: Conversation, identity: ChannelIdentity | None
     await db.flush()
 
 
+@pytest.fixture
+def still_in_the_channel(monkeypatch) -> AsyncMock:
+    """The platform's answer, stubbed at the one call that would leave the
+    process. Defaults to "still a member"; a test about removal flips it."""
+    answer = AsyncMock(return_value=True)
+    monkeypatch.setattr(membership, "is_still_member", answer)
+    return answer
+
+
+async def _listed(db, reader: User, organization: Organization) -> list[uuid.UUID]:
+    items, _total = await ConversationService(db).list_conversations(
+        user_id=reader.id, organization_id=organization.id
+    )
+    return [c.id for c in items]
+
+
 class TestWhoSeesARoomThread:
-    async def test_somebody_who_spoke_in_it_sees_it(self, db) -> None:
+    async def test_a_participant_still_in_the_channel_sees_it(
+        self, db, still_in_the_channel
+    ) -> None:
         organization = await _org(db)
         reader = await _user(db)
+        identity = await _identity(db, user=reader)
         thread = await _room_thread(db, organization)
-        await _said(db, thread, await _identity(db, user=reader))
+        await _channel(db, organization, thread, identity)
+        await _said(db, thread, identity)
 
-        listed = await conversation_repo.get_conversations_by_user(
-            db, user_id=reader.id, organization_id=organization.id
-        )
+        assert await _listed(db, reader, organization) == [thread.id]
+        asked_bot, asked_chat, asked_account = still_in_the_channel.await_args.args
+        assert asked_bot.platform == "mattermost"
+        assert asked_chat == "town-square"
+        assert asked_account == identity.platform_user_id
 
-        assert [c.id for c in listed] == [thread.id]
+    async def test_a_participant_removed_from_the_channel_loses_the_thread(
+        self, db, still_in_the_channel
+    ) -> None:
+        """The defect #641 names: they spoke, the platform removed them, and the
+        thread must leave their list rather than outlive their access."""
+        still_in_the_channel.return_value = False
+        organization = await _org(db)
+        reader = await _user(db)
+        identity = await _identity(db, user=reader)
+        thread = await _room_thread(db, organization)
+        await _channel(db, organization, thread, identity)
+        await _said(db, thread, identity)
 
-    async def test_somebody_who_never_spoke_in_it_does_not(self, db) -> None:
+        assert await _listed(db, reader, organization) == []
+
+    async def test_a_thread_whose_session_moved_on_is_not_reachable_by_participation(
+        self, db, still_in_the_channel
+    ) -> None:
+        """`/new` re-points the session at a fresh conversation, so the old
+        thread names no channel anybody can ask about - and a claim that cannot
+        be checked is refused rather than trusted."""
+        organization = await _org(db)
+        reader = await _user(db)
+        identity = await _identity(db, user=reader)
+        thread = await _room_thread(db, organization)
+        await _said(db, thread, identity)
+
+        assert await _listed(db, reader, organization) == []
+        still_in_the_channel.assert_not_awaited()
+
+    async def test_somebody_who_never_spoke_in_it_does_not_see_it(
+        self, db, still_in_the_channel
+    ) -> None:
         organization = await _org(db)
         reader = await _user(db)
         stranger = await _user(db)
+        identity = await _identity(db, user=stranger)
         thread = await _room_thread(db, organization)
-        await _said(db, thread, await _identity(db, user=stranger))
+        await _channel(db, organization, thread, identity)
+        await _said(db, thread, identity)
 
-        listed = await conversation_repo.get_conversations_by_user(
-            db, user_id=reader.id, organization_id=organization.id
-        )
+        assert await _listed(db, reader, organization) == []
 
-        assert listed == []
-
-    async def test_an_unlinked_account_reaches_nobody(self, db) -> None:
+    async def test_an_unlinked_account_reaches_nobody(self, db, still_in_the_channel) -> None:
         """The turn is recorded and attributable; it is nobody's list yet.
 
         This is the state every room thread starts in, and the reason the thread
@@ -132,53 +215,50 @@ class TestWhoSeesARoomThread:
         """
         organization = await _org(db)
         reader = await _user(db)
+        identity = await _identity(db, user=None)
         thread = await _room_thread(db, organization)
-        await _said(db, thread, await _identity(db, user=None))
+        await _channel(db, organization, thread, identity)
+        await _said(db, thread, identity)
 
-        listed = await conversation_repo.get_conversations_by_user(
-            db, user_id=reader.id, organization_id=organization.id
-        )
+        assert await _listed(db, reader, organization) == []
 
-        assert listed == []
-
-    async def test_linking_the_account_is_what_makes_it_appear(self, db) -> None:
+    async def test_linking_the_account_is_what_makes_it_appear(
+        self, db, still_in_the_channel
+    ) -> None:
         """No backfill, and none needed: the message points at the identity, and
         the identity gains a person."""
         organization = await _org(db)
         reader = await _user(db)
         identity = await _identity(db, user=None)
         thread = await _room_thread(db, organization)
+        await _channel(db, organization, thread, identity)
         await _said(db, thread, identity)
 
-        before = await conversation_repo.get_conversations_by_user(
-            db, user_id=reader.id, organization_id=organization.id
-        )
+        before = await _listed(db, reader, organization)
         identity.user_id = reader.id
         await db.flush()
-        after = await conversation_repo.get_conversations_by_user(
-            db, user_id=reader.id, organization_id=organization.id
-        )
+        after = await _listed(db, reader, organization)
 
         assert before == []
-        assert [c.id for c in after] == [thread.id]
+        assert after == [thread.id]
 
-    async def test_a_thread_appears_once_however_often_they_spoke(self, db) -> None:
-        """`EXISTS`, not a join: four turns must not be four rows in the list."""
+    async def test_a_thread_appears_once_however_often_they_spoke(
+        self, db, still_in_the_channel
+    ) -> None:
+        """Four turns are one claim, one platform question and one row."""
         organization = await _org(db)
         reader = await _user(db)
         identity = await _identity(db, user=reader)
         thread = await _room_thread(db, organization)
+        await _channel(db, organization, thread, identity)
         for _ in range(4):
             await _said(db, thread, identity)
 
-        listed = await conversation_repo.get_conversations_by_user(
-            db, user_id=reader.id, organization_id=organization.id
-        )
+        assert await _listed(db, reader, organization) == [thread.id]
+        still_in_the_channel.assert_awaited_once()
 
-        assert [c.id for c in listed] == [thread.id]
-
-    async def test_the_count_agrees_with_the_page(self, db) -> None:
-        """A total counted without the participation predicate is a number that
+    async def test_the_count_agrees_with_the_page(self, db, still_in_the_channel) -> None:
+        """A total counted without the vetted participation set is a number that
         contradicts the rows under it."""
         organization = await _org(db)
         reader = await _user(db)
@@ -189,35 +269,37 @@ class TestWhoSeesARoomThread:
             title="Mine",
         )
         db.add(owned)
+        identity = await _identity(db, user=reader)
         thread = await _room_thread(db, organization)
-        await _said(db, thread, await _identity(db, user=reader))
+        await _channel(db, organization, thread, identity)
+        await _said(db, thread, identity)
         await _said(db, thread, await _identity(db, user=await _user(db)))
 
-        listed = await conversation_repo.get_conversations_by_user(
-            db, user_id=reader.id, organization_id=organization.id
-        )
-        total = await conversation_repo.count_conversations(
-            db, user_id=reader.id, organization_id=organization.id
+        items, total = await ConversationService(db).list_conversations(
+            user_id=reader.id, organization_id=organization.id
         )
 
-        assert total == len(listed) == 2
+        assert total == len(items) == 2
 
-    async def test_another_organizations_room_is_not_reachable_by_speaking_in_it(self, db) -> None:
+    async def test_another_organizations_room_is_not_reachable_by_speaking_in_it(
+        self, db, still_in_the_channel
+    ) -> None:
         """Participation widens whose list a thread is in - never which tenant."""
         organization = await _org(db)
         other = await _org(db)
         reader = await _user(db)
+        identity = await _identity(db, user=reader)
         thread = await _room_thread(db, other)
-        await _said(db, thread, await _identity(db, user=reader))
+        await _channel(db, other, thread, identity)
+        await _said(db, thread, identity)
 
-        listed = await conversation_repo.get_conversations_by_user(
-            db, user_id=reader.id, organization_id=organization.id
-        )
+        assert await _listed(db, reader, organization) == []
 
-        assert listed == []
-
-    async def test_a_dashboard_thread_still_reaches_its_owner(self, db) -> None:
-        """The predicate widens the listing; it must not narrow the ordinary case."""
+    async def test_a_dashboard_thread_still_reaches_its_owner(
+        self, db, still_in_the_channel
+    ) -> None:
+        """The predicate widens the listing; it must not narrow the ordinary
+        case, and a dashboard-only user costs no platform call at all."""
         organization = await _org(db)
         reader = await _user(db)
         owned = Conversation(
@@ -230,27 +312,26 @@ class TestWhoSeesARoomThread:
         await db.flush()
         await _said(db, owned, None)
 
-        listed = await conversation_repo.get_conversations_by_user(
-            db, user_id=reader.id, organization_id=organization.id
-        )
-
-        assert [c.id for c in listed] == [owned.id]
+        assert await _listed(db, reader, organization) == [owned.id]
+        still_in_the_channel.assert_not_awaited()
 
 
 class TestWhoMayOpenARoomThread:
-    """The read path of the same rule. The list widened to participants (#639);
-    the detail read did not, so a participant saw the thread and got a 404
-    opening it - and a room thread has no owner, so the owner guard was skipped
-    entirely and any member of the organization could read one the list showed
-    them nothing of. Opening a thread is now allowed for exactly the set the list
-    is: the owner, a share, or somebody who spoke in it.
+    """The read path of the same rule, so the list and the read cannot disagree:
+    a participant the platform still places in the channel opens the thread, a
+    removed one gets the same 404 a stranger does, and the owner and a share are
+    doors the membership check never touches.
     """
 
-    async def test_a_participant_may_open_a_room_thread(self, db) -> None:
+    async def test_a_participant_still_in_the_channel_may_open_it(
+        self, db, still_in_the_channel
+    ) -> None:
         organization = await _org(db)
         reader = await _user(db)
+        identity = await _identity(db, user=reader)
         thread = await _room_thread(db, organization)
-        await _said(db, thread, await _identity(db, user=reader))
+        await _channel(db, organization, thread, identity)
+        await _said(db, thread, identity)
 
         opened = await ConversationService(db).get_conversation(
             thread.id, organization_id=organization.id, user_id=reader.id
@@ -258,20 +339,68 @@ class TestWhoMayOpenARoomThread:
 
         assert opened.id == thread.id
 
-    async def test_a_member_who_never_spoke_cannot_open_an_unowned_room_thread(self, db) -> None:
-        """The hole this closes: user_id is None, so the owner guard was skipped
+    async def test_a_participant_removed_from_the_channel_is_refused(
+        self, db, still_in_the_channel
+    ) -> None:
+        still_in_the_channel.return_value = False
+        organization = await _org(db)
+        reader = await _user(db)
+        identity = await _identity(db, user=reader)
+        thread = await _room_thread(db, organization)
+        await _channel(db, organization, thread, identity)
+        await _said(db, thread, identity)
+
+        with pytest.raises(NotFoundError):
+            await ConversationService(db).get_conversation(
+                thread.id, organization_id=organization.id, user_id=reader.id
+            )
+
+    async def test_the_owner_keeps_the_thread_even_after_leaving_the_channel(
+        self, db, still_in_the_channel
+    ) -> None:
+        """Ownership is the platform's business to grant and ours to keep: the
+        membership check gates participation, never the owner's own thread."""
+        still_in_the_channel.return_value = False
+        organization = await _org(db)
+        owner = await _user(db)
+        identity = await _identity(db, user=owner)
+        thread = Conversation(
+            id=uuid.uuid4(),
+            user_id=owner.id,
+            organization_id=organization.id,
+            title="Mattermost Chat",
+        )
+        db.add(thread)
+        await db.flush()
+        await _channel(db, organization, thread, identity)
+        await _said(db, thread, identity)
+
+        opened = await ConversationService(db).get_conversation(
+            thread.id, organization_id=organization.id, user_id=owner.id
+        )
+
+        assert opened.id == thread.id
+
+    async def test_a_member_who_never_spoke_cannot_open_an_unowned_room_thread(
+        self, db, still_in_the_channel
+    ) -> None:
+        """The hole #639 closed: user_id is None, so the owner guard was skipped
         and every member of the organization could read it."""
         organization = await _org(db)
         stranger = await _user(db)
+        identity = await _identity(db, user=await _user(db))
         thread = await _room_thread(db, organization)
-        await _said(db, thread, await _identity(db, user=await _user(db)))
+        await _channel(db, organization, thread, identity)
+        await _said(db, thread, identity)
 
         with pytest.raises(NotFoundError):
             await ConversationService(db).get_conversation(
                 thread.id, organization_id=organization.id, user_id=stranger.id
             )
 
-    async def test_the_owner_of_a_dashboard_thread_still_opens_it(self, db) -> None:
+    async def test_the_owner_of_a_dashboard_thread_still_opens_it(
+        self, db, still_in_the_channel
+    ) -> None:
         organization = await _org(db)
         owner = await _user(db)
         owned = Conversation(
@@ -285,8 +414,11 @@ class TestWhoMayOpenARoomThread:
         )
 
         assert opened.id == owned.id
+        still_in_the_channel.assert_not_awaited()
 
-    async def test_a_stranger_cannot_open_a_dashboard_thread_that_is_not_theirs(self, db) -> None:
+    async def test_a_stranger_cannot_open_a_dashboard_thread_that_is_not_theirs(
+        self, db, still_in_the_channel
+    ) -> None:
         organization = await _org(db)
         owner = await _user(db)
         stranger = await _user(db)
@@ -322,12 +454,16 @@ class TestWhatAParticipantMayChange:
         await db.flush()
         return conversation
 
-    async def test_a_participant_opens_the_thread_and_cannot_delete_it(self, db) -> None:
+    async def test_a_participant_opens_the_thread_and_cannot_delete_it(
+        self, db, still_in_the_channel
+    ) -> None:
         organization = await _org(db)
         owner = await _user(db)
         speaker = await _user(db)
+        identity = await _identity(db, user=speaker)
         thread = await self._owned_room(db, organization, owner)
-        await _said(db, thread, await _identity(db, user=speaker))
+        await _channel(db, organization, thread, identity)
+        await _said(db, thread, identity)
         service = ConversationService(db)
 
         opened = await service.get_conversation(
@@ -344,12 +480,16 @@ class TestWhatAParticipantMayChange:
             "the row survived the refusal"
         )
 
-    async def test_a_participant_cannot_append_a_turn_as_the_agent(self, db) -> None:
+    async def test_a_participant_cannot_append_a_turn_as_the_agent(
+        self, db, still_in_the_channel
+    ) -> None:
         organization = await _org(db)
         owner = await _user(db)
         speaker = await _user(db)
+        identity = await _identity(db, user=speaker)
         thread = await self._owned_room(db, organization, owner)
-        await _said(db, thread, await _identity(db, user=speaker))
+        await _channel(db, organization, thread, identity)
+        await _said(db, thread, identity)
 
         with pytest.raises(NotFoundError):
             await ConversationService(db).add_message(
@@ -363,11 +503,15 @@ class TestWhatAParticipantMayChange:
             "only what the speaker actually said"
         )
 
-    async def test_the_owner_of_a_room_thread_still_deletes_it(self, db) -> None:
+    async def test_the_owner_of_a_room_thread_still_deletes_it(
+        self, db, still_in_the_channel
+    ) -> None:
         organization = await _org(db)
         owner = await _user(db)
+        identity = await _identity(db, user=owner)
         thread = await self._owned_room(db, organization, owner)
-        await _said(db, thread, await _identity(db, user=owner))
+        await _channel(db, organization, thread, identity)
+        await _said(db, thread, identity)
 
         assert await ConversationService(db).delete_conversation(
             thread.id, organization_id=organization.id, user_id=owner.id

--- a/backend/tests/test_channel_membership.py
+++ b/backend/tests/test_channel_membership.py
@@ -301,6 +301,63 @@ class TestConfirmedParticipantThreads:
         assert confirmed == {first, second}
         is_still_member.assert_awaited_once()
 
+    async def test_a_thread_id_is_stripped_to_its_channel_before_the_platform_is_asked(self):
+        """Slack and Mattermost fold a thread id into `platform_chat_id`
+        (`C1:1721234.5678`), and asked about that composite the platform answers
+        `channel_not_found` - a member still in the room would be refused."""
+        bot = _bot()
+        thread = uuid4()
+
+        with (
+            patch(
+                "app.services.channels.membership.conversation_repo.participation_claims",
+                AsyncMock(return_value=[_claim(thread, bot.id, chat="C1:1721234.5678")]),
+            ),
+            patch(
+                "app.services.channels.membership.channel_bot_repo.get_by_ids",
+                AsyncMock(return_value={bot.id: bot}),
+            ),
+            patch(
+                "app.services.channels.membership.is_still_member", AsyncMock(return_value=True)
+            ) as is_still_member,
+        ):
+            confirmed = await membership.confirmed_participant_threads(
+                AsyncMock(), user_id=uuid4(), organization_id=uuid4()
+            )
+
+        assert confirmed == {thread}
+        assert is_still_member.await_args.args[1] == "C1"
+
+    async def test_two_threads_of_one_channel_are_one_question(self):
+        """Different thread suffixes, one channel: one platform call answers
+        both claims rather than one per thread."""
+        bot = _bot()
+        first, second = uuid4(), uuid4()
+        claims = [
+            _claim(first, bot.id, chat="C1:1721234.5678"),
+            _claim(second, bot.id, chat="C1:1721299.0001"),
+        ]
+
+        with (
+            patch(
+                "app.services.channels.membership.conversation_repo.participation_claims",
+                AsyncMock(return_value=claims),
+            ),
+            patch(
+                "app.services.channels.membership.channel_bot_repo.get_by_ids",
+                AsyncMock(return_value={bot.id: bot}),
+            ),
+            patch(
+                "app.services.channels.membership.is_still_member", AsyncMock(return_value=True)
+            ) as is_still_member,
+        ):
+            confirmed = await membership.confirmed_participant_threads(
+                AsyncMock(), user_id=uuid4(), organization_id=uuid4()
+            )
+
+        assert confirmed == {first, second}
+        is_still_member.assert_awaited_once()
+
 
 class TestConfirmsParticipation:
     async def test_a_confirmed_claim_opens_the_thread(self):

--- a/backend/tests/test_channel_membership.py
+++ b/backend/tests/test_channel_membership.py
@@ -1,0 +1,371 @@
+"""The membership check behind the participant model (#641).
+
+`messages.channel_identity_id` says who spoke; these tests pin that nothing
+here treats it as who may read. Every claim is confirmed against the platform,
+every way the platform cannot answer refuses, and the cache never widens an
+answer - it only remembers one.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.repositories.conversation import ParticipationClaim
+from app.services.channels import membership
+from app.services.channels.base import ChannelDirectoryUnsupported
+
+pytestmark = pytest.mark.anyio
+
+
+class FakeRedis:
+    """The two calls membership makes, over a dict."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+        self.ttls: dict[str, int] = {}
+
+    async def get(self, key: str) -> str | None:
+        return self.store.get(key)
+
+    async def set(self, key: str, value: str, ttl: int | None = None, nx: bool = False) -> bool:
+        self.store[key] = value
+        if ttl is not None:
+            self.ttls[key] = ttl
+        return True
+
+
+class BrokenRedis:
+    async def get(self, key: str) -> str | None:
+        raise ConnectionError("redis is down")
+
+    async def set(self, key: str, value: str, ttl: int | None = None, nx: bool = False) -> bool:
+        raise ConnectionError("redis is down")
+
+
+@pytest.fixture(autouse=True)
+def unconfigured():
+    """Every test starts and ends with no Redis handed over."""
+    membership.configure(None)
+    yield
+    membership.configure(None)
+
+
+def _bot(platform: str = "mattermost"):
+    bot = MagicMock()
+    bot.id = uuid4()
+    bot.platform = platform
+    bot.api_base_url = "https://mm.example.com"
+    return bot
+
+
+def _adapter(answer: bool | BaseException) -> MagicMock:
+    adapter = MagicMock()
+    if isinstance(answer, BaseException):
+        adapter.is_channel_member = AsyncMock(side_effect=answer)
+    else:
+        adapter.is_channel_member = AsyncMock(return_value=answer)
+    return adapter
+
+
+class TestIsStillMember:
+    async def test_the_platforms_yes_is_a_yes_and_is_cached(self):
+        redis = FakeRedis()
+        membership.configure(redis)
+        bot = _bot()
+        adapter = _adapter(True)
+
+        with (
+            patch("app.services.channels.membership.get_adapter", return_value=adapter),
+            patch("app.services.channels.membership.unseal_bot_token", return_value="token"),
+        ):
+            assert await membership.is_still_member(bot, "town-square", "acc-1") is True
+
+        adapter.is_channel_member.assert_awaited_once_with(
+            "token", "town-square", "acc-1", api_base_url="https://mm.example.com"
+        )
+        key = membership._key(bot.id, "town-square", "acc-1")
+        assert redis.store[key] == "1"
+        assert redis.ttls[key] == membership.MEMBERSHIP_TTL_SECONDS
+
+    async def test_the_platforms_no_is_a_no_and_is_cached(self):
+        redis = FakeRedis()
+        membership.configure(redis)
+        bot = _bot()
+
+        with (
+            patch("app.services.channels.membership.get_adapter", return_value=_adapter(False)),
+            patch("app.services.channels.membership.unseal_bot_token", return_value="token"),
+        ):
+            assert await membership.is_still_member(bot, "town-square", "acc-1") is False
+
+        assert redis.store[membership._key(bot.id, "town-square", "acc-1")] == "0"
+
+    async def test_a_cached_answer_never_reaches_the_platform(self):
+        redis = FakeRedis()
+        membership.configure(redis)
+        bot = _bot()
+        redis.store[membership._key(bot.id, "town-square", "acc-1")] = "1"
+        redis.store[membership._key(bot.id, "town-square", "acc-2")] = "0"
+
+        with patch("app.services.channels.membership.get_adapter") as get_adapter:
+            assert await membership.is_still_member(bot, "town-square", "acc-1") is True
+            assert await membership.is_still_member(bot, "town-square", "acc-2") is False
+
+        get_adapter.assert_not_called()
+
+    async def test_a_platform_that_cannot_answer_refuses(self):
+        """`ChannelDirectoryUnsupported` is the safe default the issue names:
+        a claim nobody can check is a claim, not access."""
+        bot = _bot("telegram")
+        unsupported = _adapter(ChannelDirectoryUnsupported("telegram will not tell a bot"))
+
+        with (
+            patch("app.services.channels.membership.get_adapter", return_value=unsupported),
+            patch("app.services.channels.membership.unseal_bot_token", return_value="token"),
+        ):
+            assert await membership.is_still_member(bot, "-100123", "42") is False
+
+    async def test_a_failing_platform_call_refuses_rather_than_admits(self):
+        bot = _bot()
+
+        with (
+            patch(
+                "app.services.channels.membership.get_adapter",
+                return_value=_adapter(ConnectionError("timeout")),
+            ),
+            patch("app.services.channels.membership.unseal_bot_token", return_value="token"),
+        ):
+            assert await membership.is_still_member(bot, "town-square", "acc-1") is False
+
+    async def test_an_unregistered_adapter_refuses(self):
+        """A platform with no adapter in this process cannot vouch for anybody."""
+        bot = _bot("nothing-registered")
+
+        assert await membership.is_still_member(bot, "town-square", "acc-1") is False
+
+    async def test_a_refusal_is_cached_so_a_dead_platform_is_not_hammered(self):
+        redis = FakeRedis()
+        membership.configure(redis)
+        bot = _bot()
+        adapter = _adapter(ConnectionError("timeout"))
+
+        with (
+            patch("app.services.channels.membership.get_adapter", return_value=adapter),
+            patch("app.services.channels.membership.unseal_bot_token", return_value="token"),
+        ):
+            await membership.is_still_member(bot, "town-square", "acc-1")
+            await membership.is_still_member(bot, "town-square", "acc-1")
+
+        adapter.is_channel_member.assert_awaited_once()
+
+    async def test_no_redis_means_slower_never_wider(self):
+        """Unconfigured, every check goes to the platform - and the answer is
+        still the platform's."""
+        bot = _bot()
+        adapter = _adapter(True)
+
+        with (
+            patch("app.services.channels.membership.get_adapter", return_value=adapter),
+            patch("app.services.channels.membership.unseal_bot_token", return_value="token"),
+        ):
+            assert await membership.is_still_member(bot, "town-square", "acc-1") is True
+            assert await membership.is_still_member(bot, "town-square", "acc-1") is True
+
+        assert adapter.is_channel_member.await_count == 2
+
+    async def test_a_broken_cache_reads_as_a_miss_and_the_write_is_best_effort(self):
+        membership.configure(BrokenRedis())
+        bot = _bot()
+        adapter = _adapter(True)
+
+        with (
+            patch("app.services.channels.membership.get_adapter", return_value=adapter),
+            patch("app.services.channels.membership.unseal_bot_token", return_value="token"),
+        ):
+            assert await membership.is_still_member(bot, "town-square", "acc-1") is True
+
+        adapter.is_channel_member.assert_awaited_once()
+
+
+def _claim(conversation_id, bot_id, chat: str = "town-square", account: str = "acc-1"):
+    return ParticipationClaim(
+        conversation_id=conversation_id,
+        platform_user_id=account,
+        bot_id=bot_id,
+        platform_chat_id=chat,
+    )
+
+
+class TestConfirmedParticipantThreads:
+    async def test_only_threads_the_platform_confirms_survive(self):
+        reader, organization = uuid4(), uuid4()
+        kept_thread, lost_thread = uuid4(), uuid4()
+        bot = _bot()
+        claims = [
+            _claim(kept_thread, bot.id, chat="kept"),
+            _claim(lost_thread, bot.id, chat="lost"),
+        ]
+
+        async def answer(found_bot, chat, account):
+            return chat == "kept"
+
+        with (
+            patch(
+                "app.services.channels.membership.conversation_repo.participation_claims",
+                AsyncMock(return_value=claims),
+            ) as participation_claims,
+            patch(
+                "app.services.channels.membership.channel_bot_repo.get_by_ids",
+                AsyncMock(return_value={bot.id: bot}),
+            ),
+            patch(
+                "app.services.channels.membership.is_still_member", AsyncMock(side_effect=answer)
+            ),
+        ):
+            confirmed = await membership.confirmed_participant_threads(
+                AsyncMock(), user_id=reader, organization_id=organization
+            )
+
+        assert confirmed == {kept_thread}
+        assert participation_claims.await_args.kwargs == {
+            "user_id": reader,
+            "organization_id": organization,
+        }
+
+    async def test_no_claims_asks_nothing(self):
+        """The common case - a dashboard-only user - costs no bot load and no
+        platform call."""
+        with (
+            patch(
+                "app.services.channels.membership.conversation_repo.participation_claims",
+                AsyncMock(return_value=[]),
+            ),
+            patch("app.services.channels.membership.channel_bot_repo.get_by_ids") as get_by_ids,
+        ):
+            confirmed = await membership.confirmed_participant_threads(
+                AsyncMock(), user_id=uuid4(), organization_id=uuid4()
+            )
+
+        assert confirmed == set()
+        get_by_ids.assert_not_called()
+
+    async def test_a_deleted_bot_takes_its_claims_with_it(self):
+        """A claim whose bot row is gone cannot be checked, so it is refused."""
+        thread = uuid4()
+
+        with (
+            patch(
+                "app.services.channels.membership.conversation_repo.participation_claims",
+                AsyncMock(return_value=[_claim(thread, uuid4())]),
+            ),
+            patch(
+                "app.services.channels.membership.channel_bot_repo.get_by_ids",
+                AsyncMock(return_value={}),
+            ),
+            patch("app.services.channels.membership.is_still_member") as is_still_member,
+        ):
+            confirmed = await membership.confirmed_participant_threads(
+                AsyncMock(), user_id=uuid4(), organization_id=uuid4()
+            )
+
+        assert confirmed == set()
+        is_still_member.assert_not_called()
+
+    async def test_one_room_is_one_question_however_many_threads_and_speakers(self):
+        """Slack folds a thread into `platform_chat_id`, so several conversations
+        can share one (bot, chat, account) - the platform is asked once."""
+        bot = _bot()
+        first, second = uuid4(), uuid4()
+        claims = [_claim(first, bot.id), _claim(second, bot.id)]
+
+        with (
+            patch(
+                "app.services.channels.membership.conversation_repo.participation_claims",
+                AsyncMock(return_value=claims),
+            ),
+            patch(
+                "app.services.channels.membership.channel_bot_repo.get_by_ids",
+                AsyncMock(return_value={bot.id: bot}),
+            ),
+            patch(
+                "app.services.channels.membership.is_still_member", AsyncMock(return_value=True)
+            ) as is_still_member,
+        ):
+            confirmed = await membership.confirmed_participant_threads(
+                AsyncMock(), user_id=uuid4(), organization_id=uuid4()
+            )
+
+        assert confirmed == {first, second}
+        is_still_member.assert_awaited_once()
+
+
+class TestConfirmsParticipation:
+    async def test_a_confirmed_claim_opens_the_thread(self):
+        thread, reader = uuid4(), uuid4()
+        bot = _bot()
+
+        with (
+            patch(
+                "app.services.channels.membership.conversation_repo.participation_claims",
+                AsyncMock(return_value=[_claim(thread, bot.id)]),
+            ) as participation_claims,
+            patch(
+                "app.services.channels.membership.channel_bot_repo.get_by_ids",
+                AsyncMock(return_value={bot.id: bot}),
+            ),
+            patch("app.services.channels.membership.is_still_member", AsyncMock(return_value=True)),
+        ):
+            assert (
+                await membership.confirms_participation(
+                    AsyncMock(), conversation_id=thread, user_id=reader
+                )
+                is True
+            )
+
+        assert participation_claims.await_args.kwargs == {
+            "user_id": reader,
+            "conversation_id": thread,
+        }
+
+    async def test_a_removed_member_is_refused_the_thread(self):
+        """The defect itself: they spoke, the platform since removed them, the
+        thread does not open."""
+        thread = uuid4()
+        bot = _bot()
+
+        with (
+            patch(
+                "app.services.channels.membership.conversation_repo.participation_claims",
+                AsyncMock(return_value=[_claim(thread, bot.id)]),
+            ),
+            patch(
+                "app.services.channels.membership.channel_bot_repo.get_by_ids",
+                AsyncMock(return_value={bot.id: bot}),
+            ),
+            patch(
+                "app.services.channels.membership.is_still_member", AsyncMock(return_value=False)
+            ),
+        ):
+            assert (
+                await membership.confirms_participation(
+                    AsyncMock(), conversation_id=thread, user_id=uuid4()
+                )
+                is False
+            )
+
+    async def test_a_thread_with_no_claims_does_not_open(self):
+        """Never spoke there - or the session moved on and nothing names the
+        channel any more. Both refuse; owner and share are other doors."""
+        with patch(
+            "app.services.channels.membership.conversation_repo.participation_claims",
+            AsyncMock(return_value=[]),
+        ):
+            assert (
+                await membership.confirms_participation(
+                    AsyncMock(), conversation_id=uuid4(), user_id=uuid4()
+                )
+                is False
+            )

--- a/backend/tests/test_channel_mentions.py
+++ b/backend/tests/test_channel_mentions.py
@@ -23,11 +23,10 @@ import pytest
 from app.core.exceptions import AuthorizationError, BadRequestError, NotFoundError
 from app.core.permissions import AuthContext, OrgRoleName
 from app.db.models.agent_run import RunSurface
-from app.services.channels.base import ROOM_HANDLES
+from app.services.channels.base import ROOM_HANDLES, channel_key
 from app.services.channels.mentions import (
     ChannelAgentRouter,
     UnaddressedMessage,
-    channel_key,
     parse_mention,
 )
 from app.services.usage_report import UsageReport

--- a/backend/tests/test_channel_tools.py
+++ b/backend/tests/test_channel_tools.py
@@ -14,6 +14,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from aiogram.exceptions import TelegramBadRequest
 from pydantic_ai.models.test import TestModel
 
 from app.agents.capabilities import build as build_capabilities
@@ -561,3 +562,200 @@ class TestWhatAnAdapterActuallyBuilds:
             "Customer questions",
             "On call: Ada",
         )
+
+
+class TestIsChannelMember:
+    """The per-account membership question the participant model asks (#641).
+
+    Deliberately not a fifth registered tool: an agent has `list_channel_members`
+    for the room it stands in, while this is `channels.membership` asking whether
+    a `/chat` reader is *still* in the channel their thread came from. The list
+    cannot answer that - Telegram's holds only administrators and the other two
+    stop at `limit` - so each platform is asked about one account.
+    """
+
+    @staticmethod
+    def _telegram_bot(result: Any) -> MagicMock:
+        bot = MagicMock()
+        if isinstance(result, BaseException):
+            bot.get_chat_member = AsyncMock(side_effect=result)
+        else:
+            bot.get_chat_member = AsyncMock(return_value=MagicMock(status=result))
+        bot.session.close = AsyncMock()
+        return bot
+
+    @pytest.mark.parametrize("status", ["member", "administrator", "restricted", "creator"])
+    async def test_telegram_counts_everybody_still_in_the_room(self, status: str):
+        """`restricted` is a member who may not speak - reading their own room's
+        thread is exactly what they may still do."""
+        bot = self._telegram_bot(status)
+
+        with patch("app.services.channels.telegram.Bot", return_value=bot):
+            found = await TelegramAdapter().is_channel_member(
+                "tok", "-100200300", "42", api_base_url=None
+            )
+
+        assert found is True
+        bot.get_chat_member.assert_awaited_once_with(chat_id="-100200300", user_id=42)
+
+    @pytest.mark.parametrize("status", ["left", "kicked"])
+    async def test_telegram_reads_left_and_kicked_as_gone(self, status: str):
+        bot = self._telegram_bot(status)
+
+        with patch("app.services.channels.telegram.Bot", return_value=bot):
+            assert (
+                await TelegramAdapter().is_channel_member(
+                    "tok", "-100200300", "42", api_base_url=None
+                )
+                is False
+            )
+
+    async def test_telegram_treats_an_unplaceable_account_as_not_a_member(self):
+        """`getChatMember` raises where the chat never held the account; for the
+        question being asked that is the same answer as `left`."""
+        refusal = TelegramBadRequest(method=None, message="Bad Request: user not found")  # type: ignore[arg-type]
+        bot = self._telegram_bot(refusal)
+
+        with patch("app.services.channels.telegram.Bot", return_value=bot):
+            assert (
+                await TelegramAdapter().is_channel_member(
+                    "tok", "-100200300", "42", api_base_url=None
+                )
+                is False
+            )
+        bot.session.close.assert_awaited_once()
+
+    async def test_telegram_refuses_an_account_id_it_cannot_even_ask_about(self):
+        """Telegram user ids are numeric; a foreign-looking id is refused without
+        a network call rather than sent to the API to fail there."""
+        with patch("app.services.channels.telegram.Bot") as bot_cls:
+            assert (
+                await TelegramAdapter().is_channel_member(
+                    "tok", "-100200300", "U123ABC", api_base_url=None
+                )
+                is False
+            )
+        bot_cls.assert_not_called()
+
+    async def test_slack_finds_the_account_on_a_later_page(self):
+        """Membership must survive pagination: the account on page two is as much
+        a member as one on page one."""
+        client = MagicMock()
+        client.conversations_members = AsyncMock(
+            side_effect=[
+                {"members": ["U1", "U2"], "response_metadata": {"next_cursor": "c2"}},
+                {"members": ["U3"], "response_metadata": {"next_cursor": ""}},
+            ]
+        )
+
+        with patch("slack_sdk.web.async_client.AsyncWebClient", return_value=client, create=True):
+            assert (
+                await SlackAdapter().is_channel_member("tok", "C1", "U3", api_base_url=None) is True
+            )
+
+        assert client.conversations_members.await_count == 2
+
+    async def test_slack_answers_no_when_the_list_ends_without_the_account(self):
+        client = MagicMock()
+        client.conversations_members = AsyncMock(
+            side_effect=[{"members": ["U1"], "response_metadata": {"next_cursor": ""}}]
+        )
+
+        with patch("slack_sdk.web.async_client.AsyncWebClient", return_value=client, create=True):
+            assert (
+                await SlackAdapter().is_channel_member("tok", "C1", "U9", api_base_url=None)
+                is False
+            )
+
+    async def test_slack_stops_walking_at_the_page_cap_and_refuses(self):
+        """A runaway cursor must not loop forever, and a walk that gave up says
+        "not a member" - the participant model's safe default - rather than a
+        claim about a room it never finished reading."""
+        client = MagicMock()
+        client.conversations_members = AsyncMock(
+            return_value={"members": ["U1"], "response_metadata": {"next_cursor": "again"}}
+        )
+
+        with (
+            patch("slack_sdk.web.async_client.AsyncWebClient", return_value=client, create=True),
+            patch("app.services.channels.slack._MEMBERSHIP_PAGES", 3),
+        ):
+            assert (
+                await SlackAdapter().is_channel_member("tok", "C1", "U9", api_base_url=None)
+                is False
+            )
+
+        assert client.conversations_members.await_count == 3
+
+    @staticmethod
+    def _mattermost_client(answer: MagicMock) -> MagicMock:
+        client = MagicMock()
+        client.get = AsyncMock(return_value=answer)
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+        return client
+
+    async def test_mattermost_reads_the_platforms_yes(self):
+        client = self._mattermost_client(MagicMock(status_code=200))
+
+        with patch("app.services.channels.mattermost.httpx.AsyncClient", return_value=client):
+            found = await MattermostAdapter().is_channel_member(
+                "tok", "c1", "u1", api_base_url="https://mattermost.acme.com"
+            )
+
+        assert found is True
+        asked = client.get.await_args.args[0]
+        assert asked == "https://mattermost.acme.com/api/v4/channels/c1/members/u1"
+
+    async def test_mattermost_reads_a_404_as_not_a_member(self):
+        """404 is Mattermost's answer, not a failure - it must not raise and must
+        not be mistaken for an unreachable server."""
+        answer = MagicMock(status_code=404)
+        client = self._mattermost_client(answer)
+
+        with patch("app.services.channels.mattermost.httpx.AsyncClient", return_value=client):
+            assert (
+                await MattermostAdapter().is_channel_member(
+                    "tok", "c1", "u1", api_base_url="https://mattermost.acme.com"
+                )
+                is False
+            )
+        answer.raise_for_status.assert_not_called()
+
+    async def test_mattermost_raises_on_anything_that_is_not_an_answer(self):
+        """A 403 - the bot itself removed - is a question that could not be
+        asked, and the caller's fail-closed handling owns it, not this method."""
+        answer = MagicMock(status_code=403)
+        answer.raise_for_status = MagicMock(side_effect=RuntimeError("403 Forbidden"))
+        client = self._mattermost_client(answer)
+
+        with (
+            patch("app.services.channels.mattermost.httpx.AsyncClient", return_value=client),
+            pytest.raises(RuntimeError, match="403"),
+        ):
+            await MattermostAdapter().is_channel_member(
+                "tok", "c1", "u1", api_base_url="https://mattermost.acme.com"
+            )
+
+    async def test_mattermost_without_a_server_url_says_so(self):
+        with pytest.raises(ChannelDirectoryUnsupported, match="server URL"):
+            await MattermostAdapter().is_channel_member("tok", "c1", "u1", api_base_url=None)
+
+    async def test_a_platform_without_an_implementation_refuses_by_default(self):
+        class Bare(ChannelAdapter):
+            platform = "carrier-pigeon"
+
+            async def send_message(self, bot_token: str, msg: Any) -> None: ...
+            async def start_polling(self, bot_id: str, bot_token: str) -> None: ...
+            async def stop_polling(self, bot_id: str) -> None: ...
+            async def register_webhook(
+                self, bot_token: str, url: str, secret: str | None
+            ) -> bool: ...
+            async def delete_webhook(self, bot_token: str) -> bool: ...
+            def verify_webhook_signature(
+                self, headers: dict[str, str], secret: str, body: str | None = None
+            ) -> bool: ...
+            def parse_incoming(self, raw_payload: dict[str, Any], bot_id: str) -> None: ...
+
+        with pytest.raises(ChannelDirectoryUnsupported, match="carrier-pigeon"):
+            await Bare().is_channel_member("tok", "c1", "u1", api_base_url=None)

--- a/backend/tests/test_services_conversation.py
+++ b/backend/tests/test_services_conversation.py
@@ -189,10 +189,11 @@ class TestConversationServiceGetConversation:
         with (
             patch("app.services.conversation.conversation_repo") as mock_repo,
             patch("app.services.conversation.conversation_share_repo") as mock_share_repo,
+            patch("app.services.conversation.channel_membership") as mock_membership,
         ):
             mock_repo.get_conversation_by_id = AsyncMock(return_value=mock_conv)
             mock_share_repo.get_share = AsyncMock(return_value=None)
-            mock_repo.spoke_in = AsyncMock(return_value=False)
+            mock_membership.confirms_participation = AsyncMock(return_value=False)
 
             with pytest.raises(NotFoundError):
                 await service.get_conversation(
@@ -242,10 +243,11 @@ class TestConversationServiceGetConversation:
         with (
             patch("app.services.conversation.conversation_repo") as mock_repo,
             patch("app.services.conversation.conversation_share_repo") as mock_share_repo,
+            patch("app.services.conversation.channel_membership") as mock_membership,
         ):
             mock_repo.get_conversation_by_id = AsyncMock(return_value=mock_conv)
             mock_share_repo.get_share = AsyncMock(return_value=None)
-            mock_repo.spoke_in = AsyncMock(return_value=False)
+            mock_membership.confirms_participation = AsyncMock(return_value=False)
 
             with pytest.raises(NotFoundError):
                 await service.get_conversation(
@@ -256,17 +258,19 @@ class TestConversationServiceGetConversation:
     async def test_get_conversation_null_owner_allows_a_participant(
         self, service: ConversationService
     ):
-        """The other half: somebody who spoke in the room may open it."""
+        """The other half: a participant the platform still places in the
+        channel may open it. Speaking alone stopped being enough with #641."""
         conv_id = uuid4()
         mock_conv = MockConversation(id=conv_id, user_id=None)
 
         with (
             patch("app.services.conversation.conversation_repo") as mock_repo,
             patch("app.services.conversation.conversation_share_repo") as mock_share_repo,
+            patch("app.services.conversation.channel_membership") as mock_membership,
         ):
             mock_repo.get_conversation_by_id = AsyncMock(return_value=mock_conv)
             mock_share_repo.get_share = AsyncMock(return_value=None)
-            mock_repo.spoke_in = AsyncMock(return_value=True)
+            mock_membership.confirms_participation = AsyncMock(return_value=True)
 
             result = await service.get_conversation(
                 conv_id, user_id=uuid4(), organization_id=TEST_ORG_ID
@@ -307,10 +311,11 @@ class TestParticipationDoesNotCarryTheWrite:
         with (
             patch("app.services.conversation.conversation_repo") as mock_repo,
             patch("app.services.conversation.conversation_share_repo") as mock_share_repo,
+            patch("app.services.conversation.channel_membership") as mock_membership,
         ):
             mock_repo.get_conversation_by_id = AsyncMock(return_value=conversation)
             mock_share_repo.get_share = AsyncMock(return_value=None)
-            mock_repo.spoke_in = AsyncMock(return_value=True)
+            mock_membership.confirms_participation = AsyncMock(return_value=True)
 
             opened = await service.get_conversation(
                 conversation.id, user_id=speaker, organization_id=TEST_ORG_ID
@@ -335,11 +340,12 @@ class TestParticipationDoesNotCarryTheWrite:
         with (
             patch("app.services.conversation.conversation_repo") as mock_repo,
             patch("app.services.conversation.conversation_share_repo") as mock_share_repo,
+            patch("app.services.conversation.channel_membership") as mock_membership,
         ):
             mock_repo.get_conversation_by_id = AsyncMock(return_value=conversation)
             mock_repo.delete_conversation = AsyncMock()
             mock_share_repo.get_share = AsyncMock(return_value=None)
-            mock_repo.spoke_in = AsyncMock(return_value=True)
+            mock_membership.confirms_participation = AsyncMock(return_value=True)
 
             with pytest.raises(NotFoundError):
                 await service.delete_conversation(
@@ -358,11 +364,12 @@ class TestParticipationDoesNotCarryTheWrite:
         with (
             patch("app.services.conversation.conversation_repo") as mock_repo,
             patch("app.services.conversation.conversation_share_repo") as mock_share_repo,
+            patch("app.services.conversation.channel_membership") as mock_membership,
         ):
             mock_repo.get_conversation_by_id = AsyncMock(return_value=conversation)
             mock_repo.archive_conversation = AsyncMock()
             mock_share_repo.get_share = AsyncMock(return_value=None)
-            mock_repo.spoke_in = AsyncMock(return_value=True)
+            mock_membership.confirms_participation = AsyncMock(return_value=True)
 
             with pytest.raises(NotFoundError):
                 await service.archive_conversation(
@@ -383,11 +390,12 @@ class TestParticipationDoesNotCarryTheWrite:
         with (
             patch("app.services.conversation.conversation_repo") as mock_repo,
             patch("app.services.conversation.conversation_share_repo") as mock_share_repo,
+            patch("app.services.conversation.channel_membership") as mock_membership,
         ):
             mock_repo.get_conversation_by_id = AsyncMock(return_value=conversation)
             mock_repo.create_message = AsyncMock()
             mock_share_repo.get_share = AsyncMock(return_value=None)
-            mock_repo.spoke_in = AsyncMock(return_value=True)
+            mock_membership.confirms_participation = AsyncMock(return_value=True)
 
             with pytest.raises(NotFoundError):
                 await service.add_message(
@@ -551,6 +559,54 @@ class TestConversationServiceListConversations:
             call_kwargs = mock_repo.get_conversations_by_user.call_args[1]
             assert (call_kwargs["sort_by"], call_kwargs["sort_dir"]) == ("title", "asc")
 
+    @pytest.mark.anyio
+    async def test_a_users_page_carries_the_vetted_participation_set(
+        self, service: ConversationService
+    ):
+        """The membership-confirmed threads reach the page *and* the count - a
+        total counted without them contradicts the rows under it - and the repo
+        never sees an unvetted claim (#641)."""
+        reader = uuid4()
+        vetted = {uuid4()}
+
+        with (
+            patch("app.services.conversation.conversation_repo") as mock_repo,
+            patch("app.services.conversation.channel_membership") as mock_membership,
+        ):
+            mock_repo.get_conversations_by_user = AsyncMock(return_value=[])
+            mock_repo.count_conversations = AsyncMock(return_value=0)
+            mock_repo.agents_in_conversations = AsyncMock(return_value={})
+            mock_membership.confirmed_participant_threads = AsyncMock(return_value=vetted)
+
+            await service.list_conversations(user_id=reader, organization_id=TEST_ORG_ID)
+
+            page = mock_repo.get_conversations_by_user.call_args[1]
+            count = mock_repo.count_conversations.call_args[1]
+            assert page["participant_conversation_ids"] == vetted
+            assert count["participant_conversation_ids"] == vetted
+            mock_membership.confirmed_participant_threads.assert_awaited_once_with(
+                service.db, user_id=reader, organization_id=TEST_ORG_ID
+            )
+
+    @pytest.mark.anyio
+    async def test_an_unnarrowed_listing_never_asks_the_platform(
+        self, service: ConversationService
+    ):
+        """No reader means no participation to vet - an admin-shaped listing must
+        not spend a membership call per channel."""
+        with (
+            patch("app.services.conversation.conversation_repo") as mock_repo,
+            patch("app.services.conversation.channel_membership") as mock_membership,
+        ):
+            mock_repo.get_conversations_by_user = AsyncMock(return_value=[])
+            mock_repo.count_conversations = AsyncMock(return_value=0)
+            mock_repo.agents_in_conversations = AsyncMock(return_value={})
+            mock_membership.confirmed_participant_threads = AsyncMock()
+
+            await service.list_conversations(organization_id=TEST_ORG_ID)
+
+            mock_membership.confirmed_participant_threads.assert_not_awaited()
+
 
 class TestConversationServiceCreate:
     """Tests for create_conversation."""
@@ -643,7 +699,6 @@ class TestConversationServiceUpdate:
         ):
             mock_repo.get_conversation_by_id = AsyncMock(return_value=mock_conv)
             mock_share_repo.get_share = AsyncMock(return_value=None)
-            mock_repo.spoke_in = AsyncMock(return_value=False)
 
             with pytest.raises(NotFoundError):
                 await service.update_conversation(
@@ -705,7 +760,6 @@ class TestConversationServiceArchive:
         ):
             mock_repo.get_conversation_by_id = AsyncMock(return_value=mock_conv)
             mock_share_repo.get_share = AsyncMock(return_value=None)
-            mock_repo.spoke_in = AsyncMock(return_value=False)
 
             with pytest.raises(NotFoundError):
                 await service.archive_conversation(
@@ -766,7 +820,6 @@ class TestConversationServiceDelete:
         ):
             mock_repo.get_conversation_by_id = AsyncMock(return_value=mock_conv)
             mock_share_repo.get_share = AsyncMock(return_value=None)
-            mock_repo.spoke_in = AsyncMock(return_value=False)
 
             with pytest.raises(NotFoundError):
                 await service.delete_conversation(

--- a/backend/tests/test_tenant_isolation.py
+++ b/backend/tests/test_tenant_isolation.py
@@ -45,6 +45,10 @@ class TestConversationTenantIsolation:
                 "app.repositories.conversation_repo.count_conversations",
                 new=AsyncMock(return_value=0),
             ) as mock_count,
+            patch(
+                "app.services.conversation.channel_membership.confirmed_participant_threads",
+                new=AsyncMock(return_value=set()),
+            ),
         ):
             svc = ConversationService(mock_db)
             await svc.list_conversations(user_id=user_id, organization_id=org_id)
@@ -92,6 +96,10 @@ class TestConversationTenantIsolation:
                 "app.repositories.conversation_repo.count_conversations",
                 new=AsyncMock(return_value=0),
             ),
+            patch(
+                "app.services.conversation.channel_membership.confirmed_participant_threads",
+                new=AsyncMock(return_value=set()),
+            ),
         ):
             svc = ConversationService(mock_db)
             items, total = await svc.list_conversations(user_id=user_a, organization_id=org_a)
@@ -112,6 +120,10 @@ class TestConversationTenantIsolation:
             patch(
                 "app.repositories.conversation_repo.count_conversations",
                 new=AsyncMock(return_value=0),
+            ),
+            patch(
+                "app.services.conversation.channel_membership.confirmed_participant_threads",
+                new=AsyncMock(return_value=set()),
             ),
         ):
             svc = ConversationService(mock_db)

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -805,11 +805,19 @@ it is about to wait.
     somebody, with no backfill: the turn points at the chat account and the
     account gains a person.
 
-    **That list says who spoke, not who may read.** Participation is never
-    re-checked against the platform, so somebody removed from the channel there
-    keeps the thread in their list here — deliberately, and [#641][641] is what it
-    would take to change. Nothing may use it as an authorization check without
-    asking the platform first.
+    **Speaking is a claim; the platform decides whether it still holds.** The
+    turn record says who *spoke*, and before [#641][641] that was the whole
+    check — somebody removed from the channel kept reading the thread,
+    including everything said after they left. Now every participation claim is
+    confirmed against the platform's current membership (`getChatMember` on
+    Telegram, `conversations.members` on Slack, the per-user member lookup on
+    Mattermost) before the listing shows the thread and before it opens, behind
+    a shared Redis cache of about a minute. The check **fails closed**: a
+    platform that cannot answer, a bot that is gone, and a thread whose channel
+    nothing names any more — `/new` re-points the session at a fresh
+    conversation — all refuse participation rather than trust the claim. The
+    thread's owner and anybody it was explicitly shared with keep their access
+    regardless; the membership check gates participation and nothing else.
 
     **And it opens a thread rather than owning one.** Speaking in a room admits
     you to reading it; renaming it, archiving it, deleting it or appending a turn


### PR DESCRIPTION
## What this fixes

`/chat` showed a channel thread to everybody whose linked chat account had ever written in it, and never asked the platform again — so somebody removed from the channel kept the thread, including everything said after they left. A second access path to channel content that outlived the access the platform grants. Closes #641.

## What changed

- `backend/app/services/channels/base.py` — new `ChannelAdapter.is_channel_member`, a per-account membership question. Asked per account rather than read off `channel_members`, because that list cannot answer it: Telegram's is only the administrators, and Slack's/Mattermost's stop at `limit`.
- `backend/app/services/channels/{telegram,slack,mattermost}.py` — the three implementations: `getChatMember` (with `left`/`kicked` as gone and a `TelegramBadRequest` as never-here), paged `conversations.members` behind a runaway-cursor cap, `GET /channels/{id}/members/{user_id}` with 404 as an answer rather than a failure.
- `backend/app/services/channels/membership.py` (new, in the 100% gate) — the check behind a 60-second shared-Redis cache, the same `configure()` contract as `dedupe`/`rate_limit`. **Fails closed, loudly**: `ChannelDirectoryUnsupported`, a missing adapter, an unsealable token and an errored call all refuse, each logged; refusals are cached too, so a dead platform costs one timeout per TTL rather than one per listing.
- `backend/app/repositories/conversation.py` — the correlated `EXISTS` over `messages.channel_identity_id` is gone. `participation_claims` returns who-spoke-where (conversation, account, bot, chat), and the listing/count take an explicitly vetted id set whose default is empty — forgetting the participation step now hides a thread rather than showing it to somebody who was removed.
- `backend/app/services/conversation.py` — `_may_read` asks `membership.confirms_participation`; `list_conversations` vets once per page and hands the same set to the page and the count.
- `backend/app/main.py` — lifespan hands the shared Redis client over, and withdraws it on shutdown.
- `docs/channels.md` — the participant-model section now describes the check instead of the caveat.

## Decisions worth a look

- **A thread whose session moved on is unreachable via participation.** `/new` re-points `channel_sessions.conversation_id` at a fresh row, so the old thread names no channel anybody can ask about — and a claim that cannot be checked is refused (the issue's safe default). The owner and an explicit share keep access on every path, including after leaving the channel.
- **TTL is a constant (60 s), not a setting.** It is the window in which a removed member can still open the thread; if a deployment ever needs to tune it, promoting it to `config.py` is a two-line change.
- The membership question is deliberately **not a fourth registered agent tool** — agents keep `list_channel_members`; this is the platform asking about one `/chat` reader.

## How it failed before

Speak once in a Mattermost channel the bot is in, link the account, get removed from the channel — the thread stays in the `/chat` list and keeps updating with the room's conversation.

## Testing

- `tests/test_channel_membership.py` — new, the module at 100% (cache both ways, every refusal path, dedup of questions, deleted bot).
- `tests/test_channel_tools.py::TestIsChannelMember` — the three adapter implementations against stubbed clients, including Slack pagination and the page cap.
- `tests/integration/test_channel_thread_participants.py` — reworked to run the claims query, the session/bot joins and both service paths on real rows, stubbing only `membership.is_still_member` (the one call that would leave the process). Removal now loses both the listing and the read; fails on `main`.
- `make lint`, `make test` (4834 passed, platform gate at 100%), `make test-integration` (465 passed) — all green locally.

## Noticed, not fixed

- `#701` (already filed): a room thread with no recorded owner stays writable by the whole organization — unchanged here, the write path was not this issue's scope.
- Sits with #639 (participation model) and #131; the rule from #641's body — "`messages.channel_identity_id` says who spoke, not who may read" — is now enforced by code rather than by a comment.
