### PR TITLE
fix(mcp): answer a blocked server URL with the refusal, not a 500

### DIFF
--- a/backend/app/agents/capabilities/browser_use/__init__.py
+++ b/backend/app/agents/capabilities/browser_use/__init__.py
@@ -90,7 +90,10 @@ def validate_cdp_url(config: BrowserUseConfig) -> None:
 
     Raises:
         SSRFBlockedError: the endpoint is loopback, private, reserved or metadata.
-        ValueError: the URL is malformed.
+        UrlRefusedError: the URL is malformed. `_browser_use_problems` quotes the
+            message into a publish problem a person reads, which is safe because
+            every refusal `validate_webhook_url` raises is one written there
+            rather than by the standard library about the caller's text (#861).
     """
     if config.mode == "remote" and config.cdp_url is not None:
         validate_webhook_url(config.cdp_url, allowed_schemes=_CDP_SCHEMES)

--- a/backend/app/core/sanitize.py
+++ b/backend/app/core/sanitize.py
@@ -16,11 +16,27 @@ WEBHOOK_ALLOWED_SCHEMES = frozenset({"http", "https"})
 _CGNAT_NETWORK = ipaddress.ip_network("100.64.0.0/10")
 
 
-class SSRFBlockedError(ValueError):
+class UrlRefusedError(ValueError):
+    """A URL this deployment will not request, refused in a message we wrote.
+
+    The type is the promise, and callers depend on it: both quote the message
+    to a person - `mcp_connection._checked_url` as a 400, and
+    `agent_registry._browser_use_problems` as a publish problem - and
+    `.claude/rules/exceptions-security.md` allows that only for text written in
+    this repository. `urlsplit` defers port parsing to attribute access and
+    answers a bad one with `Port could not be cast to integer value as
+    '<what you sent>'`, so a URL like `http://host:client_secret=sh-key/mcp`
+    turns the stdlib's message into an echo of a secret (#861). Every refusal
+    raised below is this type or a subclass, and `tests/test_ssrf.py` fails on
+    one that is not.
+    """
+
+
+class SSRFBlockedError(UrlRefusedError):
     """Raised when a URL is blocked by SSRF protection.
 
     Dedicated exception type to avoid fragile string matching when
-    distinguishing SSRF blocks from other ValueErrors.
+    distinguishing SSRF blocks from other refusals.
     """
 
 
@@ -102,7 +118,11 @@ def validate_webhook_url(
 
     Raises:
         SSRFBlockedError: If the URL is blocked by SSRF protection.
-        ValueError: If the URL is malformed.
+        UrlRefusedError: If the URL is malformed. Every refusal raised here is
+            one of these two, so a caller may quote the message; a bare
+            `ValueError` reaching a caller from this function is a bug rather
+            than a refusal, and would be one written by the standard library
+            about text the caller sent.
 
     Example:
         >>> validate_webhook_url("https://example.com/webhook")
@@ -116,7 +136,7 @@ def validate_webhook_url(
     try:
         parsed = urlparse(url)
     except Exception as err:
-        raise ValueError("The URL could not be parsed") from err
+        raise UrlRefusedError("The URL could not be parsed") from err
 
     if parsed.scheme not in allowed_schemes:
         raise SSRFBlockedError(
@@ -126,7 +146,7 @@ def validate_webhook_url(
 
     hostname = parsed.hostname
     if not hostname:
-        raise ValueError("The URL has no hostname")
+        raise UrlRefusedError("The URL has no hostname")
 
     # Reject URLs with userinfo (credentials) to prevent URL parsing ambiguities
     # e.g. http://user:pass@host/ or http://foo@169.254.169.254%00@public.com/
@@ -135,6 +155,18 @@ def validate_webhook_url(
             "The URL must not contain credentials (userinfo). "
             "Remove the user:password@ portion from the URL."
         )
+
+    default_port = 443 if parsed.scheme == "https" else 80
+    try:
+        port = parsed.port or default_port
+    except ValueError as err:
+        # `urlsplit` parses the port at attribute access rather than up front,
+        # and says what it could not cast - which is the caller's text, and
+        # reaches a response body through every caller of this function (#861).
+        # Read here rather than beside `getaddrinfo` so an unrequestable port is
+        # refused on an IP literal too, and so the `except ValueError` below
+        # cannot swallow this.
+        raise UrlRefusedError("The URL has an invalid port") from err
 
     try:
         addr = ipaddress.ip_address(hostname)
@@ -149,9 +181,6 @@ def validate_webhook_url(
     except ValueError:
         # Not an IP literal - continue to DNS resolution below
         pass
-
-    default_port = 443 if parsed.scheme == "https" else 80
-    port = parsed.port or default_port
 
     try:
         addr_infos = socket.getaddrinfo(hostname, port, proto=socket.IPPROTO_TCP)

--- a/backend/app/core/sanitize.py
+++ b/backend/app/core/sanitize.py
@@ -1,6 +1,6 @@
 """Input sanitization utilities.
 
-Webhook URL validation to prevent SSRF attacks.
+URL validation to prevent SSRF attacks.
 """
 
 import ipaddress
@@ -88,10 +88,13 @@ def validate_webhook_url(
     Because of that, the refusals below name the **host**, or nothing, but never
     the URL. A URL carries a key in its query string, and the one being refused
     may have been written by the party being refused
-    (`.claude/rules/exceptions-security.md`).
+    (`.claude/rules/exceptions-security.md`). They name no *caller* either: this
+    function has had no webhook caller for some time, and every message it
+    raises is read by somebody who typed an MCP server URL or a `cdp_url`
+    (#861).
 
     Args:
-        url: The webhook URL to validate.
+        url: The URL to validate.
         allowed_schemes: Allowed URL schemes. Defaults to {"http", "https"}.
 
     Returns:
@@ -113,7 +116,7 @@ def validate_webhook_url(
     try:
         parsed = urlparse(url)
     except Exception as err:
-        raise ValueError("Webhook URL could not be parsed") from err
+        raise ValueError("The URL could not be parsed") from err
 
     if parsed.scheme not in allowed_schemes:
         raise SSRFBlockedError(
@@ -123,13 +126,13 @@ def validate_webhook_url(
 
     hostname = parsed.hostname
     if not hostname:
-        raise ValueError("Webhook URL has no hostname")
+        raise ValueError("The URL has no hostname")
 
     # Reject URLs with userinfo (credentials) to prevent URL parsing ambiguities
     # e.g. http://user:pass@host/ or http://foo@169.254.169.254%00@public.com/
     if parsed.username is not None or parsed.password is not None:
         raise SSRFBlockedError(
-            "Webhook URL must not contain credentials (userinfo). "
+            "The URL must not contain credentials (userinfo). "
             "Remove the user:password@ portion from the URL."
         )
 
@@ -137,7 +140,7 @@ def validate_webhook_url(
         addr = ipaddress.ip_address(hostname)
         if _is_ip_blocked(str(addr)):
             raise SSRFBlockedError(
-                f"Webhook URL blocked: {hostname!r} resolves to a private/internal "
+                f"Blocked: {hostname!r} resolves to a private/internal "
                 f"address. SSRF protection does not allow requests to internal networks."
             )
         return url
@@ -153,20 +156,16 @@ def validate_webhook_url(
     try:
         addr_infos = socket.getaddrinfo(hostname, port, proto=socket.IPPROTO_TCP)
     except socket.gaierror as err:
-        raise SSRFBlockedError(
-            f"Webhook URL blocked: unable to resolve hostname {hostname!r}"
-        ) from err
+        raise SSRFBlockedError(f"Blocked: unable to resolve hostname {hostname!r}") from err
 
     if not addr_infos:
-        raise SSRFBlockedError(
-            f"Webhook URL blocked: hostname {hostname!r} did not resolve to any address"
-        )
+        raise SSRFBlockedError(f"Blocked: hostname {hostname!r} did not resolve to any address")
 
     for _family, _type, _proto, _canonname, sockaddr in addr_infos:
         ip_str = str(sockaddr[0])
         if _is_ip_blocked(ip_str):
             raise SSRFBlockedError(
-                f"Webhook URL blocked: {hostname!r} resolves to private/internal "
+                f"Blocked: {hostname!r} resolves to private/internal "
                 f"address {ip_str!r}. SSRF protection does not allow requests to "
                 f"internal networks."
             )

--- a/backend/app/services/mcp_connection.py
+++ b/backend/app/services/mcp_connection.py
@@ -54,6 +54,7 @@ from app.core.audit import record_audit
 from app.core.config import settings
 from app.core.exceptions import AlreadyExistsError, BadRequestError, NotFoundError
 from app.core.permissions import AuthContext
+from app.core.sanitize import UrlRefusedError
 from app.core.vault import SealedSecret, VaultScope, seal, unseal
 from app.db.models.mcp_connection import McpConnection
 from app.db.updates import writable
@@ -93,13 +94,25 @@ async def _checked_url(url: str) -> str:
     is the validator's own message, which names a host and never a URL - a URL
     carries a key in its query string (#840).
 
+    Which is why this catches `UrlRefusedError` and not `ValueError`. Only the
+    narrower type is a refusal *written here* and so safe to quote; a bare
+    `ValueError` escaping the validator is the standard library talking about
+    the caller's own text - `Port could not be cast to integer value as
+    'client_secret=...'` - and quoting that would put a query-string secret in
+    the response body. Nothing below the validator can raise one today, so there
+    is no second branch to answer with a controlled sentence: if that changes,
+    it is a bug and the generic 500 is the honest answer, since the traceback
+    goes to the log and the body stays empty. `tests/test_ssrf.py` fails on a
+    refusal that is not a `UrlRefusedError`.
+
     Raises:
         BadRequestError: If the URL is malformed or points inside the
             deployment's network.
     """
     try:
         return await validate_mcp_url(url)
-    except ValueError as exc:
+    except UrlRefusedError as exc:
+        # Ours to quote, in the log as much as in the body - see the docstring.
         logger.warning("MCP server URL refused: %s", exc)
         raise BadRequestError(
             message=f"This MCP server URL cannot be used: {exc}",

--- a/backend/app/services/mcp_connection.py
+++ b/backend/app/services/mcp_connection.py
@@ -79,6 +79,34 @@ def _now_epoch() -> float:
     return datetime.now(UTC).timestamp()
 
 
+async def _checked_url(url: str) -> str:
+    """SSRF-check a submitted URL, refusing it as a 400 rather than a crash.
+
+    `validate_mcp_url` raises `SSRFBlockedError`, which subclasses `ValueError`
+    and which no handler in `app/api/exception_handlers.py` maps - so pasting a
+    `localhost` server URL into the connection dialog answered 500 "An
+    unexpected error occurred" with `details: null`, and left a traceback in the
+    log, for a guard doing exactly what it is there for. The operator who could
+    have fixed it in five seconds was told the platform had broken (#861).
+
+    `details` names the field rather than repeating the address, and the reason
+    is the validator's own message, which names a host and never a URL - a URL
+    carries a key in its query string (#840).
+
+    Raises:
+        BadRequestError: If the URL is malformed or points inside the
+            deployment's network.
+    """
+    try:
+        return await validate_mcp_url(url)
+    except ValueError as exc:
+        logger.warning("MCP server URL refused: %s", exc)
+        raise BadRequestError(
+            message=f"This MCP server URL cannot be used: {exc}",
+            details={"field": "url"},
+        ) from exc
+
+
 def _apply_token(payload: McpOAuthPayload, token: OAuthToken) -> McpOAuthPayload:
     """Fold a fresh token grant/refresh into the stored payload."""
     return payload.model_copy(
@@ -285,7 +313,7 @@ class McpConnectionService:
         return await mcp_connection_repo.list_for_user(self.db, user_id=user_id)
 
     async def create(self, *, user_id: UUID, data: McpConnectionCreate) -> McpConnection:
-        url = await validate_mcp_url(data.url)
+        url = await _checked_url(data.url)
         existing = await mcp_connection_repo.get_by_name(self.db, user_id=user_id, name=data.name)
         if existing is not None:
             raise AlreadyExistsError(
@@ -320,7 +348,7 @@ class McpConnectionService:
         )
 
         if "url" in update_data:
-            update_data["url"] = await validate_mcp_url(update_data["url"])
+            update_data["url"] = await _checked_url(update_data["url"])
 
         if "name" in update_data and update_data["name"] != db_connection.name:
             collision = await mcp_connection_repo.get_by_name(
@@ -472,7 +500,7 @@ class McpConnectionService:
         once. Two copies of an OAuth handshake is two places for a PKCE verifier
         to be dropped.
         """
-        url = await validate_mcp_url(url)
+        url = await _checked_url(url)
         server = await mcp_oauth.discover(url)  # raises OAuthError if unsupported
         redirect_uri = _oauth_redirect_uri()
         client_id, client_secret = await mcp_oauth.register_client(server, redirect_uri)
@@ -612,7 +640,7 @@ class McpConnectionService:
                 message=f"Unknown catalog server: {data.catalog_key}",
                 details={"catalog_key": data.catalog_key},
             )
-        url = await validate_mcp_url(data.url)
+        url = await _checked_url(data.url)
         existing = await mcp_connection_repo.get_org_scoped_by_name(
             self.db, organization_id=ctx.organization_id, name=data.name
         )
@@ -663,7 +691,7 @@ class McpConnectionService:
         )
 
         if "url" in update_data:
-            update_data["url"] = await validate_mcp_url(update_data["url"])
+            update_data["url"] = await _checked_url(update_data["url"])
 
         if "name" in update_data and update_data["name"] != db_connection.name:
             collision = await mcp_connection_repo.get_org_scoped_by_name(

--- a/backend/tests/api/test_mcp_connection_url_refusal.py
+++ b/backend/tests/api/test_mcp_connection_url_refusal.py
@@ -1,0 +1,137 @@
+"""A blocked MCP server URL, through the app.
+
+The guard itself is covered by `tests/test_ssrf.py`; what is asserted here is
+how its refusal *arrives*. `SSRFBlockedError` subclasses `ValueError`, which no
+handler in `app/api/exception_handlers.py` maps, so every one of these requests
+used to answer 500 "An unexpected error occurred" with `details: null` and a
+traceback in the log - a crash report for the ordinary case of a self-hosted
+deployment pasting a `localhost` address (#861).
+
+The service is the real one; only the session and Redis are mocked. Validation
+refuses before any row is read, so nothing here reaches the database.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.api import deps
+from app.core.config import settings
+from app.core.permissions import AuthContext, OrgRoleName
+from app.main import app
+
+pytestmark = pytest.mark.anyio
+
+# An address that is refused without resolving anything: an IP literal, so no
+# test in this file touches DNS.
+_LOOPBACK_URL = "http://127.0.0.1:3000/mcp"
+
+# The same refusal, asked for by a URL that carries a credential in both places
+# a URL can carry one.
+_URL_WITH_SECRETS = "http://console:hunter2@10.0.0.5:3000/mcp?token=sh-secret-value"
+
+
+@pytest.fixture
+def client(mock_db_session: Any, mock_redis: MagicMock) -> Iterator[Any]:
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    context = AuthContext(user_id=user.id, organization_id=uuid.uuid4(), role=OrgRoleName.OWNER)
+    # An AsyncMock's children are AsyncMocks, so `execute(...).scalar_one_or_none()`
+    # would hand a repository a coroutine nobody awaits.
+    mock_db_session.execute.return_value = MagicMock()
+    app.dependency_overrides[deps.get_db_session] = lambda: mock_db_session
+    app.dependency_overrides[deps.get_redis] = lambda: mock_redis
+    app.dependency_overrides[deps.get_current_user] = lambda: user
+    app.dependency_overrides[deps.get_auth_context] = lambda: context
+
+    @asynccontextmanager
+    async def open_client() -> AsyncIterator[AsyncClient]:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as opened:
+            yield opened
+
+    yield open_client
+    app.dependency_overrides.clear()
+
+
+class TestTheRefusalReachesTheOperator:
+    async def test_a_personal_connection_to_a_loopback_url_is_refused_with_a_400(
+        self, client
+    ) -> None:
+        async with client() as opened:
+            response = await opened.post(
+                f"{settings.API_V1_STR}/me/mcp-connections",
+                json={"name": "internal", "url": _LOOPBACK_URL},
+            )
+
+        assert response.status_code == 400
+        error = response.json()["error"]
+        assert error["code"] == "BAD_REQUEST"
+        assert error["details"] == {"field": "url"}
+
+    async def test_an_organization_connection_to_a_loopback_url_is_refused_with_a_400(
+        self, client
+    ) -> None:
+        async with client() as opened:
+            response = await opened.post(
+                f"{settings.API_V1_STR}/mcp-connections",
+                json={"name": "internal", "url": _LOOPBACK_URL},
+            )
+
+        assert response.status_code == 400
+        error = response.json()["error"]
+        assert error["code"] == "BAD_REQUEST"
+        assert error["details"] == {"field": "url"}
+
+    async def test_starting_oauth_against_a_loopback_url_is_refused_with_a_400(
+        self, client
+    ) -> None:
+        """The OAuth flow validates before it discovers anything, so this is the
+        same refusal one call earlier - and it too used to be a 500."""
+        async with client() as opened:
+            response = await opened.post(
+                f"{settings.API_V1_STR}/me/mcp-connections/oauth/start",
+                json={"name": "internal", "url": _LOOPBACK_URL},
+            )
+
+        assert response.status_code == 400
+        assert response.json()["error"]["code"] == "BAD_REQUEST"
+
+    async def test_the_refusal_says_what_the_reader_can_act_on(self, client) -> None:
+        """A message naming the host is the difference between "fix the address"
+        and "the platform is broken"."""
+        async with client() as opened:
+            response = await opened.post(
+                f"{settings.API_V1_STR}/me/mcp-connections",
+                json={"name": "internal", "url": _LOOPBACK_URL},
+            )
+
+        message = response.json()["error"]["message"]
+        assert "127.0.0.1" in message
+        assert message != "An unexpected error occurred"
+
+
+class TestTheRefusalQuotesNoSecret:
+    async def test_neither_userinfo_nor_a_query_token_appears_in_the_body(self, client) -> None:
+        """`details` names the field, and the message names a host at most.
+
+        A URL carries a key in its query string and a password in its userinfo,
+        and the URL being refused may have been written by the party being
+        refused (`.claude/rules/exceptions-security.md`).
+        """
+        async with client() as opened:
+            response = await opened.post(
+                f"{settings.API_V1_STR}/me/mcp-connections",
+                json={"name": "internal", "url": _URL_WITH_SECRETS},
+            )
+
+        assert response.status_code == 400
+        assert "hunter2" not in response.text
+        assert "sh-secret-value" not in response.text
+        assert response.json()["error"]["details"] == {"field": "url"}

--- a/backend/tests/api/test_mcp_connection_url_refusal.py
+++ b/backend/tests/api/test_mcp_connection_url_refusal.py
@@ -37,6 +37,12 @@ _LOOPBACK_URL = "http://127.0.0.1:3000/mcp"
 # a URL can carry one.
 _URL_WITH_SECRETS = "http://console:hunter2@10.0.0.5:3000/mcp?token=sh-secret-value"
 
+# A third place, and the one the standard library used to read back out: a port
+# that is not a number. `urlsplit` parses it lazily and quotes what it could not
+# cast, so this shape - not the two above - is what an uncontrolled `str(exc)`
+# echoes.
+_URL_WITH_A_SECRET_FOR_A_PORT = "http://mcp.example.com:client_secret=sh-port-secret/mcp"
+
 
 @pytest.fixture
 def client(mock_db_session: Any, mock_redis: MagicMock) -> Iterator[Any]:
@@ -134,4 +140,22 @@ class TestTheRefusalQuotesNoSecret:
         assert response.status_code == 400
         assert "hunter2" not in response.text
         assert "sh-secret-value" not in response.text
+        assert response.json()["error"]["details"] == {"field": "url"}
+
+    async def test_a_secret_parked_where_the_port_belongs_is_not_read_back(self, client) -> None:
+        """The refusal for this one is written by `urlsplit`, not by us.
+
+        It answers a port it cannot cast with `Port could not be cast to integer
+        value as '<what you sent>'`, so a boundary that quotes any `ValueError`
+        echoes whatever was parked there - which is why `_checked_url` catches
+        `UrlRefusedError` and `validate_webhook_url` raises its own for this.
+        """
+        async with client() as opened:
+            response = await opened.post(
+                f"{settings.API_V1_STR}/me/mcp-connections",
+                json={"name": "internal", "url": _URL_WITH_A_SECRET_FOR_A_PORT},
+            )
+
+        assert response.status_code == 400
+        assert "sh-port-secret" not in response.text
         assert response.json()["error"]["details"] == {"field": "url"}

--- a/backend/tests/test_mcp_connections.py
+++ b/backend/tests/test_mcp_connections.py
@@ -26,7 +26,6 @@ from app.agents.mcp import (
 from app.agents.mcp_oauth import McpOAuthPayload
 from app.core.exceptions import AlreadyExistsError, BadRequestError, NotFoundError
 from app.core.permissions import AuthContext, OrgRoleName
-from app.core.sanitize import SSRFBlockedError
 from app.core.vault import VaultScope, seal, unseal
 from app.db.models.mcp_connection import McpConnection
 from app.schemas.mcp_connection import (
@@ -887,9 +886,13 @@ class TestMcpConnectionService:
 
     @pytest.mark.anyio
     async def test_create_blocks_internal_urls(self, service, repo):
+        """As a refusal naming the field, not as the `ValueError` the guard
+        raises - which no handler maps, so it left as a 500 (#861)."""
         data = McpConnectionCreate(name="internal", url="http://127.0.0.1:8000/mcp")
-        with pytest.raises(SSRFBlockedError):
+        with pytest.raises(BadRequestError) as excinfo:
             await service.create(user_id=uuid4(), data=data)
+        assert excinfo.value.details == {"field": "url"}
+        assert excinfo.value.status_code == 400
         repo.create.assert_not_called()
 
     @pytest.mark.anyio
@@ -1082,12 +1085,15 @@ class TestMcpConnectionService:
         conn = _connection(user_id=user_id)
         repo.get_by_id.return_value = conn
 
-        with pytest.raises(SSRFBlockedError):
+        with pytest.raises(BadRequestError) as excinfo:
             await service.update(
                 user_id=user_id,
                 connection_id=conn.id,
                 data=McpConnectionUpdate(url="http://169.254.169.254/mcp"),
             )
+
+        assert excinfo.value.details == {"field": "url"}
+        repo.update.assert_not_called()
 
     @pytest.mark.anyio
     async def test_other_users_connection_is_not_found(self, service, repo):
@@ -1244,10 +1250,11 @@ class TestMcpConnectionService:
 
     @pytest.mark.anyio
     async def test_oauth_start_rejects_internal_urls(self, service, repo):
-        with pytest.raises(SSRFBlockedError):
+        with pytest.raises(BadRequestError) as excinfo:
             await service.oauth_start(
                 user_id=uuid4(), name="evil", url="http://169.254.169.254/mcp"
             )
+        assert excinfo.value.details == {"field": "url"}
         repo.create.assert_not_called()
 
     @pytest.mark.anyio
@@ -1479,10 +1486,11 @@ class TestOrganizationConnections:
 
     @pytest.mark.anyio
     async def test_creating_blocks_internal_urls(self, service, ctx, repo, audit):
-        with pytest.raises(SSRFBlockedError):
+        with pytest.raises(BadRequestError) as excinfo:
             await service.create_for_org(
                 ctx, OrgMcpConnectionCreate(name="internal", url="http://127.0.0.1:8000/mcp")
             )
+        assert excinfo.value.details == {"field": "url"}
         repo.create_org_scoped.assert_not_called()
 
     @pytest.mark.anyio
@@ -1578,6 +1586,21 @@ class TestOrganizationConnections:
         # No new envelope, so the version that sealed the old one is left alone
         # rather than rewritten to describe a token that no longer exists.
         assert "secret_key_version" not in update_data
+
+    @pytest.mark.anyio
+    async def test_moving_the_url_somewhere_internal_is_refused_by_field(self, service, ctx, repo):
+        """The other half of #861: a connection may not be *edited* into the
+        deployment's own network either, and that refusal is a 400 too."""
+        conn = self._org_connection(ctx)
+        repo.get_org_scoped_by_id.return_value = conn
+
+        with pytest.raises(BadRequestError) as excinfo:
+            await service.update_for_org(
+                ctx, connection_id=conn.id, data=OrgMcpConnectionUpdate(url="http://[::1]/mcp")
+            )
+
+        assert excinfo.value.details == {"field": "url"}
+        repo.update.assert_not_called()
 
     @pytest.mark.anyio
     async def test_moving_the_url_discards_the_previous_check_result(

--- a/backend/tests/test_ssrf.py
+++ b/backend/tests/test_ssrf.py
@@ -9,6 +9,7 @@ import pytest
 
 from app.core.sanitize import (
     SSRFBlockedError,
+    UrlRefusedError,
     _is_ip_blocked,
     validate_webhook_url,
 )
@@ -221,6 +222,49 @@ class TestRefusalText:
         assert "oauth.attacker.test" in message
         assert "sh-secret" not in message
 
+    def test_a_malformed_port_is_refused_without_quoting_what_was_sent(self):
+        """The one refusal the standard library used to write for us.
+
+        `urlsplit` parses the port at attribute access and answers a bad one
+        with `Port could not be cast to integer value as '<what you sent>'` -
+        so a secret parked where a port belongs came back out through every
+        caller that quotes the message (#861).
+        """
+        with pytest.raises(UrlRefusedError) as excinfo:
+            validate_webhook_url("http://example.com:client_secret=sh-secret-value/mcp")
+
+        assert "sh-secret-value" not in str(excinfo.value)
+
+
+class TestEveryRefusalIsWrittenHere:
+    """The type is what makes a message safe to quote to a person.
+
+    `mcp_connection._checked_url` puts it in a 400 and
+    `agent_registry._browser_use_problems` puts it in a publish problem, and
+    both may do that only because the message was written in this repository
+    (`.claude/rules/exceptions-security.md`). A bare `ValueError` from here
+    would be the standard library describing what the caller sent.
+    """
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "ftp://example.com/hook",
+            "https:///reset",
+            "http://[::1",
+            "http://user:pass@example.com/hook",
+            "http://127.0.0.1/hook",
+            "http://example.com:not-a-port/hook",
+            # A public IP literal, so the port is the only thing wrong with it -
+            # and it is read before the IP-literal branch, which used to return
+            # this URL as validated for a client that cannot dial it.
+            "http://8.8.8.8:not-a-port/hook",
+        ],
+    )
+    def test_a_refused_url_raises_our_own_type(self, url: str):
+        with pytest.raises(UrlRefusedError):
+            validate_webhook_url(url)
+
 
 # SSRFBlockedError is a subclass of ValueError
 
@@ -230,6 +274,11 @@ class TestSSRFBlockedError:
 
     def test_is_value_error_subclass(self):
         assert issubclass(SSRFBlockedError, ValueError)
+
+    def test_is_a_refusal_written_here(self):
+        """What lets `_checked_url` catch the narrow type and still cover
+        blocks."""
+        assert issubclass(SSRFBlockedError, UrlRefusedError)
 
     def test_catchable_as_value_error(self):
         with pytest.raises(ValueError):

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -31,10 +31,13 @@ Atlassian works alongside a streamable-HTTP one with nothing to configure.
 **An address this deployment must not reach is refused, and the refusal says
 so.** A URL that resolves to a loopback, private, link-local or shared-CGNAT
 address, one that does not resolve at all, one carrying credentials in its
-userinfo, or one on a scheme other than `http`/`https`, comes back as a **400**
+userinfo, one on a scheme other than `http`/`https`, or one that is simply
+malformed, comes back as a **400**
 naming `url` as the field at fault — on create, on edit, and on starting an
 OAuth flow, personal and organization-wide alike. What it names beyond that is
-the *host*, never the URL, because a URL carries a key in its query string. It
+the *host*, never the URL — a URL carries a key in its query string, and the
+sentence explaining the refusal is one written in this repository rather than
+whatever the URL parser had to say about the text you sent. It
 used to be a 500 with no details and a traceback in the log, which reads as the
 platform breaking rather than as an address to correct
 ([#861](https://github.com/vstorm-co/agenticos/issues/861)) — self-hosting and

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -28,6 +28,18 @@ Atlassian works alongside a streamable-HTTP one with nothing to configure.
 | `is_enabled` | Off without losing the credential |
 | `last_status` | What the last probe found, and when |
 
+**An address this deployment must not reach is refused, and the refusal says
+so.** A URL that resolves to a loopback, private, link-local or shared-CGNAT
+address, one that does not resolve at all, one carrying credentials in its
+userinfo, or one on a scheme other than `http`/`https`, comes back as a **400**
+naming `url` as the field at fault — on create, on edit, and on starting an
+OAuth flow, personal and organization-wide alike. What it names beyond that is
+the *host*, never the URL, because a URL carries a key in its query string. It
+used to be a 500 with no details and a traceback in the log, which reads as the
+platform breaking rather than as an address to correct
+([#861](https://github.com/vstorm-co/agenticos/issues/861)) — self-hosting and
+pasting a `localhost` URL is the ordinary case, not the exotic one.
+
 ### Personal or organization-wide
 
 Two kinds, and the difference is the point.


### PR DESCRIPTION
## What this fixes

Pasting an internal MCP server URL into the connection dialog answered **500
"An unexpected error occurred"** with `details: null`, and left a traceback in
the log. The guard was working exactly as designed; only its presentation was
wrong — and what an operator reads from a 500 is "the platform is broken", so
the report that arrives is a crash report rather than "I pointed it at a host it
will not reach".

`SSRFBlockedError` subclasses `ValueError`, and `register_exception_handlers`
maps `AppException`, `BudgetExceeded`, `RequestValidationError` and bare
`Exception` — nothing in between, so it fell through to
`unhandled_exception_handler`. Self-hosting and typing a `localhost` address is
the ordinary case here, not the exotic one.

## The change

All five call sites — `create`, `update`, `_oauth_start`, `create_for_org`,
`update_for_org` — go through one `_checked_url` helper rather than calling
`validate_mcp_url` directly, so the two scopes and the three verbs are one
refusal instead of five chances to forget:

```python
raise BadRequestError(
    message=f"This MCP server URL cannot be used: {exc}",
    details={"field": "url"},
) from exc
```

`details` names the **field**, never the endpoint. The reason comes from the
validator's own message, which is safe to surface because #842 narrowed those
messages to name a host and never a URL — a URL carries a key in its query
string, and the one being refused may have been written by the party being
refused (`.claude/rules/exceptions-security.md`). The traceback becomes a
`logger.warning` naming the same thing.

**One follow-on in `sanitize.py`.** Those messages named the wrong caller:
`validate_webhook_url` has had no webhook caller for some time, so every one of
them said "Webhook URL blocked: …" to somebody who had typed an *MCP server URL*
or a `cdp_url`. Surfacing them made that visible; the noun goes, the host stays.
It fixes the browser-automation publish problem in the same stroke, which had
been reading "…cannot be reached from here: Webhook URL blocked: …".

## What is asserted

- `tests/api/test_mcp_connection_url_refusal.py` (new) — through the app, real
  service, only the session and Redis mocked. A loopback URL on the personal
  create route, the organization create route and `oauth/start` each answer
  **400** with `error.code == "BAD_REQUEST"` and `details == {"field": "url"}`;
  the message names the host rather than being the generic sentence; and a URL
  carrying `console:hunter2@` plus `?token=sh-secret-value` leaves **neither**
  in the response body. All five fail on `main` — three of them with a 500.
- `tests/test_mcp_connections.py` — the four service tests that asserted the raw
  `SSRFBlockedError` now assert the field-named 400 and that the repository was
  never called, plus a fifth for `update_for_org`, the one call site that had
  no test at all: a connection may not be *edited* onto an internal address
  either.

## Sweep

`SSRFBlockedError` is the only `ValueError` subclass in `app/`, and this change
covers every one of its callers that a request can reach. `validate_cdp_url`'s
caller was already correct — `agent_registry._browser_use_problems` catches
`ValueError` and turns it into a publish problem — and the OAuth hops inside
`mcp_oauth` already convert theirs to `OAuthError`, which both route modules map
to a 400.

The wider sweep — every plain `ValueError` in `app/services/**` and
`app/agents/**` that a request can reach uncaught — found two more, both a
different defect and both filed rather than folded in here:

- **#873** — `POST /agents/{id}/spec.yaml` calls `AgentSpec.from_yaml` inline in
  the route expression, so a typo in a hand-edited spec is a 500. A raw pydantic
  `ValidationError` is a `ValueError` but **not** a `RequestValidationError`, so
  the validation handler never sees it and no field path reaches the person who
  edited the file. Worst of the three: bad input is this endpoint's ordinary case.
- **#874** — an `ingestion` override whose `chunk_overlap` is at or above the
  collection's `chunk_size` is refused by a validator whose own docstring says
  "the form is what says so", and the form gets a 500.

Seen and **not** filed: `embed_query` raising on an embedding-dimension mismatch
(`app/services/rag/embeddings.py:159`) reaches `POST /rag/search` uncaught, but
that is a misconfigured deployment rather than caller input, and 5xx is the right
class for it. The message is worth surfacing one day; the status code is not wrong.

Everything else checked out: `users.py:57` already catches the avatar
`ValueError`, capability config goes through `CapabilityDef.validate_config`, and
the RAG parser/splitter raises are worker-side, where no client is waiting.

## Verification

`make test` — 5589 passed, 15 skipped, **100.00%** on the platform layer.
`make lint` and `make docs-build` green. `make db-check` not run: no model
changed, and no database was reachable locally. `test-frontend-cov` and
`build-frontend` not run and not applicable — this branch touches no frontend
file, and CI skips them on the same grounds.

`docs/mcp.md` gains what a connection's `url` now answers when it is refused;
`python3 scripts/docs_drift.py` is quiet.

Closes #861

## Review round — the fix had the defect it was fixing

Codex found that `_checked_url` caught `ValueError` broadly, and not everything
that catches is ours. `urlsplit` parses the port at attribute access, so
`http://example.com:client_secret=abc123/mcp` came back as `Port could not be
cast to integer value as 'client_secret=abc123'` — the standard library quoting
the caller's text straight into the response body.

Fixed at the source, not at the boundary, because
`agent_registry._browser_use_problems` quotes the same `{exc}` into a publish
problem: sanitising it in the MCP service alone would have left the `cdp_url`
path echoing.

- `UrlRefusedError(ValueError)` is now the base for refusals written here, with
  `SSRFBlockedError` under it and the two bare `ValueError` raises converted —
  the type is what says a message may be shown to a person.
- The port is read inside a `try` answering with our own sentence, and read
  **before** the IP-literal branch: that branch's `except ValueError: pass`
  would otherwise swallow the new refusal, and a public IP literal with a
  garbage port (`http://8.8.8.8:not-a-port/x`) used to be returned as validated
  for a client that cannot dial it.
- `_checked_url` catches the narrow type, with no second branch for a
  controlled sentence — nothing below the validator can raise a bare
  `ValueError` now, so it would be unreachable. If one ever appears it is a bug,
  and the generic 500 (empty body, traceback in the log) is the honest answer.
- The warning line still quotes the message, deliberately and with a comment
  saying so: that text is ours in the log as much as in the body.

Both new tests fail without it: the API one posts a URL of exactly that shape
and asserts the secret appears nowhere in the body (verified by reverting the
two lines), and `TestEveryRefusalIsWrittenHere` parametrises seven shapes over
the invariant itself, so the next bare `ValueError` fails a test rather than
reaching a response body.

Re-verified: `make test` — 5599 passed, 15 skipped, **100.00%** on the platform
layer (18m29s; this run picked up `tests/integration/` against a real database).
`make lint` green, `scripts/docs_drift.py` quiet.
