### PR TITLE
chore: cut 0.0.161

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.161] - 2026-08-16
+
+An agent can draw an image, with the spend on the ledger like everything else.
+
+### Added
+
+- **The `image_generation` capability.** One tool, `generate_image`, that renders
+  an image from a prompt with a dedicated image model (OpenAI Responses or
+  Google), whatever model the agent itself runs on. The provider key is a
+  `SecretRequirement`, so publishing without one is refused at the form; the tool
+  is `side_effecting`, so every call can sit behind the approval gate; and the
+  subagent's usage is booked to the run's ledger — an unpriced image model
+  records zero and flags the run's cost partial rather than hiding it. Images
+  land in organization-scoped storage (`generated/{org}`), served only under the
+  caller's own organization at `GET /api/v1/generated/{filename}`, rendered
+  inline in chat, and — when the run has a workspace open — also written under
+  `/output` so a later `execute` step can build with them. (#58)
+
 ## [0.0.160] - 2026-08-16
 
 Every person, organization and agent gets a designed default avatar, and a colour

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.160"
+version = "0.0.161"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.160"
+version = "0.0.161"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.160",
+  "version": "0.0.161",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.161. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json` to 0.0.161 and adds the CHANGELOG entry.

Releases:
- The `image_generation` capability — `generate_image` on a dedicated image model (OpenAI Responses or Google), metered to the run's ledger, keyed by a `SecretRequirement`, gateable as side-effecting, with tenant-scoped storage and inline rendering in chat (#58, landed in #807).