### PR TITLE
chore: cut 0.0.166

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,25 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
-## [0.0.165] - 2026-08-16
+## [0.0.166] - 2026-08-16
+
+A run's spills no longer pile up on a container workspace that outlives it.
+
+### Fixed
+
+- **A run's spills are pruned off a container workspace at close.** #804
+  stopped `tool_output/` spills outliving the run on a `state` backend, but a
+  longer-scoped container workspace (`conversation`/`user`/`agent`) still kept
+  every past run's blobs on its filesystem forever. The overflow store now
+  records each handle it writes to a per-run spill log — shared with delegates
+  that share the parent's sandbox — and `close` deletes exactly those paths
+  through the backend's own `execute`. Exact handles, not a prefix sweep, so
+  two concurrent runs on a shared workspace cannot take each other's spills
+  mid-flight; the `rmdir` of a still-shared spill directory fails silently,
+  which is the correct answer, while a refused `rm` keeps its status and is
+  logged (`workspace_spill_prune_failed`) rather than raised. Every path is
+  checked against the reserved-prefix invariant — `..` refused outright —
+  before it reaches the shell. (#803)
 
 A delegated run's failure is written in the platform's words, never the
 provider's.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.165"
+version = "0.0.166"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.165"
+version = "0.0.166"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.165",
+  "version": "0.0.166",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.166. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json` to 0.0.166 and adds the CHANGELOG entry.

Releases:
- A run's `tool_output/` spills are pruned off a container workspace at close — exact recorded handles, never a prefix sweep, so concurrent runs on a shared workspace cannot race each other (#803, landed in #817).