### PR TITLE
chore: cut 0.0.181

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.181] - 2026-08-18
+
+### Changed
+
+- **jsdom moves to 30.0.1** in the frontend test environment. The bump arrived
+  without a regenerated `bun.lock`, so `test-frontend` and `e2e` both failed at
+  the install step — `lockfile had changes, but lockfile is frozen` — before
+  either had run a single test, which is why the red read like the major version
+  breaking the suite. With the lock regenerated the suite is green on jsdom 30:
+  308 files, 4704 tests. (#850)
+
 ## [0.0.180] - 2026-08-18
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.180"
+version = "0.0.181"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.180"
+version = "0.0.181"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.180",
+  "version": "0.0.181",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.181. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json` to 0.0.181 and adds the CHANGELOG entry.

Releases jsdom 30.0.1 in the frontend test environment (#850), with the lockfile the bump arrived without — the missing regeneration was the whole of its red, since both frontend jobs died at the install step before running a test.

## Verified

CI green on #850 with `main` merged in, including `e2e` and `test-frontend` (308 files, 4704 tests).