### PR TITLE
chore: cut 0.0.148

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.148] - 2026-08-13
+
+A photo sent with no caption read as somebody sending nothing.
+
+### Fixed
+
+- **A caption-less turn's user message names its files.** A channel turn whose
+  attachment produced no prompt text wrote a blank user message, so the thread
+  in `/chat` jumped straight to the answer with the file card as the only
+  trace of the question. The transcript now composes the empty turn's body
+  from its attachments — `Attached image: photo.jpg`, one line per file —
+  reusing the vocabulary the model's briefing already uses. A caption is never
+  replaced, and a resume still writes no user turn at all. (#704)
+
 ## [0.0.147] - 2026-08-13
 
 A failed tool's raw error was stored where every reader of the run can see it.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.147"
+version = "0.0.148"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.147"
+version = "0.0.148"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.147",
+  "version": "0.0.148",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Name a caption-less turn's files in its user message — #747, closes #704.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than
promoted from `[Unreleased]`, because #747 wrote none.