### PR TITLE
chore: cut 0.0.169

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,24 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
-## [0.0.168] - 2026-08-16
+## [0.0.169] - 2026-08-16
+
+The sandboxes page stops stacking two clocks down one scroll.
+
+### Changed
+
+- **`/sandboxes` is two tabs: connections, and what is running.** The
+  configuration table and the live **Running on {host}** panel were one scroll
+  on two clocks; now the active tab lives in the URL (`?tab=running`
+  deep-links, the default keeps the parameter off) and the live query only
+  exists while its tab is on screen — the ten-second poll stops on a page
+  nobody is looking at, pinned by a test that the sessions hook is never even
+  constructed. The running tab names its host and lets an operator switch
+  (closing the activity log on the switch, so one host is never asked for
+  another's session); a failed connections request renders the error, never a
+  false "no container connection registered"; the sessions table sorts,
+  filters and explains an empty match; and the activity log is a labelled
+  `DataTable` instead of a bare table in a grey box. (#140)
 
 "dev should serve v3" is answered on the environment's own row.
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.168"
+version = "0.0.169"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.168"
+version = "0.0.169"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.168",
+  "version": "0.0.169",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.169. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json` to 0.0.169 and adds the CHANGELOG entry.

Releases:
- `/sandboxes` split into connections and running tabs — the live poll unmounted with its tab, host switching that closes the activity log, and honest error/empty states (#140, landed in #814).