### PR TITLE
chore: cut 0.0.184

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.184] - 2026-08-18
+
+### Fixed
+
+- **The storage-root check is written so a static analyser can follow it**, which
+  is what closes three CodeQL `py/path-injection` alerts — a `Path.parents`
+  membership test is correct and invisible to the query, and an alert nobody can
+  close is an alert everybody learns to ignore. (#841)
+- **A filesystem root can be the storage root again.** The rewritten check built
+  its prefix as `base + os.sep` unconditionally, so with `MEDIA_DIR=/` the prefix
+  was `//` — which nothing under `/` starts with. `load`, `delete` and
+  `get_full_path` all refused with "Path escapes storage root" while `save`
+  carried on writing, leaving the store handing back paths it could no longer
+  read. The separator is appended only when the root lacks one, and the
+  comparison stays a `startswith` on a `realpath` result rather than moving to
+  `commonpath` or `is_relative_to`: both are correct, and neither is a barrier
+  the query models. (#841)
+
 ## [0.0.183] - 2026-08-18
 
 Chunking is ours, and `langsmith` is out of the image.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.183"
+version = "0.0.184"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.183"
+version = "0.0.184"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.183",
+  "version": "0.0.184",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.184. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json` to 0.0.184 and adds the CHANGELOG entry.

Releases the storage-root check rewritten so CodeQL can follow it (#841), and the filesystem root it stopped handling on the way: with `MEDIA_DIR=/` the prefix became `//`, so reads refused while writes carried on.

## Verified

CI green on #841 with `main` merged in — including the Python CodeQL analysis, which is the signal that the guard is still legible to the query after the fix.