### PR TITLE
chore: cut 0.0.179

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.179] - 2026-08-18
+
+### Changed
+
+- **Disconnecting an MCP server asks in the product, not in the browser.**
+  `window.confirm` was the lone holdout after rag, agents, skills and embeds
+  moved to `ConfirmDialog`; the confirmation is now keyed on the pending
+  connection, and a second click while the DELETE is in flight is a no-op rather
+  than a second request. (#554)
+- **The two MCP dialogs left the list component.** The connect/edit dialog and
+  the tool picker move into their own modules, taking `mcp-server-list.tsx` from
+  about 985 lines to 765. A pure move — the JSX is unchanged and the parent
+  keeps its state and both handlers — with the shapes all three share extracted
+  to a leaf module so a dialog never imports the component that renders it.
+  (#569)
+
 ## [0.0.178] - 2026-08-18
 
 The collection page is server state again, not seven `useState` slots.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.178"
+version = "0.0.179"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.178"
+version = "0.0.179"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.178",
+  "version": "0.0.179",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.179. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json` to 0.0.179 and adds the CHANGELOG entry.

Releases the MCP-server-list cluster of the 2026-08-10 audit (#845, closing #554, part of #569): disconnect asks through `ConfirmDialog` rather than `window.confirm` and refuses a second click while the DELETE is in flight, and the connect/edit and tool-picker dialogs move out of the list component.

## Verified

CI green on #845 with current `main` merged in — it was re-run after #844 landed, since both branches touch the frontend.