### PR TITLE
fix(chat): stop storing a tool's raw retry text on the transcript row

### DIFF
--- a/backend/app/services/run_stream.py
+++ b/backend/app/services/run_stream.py
@@ -40,38 +40,9 @@ from pydantic_ai.messages import RetryPromptPart, TextPart, ThinkingPart, Thinki
 
 from app.services.agent_chat import display_output
 from app.services.chat_timeline import TurnTimeline
+from app.services.transcript import tool_retry_notice
 
 logger = logging.getLogger(__name__)
-
-
-def _tool_retry(part: RetryPromptPart) -> str:
-    """What a tool that asked the model to try again may tell the client.
-
-    The `tool_result` frame used to carry `str(part.content)`, and that content is
-    written by whichever tool raised: `web_search` turns a search provider's
-    failure into a `ModelRetry` built out of the `httpx` or SDK exception it
-    caught, so a broken key put "401 Unauthorized for url
-    'https://api.tavily.com/search'" - an endpoint, a host, and whatever the
-    query string held - in front of everyone watching the run (#681). An MCP
-    tool's retry is a third party's string entirely, which is why this is done
-    here rather than at each raise. Every surface streams through this module, so
-    the widget and a hosted page are covered by the same sentence web chat is.
-
-    The model still reads the retry whole: Pydantic AI puts the part into the
-    next request itself and nothing here touches that, so the detail that decides
-    whether it retries, switches tack or gives up is unchanged. Only the wire is
-    trimmed, and the tool's own text stays in the `logger.warning` beside the
-    send.
-
-    The tool's *name* still goes out, because it is what makes the frame worth
-    sending: a card that resolves saying which step failed is the difference from
-    one that spins for ever. `tool_name` is optional on the part - output
-    validation raises a retry that names no tool - hence the two forms.
-    """
-    called = f"The {part.tool_name} call" if part.tool_name else "A tool call"
-    return (
-        f"{called} failed and the model was asked to try again. The server log has the full error."
-    )
 
 
 type FrameSink = Callable[[str, dict[str, Any]], Awaitable[None]]
@@ -225,7 +196,7 @@ class RunFrames:
                         tool_event.tool_call_id,
                         tool_event.part.content,
                     )
-                    content = _tool_retry(tool_event.part)
+                    content = tool_retry_notice(tool_event.part)
                 else:
                     content = str(tool_event.part.content)
                 call = pending.get(tool_event.tool_call_id)

--- a/backend/app/services/transcript.py
+++ b/backend/app/services/transcript.py
@@ -133,6 +133,13 @@ def tool_calls_in(messages: Sequence[ModelMessage]) -> list[RecordedToolCall]:
     A `RetryPromptPart` counts as a result. A call the model was told to retry
     did happen and did fail, and dropping it would leave the transcript showing
     an argument list with no outcome - which reads as "still running" for ever.
+
+    A result whose call is not here is skipped rather than collected and then
+    dropped: it is :func:`settled_calls_in`'s to store, and reading it in both
+    places logged a settled retry's vendor text twice. Gating on `calls` is
+    sound because a result part sits in the `ModelRequest` that answers its
+    call's `ModelResponse`, so the call - when it is in these messages at all -
+    has always been seen first.
     """
     calls: dict[str, RecordedToolCall] = {}
     results: dict[str, str] = {}
@@ -144,7 +151,7 @@ def tool_calls_in(messages: Sequence[ModelMessage]) -> list[RecordedToolCall]:
                     tool_name=part.tool_name,
                     args=part.args_as_dict(raise_if_invalid=False),
                 )
-            elif isinstance(part, ToolReturnPart | RetryPromptPart):
+            elif isinstance(part, ToolReturnPart | RetryPromptPart) and part.tool_call_id in calls:
                 results[part.tool_call_id] = _result_text(part)
     return [
         RecordedToolCall(

--- a/backend/app/services/transcript.py
+++ b/backend/app/services/transcript.py
@@ -60,15 +60,65 @@ class RecordedToolCall:
         tool_name: What was called.
         args: What it was called with. Stored because "the agent sent an email"
             is not reviewable and "the agent sent an email to X" is.
-        result: What it returned, or the retry message when it failed. `None`
-            for a call that never returned - the run was parked on it, stopped,
-            or broke before it completed.
+        result: What it returned, or - when it failed - the notice that the
+            model was asked to retry, never the retry text itself
+            (:func:`_result_text`). `None` for a call that never returned - the
+            run was parked on it, stopped, or broke before it completed.
     """
 
     tool_call_id: str
     tool_name: str
     args: dict[str, Any]
     result: str | None = None
+
+
+def tool_retry_notice(part: RetryPromptPart) -> str:
+    """What a tool that asked the model to try again may tell a reader.
+
+    A retry's content is written by whichever tool raised: `web_search` turns a
+    search provider's failure into a `ModelRetry` built out of the `httpx` or
+    SDK exception it caught, so a broken key put "401 Unauthorized for url
+    'https://api.tavily.com/search'" - an endpoint, a host, and whatever the
+    query string held - in front of everyone watching the run (#681), and on
+    the tool-call row every member who can read the run opens weeks later
+    (#695). An MCP tool's retry is a third party's string entirely, which is
+    why this is one sentence at the two choke points rather than a rule at each
+    raise: `run_stream` sends it in the `tool_result` frame, and
+    :func:`_result_text` below stores it.
+
+    The model still reads the retry whole: Pydantic AI puts the part into the
+    next request itself and nothing here touches that, so the detail that
+    decides whether it retries, switches tack or gives up is unchanged. Only
+    what is shown and stored is trimmed, and the tool's own text stays in the
+    `logger.warning` beside the send or the write.
+
+    The tool's *name* still goes out, because it is what makes the frame worth
+    sending: a card that resolves saying which step failed is the difference
+    from one that spins for ever. `tool_name` is optional on the part - output
+    validation raises a retry that names no tool - hence the two forms.
+    """
+    called = f"The {part.tool_name} call" if part.tool_name else "A tool call"
+    return (
+        f"{called} failed and the model was asked to try again. The server log has the full error."
+    )
+
+
+def _result_text(part: ToolReturnPart | RetryPromptPart) -> str:
+    """What the row stores as the call's outcome.
+
+    A return is the tool's own answer and is stored whole. A retry's content is
+    written by whatever raised - `web_search` builds one out of the vendor
+    exception it caught, failing endpoint and query string included, and an MCP
+    tool's is a third party's string entirely - so the row holds the same
+    sentence the `tool_result` frame sends (#681) and the text itself goes to
+    the log beside the write, where run history read weeks later cannot reach
+    it (#695). The model is untouched either way: Pydantic AI carries the part
+    into the next request itself, and this function only decides what is stored.
+    """
+    if isinstance(part, RetryPromptPart):
+        logger.warning("Tool call %s asked the model to retry: %s", part.tool_call_id, part.content)
+        return tool_retry_notice(part)
+    return str(part.content)
 
 
 def tool_calls_in(messages: Sequence[ModelMessage]) -> list[RecordedToolCall]:
@@ -95,7 +145,7 @@ def tool_calls_in(messages: Sequence[ModelMessage]) -> list[RecordedToolCall]:
                     args=part.args_as_dict(raise_if_invalid=False),
                 )
             elif isinstance(part, ToolReturnPart | RetryPromptPart):
-                results[part.tool_call_id] = str(part.content)
+                results[part.tool_call_id] = _result_text(part)
     return [
         RecordedToolCall(
             tool_call_id=call.tool_call_id,
@@ -127,7 +177,7 @@ def settled_calls_in(messages: Sequence[ModelMessage]) -> dict[str, str]:
         if isinstance(part, ToolCallPart)
     }
     return {
-        part.tool_call_id: str(part.content)
+        part.tool_call_id: _result_text(part)
         for message in messages
         for part in message.parts
         if isinstance(part, ToolReturnPart | RetryPromptPart) and part.tool_call_id not in called

--- a/backend/tests/test_transcript.py
+++ b/backend/tests/test_transcript.py
@@ -232,6 +232,25 @@ class TestReadingWhatAnInheritedCallReturned:
         }
         assert vendor_text in caplog.text
 
+    def test_a_settled_retry_is_logged_once_across_both_readers(self, caplog):
+        """`agent_runner` reads one run's messages through both functions, so a
+        retry that settles an inherited call used to reach the log twice - once
+        from `tool_calls_in` collecting a result it then dropped, once from
+        here. One failure, one WARNING."""
+        vendor_text = "Client error '401 Unauthorized' for url 'https://api.tavily.com/search'"
+        messages = [
+            ModelRequest(
+                parts=[
+                    RetryPromptPart(content=vendor_text, tool_name="web_search", tool_call_id="c1")
+                ]
+            )
+        ]
+        with caplog.at_level(logging.WARNING, logger="app.services.transcript"):
+            assert tool_calls_in(messages) == []
+            assert "c1" in settled_calls_in(messages)
+
+        assert sum(vendor_text in record.getMessage() for record in caplog.records) == 1
+
 
 class TestWritingTheTranscript:
     @pytest.fixture

--- a/backend/tests/test_transcript.py
+++ b/backend/tests/test_transcript.py
@@ -17,6 +17,7 @@ opposite case, and it is written: the calls are what happened.
 
 from __future__ import annotations
 
+import logging
 import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -107,25 +108,48 @@ class TestReadingToolCallsOffARun:
             )
         ]
 
-    def test_a_call_the_model_was_told_to_retry_records_the_refusal(self):
-        """It happened and it failed. Dropping it would leave an argument list
-        with no outcome, which reads as "still running" for ever."""
+    def test_a_call_the_model_was_told_to_retry_records_a_notice_not_its_text(self, caplog):
+        """It happened and it failed, so dropping it would read as "still
+        running" for ever - but the retry text is written by whatever raised,
+        and `web_search` builds one out of the vendor exception it caught, so
+        storing it put the failing endpoint and its query string in a row every
+        member who can read the run sees weeks later (#695). The row names the
+        tool and the retry; the vendor's text goes to the log beside the write.
+        """
+        vendor_text = "Tavily search failed: 401 for url 'https://api.tavily.com/search?k=sk-9f2c'"
+        with caplog.at_level(logging.WARNING, logger="app.services.transcript"):
+            calls = tool_calls_in(
+                [
+                    _called("web_search", "c1", query="refunds"),
+                    ModelRequest(
+                        parts=[
+                            RetryPromptPart(
+                                content=vendor_text,
+                                tool_name="web_search",
+                                tool_call_id="c1",
+                            )
+                        ]
+                    ),
+                ]
+            )
+
+        assert calls[0].result == (
+            "The web_search call failed and the model was asked to try again. "
+            "The server log has the full error."
+        )
+        assert vendor_text in caplog.text
+
+    def test_a_return_holding_a_url_is_stored_whole(self):
+        """The success case is the tool's own answer, not a vendor's exception -
+        trimming it too would eat the results a person opens the run to read."""
         calls = tool_calls_in(
             [
-                _called("send_email", "c1", to="not-an-address"),
-                ModelRequest(
-                    parts=[
-                        RetryPromptPart(
-                            content="to is not a valid address",
-                            tool_name="send_email",
-                            tool_call_id="c1",
-                        )
-                    ]
-                ),
+                _called("web_search", "c1", query="refunds"),
+                _returned("web_search", "c1", "3 hits, best: https://example.com/refunds"),
             ]
         )
 
-        assert calls[0].result == "to is not a valid address"
+        assert calls[0].result == "3 hits, best: https://example.com/refunds"
 
     def test_a_call_that_never_came_back_has_no_result(self):
         """The run parked on it, was stopped, or broke. `None` is not the empty
@@ -181,22 +205,32 @@ class TestReadingWhatAnInheritedCallReturned:
 
         assert settled == {}
 
-    def test_a_refusal_settles_the_call_too(self):
-        """A call the model was told to retry did happen and did fail. Leaving the
-        row open would read as "still running" for ever."""
-        settled = settled_calls_in(
-            [
-                ModelRequest(
-                    parts=[
-                        RetryPromptPart(
-                            content="no such file", tool_name="execute", tool_call_id="c1"
-                        )
-                    ]
-                )
-            ]
-        )
+    def test_a_refusal_settles_the_call_with_a_notice_not_its_text(self, caplog):
+        """A call the model was told to retry did happen and did fail, so it
+        settles the row rather than leaving it "still running" for ever - but
+        with the same sentence :func:`tool_calls_in` stores, because the resume
+        shape writes to the same column the streaming shape does (#695)."""
+        vendor_text = "Client error '401 Unauthorized' for url 'https://api.tavily.com/search'"
+        with caplog.at_level(logging.WARNING, logger="app.services.transcript"):
+            settled = settled_calls_in(
+                [
+                    ModelRequest(
+                        parts=[
+                            RetryPromptPart(
+                                content=vendor_text, tool_name="web_search", tool_call_id="c1"
+                            )
+                        ]
+                    )
+                ]
+            )
 
-        assert settled == {"c1": "no such file"}
+        assert settled == {
+            "c1": (
+                "The web_search call failed and the model was asked to try again. "
+                "The server log has the full error."
+            )
+        }
+        assert vendor_text in caplog.text
 
 
 class TestWritingTheTranscript:


### PR DESCRIPTION
## What changed and why

#681 sanitized the chat `tool_result` **frame**; the transcript **row** was the same leak on the run paths that never open a socket — the HTTP API and the channel bots. `tool_calls_in` (`transcript.py`) and `settled_calls_in` both stored `str(part.content)` for a `RetryPromptPart`, and that content is written by whichever tool raised: `web_search` builds one straight from the vendor exception it caught, so a broken key put `Tavily search failed: Client error '401 Unauthorized' for url 'https://api.tavily.com/search'` — an endpoint, a host, and whatever the query string held — on a tool-call row rendered in conversation and run history to every member who can read the run, weeks later. An MCP tool's retry text is a third party's entirely, so the choke point is `transcript.py`, not each raise — the same conclusion #681 reached for the frame.

The stored row now holds the sentence the frame already sends — which tool failed and that the model was asked to retry — and the vendor's own text goes to a `logger.warning` beside the write, nowhere else. Concretely:

- `tool_retry_notice` (the sentence #681 built as `_tool_retry` in `run_stream.py`) **moved to `transcript.py` and became public**, because the reuse can only flow that way round: `run_stream` imports `agent_chat`, which imports `agent_runner`, which imports `transcript` — importing `run_stream` from `transcript` is a cycle. `run_stream` now imports the sentence back; the wire behaviour of #681 is unchanged.
- `_result_text` in `transcript.py` is the one place a part's content becomes a stored string on this path: a `ToolReturnPart` — the success case — is stored whole; a `RetryPromptPart` stores the notice and logs the text. Both `tool_calls_in` (streaming shape) and `settled_calls_in` (resume shape) go through it.
- The model still reads the retry whole: Pydantic AI carries the part into the next request itself, and nothing on this path touches `result.all_messages()` or the paused state — only what is stored changed.
- Mirrors `_tool_retry`'s behaviour exactly, including replacing our own controlled refusals: the frame already does, and one sentence at two choke points beats two rules.

## How verified

- Regression tests on both shapes **fail without the fix**: a `RetryPromptPart` whose content is a vendor-shaped exception string with a URL reaches the row as the notice naming the tool, not the URL, and the vendor text is asserted present in the log (`caplog`) — `test_a_call_the_model_was_told_to_retry_records_a_notice_not_its_text` (streaming shape) and `test_a_refusal_settles_the_call_with_a_notice_not_its_text` (resume shape).
- `test_a_return_holding_a_url_is_stored_whole` pins the boundary: a successful return with a URL in it is untouched.
- `make lint-backend` and `make test` green — 4797 passed, platform layer at 100%. Backend-only change; frontend targets not run. `scripts/docs_drift.py` reports nothing owed — no docs page describes the retry text (nor did #681 add one).

## Deliberately not taken

The issue asks whether `_turn_failed` (#659), this sentence (#681) and the run's own failure summary should live together — three sentences on one socket's worth of failures. They still live in three modules (`agent_session.py`, `transcript.py`, `agent_runner.py`'s `run_failure_summary`); consolidating them did not fall out of this diff naturally, so it is left as a possible follow-up rather than folded in here.

Closes #695
