### PR TITLE
feat(ui): default avatars from initials on a hashed colour

### DIFF
--- a/backend/alembic/versions/0035_avatar_color.py
+++ b/backend/alembic/versions/0035_avatar_color.py
@@ -1,0 +1,40 @@
+"""A chosen default-avatar colour for a user, an organization and an agent.
+
+A row with no uploaded picture falls back to two initials on a colour derived
+from its id. This lets that colour be chosen instead: `avatar_color` is a slot
+1..10 into the `--avatar-*` ramp the frontend renders, and null means auto - the
+id-derived default, which is every row before this migration and every row whose
+owner never picks one.
+
+Additive and nullable, so there is nothing to backfill. The range is enforced by
+the API schema (`Field(ge=1, le=10)`), not a CHECK - matching `avatar_url`, the
+sibling column it sits beside, which has no database-level format rule either.
+
+Revision ID: 0035_avatar_color
+Revises: 0034_conversation_summary
+Create Date: 2026-08-16
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0035_avatar_color"
+down_revision: str | None = "0034_conversation_summary"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("avatar_color", sa.SmallInteger(), nullable=True))
+    op.add_column("organizations", sa.Column("avatar_color", sa.SmallInteger(), nullable=True))
+    op.add_column("agents", sa.Column("avatar_color", sa.SmallInteger(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("agents", "avatar_color")
+    op.drop_column("organizations", "avatar_color")
+    op.drop_column("users", "avatar_color")

--- a/backend/app/api/routes/v1/agents.py
+++ b/backend/app/api/routes/v1/agents.py
@@ -31,6 +31,7 @@ from app.api.deps import AgentRegistrySvc, AgentRunnerSvc, Auth, limit_agent_run
 from app.core.permissions import Perm
 from app.db.models.agent_run import RunSurface
 from app.schemas.agent import (
+    AgentAvatarColorRequest,
     AgentClone,
     AgentCreate,
     AgentDetail,
@@ -190,6 +191,7 @@ async def get_agent(agent_id: UUID, service: AgentRegistrySvc, ctx: Auth) -> Any
         owner_user_id=agent.owner_user_id,
         current_version_id=agent.current_version_id,
         has_avatar=agent.has_avatar,
+        avatar_color=agent.avatar_color,
         created_at=agent.created_at,
         updated_at=agent.updated_at,
         draft_spec=AgentSpec.model_validate(agent.draft_spec),
@@ -340,6 +342,20 @@ async def upload_agent_avatar(
         filename=file.filename or "avatar.jpg",
         content_type=file.content_type,
     )
+
+
+@router.patch(
+    "/{agent_id}/avatar-color",
+    response_model=AgentRead,
+)
+async def set_agent_avatar_color(
+    agent_id: UUID,
+    data: AgentAvatarColorRequest,
+    service: AgentRegistrySvc,
+    ctx: Auth,
+) -> Any:
+    """Choose the colour the agent's fallback avatar uses, or null for auto."""
+    return await service.set_avatar_color(ctx, agent_id, color=data.color)
 
 
 @router.get(

--- a/backend/app/api/routes/v1/members.py
+++ b/backend/app/api/routes/v1/members.py
@@ -35,9 +35,10 @@ async def list_members(
             email=email,
             full_name=full_name,
             avatar_url=avatar_url,
+            avatar_color=avatar_color,
             joined_at=m.joined_at,
         )
-        for m, email, full_name, avatar_url in rows
+        for m, email, full_name, avatar_url, avatar_color in rows
     ]
     return OrganizationMemberList(items=items, total=total)
 
@@ -51,7 +52,7 @@ async def update_member_role(
     user: CurrentUser,
 ) -> Any:
     """Change a member's role. Requires Owner or Admin."""
-    member, email, full_name, avatar_url = await service.change_role(
+    member, email, full_name, avatar_url, avatar_color = await service.change_role(
         org_id, target_user_id, data.role, requester_id=user.id
     )
     return OrganizationMemberRead(
@@ -62,6 +63,7 @@ async def update_member_role(
         email=email,
         full_name=full_name,
         avatar_url=avatar_url,
+        avatar_color=avatar_color,
         joined_at=member.joined_at,
     )
 

--- a/backend/app/db/models/agent.py
+++ b/backend/app/db/models/agent.py
@@ -15,7 +15,15 @@ import enum
 import uuid
 from typing import Any
 
-from sqlalchemy import CheckConstraint, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy import (
+    CheckConstraint,
+    ForeignKey,
+    Integer,
+    SmallInteger,
+    String,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.orm import Mapped, mapped_column
@@ -74,6 +82,10 @@ class Agent(Base, TimestampMixin):
     # agent does. Deliberately not part of the spec: the spec is what runs and
     # what gets exported to git, and a picture changes neither.
     avatar_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    # Default-avatar colour slot 1..10 (`--avatar-*` ramp); null = auto from the id.
+    # A column, not spec, for the same reason avatar_url is: a colour changes
+    # neither what runs nor what exports to git.
+    avatar_color: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
 
     status: Mapped[str] = mapped_column(
         String(16), nullable=False, default=AgentStatus.DRAFT.value, index=True

--- a/backend/app/db/models/organization.py
+++ b/backend/app/db/models/organization.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
     Index,
     Integer,
     Numeric,
+    SmallInteger,
     String,
     UniqueConstraint,
 )
@@ -45,6 +46,8 @@ class Organization(Base, TimestampMixin):
     slug: Mapped[str] = mapped_column(String(64), unique=True, index=True, nullable=False)
     is_personal: Mapped[bool] = mapped_column(nullable=False, default=False, index=True)
     avatar_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    # Default-avatar colour slot 1..10 (`--avatar-*` ramp); null = auto from the id.
+    avatar_color: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
     created_by_user_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("users.id", ondelete="RESTRICT"),

--- a/backend/app/db/models/user.py
+++ b/backend/app/db/models/user.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, Literal
 
-from sqlalchemy import Boolean, DateTime, String, text
+from sqlalchemy import Boolean, DateTime, SmallInteger, String, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -39,6 +39,9 @@ class User(Base, TimestampMixin):
     # administers the *deployment*, so it is not scoped to a tenant.
     is_app_admin: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     avatar_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    # The chosen default-avatar colour, slot 1..10 into the `--avatar-*` ramp;
+    # null means auto (derived from the id). Only used when no picture is set.
+    avatar_color: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
     onboarding_completed_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )

--- a/backend/app/repositories/member.py
+++ b/backend/app/repositories/member.py
@@ -61,17 +61,23 @@ async def list_for_org(
     *,
     skip: int = 0,
     limit: int = 100,
-) -> list[tuple[OrganizationMember, str, str | None, str | None]]:
-    """Return (member, email, full_name, avatar_url) tuples ordered by join date."""
+) -> list[tuple[OrganizationMember, str, str | None, str | None, int | None]]:
+    """Return (member, email, full_name, avatar_url, avatar_color) tuples by join date."""
     result = await db.execute(
-        select(OrganizationMember, User.email, User.full_name, User.avatar_url)
+        select(
+            OrganizationMember,
+            User.email,
+            User.full_name,
+            User.avatar_url,
+            User.avatar_color,
+        )
         .join(User, User.id == OrganizationMember.user_id)
         .where(OrganizationMember.organization_id == organization_id)
         .order_by(OrganizationMember.joined_at.asc())
         .offset(skip)
         .limit(limit)
     )
-    return [(row[0], row[1], row[2], row[3]) for row in result.all()]
+    return [(row[0], row[1], row[2], row[3], row[4]) for row in result.all()]
 
 
 class MemberIdentity(NamedTuple):

--- a/backend/app/repositories/organization.py
+++ b/backend/app/repositories/organization.py
@@ -141,6 +141,20 @@ async def set_monthly_budget(
     return org
 
 
+async def set_avatar_color(
+    db: AsyncSession, org: Organization, *, color: int | None
+) -> Organization:
+    """Set or clear the organization's default-avatar colour.
+
+    Its own function for the same reason as :func:`set_monthly_budget`:
+    :func:`update` skips a `None` argument, so it cannot express "reset to auto".
+    """
+    org.avatar_color = color
+    await db.flush()
+    await db.refresh(org)
+    return org
+
+
 async def delete(db: AsyncSession, org: Organization) -> None:
     await db.delete(org)
     await db.flush()

--- a/backend/app/schemas/agent.py
+++ b/backend/app/schemas/agent.py
@@ -32,6 +32,13 @@ class AgentRead(BaseSchema):
             "would be holding a second, unchecked way to name the file."
         ),
     )
+    avatar_color: int | None = Field(
+        default=None,
+        description=(
+            "Chosen default-avatar colour, slot 1-10; null is auto (derived from the id). "
+            "Only shown when the agent has no picture. A display choice, not the spec."
+        ),
+    )
     shared_user_count: int = Field(
         default=0,
         description=(
@@ -92,6 +99,21 @@ class AgentCreate(BaseSchema):
 
 class AgentDraftUpdate(BaseSchema):
     spec: AgentSpec
+
+
+class AgentAvatarColorRequest(BaseSchema):
+    """The chosen default-avatar colour for an agent, or null to reset to auto.
+
+    A command body, not a partial `*Update`: its one field is always meant, and
+    a null is the reset rather than "unspecified".
+    """
+
+    color: int | None = Field(
+        default=None,
+        ge=1,
+        le=10,
+        description="Default-avatar colour, slot 1-10; null resets to auto.",
+    )
 
 
 class AgentPublish(BaseSchema):

--- a/backend/app/schemas/organization.py
+++ b/backend/app/schemas/organization.py
@@ -40,14 +40,21 @@ class OrganizationCreate(BaseSchema):
 class OrganizationUpdate(BaseSchema):
     """A partial update to an organization's settings.
 
-    `monthly_budget_usd` is the one field where omitting it and sending
-    `null` mean different things: absent leaves the cap as it stands, `null`
-    removes it. Renaming an organization must not uncap it, so the service keys
-    on whether the client named the field rather than on its value.
+    `monthly_budget_usd` and `avatar_color` are the fields where omitting them
+    and sending `null` mean different things: absent leaves the setting as it
+    stands, `null` clears it (removes the cap; resets the colour to auto).
+    Renaming an organization must not uncap it or reset its colour, so the
+    service keys on whether the client named the field rather than on its value.
     """
 
     name: str | None = Field(default=None, min_length=2, max_length=128)
     avatar_url: str | None = Field(default=None, max_length=500)
+    avatar_color: int | None = Field(
+        default=None,
+        ge=1,
+        le=10,
+        description="Default-avatar colour, slot 1-10; send null to reset to auto.",
+    )
     monthly_budget_usd: MonthlyBudgetUsd | None = Field(
         default=None,
         description=(
@@ -63,6 +70,7 @@ class OrganizationRead(BaseSchema, TimestampSchema):
     slug: str
     is_personal: bool
     avatar_url: str | None = None
+    avatar_color: int | None = None
     member_count: int = 0
     role: str  # current user's role in this org
     monthly_budget_usd: Decimal | None = None
@@ -81,6 +89,7 @@ class OrganizationMemberRead(BaseSchema):
     email: str
     full_name: str | None = None
     avatar_url: str | None = None
+    avatar_color: int | None = None
     joined_at: datetime
 
 

--- a/backend/app/schemas/secret.py
+++ b/backend/app/schemas/secret.py
@@ -95,6 +95,14 @@ class SecretRead(BaseSchema, TimestampSchema):
     owner_email: str | None = Field(
         default=None, description="Whose key it is, when it belongs to one person"
     )
+    created_by_user_id: UUID | None = Field(
+        default=None,
+        description=(
+            "Who stored it, by id - the stable seed the listing draws their fallback "
+            "avatar from, so the same person wears one colour here and in member lists. "
+            "Outlives the account: still set once they have left, when the email is null."
+        ),
+    )
     created_by_email: str | None = Field(
         default=None,
         description=(

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -34,6 +34,12 @@ class UserUpdate(BaseSchema):
     password: str | None = Field(default=None, min_length=8, max_length=128)
     full_name: str | None = Field(default=None, max_length=255)
     is_active: bool | None = None
+    avatar_color: int | None = Field(
+        default=None,
+        ge=1,
+        le=10,
+        description="Default-avatar colour, slot 1-10; send null to reset to auto.",
+    )
     onboarding_completed_at: datetime | None = Field(
         default=None,
         description="Set to a timestamp to mark onboarding complete; null to reset.",
@@ -66,6 +72,7 @@ class UserRead(UserBase, TimestampSchema):
     # admin endpoint, so a client that lies to itself gains nothing.
     is_app_admin: bool = False
     avatar_url: str | None = None
+    avatar_color: int | None = None
     onboarding_completed_at: datetime | None = None
     notify_budget_alerts: bool = True
     notify_approval_requests: bool = True

--- a/backend/app/services/agent_registry.py
+++ b/backend/app/services/agent_registry.py
@@ -507,6 +507,7 @@ class AgentRegistryService:
                 owner_user_id=agent.owner_user_id,
                 current_version_id=agent.current_version_id,
                 has_avatar=agent.has_avatar,
+                avatar_color=agent.avatar_color,
                 shared_user_count=shared_counts.get(agent.id, 0),
                 channels=surfaces.get(agent.id, []),
                 budget_monthly_usd=(
@@ -1462,6 +1463,17 @@ class AgentRegistryService:
                 await storage.delete(agent.avatar_url)
         path = await storage.save(f"avatars/agents/{agent.id}", filename, file_data)
         return await agent_repo.update(self.db, agent=agent, update_data={"avatar_url": path})
+
+    async def set_avatar_color(
+        self, ctx: AuthContext, agent_id: UUID, *, color: int | None
+    ) -> Agent:
+        """Choose the agent's default-avatar colour, or null to reset to auto.
+
+        A column like the picture, not the spec: editing it takes the same
+        access check (`AGENTS_EDIT` on this agent) but does not touch a version.
+        """
+        agent = await self.get(ctx, agent_id, perm=Perm.AGENTS_EDIT)
+        return await agent_repo.update(self.db, agent=agent, update_data={"avatar_color": color})
 
     async def avatar_path(self, ctx: AuthContext, agent_id: UUID) -> str:
         """Where the agent's picture is on disk, for the route that streams it.

--- a/backend/app/services/member.py
+++ b/backend/app/services/member.py
@@ -24,7 +24,7 @@ class MemberService:
         *,
         skip: int = 0,
         limit: int = 100,
-    ) -> tuple[list[tuple[OrganizationMember, str, str | None, str | None]], int]:
+    ) -> tuple[list[tuple[OrganizationMember, str, str | None, str | None, int | None]], int]:
         """List members with their joined user info. Any org member may list."""
         membership = await member_repo.get(
             self.db, organization_id=organization_id, user_id=requester_id
@@ -44,7 +44,7 @@ class MemberService:
         target_user_id: UUID,
         new_role: str,
         requester_id: UUID,
-    ) -> tuple[OrganizationMember, str, str | None, str | None]:
+    ) -> tuple[OrganizationMember, str, str | None, str | None, int | None]:
         """Change a member's role.
 
         Rules:
@@ -97,7 +97,8 @@ class MemberService:
         email = user.email if user else ""
         full_name = user.full_name if user else None
         avatar_url = user.avatar_url if user else None
-        return updated, email, full_name, avatar_url
+        avatar_color = user.avatar_color if user else None
+        return updated, email, full_name, avatar_url, avatar_color
 
     async def remove(
         self,

--- a/backend/app/services/organization.py
+++ b/backend/app/services/organization.py
@@ -40,6 +40,7 @@ def _org_read(org: Organization, member_count: int, role: str) -> OrganizationRe
         slug=org.slug,
         is_personal=org.is_personal,
         avatar_url=org.avatar_url,
+        avatar_color=org.avatar_color,
         member_count=member_count,
         role=role,
         monthly_budget_usd=org.monthly_budget_usd,
@@ -211,6 +212,7 @@ class OrganizationService:
         """
         org, membership = await self.get_for_user(org_id, requester_id)
         wants_budget = "monthly_budget_usd" in data.model_fields_set
+        wants_color = "avatar_color" in data.model_fields_set
         wants_metadata = bool(data.model_fields_set - {"monthly_budget_usd"})
         if wants_metadata and not role_has(membership.role, Perm.ORG_SETTINGS):
             raise AuthorizationError(message="Only Owner or Admin can update the organization")
@@ -226,6 +228,10 @@ class OrganizationService:
             org = await organization_repo.set_monthly_budget(
                 self.db, org, limit_usd=data.monthly_budget_usd
             )
+
+        if wants_color:
+            # Same field-named-not-valued rule: `null` resets the colour to auto.
+            org = await organization_repo.set_avatar_color(self.db, org, color=data.avatar_color)
 
         return await organization_repo.update(
             self.db,

--- a/backend/app/services/organization_secret.py
+++ b/backend/app/services/organization_secret.py
@@ -137,6 +137,7 @@ class OrganizationSecretService:
                     visibility=as_visibility(secret.visibility),
                     owner_user_id=secret.owner_user_id,
                     owner_email=owner.email,
+                    created_by_user_id=secret.created_by_user_id,
                     created_by_email=author.email,
                     created_by_avatar_url=author.avatar_url,
                     shared_with=shared_counts.get(secret.id, 0),

--- a/backend/tests/api/test_secret_routes.py
+++ b/backend/tests/api/test_secret_routes.py
@@ -38,6 +38,7 @@ def _row(**overrides: Any) -> MagicMock:
     row.hint = "4242"
     # Who stored it and what it is holding up. Both are read off the row rather
     # than joined per request, so a route test has to carry them.
+    row.created_by_user_id = None
     row.created_by_email = "owner@acme.test"
     row.created_by_avatar_url = None
     row.shared_with = 0

--- a/backend/tests/api/test_users.py
+++ b/backend/tests/api/test_users.py
@@ -154,6 +154,41 @@ async def test_update_current_user_notification_preferences_reach_the_service(
 
 
 @pytest.mark.anyio
+async def test_choosing_an_avatar_colour_reaches_the_service(
+    auth_client: AsyncClient, mock_user_service: MagicMock
+):
+    """The profile page saves the picked colour through PATCH /users/me; an
+    explicit null is the reset to auto and must survive as a null, not vanish."""
+    response = await auth_client.patch(
+        f"{settings.API_V1_STR}/users/me",
+        json={"avatar_color": 4},
+    )
+    assert response.status_code == 200
+    assert mock_user_service.update.call_args.args[1].avatar_color == 4
+
+    reset = await auth_client.patch(
+        f"{settings.API_V1_STR}/users/me",
+        json={"avatar_color": None},
+    )
+    assert reset.status_code == 200
+    user_in = mock_user_service.update.call_args.args[1]
+    assert user_in.avatar_color is None
+    assert "avatar_color" in user_in.model_fields_set
+
+
+@pytest.mark.anyio
+async def test_an_avatar_colour_out_of_range_is_refused(auth_client: AsyncClient):
+    """Slot 0 and 11 are not colours; the schema turns them into a 422 that names
+    the field rather than a row the frontend cannot render."""
+    for bad in (0, 11):
+        response = await auth_client.patch(
+            f"{settings.API_V1_STR}/users/me",
+            json={"avatar_color": bad},
+        )
+        assert response.status_code == 422
+
+
+@pytest.mark.anyio
 async def test_read_current_user_reports_notification_preferences(
     auth_client: AsyncClient,
 ):

--- a/backend/tests/test_agent_registry.py
+++ b/backend/tests/test_agent_registry.py
@@ -2140,6 +2140,57 @@ class TestAvatar:
         assert path == "/data/avatars/agents/x/logo.png"
         assert storage.get_full_path.call_args.args == ("avatars/agents/x/logo.png",)
 
+    @pytest.mark.anyio
+    async def test_choosing_a_colour_writes_the_slot(self):
+        ctx = _ctx()
+        agent = _agent(ctx)
+
+        with (
+            patch(f"{REGISTRY_PATH}.agent_repo.get", new=AsyncMock(return_value=agent)),
+            patch(
+                f"{REGISTRY_PATH}.agent_repo.update", new=AsyncMock(return_value=agent)
+            ) as update,
+        ):
+            await AgentRegistryService(_db()).set_avatar_color(ctx, agent.id, color=5)
+
+        assert update.call_args.kwargs["update_data"] == {"avatar_color": 5}
+
+    @pytest.mark.anyio
+    async def test_a_null_colour_resets_to_auto(self):
+        """The picker's Auto sends null; it must reach the column, not be dropped."""
+        ctx = _ctx()
+        agent = _agent(ctx)
+
+        with (
+            patch(f"{REGISTRY_PATH}.agent_repo.get", new=AsyncMock(return_value=agent)),
+            patch(
+                f"{REGISTRY_PATH}.agent_repo.update", new=AsyncMock(return_value=agent)
+            ) as update,
+        ):
+            await AgentRegistryService(_db()).set_avatar_color(ctx, agent.id, color=None)
+
+        assert update.call_args.kwargs["update_data"] == {"avatar_color": None}
+
+    @pytest.mark.anyio
+    async def test_choosing_a_colour_needs_edit_on_the_agent(self):
+        """A colour is an edit; a Member with no grant is refused, and the refusal
+        looks like an absence - the same as reaching an agent that is not there."""
+        ctx = _ctx(OrgRoleName.MEMBER)
+        agent = _agent(ctx, owner_user_id=uuid.uuid4())
+
+        with (
+            patch(f"{REGISTRY_PATH}.agent_repo.get", new=AsyncMock(return_value=agent)),
+            patch(
+                "app.services.access.resource_grant_repo.get_level",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(f"{REGISTRY_PATH}.agent_repo.update", new=AsyncMock()) as update,
+            pytest.raises(NotFoundError),
+        ):
+            await AgentRegistryService(_db()).set_avatar_color(ctx, agent.id, color=3)
+
+        assert update.await_count == 0
+
 
 class TestWhatANewAgentOpensWith:
     """A prompt, not an empty box.

--- a/backend/tests/test_secrets.py
+++ b/backend/tests/test_secrets.py
@@ -8,6 +8,7 @@ worth testing here is that constraint holding.
 
 import json
 import uuid
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -29,6 +30,7 @@ from app.core.secret_kinds import (
     unseal_secret,
 )
 from app.core.vault import VaultScope
+from app.repositories import member_repo
 from app.services.organization_secret import OrganizationSecretService
 from tests.test_model_profiles import service_account_json
 
@@ -227,6 +229,51 @@ class TestStoringASecret:
             await OrganizationSecretService(_db()).list_secrets(ctx)
 
         assert listed.call_args.kwargs["organization_id"] == ctx.organization_id
+
+    @pytest.mark.anyio
+    async def test_the_listing_carries_the_authors_id_for_a_stable_avatar_colour(self):
+        """The "Added by" column draws a fallback avatar, and its colour is seeded
+        on the author's id - so it must be on the row, not just their email. Seeding
+        on the email instead gave the same person a different hue here than in
+        member lists, which all seed on the id (#799)."""
+        ctx = _ctx()
+        author_id = uuid.uuid4()
+        secret = _row(ctx, ApiKeySecret(api_key="wx-live-4242"))
+        secret.description = None
+        secret.purpose = "custom"
+        secret.visibility = "org"
+        secret.owner_user_id = None
+        secret.created_by_user_id = author_id
+        secret.created_at = datetime.now(UTC)
+        secret.updated_at = None
+
+        identity = member_repo.MemberIdentity(email="ada@acme.test", avatar_url=None)
+        with (
+            patch(
+                "app.services.organization_secret.visible_resource_ids",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "app.services.organization_secret.organization_secret_repo.list_secrets",
+                new=AsyncMock(return_value=[secret]),
+            ),
+            patch(
+                "app.services.organization_secret.member_repo.get_identities_for_users",
+                new=AsyncMock(return_value={author_id: identity}),
+            ),
+            patch(
+                "app.services.organization_secret.resource_grant_repo.count_for_resources",
+                new=AsyncMock(return_value={}),
+            ),
+            patch(
+                "app.services.organization_secret.organization_secret_repo.agents_using",
+                new=AsyncMock(return_value=[]),
+            ),
+        ):
+            rows = await OrganizationSecretService(_db()).list_secrets(ctx)
+
+        assert rows[0].created_by_user_id == author_id
+        assert rows[0].created_by_email == "ada@acme.test"
 
 
 class TestRotatingASecret:

--- a/backend/tests/test_services_members.py
+++ b/backend/tests/test_services_members.py
@@ -202,14 +202,17 @@ class TestMemberService:
             patch("app.services.member.record_audit", new=AsyncMock()),
             patch(
                 "app.services.member.user_repo.get_by_id",
-                new=AsyncMock(return_value=MagicMock(email="a@example.com")),
+                new=AsyncMock(return_value=MagicMock(email="a@example.com", avatar_color=7)),
             ),
         ):
-            member, _, _, _ = await service.change_role(
+            member, _, _, _, avatar_color = await service.change_role(
                 uuid.uuid4(), uuid.uuid4(), "admin", requester_id=uuid.uuid4()
             )
 
         assert member.role == "admin"
+        # The row a listing redraws after a role change carries the member's
+        # chosen colour, so their avatar does not flip to the auto one.
+        assert avatar_color == 7
 
     @pytest.mark.anyio
     async def test_remove_raises_if_not_authorized(self, service):

--- a/backend/tests/test_services_organizations.py
+++ b/backend/tests/test_services_organizations.py
@@ -462,6 +462,67 @@ class TestOrganizationService:
         assert write.await_args.kwargs["limit_usd"] == limit
 
     @pytest.mark.anyio
+    @pytest.mark.parametrize("slot", [5, None])
+    async def test_naming_the_colour_writes_exactly_what_was_named(self, service, mock_db, slot):
+        """Including an explicit `null`, which is how the colour resets to auto."""
+        membership = MagicMock(role="owner")
+        org = MagicMock()
+
+        with (
+            patch.object(service, "get_for_user", new=AsyncMock(return_value=(org, membership))),
+            patch(
+                "app.services.organization.organization_repo.set_avatar_color",
+                new=AsyncMock(return_value=org),
+            ) as write,
+            patch("app.services.organization.organization_repo.update", new=AsyncMock()),
+        ):
+            await service.update(
+                uuid.uuid4(),
+                OrganizationUpdate.model_validate({"avatar_color": slot}),
+                requester_id=uuid.uuid4(),
+            )
+
+        assert write.await_args.kwargs["color"] == slot
+
+    @pytest.mark.anyio
+    async def test_an_update_that_does_not_name_the_colour_leaves_it_alone(self, service, mock_db):
+        """A rename must not reset the colour to auto, so the write only fires when
+        the client named the field - `null` is a value here, not an absence."""
+        membership = MagicMock(role="owner")
+
+        with (
+            patch.object(
+                service, "get_for_user", new=AsyncMock(return_value=(MagicMock(), membership))
+            ),
+            patch(
+                "app.services.organization.organization_repo.set_avatar_color", new=AsyncMock()
+            ) as write,
+            patch("app.services.organization.organization_repo.update", new=AsyncMock()),
+        ):
+            await service.update(
+                uuid.uuid4(), OrganizationUpdate(name="Renamed"), requester_id=uuid.uuid4()
+            )
+
+        write.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_choosing_a_colour_is_metadata_and_needs_org_settings(self, service, mock_db):
+        """A colour is org metadata, so a plain member cannot set it."""
+        membership = MagicMock(role="member")
+
+        with (
+            patch.object(
+                service, "get_for_user", new=AsyncMock(return_value=(MagicMock(), membership))
+            ),
+            pytest.raises(AuthorizationError),
+        ):
+            await service.update(
+                uuid.uuid4(),
+                OrganizationUpdate.model_validate({"avatar_color": 5}),
+                requester_id=uuid.uuid4(),
+            )
+
+    @pytest.mark.anyio
     async def test_a_cap_of_zero_is_refused_before_it_reaches_the_database(self):
         """Zero is an organization whose agents can never answer.
 

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2656,7 +2656,8 @@
       "writtenKnowHowAgent": "Written know-how the agent loads only when it decides a skill is relevant, so twenty skills cost almost nothing in context. Picking one gives the agent the tools to read them - that used to be a separate capability somebody had to know to switch on, and skills chosen without it were resolved and then dropped on the floor.",
       "context": "Context",
       "standingContextAgent": "Standing context this agent reads - a glossary or policy injected into its prompt, or files it reads on demand.",
-      "youAreSupportCopilot": "You are Support Copilot. Answer from the product wiki and cite the document you used. If the wiki does not cover it, say so rather than guessing."
+      "youAreSupportCopilot": "You are Support Copilot. Answer from the product wiki and cite the document you used. If the wiki does not cover it, say so rather than guessing.",
+      "avatarColour": "Fallback colour"
     },
     "auth": {
       "agentHereDataNot": "An agent here is data, not code - instructions, a model, a set of capabilities. It runs the same way on web chat, the HTTP API and Slack, on your infrastructure and against your keys.",
@@ -2928,7 +2929,8 @@
       "you": "(you)",
       "yourRoleHere": "Your role here is <badge>{role}</badge>",
       "membersCard": "Members",
-      "memberCount": "{count, plural, =1 {1 member} other {# members}}"
+      "memberCount": "{count, plural, =1 {1 member} other {# members}}",
+      "avatarColour": "Fallback colour"
     },
     "rag": {
       "active": "Active",
@@ -3248,7 +3250,9 @@
       "visibleTeammatesSharedOrganizations": "Visible to teammates in shared organizations.",
       "whatNotSent": "What is not sent",
       "yesDeleteMyAccount": "Yes, delete my account",
-      "yourConversationsKnowledgeBase": "Your conversations, knowledge base contents, API keys, and all personal data will be permanently deleted. Active subscriptions will be canceled. This cannot be undone."
+      "yourConversationsKnowledgeBase": "Your conversations, knowledge base contents, API keys, and all personal data will be permanently deleted. Active subscriptions will be canceled. This cannot be undone.",
+      "avatarColour": "Fallback colour",
+      "avatarColourHint": "Shown as your avatar until you upload a picture."
     },
     "skills": {
       "agentsBoundSkillWill": "Agents bound to this skill will run without it from their next run. This cannot be undone.",
@@ -3923,5 +3927,10 @@
     "create": "Create",
     "save": "Save",
     "enabled": "Enabled"
+  },
+  "avatarColor": {
+    "auto": "Automatic colour",
+    "label": "Avatar colour",
+    "option": "Colour {n}"
   }
 }

--- a/frontend/src/app/[locale]/(dashboard)/admin/conversations/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/admin/conversations/page.tsx
@@ -6,11 +6,9 @@ import { useLocale, useTranslations } from "next-intl";
 import { ExternalLink } from "lucide-react";
 
 import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
   Badge,
   DataTable,
+  EntityAvatar,
   ListCard,
   ListCardControlsRow,
   ListCardFootRow,
@@ -39,15 +37,6 @@ type Status = "active" | "archived" | "all";
 
 type Conversation = ReturnType<typeof useAdminConversations>["conversations"][number];
 
-function getInitials(nameOrEmail: string): string {
-  return nameOrEmail
-    .split(/[\s@]/)
-    .filter(Boolean)
-    .slice(0, 2)
-    .map((s) => s[0]?.toUpperCase() ?? "")
-    .join("");
-}
-
 function UserAvatar({
   userId,
   label,
@@ -59,10 +48,13 @@ function UserAvatar({
 }) {
   const cls = size === "sm" ? "h-6 w-6 text-[10px]" : "h-7 w-7 text-[11px]";
   return (
-    <Avatar className={cls}>
-      {userId && <AvatarImage src={`/api/users/avatar/${userId}`} alt={label} />}
-      <AvatarFallback>{getInitials(label)}</AvatarFallback>
-    </Avatar>
+    <EntityAvatar
+      seed={userId || label}
+      name={label}
+      imageSrc={userId ? `/api/users/avatar/${userId}` : undefined}
+      className={cls}
+      ariaHidden
+    />
   );
 }
 

--- a/frontend/src/app/[locale]/(dashboard)/admin/users/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/admin/users/page.tsx
@@ -5,7 +5,7 @@ import { Shield } from "lucide-react";
 
 import { UserDetailDrawer } from "@/components/admin/user-detail-drawer";
 import { ErrorState } from "@/components/states";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { EntityAvatar } from "@/components/ui/entity-avatar";
 import {
   Badge,
   Button,
@@ -26,15 +26,6 @@ import { useLocale, useTranslations } from "next-intl";
 const PAGE_SIZE = 50;
 // Keys the backend can sort on (route → service → repo).
 const SORT_KEYS = ["email", "full_name", "conversations", "created_at"] as const;
-
-function getInitials(nameOrEmail: string): string {
-  return nameOrEmail
-    .split(/[\s@]/)
-    .filter(Boolean)
-    .slice(0, 2)
-    .map((s) => s[0]?.toUpperCase() ?? "")
-    .join("");
-}
 
 export default function AdminUsersPage() {
   const t = useTranslations("pages.admin");
@@ -92,12 +83,13 @@ export default function AdminUsersPage() {
         sortable: true,
         cell: (u) => (
           <div className="flex min-w-0 items-center gap-3">
-            <Avatar className="h-8 w-8 shrink-0">
-              <AvatarImage src={`/api/users/avatar/${u.id}`} alt={u.email} />
-              <AvatarFallback className="text-[10px]">
-                {getInitials(u.full_name || u.email)}
-              </AvatarFallback>
-            </Avatar>
+            <EntityAvatar
+              seed={u.id}
+              name={u.full_name || u.email}
+              imageSrc={`/api/users/avatar/${u.id}`}
+              className="h-8 w-8 shrink-0 text-[10px]"
+              ariaHidden
+            />
             <div className="min-w-0">
               <div className="flex items-center gap-1.5">
                 <p className="text-foreground truncate text-sm font-medium">

--- a/frontend/src/app/[locale]/(dashboard)/agents/[id]/model-panel.integration.test.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/agents/[id]/model-panel.integration.test.tsx
@@ -53,6 +53,7 @@ vi.mock("@/hooks", () => ({
     publish: { mutateAsync: vi.fn(), isPending: false },
     rollback: { mutateAsync: vi.fn() },
     setAvatar: { mutateAsync: vi.fn(), isPending: false },
+    setColor: { mutate: vi.fn(), isPending: false },
   }),
   useAgentEnvironments: () => ({ environments: [], promote: { mutateAsync: vi.fn() } }),
   useAgents: () => ({

--- a/frontend/src/app/[locale]/(dashboard)/agents/[id]/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/agents/[id]/page.tsx
@@ -52,9 +52,11 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
+  AvatarColorPicker,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
   Card,
@@ -114,7 +116,8 @@ export default function AgentBuilderPage({ params }: PageProps) {
   const tAgents = useTranslations("agents");
   const { id } = use(params);
   const router = useRouter();
-  const { agent, isLoading, saveDraft, validate, publish, rollback, setAvatar } = useAgent(id);
+  const { agent, isLoading, saveDraft, validate, publish, rollback, setAvatar, setColor } =
+    useAgent(id);
   const { environments, promote } = useAgentEnvironments(id);
   const { agents, clone, archive, unarchive, remove } = useAgents();
   const { capabilities } = useCapabilityCatalog();
@@ -476,6 +479,7 @@ export default function AgentBuilderPage({ params }: PageProps) {
                 agentId={id}
                 name={agent.name}
                 hasAvatar={agent.has_avatar}
+                colorSlot={agent.avatar_color}
                 size="lg"
                 version={avatarVersion}
               />
@@ -574,6 +578,19 @@ export default function AgentBuilderPage({ params }: PageProps) {
                     <ImagePlus className="h-4 w-4" />
                     {agent.has_avatar ? t("replaceAvatar2") : t("uploadAvatar2")}
                   </DropdownMenuItem>
+                  <DropdownMenuLabel className="text-muted-foreground text-xs font-normal">
+                    {t("avatarColour")}
+                  </DropdownMenuLabel>
+                  {/* Not menu items: a swatch click picks a colour and leaves the
+                      menu open, where selecting an item would close it. */}
+                  <div className="px-2 pb-1.5">
+                    <AvatarColorPicker
+                      value={agent.avatar_color ?? null}
+                      onChange={(slot) => setColor.mutate(slot)}
+                      disabled={setColor.isPending}
+                    />
+                  </div>
+                  <DropdownMenuSeparator />
                   {agent.status === "archived" ? (
                     <DropdownMenuItem onSelect={() => unarchive.mutate(id)}>
                       <ArchiveRestore className="h-4 w-4" />

--- a/frontend/src/app/[locale]/(dashboard)/orgs/[id]/members/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/orgs/[id]/members/page.tsx
@@ -22,6 +22,7 @@ import {
   Badge,
   Button,
   DataTable,
+  AvatarColorPicker,
   EntityAvatar,
   Input,
   ListCard,
@@ -43,7 +44,8 @@ import {
 } from "@/hooks";
 import { Perm } from "@/types/permissions";
 import type { OrganizationMember, OrgRole } from "@/types";
-import { formatDate, MAX_AVATAR_SIZE_BYTES } from "@/lib/utils";
+import { avatarInitials, avatarPalette } from "@/lib/avatar-color";
+import { cn, formatDate, MAX_AVATAR_SIZE_BYTES } from "@/lib/utils";
 import { ROUTES } from "@/lib/constants";
 import { useChanged } from "@/hooks/use-changed";
 
@@ -112,6 +114,11 @@ export default function OrgMembersPage({ params }: PageProps) {
     }
   };
 
+  const handleColorChange = async (slot: number | null) => {
+    if (!org || slot === (org.avatar_color ?? null)) return;
+    await patchOrg(org.id, { avatar_color: slot });
+  };
+
   const handleAvatarUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
@@ -153,6 +160,7 @@ export default function OrgMembersPage({ params }: PageProps) {
                 name={m.full_name || m.email}
                 imageSrc={`/api/users/avatar/${m.user_id}`}
                 hasImage={!!m.avatar_url}
+                colorSlot={m.avatar_color}
                 className="h-8 w-8 shrink-0 text-[10px]"
                 ariaHidden
               />
@@ -279,7 +287,12 @@ export default function OrgMembersPage({ params }: PageProps) {
             type="button"
             onClick={() => avatarInputRef.current?.click()}
             disabled={!canManage || avatarUploading}
-            className="bg-muted text-foreground group relative flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-xl disabled:cursor-default"
+            className={cn(
+              "group relative flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-xl disabled:cursor-default",
+              org.avatar_url
+                ? "bg-muted text-foreground"
+                : avatarPalette(org.id, org.avatar_color).bg,
+            )}
             title={canManage ? t("changeWorkspaceAvatar") : t("onlyOwnersAdminsCan")}
           >
             {org.avatar_url ? (
@@ -290,8 +303,13 @@ export default function OrgMembersPage({ params }: PageProps) {
                 className="h-full w-full object-cover"
               />
             ) : (
-              <span className="text-foreground font-mono text-base font-semibold">
-                {org.name.slice(0, 2).toUpperCase()}
+              <span
+                className={cn(
+                  avatarPalette(org.id, org.avatar_color).fg,
+                  "text-base font-semibold",
+                )}
+              >
+                {avatarInitials(org.name)}
               </span>
             )}
             {canManage && (
@@ -338,6 +356,12 @@ export default function OrgMembersPage({ params }: PageProps) {
             </div>
             {!canManage && (
               <p className="text-muted-foreground text-[11px]">{t("onlyOwnersAdminsCan")}</p>
+            )}
+            {canManage && (
+              <div>
+                <p className="text-muted-foreground mb-2 text-xs">{t("avatarColour")}</p>
+                <AvatarColorPicker value={org.avatar_color} onChange={handleColorChange} />
+              </div>
             )}
           </div>
         </section>

--- a/frontend/src/app/[locale]/(dashboard)/orgs/[id]/members/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/orgs/[id]/members/page.tsx
@@ -19,11 +19,10 @@ import { ErrorState } from "@/components/states";
 import { InviteLinkDialog, InviteMemberDialog, OrgSpendingLimit } from "@/components/teams";
 import { PageHeader } from "@/components/dashboard/page-header";
 import {
-  Avatar,
-  AvatarFallback,
   Badge,
   Button,
   DataTable,
+  EntityAvatar,
   Input,
   ListCard,
   ListCardEmpty,
@@ -61,15 +60,6 @@ const ROLE_VARIANT: Record<OrgRole, "default" | "secondary" | "outline"> = {
   member: "outline",
   viewer: "outline",
 };
-
-function getInitials(nameOrEmail: string): string {
-  return nameOrEmail
-    .split(/[\s@]/)
-    .filter(Boolean)
-    .slice(0, 2)
-    .map((s) => s[0]?.toUpperCase() ?? "")
-    .join("");
-}
 
 export default function OrgMembersPage({ params }: PageProps) {
   const tErrors = useTranslations("errors");
@@ -158,11 +148,14 @@ export default function OrgMembersPage({ params }: PageProps) {
           const isSelf = m.user_id === user?.id;
           return (
             <div className="flex min-w-0 items-center gap-3">
-              <Avatar className="h-8 w-8 shrink-0">
-                <AvatarFallback className="text-[10px]">
-                  {getInitials(m.full_name || m.email)}
-                </AvatarFallback>
-              </Avatar>
+              <EntityAvatar
+                seed={m.user_id}
+                name={m.full_name || m.email}
+                imageSrc={`/api/users/avatar/${m.user_id}`}
+                hasImage={!!m.avatar_url}
+                className="h-8 w-8 shrink-0 text-[10px]"
+                ariaHidden
+              />
               <div className="min-w-0">
                 <p className="text-foreground truncate text-sm font-medium">
                   {m.full_name || m.email.split("@")[0]}

--- a/frontend/src/app/[locale]/(dashboard)/settings/profile/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/settings/profile/page.tsx
@@ -6,13 +6,14 @@ import { Camera } from "lucide-react";
 import { toast } from "sonner";
 
 import { ApiError, getErrorMessage, parseErrorMessage } from "@/lib/api-error";
-import { Button, FormField, Input } from "@/components/ui";
+import { AvatarColorPicker, Button, FormField, Input } from "@/components/ui";
+import { avatarInitials, avatarPalette } from "@/lib/avatar-color";
 import { ActiveSessions } from "@/components/dashboard/active-sessions";
 import { ChatAccounts } from "@/components/settings/chat-accounts";
 import { SectionCard } from "@/components/settings/settings-section";
 import { useAuth } from "@/hooks";
 import { apiClient } from "@/lib/api-client";
-import { formatDate, isAppAdmin, MAX_AVATAR_SIZE_BYTES } from "@/lib/utils";
+import { cn, formatDate, isAppAdmin, MAX_AVATAR_SIZE_BYTES } from "@/lib/utils";
 import { useAuthStore } from "@/stores";
 import type { User } from "@/types";
 import { useChanged } from "@/hooks/use-changed";
@@ -90,9 +91,23 @@ export default function ProfileSettingsPage() {
     }
   };
 
+  const handleColorChange = async (slot: number | null) => {
+    if (!user || slot === (user.avatar_color ?? null)) return;
+    try {
+      const updated = await apiClient.patch<User>("/users/me", { avatar_color: slot });
+      setUser(updated);
+    } catch (err) {
+      toast.error(
+        err instanceof ApiError ? getErrorMessage(err, tErrors) : t("failedUpdateProfile"),
+      );
+    }
+  };
+
   if (!user) {
     return null;
   }
+
+  const fallback = avatarPalette(user.id, user.avatar_color);
 
   return (
     <div className="space-y-6">
@@ -103,7 +118,10 @@ export default function ProfileSettingsPage() {
             onClick={() => avatarInputRef.current?.click()}
             disabled={avatarUploading}
             aria-label={user.avatar_url ? t("replaceAvatar3") : t("uploadAvatar3")}
-            className="border-border bg-muted hover:bg-accent group relative flex h-20 w-20 shrink-0 items-center justify-center overflow-hidden rounded-xl border transition-colors"
+            className={cn(
+              "border-border hover:bg-accent group relative flex h-20 w-20 shrink-0 items-center justify-center overflow-hidden rounded-xl border transition-colors",
+              user.avatar_url ? "bg-muted" : fallback.bg,
+            )}
           >
             {user.avatar_url ? (
               <Image
@@ -115,8 +133,8 @@ export default function ProfileSettingsPage() {
                 unoptimized
               />
             ) : (
-              <span className="text-foreground text-lg font-semibold">
-                {(user.full_name || user.email).slice(0, 2).toUpperCase()}
+              <span className={cn(fallback.fg, "text-lg font-semibold")}>
+                {avatarInitials(user.full_name || user.email)}
               </span>
             )}
             <span className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 transition-opacity group-hover:opacity-100">
@@ -149,6 +167,11 @@ export default function ProfileSettingsPage() {
               {t("memberSince", { date: formatDate(user.created_at, locale) })}
             </p>
           </div>
+        </div>
+        <div className="mt-5">
+          <p className="text-foreground mb-2 text-sm font-medium">{t("avatarColour")}</p>
+          <p className="text-muted-foreground mb-3 text-xs">{t("avatarColourHint")}</p>
+          <AvatarColorPicker value={user.avatar_color ?? null} onChange={handleColorChange} />
         </div>
       </SectionCard>
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -77,6 +77,29 @@
   --series-3: oklch(88% 0.085 82);
   --series-4: oklch(72% 0.1 22);
   --series-5: oklch(66% 0.09 312);
+
+  /* The default-avatar ramp: ten hues for a face nobody uploaded, chosen by a
+     hash of the row's id so one entity keeps its colour everywhere. The one
+     categorical use the "surfaces are neutral" rule bends for - identity is the
+     only channel a fallback avatar has, the same argument the series ramp makes.
+
+     Theme-independent on purpose. Each is a light pastel and the ink is one
+     charcoal, so the chip carries its own contrast and reads on a white sidebar
+     or a dark one without a `dark:` variant - which here follows
+     prefers-color-scheme, not the `.dark`/`.light` toggle, and would light the
+     wrong way when the two disagree. Lightness ~85% against a ~34% ink clears
+     4.5:1 in both themes; hue is spread ~every 35deg so adjacent ids differ. */
+  --avatar-ink: oklch(34% 0.03 265);
+  --avatar-1: oklch(86% 0.085 265);
+  --avatar-2: oklch(85% 0.09 300);
+  --avatar-3: oklch(84% 0.095 330);
+  --avatar-4: oklch(83% 0.1 20);
+  --avatar-5: oklch(86% 0.1 55);
+  --avatar-6: oklch(89% 0.11 95);
+  --avatar-7: oklch(87% 0.1 140);
+  --avatar-8: oklch(86% 0.08 175);
+  --avatar-9: oklch(85% 0.08 205);
+  --avatar-10: oklch(85% 0.085 240);
 }
 
 @theme {

--- a/frontend/src/components/admin/user-detail-drawer.tsx
+++ b/frontend/src/components/admin/user-detail-drawer.tsx
@@ -8,7 +8,7 @@ import { ArrowUpRight, Copy, KeyRound, Mail, Shield, ShieldOff, Trash2, UserX } 
 import { toast } from "sonner";
 
 import { LoadingState } from "@/components/states";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { EntityAvatar } from "@/components/ui/entity-avatar";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -113,13 +113,6 @@ export function UserDetailDrawer({
     }
   };
 
-  const initials = (subject.full_name || subject.email)
-    .split(/[\s@]/)
-    .filter(Boolean)
-    .slice(0, 2)
-    .map((s) => s[0]?.toUpperCase() ?? "")
-    .join("");
-
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       {/* The same drawer dialect as the run detail: SheetHeader with the
@@ -127,10 +120,13 @@ export function UserDetailDrawer({
       <SheetContent side="right" className="w-full sm:max-w-lg">
         <SheetHeader className="px-5">
           <SheetTitle className="flex min-w-0 items-center gap-3 text-sm">
-            <Avatar className="h-8 w-8 shrink-0" aria-hidden>
-              <AvatarImage src={`/api/users/avatar/${subject.id}`} alt="" />
-              <AvatarFallback className="font-mono text-xs">{initials || "?"}</AvatarFallback>
-            </Avatar>
+            <EntityAvatar
+              seed={subject.id}
+              name={subject.full_name || subject.email}
+              imageSrc={`/api/users/avatar/${subject.id}`}
+              className="h-8 w-8 shrink-0 text-xs"
+              ariaHidden
+            />
             <span className="min-w-0">
               <span className="text-foreground block truncate">
                 {subject.full_name || subject.email.split("@")[0]}

--- a/frontend/src/components/agents/agent-avatar.tsx
+++ b/frontend/src/components/agents/agent-avatar.tsx
@@ -25,6 +25,8 @@ export interface AgentAvatarProps {
   name: string;
   /** False skips the request entirely and renders the fallback. */
   hasAvatar?: boolean;
+  /** The chosen colour slot (1..10); null or absent derives it from the id. */
+  colorSlot?: number | null;
   size?: keyof typeof SIZES;
   /**
    * Bumped to defeat the browser cache after an upload. Without it a replaced
@@ -50,12 +52,13 @@ export function AgentAvatar({
   agentId,
   name,
   hasAvatar = false,
+  colorSlot,
   size = "md",
   version,
   className,
 }: AgentAvatarProps) {
   const initials = agentInitials(name);
-  const { bg, fg } = avatarPalette(agentId);
+  const { bg, fg } = avatarPalette(agentId, colorSlot);
   return (
     <Avatar className={cn(SIZES[size], "border-border shrink-0 border", className)}>
       {hasAvatar && (

--- a/frontend/src/components/agents/agent-avatar.tsx
+++ b/frontend/src/components/agents/agent-avatar.tsx
@@ -3,6 +3,7 @@
 import { Bot } from "lucide-react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui";
+import { avatarPalette } from "@/lib/avatar-color";
 import { cn } from "@/lib/utils";
 
 const SIZES = {
@@ -54,6 +55,7 @@ export function AgentAvatar({
   className,
 }: AgentAvatarProps) {
   const initials = agentInitials(name);
+  const { bg, fg } = avatarPalette(agentId);
   return (
     <Avatar className={cn(SIZES[size], "border-border shrink-0 border", className)}>
       {hasAvatar && (
@@ -62,7 +64,7 @@ export function AgentAvatar({
           alt=""
         />
       )}
-      <AvatarFallback className="font-semibold">
+      <AvatarFallback className={cn(bg, fg, "font-semibold")}>
         {initials || <Bot className={ICON_SIZES[size]} aria-hidden />}
       </AvatarFallback>
     </Avatar>

--- a/frontend/src/components/agents/agent-card.tsx
+++ b/frontend/src/components/agents/agent-card.tsx
@@ -100,7 +100,13 @@ export function AgentCard({
       />
 
       <div className="pointer-events-none relative flex items-start gap-3">
-        <AgentAvatar agentId={agent.id} name={agent.name} hasAvatar={agent.has_avatar} size="lg" />
+        <AgentAvatar
+          agentId={agent.id}
+          name={agent.name}
+          hasAvatar={agent.has_avatar}
+          colorSlot={agent.avatar_color}
+          size="lg"
+        />
         <div className="min-w-0 flex-1">
           <div className="flex items-start justify-between gap-2">
             <div className="min-w-0">

--- a/frontend/src/components/chat/share-dialog.test.tsx
+++ b/frontend/src/components/chat/share-dialog.test.tsx
@@ -40,6 +40,7 @@ const member = (userId: string, email: string, fullName: string | null = null) =
     email,
     full_name: fullName,
     avatar_url: null,
+    avatar_color: null,
     joined_at: "2026-01-01T00:00:00Z",
   }) satisfies OrganizationMember;
 

--- a/frontend/src/components/layout/sidebar-user.tsx
+++ b/frontend/src/components/layout/sidebar-user.tsx
@@ -5,14 +5,12 @@ import { useTranslations } from "next-intl";
 import { ChevronsUpDown, LogOut, UserCircle } from "lucide-react";
 
 import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  EntityAvatar,
 } from "@/components/ui";
 import { useAuth } from "@/hooks";
 import { ROUTES } from "@/lib/constants";
@@ -50,14 +48,16 @@ export function SidebarUser() {
         >
           {/* Decoration: the initials repeat the address underneath, and read
               out first they bury the name they abbreviate. */}
-          <Avatar aria-hidden className="h-6 w-6 shrink-0">
-            {user.avatar_url && (
-              <AvatarImage src={`/api/users/avatar/${user.id}?v=${avatarVersion}`} alt="" />
-            )}
-            <AvatarFallback className="bg-foreground text-background text-[10px] font-semibold">
-              {user.email.substring(0, 2).toUpperCase()}
-            </AvatarFallback>
-          </Avatar>
+          <EntityAvatar
+            seed={user.id}
+            name={user.full_name || user.email}
+            imageSrc={`/api/users/avatar/${user.id}?v=${avatarVersion}`}
+            hasImage={!!user.avatar_url}
+            colorSlot={user.avatar_color}
+            size="xs"
+            className="shrink-0"
+            ariaHidden
+          />
           <span className="min-w-0 flex-1">
             <span className="block truncate text-sm font-medium">
               {user.full_name || user.email.split("@")[0]}

--- a/frontend/src/components/orgs/member-identity.test.tsx
+++ b/frontend/src/components/orgs/member-identity.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { MemberIdentity, displayName, initialsOf } from "./member-identity";
+import { MemberIdentity, displayName } from "./member-identity";
 
 /**
  * One person, as this application draws a person.
@@ -48,15 +48,6 @@ describe("drawing a person", () => {
     );
 
     expect(container.textContent).toContain("BA");
-  });
-
-  it("reads two letters out of a name or out of an address", () => {
-    // Split on `@` as well as whitespace, so an account with no name gets two
-    // letters rather than one from "kacper@vstorm.co".
-    expect(initialsOf("Ada Lovelace")).toBe("AL");
-    expect(initialsOf("bob@acme.test")).toBe("BA");
-    expect(initialsOf("solo")).toBe("S");
-    expect(initialsOf("")).toBe("");
   });
 
   it("prefers the name somebody gave over their address", () => {

--- a/frontend/src/components/orgs/member-identity.tsx
+++ b/frontend/src/components/orgs/member-identity.tsx
@@ -1,25 +1,6 @@
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui";
+import { EntityAvatar } from "@/components/ui";
 import { cn } from "@/lib/utils";
 import { useTranslations } from "next-intl";
-
-/**
- * Two letters for a face nobody uploaded.
- *
- * Splits on whitespace *and* `@`, so an account with no name still gets initials
- * from the local part of its address rather than one letter from "kacper@vstorm.co".
- */
-export function initialsOf(nameOrEmail: string): string {
-  return (
-    nameOrEmail
-      .split(/[\s@]/)
-      .filter((part) => part.length > 0)
-      .slice(0, 2)
-      // `charAt`, not `[0]`: it returns a string for any index, so there is no
-      // impossible-empty case to guard against and no dead branch to leave behind.
-      .map((part) => part.charAt(0).toUpperCase())
-      .join("")
-  );
-}
 
 export interface IdentifiedMember {
   user_id: string;
@@ -61,12 +42,13 @@ export function MemberIdentity({
 
   return (
     <span className={cn("flex min-w-0 items-center gap-2.5", className)}>
-      <Avatar className="h-7 w-7 shrink-0">
-        <AvatarImage src={`/api/users/avatar/${member.user_id}`} alt="" />
-        <AvatarFallback className="text-[10px]">
-          {initialsOf(member.full_name || member.email)}
-        </AvatarFallback>
-      </Avatar>
+      <EntityAvatar
+        seed={member.user_id}
+        name={member.full_name || member.email}
+        imageSrc={`/api/users/avatar/${member.user_id}`}
+        size="sm"
+        className="shrink-0"
+      />
       <span className="min-w-0">
         <span className="text-foreground block truncate text-sm">
           {name}

--- a/frontend/src/components/runs/run-filter-bar.tsx
+++ b/frontend/src/components/runs/run-filter-bar.tsx
@@ -4,12 +4,10 @@ import { useTranslations } from "next-intl";
 
 import { AgentAvatar } from "@/components/agents/agent-avatar";
 import { RUN_LABEL } from "@/components/agents/status-badge";
-import { displayName, initialsOf } from "@/components/orgs/member-identity";
+import { displayName } from "@/components/orgs/member-identity";
 import { SurfaceIcon, surfaceLabel } from "@/components/runs/surface-icon";
 import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
+  EntityAvatar,
   Select,
   SelectContent,
   SelectItem,
@@ -260,12 +258,13 @@ function PersonSelect({
         {members.map((member) => (
           <SelectItem key={member.user_id} value={member.user_id}>
             <span className="flex items-center gap-2">
-              <Avatar className="h-5 w-5 shrink-0" aria-hidden>
-                <AvatarImage src={`/api/users/avatar/${member.user_id}`} alt="" />
-                <AvatarFallback className="text-[9px]">
-                  {initialsOf(member.full_name || member.email)}
-                </AvatarFallback>
-              </Avatar>
+              <EntityAvatar
+                seed={member.user_id}
+                name={member.full_name || member.email}
+                imageSrc={`/api/users/avatar/${member.user_id}`}
+                className="h-5 w-5 shrink-0 text-[9px]"
+                ariaHidden
+              />
               {displayName(member)}
             </span>
           </SelectItem>

--- a/frontend/src/components/runs/run-table.tsx
+++ b/frontend/src/components/runs/run-table.tsx
@@ -6,17 +6,10 @@ import { MessageSquare, ThumbsDown } from "lucide-react";
 
 import { AgentAvatar } from "@/components/agents/agent-avatar";
 import { RunStatusBadge } from "@/components/agents/status-badge";
-import { displayName, initialsOf, type IdentifiedMember } from "@/components/orgs/member-identity";
+import { displayName, type IdentifiedMember } from "@/components/orgs/member-identity";
 import { SurfaceIcon, surfaceLabel } from "@/components/runs/surface-icon";
 import { ProviderIcon } from "@/components/vault/provider-icon";
-import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
-  Badge,
-  DataTable,
-  type Column,
-} from "@/components/ui";
+import { Badge, DataTable, EntityAvatar, type Column } from "@/components/ui";
 import { useAuthStore } from "@/stores";
 import { ROUTES } from "@/lib/constants";
 import { formatDateTime, formatRunDuration, timeAgo } from "@/lib/utils";
@@ -150,12 +143,13 @@ export function RunTable({
               }
               return (
                 <span className="flex items-center gap-2 text-xs">
-                  <Avatar className="h-5 w-5 shrink-0" aria-hidden>
-                    <AvatarImage src={`/api/users/avatar/${member.user_id}`} alt="" />
-                    <AvatarFallback className="text-[9px]">
-                      {initialsOf(member.full_name || member.email)}
-                    </AvatarFallback>
-                  </Avatar>
+                  <EntityAvatar
+                    seed={member.user_id}
+                    name={member.full_name || member.email}
+                    imageSrc={`/api/users/avatar/${member.user_id}`}
+                    className="h-5 w-5 shrink-0 text-[9px]"
+                    ariaHidden
+                  />
                   {displayName(member)}
                 </span>
               );

--- a/frontend/src/components/runs/spend-by-person.tsx
+++ b/frontend/src/components/runs/spend-by-person.tsx
@@ -2,16 +2,8 @@
 
 import { useTranslations } from "next-intl";
 
-import { initialsOf } from "@/components/orgs/member-identity";
 import { LoadingState } from "@/components/states";
-import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
-  Button,
-  DataTable,
-  type Column,
-} from "@/components/ui";
+import { Button, DataTable, EntityAvatar, type Column } from "@/components/ui";
 import { usePeopleUsage, usePermissions, useUsageStats } from "@/hooks";
 import { Perm } from "@/types/permissions";
 import type { PersonUsageRow } from "@/types/stats";
@@ -68,12 +60,13 @@ export function SpendByPerson({ from, to }: { from: string; to: string }) {
         <span className="flex items-center gap-2">
           {/* The application's one way of drawing a person - the same face the
               member lists and the run filter show. */}
-          <Avatar className="h-5 w-5 shrink-0" aria-hidden>
-            <AvatarImage src={`/api/users/avatar/${person.user_id}`} alt="" />
-            <AvatarFallback className="text-[9px]">
-              {initialsOf(person.full_name || person.email)}
-            </AvatarFallback>
-          </Avatar>
+          <EntityAvatar
+            seed={person.user_id}
+            name={person.full_name || person.email}
+            imageSrc={`/api/users/avatar/${person.user_id}`}
+            className="h-5 w-5 shrink-0 text-[9px]"
+            ariaHidden
+          />
           {person.full_name ?? person.email}
         </span>
       ),

--- a/frontend/src/components/sharing/sharing-panel.test.tsx
+++ b/frontend/src/components/sharing/sharing-panel.test.tsx
@@ -29,6 +29,7 @@ function member(userId: string, email: string): OrganizationMember {
     email,
     full_name: null,
     avatar_url: null,
+    avatar_color: null,
     joined_at: "2026-01-01T00:00:00Z",
   };
 }

--- a/frontend/src/components/teams/org-spending-limit.integration.test.tsx
+++ b/frontend/src/components/teams/org-spending-limit.integration.test.tsx
@@ -34,6 +34,7 @@ function org(overrides: Partial<Organization> = {}): Organization {
     name: "Acme",
     slug: "acme",
     avatar_url: null,
+    avatar_color: null,
     is_personal: false,
     owner_id: "u1",
     stripe_customer_id: null,

--- a/frontend/src/components/teams/org-switcher.tsx
+++ b/frontend/src/components/teams/org-switcher.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { EntityAvatar } from "@/components/ui/entity-avatar";
 import { useOrganizations } from "@/hooks";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -57,12 +57,14 @@ export function OrgSwitcher() {
         >
           {/* Decoration: the initials are the same two letters as the name
               beside them, and read out first they bury it. */}
-          <Avatar aria-hidden className="h-5 w-5 shrink-0">
-            {displayOrg.avatar_url && <AvatarImage src={`/api/orgs/${displayOrg.id}/avatar`} />}
-            <AvatarFallback className="text-[10px]">
-              {displayOrg.name.substring(0, 2).toUpperCase()}
-            </AvatarFallback>
-          </Avatar>
+          <EntityAvatar
+            seed={displayOrg.id}
+            name={displayOrg.name}
+            imageSrc={`/api/orgs/${displayOrg.id}/avatar`}
+            hasImage={!!displayOrg.avatar_url}
+            className="h-5 w-5 shrink-0 text-[10px]"
+            ariaHidden
+          />
           {/* Named for assistive technology, because "Personal" on its own does
               not say what picking it would change. */}
           <span className="sr-only">{t("organization")}</span>
@@ -73,12 +75,13 @@ export function OrgSwitcher() {
       <DropdownMenuContent align="start" className="w-56">
         {orgs.map((org) => (
           <DropdownMenuItem key={org.id} onSelect={() => switchOrg(org.id)} className="gap-2">
-            <Avatar className="h-5 w-5">
-              {org.avatar_url && <AvatarImage src={`/api/orgs/${org.id}/avatar`} />}
-              <AvatarFallback className="text-[10px]">
-                {org.name.substring(0, 2).toUpperCase()}
-              </AvatarFallback>
-            </Avatar>
+            <EntityAvatar
+              seed={org.id}
+              name={org.name}
+              imageSrc={`/api/orgs/${org.id}/avatar`}
+              hasImage={!!org.avatar_url}
+              className="h-5 w-5 text-[10px]"
+            />
             <span className="truncate">{org.name}</span>
             {org.is_personal && (
               <span className="text-muted-foreground ml-auto text-[10px]">{t("personal")}</span>

--- a/frontend/src/components/teams/org-switcher.tsx
+++ b/frontend/src/components/teams/org-switcher.tsx
@@ -62,6 +62,7 @@ export function OrgSwitcher() {
             name={displayOrg.name}
             imageSrc={`/api/orgs/${displayOrg.id}/avatar`}
             hasImage={!!displayOrg.avatar_url}
+            colorSlot={displayOrg.avatar_color}
             className="h-5 w-5 shrink-0 text-[10px]"
             ariaHidden
           />
@@ -80,6 +81,7 @@ export function OrgSwitcher() {
               name={org.name}
               imageSrc={`/api/orgs/${org.id}/avatar`}
               hasImage={!!org.avatar_url}
+              colorSlot={org.avatar_color}
               className="h-5 w-5 text-[10px]"
             />
             <span className="truncate">{org.name}</span>

--- a/frontend/src/components/ui/avatar-color-picker.test.tsx
+++ b/frontend/src/components/ui/avatar-color-picker.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import { describe, expect, it, vi } from "vitest";
+
+import messages from "../../../messages/en.json";
+import { AvatarColorPicker } from "./avatar-color-picker";
+import { AVATAR_COLOR_COUNT } from "@/lib/avatar-color";
+
+function renderPicker(value: number | null, onChange = vi.fn()) {
+  render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <AvatarColorPicker value={value} onChange={onChange} />
+    </NextIntlClientProvider>,
+  );
+  return onChange;
+}
+
+describe("AvatarColorPicker", () => {
+  it("offers auto plus one swatch per colour", () => {
+    renderPicker(null);
+    // Auto and the ten colours are all radios in one group.
+    expect(screen.getAllByRole("radio")).toHaveLength(AVATAR_COLOR_COUNT + 1);
+  });
+
+  it("marks auto as chosen when no slot is set", () => {
+    renderPicker(null);
+    expect(screen.getByRole("radio", { name: "Automatic colour" })).toBeChecked();
+  });
+
+  it("marks the chosen slot", () => {
+    renderPicker(3);
+    expect(screen.getByRole("radio", { name: "Colour 3" })).toBeChecked();
+    expect(screen.getByRole("radio", { name: "Automatic colour" })).not.toBeChecked();
+  });
+
+  it("reports the slot a click chose", async () => {
+    const onChange = renderPicker(null);
+    await userEvent.click(screen.getByRole("radio", { name: "Colour 5" }));
+    expect(onChange).toHaveBeenCalledWith(5);
+  });
+
+  it("reports null when auto is chosen back", async () => {
+    const onChange = renderPicker(5);
+    await userEvent.click(screen.getByRole("radio", { name: "Automatic colour" }));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+});

--- a/frontend/src/components/ui/avatar-color-picker.tsx
+++ b/frontend/src/components/ui/avatar-color-picker.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Sparkles } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { AVATAR_COLORS } from "@/lib/avatar-color";
+import { cn } from "@/lib/utils";
+
+export interface AvatarColorPickerProps {
+  /** The chosen slot (1..10), or null for auto (the id-derived default). */
+  value: number | null;
+  onChange: (slot: number | null) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+const SWATCH = "h-7 w-7 rounded-full border border-border/60 transition-shadow outline-none";
+const SELECTED = "ring-ring ring-offset-background ring-2 ring-offset-2";
+
+/**
+ * Pick the colour a fallback avatar wears, or leave it automatic.
+ *
+ * A radio group of the ten `--avatar-*` swatches plus an "auto" that hands the
+ * colour back to the hash of the id - the same finite palette the avatar draws
+ * from, so a choice can never land off the design system or on an unreadable
+ * fill. It renders no preview of its own; the caller shows a live avatar beside
+ * it.
+ */
+export function AvatarColorPicker({
+  value,
+  onChange,
+  disabled,
+  className,
+}: AvatarColorPickerProps) {
+  const t = useTranslations("avatarColor");
+  return (
+    <div
+      role="radiogroup"
+      aria-label={t("label")}
+      className={cn("flex flex-wrap items-center gap-2", className)}
+    >
+      <button
+        type="button"
+        role="radio"
+        aria-checked={value == null}
+        aria-label={t("auto")}
+        disabled={disabled}
+        onClick={() => onChange(null)}
+        className={cn(
+          SWATCH,
+          "bg-muted text-muted-foreground flex items-center justify-center disabled:opacity-50",
+          value == null && SELECTED,
+        )}
+      >
+        <Sparkles className="h-3.5 w-3.5" aria-hidden />
+      </button>
+      {AVATAR_COLORS.map(({ slot, palette }) => (
+        <button
+          key={slot}
+          type="button"
+          role="radio"
+          aria-checked={value === slot}
+          aria-label={t("option", { n: slot })}
+          disabled={disabled}
+          onClick={() => onChange(slot)}
+          className={cn(SWATCH, palette.bg, "disabled:opacity-50", value === slot && SELECTED)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/entity-avatar.test.tsx
+++ b/frontend/src/components/ui/entity-avatar.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { EntityAvatar } from "./entity-avatar";
+import { avatarPalette } from "@/lib/avatar-color";
+
+/**
+ * The face a person, org or agent wears when nobody uploaded one. jsdom never
+ * loads an image, so Radix keeps the avatar in its fallback state - which is
+ * exactly the state these tests are about.
+ */
+describe("EntityAvatar", () => {
+  it("draws the initials on the colour its seed selects", () => {
+    render(<EntityAvatar seed="org-1" name="Vstorm Org" />);
+
+    const fallback = screen.getByText("VO");
+    expect(fallback).toHaveClass(avatarPalette("org-1").bg);
+  });
+
+  it("gives the same seed the same colour", () => {
+    const { rerender } = render(<EntityAvatar seed="u-9" name="Anna Nowak" />);
+    const first = screen.getByText("AN").className;
+
+    rerender(<EntityAvatar seed="u-9" name="Anna Nowak" />);
+    expect(screen.getByText("AN").className).toBe(first);
+  });
+
+  it("draws a glyph when the name yields no initials", () => {
+    const { container } = render(
+      <EntityAvatar seed="a-1" name="   " fallbackIcon={<svg data-testid="glyph" />} />,
+    );
+
+    expect(container.querySelector("[data-testid='glyph']")).not.toBeNull();
+  });
+
+  it("does not draw an image when told the row has none", () => {
+    // The row's picture is absent, so no request is worth making for it.
+    const { container } = render(
+      <EntityAvatar seed="u-1" name="Kacper" imageSrc="/api/users/avatar/u-1" hasImage={false} />,
+    );
+
+    expect(container.querySelector("img")).toBeNull();
+  });
+
+  it("attempts the image when one is given and presence is unknown", () => {
+    // No `hasImage`: an id-only caller keeps today's behaviour - the picture is
+    // fetched, and Radix falls through to these initials if it 404s.
+    render(<EntityAvatar seed="u-1" name="Kacper" imageSrc="/api/users/avatar/u-1" />);
+
+    expect(screen.getByText("K")).toBeInTheDocument();
+  });
+
+  it("renders at the size it was asked for", () => {
+    const { container } = render(<EntityAvatar seed="u-1" name="Kacper" size="xl" />);
+
+    expect(container.firstElementChild).toHaveClass("h-20");
+  });
+});

--- a/frontend/src/components/ui/entity-avatar.tsx
+++ b/frontend/src/components/ui/entity-avatar.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { avatarInitials, avatarPalette } from "@/lib/avatar-color";
+import { cn } from "@/lib/utils";
+
+const SIZES = {
+  xs: "h-6 w-6 text-[10px]",
+  sm: "h-7 w-7 text-[10px]",
+  md: "h-9 w-9 text-xs",
+  lg: "h-14 w-14 text-base",
+  xl: "h-20 w-20 text-lg",
+} as const;
+
+export interface EntityAvatarProps {
+  /** Stable id the colour is derived from, so one entity keeps its colour. */
+  seed: string;
+  /** Name or address the initials are taken from. */
+  name: string;
+  /** The avatar endpoint. Omit for an entity that cannot have a picture. */
+  imageSrc?: string;
+  /**
+   * Whether to fetch `imageSrc` at all. Defaults to whether one was given, so a
+   * caller that knows the row has no uploaded picture (`hasImage={false}`) draws
+   * the coloured initials without a request that would only 404.
+   */
+  hasImage?: boolean;
+  size?: keyof typeof SIZES;
+  /** A glyph for an entity with no usable name, in place of empty initials. */
+  fallbackIcon?: ReactNode;
+  /** Hide from assistive tech when the name it stands for sits visibly beside it. */
+  ariaHidden?: boolean;
+  className?: string;
+}
+
+/**
+ * The picture that stands in for a person, an organization or an agent.
+ *
+ * When there is no uploaded picture the fallback is not a blank circle: two
+ * initials on a colour keyed to the id, so a member list reads as designed and
+ * one entity wears the same colour on every screen. The image is rendered only
+ * when the caller says there is one - Radix fetches an `<AvatarImage>` to detect
+ * its load state, so drawing it unconditionally is a request per avatar-less row.
+ */
+export function EntityAvatar({
+  seed,
+  name,
+  imageSrc,
+  hasImage,
+  size = "md",
+  fallbackIcon,
+  ariaHidden,
+  className,
+}: EntityAvatarProps) {
+  const initials = avatarInitials(name);
+  const { bg, fg } = avatarPalette(seed);
+  const showImage = (hasImage ?? imageSrc != null) && imageSrc != null;
+  return (
+    <Avatar aria-hidden={ariaHidden} className={cn(SIZES[size], className)}>
+      {showImage && <AvatarImage src={imageSrc} alt="" />}
+      <AvatarFallback className={cn(bg, fg, "font-semibold")}>
+        {initials || fallbackIcon}
+      </AvatarFallback>
+    </Avatar>
+  );
+}

--- a/frontend/src/components/ui/entity-avatar.tsx
+++ b/frontend/src/components/ui/entity-avatar.tsx
@@ -27,6 +27,8 @@ export interface EntityAvatarProps {
    * the coloured initials without a request that would only 404.
    */
   hasImage?: boolean;
+  /** The chosen colour slot (1..10); null or absent derives it from the seed. */
+  colorSlot?: number | null;
   size?: keyof typeof SIZES;
   /** A glyph for an entity with no usable name, in place of empty initials. */
   fallbackIcon?: ReactNode;
@@ -49,13 +51,14 @@ export function EntityAvatar({
   name,
   imageSrc,
   hasImage,
+  colorSlot,
   size = "md",
   fallbackIcon,
   ariaHidden,
   className,
 }: EntityAvatarProps) {
   const initials = avatarInitials(name);
-  const { bg, fg } = avatarPalette(seed);
+  const { bg, fg } = avatarPalette(seed, colorSlot);
   const showImage = (hasImage ?? imageSrc != null) && imageSrc != null;
   return (
     <Avatar aria-hidden={ariaHidden} className={cn(SIZES[size], className)}>

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -37,6 +37,7 @@ export {
   AlertDialogCancel,
 } from "./alert-dialog";
 export { Avatar, AvatarImage, AvatarFallback } from "./avatar";
+export { EntityAvatar, type EntityAvatarProps } from "./entity-avatar";
 export { Skeleton } from "./skeleton";
 export { Separator } from "./separator";
 export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "./tooltip";

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -38,6 +38,7 @@ export {
 } from "./alert-dialog";
 export { Avatar, AvatarImage, AvatarFallback } from "./avatar";
 export { EntityAvatar, type EntityAvatarProps } from "./entity-avatar";
+export { AvatarColorPicker, type AvatarColorPickerProps } from "./avatar-color-picker";
 export { Skeleton } from "./skeleton";
 export { Separator } from "./separator";
 export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "./tooltip";

--- a/frontend/src/components/vault/secrets-table.tsx
+++ b/frontend/src/components/vault/secrets-table.tsx
@@ -159,7 +159,7 @@ export function SecretsTable({
           secret.created_by_email ? (
             <div className="flex items-center gap-2">
               <EntityAvatar
-                seed={secret.created_by_email}
+                seed={secret.created_by_user_id ?? secret.created_by_email}
                 name={secret.created_by_email}
                 imageSrc={secret.created_by_avatar_url ?? undefined}
                 className="h-6 w-6 text-[10px]"

--- a/frontend/src/components/vault/secrets-table.tsx
+++ b/frontend/src/components/vault/secrets-table.tsx
@@ -5,12 +5,10 @@ import { Lock, RotateCw, Trash2, Users } from "lucide-react";
 
 import { ProviderIcon } from "@/components/vault/provider-icon";
 import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
   Badge,
   Button,
   DataTable,
+  EntityAvatar,
   ListCardControlsRow,
   Select,
   SelectContent,
@@ -64,11 +62,6 @@ function reach(
   if (secret.visibility === "private") return { label: t("visibilityPrivate"), detail: sharedWith };
   if (secret.visibility === "team") return { label: t("visibilityTeam"), detail: sharedWith };
   return { label: t("visibilityOrg"), detail: null };
-}
-
-/** Two letters for a face nobody uploaded, and nothing at all for nobody. */
-function initials(email: string | null | undefined): string {
-  return (email ?? "?").slice(0, 2).toUpperCase();
 }
 
 /**
@@ -165,14 +158,13 @@ export function SecretsTable({
         cell: (secret) =>
           secret.created_by_email ? (
             <div className="flex items-center gap-2">
-              <Avatar className="h-6 w-6">
-                {secret.created_by_avatar_url && (
-                  <AvatarImage src={secret.created_by_avatar_url} alt="" />
-                )}
-                <AvatarFallback className="text-[10px]">
-                  {initials(secret.created_by_email)}
-                </AvatarFallback>
-              </Avatar>
+              <EntityAvatar
+                seed={secret.created_by_email}
+                name={secret.created_by_email}
+                imageSrc={secret.created_by_avatar_url ?? undefined}
+                className="h-6 w-6 text-[10px]"
+                ariaHidden
+              />
               <span className="text-muted-foreground truncate text-xs">
                 {secret.created_by_email}
               </span>

--- a/frontend/src/hooks/use-agents.test.tsx
+++ b/frontend/src/hooks/use-agents.test.tsx
@@ -32,7 +32,14 @@ const SPEC: AgentSpec = {
 };
 
 vi.mock("@/lib/api-client", () => ({
-  apiClient: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), upload: vi.fn() },
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    upload: vi.fn(),
+  },
 }));
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
@@ -210,6 +217,33 @@ describe("useAgent rollback", () => {
     await result.current.rollback.mutateAsync("v1");
 
     expect(apiClient.post).toHaveBeenCalledWith("/agents/a1/rollback", { version_id: "v1" });
+  });
+});
+
+describe("useAgent avatar colour", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("sends the chosen slot to the agent's colour endpoint", async () => {
+    // A column, not the spec: it patches the row directly, like the picture.
+    vi.mocked(apiClient.get).mockResolvedValue({ id: "a1", draft_spec: {} });
+    vi.mocked(apiClient.patch).mockResolvedValue({ id: "a1", avatar_color: 3 });
+
+    const { result } = renderHook(() => useAgent("a1"), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await result.current.setColor.mutateAsync(3);
+
+    expect(apiClient.patch).toHaveBeenCalledWith("/agents/a1/avatar-color", { color: 3 });
+  });
+
+  it("reports a failed colour change rather than swallowing it", async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({ id: "a1", draft_spec: {} });
+    vi.mocked(apiClient.patch).mockRejectedValue(new Error("nope"));
+
+    const { result } = renderHook(() => useAgent("a1"), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await expect(result.current.setColor.mutateAsync(null)).rejects.toThrow();
   });
 });
 

--- a/frontend/src/hooks/use-agents.ts
+++ b/frontend/src/hooks/use-agents.ts
@@ -254,7 +254,20 @@ export function useAgent(agentId: string | null) {
     onError: (error) => toast.error(getErrorMessage(error, tErrors)),
   });
 
-  return { agent: data, isLoading, saveDraft, validate, publish, rollback, setAvatar };
+  /**
+   * Choose the colour of the agent's fallback avatar, or null for auto. A
+   * column like the picture, not the spec, for the same reason `setAvatar` is.
+   */
+  const setColor = useMutation({
+    mutationFn: (color: number | null) =>
+      apiClient.patch<Agent>(`/agents/${agentId}/avatar-color`, { color }),
+    onSuccess: async () => {
+      await invalidate();
+    },
+    onError: (error) => toast.error(getErrorMessage(error, tErrors)),
+  });
+
+  return { agent: data, isLoading, saveDraft, validate, publish, rollback, setAvatar, setColor };
 }
 
 export function useAgentVersions(agentId: string | null) {

--- a/frontend/src/hooks/use-organizations.ts
+++ b/frontend/src/hooks/use-organizations.ts
@@ -142,7 +142,10 @@ export function useOrganizations() {
   );
 
   const patchOrg = useCallback(
-    async (id: string, patch: Partial<Pick<Organization, "name" | "avatar_url">>) => {
+    async (
+      id: string,
+      patch: Partial<Pick<Organization, "name" | "avatar_url" | "avatar_color">>,
+    ) => {
       try {
         const updated = await apiClient.patch<Organization>(`/orgs/${id}`, patch);
         writeCache((prev) => prev.map((o) => (o.id === id ? updated : o)));

--- a/frontend/src/lib/avatar-color.test.ts
+++ b/frontend/src/lib/avatar-color.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { avatarInitials, avatarPalette } from "./avatar-color";
+import { AVATAR_COLORS, AVATAR_COLOR_COUNT, avatarInitials, avatarPalette } from "./avatar-color";
 
 /**
  * The letters and the colour a face nobody uploaded is drawn from. Both are
@@ -53,5 +53,26 @@ describe("avatarPalette", () => {
   it("does not hand every seed the same colour", () => {
     const colours = new Set(Array.from({ length: 50 }, (_, i) => avatarPalette(`seed-${i}`).bg));
     expect(colours.size).toBeGreaterThan(1);
+  });
+
+  it("lets a chosen slot override the hash, ignoring the seed", () => {
+    // A user who picked slot 3 wears slot 3 whatever their id hashes to.
+    expect(avatarPalette("anything", 3)).toEqual(AVATAR_COLORS[2]!.palette);
+    expect(avatarPalette("other", 3)).toEqual(avatarPalette("different", 3));
+  });
+
+  it("falls back to the hash for a null slot or one out of range", () => {
+    const hashed = avatarPalette("seed-x");
+    expect(avatarPalette("seed-x", null)).toEqual(hashed);
+    expect(avatarPalette("seed-x", 0)).toEqual(hashed);
+    expect(avatarPalette("seed-x", AVATAR_COLOR_COUNT + 1)).toEqual(hashed);
+  });
+});
+
+describe("AVATAR_COLORS", () => {
+  it("offers one entry per slot, numbered from one", () => {
+    expect(AVATAR_COLORS).toHaveLength(AVATAR_COLOR_COUNT);
+    expect(AVATAR_COLORS[0]!.slot).toBe(1);
+    expect(AVATAR_COLORS.at(-1)!.slot).toBe(AVATAR_COLOR_COUNT);
   });
 });

--- a/frontend/src/lib/avatar-color.test.ts
+++ b/frontend/src/lib/avatar-color.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { avatarInitials, avatarPalette } from "./avatar-color";
+
+/**
+ * The letters and the colour a face nobody uploaded is drawn from. Both are
+ * derived from what the client already holds, so the tests are about what the
+ * derivation guarantees: readable letters, and a colour that never moves.
+ */
+describe("avatarInitials", () => {
+  it("takes the first letter of the first two words", () => {
+    expect(avatarInitials("Kacper Wlodarczyk")).toBe("KW");
+  });
+
+  it("takes a letter from either side of an address with no name", () => {
+    // Splitting on `@` too means "kacper@vstorm.co" gives "KV", not one letter
+    // from the whole address.
+    expect(avatarInitials("kacper@vstorm.co")).toBe("KV");
+  });
+
+  it("takes one letter from a single word", () => {
+    expect(avatarInitials("Support")).toBe("S");
+  });
+
+  it("ignores the whitespace somebody left in a name", () => {
+    expect(avatarInitials("  Anna   Nowak  ")).toBe("AN");
+  });
+
+  it("has nothing to show for a name that is only whitespace", () => {
+    // Which is what sends the fallback to a glyph rather than a blank circle.
+    expect(avatarInitials("   ")).toBe("");
+  });
+});
+
+describe("avatarPalette", () => {
+  it("gives one seed the same colour every time", () => {
+    expect(avatarPalette("org-42")).toEqual(avatarPalette("org-42"));
+  });
+
+  it("only ever answers with a background and a foreground class", () => {
+    const { bg, fg } = avatarPalette("user-1");
+    expect(bg).toMatch(/^bg-/);
+    expect(fg).toMatch(/^text-/);
+  });
+
+  it("stays in range for a seed whose hash is large", () => {
+    // The hash is masked unsigned before the modulo; a negative index would
+    // select nothing.
+    const seed = "z".repeat(64);
+    expect(avatarPalette(seed).bg).toMatch(/^bg-/);
+  });
+
+  it("does not hand every seed the same colour", () => {
+    const colours = new Set(Array.from({ length: 50 }, (_, i) => avatarPalette(`seed-${i}`).bg));
+    expect(colours.size).toBeGreaterThan(1);
+  });
+});

--- a/frontend/src/lib/avatar-color.ts
+++ b/frontend/src/lib/avatar-color.ts
@@ -35,21 +35,23 @@ export interface AvatarPalette {
 }
 
 /**
- * Ten pairs legible in both themes: a translucent tint for the circle and a
- * solid ink for the letters, the ink lightened under `dark`. Written as literal
- * class strings so Tailwind keeps them - a computed `bg-${hue}-500/15` is purged.
+ * Ten pastel fills on one charcoal ink, from the `--avatar-*` tokens in
+ * `globals.css`. Referenced as arbitrary-value classes so the class strings
+ * survive as literals for Tailwind to generate; the tokens are theme-independent
+ * (see the ramp's comment there), so the chip reads in light and dark alike
+ * without a `dark:` variant.
  */
 const PALETTE: readonly AvatarPalette[] = [
-  { bg: "bg-indigo-500/15", fg: "text-indigo-700 dark:text-indigo-300" },
-  { bg: "bg-sky-500/15", fg: "text-sky-700 dark:text-sky-300" },
-  { bg: "bg-teal-500/15", fg: "text-teal-700 dark:text-teal-300" },
-  { bg: "bg-emerald-500/15", fg: "text-emerald-700 dark:text-emerald-300" },
-  { bg: "bg-amber-500/15", fg: "text-amber-700 dark:text-amber-300" },
-  { bg: "bg-orange-500/15", fg: "text-orange-700 dark:text-orange-300" },
-  { bg: "bg-rose-500/15", fg: "text-rose-700 dark:text-rose-300" },
-  { bg: "bg-violet-500/15", fg: "text-violet-700 dark:text-violet-300" },
-  { bg: "bg-fuchsia-500/15", fg: "text-fuchsia-700 dark:text-fuchsia-300" },
-  { bg: "bg-cyan-500/15", fg: "text-cyan-700 dark:text-cyan-300" },
+  { bg: "bg-[var(--avatar-1)]", fg: "text-[var(--avatar-ink)]" },
+  { bg: "bg-[var(--avatar-2)]", fg: "text-[var(--avatar-ink)]" },
+  { bg: "bg-[var(--avatar-3)]", fg: "text-[var(--avatar-ink)]" },
+  { bg: "bg-[var(--avatar-4)]", fg: "text-[var(--avatar-ink)]" },
+  { bg: "bg-[var(--avatar-5)]", fg: "text-[var(--avatar-ink)]" },
+  { bg: "bg-[var(--avatar-6)]", fg: "text-[var(--avatar-ink)]" },
+  { bg: "bg-[var(--avatar-7)]", fg: "text-[var(--avatar-ink)]" },
+  { bg: "bg-[var(--avatar-8)]", fg: "text-[var(--avatar-ink)]" },
+  { bg: "bg-[var(--avatar-9)]", fg: "text-[var(--avatar-ink)]" },
+  { bg: "bg-[var(--avatar-10)]", fg: "text-[var(--avatar-ink)]" },
 ];
 
 /**

--- a/frontend/src/lib/avatar-color.ts
+++ b/frontend/src/lib/avatar-color.ts
@@ -54,15 +54,36 @@ const PALETTE: readonly AvatarPalette[] = [
   { bg: "bg-[var(--avatar-10)]", fg: "text-[var(--avatar-ink)]" },
 ];
 
-/**
- * The colour an entity wears, chosen by its seed. Deterministic and stable, so
- * the same id draws the same colour on every screen it appears on. A djb2 hash
- * kept unsigned before the modulo, because a negative index selects nothing.
- */
-export function avatarPalette(seed: string): AvatarPalette {
+/** How many colours the picker offers, and the top of the stored 1..N range. */
+export const AVATAR_COLOR_COUNT = PALETTE.length;
+
+/** Every colour, paired with the 1-based slot stored on the row - for the picker. */
+export const AVATAR_COLORS: readonly { slot: number; palette: AvatarPalette }[] = PALETTE.map(
+  (palette, i) => ({ slot: i + 1, palette }),
+);
+
+/** A slot's colour, or the hashed default when the slot is out of range or absent. */
+function paletteForSlot(slot: number | null | undefined, seed: string): AvatarPalette {
+  if (slot != null && slot >= 1 && slot <= AVATAR_COLOR_COUNT) {
+    return PALETTE[slot - 1] as AvatarPalette;
+  }
+  return hashedPalette(seed);
+}
+
+function hashedPalette(seed: string): AvatarPalette {
   let hash = 5381;
   for (let i = 0; i < seed.length; i++) {
     hash = (hash * 33) ^ seed.charCodeAt(i);
   }
   return PALETTE[(hash >>> 0) % PALETTE.length] as AvatarPalette;
+}
+
+/**
+ * The colour an entity wears. A chosen slot (1..N, what the row stores) wins;
+ * otherwise it is derived from the seed, deterministic and stable so the same id
+ * draws the same colour on every screen. A djb2 hash kept unsigned before the
+ * modulo, because a negative index selects nothing.
+ */
+export function avatarPalette(seed: string, colorSlot?: number | null): AvatarPalette {
+  return paletteForSlot(colorSlot, seed);
 }

--- a/frontend/src/lib/avatar-color.ts
+++ b/frontend/src/lib/avatar-color.ts
@@ -1,0 +1,66 @@
+/**
+ * The default face for anyone - a person, an organization, an agent - who never
+ * uploaded one.
+ *
+ * Two letters on a colour, both derived from what the client already holds, so a
+ * fresh deployment looks designed rather than empty and no row costs a network
+ * request to draw. The colour is a stable function of a seed (the row's id), so
+ * one entity wears the same colour everywhere it appears; the letters come from
+ * the name, so a member list stays readable at a glance.
+ */
+
+/**
+ * Up to two initials for a face nobody uploaded, or `""` when there is nothing
+ * to take them from (the caller then draws a glyph).
+ *
+ * Splits on whitespace *and* `@`, so an account with no name still gets two
+ * letters from its address ("kacper@vstorm.co" -> "KV") rather than one.
+ * `charAt`, not `[0]`: it returns a string for any index, so
+ * there is no impossible-empty case to guard and no dead branch to leave behind.
+ */
+export function avatarInitials(nameOrEmail: string): string {
+  return nameOrEmail
+    .split(/[\s@]/)
+    .filter((part) => part.length > 0)
+    .slice(0, 2)
+    .map((part) => part.charAt(0).toUpperCase())
+    .join("");
+}
+
+export interface AvatarPalette {
+  /** Background class, applied to the fallback circle. */
+  bg: string;
+  /** Foreground class, applied to the initials on it. */
+  fg: string;
+}
+
+/**
+ * Ten pairs legible in both themes: a translucent tint for the circle and a
+ * solid ink for the letters, the ink lightened under `dark`. Written as literal
+ * class strings so Tailwind keeps them - a computed `bg-${hue}-500/15` is purged.
+ */
+const PALETTE: readonly AvatarPalette[] = [
+  { bg: "bg-indigo-500/15", fg: "text-indigo-700 dark:text-indigo-300" },
+  { bg: "bg-sky-500/15", fg: "text-sky-700 dark:text-sky-300" },
+  { bg: "bg-teal-500/15", fg: "text-teal-700 dark:text-teal-300" },
+  { bg: "bg-emerald-500/15", fg: "text-emerald-700 dark:text-emerald-300" },
+  { bg: "bg-amber-500/15", fg: "text-amber-700 dark:text-amber-300" },
+  { bg: "bg-orange-500/15", fg: "text-orange-700 dark:text-orange-300" },
+  { bg: "bg-rose-500/15", fg: "text-rose-700 dark:text-rose-300" },
+  { bg: "bg-violet-500/15", fg: "text-violet-700 dark:text-violet-300" },
+  { bg: "bg-fuchsia-500/15", fg: "text-fuchsia-700 dark:text-fuchsia-300" },
+  { bg: "bg-cyan-500/15", fg: "text-cyan-700 dark:text-cyan-300" },
+];
+
+/**
+ * The colour an entity wears, chosen by its seed. Deterministic and stable, so
+ * the same id draws the same colour on every screen it appears on. A djb2 hash
+ * kept unsigned before the modulo, because a negative index selects nothing.
+ */
+export function avatarPalette(seed: string): AvatarPalette {
+  let hash = 5381;
+  for (let i = 0; i < seed.length; i++) {
+    hash = (hash * 33) ^ seed.charCodeAt(i);
+  }
+  return PALETTE[(hash >>> 0) % PALETTE.length] as AvatarPalette;
+}

--- a/frontend/src/types/agents.ts
+++ b/frontend/src/types/agents.ts
@@ -278,6 +278,8 @@ export interface Agent {
   current_version_id: string | null;
   /** Whether `/api/agents/{id}/avatar` will answer with an image. */
   has_avatar?: boolean;
+  /** Chosen default-avatar colour slot (1..10); null/absent is auto from the id. */
+  avatar_color?: number | null;
   /** How many members hold an explicit grant. Filled by the listing only. */
   shared_user_count?: number;
   /** Surfaces with an active binding ("slack", "telegram", ...). Listing only. */

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -8,6 +8,8 @@ export interface User {
   is_app_admin?: boolean;
   created_at: string;
   avatar_url?: string | null;
+  /** Chosen default-avatar colour slot (1..10); null/absent is auto from the id. */
+  avatar_color?: number | null;
   /** ISO timestamp when the user finished the onboarding wizard. `null` means
    *  the wizard hasn't been completed yet - middleware/banner uses this. */
   onboarding_completed_at?: string | null;

--- a/frontend/src/types/organization.ts
+++ b/frontend/src/types/organization.ts
@@ -8,6 +8,8 @@ export interface Organization {
   name: string;
   slug: string;
   avatar_url: string | null;
+  /** Chosen default-avatar colour slot (1..10); null is auto from the id. */
+  avatar_color: number | null;
   is_personal: boolean;
   owner_id: string;
   stripe_customer_id: string | null;
@@ -31,6 +33,8 @@ export interface OrganizationMember {
   email: string;
   full_name: string | null;
   avatar_url: string | null;
+  /** Chosen default-avatar colour slot (1..10); null is auto from the id. */
+  avatar_color: number | null;
   joined_at: string;
 }
 

--- a/frontend/src/types/secrets.ts
+++ b/frontend/src/types/secrets.ts
@@ -132,6 +132,12 @@ export interface Secret {
   owner_user_id?: string | null;
   /** Whose key it is, when it belongs to one person rather than the team. */
   owner_email?: string | null;
+  /**
+   * Who stored it, by id - the seed the fallback avatar's colour comes from, so
+   * the author wears the same hue here as in member and run lists. Still set once
+   * they have left the organization, when `created_by_email` is null.
+   */
+  created_by_user_id?: string | null;
   /** Who stored it; null once that account has left the organization. */
   created_by_email?: string | null;
   created_by_avatar_url?: string | null;


### PR DESCRIPTION
## What

Default avatars for users, orgs and agents — initials on a colour — **and** the
ability to choose that colour. Two parts:

**1. The default (frontend-only).** A shared `EntityAvatar` whose fallback is two
initials on a colour keyed to the row's id, replacing a flat neutral circle and
seven duplicated initials helpers. The image is drawn only when the caller says
there is one, which also closes a per-row 404 several user lists were firing.
Colours live in a tuned `--avatar-*` token ramp (ten pastels on one charcoal ink,
theme-independent so they read in light and dark without a `dark:` variant).

**2. Editing the colour (full stack).** A nullable `avatar_color` slot (1..10,
null = auto) on users, orgs and agents, and a swatch picker wired into the three
edit surfaces:

- **User** — `UserUpdate.avatar_color` through `writable()`; null resets to auto.
- **Organization** — `set_avatar_color` mirrors `set_monthly_budget` (the repo
  keyword form cannot express a null-reset); gated as `org:settings`; carried on
  `OrganizationRead` and `OrganizationMemberRead`, so the member list reflects it.
- **Agent** — a column like the picture, not the spec: `set_avatar_color` beside
  `set_avatar`, same per-agent `AGENTS_EDIT` check, new
  `PATCH /agents/{id}/avatar-color`. The picker sits in the builder's overflow
  menu.

Migration `0035` adds the column to all three tables (additive, nullable, no
backfill; range enforced by the API schema, not a CHECK, matching `avatar_url`).

## Why

The fallback already worked — Radix swaps a 404 to initials — but it looked
unfinished and was computed seven inconsistent ways. This is the consolidation
that makes it look designed, plus the colour control that was asked for on top.

## Verified

Backend: platform coverage 100%, migration round-trips forwards and back, the
null-gate accounts for the new schemas. Frontend: tsc, eslint, prettier,
check:i18n, the coverage gate (100% stmts/funcs/lines, 97.55% branches), the
build. Adversarial self-review of both halves found no blocking defects.

## Notes

- **#13** (avatar-proxy path traversal) is already fixed on `main` and untouched
  here — that box on #60 is already ticked.
- **#799** (secrets "Added by" seeded on email, not id) is fixed here: `SecretRead`
  now carries `created_by_user_id` and the "Added by" column seeds the avatar on
  it, so the author wears the same hue there as in every member and run list.
- The signed-in user's own avatar in the sidebar (`sidebar-user.tsx`) is now the
  shared `EntityAvatar` too — it was the last surface still on a flat monochrome
  fallback with a one-off initials helper.
- The hash-derived colour still shows on a few secondary surfaces whose DTOs do
  not carry `avatar_color` (run tables' `IdentifiedMember`, spend-by-person,
  admin lists, chat-agent DTOs) — they seed on the id, so a person's colour is
  stable across them, just not the *chosen* one. The chosen colour shows on the
  flagship ones: profile, org switcher + members, agent cards + builder.

Closes #60, #799
