### PR TITLE
chore: cut 0.0.172

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,49 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.172] - 2026-08-17
+
+All files answers "what is that file", not only "who is holding a copy of it".
+
+### Added
+
+- **Search and sort on the All files grid.** The same `useListControls` +
+  `SearchInput` pair the five galleries use, filtering on path, agent name and
+  extension — `.csv` matches the suffix rather than the string — and ordering by
+  name, size, modified or agent. Size and modified descend, because "what is
+  biggest" and "what changed" are the questions those orders answer. The bound
+  stays on screen while a filter is applied, with a line saying the filter
+  searched only what was read: a client-side filter over a truncated listing
+  searched a sample, and "3 results" with no caveat would claim the search was
+  exhaustive. (#138)
+- **A tile is the file card every other surface draws.** The three-line row is
+  gone; the grid now uses `components/files`' `FileCard`, so a CSV looks like the
+  same thing in the composer, the transcript and here — including the suffix and
+  size band (`CSV · 2.0 KB`) that was the extension-legibility half of the issue.
+  The line under each card carries what only this view knows: the agent holding
+  the file, who else can see it, and the download. (#138)
+- **A stored text file previews its first lines, and a stored image draws
+  itself.** Both come out of the JSONB document the listing already reads, so a
+  grid of thirty tiles is still one request: eight lines capped at 200 characters
+  for text, and a 160×128 `data:` URI for a raster image. A container-backed
+  workspace answers `null` for both — its bytes are on a host, and one round trip
+  per file is exactly what this listing refuses. (#827)
+
+### Fixed
+
+- **A thumbnail's decode is bounded by pixels, not by bytes.** A PNG under a
+  kilobyte can declare 8000×8000, and scaling it allocates all 64 megapixels on a
+  request somebody made by opening a page. Pillow's own ceiling does not catch
+  it — it refuses at 89 megapixels — so the declared size is checked against a
+  16 Mpx limit in the header, before any pixel is read. (#827)
+- **A thumbnail is drawn as the image is.** Transparency survives (converting to
+  `RGB` does not remove what the alpha channel hid, it paints it — usually
+  black), and a camera's EXIF orientation is applied before the scale, so a
+  portrait photograph is no longer sideways on its tile. (#827)
+- **A file's React key joins its workspace and path with a separator.** Without
+  one, `{workspace: "ab", path: "c"}` and `{workspace: "a", path: "bc"}`
+  collided into a single key. (#138)
+
 ## [0.0.171] - 2026-08-16
 
 Tool search's scale guarantee is pinned by a fixture, not a claim.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.171"
+version = "0.0.172"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.171"
+version = "0.0.172"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.171",
+  "version": "0.0.172",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.172. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.172 and adds the CHANGELOG entry.

Releases:

- **The All files grid answers "what is that file".** Search and sort over
  path, agent and extension; the tile is the `FileCard` the composer and the
  transcript already draw, so a CSV looks like the same thing on all three
  surfaces; a stored text file previews its first lines and a stored image
  draws itself, both out of the JSONB document the listing already reads, so
  the grid is still one request. (#828, closing #138 and #827)
- **Three defects in that thumbnail, found reviewing it.** The decode is now
  bounded by declared pixels rather than by compressed bytes — a sub-kilobyte
  PNG can declare 64 megapixels, which Pillow's own 89 Mpx ceiling lets
  through; transparency survives the encode instead of being painted black;
  and EXIF orientation is applied before the scale, so a portrait photograph
  is upright.

## Verified

`make lint` green on this branch. Everything being released was green on
`main` before the cut: `lint`, `test` (5464 passed, platform gate at 100%),
`test-frontend`, `e2e`, `docs` and the security scan on #828.
