### PR TITLE
feat(capabilities): add guardrails that redact or block a run

### DIFF
--- a/backend/app/agents/capabilities/_registry.py
+++ b/backend/app/agents/capabilities/_registry.py
@@ -596,6 +596,7 @@ def load_builtins() -> None:
         charts,
         clock,
         code_execution,
+        guardrails,
         knowledge,
         sandbox,
         skills,

--- a/backend/app/agents/capabilities/guardrails/README.md
+++ b/backend/app/agents/capabilities/guardrails/README.md
@@ -1,0 +1,63 @@
+# Guardrails
+
+An input/output/tool-result check that can **redact** content or **stop** a run.
+This is the one capability that is governance rather than convenience: the
+platform's value is "mostly in what it refuses", and a guardrail is that sentence
+made executable.
+
+## What it does
+
+Three edges, each configured independently:
+
+- **input** — the user's prompt, before the first model request.
+- **output** — the agent's final answer.
+- **tool result** — what a tool returned, before the model reads it. This is the
+  only guard on untrusted content entering the loop: a fetched page, a file, an MCP
+  server's response.
+
+On each edge, two kinds of check, drawn from `pydantic-ai-harness`'s ready-made
+detectors:
+
+- **redact** secrets (API keys, tokens, JWTs, PEM blocks) and/or personal data
+  (email, IBAN with mod-97, card with Luhn, US SSN). A match is rewritten in place
+  and the run carries on — an agent that quoted a key back has still done the work.
+- **block** on a keyword list. A match ends the run.
+
+## Why a block *stops* the run
+
+The harness makes a `block` graceful: an input block substitutes a refusal and the
+run *completes* with it, a tool block replaces the result and the model continues.
+Here a block instead raises `GuardrailBlocked`, which the runner maps to
+`RunStatus.GUARDRAIL_BLOCKED` — its own status, beside `BUDGET_EXCEEDED`, because a
+trip is the platform working and an operator filtering for problems should not wade
+through it. A refusal that reads like a normal completed answer is not a refusal
+anyone can find later.
+
+Redaction keeps the harness semantics: `replace` rewrites and the run finishes.
+
+## What it deliberately does not do
+
+- **No `guard=<callable>`.** An agent is data, not code. The config selects and
+  parameterises detectors; it cannot carry a Python function. A detector the config
+  cannot express is a follow-up to the detector library, not a hole here.
+- **No tool-argument screening.** The harness's text detectors adapt to the prompt,
+  the output and a tool *result*; tool *arguments* are a structured mapping with no
+  text adapter. Screening them needs a bespoke, non-shipped adapter — out of scope.
+- **No `approve` verdict.** The harness tool guard can defer a call for human
+  approval. AgenticOS already has that: the approval gate (`approval/`) parks a run
+  at `AWAITING_APPROVAL` per tool. A second, rule-driven path to the same mechanism
+  would be the thing this capability is here to avoid — two ways to do one thing,
+  drifting. A guardrail here is automated; the human decision stays with the gate.
+- **No model-calling detector.** Every detector shipped is a pure function, so an
+  agent's budget is untouched and #16's ambient-spend metering is not engaged. A
+  future detector that calls a model must book its spend through
+  `record_ambient_usage`, the way `MeteredCompaction` does, before the guard can be
+  trusted not to hide cost.
+
+## Known edge
+
+An **input** redaction on a **multimodal** prompt raises `UserError` in the harness
+(substituting a scrubbed string would drop the attachments), which fails the run
+rather than blocking it cleanly. Redaction is intended for text prompts; a
+multimodal agent should not enable input redaction until the harness grows a
+text-part-only rewrite.

--- a/backend/app/agents/capabilities/guardrails/__init__.py
+++ b/backend/app/agents/capabilities/guardrails/__init__.py
@@ -1,0 +1,37 @@
+"""Guardrails capability - a check that can redact or stop a run at its edges."""
+
+from pydantic_ai.capabilities import CombinedCapability
+
+from app.agents.capabilities._registry import CapabilityBuildContext, register
+from app.agents.capabilities.guardrails._capability import (
+    GuardrailBlocked,
+    GuardrailsConfig,
+    build_guardrails,
+)
+
+__all__ = ["GuardrailBlocked", "GuardrailsConfig", "build_guardrails"]
+
+
+@register(
+    id="guardrails",
+    name="Guardrails",
+    category="utility",
+    description=(
+        "Redact secrets or personal data, or block a run, when a prompt, an answer or a tool "
+        "result matches a rule."
+    ),
+    # No tools by design: this inspects and rewrites the text flowing through a run,
+    # so there is nothing here for a person to approve. See `guardrails/_capability.py`.
+    tools=(),
+    config_schema=GuardrailsConfig,
+)
+def _build(ctx: CapabilityBuildContext) -> CombinedCapability[object] | None:
+    """Build the configured guardrail edges, or nothing when none are configured.
+
+    Returns `None` for an all-default config: enabling the capability without
+    turning on any edge attaches no guardrail, which is the "pays nothing when
+    absent" contract. A configured edge that only redacts costs a few regex passes
+    per request and never calls a model, so an agent's budget is untouched.
+    """
+    config = ctx.config if isinstance(ctx.config, GuardrailsConfig) else GuardrailsConfig()
+    return build_guardrails(config)

--- a/backend/app/agents/capabilities/guardrails/_capability.py
+++ b/backend/app/agents/capabilities/guardrails/_capability.py
@@ -1,0 +1,219 @@
+"""Input, output and tool-result guardrails - a check that can stop a run.
+
+The edges, the detectors and the guard vocabulary all come from
+`pydantic-ai-harness`; what this module adds is the two things a platform has to
+add to a library that expects hand-written Python guards.
+
+**Config, not callables.** An agent here is *data* - a spec with a config blob,
+never code - so a client cannot hand us a `guard=my_function`. The config selects
+and parameterises the ready-made detectors instead: three toggles and a keyword
+list per edge, assembled into one detector chain per edge by :func:`_edge_detector`.
+
+**A block is an outcome, not a graceful answer.** The harness makes a `block`
+verdict graceful - an input block substitutes a refusal response and the run
+*completes* with it as the answer, a tool block replaces the result and the model
+carries on. For governance that is exactly wrong: a refusal should be a visible run
+outcome an operator can filter for, not a completed answer that reads like any
+other. So the detector chain *raises* :class:`GuardrailBlocked` on a block instead
+of returning one, and the runner maps that to `RunStatus.GUARDRAIL_BLOCKED` the way
+it maps `BudgetExceeded`. Redaction (`replace`) keeps its harness semantics: a
+detector that scrubs a key and lets the run finish is the whole point.
+
+The raise escapes `agent.run()` cleanly from every edge - `wrap_model_request`
+(input), `after_output_process` (output) and `after_tool_execute` (tool result) all
+propagate a guard's exception rather than converting it, which is what makes one
+`GuardrailBlocked` type serve all three.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Callable
+
+from pydantic import BaseModel, Field
+from pydantic_ai.capabilities import AbstractCapability, CombinedCapability
+from pydantic_ai_harness.guardrails import (
+    GuardrailResult,
+    InputGuardrail,
+    OutputGuardrail,
+    ToolGuardrail,
+)
+from pydantic_ai_harness.guardrails.detectors import (
+    blocked_keywords,
+    for_text,
+    for_tool_result_text,
+    redact_personal_data,
+    redact_secrets,
+)
+
+logger = logging.getLogger(__name__)
+
+TextDetector = Callable[[str], GuardrailResult]
+"""A detector reads text and returns a verdict. The harness's own signature."""
+
+_KEYWORD_SPLIT = re.compile(r"[,\n]")
+"""Blocked keywords arrive as one string, comma- or newline-separated.
+
+A string rather than a `list[str]` because the Builder's generated form renders
+only scalar and enum fields - a list arrives as a text box either way, so it is
+one honestly rather than a control that looks structured and is not.
+"""
+
+_BLOCK_MESSAGE = {
+    "input": "This request was blocked by an input guardrail.",
+    "output": "This response was blocked by an output guardrail.",
+    "tool_result": "A tool result was blocked by a guardrail.",
+}
+"""What the run row records on a block. Names the edge and the refusal, never the
+content that tripped it - the row is read by every member who can see the run, and
+the matched term (an org's own configured keyword) belongs in the log beside it."""
+
+
+class GuardrailBlocked(Exception):
+    """A guardrail refused a run at one of its edges.
+
+    A plain `Exception`, not an `AppException`, for the reason `BudgetExceeded` is:
+    the runner catches it and maps it to its own `RunStatus`, and a trip is the
+    platform working rather than a malfunction. The message is safe to store on the
+    run - it names the edge and the refusal, never the offending text.
+    """
+
+    def __init__(self, *, edge: str, message: str) -> None:
+        self.edge = edge
+        super().__init__(message)
+
+
+class GuardrailsConfig(BaseModel):
+    """Which checks run on which edge.
+
+    Flat booleans and one delimited string per edge, so the Builder can render the
+    whole form. Every field defaults off: an agent that enables the capability but
+    configures no edge gets no guardrail at all, and the builder returns `None`.
+
+    The three edges are the three the harness's text detectors have adapters for -
+    the prompt (a `str`), the output (via `for_text`) and a tool result (via
+    `for_tool_result_text`). Tool *arguments* are a structured mapping with no text
+    adapter, so they are not an edge here.
+    """
+
+    redact_secrets_in: bool = Field(
+        default=False, description="Redact API keys and tokens from the user's prompt"
+    )
+    redact_pii_in: bool = Field(
+        default=False, description="Redact emails, IBANs, cards and SSNs from the prompt"
+    )
+    blocked_keywords_in: str = Field(
+        default="",
+        description="Block the run if the prompt contains any of these terms (comma or newline separated)",
+    )
+    redact_secrets_out: bool = Field(
+        default=False, description="Redact API keys and tokens from the agent's answer"
+    )
+    redact_pii_out: bool = Field(
+        default=False, description="Redact emails, IBANs, cards and SSNs from the answer"
+    )
+    blocked_keywords_out: str = Field(
+        default="",
+        description="Block the run if the answer contains any of these terms (comma or newline separated)",
+    )
+    redact_secrets_tool: bool = Field(
+        default=False,
+        description="Redact API keys and tokens from tool results before the model reads them",
+    )
+    redact_pii_tool: bool = Field(
+        default=False, description="Redact emails, IBANs, cards and SSNs from tool results"
+    )
+    blocked_keywords_tool: str = Field(
+        default="",
+        description="Block the run if a tool result contains any of these terms (comma or newline separated)",
+    )
+
+
+def _keywords(raw: str) -> list[str]:
+    """The terms in a delimited keyword string, blanks dropped."""
+    return [term.strip() for term in _KEYWORD_SPLIT.split(raw) if term.strip()]
+
+
+def _edge_detector(
+    *, redact_secrets_on: bool, redact_pii_on: bool, keywords: list[str], edge: str
+) -> TextDetector | None:
+    """One text detector for an edge: redact first, then block.
+
+    Redactors run in order and thread their cleaned text forward, so a key scrubbed
+    by the first is invisible to the keyword check after it. The keyword check runs
+    last, on already-redacted text, and *raises* :class:`GuardrailBlocked` rather
+    than returning a `block` verdict - that is what turns a block into a run outcome
+    instead of a graceful answer.
+
+    Returns `None` when nothing is configured for the edge, so the caller attaches
+    no guardrail there rather than an inert one.
+    """
+    redactors: list[TextDetector] = []
+    if redact_secrets_on:
+        redactors.append(redact_secrets)
+    if redact_pii_on:
+        redactors.append(redact_personal_data)
+    keyword_detector = blocked_keywords(keywords) if keywords else None
+    if not redactors and keyword_detector is None:
+        return None
+
+    def detect(text: str) -> GuardrailResult:
+        cleaned = text
+        replaced = False
+        for redactor in redactors:
+            verdict = redactor(cleaned)
+            if verdict.action == "replace":
+                # A redactor's replacement is always the cleaned string.
+                cleaned = str(verdict.replacement)
+                replaced = True
+        if keyword_detector is not None and keyword_detector(cleaned).action == "block":
+            logger.info("Guardrail blocked a run at the %s edge", edge)
+            raise GuardrailBlocked(edge=edge, message=_BLOCK_MESSAGE[edge])
+        return GuardrailResult.replace(cleaned) if replaced else GuardrailResult.allow()
+
+    return detect
+
+
+def build_guardrails(config: GuardrailsConfig) -> CombinedCapability[object] | None:
+    """The harness capabilities this configuration asks for, combined into one.
+
+    One capability per configured edge, wrapped in a `CombinedCapability` so a
+    single binding attaches all of them. `None` when no edge is configured - the
+    "enabled but inert" state does not exist, which is the "pays nothing when
+    absent" contract every capability owes.
+    """
+    edges: list[AbstractCapability[object]] = []
+
+    input_detector = _edge_detector(
+        redact_secrets_on=config.redact_secrets_in,
+        redact_pii_on=config.redact_pii_in,
+        keywords=_keywords(config.blocked_keywords_in),
+        edge="input",
+    )
+    if input_detector is not None:
+        edges.append(InputGuardrail(guard=input_detector))
+
+    output_detector = _edge_detector(
+        redact_secrets_on=config.redact_secrets_out,
+        redact_pii_on=config.redact_pii_out,
+        keywords=_keywords(config.blocked_keywords_out),
+        edge="output",
+    )
+    if output_detector is not None:
+        edges.append(OutputGuardrail(guard=for_text(output_detector, on_other="allow")))
+
+    tool_detector = _edge_detector(
+        redact_secrets_on=config.redact_secrets_tool,
+        redact_pii_on=config.redact_pii_tool,
+        keywords=_keywords(config.blocked_keywords_tool),
+        edge="tool_result",
+    )
+    if tool_detector is not None:
+        edges.append(
+            ToolGuardrail(result_guard=for_tool_result_text(tool_detector, on_other="allow"))
+        )
+
+    if not edges:
+        return None
+    return CombinedCapability(capabilities=edges)

--- a/backend/app/db/models/agent_run.py
+++ b/backend/app/db/models/agent_run.py
@@ -40,9 +40,10 @@ class RunStatus(enum.StrEnum):
 
     `AWAITING_APPROVAL` is a real terminal-ish state, not a transient one: the
     run is parked until a human decides, which may be tomorrow. `BUDGET_EXCEEDED`
-    is separated from `FAILED` because it is not a malfunction - it is the
-    platform working - and an operator filtering for problems should not have to
-    wade through it.
+    and `GUARDRAIL_BLOCKED` are separated from `FAILED` for the same reason - each
+    is not a malfunction but the platform working, and an operator filtering for
+    problems should not have to wade through them. A guardrail that redacted rather
+    than blocked leaves no trace here: the run `COMPLETED`, which is the point.
     """
 
     RUNNING = "running"
@@ -51,6 +52,7 @@ class RunStatus(enum.StrEnum):
     CANCELLED = "cancelled"
     AWAITING_APPROVAL = "awaiting_approval"
     BUDGET_EXCEEDED = "budget_exceeded"
+    GUARDRAIL_BLOCKED = "guardrail_blocked"
 
     @classmethod
     def parse_csv(cls, raw: str | None) -> list[str] | None:

--- a/backend/app/repositories/agent.py
+++ b/backend/app/repositories/agent.py
@@ -223,9 +223,9 @@ async def list_active_run_versions(db: AsyncSession) -> list[tuple[Agent, AgentV
     `audit-skill-bindings` sweep is deployment-wide. A run records the version it
     executed in `agent_version_id`, and a run that has not ended still loads it: a
     `running` run is executing it now, and an `awaiting_approval` run reloads it
-    when :meth:`AgentRunnerService.resume` continues it. The four terminal states -
-    `completed`, `failed`, `cancelled` and `budget_exceeded` - never load it again,
-    so there `agent_version_id` is only a historical record.
+    when :meth:`AgentRunnerService.resume` continues it. The five terminal states -
+    `completed`, `failed`, `cancelled`, `budget_exceeded` and `guardrail_blocked` -
+    never load it again, so there `agent_version_id` is only a historical record.
     A parked run resumes only from stored `paused_state`; one without it can never
     continue, so it is excluded rather than seeding a version no resume can reach.
 

--- a/backend/app/services/agent_chat.py
+++ b/backend/app/services/agent_chat.py
@@ -36,6 +36,7 @@ from pydantic_ai.tools import DeferredToolRequests
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agents.capabilities.budget import BudgetExceeded, BudgetScope
+from app.agents.capabilities.guardrails import GuardrailBlocked
 from app.agents.deps import AgentDeps, AskUserCallback
 from app.agents.subagent_events import SubagentEventSink
 from app.core.exceptions import AuthorizationError, BadRequestError
@@ -305,6 +306,9 @@ class ChatAgentRunner:
             BadRequestError: If the agent is unpublished or archived.
             BudgetExceeded: If a limit stopped the run. Surfaced rather than
                 swallowed so the client can say why the answer stopped.
+            GuardrailBlocked: If a guardrail refused the run at one of its edges.
+                Surfaced rather than swallowed so the client sees the guard's
+                safe refusal, not a generic failure.
         """
         ctx = await self._context(user, organization_id)
         prepared = await self.runner.prepare(
@@ -388,6 +392,15 @@ class ChatAgentRunner:
             error = str(exc)
             budget_scope = exc.scope
             logger.info("Chat run %s stopped by budget: %s", prepared.run.id, exc)
+            raise
+        except GuardrailBlocked as exc:
+            # A refusal, not a malfunction - its own status for the same reason
+            # `BUDGET_EXCEEDED` is. The message names the edge and the refusal, not
+            # the content that tripped it, so it is safe to store and to surface.
+            # Raised on so the visitor is told the guard's plain reason.
+            status = RunStatus.GUARDRAIL_BLOCKED
+            error = str(exc)
+            logger.info("Chat run %s blocked by a %s guardrail", prepared.run.id, exc.edge)
             raise
         except Exception as exc:
             error = run_failure_summary(exc)

--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -91,6 +91,7 @@ from app.agents.capabilities.channel_tools import (
     CHANNEL_TOOLS_CAPABILITY_ID,
     ChannelDirectory,
 )
+from app.agents.capabilities.guardrails import GuardrailBlocked
 from app.agents.capabilities.sandbox import WORKSPACE_BACKEND_RESOURCE, WorkspaceIdentity
 from app.agents.capabilities.sandbox._identity import SessionScope
 from app.agents.capabilities.subagents import SubagentsConfig, acting_delegate
@@ -3240,6 +3241,13 @@ class AgentRunnerService:
             error = str(exc)
             budget_scope = exc.scope
             logger.info("Run %s stopped by budget: %s", prepared.run.id, exc)
+        except GuardrailBlocked as exc:
+            # A refusal, not a malfunction - its own status for the same reason
+            # `BUDGET_EXCEEDED` is. The message names the edge and the refusal, not
+            # the content that tripped it, so it is safe to store on the row.
+            status = RunStatus.GUARDRAIL_BLOCKED
+            error = str(exc)
+            logger.info("Run %s blocked by a %s guardrail", prepared.run.id, exc.edge)
         except Exception as exc:
             error = run_failure_summary(exc)
             logger.exception("Agent run %s failed", prepared.run.id)

--- a/backend/app/services/agent_session.py
+++ b/backend/app/services/agent_session.py
@@ -9,6 +9,7 @@ from fastapi import WebSocket, WebSocketDisconnect
 
 from app.agents.ask_user import QuestionItem, render_answer
 from app.agents.capabilities.budget import BudgetExceeded
+from app.agents.capabilities.guardrails import GuardrailBlocked
 from app.agents.subagent_events import SubagentEvent
 from app.core.exceptions import AppException
 from app.db.models.chat_file import ChatFile
@@ -55,9 +56,9 @@ def _turn_failed(exc: Exception) -> str:
     and goes no further, and the frame names only what the reader can act on.
     The class still goes out: it separates an upstream that timed out from one
     that refused a credential, and a class name has never carried a URL. Our own
-    refusals do not come here at all - an `AppException` and a `BudgetExceeded`
-    are caught above and passed through whole, because their messages are
-    written in this repository.
+    refusals do not come here at all - an `AppException`, a `BudgetExceeded` and a
+    `GuardrailBlocked` are caught above and passed through whole, because their
+    messages are written in this repository.
     """
     return (
         f"The agent could not finish this turn ({type(exc).__name__}). "
@@ -359,11 +360,11 @@ class AgentSession:
             )
         except WebSocketDisconnect:
             raise
-        except (AppException, BudgetExceeded) as exc:
+        except (AppException, BudgetExceeded, GuardrailBlocked) as exc:
             # A refusal - an agent that is unpublished, archived, or not theirs
-            # to see - and a budget stop are the platform working, not a crash.
-            # The client is told plainly; nothing answers in the named agent's
-            # place.
+            # to see - a budget stop, and a guardrail block are the platform
+            # working, not a crash. The client is told plainly; nothing answers
+            # in the named agent's place.
             logger.info("Agent turn refused: %s", exc)
             await send_event(self.websocket, "error", {"message": str(exc)})
         except Exception as exc:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -42,9 +42,17 @@ dependencies = [
     "aiosmtplib>=3.0.0",
     "itsdangerous>=2.2.0",
     "prefect>=3.8.0",
-    "pydantic-ai-slim[openrouter,anthropic,google,duckduckgo,web-fetch,groq,mistral,cohere,huggingface,xai]>=2.26.0",
+    # Floored at 2.28.0 because `pydantic-ai-harness` requires it. Nothing here
+    # needs a 2.28 feature; the floor is the harness's, and stating it is what
+    # keeps a resolver from picking 2.26 and failing at import instead.
+    "pydantic-ai-slim[openrouter,anthropic,google,duckduckgo,web-fetch,groq,mistral,cohere,huggingface,xai]>=2.28.0",
     "genai-prices>=0.1.1",
-    "pydantic-ai-slim[mcp]>=2.26.0",
+    "pydantic-ai-slim[mcp]>=2.28.0",
+    # The guardrail capability wraps this library's ready-made detectors and its
+    # input/output/tool guard edges. Uncapped for the same reason Pydantic AI is:
+    # this is where the detector patterns are maintained, and pinning would freeze
+    # the secret/PII catalogues it ships.
+    "pydantic-ai-harness>=0.21.0",
     "websockets>=15.0",
     "langchain-text-splitters>=0.4.0",
     "rank-bm25>=0.2.2",

--- a/backend/tests/test_agent_chat.py
+++ b/backend/tests/test_agent_chat.py
@@ -33,6 +33,7 @@ from app.agents.capabilities.budget import (
     SpendLedger,
     record_ambient_usage,
 )
+from app.agents.capabilities.guardrails import GuardrailBlocked
 from app.agents.deps import AgentDeps
 from app.core.exceptions import AuthorizationError, BadRequestError
 from app.core.permissions import OrgRoleName
@@ -537,6 +538,19 @@ class TestRecordingTheRun:
         finished = runner.finish.call_args.kwargs
         assert finished["status"] is RunStatus.BUDGET_EXCEEDED
         assert "budget exhausted" in finished["error"]
+
+    async def test_a_guardrail_block_is_recorded_as_blocked_not_a_failure(self):
+        """The streaming surface does not go through the runner's `_run`, so a
+        block here would have been logged like a crash and recorded as FAILED
+        without its own clause - the visitor owed the guard's safe refusal."""
+        blocked = GuardrailBlocked(edge="input", message="This request was blocked.")
+
+        with _runner(_prepared()) as runner, pytest.raises(GuardrailBlocked):
+            await _run(_db(), stream=AsyncMock(side_effect=blocked))
+
+        finished = runner.finish.call_args.kwargs
+        assert finished["status"] is RunStatus.GUARDRAIL_BLOCKED
+        assert finished["error"] == "This request was blocked."
 
     async def test_a_run_that_ends_with_nothing_at_all_fails_loudly(self):
         """An empty answer persisted as the agent's reply would be a lie about it."""

--- a/backend/tests/test_agent_runner.py
+++ b/backend/tests/test_agent_runner.py
@@ -24,6 +24,7 @@ from pydantic_ai.usage import RequestUsage
 from app.agents.capabilities.approval import ApprovalGranted, ApprovalRejected
 from app.agents.capabilities.budget import BudgetExceeded, BudgetScope, SpendLedger
 from app.agents.capabilities.channel_tools import CHANNEL_DIRECTORY_RESOURCE
+from app.agents.capabilities.guardrails import GuardrailBlocked
 from app.agents.spec import AgentSpec, CapabilityBindingSpec, ObservabilitySpec
 from app.agents.subagent_runtime import DelegationSpend, DelegationStash, ParkedDelegation
 from app.core.exceptions import BadRequestError, NotFoundError, RunExecutionError
@@ -941,6 +942,33 @@ class TestRunAccounting:
         # ends silently otherwise, and the first anybody hears of the limit is
         # somebody asking why the agent went quiet.
         assert notify.call_args.kwargs["status"] is RunStatus.BUDGET_EXCEEDED
+
+    @pytest.mark.anyio
+    async def test_a_guardrail_block_is_its_own_outcome_not_a_failure(self):
+        """A refusal, recorded like `BUDGET_EXCEEDED` rather than `FAILED`.
+
+        The clause does not re-raise, so `execute` returns the empty answer, and
+        the stored `error` is the guardrail's safe message - the edge and the
+        refusal, never the content that tripped it.
+        """
+        service = AgentRunnerService(_db())
+        prepared = _prepared()
+        prepared.built.agent.run = AsyncMock(
+            side_effect=GuardrailBlocked(
+                edge="input", message="This request was blocked by an input guardrail."
+            )
+        )
+
+        with (
+            patch.object(service, "prepare", new=AsyncMock(return_value=prepared)),
+            patch("app.services.agent_runner.agent_run_repo.finish_run", new=AsyncMock()) as finish,
+            patch.object(service, "_notify", new=AsyncMock()),
+        ):
+            output, _ = await service.execute(_ctx(), uuid.uuid4(), "hello")
+
+        assert output == ""
+        assert finish.call_args.kwargs["status"] == RunStatus.GUARDRAIL_BLOCKED.value
+        assert finish.call_args.kwargs["error"] == "This request was blocked by an input guardrail."
 
     @pytest.mark.anyio
     async def test_a_successful_run_returns_its_answer(self):

--- a/backend/tests/test_agent_session.py
+++ b/backend/tests/test_agent_session.py
@@ -79,6 +79,7 @@ from subagents_pydantic_ai import TaskStatus
 
 from app.agents.capabilities import CapabilityBinding, build
 from app.agents.capabilities.budget import BudgetExceeded, BudgetScope, SpendEntry, SpendLedger
+from app.agents.capabilities.guardrails import GuardrailBlocked
 from app.agents.capabilities.subagents import Delegation
 from app.agents.deps import AgentDeps
 from app.agents.subagent_events import (
@@ -666,6 +667,30 @@ class TestATurnThatDidNotFinish:
             "error",
             {"message": "Organization monthly budget exhausted: $20.0100 spent of $20.00 limit"},
         )
+
+    async def test_a_guardrail_block_says_its_safe_reason_not_a_generic_failure(self, caplog):
+        """The streaming surface is where a block actually happens, and without its
+        own clause it hit the generic handler - logged as a crash with a stack
+        trace and shown to the visitor as "the agent could not finish this turn".
+        The guard's message names the edge and the refusal, never the offending
+        text, so it goes out whole."""
+        session = _session()
+        blocked = GuardrailBlocked(
+            edge="input", message="This request was blocked by an input guardrail."
+        )
+
+        with (
+            _chat(AsyncMock(side_effect=blocked)),
+            caplog.at_level(logging.ERROR, logger="app.services.agent_session"),
+        ):
+            await session.process_message(_message())
+
+        assert _frame_types(session) == ["user_prompt", "error"]
+        assert _sent_events(session)[-1] == (
+            "error",
+            {"message": "This request was blocked by an input guardrail."},
+        )
+        assert "Error processing agent request" not in caplog.text
 
     @pytest.mark.parametrize(
         ("failure", "named"), [(RuntimeError, "RuntimeError"), (TimeoutError, "TimeoutError")]

--- a/backend/tests/test_capability_layout.py
+++ b/backend/tests/test_capability_layout.py
@@ -40,6 +40,8 @@ TOOLLESS = {
     # Gates other capabilities' tools. Owning one of its own would mean an
     # approval that could itself be approved.
     "approval",
+    # Inspects and rewrites the text flowing through a run; never a tool.
+    "guardrails",
 }
 
 # Capabilities whose tools come from a library rather than this repository.

--- a/backend/tests/test_capability_registry.py
+++ b/backend/tests/test_capability_registry.py
@@ -225,6 +225,10 @@ class TestToolDeclarations:
         # subagents resource above is at its widest - an undeclared tool can only
         # appear where the most tools do.
         "channel_tools": {"tools": sorted(get("channel_tools").tool_ids)},
+        # Builds `None` from an empty blob on purpose - enabling the capability
+        # without turning on an edge attaches no guardrail. One edge on is what
+        # makes it build here; it offers no tools either way.
+        "guardrails": {"blocked_keywords_in": "secret"},
     }
     """Configurations a capability needs before it offers anything.
 

--- a/backend/tests/test_guardrails_capability.py
+++ b/backend/tests/test_guardrails_capability.py
@@ -1,0 +1,228 @@
+"""The guardrails capability - what it redacts, what it blocks, and what it costs.
+
+Most of the value here is in the refusal: a blocked prompt, answer or tool result
+ends the run as `GUARDRAIL_BLOCKED` rather than completing with a refusal that reads
+like any other answer. The redaction path is the opposite promise - a scrubbed key
+lets the run finish - and both are checked here against a real agent run, because
+the block has to *escape* `agent.run()` for the runner to record it.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import CombinedCapability
+from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart, UserPromptPart
+from pydantic_ai.models.function import FunctionModel
+from pydantic_ai_harness.guardrails import InputGuardrail, OutputGuardrail, ToolGuardrail
+
+from app.agents.capabilities import CapabilityBinding, CapabilityBuildContext, get, load_builtins
+from app.agents.capabilities.guardrails import (
+    GuardrailBlocked,
+    GuardrailsConfig,
+    build_guardrails,
+)
+from app.agents.capabilities.guardrails._capability import _edge_detector, _keywords
+
+pytestmark = pytest.mark.anyio
+
+SECRET = "sk-ant-api03-ABCDEFGHIJKLMNOPQR"
+
+
+@pytest.fixture(autouse=True)
+def _builtins_loaded():
+    load_builtins()
+
+
+def _answers(text: str) -> FunctionModel:
+    """Answer with fixed text, ignoring the prompt."""
+
+    def respond(messages, info):  # type: ignore[no-untyped-def]
+        return ModelResponse(parts=[TextPart(text)])
+
+    return FunctionModel(respond)
+
+
+def _echoes_prompt() -> FunctionModel:
+    """Answer with the prompt text the model was actually handed."""
+
+    def respond(messages, info):  # type: ignore[no-untyped-def]
+        seen = ""
+        for message in messages:
+            for part in getattr(message, "parts", []):
+                if isinstance(part, UserPromptPart) and isinstance(part.content, str):
+                    seen = part.content
+        return ModelResponse(parts=[TextPart(seen)])
+
+    return FunctionModel(respond)
+
+
+def _calls_tool_then_answers() -> FunctionModel:
+    """Call `fetch` on the first turn, then answer once it has a result."""
+
+    def respond(messages, info):  # type: ignore[no-untyped-def]
+        called = any(
+            isinstance(part, ToolCallPart)
+            for message in messages
+            for part in getattr(message, "parts", [])
+        )
+        if called:
+            return ModelResponse(parts=[TextPart("answered")])
+        return ModelResponse(parts=[ToolCallPart(tool_name="fetch", args={}, tool_call_id="c1")])
+
+    return FunctionModel(respond)
+
+
+def _agent(
+    config: GuardrailsConfig, model: FunctionModel, *, tool_result: str | None = None
+) -> Agent:
+    capability = build_guardrails(config)
+    agent: Agent = Agent(model=model, capabilities=[capability] if capability else [])
+    if tool_result is not None:
+
+        async def fetch() -> str:
+            return tool_result
+
+        agent.tool_plain(fetch)
+    return agent
+
+
+def test_keywords_split_on_comma_and_newline_and_drop_blanks():
+    assert _keywords("alpha, beta\ngamma") == ["alpha", "beta", "gamma"]
+    assert _keywords("  spaced  ,\n , ") == ["spaced"]
+    assert _keywords("") == []
+
+
+def test_an_edge_with_nothing_configured_is_not_built():
+    detector = _edge_detector(
+        redact_secrets_on=False, redact_pii_on=False, keywords=[], edge="input"
+    )
+    assert detector is None
+
+
+def test_a_redactor_rewrites_a_match_and_allows_clean_text():
+    detect = _edge_detector(redact_secrets_on=True, redact_pii_on=False, keywords=[], edge="input")
+    assert detect is not None
+
+    hit = detect(f"my key {SECRET} ok")
+    assert hit.action == "replace"
+    assert SECRET not in str(hit.replacement)
+
+    clean = detect("nothing to redact here")
+    assert clean.action == "allow"
+
+
+def test_a_blocked_keyword_raises_naming_the_edge():
+    detect = _edge_detector(
+        redact_secrets_on=False, redact_pii_on=False, keywords=["forbidden"], edge="output"
+    )
+    assert detect is not None
+    with pytest.raises(GuardrailBlocked) as exc:
+        detect("this is forbidden text")
+    assert exc.value.edge == "output"
+
+    assert detect("this is fine").action == "allow"
+
+
+def test_the_keyword_check_reads_already_redacted_text():
+    """Redaction threads forward, so the keyword check runs on the clean text.
+
+    Both a redactor and a keyword list on one edge: the secret is scrubbed first,
+    and the keyword - which does not appear in the placeholder - does not match, so
+    the run is allowed with the redaction applied rather than blocked.
+    """
+    detect = _edge_detector(
+        redact_secrets_on=True, redact_pii_on=True, keywords=[SECRET], edge="input"
+    )
+    assert detect is not None
+    verdict = detect(f"leaking {SECRET} now")
+    assert verdict.action == "replace"
+    assert SECRET not in str(verdict.replacement)
+
+
+def test_no_edge_configured_builds_nothing():
+    assert build_guardrails(GuardrailsConfig()) is None
+
+
+def test_each_configured_edge_attaches_its_harness_capability():
+    combined = build_guardrails(
+        GuardrailsConfig(
+            blocked_keywords_in="a",
+            redact_secrets_out=True,
+            blocked_keywords_tool="b",
+        )
+    )
+    assert isinstance(combined, CombinedCapability)
+    kinds = {type(edge) for edge in combined.capabilities}
+    assert kinds == {InputGuardrail, OutputGuardrail, ToolGuardrail}
+
+
+def test_only_the_configured_edge_is_attached():
+    combined = build_guardrails(GuardrailsConfig(redact_pii_out=True))
+    assert isinstance(combined, CombinedCapability)
+    assert [type(edge) for edge in combined.capabilities] == [OutputGuardrail]
+
+
+async def test_input_redaction_rewrites_the_prompt_the_model_sees():
+    agent = _agent(GuardrailsConfig(redact_secrets_in=True), _echoes_prompt())
+    result = await agent.run(f"here is {SECRET} keep it")
+    assert SECRET not in result.output
+    assert "[redacted:anthropic_key]" in result.output
+
+
+async def test_a_blocked_prompt_stops_the_run():
+    agent = _agent(GuardrailsConfig(blocked_keywords_in="classified"), _answers("hi"))
+    with pytest.raises(GuardrailBlocked) as exc:
+        await agent.run("this is classified information")
+    assert exc.value.edge == "input"
+
+
+async def test_a_blocked_output_stops_the_run():
+    agent = _agent(GuardrailsConfig(blocked_keywords_out="leaked"), _answers("this is leaked"))
+    with pytest.raises(GuardrailBlocked) as exc:
+        await agent.run("go")
+    assert exc.value.edge == "output"
+
+
+async def test_a_blocked_tool_result_stops_the_run():
+    agent = _agent(
+        GuardrailsConfig(blocked_keywords_tool="injection"),
+        _calls_tool_then_answers(),
+        tool_result="a page with an injection payload",
+    )
+    with pytest.raises(GuardrailBlocked) as exc:
+        await agent.run("go")
+    assert exc.value.edge == "tool_result"
+
+
+async def test_tool_result_redaction_lets_the_run_finish():
+    agent = _agent(
+        GuardrailsConfig(redact_secrets_tool=True),
+        _calls_tool_then_answers(),
+        tool_result=f"the file held {SECRET}",
+    )
+    result = await agent.run("go")
+    assert result.output == "answered"
+
+
+def _build(config_blob: object) -> object:
+    definition = get("guardrails")
+    return definition.builder(
+        CapabilityBuildContext(
+            binding=CapabilityBinding(capability_id="guardrails", config=config_blob),
+            config=config_blob if isinstance(config_blob, GuardrailsConfig) else None,
+        )
+    )
+
+
+def test_the_builder_contributes_nothing_for_a_default_config():
+    assert _build(GuardrailsConfig()) is None
+
+
+def test_the_builder_falls_back_to_defaults_for_a_foreign_config():
+    assert _build(None) is None
+
+
+def test_a_configured_binding_builds_the_capability():
+    built = _build(GuardrailsConfig(redact_secrets_in=True))
+    assert isinstance(built, CombinedCapability)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -40,6 +40,7 @@ dependencies = [
     { name = "psycopg2-binary" },
     { name = "pydantic", extra = ["email"] },
     { name = "pydantic-ai-backend", extra = ["console", "remote"] },
+    { name = "pydantic-ai-harness" },
     { name = "pydantic-ai-skills" },
     { name = "pydantic-ai-slim", extra = ["anthropic", "cohere", "duckduckgo", "google", "groq", "huggingface", "mcp", "mistral", "openrouter", "web-fetch", "xai"] },
     { name = "pydantic-monty" },
@@ -109,9 +110,10 @@ requires-dist = [
     { name = "psycopg2-binary", specifier = ">=2.9.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.13.4" },
     { name = "pydantic-ai-backend", extras = ["console", "remote"], specifier = ">=0.2.25" },
+    { name = "pydantic-ai-harness", specifier = ">=0.21.0" },
     { name = "pydantic-ai-skills", specifier = ">=0.11.0" },
-    { name = "pydantic-ai-slim", extras = ["mcp"], specifier = ">=2.26.0" },
-    { name = "pydantic-ai-slim", extras = ["openrouter", "anthropic", "google", "duckduckgo", "web-fetch", "groq", "mistral", "cohere", "huggingface", "xai"], specifier = ">=2.26.0" },
+    { name = "pydantic-ai-slim", extras = ["mcp"], specifier = ">=2.28.0" },
+    { name = "pydantic-ai-slim", extras = ["openrouter", "anthropic", "google", "duckduckgo", "web-fetch", "groq", "mistral", "cohere", "huggingface", "xai"], specifier = ">=2.28.0" },
     { name = "pydantic-monty", specifier = ">=0.0.19" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pyjwt", specifier = ">=2.9.0" },
@@ -3822,6 +3824,20 @@ remote = [
 ]
 
 [[package]]
+name = "pydantic-ai-harness"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "genai-prices" },
+    { name = "httpx" },
+    { name = "pydantic-ai-slim" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/91/637f34cfb65b9b1a627dc3e4500dff0740c3bd1d369259d40fa11d87e157/pydantic_ai_harness-0.21.0.tar.gz", hash = "sha256:5eb429d47977913ccec3e74e48479a6207863efebff9fa9afc4b20e52b01e44a", size = 2189073, upload-time = "2026-08-15T03:12:54.135Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/c1/dd669f17415da4d233581cbac8809ea1c2c3078d113289b96103362cdadc/pydantic_ai_harness-0.21.0-py3-none-any.whl", hash = "sha256:61c1facec51849adc2680569b5abe337e98836ad0e2adc8f79954d01aaa706e6", size = 632221, upload-time = "2026-08-15T03:12:52.466Z" },
+]
+
+[[package]]
 name = "pydantic-ai-skills"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3837,7 +3853,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "2.26.0"
+version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -3849,9 +3865,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/51/dc39f52dd38c8bf7d8ad6601a936d22064c935505a897c1bf5060e278c95/pydantic_ai_slim-2.26.0.tar.gz", hash = "sha256:d41a40a976885d5f9c6848552fcd6732d5daa8294faf4d3e0138fb28118b6734", size = 1004525, upload-time = "2026-08-07T03:34:19.129Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/4e/2165d9b90edcd5dfc8e9465b3bdc0aa66a67760843ddb0ac99ee396898f0/pydantic_ai_slim-2.31.0.tar.gz", hash = "sha256:a9310d2464154b028096f1d680f17837f16e5c6cd209b4542e4f60ca5d344789", size = 1214087, upload-time = "2026-08-15T03:17:28.353Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/ac/e09eb468ccec3180f73828b1e0c59b891cc9ee442be2d28410b02c1d09a3/pydantic_ai_slim-2.26.0-py3-none-any.whl", hash = "sha256:855a23f120328e7a12e8f4371db597d74f65925e20ce335d3a6db81203238f58", size = 1201143, upload-time = "2026-08-07T03:34:11.305Z" },
+    { url = "https://files.pythonhosted.org/packages/db/09/233e529fadbece38580c3a390783f55fa196afad875ce535ee9a57a5ad71/pydantic_ai_slim-2.31.0-py3-none-any.whl", hash = "sha256:cb809ad949ca68be6bb9a0e0b994fc73a95f4cd405e8609a71034f2e2080e2a1", size = 1432053, upload-time = "2026-08-15T03:17:21.208Z" },
 ]
 
 [package.optional-dependencies]
@@ -3980,7 +3996,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-graph"
-version = "2.26.0"
+version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -3989,9 +4005,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/39/64/05bf73d982dd778b5613ad224a58ca510aaccf622644d97af93e6006a680/pydantic_graph-2.26.0.tar.gz", hash = "sha256:12d9da6c5a0e2634d89f2795ca15783ee37250fdc295b33b5c14232576dafdac", size = 45181, upload-time = "2026-08-07T03:34:22.049Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/2c/3817ae318ecc729a258fc85aaad84fc110b9467a292b98bb10e65ae71183/pydantic_graph-2.31.0.tar.gz", hash = "sha256:a19919408dfaa5a1b8713618bcce7a5135d83664321862b0d9be1f4216c432ef", size = 45180, upload-time = "2026-08-15T03:17:30.398Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/59/54302729598308ba437e250473c99ef51625e86997f7ae2ba6b61a2ad00f/pydantic_graph-2.26.0-py3-none-any.whl", hash = "sha256:4599a980747588faf17ac56cfa9c10b2a79723a5a20c3c7ee479e8366653097c", size = 52662, upload-time = "2026-08-07T03:34:14.831Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ef/a3217caed3189cfcc6857316e06cb900990e4d5cb59e42ec517cfdda6a7f/pydantic_graph-2.31.0-py3-none-any.whl", hash = "sha256:062555c89b1d5699ddaaa6f09ae62fc1d0f5cc189d0867e2fafca68c24797ba5", size = 52662, upload-time = "2026-08-15T03:17:24.42Z" },
 ]
 
 [[package]]

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -70,7 +70,9 @@ and a cost.
 
 A run that fails still records what it spent. A run that stops on its budget is
 recorded as `budget_exceeded` rather than `failed`, so an operator filtering for
-problems does not wade through the platform working correctly. A run somebody
+problems does not wade through the platform working correctly. A run a
+[guardrail](reference/capabilities.md#guardrails) blocked is `guardrail_blocked`
+for the same reason - a refusal is the platform working, not a malfunction. A run somebody
 stopped - the composer's stop button, a socket that went away, a delegation
 cancelled from above - is `cancelled` for the same reason, on every surface and
 not only the streaming one. A run that parks on an approval is

--- a/docs/plans/guardrails-capability.md
+++ b/docs/plans/guardrails-capability.md
@@ -1,0 +1,190 @@
+# Plan — Guardrails capability (#46)
+
+Port `pydantic-ai-harness` guardrails into the AgenticOS capability registry. A
+guardrail is an input/output/tool check that can stop, redact, or retry a run —
+the platform's "value is in what it refuses" made executable.
+
+## What the library gives us
+
+`pydantic_ai_harness.guardrails` ships three `AbstractCapability` subclasses and a
+set of ready-made detectors. All three plug into a run purely by overriding hook
+methods on `pydantic_ai.capabilities.AbstractCapability` — the same base every
+capability here already uses.
+
+| Class | Hook | Edge | Verdicts it accepts |
+|---|---|---|---|
+| `InputGuardrail` | `wrap_model_request` (first request only) | the user prompt (`str`) | allow, block, replace |
+| `OutputGuardrail` | `after_output_process` | the agent output (`object`) | allow, block, replace, retry |
+| `ToolGuardrail` | `before_tool_execute` / `after_tool_execute` / `wrap_tool_execute` | tool args & results | allow, block, replace, retry, approve |
+
+`GuardrailResult` is the shared vocabulary (`_shared.py`): a frozen dataclass with
+`action ∈ {allow, block, replace, retry, approve}`, `message`, `replacement`. A
+guard may return a bare `bool` (`True→allow`, `False→block`). A `guard=` may be a
+single callable **or a Sequence** — a chain, where `replace` threads the
+substituted value forward to every later guard (the reason chains and detectors
+ship together in PR #478).
+
+Detectors (`detectors.py`), the pieces a data-defined agent can actually select:
+- `redact_secrets` — `secret_data()` over API-key/token/JWT/PEM patterns; **rewrites**, does not refuse.
+- `redact_personal_data` — `personal_data()` over IBAN (mod-97), credit card (Luhn), US SSN, email.
+- `secret_data(only=/extra=/placeholder=)` / `personal_data(...)` — narrow or extend.
+- `blocked_keywords([...], case_sensitive=, whole_words=)` — **blocks** on the first hit.
+- `for_text(detector, on_other='raise'|'allow')` — adapts a text detector to a
+  non-string output (an `OutputGuardrail` may be handed a Pydantic model).
+
+## The core tension
+
+The harness takes **arbitrary Python callables**. An AgenticOS agent is **data** —
+config, no code. A client cannot supply a callable, so the config schema must
+*select and parameterise the ready-made detectors*. Everything below follows from
+that: the config is a set of toggles + a delimited keyword string, and the builder
+turns them into the harness detector list.
+
+Second constraint, verified in `frontend/src/components/agents/schema-form.tsx`:
+the Builder's generic form renders only **enum / number / boolean / string** —
+`resolveKind` has no array branch. So a `list[str]` of keywords is not a
+config field. Blocked keywords ship as a **newline/comma-delimited string** parsed
+in the builder.
+
+## Decision 1 — one capability, not three
+
+One `guardrails` capability (`id="guardrails"`, `tools=()`, `category="utility"`),
+config selecting which edges are active and which detectors run on each. Rationale:
+a capability is the unit an operator switches on — "protect this agent" is one
+decision, and the Builder shows one switch with a sub-form. Modelled on
+`compaction/` (a non-tool, harness-wrapping capability). The three harness classes
+are an implementation detail the builder assembles from config.
+
+## Decision 2 — where a trip lands: `RunStatus.GUARDRAIL_BLOCKED`
+
+The issue is explicit: "a guardrail trip is the platform working, not a
+malfunction — model it that way." That is the exact argument `BUDGET_EXCEEDED` was
+given its own status for. So: a new `RunStatus.GUARDRAIL_BLOCKED`, mirroring the
+`BUDGET_EXCEEDED` mechanics end to end:
+
+- A domain exception `GuardrailBlocked(edge, detector, message)` (a plain
+  `Exception`, **not** `AppException` — same as `BudgetExceeded`), raised by the
+  capability on any **block** verdict, on every edge.
+- Caught in `agent_runner._run` in a new `except` clause that **does not re-raise**,
+  sets `status = RunStatus.GUARDRAIL_BLOCKED`, and stores a safe `error` string
+  (the refusal, never the offending content).
+- New `RunStatus` member (`guardrail_blocked`, 17 chars — fits `String(24)`);
+  `parse_csv` and the status filter pick it up for free.
+- `_notify`: reuse the failure path or a light `notifications.guardrail_blocked`
+  (optional; a distinct status already keeps operators out of the `FAILED` bucket).
+
+**Deliberate divergence from the harness on `block`.** The harness makes an input
+`block` a *graceful refusal* (`SkipModelRequest` → the refusal text becomes the
+answer, run COMPLETES) and a tool `block` a `SkipToolExecution` (model continues).
+For governance we want a block to be **visible**, not disguised as a completed
+answer, so the capability intercepts a `block` and raises `GuardrailBlocked`
+instead. `replace` (redaction) and `retry` keep harness semantics — a redactor that
+scrubs a key and lets the run finish is the whole point of #478.
+
+## Decision 3 — what NOT to port, because we already have it
+
+An overlap pass against the existing capabilities decides two harness features out
+of scope:
+
+- **The tool-guard `approve` verdict → dropped.** AgenticOS already has
+  `ApprovalGate` (`approval/_capability.py`): per-tool *human* approval that parks
+  the run at `AWAITING_APPROVAL` and replays the approved arguments. That is what
+  `approve` is for. Porting it would be a second, rule-driven path to the same
+  `ApprovalRequired` mechanism — and the "order vs the approval gate" problem the
+  issue flags exists *only* because of `approve`. Dropping it removes the collision
+  entirely: the remaining tool-edge verdicts (`block`/`replace`/`retry`) are
+  automated and compose cleanly with the human gate — the guardrail auto-redacts or
+  refuses; the gate still asks a human for a side-effecting tool.
+- **`hidden=` → dropped.** "Drop a tool from what the model sees" is already
+  expressed by not binding the capability. A second mechanism is dead weight.
+
+For completeness: pydantic-ai core ships `RaiseContentFilterError`, which reacts to
+the *provider's own* safety-filter finish reason. It is unused here and orthogonal
+— it does not inspect content against our rules — so it is neither a substitute for
+guardrails nor part of this port.
+
+## Decision 4 — order vs budget
+
+Factory middleware order is outermost-first: `ReinjectSystemPrompt, budget,
+ApprovalGate, *configured, gauge`. The guardrail arrives inside `*configured`, so
+budget is checked before a guardrail could spend. A config-driven port spends
+nothing (detectors are pure functions), so #16's metering is not yet engaged. A
+future model-calling detector must wrap its spend in `record_ambient_usage` exactly
+like `MeteredCompaction`; the plan reserves that seam and tests it as inert for now.
+
+## Scope — three text edges, one branch
+
+The detectors are **text** detectors, and the harness ships adapters for exactly the
+text edges: native `str` (input prompt), `for_text` (output), `for_tool_result_text`
+(tool result). Tool *arguments* are a structured `Mapping` with no ready-made text
+adapter, so they are out of scope — not deferred so much as "the library does not
+offer a config-driven way to do it." So the port is three edges:
+
+- **input** — `InputGuardrail(guard=[...])` on the prompt.
+- **output** — `OutputGuardrail(guard=[for_text(d, on_other='allow'), ...])`.
+- **tool result** — `ToolGuardrail(result_guard=..., guard=None)` — result screening
+  only; no `guard` (args), no `approve`, no `hidden`.
+
+`on_other='allow'` on the output/result adapters is deliberate and hardcoded: a
+typed output or a non-text tool result cannot be scrubbed, and *raising* there would
+fail a run over content a guard could not even read. Allowing it through is the
+harness's own recommended default and the honest one.
+
+## Config schema
+
+```python
+class GuardrailsConfig(BaseModel):
+    # input edge — the user prompt
+    redact_secrets_in: bool = False
+    redact_pii_in: bool = False
+    blocked_keywords_in: str = ""     # newline/comma-delimited, parsed in the builder
+    # output edge — the final answer
+    redact_secrets_out: bool = False
+    redact_pii_out: bool = False
+    blocked_keywords_out: str = ""
+    # tool-result edge — untrusted content from MCP / RAG / files
+    redact_secrets_tool: bool = False
+    redact_pii_tool: bool = False
+    blocked_keywords_tool: str = ""
+```
+
+All flat scalars + strings — renders in the Builder's generic form. An agent that
+enables the capability but leaves every field default produces empty guard chains on
+every edge → the builder returns `None` ("contributes nothing to this agent", the way
+`knowledge` does with no collections). That is the "pays nothing when absent" test.
+
+## Work breakdown (one branch)
+
+1. **Capability** — `capabilities/guardrails/{__init__.py,_capability.py,README.md}`
+   (no `_toolset.py`; `tools=()`). `_capability.py` builds the harness
+   `InputGuardrail` / `OutputGuardrail` / `ToolGuardrail(result_guard=...)` from
+   config, and wraps each edge's `block` verdict to raise `GuardrailBlocked` instead
+   of the harness's graceful-refusal control flow. Register with `tools=()`,
+   `config_schema=GuardrailsConfig`, `category="utility"`. Add to `load_builtins()`.
+2. **Outcome** — `RunStatus.GUARDRAIL_BLOCKED` in `db/models/agent_run.py`; a new
+   `except GuardrailBlocked` clause in `agent_runner._run` that sets the status and a
+   safe `error` (the refusal, never the offending content) and does not re-raise; a
+   `_notify` branch (light — a distinct status already keeps it out of `FAILED`).
+3. **Exception** — `GuardrailBlocked(edge, detector, message)` in the capability
+   package, a plain `Exception` like `BudgetExceeded`.
+4. **Tests** (100% on `app/agents/**`): each toggle builds the right detector chain;
+   a `block` on each edge → `GuardrailBlocked` → `GUARDRAIL_BLOCKED`; a redaction
+   rewrites and the run COMPLETES; all-default config → `None` (pays nothing); the
+   runner mapping; the keyword-string parser (blank, whitespace, delimiters).
+5. **Docs** — `docs/reference/capabilities.md` (docstring-generated) and
+   `docs/governance.md` (guardrails beside budgets/approvals), plus the new
+   `RunStatus` wherever run outcomes are described.
+
+If a follow-up wants tool-**argument** screening or a model-calling detector, that is
+a separate issue: args need a custom (non-shipped) adapter, and a model call engages
+the `record_ambient_usage` metering seam this port leaves reserved and inert.
+
+## Open risk to watch
+
+- `String(24)` and any `ck_` check constraint on `agent_runs.status` — confirm the
+  width and that no enum-restricting DB constraint needs an Alembic migration for
+  the new value. `agent-spec`/`alembic-migration` skills apply if the column is
+  constrained.
+- The E2E/status filter surfaces (`RunStatus.parse_csv`, frontend status chips) —
+  a new member may need an i18n label and a filter chip; scope-check before Phase 1
+  ships so the status is not invisible in the UI.

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -31,13 +31,15 @@ tools listed.
 | `subagents` | Delegation | reasoning | `task`, `check_task`, `wait_tasks`, `list_active_tasks`, `answer_subagent`, `send_message_to_subagent`, `soft_cancel_task`, `hard_cancel_task`, `create_agent`, `delegate` | `agents:delegate` | — |
 | `thinking` | Thinking | reasoning | none, by design | — | — |
 | `clock` | Date and time | utility | none, by design | — | — |
+| `guardrails` | Guardrails | utility | none, by design | — | — |
 | `channel_tools` | Chat channel lookup | channels | `get_channel_info`, `list_channel_members`, `search_channels`, `read_channel_history` | — | — |
 
-Two of those have no tools on purpose. `thinking` changes how the model runs
-rather than what it can reach, and `clock` puts the date in the instructions —
-neither leaves anything for a person to approve, so neither declares a tool. A
-capability with genuinely no tools says so with `tools=()` rather than omitting
-the argument; see [Add a capability](../howto/add-capability.md).
+Three of those have no tools on purpose. `thinking` changes how the model runs
+rather than what it can reach, `clock` puts the date in the instructions, and
+`guardrails` inspects and rewrites the text flowing through a run — none leaves
+anything for a person to approve, so none declares a tool. A capability with
+genuinely no tools says so with `tools=()` rather than omitting the argument; see
+[Add a capability](../howto/add-capability.md).
 
 **This column is what a capability declares, which is not always what a model is
 offered.** Delegation is the one place the two differ: `create_agent` and `delegate`
@@ -520,6 +522,45 @@ about "this quarter" from its training cutoff.
 | Config | Default | |
 |---|---|---|
 | `timezone` | `UTC` | any IANA name, e.g. `Europe/Warsaw` |
+
+## Guardrails
+
+No tools. Inspects the text flowing through a run at three edges and either
+**redacts** a match or **blocks** the run. The checks are ready-made detectors from
+`pydantic-ai-harness`; an agent is data, so the config selects and parameterises
+them rather than carrying a Python guard.
+
+| Edge | Reads | Redact | Block |
+|---|---|---|---|
+| input | the user's prompt | `redact_secrets_in`, `redact_pii_in` | `blocked_keywords_in` |
+| output | the agent's answer | `redact_secrets_out`, `redact_pii_out` | `blocked_keywords_out` |
+| tool result | what a tool returned, before the model reads it | `redact_secrets_tool`, `redact_pii_tool` | `blocked_keywords_tool` |
+
+| Config | Default | |
+|---|---|---|
+| `redact_secrets_*` | `false` | scrub API keys, tokens, JWTs and PEM blocks |
+| `redact_pii_*` | `false` | scrub email, IBAN (mod-97), card (Luhn) and US SSN |
+| `blocked_keywords_*` | `""` | comma- or newline-separated terms; a match ends the run |
+
+Every field defaults off, and a capability enabled with no edge configured attaches
+nothing — an agent that does not use it pays nothing.
+
+**Redaction rewrites; a block is a run outcome.** A redactor scrubs the match and
+the run finishes — an answer that quoted a key back has still done the work. A
+keyword block instead ends the run with status `guardrail_blocked`, its own outcome
+beside `budget_exceeded`, because a refusal is the platform working and an operator
+filtering for problems should be able to find it rather than have it read like any
+completed answer. See [Governance](../governance.md).
+
+**Tool-result screening is the reason this edge matters most.** It is the only guard
+on untrusted content entering the loop — a fetched page, a file, an MCP server's
+response — where a prompt-injection payload would otherwise reach the model unread.
+
+Two things are deliberately out of scope. **Tool arguments** are a structured
+mapping with no text detector, so they are not an edge. And the harness's tool
+`approve` verdict is not ported: [approvals](../governance.md) already park a run per
+tool for a human decision, and a second, rule-driven path to the same mechanism is
+what a single door avoids.
 
 ## Chat channel lookup
 

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -389,6 +389,7 @@
     "runCancelled": "Cancelled",
     "runCompleted": "Completed",
     "runFailed": "Failed",
+    "runGuardrailBlocked": "Blocked by guardrail",
     "runRunning": "Running",
     "runningThemOneAt": "Running them one at a time makes a conversation easier to follow, and easier to approve.",
     "runs": "Runs",

--- a/frontend/src/components/agents/status-badge.test.tsx
+++ b/frontend/src/components/agents/status-badge.test.tsx
@@ -31,6 +31,14 @@ describe("RunStatusBadge", () => {
     expect(container.querySelector('[class*="destructive"]')).not.toBeNull();
   });
 
+  it("does not present a guardrail block as a failure", () => {
+    // A refusal is the platform working, like a budget stop - a warning tone,
+    // never the destructive one an operator reads as a crash.
+    const { container } = render(<RunStatusBadge status="guardrail_blocked" />);
+    expect(screen.getByText("Blocked by guardrail")).toBeInTheDocument();
+    expect(container.querySelector('[class*="destructive"]')).toBeNull();
+  });
+
   it.each([
     ["completed", "Completed"],
     ["running", "Running"],

--- a/frontend/src/components/agents/status-badge.tsx
+++ b/frontend/src/components/agents/status-badge.tsx
@@ -49,16 +49,17 @@ export function AgentStatusBadge({ status }: { status: AgentStatus }) {
 }
 
 /**
- * `budget_exceeded` reads as a warning, not an error.
+ * `budget_exceeded` and `guardrail_blocked` read as a warning, not an error.
  *
- * It is the platform working as designed, and colouring it like a crash makes
- * operators chase a problem that is not one.
+ * Each is the platform working as designed - a cap reached, a rule enforced -
+ * and colouring it like a crash makes operators chase a problem that is not one.
  */
 const RUN_DOT: Record<RunStatus, string> = {
   completed: "bg-success",
   running: "bg-brand animate-pulse",
   awaiting_approval: "bg-warning",
   budget_exceeded: "bg-warning",
+  guardrail_blocked: "bg-warning",
   cancelled: "bg-muted-foreground/50",
   failed: "bg-destructive",
 };
@@ -70,6 +71,7 @@ export const RUN_LABEL: Record<RunStatus, string> = {
   running: "runRunning",
   awaiting_approval: "runAwaitingApproval",
   budget_exceeded: "runBudgetExceeded",
+  guardrail_blocked: "runGuardrailBlocked",
   cancelled: "runCancelled",
   failed: "runFailed",
 };

--- a/frontend/src/components/dashboard/widgets/outcomes.tsx
+++ b/frontend/src/components/dashboard/widgets/outcomes.tsx
@@ -51,7 +51,11 @@ export function OutcomesWidget({ title, hint, period, seeAll, options }: Dashboa
           const failed = of("failed");
           const budget = of("budget_exceeded");
           const awaiting = of("awaiting_approval");
-          const other = of("running") + of("cancelled");
+          // `guardrail_blocked` joins `other`: the ramp is five colours by
+          // design and the four attention/terminal statuses spend them, so a
+          // sixth is "other" (see `seriesColor`). Without it a blocked run sits
+          // in `total` behind no arc, and the ring stops summing to the whole.
+          const other = of("running") + of("cancelled") + of("guardrail_blocked");
           const attention = failed + budget;
           // The order is the ramp's, and it is fixed by status rather than by
           // which statuses this window happens to hold: "failed" is the same

--- a/frontend/src/lib/delegations.ts
+++ b/frontend/src/lib/delegations.ts
@@ -194,14 +194,16 @@ export function closeOpenDelegations(current: Delegation[]): Delegation[] {
  *
  * `running` and `awaiting_approval` are absent on purpose: neither is terminal, so
  * a panel waiting on a person stays waiting (`resolveAwaitingOnResume`). A run has
- * no `budget_exceeded` counterpart on a delegation panel, so it reads as `failed` -
- * the delegate stopped without finishing, which is what `failed` says.
+ * no `budget_exceeded` or `guardrail_blocked` counterpart on a delegation panel,
+ * so each reads as `failed` - the delegate stopped without finishing, which is
+ * what `failed` says.
  */
 const TERMINAL_DELEGATION_STATUS: Partial<Record<RunStatus, DelegationStatus>> = {
   completed: "completed",
   failed: "failed",
   cancelled: "cancelled",
   budget_exceeded: "failed",
+  guardrail_blocked: "failed",
 };
 
 /**

--- a/frontend/src/types/runs.ts
+++ b/frontend/src/types/runs.ts
@@ -1,7 +1,13 @@
 /** Types for run history, approvals and the cost dashboard. */
 
 export type RunStatus =
-  "running" | "completed" | "failed" | "cancelled" | "awaiting_approval" | "budget_exceeded";
+  | "running"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "awaiting_approval"
+  | "budget_exceeded"
+  | "guardrail_blocked";
 
 export interface AgentRun {
   id: string;


### PR DESCRIPTION
Ports the `pydantic-ai-harness` guardrails into the capability registry as a
single `guardrails` capability, and gives a tripped guardrail its own run
outcome. Closes #46.

## What it does

A guardrail inspects the text flowing through a run at three edges and either
**redacts** a match or **blocks** the run:

| Edge | Reads | Redact | Block |
|---|---|---|---|
| input | the user's prompt | secrets, PII | keyword list |
| output | the agent's answer | secrets, PII | keyword list |
| tool result | what a tool returned, before the model reads it | secrets, PII | keyword list |

Redactors cover API keys/tokens/JWTs/PEM blocks and email/IBAN (mod-97)/card
(Luhn)/US-SSN. Tool-result screening is the headline: it is the only guard on
untrusted content entering the loop — a fetched page, a file, an MCP response —
where a prompt-injection payload would otherwise reach the model unread.

## Design decisions

- **Config, not callables.** An agent is data, so the harness's `guard=<fn>`
  cannot cross the wire. The config selects and parameterises the ready-made
  detectors: flat toggles + a delimited keyword string per edge, which is all the
  Builder's generated form renders (it has no array control). Shaped like the
  compaction capability — a non-tool, harness-wrapping capability.
- **A block is a run outcome, not a graceful answer.** The harness makes a block
  graceful (an input block completes the run with a refusal as the answer). For
  governance that is exactly wrong — a refusal should be visible. So the detector
  chain raises `GuardrailBlocked`, and the runner maps it to a new
  `RunStatus.GUARDRAIL_BLOCKED`, beside `BUDGET_EXCEEDED` and for the same reason:
  the platform working, not a malfunction. Verified that the raise escapes
  `agent.run()` cleanly from all three edges against a real `FunctionModel` run.
- **What was deliberately not ported.** The tool `approve` verdict duplicates the
  approval gate (which already parks a run per tool for a human) — dropping it also
  removes the guardrail-vs-approval ordering question entirely. Tool arguments have
  no text detector, so they are not an edge. Every detector is a pure function, so
  budget metering (#16) is not engaged; a future model-calling detector must book
  spend through `record_ambient_usage` first.
- **No migration.** `agent_runs.status` is a plain `String(24)` with no check
  constraint, so the new value stores as-is and `parse_csv`/the filter pick it up.
- **Frontend.** The new status is wired through the type union, the badge (warning
  tone, like a budget stop), its label, the delegation map, and the outcomes donut
  (folded into `other` — the ramp is five colours by design). Left alone on
  purpose: the "Recent failures" widget and the run-history "Problems" preset — a
  governance refusal is not a failure, and it stays visible and filterable under
  its own status in run history.

## Verification

- Backend: 100% line + branch coverage on the new module; the runner maps
  `GuardrailBlocked` → `GUARDRAIL_BLOCKED` without re-raising; registry drift and
  layout tests accept a toolless capability that builds `None` on empty config.
- `make lint-backend`, `make lint-frontend`, the frontend coverage gate (100%
  statements/functions/lines, 97.52% branches) and a strict docs build all pass
  locally. The full `make test` backend gate was still running when this was
  opened — CI runs it.
- Docs updated: `docs/reference/capabilities.md`, `docs/concepts.md`, and a design
  note in `docs/plans/`.
