### PR TITLE
chore: cut 0.0.163

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,40 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.163] - 2026-08-16
+
+An oversized tool return stops eating the run, and nothing spills onto shared disk.
+
+### Added
+
+- **The `tool_output_limits` capability.** A tool return too large for the
+  model's window is reduced once, when it is produced, instead of being re-sent
+  in full on every later request of the run. Three actions per binding: `spill`
+  (default, lossless — the full return goes to the agent's own sandbox backend
+  under a `tool_output/` prefix and is replaced with a handle + preview the model
+  pages through with `read_tool_result`), `truncate` (a cheap clamp with a marker
+  saying what was cut), and `summarize` (an LLM summary on the run's own model,
+  its spend booked to the run's ledger). Spills land on the tenant's own backend,
+  never shared disk — an agent with no backend gets an in-memory one discarded
+  with the run — and a spill the backend refuses degrades to a truncation, never
+  a silent drop. (#57)
+
+### Fixed
+
+- **Spills no longer outlive the run on a `state` backend.** A longer-scoped
+  `state` workspace was persisting `tool_output/` spills into its stored document
+  every run, counting them against `SANDBOX_STATE_MAX_BYTES` until the agent's
+  own writes were refused. The flush now strips the reserved prefix, so every run
+  self-heals what a prior one left. The container-backend half stays open as
+  #803. (#803)
+
+### Changed
+
+- **The ambient-usage delta is one helper, not two copies.** `compaction` and
+  `tool_output_limits` each carried an identical snapshot-and-diff for booking a
+  self-run `Agent`'s tokens; both now import `usage_counts`/`usage_delta` from
+  `budget`, so a pricing fix lands in one place.
+
 ## [0.0.162] - 2026-08-16
 
 An agent can drive a real browser, with the same guards as everything else.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.162"
+version = "0.0.163"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.162"
+version = "0.0.163"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.162",
+  "version": "0.0.163",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.163. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json` to 0.0.163 and adds the CHANGELOG entry.

Releases:
- The `tool_output_limits` capability — spill/truncate/summarize on an oversized tool return, spilling to the run's own backend with `read_tool_result` paging, `summarize` metered to the run's ledger, and the `state`-backend spill-lifetime fix (#57, #803, landed in #804).