### PR TITLE
chore: cut 0.0.146

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.146] - 2026-08-13
+
+A thread nobody owned was everybody's to delete.
+
+### Security
+
+- **An unowned room thread is writable only by its participants.** A channel
+  thread's owner is its first *linked* speaker, so a room where nobody linked
+  an account had no owner — and the write check answered yes to any member of
+  the organization: renaming it, archiving it, deleting the transcript, or
+  appending a `role: "assistant"` turn the model reads back as its own words,
+  including for threads their own list never showed them. The write now stops
+  at the same membership-confirmed participation the read admits; an owned
+  thread still refuses its participants the write. (#701)
+
 ## [0.0.145] - 2026-08-13
 
 A webhook bot's files had no server to be fetched from.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.145"
+version = "0.0.146"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.145"
+version = "0.0.146"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.145",
+  "version": "0.0.146",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Refuse writes to an unowned room thread from non-participants — #744, closes #701.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than
promoted from `[Unreleased]`, because #744 wrote none.