### PR TITLE
test(mcp): pin tool-search schema surface at scale

### DIFF
--- a/backend/tests/test_tool_search_factory_fixture.py
+++ b/backend/tests/test_tool_search_factory_fixture.py
@@ -1,0 +1,194 @@
+"""Keyless scale fixture for the factory's MCP tool-search assembly seam."""
+
+import json
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart, ToolCallPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.tools import ToolDefinition
+from pydantic_ai.toolsets import AbstractToolset, FunctionToolset
+
+from app.agents.capabilities import load_builtins
+from app.agents.factory import BuiltAgent, build_agent
+from app.agents.model_resolver import ModelRequestSpec, ResolvedCredential
+from app.agents.spec import AgentSpec
+from app.core.secret_kinds import NoSecret
+
+pytestmark = pytest.mark.anyio
+
+_TARGET_INDEX = 7
+_TARGET_NAME = "catalog_lookup_record_0007"
+_FIRST_REQUEST_BYTES = {12: 3_480, 100: 28_736, 1000: 287_036}
+_SEARCH_ONLY_BYTES = 786
+_REVEALED_TARGET_BYTES = 1_108
+
+
+@dataclass(frozen=True)
+class _ToolCall:
+    index: int
+    record_id: str
+    include_history: bool
+
+
+@dataclass
+class _Observation:
+    requests: list[list[ToolDefinition]]
+    calls: list[_ToolCall]
+
+
+@pytest.fixture(autouse=True)
+def _builtins_loaded() -> None:
+    load_builtins()
+
+
+def _model_spec() -> ModelRequestSpec:
+    return ModelRequestSpec(
+        profile_id=uuid.uuid4(),
+        label="Keyless fixture",
+        provider="ollama",
+        model="fixture",
+        params={},
+        credential=ResolvedCredential(
+            provider="ollama",
+            secret=NoSecret(),
+            base_url="http://127.0.0.1:11434/v1",
+        ),
+        fallbacks=[],
+    )
+
+
+def _lookup_tool(index: int, calls: list[_ToolCall]) -> Callable[[str, bool], str]:
+    def lookup(record_id: str, include_history: bool = False) -> str:
+        calls.append(_ToolCall(index=index, record_id=record_id, include_history=include_history))
+        return f"record-{index:04d}:{record_id}"
+
+    return lookup
+
+
+def _catalog(tool_count: int) -> tuple[AbstractToolset[Any], list[_ToolCall]]:
+    calls: list[_ToolCall] = []
+    toolset: FunctionToolset[Any] = FunctionToolset()
+    for index in range(tool_count):
+        description = f"Read deterministic café record {index:04d}."
+        if index == _TARGET_INDEX:
+            description += " Needle target for reveal and call."
+        toolset.add_function(
+            _lookup_tool(index, calls),
+            takes_ctx=False,
+            name=f"lookup_record_{index:04d}",
+            description=description,
+        )
+    return toolset.prefixed("catalog"), calls
+
+
+def _build(tool_count: int, *, with_search: bool) -> tuple[BuiltAgent, list[_ToolCall]]:
+    toolset, calls = _catalog(tool_count)
+    capabilities: list[dict[str, Any]] = []
+    if with_search:
+        capabilities.append(
+            {"id": "tool_search", "config": {"strategy": "keywords", "max_results": 1}}
+        )
+    built = build_agent(
+        AgentSpec(name="Tool search scale fixture", capabilities=capabilities),
+        _model_spec(),
+        organization_id=uuid.uuid4(),
+        extra_toolsets=[toolset],
+    )
+    return built, calls
+
+
+def _canonical_schema_bytes(tools: list[ToolDefinition]) -> int:
+    """Measure a stable UTF-8 JSON projection of model-visible function schemas."""
+    payload = [
+        {
+            "description": tool.description,
+            "name": tool.name,
+            "parameters_json_schema": tool.parameters_json_schema,
+        }
+        for tool in sorted(tools, key=lambda item: item.name)
+    ]
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return len(encoded)
+
+
+async def _observe_without_search(tool_count: int) -> _Observation:
+    built, calls = _build(tool_count, with_search=False)
+    requests: list[list[ToolDefinition]] = []
+
+    async def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        requests.append(list(info.function_tools))
+        return ModelResponse(parts=[TextPart("done")])
+
+    with built.agent.override(model=FunctionModel(respond, model_name="gpt-4.1")):
+        await built.agent.run("Find the needle record.", deps=built.deps)
+    return _Observation(requests=requests, calls=calls)
+
+
+async def _observe_search_then_call(tool_count: int) -> _Observation:
+    built, calls = _build(tool_count, with_search=True)
+    requests: list[list[ToolDefinition]] = []
+
+    async def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        requests.append(list(info.function_tools))
+        if len(requests) == 1:
+            return ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name="search_tools",
+                        args={"queries": ["needle target"]},
+                        tool_call_id="search-1",
+                    )
+                ]
+            )
+        if len(requests) == 2:
+            return ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name=_TARGET_NAME,
+                        args={"record_id": "fixed", "include_history": True},
+                        tool_call_id="target-1",
+                    )
+                ]
+            )
+        return ModelResponse(parts=[TextPart("done")])
+
+    with built.agent.override(model=FunctionModel(respond, model_name="gpt-4.1")):
+        await built.agent.run("Find the needle record.", deps=built.deps)
+    return _Observation(requests=requests, calls=calls)
+
+
+@pytest.mark.parametrize("tool_count", [12, 100, 1000])
+async def test_tool_search_bounds_first_request_schema_bytes_and_reveals_a_callable_target(
+    tool_count: int,
+) -> None:
+    """Byte snapshots are wire-neutral regression data, not token, cost, or quality claims."""
+    unbound = await _observe_without_search(tool_count)
+    searched = await _observe_search_then_call(tool_count)
+
+    assert len(unbound.requests) == 1
+    assert len(unbound.requests[0]) == tool_count
+    assert "search_tools" not in {tool.name for tool in unbound.requests[0]}
+    assert _canonical_schema_bytes(unbound.requests[0]) == _FIRST_REQUEST_BYTES[tool_count]
+
+    assert len(searched.requests) == 3
+    assert [tool.name for tool in searched.requests[0]] == ["search_tools"]
+    assert _canonical_schema_bytes(searched.requests[0]) == _SEARCH_ONLY_BYTES
+    expected_revealed_names = [
+        _TARGET_NAME,
+        "search_tools",
+    ]
+    for request in searched.requests[1:]:
+        assert sorted(tool.name for tool in request) == expected_revealed_names
+        assert _canonical_schema_bytes(request) == _REVEALED_TARGET_BYTES
+    assert searched.calls == [
+        _ToolCall(index=_TARGET_INDEX, record_id="fixed", include_history=True)
+    ]


### PR DESCRIPTION
## What changed

- Adds an AgenticOS-native `FunctionModel` fixture at the `build_agent` seam.
- Compares unbound and `tool_search` agents over deterministic 12, 100, and
  1,000-tool prefixed catalogs.
- Captures canonical UTF-8 JSON bytes for the model-visible function schemas
  and the number of model requests in each arm.
- Drives `search_tools` through reveal and execution of the fixed
  `catalog_lookup_record_0007` target, then proves the other deferred tools stay
  absent after the call returns.

This is intentionally separate from the two first-request behavior tests added
in `c0d7c0c2`: those pin the basic two-tool assembly, while this fixture pins the
scale boundary and the complete search -> reveal -> call closure.

## Reproducible observations

| Catalog tools | No binding, request 1 | `tool_search`, request 1 | Model requests |
| ---: | ---: | ---: | ---: |
| 12 | 3,480 B | 786 B | 1 vs 3 |
| 100 | 28,736 B | 786 B | 1 vs 3 |
| 1,000 | 287,036 B | 786 B | 1 vs 3 |

Requests 2 and 3 in the search arm contain only `search_tools` and the revealed
target, with a canonical size of 1,108 B.

The byte calculation is a wire-neutral test projection of `name`, `description`,
and `parameters_json_schema`: tools and object keys are sorted, whitespace is
removed, non-ASCII text is left unescaped, and the result is encoded as UTF-8.
These are schema bytes and request counts, not provider tokens, cost, latency,
or model-quality claims.

## Verification

- `pytest tests/test_tool_search_factory_fixture.py tests/test_agent_spec_and_factory.py tests/test_tool_search_capability.py -q` — 48 passed.
- `ruff check`, `ruff format --check`, and scoped `ty check` — passed.
- `make lint-backend` — clean exit.
- Independent review — PASS after adding request-3 narrowed-schema assertions.
- `make test` completed 4,484 passed / 517 skipped with no test failures, but
  exited at the 100% coverage gate (99.53%) because this machine has no running
  Postgres or Docker daemon, so the integration suite was skipped. CI remains
  the database-backed coverage result.

The fixture uses an Ollama `NoSecret` profile overridden by `FunctionModel`; it
needs no provider credential and makes no network request.

Disclosure: I maintain `dsh-mcp-lens`, which motivated a similar measurement
discipline. This test is fully AgenticOS-native and has no dependency on that
project. There is no star or product-performance claim here.

Refs #780
