### PR TITLE
fix(chat): refuse linking a file the caller does not own

### DIFF
--- a/backend/app/repositories/chat_file.py
+++ b/backend/app/repositories/chat_file.py
@@ -15,21 +15,46 @@ async def get_by_id(db: AsyncSession, file_id: UUID) -> ChatFile | None:
     return await db.get(ChatFile, file_id)
 
 
-async def get_many(db: AsyncSession, file_ids: Iterable[UUID]) -> list[ChatFile]:
-    """Batch-load multiple chat files by IDs."""
+async def get_many(db: AsyncSession, file_ids: Iterable[UUID], *, user_id: UUID) -> list[ChatFile]:
+    """Batch-load `user_id`'s chat files by IDs.
+
+    The ids come off client payloads, and `chat_files` carries no organization,
+    so `user_id` is the only scope a row has: another user's id resolves to
+    nothing here rather than to their row (#706).
+    """
     ids = list(file_ids)
     if not ids:
         return []
-    result = await db.execute(select(ChatFile).where(ChatFile.id.in_(ids)))
+    result = await db.execute(
+        select(ChatFile).where(ChatFile.id.in_(ids), ChatFile.user_id == user_id)
+    )
     return list(result.scalars().all())
 
 
-async def link_to_message(db: AsyncSession, *, message_id: UUID, file_ids: Iterable[UUID]) -> None:
-    """Link multiple chat files to a message by setting message_id on each."""
+async def link_to_message(
+    db: AsyncSession, *, message_id: UUID, file_ids: Iterable[UUID], user_id: UUID
+) -> None:
+    """Link `user_id`'s unlinked chat files to a message.
+
+    The WHERE carries both halves of the rule rather than trusting the caller:
+    without them this was a blind bulk update, so a turn naming another user's
+    file id put their filename on its own message and silently pulled the file
+    off the message it already hung on (#706). An id the predicates exclude is
+    skipped here; a caller that must refuse it reads the rows first
+    (`ConversationService.link_files_to_message`).
+    """
     ids = list(file_ids)
     if not ids:
         return
-    await db.execute(sql_update(ChatFile).where(ChatFile.id.in_(ids)).values(message_id=message_id))
+    await db.execute(
+        sql_update(ChatFile)
+        .where(
+            ChatFile.id.in_(ids),
+            ChatFile.user_id == user_id,
+            ChatFile.message_id.is_(None),
+        )
+        .values(message_id=message_id)
+    )
     await db.flush()
 
 

--- a/backend/app/repositories/chat_file.py
+++ b/backend/app/repositories/chat_file.py
@@ -33,20 +33,21 @@ async def get_many(db: AsyncSession, file_ids: Iterable[UUID], *, user_id: UUID)
 
 async def link_to_message(
     db: AsyncSession, *, message_id: UUID, file_ids: Iterable[UUID], user_id: UUID
-) -> None:
-    """Link `user_id`'s unlinked chat files to a message.
+) -> int:
+    """Link `user_id`'s unlinked chat files to a message, answering how many moved.
 
     The WHERE carries both halves of the rule rather than trusting the caller:
     without them this was a blind bulk update, so a turn naming another user's
     file id put their filename on its own message and silently pulled the file
     off the message it already hung on (#706). An id the predicates exclude is
     skipped here; a caller that must refuse it reads the rows first
-    (`ConversationService.link_files_to_message`).
+    (`ConversationService.link_files_to_message`) - and compares the count,
+    because a concurrent turn can take a row between that read and this UPDATE.
     """
     ids = list(file_ids)
     if not ids:
-        return
-    await db.execute(
+        return 0
+    result = await db.execute(
         sql_update(ChatFile)
         .where(
             ChatFile.id.in_(ids),
@@ -56,6 +57,9 @@ async def link_to_message(
         .values(message_id=message_id)
     )
     await db.flush()
+    # `execute` is typed to return `Result`, which has no `rowcount`; a DML
+    # statement actually returns `CursorResult`, which does (see resource_grant).
+    return result.rowcount  # ty: ignore[unresolved-attribute]
 
 
 async def delete(db: AsyncSession, *, db_file: ChatFile) -> None:

--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -199,7 +199,10 @@ async def persist_user_turn(
     caller closes that gap once the run row is open.
 
     Raises:
-        BadRequestError: If `requested_conversation_id` is not a UUID.
+        BadRequestError: If `requested_conversation_id` is not a UUID, or a
+            file in `file_ids` is already attached to a message.
+        NotFoundError: If a file in `file_ids` is not the caller's own -
+            another user's id answers like one that does not exist (#706).
         AuthorizationError: If the requested conversation is not this
             organization's. A database failure is logged and swallowed - a lost
             message must not abort a turn - but a refusal must abort, and a
@@ -250,7 +253,12 @@ async def persist_user_turn(
             message_id = user_msg.id
             if file_ids:
                 try:
-                    await conv_service.link_files_to_message(user_msg.id, file_ids)
+                    await conv_service.link_files_to_message(user_msg.id, file_ids, user_id=user.id)
+                except AppException:
+                    # A refusal - an id that is not the caller's own unlinked
+                    # upload - must abort the turn, not read as a transient
+                    # persistence failure (#706).
+                    raise
                 except Exception as e:
                     logger.warning("Failed to link files: %s", e)
     except AppException:

--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -200,7 +200,7 @@ async def persist_user_turn(
 
     Raises:
         BadRequestError: If `requested_conversation_id` is not a UUID, or a
-            file in `file_ids` is already attached to a message.
+            file in `file_ids` is not one, or is already attached to a message.
         NotFoundError: If a file in `file_ids` is not the caller's own -
             another user's id answers like one that does not exist (#706).
         AuthorizationError: If the requested conversation is not this

--- a/backend/app/services/agent_session.py
+++ b/backend/app/services/agent_session.py
@@ -494,7 +494,7 @@ class AgentSession:
         if not file_ids:
             return []
         async with get_db_context() as file_db:
-            return await load_attached_files(file_db, file_ids)
+            return await load_attached_files(file_db, file_ids, user_id=self.user.id)
 
     async def _frame(self, kind: str, payload: dict[str, Any]) -> None:
         """Where this surface's frames go: to the member who is watching.

--- a/backend/app/services/attachments.py
+++ b/backend/app/services/attachments.py
@@ -23,6 +23,7 @@ import logging
 import re
 from dataclasses import dataclass
 from typing import Any
+from uuid import UUID
 
 from pydantic_ai.messages import BinaryContent
 from pydantic_ai_backends import AsyncBackendProtocol, BackendProtocol, ensure_async
@@ -305,8 +306,8 @@ class AttachmentRouter:
         return BinaryContent(data=data, media_type=chat_file.mime_type)
 
 
-async def load_attached_files(db: Any, file_ids: list[str]) -> list[ChatFile]:
-    """The rows behind the ids a client sent with its message."""
+async def load_attached_files(db: Any, file_ids: list[str], *, user_id: UUID) -> list[ChatFile]:
+    """The rows behind the ids a client sent with its message, scoped to the sender (#706)."""
     from app.api.deps import get_conversation_service
 
-    return await get_conversation_service(db).list_attached_files(file_ids)
+    return await get_conversation_service(db).list_attached_files(file_ids, user_id=user_id)

--- a/backend/app/services/conversation.py
+++ b/backend/app/services/conversation.py
@@ -601,12 +601,39 @@ class ConversationService:
             success=data.success,
         )
 
-    async def link_files_to_message(self, message_id: UUID, file_ids: list[str]) -> None:
+    async def link_files_to_message(
+        self, message_id: UUID, file_ids: list[str], *, user_id: UUID
+    ) -> None:
+        """Attach `user_id`'s own unlinked files to a message, refusing anything else.
+
+        The ids come off a socket payload, so each must resolve to the caller's
+        own *unlinked* row: a foreign id would render another user's filename in
+        this conversation and silently pull the file off the message it already
+        hangs on (#706). Refused, never narrowed - a turn that quietly dropped an
+        attachment would read as an agent ignoring the file it was asked about.
+        A file that is not the caller's answers exactly like one that does not
+        exist, so an id cannot be probed for whether it is taken.
+        """
+        ids = [UUID(fid) for fid in file_ids]
+        if not ids:
+            return
+        rows = await chat_file_repo.get_many(self.db, ids, user_id=user_id)
+        found = {row.id for row in rows}
+        missing = sorted(fid for fid in set(ids) if fid not in found)
+        if missing:
+            raise NotFoundError(message="File not found", details={"file_ids": missing})
+        taken = sorted(row.id for row in rows if row.message_id is not None)
+        if taken:
+            raise BadRequestError(
+                message="File is already attached to a message",
+                details={"file_ids": taken},
+            )
         await chat_file_repo.link_to_message(
-            self.db,
-            message_id=message_id,
-            file_ids=[UUID(fid) for fid in file_ids],
+            self.db, message_id=message_id, file_ids=ids, user_id=user_id
         )
 
-    async def list_attached_files(self, file_ids: list[str]) -> list[Any]:
-        return await chat_file_repo.get_many(self.db, [UUID(fid) for fid in file_ids])
+    async def list_attached_files(self, file_ids: list[str], *, user_id: UUID) -> list[Any]:
+        """The caller's rows behind the ids a client sent; anybody else's resolve to nothing (#706)."""
+        return await chat_file_repo.get_many(
+            self.db, [UUID(fid) for fid in file_ids], user_id=user_id
+        )

--- a/backend/app/services/conversation.py
+++ b/backend/app/services/conversation.py
@@ -55,6 +55,23 @@ type OrgScope = UUID | Literal["unscoped"]
 """A tenant to check against, or an explicit refusal to check one."""
 
 
+def _file_uuids(file_ids: Sequence[str]) -> tuple[list[UUID], list[str]]:
+    """Parse client-sent file ids, naming the ones that are not UUIDs at all.
+
+    `str()` first, because the socket payload is untyped JSON: a number or a
+    null in the list must land in `malformed`, not raise a `TypeError` past
+    the refusal written for it.
+    """
+    ids: list[UUID] = []
+    malformed: list[str] = []
+    for fid in file_ids:
+        try:
+            ids.append(UUID(str(fid)))
+        except ValueError:
+            malformed.append(str(fid))
+    return ids, malformed
+
+
 class ConversationService:
     def __init__(self, db: AsyncSession):
         self.db = db
@@ -612,9 +629,14 @@ class ConversationService:
         hangs on (#706). Refused, never narrowed - a turn that quietly dropped an
         attachment would read as an agent ignoring the file it was asked about.
         A file that is not the caller's answers exactly like one that does not
-        exist, so an id cannot be probed for whether it is taken.
+        exist, so an id cannot be probed for whether it is taken. An id that is
+        not a UUID at all is refused the same loud way: a `ValueError` here used
+        to fall into the caller's infrastructure net and resurface a step later
+        as a generic failed turn, after the message had already been persisted.
         """
-        ids = [UUID(fid) for fid in file_ids]
+        ids, malformed = _file_uuids(file_ids)
+        if malformed:
+            raise BadRequestError(message="Invalid file id", details={"file_ids": malformed})
         if not ids:
             return
         rows = await chat_file_repo.get_many(self.db, ids, user_id=user_id)
@@ -628,9 +650,18 @@ class ConversationService:
                 message="File is already attached to a message",
                 details={"file_ids": taken},
             )
-        await chat_file_repo.link_to_message(
+        linked = await chat_file_repo.link_to_message(
             self.db, message_id=message_id, file_ids=ids, user_id=user_id
         )
+        if linked != len(set(ids)):
+            # The read above and the UPDATE are two statements, so a concurrent
+            # turn naming the same file can take a row between them; the count
+            # is what turns that race into the same refusal instead of a message
+            # that quietly lost its attachment (#706).
+            raise BadRequestError(
+                message="File is already attached to a message",
+                details={"file_ids": sorted(set(ids))},
+            )
 
     async def list_attached_files(self, file_ids: list[str], *, user_id: UUID) -> list[Any]:
         """The caller's rows behind the ids a client sent; anybody else's resolve to nothing (#706)."""

--- a/backend/app/services/embed_session.py
+++ b/backend/app/services/embed_session.py
@@ -539,10 +539,10 @@ class EmbedSession:
 
         Two conditions, and between them they are what stops a frame from
         attaching a file that is not this visitor's to attach. The row must belong
-        to the member who published this embed - which is who
-        `accept_upload` attributes an upload to - and it must not already hang off
-        a message, so a file cannot be replayed into a second turn or into somebody
-        else's thread.
+        to the member who published this embed - which is who `accept_upload`
+        attributes an upload to, and is the owner the repository read is scoped
+        by (#706) - and it must not already hang off a message, so a file cannot
+        be replayed into a second turn or into somebody else's thread.
 
         That is proportionate rather than complete, and the reason it is enough is
         the id: `uuid4` is 122 random bits, so "an id from another visitor" is a
@@ -551,16 +551,18 @@ class EmbedSession:
         that exists to re-state what the message it ends up on already says.
 
         A dropped id is logged and the turn goes ahead. The alternative is refusing
-        somebody their answer over a stale id in a composer.
+        somebody their answer over a stale id in a composer. A page whose
+        publisher's account is gone owns no rows at all - `accept_upload` already
+        refuses new files on one - so every id it names drops the same way.
         """
         if not attached:
             return []
-        rows = await chat_file_repo.get_many(db, attached)
-        usable = [
-            row
-            for row in rows
-            if row.user_id == self.embed.owner_user_id and row.message_id is None
-        ]
+        rows = (
+            []
+            if self.embed.owner_user_id is None
+            else await chat_file_repo.get_many(db, attached, user_id=self.embed.owner_user_id)
+        )
+        usable = [row for row in rows if row.message_id is None]
         if len(usable) != len(attached):
             logger.info(
                 "embed_attachment_refused",

--- a/backend/app/services/transcript.py
+++ b/backend/app/services/transcript.py
@@ -260,16 +260,27 @@ class TranscriptService:
 
         Nothing when nothing was attached - a SAVEPOINT and its release on every
         turn in the deployment is a real cost for a list that is usually empty.
+
+        The link is scoped to each row's own uploader, because the repository
+        refuses to move anybody else's file (#706). The rows here were stored by
+        `ChannelAttachmentService.receive` for the turn's sender, so grouping by
+        owner is one UPDATE in practice - it only splits if a caller ever hands
+        it rows from more than one uploader.
         """
         if not attachments:
             return
+        by_owner: dict[UUID, list[UUID]] = {}
+        for attachment in attachments:
+            by_owner.setdefault(attachment.user_id, []).append(attachment.id)
         try:
             async with self.db.begin_nested():
-                await chat_file_repo.link_to_message(
-                    self.db,
-                    message_id=message_id,
-                    file_ids=[attachment.id for attachment in attachments],
-                )
+                for owner_id, ids in by_owner.items():
+                    await chat_file_repo.link_to_message(
+                        self.db,
+                        message_id=message_id,
+                        file_ids=ids,
+                        user_id=owner_id,
+                    )
         except Exception:
             logger.exception("transcript_file_link_failed", extra={"message_id": str(message_id)})
 

--- a/backend/tests/integration/test_chat_file_ownership.py
+++ b/backend/tests/integration/test_chat_file_ownership.py
@@ -1,0 +1,200 @@
+"""A chat turn may attach only the caller's own unlinked files.
+
+`chat_file_repo.link_to_message` was a blind bulk UPDATE - no owner predicate
+and no unlinked check - and the ids reach it straight off the socket payload.
+So a turn naming another user's file id rendered that user's filename in its
+own conversation, and silently pulled the file off the message it already hung
+on, rewriting the victim's transcript (#706). `chat_files` carries no
+organization, so `user_id` is the only scope a row has.
+
+These run against a real database because the defect is in a WHERE clause: the
+unit tests prove what the service refuses, and only reading the columns back
+proves the victim's row survived the attempt.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from app.core.exceptions import BadRequestError, NotFoundError
+from app.db.models.chat_file import ChatFile
+from app.db.models.conversation import Conversation, Message
+from app.db.models.organization import Organization
+from app.db.models.user import User
+from app.repositories import chat_file as chat_file_repo
+from app.services.conversation import ConversationService
+
+pytestmark = pytest.mark.anyio
+
+
+async def _member(db) -> User:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"{uuid.uuid4().hex}@example.com",
+        hashed_password="x",
+        is_active=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _message(db, owner: User) -> Message:
+    founder = await _member(db)
+    organization = Organization(
+        id=uuid.uuid4(),
+        name="Acme",
+        slug=f"acme-{uuid.uuid4().hex[:8]}",
+        created_by_user_id=founder.id,
+    )
+    db.add(organization)
+    await db.flush()
+    conversation = Conversation(
+        id=uuid.uuid4(),
+        user_id=owner.id,
+        organization_id=organization.id,
+        title="Quarterly numbers",
+    )
+    db.add(conversation)
+    await db.flush()
+    message = Message(id=uuid.uuid4(), conversation_id=conversation.id, role="user", content="here")
+    db.add(message)
+    await db.flush()
+    return message
+
+
+async def _upload(db, owner: User, *, filename: str = "salaries.xlsx") -> ChatFile:
+    chat_file = ChatFile(
+        id=uuid.uuid4(),
+        user_id=owner.id,
+        filename=filename,
+        mime_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        size=64,
+        storage_path=f"uploads/{uuid.uuid4().hex}.xlsx",
+        file_type="spreadsheet",
+    )
+    db.add(chat_file)
+    await db.flush()
+    return chat_file
+
+
+async def _reloaded(db, file_id: uuid.UUID) -> ChatFile:
+    return (
+        await db.execute(
+            select(ChatFile).where(ChatFile.id == file_id).execution_options(populate_existing=True)
+        )
+    ).scalar_one()
+
+
+class TestLinkingAnotherUsersFile:
+    async def test_it_is_refused_and_their_message_keeps_it(self, db) -> None:
+        """The issue's sequence, both consequences read back: the attacker gets a
+        refusal instead of the victim's filename on their message, and the
+        victim's own message still carries the file."""
+        victim = await _member(db)
+        theirs = await _message(db, victim)
+        stolen = await _upload(db, victim)
+        await chat_file_repo.link_to_message(
+            db, message_id=theirs.id, file_ids=[stolen.id], user_id=victim.id
+        )
+
+        attacker = await _member(db)
+        mine = await _message(db, attacker)
+
+        with pytest.raises(NotFoundError):
+            await ConversationService(db).link_files_to_message(
+                mine.id, [str(stolen.id)], user_id=attacker.id
+            )
+
+        assert (await _reloaded(db, stolen.id)).message_id == theirs.id
+        on_my_message = (
+            (await db.execute(select(ChatFile).where(ChatFile.message_id == mine.id)))
+            .scalars()
+            .all()
+        )
+        assert on_my_message == []
+
+    async def test_an_unlinked_file_is_refused_the_same_way(self, db) -> None:
+        """The metadata-disclosure half needs no linked message: a fresh upload's
+        filename must not be attachable to a stranger's conversation either. And
+        missing, not forbidden - "not yours" would confirm the id exists."""
+        victim = await _member(db)
+        fresh = await _upload(db, victim)
+        attacker = await _member(db)
+        mine = await _message(db, attacker)
+
+        with pytest.raises(NotFoundError):
+            await ConversationService(db).link_files_to_message(
+                mine.id, [str(fresh.id)], user_id=attacker.id
+            )
+
+        assert (await _reloaded(db, fresh.id)).message_id is None
+
+    async def test_the_update_itself_skips_a_foreign_row(self, db) -> None:
+        """The owner is in the UPDATE's WHERE, not only in the service's read -
+        so a caller that skips the read, as the channel transcript does, still
+        cannot move another user's file."""
+        victim = await _member(db)
+        fresh = await _upload(db, victim)
+        attacker = await _member(db)
+        mine = await _message(db, attacker)
+
+        await chat_file_repo.link_to_message(
+            db, message_id=mine.id, file_ids=[fresh.id], user_id=attacker.id
+        )
+
+        assert (await _reloaded(db, fresh.id)).message_id is None
+
+
+class TestTheLegitimatePaths:
+    async def test_the_callers_own_upload_still_links(self, db) -> None:
+        owner = await _member(db)
+        message = await _message(db, owner)
+        upload = await _upload(db, owner, filename="report.xlsx")
+
+        await ConversationService(db).link_files_to_message(
+            message.id, [str(upload.id)], user_id=owner.id
+        )
+
+        assert (await _reloaded(db, upload.id)).message_id == message.id
+
+    async def test_relinking_the_callers_own_file_is_refused_and_the_row_stays(self, db) -> None:
+        """The re-link decision: a file on a message never moves, not even for
+        its owner. No caller legitimately re-links - web chat links fresh uploads
+        once, channel rows are created unlinked in the same turn, and the embed
+        already drops a spent id - so the silent move only ever rewrote history."""
+        owner = await _member(db)
+        first = await _message(db, owner)
+        second = await _message(db, owner)
+        upload = await _upload(db, owner)
+        await chat_file_repo.link_to_message(
+            db, message_id=first.id, file_ids=[upload.id], user_id=owner.id
+        )
+
+        with pytest.raises(BadRequestError):
+            await ConversationService(db).link_files_to_message(
+                second.id, [str(upload.id)], user_id=owner.id
+            )
+
+        assert (await _reloaded(db, upload.id)).message_id == first.id
+
+
+class TestReadingAttachments:
+    async def test_the_read_is_scoped_to_the_caller(self, db) -> None:
+        """`get_many` filtered on id alone, which is the disclosure half: the
+        victim's filename, MIME type and size rendered in the attacker's
+        conversation. A foreign id now resolves to nothing."""
+        victim = await _member(db)
+        fresh = await _upload(db, victim)
+        attacker = await _member(db)
+
+        rows = await ConversationService(db).list_attached_files(
+            [str(fresh.id)], user_id=attacker.id
+        )
+
+        assert rows == []
+        mine = await ConversationService(db).list_attached_files([str(fresh.id)], user_id=victim.id)
+        assert [row.id for row in mine] == [fresh.id]

--- a/backend/tests/integration/test_chat_file_ownership.py
+++ b/backend/tests/integration/test_chat_file_ownership.py
@@ -97,8 +97,11 @@ class TestLinkingAnotherUsersFile:
         victim = await _member(db)
         theirs = await _message(db, victim)
         stolen = await _upload(db, victim)
-        await chat_file_repo.link_to_message(
-            db, message_id=theirs.id, file_ids=[stolen.id], user_id=victim.id
+        assert (
+            await chat_file_repo.link_to_message(
+                db, message_id=theirs.id, file_ids=[stolen.id], user_id=victim.id
+            )
+            == 1
         )
 
         attacker = await _member(db)
@@ -133,19 +136,21 @@ class TestLinkingAnotherUsersFile:
 
         assert (await _reloaded(db, fresh.id)).message_id is None
 
-    async def test_the_update_itself_skips_a_foreign_row(self, db) -> None:
+    async def test_the_update_itself_skips_a_foreign_row_and_says_so(self, db) -> None:
         """The owner is in the UPDATE's WHERE, not only in the service's read -
         so a caller that skips the read, as the channel transcript does, still
-        cannot move another user's file."""
+        cannot move another user's file. The count answers zero, which is how
+        the service tells a row taken in the race window from a linked one."""
         victim = await _member(db)
         fresh = await _upload(db, victim)
         attacker = await _member(db)
         mine = await _message(db, attacker)
 
-        await chat_file_repo.link_to_message(
+        linked = await chat_file_repo.link_to_message(
             db, message_id=mine.id, file_ids=[fresh.id], user_id=attacker.id
         )
 
+        assert linked == 0
         assert (await _reloaded(db, fresh.id)).message_id is None
 
 

--- a/backend/tests/test_agent_org_scope.py
+++ b/backend/tests/test_agent_org_scope.py
@@ -317,6 +317,88 @@ class TestPersistUserTurnOrgScope:
             )
 
 
+class TestPersistUserTurnFileLinks:
+    """A turn's files are linked as the caller, and a refusal aborts the turn (#706)."""
+
+    def _conv_service(self):
+        service = create_autospec(ConversationService, instance=True)
+        service.create_conversation.return_value = MagicMock(id=uuid.uuid4())
+        service.add_message.return_value = MagicMock(id=uuid.uuid4())
+        return service
+
+    @pytest.mark.anyio
+    async def test_files_are_linked_as_the_caller(self):
+        """`user_id` is the only scope a `chat_files` row has, so the link has to
+        carry who is asking."""
+        user = _user()
+        service = self._conv_service()
+        file_id = str(uuid.uuid4())
+
+        with (
+            patch("app.services.agent.get_db_context", _fake_db_context),
+            patch("app.services.agent.get_conversation_service", return_value=service),
+        ):
+            prompt = await persist_user_turn(
+                user,
+                "look at this",
+                [file_id],
+                requested_conversation_id=None,
+                current_conversation_id=None,
+                organization_id=uuid.uuid4(),
+            )
+
+        linked = service.link_files_to_message.await_args
+        assert linked.args == (service.add_message.return_value.id, [file_id])
+        assert linked.kwargs == {"user_id": user.id}
+        assert prompt.message_id == service.add_message.return_value.id
+
+    @pytest.mark.anyio
+    async def test_a_refused_file_aborts_the_turn(self):
+        """The refusal used to be swallowed by the same net that catches a lost
+        connection, so a turn naming somebody else's file went ahead and answered
+        as though the attachment were fine (#706)."""
+        service = self._conv_service()
+        service.link_files_to_message.side_effect = NotFoundError(
+            message="File not found", details={"file_ids": []}
+        )
+
+        with (
+            patch("app.services.agent.get_db_context", _fake_db_context),
+            patch("app.services.agent.get_conversation_service", return_value=service),
+            pytest.raises(NotFoundError),
+        ):
+            await persist_user_turn(
+                _user(),
+                "look at this",
+                [str(uuid.uuid4())],
+                requested_conversation_id=None,
+                current_conversation_id=None,
+                organization_id=uuid.uuid4(),
+            )
+
+    @pytest.mark.anyio
+    async def test_a_transient_link_failure_still_answers_the_turn(self):
+        """The swallow the refusal now escapes is kept for what it was written
+        for: an infrastructure failure loses the link, never the answer."""
+        service = self._conv_service()
+        service.link_files_to_message.side_effect = RuntimeError("connection lost")
+
+        with (
+            patch("app.services.agent.get_db_context", _fake_db_context),
+            patch("app.services.agent.get_conversation_service", return_value=service),
+        ):
+            prompt = await persist_user_turn(
+                _user(),
+                "look at this",
+                [str(uuid.uuid4())],
+                requested_conversation_id=None,
+                current_conversation_id=None,
+                organization_id=uuid.uuid4(),
+            )
+
+        assert prompt.message_id == service.add_message.return_value.id
+
+
 class TestPersistAssistantTurnRecordsWhatItCost:
     """The cost of an answer is asked about afterwards.
 

--- a/backend/tests/test_attachments.py
+++ b/backend/tests/test_attachments.py
@@ -330,12 +330,15 @@ class TestASecondTurn:
 
 
 class TestLoadingTheRows:
-    async def test_the_ids_a_client_sent_are_resolved_through_the_conversation(self, monkeypatch):
+    async def test_the_ids_a_client_sent_are_resolved_as_the_caller(self, monkeypatch):
+        """The sender's id rides along, because the read is scoped to it (#706)."""
         from app.services import attachments as module
 
+        caller = uuid4()
         service = SimpleNamespace(list_attached_files=AsyncMock(return_value=["row"]))
         monkeypatch.setattr(
             "app.api.deps.get_conversation_service", lambda db: service, raising=True
         )
 
-        assert await module.load_attached_files(object(), [uuid4()]) == ["row"]
+        assert await module.load_attached_files(object(), [uuid4()], user_id=caller) == ["row"]
+        assert service.list_attached_files.await_args.kwargs["user_id"] == caller

--- a/backend/tests/test_embed_frames.py
+++ b/backend/tests/test_embed_frames.py
@@ -421,29 +421,42 @@ class TestWhichFilesAFrameMayAttach:
 
     async def test_a_row_belonging_to_somebody_else_is_not_attached(self) -> None:
         """Two conditions, and between them they stop a frame from attaching a file
-        it was never handed: the row is the page owner's, and it hangs off no
-        message yet."""
+        it was never handed: the row is the page owner's - which since #706 is the
+        repository read's own WHERE, so a stranger's row never comes back to be
+        filtered - and it hangs off no message yet."""
         session = _session(_embed(allow_files=True))
         mine = MagicMock(id=uuid.uuid4(), user_id=session.embed.owner_user_id, message_id=None)
-        somebody_elses = MagicMock(id=uuid.uuid4(), user_id=uuid.uuid4(), message_id=None)
         already_sent = MagicMock(
             id=uuid.uuid4(), user_id=session.embed.owner_user_id, message_id=uuid.uuid4()
         )
-        asked = [mine.id, somebody_elses.id, already_sent.id]
+        asked = [mine.id, uuid.uuid4(), already_sent.id]
 
         with patch(
             "app.services.embed_session.chat_file_repo.get_many",
-            new=AsyncMock(return_value=[mine, somebody_elses, already_sent]),
-        ):
+            new=AsyncMock(return_value=[mine, already_sent]),
+        ) as read:
             usable = await session._files(MagicMock(), asked)
 
         assert usable == [mine]
+        assert read.await_args.kwargs["user_id"] == session.embed.owner_user_id
 
     async def test_a_frame_that_names_nothing_reads_no_rows(self) -> None:
         session = _session(_embed())
 
         with patch("app.services.embed_session.chat_file_repo.get_many", new=AsyncMock()) as read:
             assert await session._files(MagicMock(), []) == []
+
+        read.assert_not_awaited()
+
+    async def test_a_page_whose_publisher_is_gone_owns_no_rows_to_attach(self) -> None:
+        """`owner_user_id` is `SET NULL` when the publisher's account is deleted,
+        and the read is scoped to the owner (#706) - so there is nobody to read
+        as, and every id the frame names drops."""
+        session = _session(_embed(allow_files=True))
+        session.embed.owner_user_id = None
+
+        with patch("app.services.embed_session.chat_file_repo.get_many", new=AsyncMock()) as read:
+            assert await session._files(MagicMock(), [uuid.uuid4()]) == []
 
         read.assert_not_awaited()
 

--- a/backend/tests/test_embed_session.py
+++ b/backend/tests/test_embed_session.py
@@ -237,10 +237,13 @@ class TestWhichFilesAVisitorMayAttach:
         ]
         attached = [uuid.uuid4(), uuid.uuid4()]
 
-        with patch(f"{MODULE}.chat_file_repo.get_many", AsyncMock(return_value=rows)):
+        with patch(f"{MODULE}.chat_file_repo.get_many", AsyncMock(return_value=rows)) as get_many:
             usable = await session._files(MagicMock(), attached)
 
         assert usable == rows
+        # The ownership half of the rule lives in the query itself (#706), so a
+        # stranger's id never resolves to a row for this Python to keep.
+        assert get_many.await_args.kwargs["user_id"] == session.embed.owner_user_id
 
     async def test_an_id_that_resolves_to_nothing_usable_is_dropped_not_refused(self):
         """Refusing somebody their answer over a stale id in a composer is the

--- a/backend/tests/test_services_conversation.py
+++ b/backend/tests/test_services_conversation.py
@@ -1191,7 +1191,12 @@ class TestConversationServiceToolCalls:
 
 
 class TestConversationServiceLinkFiles:
-    """Tests for link_files_to_message."""
+    """A message may take only the caller's own unlinked files (#706).
+
+    The ids arrive off a socket payload, so before this rule a turn naming
+    another user's file id rendered their filename in its own conversation and
+    silently pulled the file off the message it already hung on.
+    """
 
     @pytest.fixture
     def mock_db(self) -> AsyncMock:
@@ -1204,27 +1209,72 @@ class TestConversationServiceLinkFiles:
         return ConversationService(mock_db)
 
     @pytest.mark.anyio
-    async def test_link_files_empty_list_returns_early(self, service: ConversationService):
-        """link_files_to_message returns immediately for empty file list."""
-        await service.link_files_to_message(uuid4(), [])
+    async def test_link_files_empty_list_links_nothing(self, service: ConversationService):
+        """link_files_to_message issues no UPDATE for an empty file list."""
+        with patch("app.services.conversation.chat_file_repo") as repo:
+            repo.get_many = AsyncMock(return_value=[])
+            repo.link_to_message = AsyncMock()
 
-        # Should not call db.execute for empty list
-        service.db.execute.assert_not_called()
+            await service.link_files_to_message(uuid4(), [], user_id=uuid4())
+
+        repo.link_to_message.assert_not_awaited()
 
     @pytest.mark.anyio
-    async def test_link_files_calls_db(self, service: ConversationService):
-        """link_files_to_message executes update and flushes."""
+    async def test_the_callers_own_unlinked_files_are_linked_as_the_caller(
+        self, service: ConversationService
+    ):
+        """The owner rides into the repository, where the UPDATE's WHERE carries it."""
         msg_id = uuid4()
-        file_ids = [str(uuid4()), str(uuid4())]
+        user_id = uuid4()
+        ids = [uuid4(), uuid4()]
 
-        with (
-            patch("app.db.models.chat_file.ChatFile") as mock_chat_file,
-            patch("sqlalchemy.update") as mock_sa_update,
-        ):
-            mock_chat_file.id.in_ = MagicMock()
-            mock_sa_update.return_value.where.return_value.values.return_value = "stmt"
+        with patch("app.services.conversation.chat_file_repo") as repo:
+            repo.get_many = AsyncMock(
+                return_value=[MagicMock(id=fid, message_id=None) for fid in ids]
+            )
+            repo.link_to_message = AsyncMock()
 
-            await service.link_files_to_message(msg_id, file_ids)
+            await service.link_files_to_message(msg_id, [str(fid) for fid in ids], user_id=user_id)
 
-            service.db.execute.assert_called_once()
-            service.db.flush.assert_called_once()
+        linked = repo.link_to_message.await_args.kwargs
+        assert (linked["message_id"], linked["file_ids"], linked["user_id"]) == (
+            msg_id,
+            ids,
+            user_id,
+        )
+
+    @pytest.mark.anyio
+    async def test_a_file_that_is_not_the_callers_is_refused_as_missing(
+        self, service: ConversationService
+    ):
+        """Missing, not forbidden: "not yours" would confirm the id exists. And
+        refused before the UPDATE, so nothing is silently narrowed."""
+        theirs = uuid4()
+
+        with patch("app.services.conversation.chat_file_repo") as repo:
+            repo.get_many = AsyncMock(return_value=[])
+            repo.link_to_message = AsyncMock()
+
+            with pytest.raises(NotFoundError) as refusal:
+                await service.link_files_to_message(uuid4(), [str(theirs)], user_id=uuid4())
+
+        assert refusal.value.details == {"file_ids": [theirs]}
+        repo.link_to_message.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_a_file_already_on_a_message_is_refused_not_moved(
+        self, service: ConversationService
+    ):
+        """Re-linking is refused outright: the silent move is how a victim's own
+        transcript lost its attachment, and no legitimate caller re-links."""
+        spent = uuid4()
+
+        with patch("app.services.conversation.chat_file_repo") as repo:
+            repo.get_many = AsyncMock(return_value=[MagicMock(id=spent, message_id=uuid4())])
+            repo.link_to_message = AsyncMock()
+
+            with pytest.raises(BadRequestError) as refusal:
+                await service.link_files_to_message(uuid4(), [str(spent)], user_id=uuid4())
+
+        assert refusal.value.details == {"file_ids": [spent]}
+        repo.link_to_message.assert_not_awaited()

--- a/backend/tests/test_services_conversation.py
+++ b/backend/tests/test_services_conversation.py
@@ -1232,7 +1232,7 @@ class TestConversationServiceLinkFiles:
             repo.get_many = AsyncMock(
                 return_value=[MagicMock(id=fid, message_id=None) for fid in ids]
             )
-            repo.link_to_message = AsyncMock()
+            repo.link_to_message = AsyncMock(return_value=len(ids))
 
             await service.link_files_to_message(msg_id, [str(fid) for fid in ids], user_id=user_id)
 
@@ -1242,6 +1242,46 @@ class TestConversationServiceLinkFiles:
             ids,
             user_id,
         )
+
+    @pytest.mark.anyio
+    async def test_an_id_that_is_not_a_uuid_is_refused_before_any_read(
+        self, service: ConversationService
+    ):
+        """A `ValueError` here used to fall into the caller's infrastructure net
+        and resurface a step later as a generic failed turn, after the message
+        had already been persisted. The refusal names only the malformed ids."""
+        good = uuid4()
+
+        with patch("app.services.conversation.chat_file_repo") as repo:
+            repo.get_many = AsyncMock()
+            repo.link_to_message = AsyncMock()
+
+            with pytest.raises(BadRequestError) as refusal:
+                await service.link_files_to_message(
+                    uuid4(), [str(good), "not-a-uuid", None], user_id=uuid4()
+                )
+
+        assert refusal.value.details == {"file_ids": ["not-a-uuid", "None"]}
+        repo.get_many.assert_not_awaited()
+        repo.link_to_message.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_a_row_taken_between_the_read_and_the_update_is_refused(
+        self, service: ConversationService
+    ):
+        """The pre-read and the UPDATE are two statements, so a concurrent turn
+        can take the row between them; the repository's count is what keeps the
+        race from answering as a message that quietly lost its attachment."""
+        contested = uuid4()
+
+        with patch("app.services.conversation.chat_file_repo") as repo:
+            repo.get_many = AsyncMock(return_value=[MagicMock(id=contested, message_id=None)])
+            repo.link_to_message = AsyncMock(return_value=0)
+
+            with pytest.raises(BadRequestError) as refusal:
+                await service.link_files_to_message(uuid4(), [str(contested)], user_id=uuid4())
+
+        assert refusal.value.details == {"file_ids": [contested]}
 
     @pytest.mark.anyio
     async def test_a_file_that_is_not_the_callers_is_refused_as_missing(

--- a/backend/tests/test_transcript.py
+++ b/backend/tests/test_transcript.py
@@ -225,7 +225,7 @@ class TestWritingTheTranscript:
         `--- Attached file: … (/uploads/…, 43 KB, image)`. The dashboard's own
         uploads have been rows since they existed.
         """
-        attachment = MagicMock(id=uuid.uuid4())
+        attachment = MagicMock(id=uuid.uuid4(), user_id=uuid.uuid4())
 
         await TranscriptService(_session()).record(
             _run(), prompt="co tu widzisz", answer="A dashboard.", attachments=[attachment]
@@ -234,6 +234,9 @@ class TestWritingTheTranscript:
         linked = files.link_to_message.await_args.kwargs
         asked = conversations.create_message.await_args_list[0].kwargs
         assert linked["file_ids"] == [attachment.id]
+        # The repository moves a file only for its own uploader (#706), so the
+        # link is issued as the sender the row was stored for.
+        assert linked["user_id"] == attachment.user_id
         assert (linked["message_id"], asked["role"]) == (
             conversations.create_message.return_value.id,
             "user",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -347,7 +347,10 @@ bounds a read; the user is what narrows it further.**
   enriches each message with the caller's own rating. That overload is why its
   authorizing half went missing for so long: the route passed it, the argument
   was plainly there in review, and it was doing the other job.
-- File downloads verify `chat_file.user_id == current_user.id`.
+- File downloads verify `chat_file.user_id == current_user.id`, and attaching a
+  file to a message carries the same owner in the `WHERE`: a turn naming
+  another user's file id — or a file already on a message — is refused, never
+  silently applied.
 
 `ConversationService` makes the distinction impossible to omit: `organization_id`
 is a **required** keyword, and a caller that genuinely reads across tenants

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -204,6 +204,11 @@ The `ChatFile` database model tracks uploaded files:
   organization role and no grant reaches another person's chat file through this
   API — unlike a collection, which a grant can open up. The comparison is against
   `user_id` and there is no second branch to hold a wider case.
+- **The link step takes the same rule.** A message attaches only the sender's
+  own *unlinked* files: an id naming another user's file, or one already on a
+  message, is refused rather than silently applied — so a turn can neither
+  render a stranger's filename nor pull an attachment off the message it
+  already hangs on.
 
 ## RAG Document Ingestion
 


### PR DESCRIPTION
## What

A web-chat turn could attach **another user's file** to its own message by sending that file's id. `chat_file_repo.link_to_message` was a blind bulk UPDATE — no owner predicate, no unlinked check — and `get_many` filtered on id alone, with the ids arriving straight off the socket payload. Two consequences from the one missing predicate: the victim's filename/MIME/size rendered in the attacker's conversation, and a non-NULL `message_id` was overwritten, so the file silently moved off the victim's own message.

`chat_files` carries no `organization_id`, so `user_id` is the only scope a row has — and now both the read and the update carry it:

- `chat_file_repo.get_many` and `link_to_message` take the owner in their `WHERE`; the UPDATE also requires `message_id IS NULL`.
- `ConversationService.link_files_to_message` reads the rows first and **refuses** rather than silently narrowing: a foreign or unknown id raises `NotFoundError` (deliberately indistinguishable, so an id cannot be probed for existence), an already-linked one raises `BadRequestError`. Both name only `file_ids` the caller sent — nothing of the victim's.
- The refusal escapes `persist_user_turn`'s swallow (which now covers only infrastructure failures), so the socket answers with an error frame instead of a turn that quietly dropped the attachment.
- The channel transcript (`TranscriptService._attach`, the second caller added by #703/#690) links rows as their own uploader; the embed's owner check moved from Python into the query, and a page whose publisher's account is gone (`owner_user_id` is `SET NULL`) reads no rows at all instead of passing `None` into the predicate.

## The re-link decision

**A file already on a message never moves, not even for its owner.** No caller legitimately re-links: web chat links fresh uploads once per send (no retry resends `file_ids`), channel rows are created server-side unlinked in the same turn, and the embed already documented and dropped a spent id. The silent move only ever rewrote history, so it is refused outright (`BadRequestError`) rather than allowed for the owner.

## How verified

- `backend/tests/integration/test_chat_file_ownership.py` — the issue's sequence against a real database, both rows read back: the attacker gets a refusal, the victim's message keeps its file; the unlinked-file disclosure case; the repo-level UPDATE skipping a foreign row even without the service's pre-read; the owner's own upload still linking; the re-link refusal leaving the row where it was; the scoped read returning nothing for a foreign id.
- Unit tests for the service refusals, the owner riding through `persist_user_turn`, `load_attached_files`, the embed session and the channel transcript, and the ownerless-embed drop.
- The pre-existing channel-turn integration test (`test_transcript_savepoint.py`) proves server-side rows still link through the new predicates.
- `make lint` and `make test` (100% platform gate) pass; `docs/architecture.md` and `docs/file-processing.md` updated in the same change.

Closes #706
