### PR TITLE
chore: cut 0.0.164

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,27 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.164] - 2026-08-16
+
+An agent stops forgetting its instructions mid-run, and remembers across turns.
+
+### Added
+
+- **The `system_reminders` capability.** Re-states steering guidance mid-run to
+  counter instruction fade — a model progressively ignoring the guidance it
+  started with after many tool-use turns. Three declarative reminder kinds, each
+  on its own cadence (`interval` / `first_after` / `max_fires`): fixed
+  `reminders[]` lines, `goal_reanchor` (the run's first user request, re-stated),
+  and `llm_reminder` (a model-written nudge from the recent transcript, metered
+  to the run's ledger, running on the run's own model under its limits minus one
+  reserved request, falling back to the goal-reanchor line on any error). The
+  cadence is durable per conversation — counters live in a new
+  `conversations.reminder_state` JSONB column, so leaving and reloading a
+  conversation resumes it; only the counters are stored, never the reminder
+  text. A fired reminder is injected as an ephemeral prompt part behind a
+  `CachePoint`, so it never enters `message_history` and the cached prefix stays
+  byte-identical turn over turn. (#787)
+
 ## [0.0.163] - 2026-08-16
 
 An oversized tool return stops eating the run, and nothing spills onto shared disk.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.163"
+version = "0.0.164"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.163"
+version = "0.0.164"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.163",
+  "version": "0.0.164",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.164. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json` to 0.0.164 and adds the CHANGELOG entry.

Releases:
- The `system_reminders` capability — fixed reminders, goal re-anchoring and a metered LLM nudge on per-reminder cadences, durable per conversation in `conversations.reminder_state` and injected cache-safely behind a `CachePoint` (#787, landed in #806).