### PR TITLE
chore: cut 0.0.176

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.176] - 2026-08-17
+
+### Changed
+
+- **Pydantic AI's floor moves to 2.30.0**, with `genai-prices` at 0.1.2 — the
+  agent-frameworks dependency group.
+- **A group bump no longer rolls the lock backwards.** The bump resolved
+  `pydantic-ai-slim` and `pydantic-graph` to 2.30.0 while `main` already held
+  2.31.0, and `backend/Dockerfile` installs the lockfile verbatim
+  (`uv sync --frozen`), so the "upgrade" would have shipped an image with an
+  older Pydantic AI than the one before it. Re-resolved to 2.31.0, with
+  `genai-prices` at 0.1.3, and the note above the floor now names that failure
+  rather than a version it had already outlived. (#837)
+
 ## [0.0.175] - 2026-08-17
 
 One mechanism draws every third-party mark, and 471 MB leaves the install.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.175"
+version = "0.0.176"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.175"
+version = "0.0.176"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.175",
+  "version": "0.0.176",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.176. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json` to 0.0.176 and adds the CHANGELOG entry.

Releases the agent-frameworks dependency group (#837): Pydantic AI floored at 2.30.0 and locked at 2.31.0, `genai-prices` at 0.1.3 — with the lock rollback that bump originally carried corrected before it landed, since the image installs the lockfile verbatim.

## Verified

CI green on #837 after the correction, including `e2e`. `make test` on the corrected resolution: 5464 passed, platform gate at 100%.