### PR TITLE
chore: cut 0.0.159

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.159] - 2026-08-16
+
+A new organization starts with a spend ceiling already in place.
+
+### Added
+
+- **A new organization defaults to a $100 monthly budget.** An org with no cap is
+  one runaway agent away from a surprise bill, and a budget only refuses if it
+  exists — so a fresh org now starts at the deployment's
+  `DEFAULT_ORG_MONTHLY_BUDGET_USD` (`$100` out of the box), editable on the org's
+  row like any other cap and enforced by the same guard. The default is applied at
+  creation across every path — team create, the personal org on signup, and
+  `bootstrap` — and `None` restores the older opt-in posture for a deployment that
+  would rather start uncapped. Existing organizations are untouched; no migration,
+  because the column already existed. (#785)
+
 ## [0.0.158] - 2026-08-16
 
 A long run compacts its own history before it hits the model's limit, metered,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.158"
+version = "0.0.159"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.158"
+version = "0.0.159"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.158",
+  "version": "0.0.159",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Releases the default organization budget (#785, #797).

Version bump + CHANGELOG only — CI is the net.

Refs #797