### PR TITLE
fix(channels): record a Mattermost webhook bot's server

### DIFF
--- a/backend/app/api/routes/v1/mattermost_webhook.py
+++ b/backend/app/api/routes/v1/mattermost_webhook.py
@@ -21,7 +21,7 @@ from app.api.deps import ChannelBotSvc
 from app.core.background import spawn
 from app.services.channel_bot import unseal_webhook_secret
 from app.services.channels import get_adapter
-from app.services.channels.mattermost import decode_webhook_body
+from app.services.channels.mattermost import MattermostAdapter, decode_webhook_body
 from app.worker.background.channel import process_channel_event
 
 logger = logging.getLogger(__name__)
@@ -52,6 +52,12 @@ async def mattermost_webhook(
     secret = unseal_webhook_secret(bot)
     if not secret or not adapter.verify_webhook_signature(dict(request.headers), secret, raw):
         raise HTTPException(status_code=403, detail="Invalid webhook token")
+
+    # A webhook-mode bot opens no stream, so this is the only place its server
+    # can reach the adapter - and the parser resolves attachment handles from
+    # it (#692). The isinstance narrows the registry's base type.
+    if isinstance(adapter, MattermostAdapter) and bot.api_base_url:
+        adapter.remember_server(str(bot_id), bot.api_base_url)
 
     incoming = adapter.parse_incoming(decode_webhook_body(raw), str(bot_id))
     if incoming is None:

--- a/backend/app/api/routes/v1/mattermost_webhook.py
+++ b/backend/app/api/routes/v1/mattermost_webhook.py
@@ -55,9 +55,11 @@ async def mattermost_webhook(
 
     # A webhook-mode bot opens no stream, so this is the only place its server
     # can reach the adapter - and the parser resolves attachment handles from
-    # it (#692). The isinstance narrows the registry's base type.
-    if isinstance(adapter, MattermostAdapter) and bot.api_base_url:
-        adapter.remember_server(str(bot_id), bot.api_base_url)
+    # it (#692). Mirrored even when empty, so clearing the row's address does
+    # not leave a stale one in the singleton map. The isinstance narrows the
+    # registry's base type.
+    if isinstance(adapter, MattermostAdapter):
+        adapter.remember_server(str(bot_id), bot.api_base_url or "")
 
     incoming = adapter.parse_incoming(decode_webhook_body(raw), str(bot_id))
     if incoming is None:

--- a/backend/app/services/channels/mattermost.py
+++ b/backend/app/services/channels/mattermost.py
@@ -735,10 +735,11 @@ class MattermostAdapter(ChannelAdapter):
             [part for part in raw_ids.split(",") if part] if isinstance(raw_ids, str) else raw_ids
         )
 
-        # The handle is the full URL, resolved here from the server this bot's
-        # stream was opened against. Every Mattermost deployment is somebody's own
-        # server, so the id alone is not enough to fetch anything - and the
-        # download signature carries a token, not a bot.
+        # The handle is the full URL, resolved from the server this bot was told
+        # about - by the stream when it opened, or by the webhook receiver per
+        # delivery (#692). Every Mattermost deployment is somebody's own server,
+        # so the id alone is not enough to fetch anything - and the download
+        # signature carries a token, not a bot.
         base_url = self._base_urls.get(bot_id, "")
 
         found: list[IncomingAttachment] = []
@@ -757,10 +758,10 @@ class MattermostAdapter(ChannelAdapter):
     async def download_attachment(self, bot_token: str, attachment: IncomingAttachment) -> bytes:
         """Fetch a Mattermost file from the URL the parser resolved.
 
-        Empty means this bot's server was not known when the message arrived - the
-        outgoing-webhook path never calls `remember_server` - and that is reported
-        rather than guessed at, because guessing a Mattermost address is guessing
-        which company's server to send a bot token to.
+        Empty means this bot's server was not known when the message arrived -
+        the bot row carries no `api_base_url` - and that is reported rather than
+        guessed at, because guessing a Mattermost address is guessing which
+        company's server to send a bot token to.
         """
         if not attachment.handle:
             raise ValueError(

--- a/backend/tests/test_channel_webhook_secret.py
+++ b/backend/tests/test_channel_webhook_secret.py
@@ -25,7 +25,8 @@ from app.db.models.channel_bot import ChannelBot
 from app.main import app
 from app.schemas.channel_bot import ChannelBotCreate, ChannelBotUpdate
 from app.services.channel_bot import ChannelBotService, unseal_webhook_secret
-from app.services.channels import register_adapter
+from app.services.channels import get_adapter, register_adapter
+from app.services.channels.base import IncomingMessage
 from app.services.channels.mattermost import MattermostAdapter
 from app.services.channels.telegram import TelegramAdapter
 
@@ -332,7 +333,7 @@ class TestTheReceiverRecordsTheServer:
     ):
         secret = "the-real-secret"
         bot = _sealed_bot(secret, api_base_url="https://mm.example.com/")
-        captured: list = []
+        captured: list[IncomingMessage] = []
 
         async def _record(incoming) -> None:
             captured.append(incoming)
@@ -360,3 +361,43 @@ class TestTheReceiverRecordsTheServer:
         assert len(captured) == 1
         handles = [attachment.handle for attachment in captured[0].attachments]
         assert handles == ["https://mm.example.com/api/v4/files/f1"]
+
+    async def test_clearing_the_bots_address_does_not_leave_a_stale_one_in_the_adapter(
+        self, client: AsyncClient
+    ):
+        """The adapter's map is process-wide state; the row is the truth. A bot
+        whose `api_base_url` was cleared must stop resolving attachments against
+        the address it used to have."""
+        secret = "the-real-secret"
+        bot = _sealed_bot(secret)
+        adapter = get_adapter("mattermost")
+        assert isinstance(adapter, MattermostAdapter)
+        adapter.remember_server(str(bot.id), "https://old.example.com")
+        captured: list[IncomingMessage] = []
+
+        async def _record(incoming) -> None:
+            captured.append(incoming)
+
+        app.dependency_overrides[deps.get_channel_bot_service] = lambda: _bot_service(bot)
+        try:
+            with patch("app.api.routes.v1.mattermost_webhook.process_channel_event", new=_record):
+                response = await client.post(
+                    f"/api/v1/mattermost/{bot.id}/webhook",
+                    json={
+                        "token": secret,
+                        "text": "what does this say",
+                        "user_id": "u-1",
+                        "user_name": "kacper",
+                        "channel_id": "c-1",
+                        "post_id": "p-1",
+                        "file_ids": "f1",
+                    },
+                )
+                assert response.status_code == 200
+                await background.drain(timeout=5.0)
+        finally:
+            app.dependency_overrides.pop(deps.get_channel_bot_service, None)
+
+        assert len(captured) == 1
+        handles = [attachment.handle for attachment in captured[0].attachments]
+        assert handles == [""]

--- a/backend/tests/test_channel_webhook_secret.py
+++ b/backend/tests/test_channel_webhook_secret.py
@@ -44,6 +44,7 @@ def _sealed_bot(
     *,
     platform: str = "mattermost",
     organization_id: uuid.UUID | None = None,
+    api_base_url: str | None = None,
 ) -> ChannelBot:
     """A bot row carrying `secret`, sealed for its own organization."""
     org_id = organization_id or uuid.uuid4()
@@ -54,6 +55,7 @@ def _sealed_bot(
         name="bot",
         token_encrypted="",
         secret_key_version=1,
+        api_base_url=api_base_url,
     )
     bot.webhook_secret_encrypted = (
         None if secret is None else seal(secret, scope=VaultScope.organization(org_id)).ciphertext
@@ -316,3 +318,45 @@ class TestTheReceiversRefuse:
             client, f"/api/v1/telegram/{uuid.uuid4()}/webhook", None, json={"update_id": 1}
         )
         assert status == 200
+
+
+@pytest.mark.usefixtures("registered_adapters")
+class TestTheReceiverRecordsTheServer:
+    """A webhook-mode bot opens no stream, so `remember_server` never ran for it
+    and every attachment parsed with an empty handle - the file could be named in
+    the reply but never fetched (#692). The receiver holds the bot row, so it is
+    the one place the address can reach the adapter on this transport."""
+
+    async def test_a_file_on_a_webhook_delivery_resolves_against_the_bots_own_server(
+        self, client: AsyncClient
+    ):
+        secret = "the-real-secret"
+        bot = _sealed_bot(secret, api_base_url="https://mm.example.com/")
+        captured: list = []
+
+        async def _record(incoming) -> None:
+            captured.append(incoming)
+
+        app.dependency_overrides[deps.get_channel_bot_service] = lambda: _bot_service(bot)
+        try:
+            with patch("app.api.routes.v1.mattermost_webhook.process_channel_event", new=_record):
+                response = await client.post(
+                    f"/api/v1/mattermost/{bot.id}/webhook",
+                    json={
+                        "token": secret,
+                        "text": "what does this say",
+                        "user_id": "u-1",
+                        "user_name": "kacper",
+                        "channel_id": "c-1",
+                        "post_id": "p-1",
+                        "file_ids": "f1",
+                    },
+                )
+                assert response.status_code == 200
+                await background.drain(timeout=5.0)
+        finally:
+            app.dependency_overrides.pop(deps.get_channel_bot_service, None)
+
+        assert len(captured) == 1
+        handles = [attachment.handle for attachment in captured[0].attachments]
+        assert handles == ["https://mm.example.com/api/v4/files/f1"]


### PR DESCRIPTION
## What this fixes

A Mattermost bot in webhook mode never had its server URL recorded, so every attachment on an outgoing-webhook post parsed with an empty handle and could not be fetched — the reply named the file and said it could not be downloaded. Closes #692.

## What changed

- `backend/app/api/routes/v1/mattermost_webhook.py` — after the token check and before the parse, the receiver tells the adapter the bot row's `api_base_url` via `remember_server`. Per delivery, which also keeps the address fresh when an operator edits the bot.
- `backend/app/services/channels/mattermost.py` — two docstrings that described the old behaviour ("the outgoing-webhook path never calls `remember_server`") corrected.
- `backend/tests/test_channel_webhook_secret.py` — route-level regression test; `_sealed_bot` grows an `api_base_url` parameter.

## How it failed before

The only writer of the adapter's per-bot address map was `remember_server`, reached through `open_inbound_stream` — which runs for polling bots only (`get_active_polling_bots` filters `webhook_mode.is_(False)`). A webhook-mode bot never appeared there, `_base_urls` had no entry, and `_attachments` produced `handle=""`. `download_attachment` refuses an empty handle by design — guessing a Mattermost address is guessing which company's server to send a bot token to.

Not a regression: before #547 the webhook parser read no `file_ids` at all, so the file was dropped silently. #547 made the failure visible; this makes the file reachable.

## Testing

- `tests/test_channel_webhook_secret.py::TestTheReceiverRecordsTheServer::test_a_file_on_a_webhook_delivery_resolves_against_the_bots_own_server` — fails on `main` with `[''] == ['https://mm.example.com/api/v4/files/f1']`, passes here. Goes through the actual route with a signed body, so it pins the wiring, not just the adapter.
- `tests/test_channel_webhook_secret.py`, `tests/test_mattermost_channel.py`, `tests/test_channel_adapter_attachments.py`, `tests/test_channel_supervisor.py` — 78 passed.
- `make lint-backend` clean.

## Noticed, not fixed

- The issue names the alternative — the server address stops being adapter-singleton state altogether — as #565's question (lift the channel transport boilerplate into `base.py`). Deliberately not taken here; the route-tells-the-adapter shape is the scoped fix and #565 can subsume it.
