### PR TITLE
feat(budgets): default a new organization's monthly budget

### DIFF
--- a/backend/app/commands/bootstrap.py
+++ b/backend/app/commands/bootstrap.py
@@ -20,6 +20,7 @@ import click
 
 from app.agents.spec import AgentSpec
 from app.commands import command, info, success, warning
+from app.core.config import settings
 from app.core.permissions import AuthContext, OrgRoleName
 from app.core.secret_kinds import ApiKeySecret
 from app.db.models.resource_grant import Visibility
@@ -138,7 +139,11 @@ async def _resolve_organization(db, owner_id: uuid.UUID, name: str):
         return personal
 
     org = await organization_repo.create(
-        db, name=name, slug=slugify(name), created_by_user_id=owner_id
+        db,
+        name=name,
+        slug=slugify(name),
+        created_by_user_id=owner_id,
+        monthly_budget_usd=settings.DEFAULT_ORG_MONTHLY_BUDGET_USD,
     )
     await member_repo.create(
         db, organization_id=org.id, user_id=owner_id, role=OrgRoleName.OWNER.value

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,6 +1,7 @@
 """Application configuration using Pydantic BaseSettings."""
 # ruff: noqa: I001 - Imports structured for Jinja2 template conditionals
 
+from decimal import Decimal
 from pathlib import Path
 from typing import Literal
 
@@ -48,6 +49,25 @@ class Settings(BaseSettings):
     # the chat path's `MAX_UPLOAD_SIZE`, never a way past either.
     EMBED_MAX_UPLOAD_SIZE_MB: int = 5
     STORAGE_SOFT_LIMIT_BYTES: int = 5 * 1024 * 1024 * 1024
+
+    # The monthly spend ceiling a brand-new organization starts with, in USD. A
+    # new org one runaway agent away from a surprise bill is the posture this
+    # avoids: a budget is only enforced if it exists, so a sensible default is
+    # the safer first-run stance. `None` restores the older opt-in behaviour -
+    # no ceiling until somebody sets one - and is how a deployment that would
+    # rather choose its own turns the default off. Existing orgs are untouched;
+    # this applies at creation only. Enforced exactly like a hand-set cap, so it
+    # must be positive - `0` is an org whose agents can never answer, which the
+    # `ck_organization_budget_positive` constraint already refuses.
+    DEFAULT_ORG_MONTHLY_BUDGET_USD: Decimal | None = Decimal("100")
+
+    @field_validator("DEFAULT_ORG_MONTHLY_BUDGET_USD")
+    @classmethod
+    def validate_default_org_budget(cls, v: Decimal | None) -> Decimal | None:
+        """A default cap of zero or below would refuse every org's first run."""
+        if v is not None and v <= 0:
+            raise ValueError("DEFAULT_ORG_MONTHLY_BUDGET_USD must be positive, or unset for no cap")
+        return v
 
     # Seconds the event loop may stop turning before the worker kills itself so
     # its supervisor replaces it; `0` or below switches the check off, which is

--- a/backend/app/db/models/organization.py
+++ b/backend/app/db/models/organization.py
@@ -52,9 +52,11 @@ class Organization(Base, TimestampMixin):
         index=True,
     )
     # The ceiling on everything this organization's agents spend in a calendar
-    # month. `None` is no ceiling, which is what an organization that has never
-    # opened the setting has - the cap is opt-in, because a default number
-    # nobody chose would stop somebody's agents on a date they did not pick.
+    # month. `None` is no ceiling. A new organization starts at the deployment's
+    # `DEFAULT_ORG_MONTHLY_BUDGET_USD` ($100 unless configured otherwise), so it
+    # is not one runaway agent away from a surprise bill; a deployment that would
+    # rather start uncapped sets that default to nothing, and any organization
+    # can be cleared back to `None` afterwards.
     #
     # Numeric to the same scale as `agent_runs.cost_usd`: the cap is compared
     # against a sum of those, and a float would drift against the total the

--- a/backend/app/repositories/organization.py
+++ b/backend/app/repositories/organization.py
@@ -93,6 +93,7 @@ async def create(
     created_by_user_id: UUID,
     is_personal: bool = False,
     avatar_url: str | None = None,
+    monthly_budget_usd: Decimal | None = None,
 ) -> Organization:
     org = Organization(
         name=name,
@@ -100,6 +101,7 @@ async def create(
         created_by_user_id=created_by_user_id,
         is_personal=is_personal,
         avatar_url=avatar_url,
+        monthly_budget_usd=monthly_budget_usd,
     )
     db.add(org)
     await db.flush()

--- a/backend/app/services/organization.py
+++ b/backend/app/services/organization.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.core.exceptions import (
     AlreadyExistsError,
     AuthorizationError,
@@ -128,6 +129,7 @@ class OrganizationService:
             slug=slug,
             created_by_user_id=owner_id,
             is_personal=False,
+            monthly_budget_usd=settings.DEFAULT_ORG_MONTHLY_BUDGET_USD,
         )
         await member_repo.create(
             self.db,
@@ -169,8 +171,10 @@ class OrganizationService:
     async def create_personal_org(self, user_id: UUID, email: str) -> Organization:
         """Create the Personal Organization for a newly registered user.
 
-        Also grants the configured free-tier credit bonus so AI usage works on
-        the free plan up to the granted amount.
+        It starts with the deployment's default monthly budget
+        (`DEFAULT_ORG_MONTHLY_BUDGET_USD`, $100 unless configured otherwise), so
+        a fresh account is not one runaway agent away from a surprise bill. A
+        deployment that would rather start uncapped sets that to nothing.
         """
         slug = await organization_repo.generate_unique_slug(self.db, email.split("@")[0])
         org = await organization_repo.create(
@@ -179,6 +183,7 @@ class OrganizationService:
             slug=slug,
             created_by_user_id=user_id,
             is_personal=True,
+            monthly_budget_usd=settings.DEFAULT_ORG_MONTHLY_BUDGET_USD,
         )
         await member_repo.create(
             self.db,

--- a/backend/tests/test_bootstrap.py
+++ b/backend/tests/test_bootstrap.py
@@ -9,6 +9,7 @@ rather than an agent that silently cannot run.
 from __future__ import annotations
 
 import uuid
+from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -64,13 +65,15 @@ class TestOrganization:
             patch(
                 "app.commands.bootstrap.organization_repo.create",
                 new=AsyncMock(return_value=created),
-            ),
+            ) as create_org,
             patch("app.commands.bootstrap.member_repo.create", new=AsyncMock()) as add_member,
         ):
             result = await _resolve_organization(MagicMock(), uuid.uuid4(), "Acme")
 
         assert result is created
         assert add_member.call_args.kwargs["role"] == OrgRoleName.OWNER.value
+        # A bootstrapped org gets the same default cap as any other (#785).
+        assert create_org.await_args.kwargs["monthly_budget_usd"] == Decimal("100")
 
 
 class TestModel:

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,27 @@
+"""Tests for application settings validation."""
+
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from app.core.config import Settings
+
+
+class TestDefaultOrgBudget:
+    def test_a_positive_default_is_accepted(self):
+        expected = Decimal("100")
+        settings = Settings(DEFAULT_ORG_MONTHLY_BUDGET_USD=expected)
+        assert expected == settings.DEFAULT_ORG_MONTHLY_BUDGET_USD
+
+    def test_none_disables_the_default(self):
+        """`None` is the older opt-in posture, not a misconfiguration."""
+        settings = Settings(DEFAULT_ORG_MONTHLY_BUDGET_USD=None)
+        assert settings.DEFAULT_ORG_MONTHLY_BUDGET_USD is None
+
+    @pytest.mark.parametrize("bad", [Decimal("0"), Decimal("-1")])
+    def test_a_non_positive_default_is_refused(self, bad):
+        """Zero or below would refuse every new org's first run - the same reason
+        `ck_organization_budget_positive` forbids it on the row."""
+        with pytest.raises(ValidationError):
+            Settings(DEFAULT_ORG_MONTHLY_BUDGET_USD=bad)

--- a/backend/tests/test_organization_spend.py
+++ b/backend/tests/test_organization_spend.py
@@ -80,6 +80,15 @@ class TestTheRefusal:
         assert exc.value.scope is BudgetScope.ORGANIZATION
         assert (exc.value.limit_usd, exc.value.spent_usd) == (Decimal("40"), Decimal("40"))
 
+    async def test_the_default_cap_a_new_org_starts_with_is_enforced(self):
+        """A fresh org's $100 default is a real ceiling, not a displayed
+        suggestion: the same guard refuses it once the month reaches it (#785)."""
+        org, runs, ingestion = self._repos(_org(Decimal("100")), Decimal("100"))
+        with org, runs, ingestion, pytest.raises(BudgetExceeded) as exc:
+            await assert_organization_within_budget(MagicMock(), uuid.uuid4())
+
+        assert exc.value.limit_usd == Decimal("100")
+
     async def test_an_organization_under_its_cap_passes(self):
         org, runs, ingestion = self._repos(_org(Decimal("40")), Decimal("39.99"))
         with org, runs, ingestion:

--- a/backend/tests/test_services_organizations.py
+++ b/backend/tests/test_services_organizations.py
@@ -132,6 +132,65 @@ class TestOrganizationService:
         assert result == mock_org
 
     @pytest.mark.anyio
+    async def test_a_new_team_org_starts_with_the_default_monthly_budget(self, service, mock_db):
+        """A fresh org is not one runaway agent away from a surprise bill (#785)."""
+        with (
+            patch(
+                "app.services.organization.organization_repo.generate_unique_slug",
+                new=AsyncMock(return_value="acme"),
+            ),
+            patch(
+                "app.services.organization.organization_repo.create",
+                new=AsyncMock(return_value=MagicMock(id=uuid.uuid4())),
+            ) as create,
+            patch("app.services.organization.member_repo.create", new=AsyncMock()),
+            patch("app.services.organization.skill_library.library", return_value=()),
+        ):
+            await service.create(OrganizationCreate(name="Acme"), owner_id=uuid.uuid4())
+
+        assert create.await_args.kwargs["monthly_budget_usd"] == Decimal("100")
+
+    @pytest.mark.anyio
+    async def test_a_personal_org_starts_with_the_default_monthly_budget(self, service, mock_db):
+        with (
+            patch(
+                "app.services.organization.organization_repo.generate_unique_slug",
+                new=AsyncMock(return_value="alice"),
+            ),
+            patch(
+                "app.services.organization.organization_repo.create",
+                new=AsyncMock(return_value=MagicMock(id=uuid.uuid4())),
+            ) as create,
+            patch("app.services.organization.member_repo.create", new=AsyncMock()),
+            patch("app.services.organization.skill_library.library", return_value=()),
+        ):
+            await service.create_personal_org(uuid.uuid4(), "alice@example.com")
+
+        assert create.await_args.kwargs["monthly_budget_usd"] == Decimal("100")
+
+    @pytest.mark.anyio
+    async def test_the_default_budget_can_be_disabled(self, service, mock_db, monkeypatch):
+        """`None` restores the older opt-in posture: a new org starts uncapped."""
+        monkeypatch.setattr(
+            "app.services.organization.settings.DEFAULT_ORG_MONTHLY_BUDGET_USD", None
+        )
+        with (
+            patch(
+                "app.services.organization.organization_repo.generate_unique_slug",
+                new=AsyncMock(return_value="acme"),
+            ),
+            patch(
+                "app.services.organization.organization_repo.create",
+                new=AsyncMock(return_value=MagicMock(id=uuid.uuid4())),
+            ) as create,
+            patch("app.services.organization.member_repo.create", new=AsyncMock()),
+            patch("app.services.organization.skill_library.library", return_value=()),
+        ):
+            await service.create(OrganizationCreate(name="Acme"), owner_id=uuid.uuid4())
+
+        assert create.await_args.kwargs["monthly_budget_usd"] is None
+
+    @pytest.mark.anyio
     async def test_a_new_organization_starts_with_the_bundled_skills(self, service, mock_db):
         """Seeded at creation, not installed by hand (#281).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,6 +45,7 @@ explicitly is also what lets stored secrets survive a `SECRET_KEY` rotation.
 | `MEDIA_DIR` | `./media` | Directory for uploaded files |
 | `MAX_UPLOAD_SIZE_MB` | `50` | Knowledge-base document cap, and the number the whole-request ceiling below is derived from. Chat and embed uploads are bounded by the hardcoded `MAX_UPLOAD_SIZE` (10 MiB in `file_storage.py`), not by this |
 | `EMBED_MAX_UPLOAD_SIZE_MB` | `5` | What a **stranger** may upload to a hosted page. A ceiling on top of the chat path's `MAX_UPLOAD_SIZE`, never a way past it |
+| `DEFAULT_ORG_MONTHLY_BUDGET_USD` | `100` | The monthly spend ceiling a **new** organization starts with, in USD, so it is not one runaway agent away from a surprise bill. Applies at creation only; existing organizations are untouched and any organization can be cleared back to no cap afterwards. Must be positive; leave **empty** to start organizations uncapped (the older opt-in posture) |
 
 ### The size of a request, as opposed to the size of a file
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -15,6 +15,14 @@ Two levels, and they are not variations on one number.
 | **Agent monthly** | the agent's spec | that agent's own runs | whoever may edit the agent |
 | **Organization monthly** | organization settings | every run *and* ingestion in the organization | whoever holds `budgets:manage` |
 
+A **new organization starts with the organization ceiling already set** — the
+deployment's `DEFAULT_ORG_MONTHLY_BUDGET_USD` ([configuration](configuration.md),
+$100 out of the box) — so a fresh tenant is not one runaway agent away from a
+surprise bill. It is an ordinary cap from that point on: editable on the org's
+row, and enforced exactly like a hand-set one. A deployment that would rather
+start uncapped leaves that setting empty; either way an existing organization's
+cap is never changed for it.
+
 ### Why they cannot be collapsed
 
 They used to be, with `min()`, and the result was wrong. An agent's cap measured


### PR DESCRIPTION
## What

A newly created organization now starts with a **default monthly budget of $100**
instead of no cap — config-driven, editable afterwards like any other org cap.

An org with no budget is one runaway agent away from a surprise bill, and a budget
is only enforced if it exists. A sensible default is the safer first-run posture and
matches "the platform's value is in what it refuses."

## How

- **`DEFAULT_ORG_MONTHLY_BUDGET_USD`** (new setting in `app/core/config.py`, default
  `100`, validated positive) is threaded through `organization_repo.create` and
  applied by **every** creation path: team create, the personal org on signup, and
  `bootstrap`. `None` restores the older opt-in posture (uncapped until somebody sets
  one), so a deployment that prefers to start uncapped turns the default off.
- **Period/scope:** monthly, org-wide — the existing budget model unchanged. No new
  concept, and **no migration**: `organizations.monthly_budget_usd` already exists (a
  nullable `Numeric(12,6)` column with a `> 0` check constraint), so this is a value
  at insert time.
- **UI:** the limits component already renders `monthly_budget_usd`, so a new org
  arrives showing an editable $100 cap — no frontend change needed.
- Reconciled two stale docstrings the change touched: the model comment calling the
  cap purely opt-in, and `create_personal_org`'s claim of a free-tier credit bonus it
  never granted.

## Tests

- A new **team** org and a new **personal** org each carry the default; the default
  can be **disabled** (`None` → uncapped). (`test_services_organizations.py`)
- A **bootstrapped** org gets the same default. (`test_bootstrap.py`)
- The default $100 is **enforced** by the same org guard that refuses a hand-set cap.
  (`test_organization_spend.py`)
- The config **refuses a zero or negative** default. (`test_config.py`)

## Done when (from #785)

- [x] Creating an org sets a $100 default budget (or the configured value)
- [x] The default is visible and editable in the org's limits UI (renders the column)
- [x] A test covers that a fresh org has the budget, and that spend is checked against it

## Verification

`make lint` hooks (ruff, ty, vulture, codespell) pass on the diff; the touched test
files pass; `make docs-build --strict` clean. `docs/governance.md` and
`docs/configuration.md` updated. The automated reviewer is off (#311), so I reviewed
the diff myself and swept every org-creation call site.

## Not done (out of scope)

- No create-time budget override on `POST /orgs` — editing after creation already
  exists via `PATCH /orgs/{id}`.
- No backfill of existing orgs — this is a first-run default, applied at creation only.

Closes #785
