### PR TITLE
chore: cut 0.0.149

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.149] - 2026-08-13
+
+A chat turn could attach another user's file by naming its id.
+
+### Security
+
+- **Linking a file the caller does not own is refused.** The link was a blind
+  bulk UPDATE with no owner predicate and no unlinked check, and the ids came
+  straight off the socket payload — so a turn naming another user's file id
+  rendered their filename, MIME and size in the attacker's conversation and
+  silently pulled the file off the victim's own message. Both the read and
+  the UPDATE now carry the owner in their WHERE; a foreign or unknown id
+  answers the same `NotFoundError` (so an id cannot be probed for existence),
+  an already-linked one is refused rather than moved — for everybody, its
+  owner included — and a malformed id is refused at the boundary instead of
+  resurfacing as a failed turn after the message persisted. (#706)
+
 ## [0.0.148] - 2026-08-13
 
 A photo sent with no caption read as somebody sending nothing.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.148"
+version = "0.0.149"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.148"
+version = "0.0.149"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.148",
+  "version": "0.0.149",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Refuse linking a file the caller does not own — #748, closes #706.

Version bumped in `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json`. The CHANGELOG entry is written here rather than
promoted from `[Unreleased]`, because #748 wrote none.