### PR TITLE
chore: cut 0.0.174

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,29 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.174] - 2026-08-17
+
+A delegate's provider text no longer reaches the parent's transcript through a
+status answer.
+
+### Fixed
+
+- **`check_task` and `wait_tasks` name the exception's class, not the provider's
+  message.** Both composed their `Error:`, `Retry N:` and `Outcome:` lines from
+  `handle.error`, which embeds the exception's own text — and a model client's
+  message carries the failing request URL with the key still in its query string
+  on a custom `base_url`. What those tools return becomes a `ToolReturnPart`, and
+  a return is stored *whole* on purpose, so `tool_retry_notice` (#695) could
+  never reach it: the key landed on a stored tool-call row, rendered in the
+  conversation and in run history to every member who can read the run, and
+  streamed live as `tool_result`. Fixed upstream in
+  `subagents-pydantic-ai` 0.2.20, which composes all four lines from
+  `TaskHandle.exception`; the floor here moves with it. (#819)
+- **The retry line leaked for delegations that eventually succeed.**
+  `TaskHandle.finish` clears `error` on completion, so the handle ends clean —
+  but a model that polled `check_task` mid-retry already has the answer on a
+  transcript row, and nothing goes back to remove it. (#819)
+
 ## [0.0.173] - 2026-08-17
 
 A dependency nothing imports is now a failing build, not a thing somebody

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.173"
+version = "0.0.174"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.173"
+version = "0.0.174"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.173",
+  "version": "0.0.174",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.174. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.174 and adds the CHANGELOG entry.

Releases:

- **A delegate's provider text no longer reaches the parent's transcript.**
  `check_task` and `wait_tasks` composed their `Error:`, `Retry N:` and
  `Outcome:` lines from the exception's own message, which on a custom
  `base_url` carries the failing request URL with the key still in its query
  string. A tool's return is stored whole, so the scrubber added in #695 could
  never reach it. Fixed upstream in `subagents-pydantic-ai` 0.2.20 and the floor
  moves with it. (#832, closing #819)

## Verified

CI green on #832 with `main` merged in — lint, test, test-frontend, e2e, docs
and the security scan.
