### PR TITLE
chore: cut 0.0.180

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.180] - 2026-08-18
+
+### Fixed
+
+- **Every `backendFetch` route says `no-store`.** The 44 route files under
+  `orgs/**`, `me/**`, `admin/**`, `sessions/**` and `auth/**` answered with no
+  `Cache-Control` at all, so the members, invitations and integrations lists
+  refetched right after a create, invite or revoke could be served from cache —
+  the same staleness class as #230, on the one surface the shared proxy does not
+  cover. `platformProxy` already stamps the header on anything the backend left
+  unmarked; a hand-rolled route owes the same, and now cannot forget it: every
+  `NextResponse.json` goes through `bffJson`, which stamps `no-store` and leaves
+  an explicit policy alone. The binary routes that set their own `max-age` keep
+  it. (#553)
+
 ## [0.0.179] - 2026-08-18
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.179"
+version = "0.0.180"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.179"
+version = "0.0.180"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.179",
+  "version": "0.0.180",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.180. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json` to 0.0.180 and adds the CHANGELOG entry.

Releases `no-store` on every `backendFetch` route (#847, closing #553), through one `bffJson` chokepoint so no route can forget it — the staleness class of #230 on the one surface `platformProxy` does not cover.

## Verified

CI green on #847 with current `main` merged in; it was re-run after #844 and #845 landed, since all three touch the frontend.