### PR TITLE
chore: cut 0.0.167

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,22 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
-## [0.0.166] - 2026-08-16
+## [0.0.167] - 2026-08-16
+
+A workspace file's header finally says when it changed, not only how big it is.
+
+### Added
+
+- **Workspace listings carry a file's modified time to the viewer.** The shared
+  file viewer's header could always render `modified …`, but only a knowledge
+  base document ever supplied a time — a workspace file stopped at the size.
+  Rides on pydantic-ai-backend 0.2.26's `FileInfo.modified_at` (ISO 8601,
+  optional): a stored workspace records one on every write inside its JSONB
+  document, a workspace archive reports `st_mtime`, and a live container's
+  shell listing honestly answers `null` — never a guess. `WorkspaceFileRead`
+  (and `FlatFileRead`) gain `modified_at`, the three listing routes pass it
+  through, and the chat panel, the workspace explorer, the flat browser and
+  the chat tool-result card all hand it to the viewer. (#500)
 
 A run's spills no longer pile up on a container workspace that outlives it.
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.166"
+version = "0.0.167"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.166"
+version = "0.0.167"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.166",
+  "version": "0.0.167",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.167. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json` to 0.0.167 and adds the CHANGELOG entry.

Releases:
- Workspace listings carry `modified_at` to the file viewer — filled where a real timestamp exists, honestly `null` where none does (#500, landed in #815).