### PR TITLE
chore: cut 0.0.177

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,13 @@ Two things are versioned separately from this file and worth knowing about:
 
 ### Changed
 
-- **Thirteen backend dependencies move up** — the backend-everything-else group:
-  `uvicorn` 0.52.3, `pydantic-settings` 2.15.0, `sqlalchemy` 2.0.52, `alembic`
-  1.19.1, `greenlet` 3.5.5, `prefect` 3.8.3, `llama-cloud` 2.14.0, `liteparse`
-  2.12.0, `boto3` 1.43.72, `pydantic-monty` 0.0.21, and `ruff` 0.16.3, `ty`
-  0.0.71 and `pre-commit` 4.6.2 among the dev tools. The lockfile was resolved
+- **Thirteen backend dependencies move up** — the backend-everything-else group,
+  at the versions the lockfile now holds: `uvicorn` 0.52.3, `pydantic-settings`
+  2.15.0, `sqlalchemy` 2.0.52, `alembic` 1.19.1, `greenlet` 3.5.5, `prefect`
+  3.8.3, `llama-cloud` 2.14.0, `liteparse` 2.13.0, `boto3` 1.43.73,
+  `pydantic-monty` 0.0.21, and `ruff` 0.16.3, `ty` 0.0.72 and `pre-commit` 4.6.2
+  among the dev tools. Three of those resolve above the floor the group asked
+  for, which is why they are quoted from the lock. The lockfile was resolved
   against the merged manifest rather than the group's own base, so Pydantic AI
   stays where 0.0.176 put it instead of being rolled back a release for the
   second time. (#838)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.177] - 2026-08-18
+
+### Changed
+
+- **Thirteen backend dependencies move up** — the backend-everything-else group:
+  `uvicorn` 0.52.3, `pydantic-settings` 2.15.0, `sqlalchemy` 2.0.52, `alembic`
+  1.19.1, `greenlet` 3.5.5, `prefect` 3.8.3, `llama-cloud` 2.14.0, `liteparse`
+  2.12.0, `boto3` 1.43.72, `pydantic-monty` 0.0.21, and `ruff` 0.16.3, `ty`
+  0.0.71 and `pre-commit` 4.6.2 among the dev tools. The lockfile was resolved
+  against the merged manifest rather than the group's own base, so Pydantic AI
+  stays where 0.0.176 put it instead of being rolled back a release for the
+  second time. (#838)
+
 ## [0.0.176] - 2026-08-17
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.176"
+version = "0.0.177"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.176"
+version = "0.0.177"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.176",
+  "version": "0.0.177",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.177. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json` to 0.0.177 and adds the CHANGELOG entry.

Releases the backend-everything-else dependency group (#838) — thirteen updates — with the lock re-resolved against the merged manifest, so Pydantic AI keeps the version 0.0.176 landed rather than being rolled back a second time.

## Verified

CI green on #838 after the conflict resolution. Locally on the merged tree: `make lint-backend` (ruff 0.16.3, ty 0.0.72) clean, `make test` 5465 passed, platform gate at 100%.