### PR TITLE
fix(capabilities): prune a run's spills off a container workspace at close

### DIFF
--- a/backend/app/agents/capabilities/tool_output_limits/__init__.py
+++ b/backend/app/agents/capabilities/tool_output_limits/__init__.py
@@ -20,6 +20,7 @@ from app.agents.capabilities.tool_output_limits._capability import (
 )
 from app.agents.capabilities.tool_output_limits._store import (
     OVERFLOW_PREFIX,
+    SPILL_LOG_RESOURCE,
     BackendOverflowStore,
     OverflowWriteError,
 )
@@ -29,6 +30,7 @@ __all__ = [
     "DEFAULT_SUMMARY_PROMPT",
     "DEFAULT_THRESHOLD",
     "OVERFLOW_PREFIX",
+    "SPILL_LOG_RESOURCE",
     "ActionName",
     "BackendOverflowStore",
     "MeteredToolOutputLimits",
@@ -68,4 +70,8 @@ def _build(ctx: CapabilityBuildContext) -> MeteredToolOutputLimits[object]:
         ctx.config if isinstance(ctx.config, ToolOutputLimitsConfig) else ToolOutputLimitsConfig()
     )
     backend = ctx.resources.get(WORKSPACE_BACKEND_RESOURCE)
-    return MeteredToolOutputLimits(wrapped=build_limits(config, backend=backend))
+    return MeteredToolOutputLimits(
+        wrapped=build_limits(
+            config, backend=backend, spill_log=ctx.resources.get(SPILL_LOG_RESOURCE)
+        )
+    )

--- a/backend/app/agents/capabilities/tool_output_limits/_capability.py
+++ b/backend/app/agents/capabilities/tool_output_limits/_capability.py
@@ -196,36 +196,38 @@ def _action(config: ToolOutputLimitsConfig) -> Action:
     return Summarize(then=spill)
 
 
-def _build_store(backend: Any) -> BackendOverflowStore:
+def _build_store(backend: Any, spill_log: list[str] | None = None) -> BackendOverflowStore:
     """Where spills go: the run's own backend, or an ephemeral one built for it.
 
     An agent that binds `sandbox` has a backend the runner opened and keyed to the
     organization; a spill lives and dies with that workspace, which on the default
-    `run` scope is exactly the run. A longer-scoped `state` workspace
-    (`conversation`, `user`, `agent`) would otherwise carry its spills into the
-    persisted document and count them against the byte cap every run, so
-    `SandboxWorkspaceService._flush_state` strips the reserved prefix at run end -
-    the spill never survives the run on a `state` backend whatever the scope. A
-    longer-scoped *container* workspace keeps its spills on the container filesystem
-    for now; deleting those needs a run-scoped delete the backend protocol does not
-    expose, tracked in #803.
+    `run` scope is exactly the run. On a longer-scoped workspace (`conversation`,
+    `user`, `agent`) a spill must not outlive the run either, and each backend
+    shape has its own mechanism: a `state` workspace has the reserved prefix
+    stripped at flush, so spills never enter the persisted document, and a
+    *container* workspace has this run's handles - recorded in `spill_log` -
+    deleted off its filesystem when the workspace closes (#803).
 
     An agent with no backend gets a fresh in-memory `StateBackend` here, so the
     store is per-run and process-local rather than on shared disk. The fallback is
     uncapped: the store itself grows with each spill, but nothing is persisted and
-    the run bounds how much it can accumulate before it is discarded whole.
+    the run bounds how much it can accumulate before it is discarded whole. No
+    handles are recorded for it - there is nothing to delete from a backend that
+    dies with the run.
     """
     if backend is None:
         return BackendOverflowStore(StateBackend())
-    return BackendOverflowStore(backend)
+    return BackendOverflowStore(backend, spill_log=spill_log)
 
 
-def build_limits(config: ToolOutputLimitsConfig, *, backend: Any) -> ToolOutputLimits[object]:
+def build_limits(
+    config: ToolOutputLimitsConfig, *, backend: Any, spill_log: list[str] | None = None
+) -> ToolOutputLimits[object]:
     """The harness capability this configuration asks for, spilling to `backend`."""
     return ToolOutputLimits(
         bands=[Band(over=config.threshold, action=_action(config))],
         over_tokens=config.over_tokens,
-        store=_build_store(backend),
+        store=_build_store(backend, spill_log),
         strip_ansi=config.strip_ansi,
         summary_prompt=config.summary_prompt,
     )

--- a/backend/app/agents/capabilities/tool_output_limits/_store.py
+++ b/backend/app/agents/capabilities/tool_output_limits/_store.py
@@ -37,6 +37,19 @@ if TYPE_CHECKING:
 # the agent wrote and are obvious for what they are when it lists its workspace.
 OVERFLOW_PREFIX = "tool_output"
 
+SPILL_LOG_RESOURCE = "spill_log"
+"""The run's shared record of every spill handle written to its workspace.
+
+The runner registers one list per run beside the workspace backend, the store
+appends each handle it writes, and `SandboxWorkspaceService.close` deletes
+exactly those paths off a container-backed workspace whose scope outlives the
+run (#803). A list of what was actually written, rather than a prefix to sweep,
+because two concurrent runs share a `user`- or `agent`-scoped workspace: a
+prefix delete would take the other run's spills with it mid-flight, while a run
+deleting only its own handles cannot race anybody. Delegates sharing the
+parent's `sandbox` share this list too, for the same reason they share the
+backend - their spills land on the same filesystem."""
+
 
 class OverflowWriteError(Exception):
     """The backend refused a spill - a `state` workspace already at its byte cap.
@@ -73,11 +86,18 @@ class BackendOverflowStore:
 
     backend: BackendProtocol | AsyncBackendProtocol
     prefix: str = OVERFLOW_PREFIX
+    spill_log: list[str] | None = None
+    """Where written handles are recorded, when the run keeps a record at all.
+
+    `None` for the in-memory fallback backend, which is discarded with the run
+    and leaves nothing to delete."""
 
     async def write(self, key: str, data: bytes) -> str:
         result = await _maybe_await(self.backend.write(f"{self.prefix}/{key}", data))
         if result.error is not None:
             raise OverflowWriteError(result.error)
+        if self.spill_log is not None:
+            self.spill_log.append(result.path)
         return result.path
 
     async def read(self, handle: str) -> bytes:

--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -102,6 +102,7 @@ from app.agents.capabilities.planning import (
 from app.agents.capabilities.sandbox import WORKSPACE_BACKEND_RESOURCE, WorkspaceIdentity
 from app.agents.capabilities.sandbox._identity import SessionScope
 from app.agents.capabilities.subagents import SubagentsConfig, acting_delegate
+from app.agents.capabilities.tool_output_limits import SPILL_LOG_RESOURCE
 from app.agents.deps import AgentDeps
 from app.agents.factory import BuiltAgent, build_agent
 from app.agents.model_resolver import ModelRequestSpec
@@ -1723,6 +1724,7 @@ class AgentRunnerService:
         started_with: set[str] | None = None
         if workspace is not None:
             resources[WORKSPACE_BACKEND_RESOURCE] = workspace.backend
+            resources[SPILL_LOG_RESOURCE] = workspace.spills
             # Skills as files, beside the shell that can run them. A skill whose
             # resource is a script was previously handed to the model as text it
             # could quote and not execute, while the same agent had `execute` one
@@ -2333,6 +2335,10 @@ class AgentRunnerService:
         }
         if any(binding.id == SANDBOX_CAPABILITY_ID for binding in shared):
             resources[WORKSPACE_BACKEND_RESOURCE] = parent_resources.get(WORKSPACE_BACKEND_RESOURCE)
+            # And the spill log with it: a delegate spilling to the shared
+            # filesystem must record its handles where the workspace's close can
+            # delete them (#803).
+            resources[SPILL_LOG_RESOURCE] = parent_resources.get(SPILL_LOG_RESOURCE)
         return resources
 
     @staticmethod

--- a/backend/app/services/channels/attachments.py
+++ b/backend/app/services/channels/attachments.py
@@ -34,6 +34,7 @@ from uuid import UUID
 from pydantic_ai_backends import AsyncBackendProtocol, BackendProtocol, ensure_async
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.agents.capabilities.tool_output_limits import OVERFLOW_PREFIX
 from app.db.models.chat_file import ChatFile
 from app.services.channels.base import (
     ChannelAdapter,
@@ -58,10 +59,12 @@ MAX_OUTBOUND_BYTES = 8 * 1024 * 1024
 be explained. Telegram's is 50 MB, Slack's depends on the workspace plan, and a
 platform-side rejection arrives as an opaque API error the agent cannot act on."""
 
-# Where the platform itself put things. Neither is the agent's work, and neither
-# should come back out: `/uploads` is the user's own file, and `/skills` is
-# organizational know-how materialised for the run.
-_NOT_THE_AGENTS = ("/uploads/", "/skills/")
+# Where the platform itself put things. None of it is the agent's work, and none
+# of it should come back out: `/uploads` is the user's own file, `/skills` is
+# organizational know-how materialised for the run, and `/tool_output` is a
+# spilled tool return `tool_output_limits` parked for the model to page through -
+# an internal artefact, not an answer (#803).
+_NOT_THE_AGENTS = ("/uploads/", "/skills/", f"/{OVERFLOW_PREFIX}/")
 
 
 @dataclass(frozen=True)

--- a/backend/app/services/sandbox_workspace.py
+++ b/backend/app/services/sandbox_workspace.py
@@ -24,9 +24,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import shlex
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
 from typing import Any
 from uuid import UUID
 
@@ -131,6 +133,17 @@ class OpenWorkspace:
     container-backed one, which keeps its files on the host rather than here.
     """
 
+    spills: list[str] = field(default_factory=list)
+    """Every spill handle `tool_output_limits` wrote to this workspace this run.
+
+    Registered beside the backend under `SPILL_LOG_RESOURCE`, appended by the
+    overflow store, and read back by `close`: a container-backed workspace whose
+    scope outlives the run deletes exactly these paths, so a spill never survives
+    the run that produced it (#803). Exact handles rather than the `tool_output/`
+    prefix, because concurrent runs share a longer-scoped workspace and a prefix
+    sweep would take another run's spills mid-flight.
+    """
+
 
 def sandbox_config(spec: AgentSpec) -> SandboxConfig | None:
     """This spec's workspace configuration, or `None` if it has no workspace.
@@ -164,6 +177,36 @@ def _without_spills(files: dict[str, Any]) -> dict[str, Any]:
         return relative == OVERFLOW_PREFIX or relative.startswith(f"{OVERFLOW_PREFIX}/")
 
     return {path: data for path, data in files.items() if not _is_spill(path)}
+
+
+def _under_overflow(path: str) -> bool:
+    """Whether this path is a file inside the reserved spill directory.
+
+    The delete in `_prune_spills` runs a shell command over paths from a list, so
+    even though only the overflow store appends to that list, every path is checked
+    against the one invariant that makes the command safe: it removes spills and
+    nothing else. Depth-agnostic because a backend normalizes handles its own way -
+    `/tool_output/…` from `state`, an absolute in-container `/workspace/tool_output/…`
+    from a service. The prefix must be a proper ancestor (`parts[:-1]`), which is
+    what every handle the store writes has, and what guarantees `_overflow_parents`
+    answers at least the spill directory itself.
+    """
+    return OVERFLOW_PREFIX in PurePosixPath(path).parts[:-1]
+
+
+def _overflow_parents(handle: str) -> list[str]:
+    """The directories above a spill handle, up to and including `tool_output/`.
+
+    What `rmdir` is offered once the files are gone, so a pruned run leaves no empty
+    run-directory behind. Ancestors above the reserved prefix are not returned:
+    the workspace root is not this function's to offer for deletion.
+    """
+    parents = []
+    current = PurePosixPath(handle).parent
+    while OVERFLOW_PREFIX in current.parts:
+        parents.append(str(current))
+        current = current.parent
+    return parents
 
 
 class SandboxWorkspaceService:
@@ -387,6 +430,8 @@ class SandboxWorkspaceService:
                 await self._flush_state(workspace)
             elif workspace.scope == "run":
                 await self._release(workspace)
+            else:
+                await self._prune_spills(workspace)
         except Exception:
             logger.exception("workspace_close_failed", extra={"scope_key": workspace.scope_key})
 
@@ -437,6 +482,48 @@ class SandboxWorkspaceService:
                 "paths_lost": overwritten,
             },
         )
+
+    async def _prune_spills(self, workspace: OpenWorkspace) -> None:
+        """Delete this run's spilled tool returns off a workspace that outlives it.
+
+        The container-backed half of #803: a `state` workspace has its spills
+        stripped at flush and a `run`-scoped container dies purged, but a
+        `conversation`/`user`/`agent`-scoped container keeps its filesystem across
+        runs, so the spills this run wrote are removed here, by the exact handles
+        the overflow store recorded. Another run's spills are untouched - its
+        handles are in its own workspace's list.
+
+        Deleted through the backend's own `execute`, because the backend protocol
+        has no delete and growing one belongs upstream. The `rmdir` afterwards
+        clears the now-empty run directories; it fails silently where a concurrent
+        run still keeps files, which is the correct answer. Best-effort like
+        `_release`: a run that crashes before its `finally` leaves its spills for
+        the next manual sweep, and `close` already logs whatever raises here.
+        """
+        handles = [handle for handle in workspace.spills if _under_overflow(handle)]
+        if not handles:
+            return
+        execute = getattr(workspace.backend, "execute", None)
+        if execute is None:
+            return
+        directories = sorted(
+            {parent for handle in handles for parent in _overflow_parents(handle)},
+            key=lambda directory: directory.count("/"),
+            reverse=True,
+        )
+        files = " ".join(shlex.quote(handle) for handle in handles)
+        emptied = " ".join(shlex.quote(directory) for directory in directories)
+        command = f"rm -f -- {files}; rmdir -- {emptied} 2>/dev/null; true"
+        result = await asyncio.to_thread(execute, command)
+        if getattr(result, "exit_code", 0) != 0:
+            logger.warning(
+                "workspace_spill_prune_failed",
+                extra={
+                    "scope_key": workspace.scope_key,
+                    "handles": len(handles),
+                    "output": getattr(result, "output", ""),
+                },
+            )
 
     async def _release(self, workspace: OpenWorkspace) -> None:
         """Stop a run-scoped sandbox, as a courtesy rather than a guarantee.

--- a/backend/app/services/sandbox_workspace.py
+++ b/backend/app/services/sandbox_workspace.py
@@ -189,9 +189,12 @@ def _under_overflow(path: str) -> bool:
     `/tool_output/…` from `state`, an absolute in-container `/workspace/tool_output/…`
     from a service. The prefix must be a proper ancestor (`parts[:-1]`), which is
     what every handle the store writes has, and what guarantees `_overflow_parents`
-    answers at least the spill directory itself.
+    answers at least the spill directory itself. A `..` component is refused
+    outright: `PurePosixPath` does not resolve one, so `tool_output/../x` would
+    pass the ancestor check while naming a file outside the spill directory.
     """
-    return OVERFLOW_PREFIX in PurePosixPath(path).parts[:-1]
+    parts = PurePosixPath(path).parts
+    return ".." not in parts and OVERFLOW_PREFIX in parts[:-1]
 
 
 def _overflow_parents(handle: str) -> list[str]:
@@ -496,9 +499,12 @@ class SandboxWorkspaceService:
         Deleted through the backend's own `execute`, because the backend protocol
         has no delete and growing one belongs upstream. The `rmdir` afterwards
         clears the now-empty run directories; it fails silently where a concurrent
-        run still keeps files, which is the correct answer. Best-effort like
-        `_release`: a run that crashes before its `finally` leaves its spills for
-        the next manual sweep, and `close` already logs whatever raises here.
+        run still keeps files, which is the correct answer - which is why the
+        command exits with `rm`'s status, captured before the `rmdir`: a refused
+        `rm` is the failure the warning below exists for, and a trailing cleanup
+        must not mask it as success. Best-effort like `_release`: a run that
+        crashes before its `finally` leaves its spills for the next manual sweep,
+        and `close` already logs whatever raises here.
         """
         handles = [handle for handle in workspace.spills if _under_overflow(handle)]
         if not handles:
@@ -513,7 +519,7 @@ class SandboxWorkspaceService:
         )
         files = " ".join(shlex.quote(handle) for handle in handles)
         emptied = " ".join(shlex.quote(directory) for directory in directories)
-        command = f"rm -f -- {files}; rmdir -- {emptied} 2>/dev/null; true"
+        command = f"rm -f -- {files}; status=$?; rmdir -- {emptied} 2>/dev/null; exit $status"
         result = await asyncio.to_thread(execute, command)
         if getattr(result, "exit_code", 0) != 0:
             logger.warning(

--- a/backend/tests/test_channel_attachments.py
+++ b/backend/tests/test_channel_attachments.py
@@ -468,6 +468,16 @@ class TestChoosingWhatToSendBack:
 
         assert (await files_written(backend, before)).attachments == []
 
+    async def test_a_spilled_tool_return_is_not_the_agents_work(self):
+        """A `tool_output_limits` spill is parked for the model to page through,
+        not produced for the user - posting it would hand a channel the raw
+        oversized return the reduction existed to keep out of sight (#803)."""
+        backend = StateBackend()
+        before = await workspace_snapshot(backend)
+        backend.write("/tool_output/run-1/call-1.0", "y" * 5_000)
+
+        assert (await files_written(backend, before)).attachments == []
+
     async def test_a_file_too_large_for_a_reply_is_named_rather_than_dropped(self):
         """An agent told its file was delivered will tell the user the same."""
         backend = StateBackend()

--- a/backend/tests/test_sandbox_workspace.py
+++ b/backend/tests/test_sandbox_workspace.py
@@ -13,6 +13,7 @@ refusals worth more than the feature itself:
 from __future__ import annotations
 
 import logging
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid4
 
@@ -1624,6 +1625,164 @@ class TestContainerBackedWorkspaces:
         await service.close(workspace)
 
         assert stopped == []
+
+    async def test_a_runs_spills_are_pruned_off_a_workspace_that_outlives_it(
+        self, monkeypatch, mock_db_session
+    ):
+        """The container half of #803: a `conversation`/`user`/`agent`-scoped
+        workspace keeps its filesystem across runs, so the spills this run wrote
+        are deleted at close - by handle, so a concurrent run's spills survive -
+        and the emptied run directories are offered to `rmdir`, deepest first.
+        """
+        from pydantic_ai_backends import remote as remote_module
+
+        commands: list[str] = []
+
+        class _Sandbox:
+            def __init__(self, url, **kwargs):
+                pass
+
+            def execute(self, command, timeout=None):
+                commands.append(command)
+                return SimpleNamespace(exit_code=0, output="")
+
+        monkeypatch.setattr(remote_module, "RemoteSandbox", _Sandbox)
+        _serve(monkeypatch, _resolved())
+        monkeypatch.setattr(workspace_repo, "get_by_key", AsyncMock(return_value=None))
+        monkeypatch.setattr(
+            workspace_repo, "create", AsyncMock(return_value=_row(backend="service"))
+        )
+        service = SandboxWorkspaceService(mock_db_session)
+
+        workspace = await service.open(_spec(backend="service"), ctx=_ctx(), identity=_identity())
+        assert workspace is not None
+        workspace.spills.extend(
+            ["/workspace/tool_output/run-1/call-1.0", "tool_output/run-1/call-2.0"]
+        )
+        await service.close(workspace)
+
+        [command] = commands
+        assert "rm -f -- /workspace/tool_output/run-1/call-1.0 tool_output/run-1/call-2.0" in (
+            command
+        )
+        assert "rmdir -- /workspace/tool_output/run-1" in command
+        assert command.index("/workspace/tool_output/run-1 ") < command.index(
+            "/workspace/tool_output "
+        )
+
+    async def test_a_path_outside_the_reserved_prefix_is_never_deleted(
+        self, monkeypatch, mock_db_session
+    ):
+        """Only the overflow store appends to the spill log, but the delete runs a
+        shell command - so every path is still checked against the one invariant
+        that makes it safe, and a log holding only foreign paths runs nothing."""
+        from pydantic_ai_backends import remote as remote_module
+
+        commands: list[str] = []
+
+        class _Sandbox:
+            def __init__(self, url, **kwargs):
+                pass
+
+            def execute(self, command, timeout=None):
+                commands.append(command)
+                return SimpleNamespace(exit_code=0, output="")
+
+        monkeypatch.setattr(remote_module, "RemoteSandbox", _Sandbox)
+        _serve(monkeypatch, _resolved())
+        monkeypatch.setattr(workspace_repo, "get_by_key", AsyncMock(return_value=None))
+        monkeypatch.setattr(
+            workspace_repo, "create", AsyncMock(return_value=_row(backend="service"))
+        )
+        service = SandboxWorkspaceService(mock_db_session)
+
+        workspace = await service.open(_spec(backend="service"), ctx=_ctx(), identity=_identity())
+        assert workspace is not None
+        workspace.spills.append("/workspace/report.md")
+        await service.close(workspace)
+
+        assert commands == []
+
+    async def test_a_workspace_with_no_spills_runs_no_command(self, monkeypatch, mock_db_session):
+        from pydantic_ai_backends import remote as remote_module
+
+        commands: list[str] = []
+
+        class _Sandbox:
+            def __init__(self, url, **kwargs):
+                pass
+
+            def execute(self, command, timeout=None):  # pragma: no cover - must not run
+                commands.append(command)
+                return SimpleNamespace(exit_code=0, output="")
+
+        monkeypatch.setattr(remote_module, "RemoteSandbox", _Sandbox)
+        _serve(monkeypatch, _resolved())
+        monkeypatch.setattr(workspace_repo, "get_by_key", AsyncMock(return_value=None))
+        monkeypatch.setattr(
+            workspace_repo, "create", AsyncMock(return_value=_row(backend="service"))
+        )
+        service = SandboxWorkspaceService(mock_db_session)
+
+        workspace = await service.open(_spec(backend="service"), ctx=_ctx(), identity=_identity())
+        await service.close(workspace)
+
+        assert commands == []
+
+    async def test_a_backend_without_execute_leaves_the_spills_for_the_host(
+        self, monkeypatch, mock_db_session
+    ):
+        """A backend that cannot run a command cannot delete a file either; close
+        must shrug rather than fail the run's `finally`."""
+        from pydantic_ai_backends import remote as remote_module
+
+        class _Sandbox:
+            def __init__(self, url, **kwargs):
+                pass
+
+        monkeypatch.setattr(remote_module, "RemoteSandbox", _Sandbox)
+        _serve(monkeypatch, _resolved())
+        monkeypatch.setattr(workspace_repo, "get_by_key", AsyncMock(return_value=None))
+        monkeypatch.setattr(
+            workspace_repo, "create", AsyncMock(return_value=_row(backend="service"))
+        )
+        service = SandboxWorkspaceService(mock_db_session)
+
+        workspace = await service.open(_spec(backend="service"), ctx=_ctx(), identity=_identity())
+        assert workspace is not None
+        workspace.spills.append("/workspace/tool_output/run-1/call-1.0")
+        await service.close(workspace)
+
+    async def test_a_failed_prune_is_logged_rather_than_raised(
+        self, monkeypatch, mock_db_session, caplog
+    ):
+        from pydantic_ai_backends import remote as remote_module
+
+        class _Sandbox:
+            def __init__(self, url, **kwargs):
+                pass
+
+            def execute(self, command, timeout=None):
+                return SimpleNamespace(exit_code=1, output="rm: read-only file system")
+
+        monkeypatch.setattr(remote_module, "RemoteSandbox", _Sandbox)
+        _serve(monkeypatch, _resolved())
+        monkeypatch.setattr(workspace_repo, "get_by_key", AsyncMock(return_value=None))
+        monkeypatch.setattr(
+            workspace_repo, "create", AsyncMock(return_value=_row(backend="service"))
+        )
+        service = SandboxWorkspaceService(mock_db_session)
+
+        workspace = await service.open(_spec(backend="service"), ctx=_ctx(), identity=_identity())
+        assert workspace is not None
+        workspace.spills.append("/workspace/tool_output/run-1/call-1.0")
+
+        with caplog.at_level(logging.WARNING):
+            await service.close(workspace)
+
+        [record] = [r for r in caplog.records if r.message == "workspace_spill_prune_failed"]
+        assert record.handles == 1
+        assert "read-only" in record.output
 
     async def test_a_backend_that_cannot_be_stopped_is_left_alone(
         self, monkeypatch, mock_db_session

--- a/backend/tests/test_sandbox_workspace.py
+++ b/backend/tests/test_sandbox_workspace.py
@@ -13,6 +13,8 @@ refusals worth more than the feature itself:
 from __future__ import annotations
 
 import logging
+import os
+import subprocess
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid4
@@ -1783,6 +1785,124 @@ class TestContainerBackedWorkspaces:
         [record] = [r for r in caplog.records if r.message == "workspace_spill_prune_failed"]
         assert record.handles == 1
         assert "read-only" in record.output
+
+    async def test_a_handle_with_a_parent_traversal_is_never_deleted(
+        self, monkeypatch, mock_db_session
+    ):
+        """`PurePosixPath` does not resolve `..`, so `tool_output/../x` would pass
+        an ancestor check while naming a file outside the spill directory; a
+        handle carrying one runs nothing."""
+        from pydantic_ai_backends import remote as remote_module
+
+        commands: list[str] = []
+
+        class _Sandbox:
+            def __init__(self, url, **kwargs):
+                pass
+
+            def execute(self, command, timeout=None):  # pragma: no cover - must not run
+                commands.append(command)
+                return SimpleNamespace(exit_code=0, output="")
+
+        monkeypatch.setattr(remote_module, "RemoteSandbox", _Sandbox)
+        _serve(monkeypatch, _resolved())
+        monkeypatch.setattr(workspace_repo, "get_by_key", AsyncMock(return_value=None))
+        monkeypatch.setattr(
+            workspace_repo, "create", AsyncMock(return_value=_row(backend="service"))
+        )
+        service = SandboxWorkspaceService(mock_db_session)
+
+        workspace = await service.open(_spec(backend="service"), ctx=_ctx(), identity=_identity())
+        assert workspace is not None
+        workspace.spills.append("/workspace/tool_output/../../etc/passwd")
+        await service.close(workspace)
+
+        assert commands == []
+
+    async def test_the_prune_command_deletes_through_a_real_shell(
+        self, monkeypatch, mock_db_session, tmp_path, caplog
+    ):
+        """The command is what a real `sh -c` runs, not what a mock accepts: the
+        spilled files are gone, the emptied directories are gone, and nothing is
+        reported as failed."""
+        from pydantic_ai_backends import remote as remote_module
+
+        class _Sandbox:
+            def __init__(self, url, **kwargs):
+                pass
+
+            def execute(self, command, timeout=None):
+                run = subprocess.run(["/bin/sh", "-c", command], capture_output=True, text=True)
+                return SimpleNamespace(exit_code=run.returncode, output=run.stdout + run.stderr)
+
+        monkeypatch.setattr(remote_module, "RemoteSandbox", _Sandbox)
+        _serve(monkeypatch, _resolved())
+        monkeypatch.setattr(workspace_repo, "get_by_key", AsyncMock(return_value=None))
+        monkeypatch.setattr(
+            workspace_repo, "create", AsyncMock(return_value=_row(backend="service"))
+        )
+        service = SandboxWorkspaceService(mock_db_session)
+
+        workspace = await service.open(_spec(backend="service"), ctx=_ctx(), identity=_identity())
+        assert workspace is not None
+        spill_dir = tmp_path / "tool_output" / "run-1"
+        spill_dir.mkdir(parents=True)
+        spill = spill_dir / "call-1.0"
+        spill.write_text("payload")
+        workspace.spills.append(str(spill))
+
+        with caplog.at_level(logging.WARNING):
+            await service.close(workspace)
+
+        assert not spill.exists()
+        assert not spill_dir.exists()
+        assert not (tmp_path / "tool_output").exists()
+        assert not [r for r in caplog.records if r.message == "workspace_spill_prune_failed"]
+
+    @pytest.mark.skipif(os.geteuid() == 0, reason="root is never refused the rm")
+    async def test_a_rm_the_shell_refuses_reaches_the_prune_warning(
+        self, monkeypatch, mock_db_session, tmp_path, caplog
+    ):
+        """The regression the mocked failure test cannot catch: the command's own
+        exit status must carry a refused `rm` out of the shell, where a trailing
+        cleanup (`; true`) would have reported the failed prune as success."""
+        from pydantic_ai_backends import remote as remote_module
+
+        class _Sandbox:
+            def __init__(self, url, **kwargs):
+                pass
+
+            def execute(self, command, timeout=None):
+                run = subprocess.run(["/bin/sh", "-c", command], capture_output=True, text=True)
+                return SimpleNamespace(exit_code=run.returncode, output=run.stdout + run.stderr)
+
+        monkeypatch.setattr(remote_module, "RemoteSandbox", _Sandbox)
+        _serve(monkeypatch, _resolved())
+        monkeypatch.setattr(workspace_repo, "get_by_key", AsyncMock(return_value=None))
+        monkeypatch.setattr(
+            workspace_repo, "create", AsyncMock(return_value=_row(backend="service"))
+        )
+        service = SandboxWorkspaceService(mock_db_session)
+
+        workspace = await service.open(_spec(backend="service"), ctx=_ctx(), identity=_identity())
+        assert workspace is not None
+        locked = tmp_path / "tool_output" / "run-1"
+        locked.mkdir(parents=True)
+        spill = locked / "call-1.0"
+        spill.write_text("payload")
+        workspace.spills.append(str(spill))
+        locked.chmod(0o555)
+
+        try:
+            with caplog.at_level(logging.WARNING):
+                await service.close(workspace)
+        finally:
+            locked.chmod(0o755)
+
+        assert spill.exists()
+        [record] = [r for r in caplog.records if r.message == "workspace_spill_prune_failed"]
+        assert record.handles == 1
+        assert "Permission denied" in record.output
 
     async def test_a_backend_that_cannot_be_stopped_is_left_alone(
         self, monkeypatch, mock_db_session

--- a/backend/tests/test_tool_output_limits.py
+++ b/backend/tests/test_tool_output_limits.py
@@ -27,6 +27,7 @@ from app.agents.capabilities.budget import SpendLedger, metered_by
 from app.agents.capabilities.sandbox import WORKSPACE_BACKEND_RESOURCE
 from app.agents.capabilities.tool_output_limits import (
     DEFAULT_SUMMARY_PROMPT,
+    SPILL_LOG_RESOURCE,
     BackendOverflowStore,
     MeteredToolOutputLimits,
     OverflowWriteError,
@@ -159,6 +160,22 @@ class TestStore:
         with pytest.raises(FileNotFoundError):
             await store.read("tool_output/never-written")
 
+    async def test_a_written_handle_is_recorded_in_the_run_spill_log(self):
+        """What lands in the log is the handle as the backend normalized it, so the
+        prune at workspace close deletes the path that actually exists (#803)."""
+        log: list[str] = []
+        store = BackendOverflowStore(StateBackend(), spill_log=log)
+        first = await store.write("run-1/call-1.0", b"payload")
+        second = await store.write("run-1/call-2.0", b"payload")
+        assert log == [first, second]
+
+    async def test_a_refused_write_records_nothing(self):
+        log: list[str] = []
+        store = BackendOverflowStore(_RefusingBackend(), spill_log=log)
+        with pytest.raises(OverflowWriteError):
+            await store.write("run-1/call-1.0", b"too big")
+        assert log == []
+
 
 class TestBuildStore:
     def test_no_backend_falls_back_to_an_in_memory_one(self):
@@ -168,6 +185,15 @@ class TestBuildStore:
     def test_a_backend_is_used_as_given(self):
         backend = StateBackend()
         assert _build_store(backend).backend is backend
+
+    def test_the_in_memory_fallback_records_no_handles(self):
+        """A backend discarded with the run leaves nothing to delete, so tracking
+        its spills would offer the prune paths that no longer exist."""
+        assert _build_store(None, ["polluted"]).spill_log is None
+
+    def test_a_bound_backend_records_into_the_run_log(self):
+        log: list[str] = []
+        assert _build_store(StateBackend(), log).spill_log is log
 
 
 class TestReduction:
@@ -287,6 +313,19 @@ class TestRegistration:
         )
         limits = built[0].wrapped
         assert limits.store.backend is backend
+
+    async def test_a_spill_is_recorded_in_the_workspace_spill_log(self):
+        """The runner's log resource reaches the store, so a spill on a shared
+        workspace is deletable at close by the run that wrote it (#803)."""
+        log: list[str] = []
+        built = build(
+            [CapabilityBinding(capability_id=CAPABILITY_ID, config={"threshold": 500})],
+            resources={WORKSPACE_BACKEND_RESOURCE: StateBackend(), SPILL_LOG_RESOURCE: log},
+        )
+        out = await built[0].after_tool_execute(
+            _run_context(), call=_call(), tool_def=_tool_def(), args={}, result="x" * 5_000
+        )
+        assert log == [out.metadata["overflow_handle"]]
 
     def test_the_builder_defaults_a_missing_config(self):
         """The defensive `isinstance` branch: a builder handed no config still builds."""

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -867,13 +867,14 @@ the run and keyed to the organization; the spill lives there, under a
 `tool_output/` prefix, so it shares that workspace's lifetime and the agent can even
 reach it through its own `read_file` and `grep`. On the default `run` session scope
 that lifetime *is* the run, which is what the "must not outlive the run" requirement
-asks for. A spill is a within-run artefact and never survives into the persisted
-document: on a longer-scoped `state` workspace (`conversation`, `user`, `agent`) the
-flush strips the reserved prefix at run end, so accumulated spills can no longer push
-the workspace toward its byte cap and refuse the agent's own writes. A longer-scoped
-*container* workspace still keeps its spills on the container filesystem —
-run-scoped deletion there needs a primitive the backend protocol does not expose yet,
-tracked in [#803](https://github.com/vstorm-co/agenticos/issues/803). An agent with
+asks for. A spill is a within-run artefact and never outlives the run on a
+longer-scoped workspace (`conversation`, `user`, `agent`) either: a `state`
+workspace has the reserved prefix stripped at flush, so accumulated spills can no
+longer push it toward its byte cap and refuse the agent's own writes, and a
+*container* workspace has the run's spills deleted off its filesystem when the
+workspace closes — by the exact handles the run recorded, never by sweeping the
+prefix, so two concurrent runs sharing a workspace cannot take each other's spills
+mid-flight ([#803](https://github.com/vstorm-co/agenticos/issues/803)). An agent with
 no backend gets an in-memory one built for the run and discarded with it, so the
 spill is never written to shared disk. A spill the backend refuses — a `state`
 workspace already at its byte cap — falls back to a truncation rather than a silent


### PR DESCRIPTION
## What this fixes

Closes #803 — the container half. #804 already stopped spills outliving the run on a `state` backend (the flush strips the reserved prefix); a longer-scoped **container** workspace (`conversation`/`user`/`agent`) still kept every past run's `tool_output/` blobs on its filesystem forever.

## How

- **The overflow store records what it writes.** `BackendOverflowStore` appends each handle (the backend's own normalized path) to a per-run spill log. The runner registers that log beside the workspace backend under `SPILL_LOG_RESOURCE`, and `_delegate_resources` shares it with delegates that share the parent's `sandbox` — their spills land on the same filesystem, so their handles belong in the same list. The in-memory fallback backend records nothing: it dies with the run and leaves nothing to delete.
- **`SandboxWorkspaceService.close` deletes exactly those paths.** For a container-backed workspace whose scope outlives the run, close runs `rm -f -- <handles>; rmdir -- <emptied dirs, deepest first> 2>/dev/null; true` through the backend's own `execute` — the backend protocol exposes no delete, and growing one belongs upstream. Every path is checked against the reserved-prefix invariant before it reaches the shell, even though only the store appends to the list.

## Why exact handles, not a prefix sweep

Two concurrent runs share a `user`- or `agent`-scoped workspace. A `tool_output/` prefix delete at one run's close would take the other run's spills mid-flight, while its `read_tool_result` can still be asked for them — the race #804 declined to rush. A run deleting only the handles its own store recorded cannot race anybody; the `rmdir` of the shared spill directory fails silently while a concurrent run still keeps files, which is the correct answer.

## Still true

- **Best-effort, like `_release`.** A run that crashes before its `finally` leaves its spills for the host; a prune the host refuses is logged (`workspace_spill_prune_failed`) rather than raised, because `close` runs in the same `finally` that records the run's cost.
- `run`-scoped containers die purged as before; `state` workspaces keep the flush-strip from #804.

## Testing

- `tests/test_sandbox_workspace.py` — the prune command (both handle forms, `rmdir` deepest-first ordering), the foreign-path guard running nothing, no spills → no command, a backend without `execute` left alone, and a failed prune logged rather than raised.
- `tests/test_tool_output_limits.py` — written handles recorded in the log (in write order, as returned), a refused write recording nothing, the in-memory fallback recording nothing, and the registry-level path: a spill through a built capability lands its handle in the resource-provided log.
- `make test` — 5422 passed, platform coverage **100.00%**. `make lint-backend`, `make docs-build` (--strict), `python3 scripts/docs_drift.py` clean.

Closes #803