### PR TITLE
fix(chat): name a caption-less turn's files in its user message

### DIFF
--- a/backend/app/services/transcript.py
+++ b/backend/app/services/transcript.py
@@ -134,6 +134,20 @@ def settled_calls_in(messages: Sequence[ModelMessage]) -> dict[str, str]:
     }
 
 
+def _what_arrived(attachments: Sequence[ChatFile]) -> str:
+    """The user turn's body when files arrived with no words around them.
+
+    A blank user message reads as somebody sending nothing, so a caption-less
+    upload names its files instead - the vocabulary `AttachmentRouter` already
+    uses for the model's briefing (#704). Only the names: the linked rows carry
+    the size and the type.
+    """
+    return "\n".join(
+        f"Attached {'image' if attachment.file_type == 'image' else 'file'}: {attachment.filename}"
+        for attachment in attachments
+    )
+
+
 class TranscriptService:
     """Writes a run's turns into the conversation the run belongs to."""
 
@@ -166,9 +180,13 @@ class TranscriptService:
         (/uploads/…, 43 KB, image)`. The dashboard's own uploads have been rows
         since they existed; a channel's became nothing at all.
 
-        An empty *prompt* is written when a file came with it, because a picture
-        posted with no caption is a turn: the row is what the file hangs off, and
-        without it the attachment belongs to nothing.
+        An empty *prompt* with a file beside it is a turn, because a picture
+        posted with no caption is one: the row is what the file hangs off, and
+        without it the attachment belongs to nothing. Its body names what
+        arrived rather than staying blank - an empty user message reads as
+        somebody sending nothing (#704). `None` is different from `""` here:
+        a resume passes `None` and no attachments, so it writes no user turn,
+        while an empty caption always arrives with the file that makes it one.
 
         An empty `answer` is written when the run called something, and skipped
         when it did not. A blank assistant message with nothing under it reads as
@@ -218,7 +236,7 @@ class TranscriptService:
                         self.db,
                         conversation_id=run.conversation_id,
                         role="user",
-                        content=prompt or "",
+                        content=prompt or _what_arrived(attachments),
                         run_id=run.id,
                         # Off the run rather than passed in: the run row already
                         # records which chat account asked, and a second route to

--- a/backend/tests/integration/test_channel_attachment_rows.py
+++ b/backend/tests/integration/test_channel_attachment_rows.py
@@ -145,6 +145,7 @@ class TestAFileThatArrivedWithATurn:
 
         The row is what the file hangs off, so skipping it because there were no
         words would lose the file - which is the original defect with an extra step.
+        The body names what arrived rather than staying blank (#704).
         """
         conversation = await _conversation(db)
         run = await _run(db, conversation)
@@ -156,5 +157,5 @@ class TestAFileThatArrivedWithATurn:
 
         written = await conversation_repo.get_messages_by_conversation(db, conversation.id)
         asked = written[0]
-        assert (asked.role, asked.content) == ("user", "")
+        assert (asked.role, asked.content) == ("user", "Attached image: report.png")
         assert [file.filename for file in asked.files] == ["report.png"]

--- a/backend/tests/integration/test_transcript_savepoint.py
+++ b/backend/tests/integration/test_transcript_savepoint.py
@@ -181,3 +181,52 @@ async def test_a_channel_turns_file_is_left_carrying_the_message_it_arrived_with
     ).scalar_one()
     linked = (await db.execute(select(ChatFile).where(ChatFile.id == stored.id))).scalar_one()
     assert linked.message_id == question.id
+
+
+async def test_a_captionless_turn_leaves_a_named_user_message_its_file_hangs_off(db) -> None:
+    """A photo posted with no words still reads as a turn somebody took.
+
+    An attachment that produces no prompt text - a caption-less image on an
+    agent with no workspace - used to jump the conversation straight to the
+    answer, leaving the `ChatFile` with `message_id` NULL. The user message is
+    written with a body naming what arrived, because a blank one reads as
+    somebody sending nothing (#704).
+    """
+    org, agent, version = await _org_and_agent(db)
+    sender = await _owner(db)
+    conversation = Conversation(
+        id=uuid.uuid4(), organization_id=org.id, user_id=sender.id, title="Telegram Chat"
+    )
+    db.add(conversation)
+    await db.flush()
+    run = AgentRun(
+        id=uuid.uuid4(),
+        organization_id=org.id,
+        agent_id=agent.id,
+        agent_version_id=version.id,
+        conversation_id=conversation.id,
+        status=RunStatus.COMPLETED.value,
+        surface=RunSurface.TELEGRAM.value,
+    )
+    db.add(run)
+    stored = ChatFile(
+        id=uuid.uuid4(),
+        user_id=sender.id,
+        filename="photo.jpg",
+        mime_type="image/jpeg",
+        size=1024,
+        storage_path=f"uploads/{uuid.uuid4().hex}.jpg",
+        file_type="image",
+    )
+    db.add(stored)
+    await db.flush()
+
+    await TranscriptService(db).record(run, prompt="", answer="A dashboard.", attachments=[stored])
+    await db.commit()
+
+    question = (
+        await db.execute(select(Message).where(Message.run_id == run.id, Message.role == "user"))
+    ).scalar_one()
+    linked = (await db.execute(select(ChatFile).where(ChatFile.id == stored.id))).scalar_one()
+    assert question.content == "Attached image: photo.jpg"
+    assert linked.message_id == question.id

--- a/backend/tests/test_surface_transcripts.py
+++ b/backend/tests/test_surface_transcripts.py
@@ -532,3 +532,60 @@ class TestTheDefaultAgentRecordsItsTranscript:
         linked = chat_files.link_to_message.await_args.kwargs
         assert linked["file_ids"] == [attachment.id]
         assert linked["message_id"] == user_message.id
+
+    async def test_a_captionless_image_on_a_workspaceless_agent_leaves_a_named_user_turn(
+        self,
+    ) -> None:
+        """A photo with no words under it, on an agent with no workspace, yields
+        no prompt text at all: the image reaches the model as bytes beside an
+        empty string. The turn still happened and was billed, so the transcript
+        holds a user message naming what arrived - not a blank one - and the
+        file hangs off it (#704).
+        """
+        exposure, agent = MagicMock(is_active=True), MagicMock(id=uuid.uuid4(), slug="support")
+        run = AsyncMock(return_value=_searched_then_answered("A dashboard."))
+        attachment = MagicMock(
+            id=uuid.uuid4(),
+            filename="photo.jpg",
+            file_type="image",
+            size=1024,
+            mime_type="image/jpeg",
+            storage_path=f"uploads/{uuid.uuid4().hex}.jpg",
+        )
+        user_message, assistant_message = MagicMock(id=uuid.uuid4()), MagicMock(id=uuid.uuid4())
+
+        with (
+            _run_yielding(run) as (_captured, conversations),
+            patch("app.services.transcript.chat_file_repo") as chat_files,
+            patch("app.services.attachments.get_file_storage") as storage,
+            patch(
+                "app.services.channels.mentions.agent_exposure_repo.list_active_for_bot",
+                new=AsyncMock(return_value=[(exposure, agent)]),
+            ),
+            patch(
+                "app.services.channels.mentions.member_repo.get",
+                new=AsyncMock(return_value=MagicMock(role="builder")),
+            ),
+            patch.object(
+                ChannelAgentRouter,
+                "_with_usage",
+                new=AsyncMock(side_effect=lambda _ctx, answer, _run, **_kw: answer),
+            ),
+        ):
+            storage.return_value.load = AsyncMock(return_value=b"\x89PNG")
+            conversations.create_message = AsyncMock(side_effect=[user_message, assistant_message])
+            chat_files.link_to_message = AsyncMock()
+            await ChannelAgentRouter(_db()).answer_default(
+                "",
+                platform="telegram",
+                organization_id=uuid.uuid4(),
+                bot_id=uuid.uuid4(),
+                user_id=uuid.uuid4(),
+                conversation_id=uuid.uuid4(),
+                platform_chat_id="123",
+                attachments=[attachment],
+            )
+
+        asked = conversations.create_message.await_args_list[0].kwargs
+        assert (asked["role"], asked["content"]) == ("user", "Attached image: photo.jpg")
+        assert chat_files.link_to_message.await_args.kwargs["message_id"] == user_message.id

--- a/backend/tests/test_transcript.py
+++ b/backend/tests/test_transcript.py
@@ -240,16 +240,40 @@ class TestWritingTheTranscript:
         ), "the file hangs off the turn that brought it, not off the answer"
 
     async def test_a_file_with_no_caption_still_gets_a_turn_to_hang_off(self, conversations, files):
-        """Somebody drops an image and says nothing. That is a turn."""
-        attachment = MagicMock(id=uuid.uuid4())
+        """Somebody drops an image and says nothing. That is a turn, and its body
+        names what arrived: a blank user message reads as somebody sending
+        nothing (#704)."""
+        attachment = MagicMock(id=uuid.uuid4(), file_type="image", filename="screenshot.png")
 
         await TranscriptService(_session()).record(
             _run(), prompt="", answer="A dashboard.", attachments=[attachment]
         )
 
         asked = conversations.create_message.await_args_list[0].kwargs
-        assert (asked["role"], asked["content"]) == ("user", "")
+        assert (asked["role"], asked["content"]) == ("user", "Attached image: screenshot.png")
         assert files.link_to_message.await_args.kwargs["file_ids"] == [attachment.id]
+
+    async def test_a_captionless_turn_names_every_file_it_brought(self, conversations, files):
+        image = MagicMock(id=uuid.uuid4(), file_type="image", filename="photo.jpg")
+        sheet = MagicMock(id=uuid.uuid4(), file_type="spreadsheet", filename="q3.xlsx")
+
+        await TranscriptService(_session()).record(
+            _run(), prompt="", answer="Looked at both.", attachments=[image, sheet]
+        )
+
+        asked = conversations.create_message.await_args_list[0].kwargs
+        assert asked["content"] == "Attached image: photo.jpg\nAttached file: q3.xlsx"
+
+    async def test_a_caption_is_the_users_words_and_is_never_replaced(self, conversations, files):
+        """The naming is for a turn that said nothing; a caption stays verbatim."""
+        attachment = MagicMock(id=uuid.uuid4(), file_type="image", filename="photo.jpg")
+
+        await TranscriptService(_session()).record(
+            _run(), prompt="co tu widzisz", answer="A dashboard.", attachments=[attachment]
+        )
+
+        asked = conversations.create_message.await_args_list[0].kwargs
+        assert asked["content"] == "co tu widzisz"
 
     async def test_a_turn_that_arrived_with_nothing_links_nothing(self, conversations, files):
         """And does not open a savepoint to say so.

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -1148,7 +1148,10 @@ had no attachment field, so no adapter parsed one and the agent answered about a
 document it never received. Now a message with a file — with or without a caption —
 reaches the agent the same way a web upload does, and is **read back the same way**:
 the file is a row on the turn it arrived with, so the thread in `/chat` shows a card
-rather than the briefing the model was given about it.
+rather than the briefing the model was given about it. A caption-less upload is
+still a turn, and its message names what arrived — `Attached image: photo.jpg` —
+rather than sitting blank above the card, because a blank user message reads as
+somebody sending nothing.
 
 **On every transport, because each adapter has exactly one parser.** Each platform
 has two ways in — a webhook and a stream, or long-polling — and the second one used


### PR DESCRIPTION
## What this fixes

Closes #704, and completes the remainder PR #703 deliberately left: a channel
turn whose attachment produced no prompt text now leaves a user message that
names what arrived, and the `ChatFile` row hangs off it.

Since #634/#703, `TranscriptService.record` already wrote the user turn under
`if prompt or attachments:` and linked the files — so the linking half of the
issue holds on `main`, and so does the `None`/`""` split the issue asks for: a
resume passes `None` and no attachments and writes no user turn, while an
empty caption always arrives with the file that makes it a turn. What remained
was the body. `content=prompt or ""` wrote a **blank** user message for a
caption-less upload, and a blank user message reads as somebody sending
nothing: the thread in `/chat` jumped straight to the answer, with the file
card as the only trace of the question.

## The choice, as the issue asked

Between "make the empty-text routings yield a textual reference" and
"distinguish the cases through the record path", this takes the **record
path**: since the `said` refactor (#634) the transcript records what the
person wrote, never the assembled prompt, so a reference added in
`AttachmentRouter.build_prompt` reaches only the model and would not have
touched the transcript at all. `record` is also the one write every
non-streaming surface reaches — the same reason the transcript and the #703
link live there.

`record` now composes the empty turn's body from its attachments —
`Attached image: photo.jpg`, one line per file — reusing the vocabulary
`build_prompt` already writes into the model's briefing, so the two compose
rather than diverge. A caption is never replaced; the naming fills only the
turn that said nothing. Web chat already does the equivalent in its composer
(`trimmed || t("analyzeFiles")`), so channels stop being the one surface with
blank turns.

## How it failed before

1. Send a Telegram bot a photo with no caption; its agent has no workspace.
2. The agent answers about the image.
3. The conversation shows a blank user bubble (the run and link were already
   recorded since #634/#703 — the issue's "no user turn at all" described the
   pre-#634 tree).

## Verified

- All new tests fail without the one-line fix in `transcript.py`.
- `backend/tests/test_surface_transcripts.py` — the issue's exact sequence
  through the real entry point: `ChannelAgentRouter.answer_default` with empty
  text and an inline image on a workspace-less agent (the router yields
  `["", BinaryContent]`), asserting the user message is named and the
  `ChatFile` links to *that* message.
- `backend/tests/test_transcript.py` — the named body for one file, for
  several (image and non-image), a caption surviving verbatim, and the
  existing `test_a_resumed_run_writes_no_user_turn` still pinning the resume
  half.
- `backend/tests/integration/test_transcript_savepoint.py` and
  `test_channel_attachment_rows.py` — both columns read back from a real
  Postgres: the message content and the `chat_files.message_id`.
- `make lint-backend` green. `make test` green: 4799 passed, platform layer at
  100%. The two tests that pinned the old blank body were updated to pin the
  named one.
- `docs/channels.md` § Files: one sentence saying a caption-less turn's
  message names its files.

## Noticed, not fixed

- **#746 (new, filed from this work)** — `attachments.py:208/:238` still hand
  the model nothing for a routing failure or an unparsed file on a
  workspace-less agent, so the agent denies receiving a file the transcript
  now names. Model-side, outside #704's acceptance criteria.

Closes #704
