### PR TITLE
chore: cut 0.0.178

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,39 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.178] - 2026-08-18
+
+The collection page is server state again, not seven `useState` slots.
+
+### Changed
+
+- **`useKBDetail` moved onto React Query.** Seven pieces of local state became
+  `qk.kb.detail(id)`, `qk.kb.documents(id)` (paged with `useInfiniteQuery`) and
+  three keyed section queries, so an external mutation can invalidate the page
+  and the two keys that were dead are live. The bespoke tenant-clearing block is
+  gone — `useTenantCacheReset`'s `removeQueries()` already covered it. A cold
+  first-load failure stays distinct from a failed refresh: one is the page's
+  error, the other is the last good answer under a stale banner. (#557)
+- **The admin query-key factories are typed to their real parameters**, the dead
+  `admin.users` factory is gone, and the `{ summary: true }` discriminator went
+  with the ratings page it distinguished against. (#558)
+- **The sandbox `usage` discriminator lives in the key**, not at the call site:
+  a listing the service sampled for per-sandbox usage is a more expensive
+  request than one without, and the two must not share a cache entry. (#569)
+
+### Fixed
+
+- **The members table waits for the permission answer before drawing its action
+  column**, rather than drawing it and then discovering the caller may not use
+  it. (#569)
+- **`api/files/[id]` encodes its path segment**, and `patchKB` rethrows the way
+  its siblings do. (#569)
+- **A sync source written into an unread cache now shows up.** The three
+  sections sit behind `connections:manage`, so a refused read leaves nothing
+  cached while the write is still allowed — the write's second arm covers that,
+  and now has the test to say so, along with the tenant guard on the two writes
+  that add a row. (#569)
+
 ## [0.0.177] - 2026-08-18
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.177"
+version = "0.0.178"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.177"
+version = "0.0.178"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.177",
+  "version": "0.0.178",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.178. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json` to 0.0.178 and adds the CHANGELOG entry.

Releases the query-keys cluster of the 2026-08-10 frontend audit (#844, closing #557 and #558, part of #569): `useKBDetail` on React Query, typed admin key factories, the sandbox `usage` discriminator moved into the key, and the smaller fixes around them.

## Verified

CI green on #844 with `main` merged in. The branch also needed five tests for its own rewrite: the coverage gate went red at 97.44% branches against a 97.5% threshold, and all thirteen uncovered branches were in `use-knowledge-bases.ts` — the tenant guard on the two writes that add a row, the arm that writes into a cache a refused read left empty, and the `Error` message reaching the toast. 97.56% after.