### PR TITLE
chore: cut 0.0.162

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,26 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.162] - 2026-08-16
+
+An agent can drive a real browser, with the same guards as everything else.
+
+### Added
+
+- **The `browser_use` capability.** One tool, `browse_web`, that hands a
+  self-contained natural-language goal to an autonomous
+  [browser-use](https://github.com/browser-use/browser-use) agent driving a real
+  Chromium — `mode='playwright'` launches a local headless browser,
+  `mode='remote'` attaches over CDP to an operator-supplied `cdp_url`. A remote
+  endpoint is SSRF-checked at publish time, off the event loop, for every binding
+  — the first production caller of `validate_webhook_url` (part of #33). The
+  browser sub-agent runs on the host run's model wrapped in a `MeteredModel`, so
+  its spend is booked against the run's ledger (#802), and the tool is
+  `side_effecting`, so every call can sit behind the approval gate. The engine is
+  an optional dependency the capability builds without: until browser-use loosens
+  its `pydantic` pin (#801), enabling and running it raises a `RuntimeError`
+  naming the fix rather than failing quietly. (#59)
+
 ## [0.0.161] - 2026-08-16
 
 An agent can draw an image, with the spend on the ledger like everything else.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.161"
+version = "0.0.162"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.161"
+version = "0.0.162"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.161",
+  "version": "0.0.162",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.162. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json` to 0.0.162 and adds the CHANGELOG entry.

Releases:
- The `browser_use` capability — `browse_web` delegating to an autonomous browser-use agent on a real Chromium, local or remote over CDP, with the remote endpoint SSRF-checked at publish, the sub-agent's spend metered to the run's ledger, and the tool gateable as side-effecting (#59, #802, landed in #805).