### PR TITLE
fix(agents): compose a delegated run's stored error, never store the library's

### DIFF
--- a/backend/app/agents/capabilities/subagents/_journal.py
+++ b/backend/app/agents/capabilities/subagents/_journal.py
@@ -78,7 +78,7 @@ from subagents_pydantic_ai import (
 )
 from subagents_pydantic_ai.registry import DynamicAgentRegistry
 
-from app.agents.capabilities.budget import SpendShare, booked_to
+from app.agents.capabilities.budget import BudgetExceeded, SpendShare, booked_to
 from app.agents.capabilities.subagents._events import FrameLabels, frame_for
 from app.agents.deps import AgentDeps
 from app.agents.failures import run_failure_summary
@@ -165,13 +165,20 @@ def _recorded_error(handle: TaskHandle, subagent: str, task_id: str) -> str | No
     `run_failure_summary` - the one the parent's row gets - and the original goes
     to the log beside it.
 
-    `UsageLimitExceeded` keeps the library's text whole. It is the delegation's
-    `BudgetExceeded`: not a malfunction but a ceiling doing its job, its message
-    is pydantic-ai's own limit sentence - a number, never a request - and the
-    `usage limit exceeded` marker in front of it is the library's telemetry
-    contract across both dispatch modes.
+    The two ceilings keep the library's text whole. A ceiling is not a
+    malfunction, and either message is controlled end to end: `UsageLimitExceeded`
+    carries pydantic-ai's own limit sentence - a number, never a request - behind
+    the `usage limit exceeded` marker that is the library's telemetry contract
+    across both dispatch modes, and `BudgetExceeded` carries this platform's own
+    ceiling sentence behind the library's type-name prefix. `BudgetExceeded`
+    reaches this settlement because a delegate's requests are budget-checked
+    inside the delegate's own run, so the breach lands on the handle rather than
+    propagating to the caller the parent's row is written by - and composing it
+    away would tell the reader to retry against a breached budget.
     """
-    if handle.exception is None or isinstance(handle.exception, UsageLimitExceeded):
+    if handle.exception is None or isinstance(
+        handle.exception, UsageLimitExceeded | BudgetExceeded
+    ):
         return handle.error
     logger.warning(
         "Delegation %r (task %s) failed: %s",

--- a/backend/app/agents/capabilities/subagents/_journal.py
+++ b/backend/app/agents/capabilities/subagents/_journal.py
@@ -65,6 +65,7 @@ from typing import Any, Literal
 from uuid import UUID, uuid4
 
 from pydantic_ai.agent import EventStreamHandler
+from pydantic_ai.exceptions import UsageLimitExceeded
 from pydantic_ai.messages import AgentStreamEvent
 from pydantic_ai.tools import RunContext
 from subagents_pydantic_ai import (
@@ -80,6 +81,7 @@ from subagents_pydantic_ai.registry import DynamicAgentRegistry
 from app.agents.capabilities.budget import SpendShare, booked_to
 from app.agents.capabilities.subagents._events import FrameLabels, frame_for
 from app.agents.deps import AgentDeps
+from app.agents.failures import run_failure_summary
 from app.agents.spec import DelegationMode
 from app.agents.subagent_events import (
     SpecialistDefinition,
@@ -146,6 +148,39 @@ def _terminal_status(handle: TaskHandle, mode: Literal["sync", "async"]) -> Dele
     if handle.status is TaskStatus.DEFERRED:
         return "failed" if mode == "async" else None
     return _RESOLVED.get(handle.status)
+
+
+def _recorded_error(handle: TaskHandle, subagent: str, task_id: str) -> str | None:
+    """The error a settled delegation may store and stream.
+
+    `handle.error` is safe only while the library composed every word of it. When
+    a delegation fails on an exception, the library embeds that exception's own
+    text - and what raises under a delegate is the same model client the parent
+    runs on, whose message routinely carries the failing request URL, key still
+    in its query string, for a profile on a custom `base_url`. The parent's row
+    already refuses that text (#676); this is the same rule for the child's row
+    and its closing frame, which used to render the provider's words on the same
+    page (#699). `TaskHandle.exception` is how the library hands over the
+    exception instead of a formatted string, so the sentence is composed by
+    `run_failure_summary` - the one the parent's row gets - and the original goes
+    to the log beside it.
+
+    `UsageLimitExceeded` keeps the library's text whole. It is the delegation's
+    `BudgetExceeded`: not a malfunction but a ceiling doing its job, its message
+    is pydantic-ai's own limit sentence - a number, never a request - and the
+    `usage limit exceeded` marker in front of it is the library's telemetry
+    contract across both dispatch modes.
+    """
+    if handle.exception is None or isinstance(handle.exception, UsageLimitExceeded):
+        return handle.error
+    logger.warning(
+        "Delegation %r (task %s) failed: %s",
+        subagent,
+        task_id,
+        handle.error,
+        exc_info=handle.exception,
+    )
+    return run_failure_summary(handle.exception)
 
 
 _NO_PREFERENCE: SubAgentConfig = SubAgentConfig(name="auto", description="", instructions="")
@@ -913,6 +948,7 @@ class DelegationJournal:
         status = _terminal_status(handle, delegation.mode)
         if status is None:
             return False
+        error = _recorded_error(handle, delegation.name, task_id)
 
         # The id the delegation is *named* by, which is the one it streamed under
         # before any park - so its recorded outcome and its closing frame reach the
@@ -937,7 +973,7 @@ class DelegationJournal:
                 cost_is_partial=billed.has_unpriced_models,
                 agent_id=delegation.agent_id,
                 agent_version_id=delegation.agent_version_id,
-                error=handle.error,
+                error=error,
                 # The delegation's own span, not this settlement. The library
                 # stamps both when the delegate starts and when it ends, which for
                 # a background one is well before the poll that collects it here.
@@ -960,7 +996,7 @@ class DelegationJournal:
                     cost_usd=spent.cost_usd,
                     input_tokens=spent.input_tokens,
                     output_tokens=spent.output_tokens,
-                    error=handle.error,
+                    error=error,
                 )
             )
         return True

--- a/backend/app/agents/failures.py
+++ b/backend/app/agents/failures.py
@@ -30,9 +30,9 @@ def run_failure_summary(exc: BaseException) -> str:
     shown - "No model profile is configured for this agent" beats any sentence
     composed here. (The one place that folds a foreign `__str__` into an
     `AppException` is `sandbox_workspace._reason`, deliberately and for a route's
-    answer; it runs outside both `try` blocks that call this.) `BudgetExceeded`
-    never reaches this function: it is caught above and its ceiling is the point
-    of it.
+    answer; it runs in a route service, outside every run a caller settles.)
+    `BudgetExceeded` must not reach this function - each caller catches or
+    filters it first, because its ceiling sentence is the point of it.
 
     Anything else is a foreign `__str__` and only its *type* is safe to store,
     plus the status code when a provider answered one. That code is what keeps

--- a/backend/app/agents/failures.py
+++ b/backend/app/agents/failures.py
@@ -1,0 +1,61 @@
+"""The one sentence a stored failure may hold, for exceptions it may not.
+
+`run_failure_summary` began life in `app.services.agent_runner` (#676), which put
+it out of the capability layer's reach - and a delegated run's row is composed
+there, from the handle the subagents library settles. It lives here so both
+layers write the same sentence for the same failure (#699).
+"""
+
+from pydantic_ai.exceptions import ModelHTTPError
+
+from app.core.exceptions import AppException
+
+
+def run_failure_summary(exc: BaseException) -> str:
+    """The sentence a failed run may store, for an exception it may not.
+
+    `agent_runs.error` used to hold `str(exc)` of whatever came out of the run.
+    It is a stored column on `AgentRunRead`, rendered in run history to every
+    member who can read it, and what raises there is a model client with `httpx`
+    underneath - so that routinely meant an endpoint, an internal host, or a URL
+    with a key still in its query string, sitting in a row somebody opens weeks
+    later. Same rule as #342 in an HTTP body, #423 in the ingestion columns and
+    #659 in the chat frame, with the longest life of the four (#676). A
+    delegated run's row takes it through `TaskHandle.exception`, which is why
+    the parameter is `BaseException` - that is what the library's retry
+    callback receives (#699).
+
+    Ours is kept whole. An `AppException` raised inside the run is written in
+    this repository, and its message is the most useful thing an operator can be
+    shown - "No model profile is configured for this agent" beats any sentence
+    composed here. (The one place that folds a foreign `__str__` into an
+    `AppException` is `sandbox_workspace._reason`, deliberately and for a route's
+    answer; it runs outside both `try` blocks that call this.) `BudgetExceeded`
+    never reaches this function: it is caught above and its ceiling is the point
+    of it.
+
+    Anything else is a foreign `__str__` and only its *type* is safe to store,
+    plus the status code when a provider answered one. That code is what keeps
+    the failures a person can act on themselves actionable - 401 a credential,
+    404 a model the profile names and the provider does not have, 429 a rate
+    limit, 400 a request the model refused - where a bare class name would make
+    all four `ModelHTTPError`. An `int` has never carried a URL.
+
+    A group is unwrapped to its first leaf first, the same unwrapping
+    `failure_summary` and `probe_error_message` do. MCP toolsets and delegated
+    runs sit on anyio task groups, so their failures arrive as an
+    `ExceptionGroup` whose own name diagnoses nothing at all - which would spend
+    the status code above on the failures most likely to carry one.
+    """
+    cause: BaseException = exc
+    while isinstance(cause, BaseExceptionGroup):
+        cause = cause.exceptions[0]
+    if isinstance(cause, AppException):
+        return str(cause)
+    diagnosis = type(cause).__name__
+    if isinstance(cause, ModelHTTPError):
+        diagnosis = f"{diagnosis}, HTTP {cause.status_code}"
+    return (
+        f"The run did not finish ({diagnosis}) - retry it, and check the agent's model "
+        "profile if it keeps failing. The server log has the full error."
+    )

--- a/backend/app/services/agent_chat.py
+++ b/backend/app/services/agent_chat.py
@@ -38,6 +38,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.agents.capabilities.budget import BudgetExceeded, BudgetScope
 from app.agents.capabilities.guardrails import GuardrailBlocked
 from app.agents.deps import AgentDeps, AskUserCallback, CompactionSink
+from app.agents.failures import run_failure_summary
 from app.agents.subagent_events import SubagentEventSink
 from app.core.exceptions import AuthorizationError, BadRequestError
 from app.core.permissions import AuthContext
@@ -52,7 +53,6 @@ from app.services.agent_runner import (
     PausedRunState,
     PreparedRun,
     _outcome,
-    run_failure_summary,
 )
 from app.services.attachments import AttachmentRouter
 from app.services.usage_report import UsageReport, UsageReportService, context_fill

--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -65,7 +65,6 @@ from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from pydantic_ai import Agent as PydanticAgent
-from pydantic_ai.exceptions import ModelHTTPError
 from pydantic_ai.messages import ModelMessage, ModelMessagesTypeAdapter, UserContent
 from pydantic_ai.run import AgentRun as AgentIteration
 from pydantic_ai.run import AgentRunResult
@@ -104,6 +103,7 @@ from app.agents.capabilities.sandbox._identity import SessionScope
 from app.agents.capabilities.subagents import SubagentsConfig, acting_delegate
 from app.agents.deps import AgentDeps
 from app.agents.factory import BuiltAgent, build_agent
+from app.agents.failures import run_failure_summary
 from app.agents.model_resolver import ModelRequestSpec
 from app.agents.observability import current_trace_id
 from app.agents.spec import (
@@ -130,7 +130,6 @@ from app.agents.subagent_runtime import (
 )
 from app.core.config import settings
 from app.core.exceptions import (
-    AppException,
     AuthorizationError,
     BadRequestError,
     NotFoundError,
@@ -1369,53 +1368,6 @@ class RunSegment:
     run: AgentRun
     tool_calls: list[RecordedToolCall]
     settled: dict[str, str]
-
-
-def run_failure_summary(exc: Exception) -> str:
-    """The sentence a failed run may store, for an exception it may not.
-
-    `agent_runs.error` used to hold `str(exc)` of whatever came out of the run.
-    It is a stored column on `AgentRunRead`, rendered in run history to every
-    member who can read it, and what raises there is a model client with `httpx`
-    underneath - so that routinely meant an endpoint, an internal host, or a URL
-    with a key still in its query string, sitting in a row somebody opens weeks
-    later. Same rule as #342 in an HTTP body, #423 in the ingestion columns and
-    #659 in the chat frame, with the longest life of the four (#676).
-
-    Ours is kept whole. An `AppException` raised inside the run is written in
-    this repository, and its message is the most useful thing an operator can be
-    shown - "No model profile is configured for this agent" beats any sentence
-    composed here. (The one place that folds a foreign `__str__` into an
-    `AppException` is `sandbox_workspace._reason`, deliberately and for a route's
-    answer; it runs outside both `try` blocks that call this.) `BudgetExceeded`
-    never reaches this function: it is caught above and its ceiling is the point
-    of it.
-
-    Anything else is a foreign `__str__` and only its *type* is safe to store,
-    plus the status code when a provider answered one. That code is what keeps
-    the failures a person can act on themselves actionable - 401 a credential,
-    404 a model the profile names and the provider does not have, 429 a rate
-    limit, 400 a request the model refused - where a bare class name would make
-    all four `ModelHTTPError`. An `int` has never carried a URL.
-
-    A group is unwrapped to its first leaf first, the same unwrapping
-    `failure_summary` and `probe_error_message` do. MCP toolsets and delegated
-    runs sit on anyio task groups, so their failures arrive as an
-    `ExceptionGroup` whose own name diagnoses nothing at all - which would spend
-    the status code above on the failures most likely to carry one.
-    """
-    cause: BaseException = exc
-    while isinstance(cause, BaseExceptionGroup):
-        cause = cause.exceptions[0]
-    if isinstance(cause, AppException):
-        return str(cause)
-    diagnosis = type(cause).__name__
-    if isinstance(cause, ModelHTTPError):
-        diagnosis = f"{diagnosis}, HTTP {cause.status_code}"
-    return (
-        f"The run did not finish ({diagnosis}) - retry it, and check the agent's model "
-        "profile if it keeps failing. The server log has the full error."
-    )
 
 
 class AgentRunnerService:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -88,8 +88,9 @@ dependencies = [
     # 0.2.17 first carried the caller-supplied-subagent ask_parent fix a sync
     # delegate needs to reach the person waiting on its parent
     # (subagents-pydantic-ai#76); 0.2.18 also fixes the general-purpose delegate
-    # (#78), so the floor is 0.2.18.
-    "subagents-pydantic-ai>=0.2.18",
+    # (#78). 0.2.19 adds `TaskHandle.exception`, which is what keeps a provider's
+    # own text off a delegated run's row (#699), so the floor is 0.2.19.
+    "subagents-pydantic-ai>=0.2.19",
     "cryptography>=50.0.0",
     "aiogram>=3.17,<4.0",
     "slack-sdk>=3.35.0",

--- a/backend/tests/test_subagents_capability.py
+++ b/backend/tests/test_subagents_capability.py
@@ -220,6 +220,21 @@ def asking(question: str, *, prefix: str = "answer: ") -> FunctionModel:
     return FunctionModel(respond)
 
 
+def crashing(text: str) -> FunctionModel:
+    """A model whose client raises, the way a provider failure arrives."""
+
+    def respond(_messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        raise RuntimeError(text)
+
+    async def stream(
+        _messages: list[ModelMessage], _info: AgentInfo
+    ) -> AsyncIterator[DeltaToolCalls]:
+        raise RuntimeError(text)
+        yield {}  # pragma: no cover - makes this an async generator, like the client's
+
+    return FunctionModel(respond, stream_function=stream)
+
+
 def looping() -> FunctionModel:
     """A model that calls the same tool forever, so only a step limit stops it."""
 
@@ -1009,6 +1024,37 @@ class TestRecording:
         (outcome,) = recorder.outcomes
         assert outcome.status == "failed"
         assert outcome.error is not None and "usage limit" in outcome.error
+
+    async def test_a_provider_failure_reaches_the_row_as_our_sentence_not_its_own(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        """A delegated run's row refuses a provider's text, like its parent's (#699).
+
+        What raises under a delegate is the same model client the parent runs on,
+        and its message routinely carries the failing request URL with the key
+        still in its query string. The parent's row already stores
+        `run_failure_summary`'s sentence (#676); the child's row and its closing
+        frame used to store the library's string with the provider's words
+        embedded, on the same page.
+        """
+        vendor_text = "connect to https://llm.acme.internal/v1?api_key=sk-live-9f2c failed"
+        recorder = Recorder()
+        sink = Sink()
+        capability = a_capability(
+            a_runtime(a_delegate(model=crashing(vendor_text)), record=recorder)
+        )
+
+        with caplog.at_level(logging.WARNING), pytest.raises(Exception, match="researcher"):
+            await delegate_to(capability, a_context(sink))
+
+        (outcome,) = recorder.outcomes
+        assert outcome.status == "failed"
+        assert outcome.error is not None and "sk-live-9f2c" not in outcome.error
+        assert outcome.error.startswith("The run did not finish (RuntimeError) - ")
+        finished = sink.frames[-1]
+        assert isinstance(finished, SubagentFinished)
+        assert finished.error == outcome.error
+        assert vendor_text in caplog.text
 
     async def test_a_delegate_the_runtime_never_resolved_records_nothing(self):
         """The library refuses the name; no delegate ran, so there is no outcome."""

--- a/backend/tests/test_subagents_capability.py
+++ b/backend/tests/test_subagents_capability.py
@@ -73,7 +73,7 @@ from app.agents.capabilities.approval import (
     ApprovalRequest,
     approval_required_tools,
 )
-from app.agents.capabilities.budget import SpendEntry, SpendLedger
+from app.agents.capabilities.budget import BudgetExceeded, BudgetScope, SpendEntry, SpendLedger
 from app.agents.capabilities.subagents import Delegation, SubagentsConfig
 from app.agents.capabilities.subagents._capability import (
     BACKGROUND_LIFECYCLE_TOOLS,
@@ -230,6 +230,26 @@ def crashing(text: str) -> FunctionModel:
         _messages: list[ModelMessage], _info: AgentInfo
     ) -> AsyncIterator[DeltaToolCalls]:
         raise RuntimeError(text)
+        yield {}  # pragma: no cover - makes this an async generator, like the client's
+
+    return FunctionModel(respond, stream_function=stream)
+
+
+def budget_stopped() -> FunctionModel:
+    """A model whose next request the budget guard refuses, mid-delegation."""
+
+    def ceiling() -> BudgetExceeded:
+        return BudgetExceeded(
+            limit_usd=Decimal("0.05"), spent_usd=Decimal("0.0500"), scope=BudgetScope.AGENT
+        )
+
+    def respond(_messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        raise ceiling()
+
+    async def stream(
+        _messages: list[ModelMessage], _info: AgentInfo
+    ) -> AsyncIterator[DeltaToolCalls]:
+        raise ceiling()
         yield {}  # pragma: no cover - makes this an async generator, like the client's
 
     return FunctionModel(respond, stream_function=stream)
@@ -1055,6 +1075,31 @@ class TestRecording:
         assert isinstance(finished, SubagentFinished)
         assert finished.error == outcome.error
         assert vendor_text in caplog.text
+
+    async def test_a_delegate_stopped_by_the_budget_keeps_the_ceiling_sentence(self):
+        """A budget breach is the second ceiling, and its numbers are the point.
+
+        A delegate's requests are budget-checked inside the delegate's own run,
+        so `BudgetExceeded` lands on the handle instead of propagating to the
+        caller the parent's row is written by. Composed away like a provider
+        crash, the row said "retry it" about a breached budget and dropped the
+        ceiling's numbers.
+        """
+        recorder = Recorder()
+        sink = Sink()
+        capability = a_capability(a_runtime(a_delegate(model=budget_stopped()), record=recorder))
+
+        with pytest.raises(Exception, match="researcher"):
+            await delegate_to(capability, a_context(sink))
+
+        (outcome,) = recorder.outcomes
+        assert outcome.status == "failed"
+        assert outcome.error is not None and "budget exhausted" in outcome.error
+        assert "$0.05" in outcome.error
+        assert "The run did not finish" not in outcome.error
+        finished = sink.frames[-1]
+        assert isinstance(finished, SubagentFinished)
+        assert finished.error == outcome.error
 
     async def test_a_delegate_the_runtime_never_resolved_records_nothing(self):
         """The library refuses the name; no delegate ran, so there is no outcome."""

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -125,7 +125,7 @@ requires-dist = [
     { name = "redis", specifier = ">=8.1.0" },
     { name = "slack-sdk", specifier = ">=3.35.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.51" },
-    { name = "subagents-pydantic-ai", specifier = ">=0.2.18" },
+    { name = "subagents-pydantic-ai", specifier = ">=0.2.19" },
     { name = "tabulate", specifier = ">=0.9.0" },
     { name = "tavily-python", specifier = ">=0.7.27" },
     { name = "tqdm", specifier = ">=4.70.0" },
@@ -4979,16 +4979,16 @@ wheels = [
 
 [[package]]
 name = "subagents-pydantic-ai"
-version = "0.2.18"
+version = "0.2.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "pydantic-ai-slim" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/1d/776ff26ca85ca659092a5cf47452577abefd22a794f49d5abcd04a3d9c28/subagents_pydantic_ai-0.2.18.tar.gz", hash = "sha256:5153bc2372f994d0f2b0ceec09b6b88fe08b8aa7990c3546f084b82a2157b1ac", size = 644494, upload-time = "2026-08-05T16:02:47.644Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/3f/5a02502cf56f7617898e8279ef51927c1e55ab02a33941dff502bed050fb/subagents_pydantic_ai-0.2.19.tar.gz", hash = "sha256:d4797d3e459dd611221d6dd72745fdaa93ec4aedfdbe6a57f2cbf8a74e2adc05", size = 645858, upload-time = "2026-08-16T18:42:56.057Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/37/98e6305c56116f297f2c82ed175c06a5ad86b2805b300733e15da24405d0/subagents_pydantic_ai-0.2.18-py3-none-any.whl", hash = "sha256:82d1933b4f8aacc63a65f098768a39170882a675afe40450ca962d34141c480a", size = 82053, upload-time = "2026-08-05T16:02:46.343Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d8/3663c63eb9826261efae0d1e7ca1c42c932bc58bd15c4e4d8130bb89ac97/subagents_pydantic_ai-0.2.19-py3-none-any.whl", hash = "sha256:fd2321dbaa1231e5f8672d2c361b4de90563f2d2330eb2ca4f8ea377bcc1be15", size = 82313, upload-time = "2026-08-16T18:42:54.361Z" },
 ]
 
 [[package]]

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -307,8 +307,8 @@ What raises under a delegate is a model client whose message can carry the faili
 request URL — key included, on a custom endpoint — so the row and the delegation's
 closing frame store the same controlled sentence the parent's row does, and the
 provider's own text goes to the server log. A delegate stopped by its usage limit
-keeps the limit's message whole: that is a ceiling doing its job, not a failure to
-diagnose.
+or by a budget ceiling keeps the limit's message whole: that is a ceiling doing
+its job, not a failure to diagnose.
 
 **The dashboard's windowed figure carries it too.** `GET /stats/usage` answers a
 `cost` block for whatever period the filter chose, and that block is runs *plus*

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -302,6 +302,14 @@ what a per-agent usage report or a budget alert on that agent fires on. The
 organization's monthly number also carries ingestion spend, which the per-agent
 number does not: indexing a shared knowledge base is nobody's agent's spend.
 
+A failed child row is also held to the parent's rule about what `error` may say.
+What raises under a delegate is a model client whose message can carry the failing
+request URL — key included, on a custom endpoint — so the row and the delegation's
+closing frame store the same controlled sentence the parent's row does, and the
+provider's own text goes to the server log. A delegate stopped by its usage limit
+keeps the limit's message whole: that is a ceiling doing its job, not a failure to
+diagnose.
+
 **The dashboard's windowed figure carries it too.** `GET /stats/usage` answers a
 `cost` block for whatever period the filter chose, and that block is runs *plus*
 ingestion — the same arithmetic the monthly cap is measured with — with


### PR DESCRIPTION
## What

A delegated run's `agent_runs.error` and its closing `SubagentFinished` frame no longer store the subagents library's exception text. The settlement in `_journal.py` composes the same controlled sentence the parent's row gets — `run_failure_summary` — and the library's text goes to the server log with the original exception beside it.

- **Upstream first**: subagents-pydantic-ai 0.2.19 (vstorm-co/subagents-pydantic-ai#80, released to PyPI) adds `TaskHandle.exception`, so the platform receives the exception rather than parsing a string the library formatted. The pin moves to `>=0.2.19`.
- `run_failure_summary` moved from `app/services/agent_runner.py` to `app/agents/failures.py`: the capability layer could not import it from a service without inverting the layering. It now takes `BaseException`, which is what the library's retry callback receives. Both former importers (`agent_runner`, `agent_chat`) repoint; behaviour unchanged.
- `UsageLimitExceeded` keeps the library's text whole, deliberately: it is the delegation's `BudgetExceeded` — a ceiling doing its job, its message is pydantic-ai's own limit sentence, and the `usage limit exceeded` marker is the library's telemetry contract across both dispatch modes.
- `docs/governance.md` gains a paragraph in the child-row section saying what a failed child row may store.

## Why

#676 fixed the two places that write `agent_runs.error` for a run this platform executes itself. A delegated run's row was written from `handle.error`, which the library composes as `Transient error (retry N): {exc}` — `{exc}` being whatever the delegate's model client raised, whose text routinely carries the failing request URL with the key still in its query string on a custom `base_url`. The parent's row was controlled and the child's was not, on the same page, for the same failure.

## Verification

- Regression test (`test_a_provider_failure_reaches_the_row_as_our_sentence_not_its_own`) drives a delegation into a provider-style crash carrying a keyed URL and asserts the row and the frame store the controlled sentence while the vendor text lands only in the log. It fails without the fix.
- Full backend suite: 5279 passed, platform layer at 100%.
- `make lint`, `make db-check` clean; `make check` run before opening.

The upstream release is verified live: PyPI serves 0.2.19 and the lock resolves it.

Closes #699
