### PR TITLE
chore: cut 0.0.165

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,28 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.165] - 2026-08-16
+
+A delegated run's failure is written in the platform's words, never the
+provider's.
+
+### Fixed
+
+- **A delegated run's stored error is composed, not copied.** A failed
+  delegation wrote `agent_runs.error` and its closing `SubagentFinished` frame
+  from the subagents library's own exception text — routinely a provider
+  client's message carrying the failing request URL, key still in its query
+  string on a custom `base_url`. The settlement now composes the same
+  controlled sentence the parent's row gets (`run_failure_summary`, moved to
+  `app/agents/failures.py` so the capability layer can reach it), and the
+  library's text goes to the server log with the original exception beside it.
+  Rides on subagents-pydantic-ai 0.2.19, whose `TaskHandle.exception` hands the
+  platform the exception instead of a string to parse. The two deliberate
+  exceptions keep their own words whole: pydantic-ai's `UsageLimitExceeded`
+  (the delegation's own ceiling doing its job) and `BudgetExceeded` raised
+  inside a delegate by the parent's shared ledger — a ceiling sentence with its
+  numbers is the one failure text the reader acts on. (#699)
+
 ## [0.0.164] - 2026-08-16
 
 An agent stops forgetting its instructions mid-run, and remembers across turns.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.164"
+version = "0.0.165"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.164"
+version = "0.0.165"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.164",
+  "version": "0.0.165",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.165. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json` to 0.0.165 and adds the CHANGELOG entry.

Releases:
- A delegated run's stored error is composed by `run_failure_summary`, never copied from the subagents library — provider text (and any keyed URL in it) stays in the server log (#699, landed in #816).