### PR TITLE
chore: cut 0.0.147

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.147] - 2026-08-13
+
+A failed tool's raw error was stored where every reader of the run can see it.
+
+### Security
+
+- **A tool's retry text stays out of the transcript row.** #681 sanitized the
+  chat `tool_result` frame; the stored row was the same leak on the run paths
+  that never open a socket — the HTTP API and the channel bots. A retry's
+  content is written by whichever tool raised (`web_search` builds one from
+  the vendor exception, endpoint and query string included; an MCP tool's is
+  a third party's entirely), and it landed on a tool-call row rendered in run
+  history weeks later. The row now stores the same sentence the frame sends —
+  which tool failed and that the model was asked to retry — and the vendor's
+  own text goes to the server log beside the write, nowhere else. (#695)
+
 ## [0.0.146] - 2026-08-13
 
 A thread nobody owned was everybody's to delete.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.146"
+version = "0.0.147"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.146"
+version = "0.0.147"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.146",
+  "version": "0.0.147",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Stop storing a tool's raw retry text on the transcript row — #745, closes #695.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than
promoted from `[Unreleased]`, because #745 wrote none.