### PR TITLE
chore: cut 0.0.186

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,28 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.186] - 2026-08-18
+
+### Fixed
+
+- **The Builder says up front when a draft can never get a model.** A member with
+  `agents:edit` but not `connections:manage`, in an organization that has stored
+  no model profile, could build an agent they cannot publish: the picker's "add"
+  control is gated on a permission they do not hold, and publish is refused
+  without a model. Nothing said so until publish failed, and then it pointed at
+  the permission rather than at what to do. The panel now says it where the
+  missing control would be. (#591)
+- **A failed profile query is no longer read as an empty organization.** The hook
+  degrades a refused `/providers/model-profiles` to `[]`, and its loading flag
+  goes false when retries are exhausted as well as when an answer arrives — so a
+  502 told somebody with a dozen models to go and ask an admin for one. The
+  notice waits on the query's own success now, not on the absence of loading.
+  (#591)
+- **The notice waits for the permission set before claiming the caller cannot add
+  a model.** `can()` answering false while the set is still loading is right for
+  *hiding* a control and wrong for a sentence that tells somebody what they may
+  not do: false there means "not known yet". (#591)
+
 ## [0.0.185] - 2026-08-18
 
 Three places where the code said something about itself that was not true.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.185"
+version = "0.0.186"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.185"
+version = "0.0.186"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.185",
+  "version": "0.0.186",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.186. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json` to 0.0.186 and adds the CHANGELOG entry.

Releases the Builder saying up front that a draft can never get a model (#846, closing #591), instead of refusing at publish and naming a permission the reader does not hold — plus the two ways that notice could itself be wrong: a failed profile query read as an empty organization, and a permission claimed before its set had loaded.

## Verified

CI green on #846 with `main` merged in. Its previously-red checks were a third-party action download answering HTTP 429, not the diff.