### PR TITLE
fix(builder): stop the model picker calling a failed read an empty org

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -296,6 +296,8 @@
     "modelIdOpenRouterHint": "Namespaced by origin, as OpenRouter lists it - openai/gpt-5, anthropic/claude-opus-5.",
     "modelIdProviderHint": "As the provider names it. Free text, because they ship new ones faster than any list here could be updated.",
     "modelTheseRunsHad": "A model in these runs had no price, so this is a floor.",
+    "modelsCouldNotBeListed": "Models could not be listed",
+    "modelsCouldNotBeListedHint": "This panel is empty because the request for this organization's models did not answer, not because it has none.",
     "moreActionsFor": "More actions for {name}",
     "name": "Name",
     "name2": "Name",

--- a/frontend/src/app/[locale]/(dashboard)/agents/[id]/model-panel.integration.test.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/agents/[id]/model-panel.integration.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import AgentBuilderPage from "./page";
 import type { AgentSpec } from "@/types/agents";
+import type { ProfilesStatus } from "@/hooks/use-model-providers";
 import { Perm } from "@/types/permissions";
 import type { Permission } from "@/types/permissions";
 
@@ -39,7 +40,7 @@ const state = {
   // Both queries settle successfully by default; a case that wants the failed
   // or still-pending read says so, because that is where an empty list stops
   // meaning "the organization has none".
-  profilesLoaded: true,
+  profilesStatus: "loaded" as ProfilesStatus,
   permissionsLoaded: true,
 };
 
@@ -89,7 +90,7 @@ vi.mock("@/hooks", () => ({
   useMcpCatalog: () => ({ servers: [] }),
   useModelProviders: () => ({
     profiles: state.profiles,
-    profilesLoaded: state.profilesLoaded,
+    profilesStatus: state.profilesStatus,
     refetchProfiles,
     isLoading: false,
     deleteProfile: { mutate: vi.fn() },
@@ -145,7 +146,7 @@ async function mount() {
 beforeEach(() => {
   state.permissions = [Perm.agentsEdit];
   state.profiles = [MODEL_PROFILE];
-  state.profilesLoaded = true;
+  state.profilesStatus = "loaded";
   state.permissionsLoaded = true;
 });
 
@@ -213,10 +214,25 @@ describe("the Builder's model panel", () => {
     // because `/providers/model-profiles` answered 502. The panel says what is
     // actually known, which is that the read did not land (#863).
     state.profiles = [];
-    state.profilesLoaded = false;
+    state.profilesStatus = "failed";
     await mount();
 
     expect(await screen.findByText("Models could not be listed")).toBeInTheDocument();
+    expect(screen.queryByText(/organization has no models/)).toBeNull();
+    expect(screen.queryByText(/no model yet/)).toBeNull();
+  });
+
+  it("raises nothing at all while the model profiles are still being read", async () => {
+    // The cold load of the Builder, which is the ordinary path rather than an
+    // event: an empty list nobody has answered for yet is neither a dead end
+    // nor a failure, and a destructive panel here would fire on every first
+    // paint until it stopped being read.
+    state.profiles = [];
+    state.profilesStatus = "pending";
+    await mount();
+
+    expect(await screen.findByRole("status", { name: "Loading" })).toBeInTheDocument();
+    expect(screen.queryByText("Models could not be listed")).toBeNull();
     expect(screen.queryByText(/organization has no models/)).toBeNull();
     expect(screen.queryByText(/no model yet/)).toBeNull();
   });

--- a/frontend/src/app/[locale]/(dashboard)/agents/[id]/model-panel.integration.test.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/agents/[id]/model-panel.integration.test.tsx
@@ -31,6 +31,8 @@ const MODEL_PROFILE = {
   secret_id: "s-1",
 };
 
+const refetchProfiles = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
 const state = {
   permissions: [] as Permission[],
   profiles: [MODEL_PROFILE] as (typeof MODEL_PROFILE)[],
@@ -88,6 +90,7 @@ vi.mock("@/hooks", () => ({
   useModelProviders: () => ({
     profiles: state.profiles,
     profilesLoaded: state.profilesLoaded,
+    refetchProfiles,
     isLoading: false,
     deleteProfile: { mutate: vi.fn() },
     createProfile: { mutateAsync: vi.fn(), isPending: false },
@@ -202,16 +205,19 @@ describe("the Builder's model panel", () => {
     expect(screen.queryByText(/no model yet/)).toBeNull();
   });
 
-  it("stays quiet when the model profiles could not be read", async () => {
+  it("claims nothing about the organization when the model profiles could not be read", async () => {
     // The empty-page trap: a request that failed and an organization with no
     // model are the same empty list, and only one of them is a dead end. An
-    // organization with a dozen models must not be told it has none because
-    // `/providers/model-profiles` answered 502.
+    // organization with a dozen models must not be told it has none, that its
+    // agents cannot run, or that a permission is what stands in the way -
+    // because `/providers/model-profiles` answered 502. The panel says what is
+    // actually known, which is that the read did not land (#863).
     state.profiles = [];
     state.profilesLoaded = false;
     await mount();
 
-    expect(await screen.findByText(/organization has no models/)).toBeInTheDocument();
+    expect(await screen.findByText("Models could not be listed")).toBeInTheDocument();
+    expect(screen.queryByText(/organization has no models/)).toBeNull();
     expect(screen.queryByText(/no model yet/)).toBeNull();
   });
 

--- a/frontend/src/app/[locale]/(dashboard)/agents/[id]/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/agents/[id]/page.tsx
@@ -840,6 +840,7 @@ export default function AgentBuilderPage({ params }: PageProps) {
                   // so it is the one panel that also takes one away.
                   allowRemove={can(Perm.connectionsManage)}
                   profiles={profiles}
+                  profilesLoaded={profilesLoaded}
                   value={spec.model_profile_id ?? null}
                   onChange={(model_profile_id) => update({ model_profile_id })}
                   disabled={!canEdit}

--- a/frontend/src/app/[locale]/(dashboard)/agents/[id]/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/agents/[id]/page.tsx
@@ -123,7 +123,7 @@ export default function AgentBuilderPage({ params }: PageProps) {
   const { environments, promote } = useAgentEnvironments(id);
   const { agents, clone, archive, unarchive, remove } = useAgents();
   const { capabilities } = useCapabilityCatalog();
-  const { profiles, profilesLoaded } = useModelProviders();
+  const { profiles, profilesStatus } = useModelProviders();
   // The Builder holds the set rather than paging it: the gallery has to know
   // which selected skills still exist, and it can only tell that from what it
   // has. 100 is the endpoint's ceiling; `total` says when that is not all.
@@ -180,10 +180,14 @@ export default function AgentBuilderPage({ params }: PageProps) {
   // A builder who cannot add a model, in an organization that has none, can
   // create a draft they can never make work. Both halves are read from a
   // *settled* query rather than from "no longer loading": a profiles read that
-  // failed also answers `[]`, and `can()` answers false until the set is in, so
+  // failed or is still in flight also answers `[]` - hence `"loaded"` rather
+  // than "not pending" - and `can()` answers false until the set is in, so
   // either alone tells a caller who has models, or who may add one, they are stuck.
   const modelDeadEnd =
-    profilesLoaded && profiles.length === 0 && permissionsLoaded && !can(Perm.connectionsManage);
+    profilesStatus === "loaded" &&
+    profiles.length === 0 &&
+    permissionsLoaded &&
+    !can(Perm.connectionsManage);
 
   // A draft differs from what is live the moment anything is edited. Showing
   // that difference is what stops someone testing a change that never shipped.
@@ -840,7 +844,7 @@ export default function AgentBuilderPage({ params }: PageProps) {
                   // so it is the one panel that also takes one away.
                   allowRemove={can(Perm.connectionsManage)}
                   profiles={profiles}
-                  profilesLoaded={profilesLoaded}
+                  profilesStatus={profilesStatus}
                   value={spec.model_profile_id ?? null}
                   onChange={(model_profile_id) => update({ model_profile_id })}
                   disabled={!canEdit}

--- a/frontend/src/components/agents/model-profile-picker.test.tsx
+++ b/frontend/src/components/agents/model-profile-picker.test.tsx
@@ -77,7 +77,7 @@ function mount(props: Partial<Parameters<typeof ModelProfilePicker>[0]> = {}) {
     // what the organization has is one the list cannot support before then.
     <ModelProfilePicker
       profiles={[profile()]}
-      profilesLoaded
+      profilesStatus="loaded"
       value={null}
       onChange={vi.fn()}
       {...props}
@@ -147,7 +147,13 @@ describe("ModelProfilePicker", () => {
     // fields kept the nothing they mounted with. "Choose a provider" over an agent
     // that plainly has one - which passed on a warm laptop and failed in CI.
     const { rerender } = render(
-      <ModelProfilePicker profiles={[]} profilesLoaded value="p1" allowAdd onChange={vi.fn()} />,
+      <ModelProfilePicker
+        profiles={[]}
+        profilesStatus="loaded"
+        value="p1"
+        allowAdd
+        onChange={vi.fn()}
+      />,
       { wrapper },
     );
     expect(screen.getByTestId("form-starts-on")).toHaveTextContent("nothing");
@@ -155,7 +161,7 @@ describe("ModelProfilePicker", () => {
     rerender(
       <ModelProfilePicker
         profiles={[profile()]}
-        profilesLoaded
+        profilesStatus="loaded"
         value="p1"
         allowAdd
         onChange={vi.fn()}
@@ -203,7 +209,7 @@ describe("ModelProfilePicker", () => {
     // the same `[]` an organization with no model does, so this panel told a
     // builder with a dozen models that it had none and that its agents could not
     // run - on a 502 (#863).
-    mount({ profiles: [], profilesLoaded: false });
+    mount({ profiles: [], profilesStatus: "failed" });
 
     expect(screen.queryByText(/no models yet/)).toBeNull();
     expect(screen.getByText("Models could not be listed")).toBeInTheDocument();
@@ -220,17 +226,41 @@ describe("ModelProfilePicker", () => {
     // failed: a control that quietly is not there reads as the product not
     // having it. The form above is untouched - this failed at listing what
     // exists, not at writing.
-    mount({ allowAdd: true, profiles: [], profilesLoaded: false });
+    mount({ allowAdd: true, profiles: [], profilesStatus: "failed" });
 
     expect(screen.getByText("Models could not be listed")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Add model" })).toBeInTheDocument();
+  });
+
+  it("neither claims nor blames while the read is still in flight", () => {
+    // Every cold load of this panel starts here, with `[]` and nothing settled.
+    // Saying the organization has no models would be the defect this file
+    // exists for; a destructive failure panel on the ordinary path would be
+    // worse - a false alarm often enough to teach people to ignore the one that
+    // is real. It waits instead.
+    mount({ profiles: [], profilesStatus: "pending" });
+
+    expect(screen.queryByText(/no models yet/)).toBeNull();
+    expect(screen.queryByText("Models could not be listed")).toBeNull();
+    expect(screen.getByRole("status", { name: "Loading" })).toBeInTheDocument();
+  });
+
+  it("says nothing about saved models while the read is still in flight either", () => {
+    // The add-capable shape has no gap to fill: the form is the panel and it
+    // already works, so a wait would stand in for a disclosure that may have
+    // nothing to disclose.
+    mount({ allowAdd: true, profiles: [], profilesStatus: "pending" });
+
+    expect(screen.getByRole("button", { name: "Add model" })).toBeInTheDocument();
+    expect(screen.queryByText("Models could not be listed")).toBeNull();
+    expect(screen.queryByRole("status", { name: "Loading" })).toBeNull();
   });
 
   it("keeps the saved models it already has when a later read fails", () => {
     // A refetch that errors over a list already on screen leaves that list
     // standing: stale rows somebody can still choose from beat a red panel
     // instead of them.
-    mount({ allowAdd: true, profilesLoaded: false });
+    mount({ allowAdd: true, profilesStatus: "failed" });
 
     expect(screen.getByText("Use a saved model (1)")).toBeInTheDocument();
     expect(screen.queryByText("Models could not be listed")).toBeNull();

--- a/frontend/src/components/agents/model-profile-picker.test.tsx
+++ b/frontend/src/components/agents/model-profile-picker.test.tsx
@@ -16,7 +16,8 @@ vi.mock("@/lib/api-client", async () => {
 });
 
 const deleteProfile = vi.hoisted(() => ({ mutate: vi.fn() }));
-vi.mock("@/hooks", () => ({ useModelProviders: () => ({ deleteProfile }) }));
+const refetchProfiles = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock("@/hooks", () => ({ useModelProviders: () => ({ deleteProfile, refetchProfiles }) }));
 
 // The real form is a provider, a model id and a key from the vault, tested in
 // `add-model.integration.test.tsx`. What this panel owes it is the callback: a
@@ -71,9 +72,18 @@ function profile(overrides: Partial<ModelProfile> = {}): ModelProfile {
 }
 
 function mount(props: Partial<Parameters<typeof ModelProfilePicker>[0]> = {}) {
-  render(<ModelProfilePicker profiles={[profile()]} value={null} onChange={vi.fn()} {...props} />, {
-    wrapper,
-  });
+  render(
+    // Loaded unless a case says otherwise: every claim this panel makes about
+    // what the organization has is one the list cannot support before then.
+    <ModelProfilePicker
+      profiles={[profile()]}
+      profilesLoaded
+      value={null}
+      onChange={vi.fn()}
+      {...props}
+    />,
+    { wrapper },
+  );
 }
 
 describe("ModelProfilePicker", () => {
@@ -137,12 +147,20 @@ describe("ModelProfilePicker", () => {
     // fields kept the nothing they mounted with. "Choose a provider" over an agent
     // that plainly has one - which passed on a warm laptop and failed in CI.
     const { rerender } = render(
-      <ModelProfilePicker profiles={[]} value="p1" allowAdd onChange={vi.fn()} />,
+      <ModelProfilePicker profiles={[]} profilesLoaded value="p1" allowAdd onChange={vi.fn()} />,
       { wrapper },
     );
     expect(screen.getByTestId("form-starts-on")).toHaveTextContent("nothing");
 
-    rerender(<ModelProfilePicker profiles={[profile()]} value="p1" allowAdd onChange={vi.fn()} />);
+    rerender(
+      <ModelProfilePicker
+        profiles={[profile()]}
+        profilesLoaded
+        value="p1"
+        allowAdd
+        onChange={vi.fn()}
+      />,
+    );
 
     expect(screen.getByTestId("form-starts-on")).toHaveTextContent("openai default");
   });
@@ -177,6 +195,45 @@ describe("ModelProfilePicker", () => {
     // tell (the delegation picker passes none yet its caller may hold it).
     expect(screen.getByText(/added in the Builder/)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Add a model" })).toBeNull();
+  });
+
+  it("does not tell an organization it has no models when the read did not answer", async () => {
+    // The empty-page trap, in the one panel that turns an empty list into a
+    // sentence: a refused or failed `/providers/model-profiles` arrives here as
+    // the same `[]` an organization with no model does, so this panel told a
+    // builder with a dozen models that it had none and that its agents could not
+    // run - on a 502 (#863).
+    mount({ profiles: [], profilesLoaded: false });
+
+    expect(screen.queryByText(/no models yet/)).toBeNull();
+    expect(screen.getByText("Models could not be listed")).toBeInTheDocument();
+    expect(screen.getByText(/did not answer/)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(refetchProfiles).toHaveBeenCalled();
+  });
+
+  it("says the saved models are missing rather than silently offering none", () => {
+    // The add-capable shape drops the disclosure when the list is empty, which
+    // is right for an organization that has saved none and wrong for a read that
+    // failed: a control that quietly is not there reads as the product not
+    // having it. The form above is untouched - this failed at listing what
+    // exists, not at writing.
+    mount({ allowAdd: true, profiles: [], profilesLoaded: false });
+
+    expect(screen.getByText("Models could not be listed")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add model" })).toBeInTheDocument();
+  });
+
+  it("keeps the saved models it already has when a later read fails", () => {
+    // A refetch that errors over a list already on screen leaves that list
+    // standing: stale rows somebody can still choose from beat a red panel
+    // instead of them.
+    mount({ allowAdd: true, profilesLoaded: false });
+
+    expect(screen.getByText("Use a saved model (1)")).toBeInTheDocument();
+    expect(screen.queryByText("Models could not be listed")).toBeNull();
   });
 
   it("moves the agent onto the model that was just created", async () => {

--- a/frontend/src/components/agents/model-profile-picker.tsx
+++ b/frontend/src/components/agents/model-profile-picker.tsx
@@ -5,9 +5,10 @@ import { Check, ChevronRight, KeyRound, Trash2 } from "lucide-react";
 
 import { AddModel } from "@/components/agents/add-model";
 import { ProviderIcon } from "@/components/vault/provider-icon";
-import { ErrorState } from "@/components/states";
+import { ErrorState, LoadingState } from "@/components/states";
 import { Badge, Button } from "@/components/ui";
 import { useModelProviders } from "@/hooks";
+import type { ProfilesStatus } from "@/hooks/use-model-providers";
 import { modelDetail } from "@/lib/model-profiles";
 import { cn } from "@/lib/utils";
 import type { ModelProfile } from "@/types/providers";
@@ -16,16 +17,16 @@ import { useTranslations } from "next-intl";
 interface ModelProfilePickerProps {
   profiles: ModelProfile[];
   /**
-   * Whether `profiles` is the organization's answer rather than a placeholder.
+   * What `profiles` is: the organization's answer, a read still in flight, or
+   * one that failed.
    *
-   * The list arrives as `?? []`, so a refused or failed read of
-   * `/providers/model-profiles` reaches this panel as the same empty array an
-   * organization with no model does - and this panel turns an empty array into a
-   * sentence. Its callers hold the query and this is `profilesLoaded` from
-   * `useModelProviders`, the same distinction the Builder's own notice is gated
-   * on (#846).
+   * The list arrives as `?? []`, so all three reach this panel as the same empty
+   * array - and this panel turns an empty array into a sentence. Its callers
+   * hold the query and this is `profilesStatus` from `useModelProviders`, the
+   * same value the Builder's own dead-end notice is gated on, so the two
+   * surfaces cannot drift.
    */
-  profilesLoaded: boolean;
+  profilesStatus: ProfilesStatus;
   /** `null` means "whatever the organization's default is". */
   value: string | null;
   onChange: (profileId: string | null) => void;
@@ -81,12 +82,15 @@ interface ModelProfilePickerProps {
  * model can be deleted from here. They were the same flag until the
  * knowledge-base dialog needed one without the other.
  *
- * An empty list is two different facts and the panel says which. "This
+ * An empty list is three different facts and the panel says which. "This
  * organization has no models yet. An agent cannot run without one" is a claim
  * about an organization, and it used to be made from an array that a 502 on
  * `/providers/model-profiles` degrades to `[]` - so a builder with a dozen
  * models was told it had none and that its agents could not run, because one
- * request failed (#863). `profilesLoaded` is what separates them.
+ * request failed (#863). The third is the ordinary one: the read is still in
+ * flight on every cold load, and a failure panel there would be a false alarm
+ * on the path everybody takes, which is how a warning stops being read at all.
+ * `profilesStatus` is what separates them.
  *
  * The current-model line renders in both shapes. It says whether the profile
  * that will actually be used has a key, which is the fact that decides whether
@@ -95,7 +99,7 @@ interface ModelProfilePickerProps {
  */
 export function ModelProfilePicker({
   profiles,
-  profilesLoaded,
+  profilesStatus,
   value,
   onChange,
   allowAdd = false,
@@ -161,10 +165,10 @@ export function ModelProfilePicker({
     </div>
   ) : null;
 
-  // An empty list nobody has answered for. Every sentence below about what this
-  // organization has is a claim the list cannot support until then, so the panel
-  // says what is actually known - the read did not land - and offers it again.
-  const unanswered = (
+  // An empty list the read failed on. Every sentence below about what this
+  // organization has is a claim that list cannot support, so the panel says what
+  // is actually known - the read did not land - and offers it again.
+  const failed = (
     <ErrorState
       title={t("modelsCouldNotBeListed")}
       description={t("modelsCouldNotBeListedHint")}
@@ -176,7 +180,11 @@ export function ModelProfilePicker({
   // saying which of them is in use.
   if (!allowAdd) {
     if (profiles.length === 0) {
-      if (!profilesLoaded) return unanswered;
+      if (profilesStatus === "failed") return failed;
+      // Still in flight, which is every cold load of this panel: a wait shaped
+      // like the rows it is waiting for, rather than a claim about the
+      // organization or a failure that has not happened.
+      if (profilesStatus === "pending") return <LoadingState variant="skeleton-list" rows={2} />;
       // No models, and this caller cannot add one — the Builder hid the form
       // above. Say why and where the fix is, rather than leave them to discover it
       // at publish: an agent with no model is refused there, and the only ways to
@@ -232,11 +240,13 @@ export function ModelProfilePicker({
         }}
       />
 
-      {/* The disclosure is absent either because the organization has saved no
-          model or because nobody knows - and a control that quietly is not there
-          reads as the product not having it. The form above is unaffected: adding
-          a model is a write, and this failed at listing what exists. */}
-      {profiles.length === 0 && !profilesLoaded && unanswered}
+      {/* The disclosure below is absent either because the organization has saved
+          no model or because the read that would have said so failed - and a
+          control that quietly is not there reads as the product not having it.
+          Nothing is said while that read is still in flight: the form above is
+          the panel here and it already works, so a wait would stand in for a
+          disclosure that may well have nothing to disclose. */}
+      {profiles.length === 0 && profilesStatus === "failed" && failed}
 
       {profiles.length > 0 && (
         <details className="group">

--- a/frontend/src/components/agents/model-profile-picker.tsx
+++ b/frontend/src/components/agents/model-profile-picker.tsx
@@ -5,6 +5,7 @@ import { Check, ChevronRight, KeyRound, Trash2 } from "lucide-react";
 
 import { AddModel } from "@/components/agents/add-model";
 import { ProviderIcon } from "@/components/vault/provider-icon";
+import { ErrorState } from "@/components/states";
 import { Badge, Button } from "@/components/ui";
 import { useModelProviders } from "@/hooks";
 import { modelDetail } from "@/lib/model-profiles";
@@ -14,6 +15,17 @@ import { useTranslations } from "next-intl";
 
 interface ModelProfilePickerProps {
   profiles: ModelProfile[];
+  /**
+   * Whether `profiles` is the organization's answer rather than a placeholder.
+   *
+   * The list arrives as `?? []`, so a refused or failed read of
+   * `/providers/model-profiles` reaches this panel as the same empty array an
+   * organization with no model does - and this panel turns an empty array into a
+   * sentence. Its callers hold the query and this is `profilesLoaded` from
+   * `useModelProviders`, the same distinction the Builder's own notice is gated
+   * on (#846).
+   */
+  profilesLoaded: boolean;
   /** `null` means "whatever the organization's default is". */
   value: string | null;
   onChange: (profileId: string | null) => void;
@@ -69,6 +81,13 @@ interface ModelProfilePickerProps {
  * model can be deleted from here. They were the same flag until the
  * knowledge-base dialog needed one without the other.
  *
+ * An empty list is two different facts and the panel says which. "This
+ * organization has no models yet. An agent cannot run without one" is a claim
+ * about an organization, and it used to be made from an array that a 502 on
+ * `/providers/model-profiles` degrades to `[]` - so a builder with a dozen
+ * models was told it had none and that its agents could not run, because one
+ * request failed (#863). `profilesLoaded` is what separates them.
+ *
  * The current-model line renders in both shapes. It says whether the profile
  * that will actually be used has a key, which is the fact that decides whether
  * the run - or the ingestion - can happen at all, and it is not something one
@@ -76,6 +95,7 @@ interface ModelProfilePickerProps {
  */
 export function ModelProfilePicker({
   profiles,
+  profilesLoaded,
   value,
   onChange,
   allowAdd = false,
@@ -83,7 +103,8 @@ export function ModelProfilePicker({
   disabled,
 }: ModelProfilePickerProps) {
   const t = useTranslations("agents");
-  const { deleteProfile } = useModelProviders();
+  const tc = useTranslations("common");
+  const { deleteProfile, refetchProfiles } = useModelProviders();
   const selected = profiles.find((profile) => profile.id === value);
   // Generated rather than a constant: the Builder and a dialog can both have a
   // picker mounted, and two elements answering to one id makes the second group's
@@ -140,10 +161,22 @@ export function ModelProfilePicker({
     </div>
   ) : null;
 
+  // An empty list nobody has answered for. Every sentence below about what this
+  // organization has is a claim the list cannot support until then, so the panel
+  // says what is actually known - the read did not land - and offers it again.
+  const unanswered = (
+    <ErrorState
+      title={t("modelsCouldNotBeListed")}
+      description={t("modelsCouldNotBeListedHint")}
+      cta={{ label: tc("retry"), onClick: () => void refetchProfiles() }}
+    />
+  );
+
   // A panel that only chooses between what exists is the list, and the line
   // saying which of them is in use.
   if (!allowAdd) {
     if (profiles.length === 0) {
+      if (!profilesLoaded) return unanswered;
       // No models, and this caller cannot add one — the Builder hid the form
       // above. Say why and where the fix is, rather than leave them to discover it
       // at publish: an agent with no model is refused there, and the only ways to
@@ -198,6 +231,12 @@ export function ModelProfilePicker({
           onChange(profile.id);
         }}
       />
+
+      {/* The disclosure is absent either because the organization has saved no
+          model or because nobody knows - and a control that quietly is not there
+          reads as the product not having it. The form above is unaffected: adding
+          a model is a write, and this failed at listing what exists. */}
+      {profiles.length === 0 && !profilesLoaded && unanswered}
 
       {profiles.length > 0 && (
         <details className="group">

--- a/frontend/src/components/agents/specialist-list.tsx
+++ b/frontend/src/components/agents/specialist-list.tsx
@@ -340,7 +340,7 @@ function SpecialistResources({
   onChange: (changes: Partial<SpecialistSpec>) => void;
 }) {
   const t = useTranslations("agents");
-  const { profiles } = useModelProviders();
+  const { profiles, profilesLoaded } = useModelProviders();
   const { kbs: collections } = useKnowledgeBases();
   const { skills, total: skillCount } = useSkills({ limit: 100 });
 
@@ -354,6 +354,7 @@ function SpecialistResources({
           <Label>{t("specialistModel")}</Label>
           <ModelProfilePicker
             profiles={profiles}
+            profilesLoaded={profilesLoaded}
             value={specialist.model_profile_id ?? null}
             disabled={disabled}
             onChange={(model_profile_id) => onChange({ model_profile_id })}

--- a/frontend/src/components/agents/specialist-list.tsx
+++ b/frontend/src/components/agents/specialist-list.tsx
@@ -340,7 +340,7 @@ function SpecialistResources({
   onChange: (changes: Partial<SpecialistSpec>) => void;
 }) {
   const t = useTranslations("agents");
-  const { profiles, profilesLoaded } = useModelProviders();
+  const { profiles, profilesStatus } = useModelProviders();
   const { kbs: collections } = useKnowledgeBases();
   const { skills, total: skillCount } = useSkills({ limit: 100 });
 
@@ -354,7 +354,7 @@ function SpecialistResources({
           <Label>{t("specialistModel")}</Label>
           <ModelProfilePicker
             profiles={profiles}
-            profilesLoaded={profilesLoaded}
+            profilesStatus={profilesStatus}
             value={specialist.model_profile_id ?? null}
             disabled={disabled}
             onChange={(model_profile_id) => onChange({ model_profile_id })}

--- a/frontend/src/components/kb/ingestion-settings.tsx
+++ b/frontend/src/components/kb/ingestion-settings.tsx
@@ -546,7 +546,7 @@ function ImageModelField({
   disabled?: boolean;
 }) {
   const t = useTranslations("kb");
-  const { profiles, profilesLoaded } = useModelProviders();
+  const { profiles, profilesStatus } = useModelProviders();
   const { can } = usePermissions();
 
   return (
@@ -568,7 +568,7 @@ function ImageModelField({
         <ModelProfilePicker
           allowAdd={can(Perm.connectionsManage)}
           profiles={profiles}
-          profilesLoaded={profilesLoaded}
+          profilesStatus={profilesStatus}
           value={value}
           onChange={onChange}
           disabled={disabled}

--- a/frontend/src/components/kb/ingestion-settings.tsx
+++ b/frontend/src/components/kb/ingestion-settings.tsx
@@ -546,7 +546,7 @@ function ImageModelField({
   disabled?: boolean;
 }) {
   const t = useTranslations("kb");
-  const { profiles } = useModelProviders();
+  const { profiles, profilesLoaded } = useModelProviders();
   const { can } = usePermissions();
 
   return (
@@ -568,6 +568,7 @@ function ImageModelField({
         <ModelProfilePicker
           allowAdd={can(Perm.connectionsManage)}
           profiles={profiles}
+          profilesLoaded={profilesLoaded}
           value={value}
           onChange={onChange}
           disabled={disabled}

--- a/frontend/src/hooks/use-model-providers.test.tsx
+++ b/frontend/src/hooks/use-model-providers.test.tsx
@@ -58,8 +58,8 @@ describe("useModelProviders", () => {
 
   it("does not call an empty list of models the organization's answer when the read failed", async () => {
     // `profiles` degrades to `[]` either way, so a caller reading it as "this
-    // organization has no model" would say that about a 502. `profilesLoaded`
-    // is the difference, and only the successful read carries it.
+    // organization has no model" would say that about a 502. `profilesStatus`
+    // is the difference, and only the successful read carries `loaded`.
     vi.mocked(apiClient.get).mockImplementation((path: string) =>
       path === "/providers/model-profiles"
         ? Promise.reject(new Error("upstream timed out"))
@@ -69,12 +69,33 @@ describe("useModelProviders", () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(result.current.profiles).toEqual([]);
-    expect(result.current.profilesLoaded).toBe(false);
+    expect(result.current.profilesStatus).toBe("failed");
+  });
+
+  it("separates a read still in flight from one that failed", async () => {
+    // The third state, and the one a pair of booleans loses: a cold render is
+    // `[]` too, and a caller that only knew "not loaded" would raise a failure
+    // on the ordinary path - every first paint of the Builder.
+    let answer: (value: { items: []; total: number }) => void = () => {};
+    vi.mocked(apiClient.get).mockImplementation((path: string) =>
+      path === "/providers/model-profiles"
+        ? new Promise((resolve) => {
+            answer = resolve;
+          })
+        : Promise.resolve({ items: [], total: 0 }),
+    );
+    const { result } = renderHook(() => useModelProviders(), { wrapper });
+
+    expect(result.current.profiles).toEqual([]);
+    expect(result.current.profilesStatus).toBe("pending");
+
+    answer({ items: [], total: 0 });
+    await waitFor(() => expect(result.current.profilesStatus).toBe("loaded"));
   });
 
   it("calls an empty list the organization's answer when the read succeeded", async () => {
     const { result } = renderHook(() => useModelProviders(), { wrapper });
-    await waitFor(() => expect(result.current.profilesLoaded).toBe(true));
+    await waitFor(() => expect(result.current.profilesStatus).toBe("loaded"));
 
     expect(result.current.profiles).toEqual([]);
   });

--- a/frontend/src/hooks/use-model-providers.ts
+++ b/frontend/src/hooks/use-model-providers.ts
@@ -27,6 +27,19 @@ export interface NewModelProfile {
 }
 
 /**
+ * Whether an organization's models are known, still coming, or unreadable.
+ *
+ * `loaded` is the only one of the three that makes an empty list a fact about
+ * the organization.
+ */
+export type ProfilesStatus = "loaded" | "pending" | "failed";
+
+function profilesStatus(query: { isSuccess: boolean; isError: boolean }): ProfilesStatus {
+  if (query.isSuccess) return "loaded";
+  return query.isError ? "failed" : "pending";
+}
+
+/**
  * The providers this deployment can reach, and the models an organization has
  * defined on them.
  *
@@ -87,12 +100,16 @@ export function useModelProviders() {
     catalog: catalog.data?.items ?? [],
     profiles: profiles.data?.items ?? [],
     /**
-     * Whether `profiles` is the organization's answer rather than a placeholder.
-     * `!isLoading` is not that question: a read that exhausted its retries also
-     * stops loading, and `?? []` then makes a failed request indistinguishable
-     * from an organization that has stored no model.
+     * What `profiles` currently is: the organization's answer, a placeholder
+     * while the read is in flight, or a read that failed.
+     *
+     * Three states rather than two, because `?? []` collapses all three into the
+     * same empty array and each owes the reader something different - a claim
+     * about the organization, a wait, and a failure with a way to try again. A
+     * pair of booleans would let a caller hold `loaded` and `failed` at once;
+     * this cannot.
      */
-    profilesLoaded: profiles.isSuccess,
+    profilesStatus: profilesStatus(profiles),
     /** Read the profiles again - what a panel that could not list them offers. */
     refetchProfiles: invalidate,
     isLoading: catalog.isLoading || profiles.isLoading,

--- a/frontend/src/hooks/use-model-providers.ts
+++ b/frontend/src/hooks/use-model-providers.ts
@@ -93,6 +93,8 @@ export function useModelProviders() {
      * from an organization that has stored no model.
      */
     profilesLoaded: profiles.isSuccess,
+    /** Read the profiles again - what a panel that could not list them offers. */
+    refetchProfiles: invalidate,
     isLoading: catalog.isLoading || profiles.isLoading,
     isFetching: catalog.isFetching || profiles.isFetching,
     createProfile,


### PR DESCRIPTION
## Summary

`ModelProfilePicker` rendered "This organization has no models yet. An agent cannot run
without one" from `profiles.length === 0` — and a `/providers/model-profiles` read that
was refused or answered 502 arrives as exactly that empty array, because the hook
degrades it with `?? []`. A builder in an organization with a dozen models was told it
had none and that its agents could not run, on one failed request. Nothing said a
request had failed, and nothing offered a retry.

This is the empty-page trap from `.claude/rules/frontend.md` in the one panel that turns
emptiness into a sentence rather than into blank space.

## Related issue

Closes #863

## Changed

- `useModelProviders` answers with three states rather than two:
  `profilesStatus: "loaded" | "pending" | "failed"`. `?? []` collapses all three into the
  same empty array and each owes the reader something different — a claim about the
  organization, a wait, and a failure with a way to try again. One field rather than a
  second boolean, so no caller can hold `loaded` and `failed` at once, and #846's own
  page-level consumer reads the same value instead of keeping `profilesLoaded` as a
  second vocabulary.
- `ModelProfilePicker` takes it as a required prop and renders per state: the
  destructive failure panel (with a Retry) only on `failed`; on `pending`, a skeleton
  shaped like the rows it is waiting for in the shape that has nothing else to show, and
  nothing at all in the add-capable shape, where the form is the panel and already works;
  the existing "this organization has no models yet" claim only on `loaded`. Required
  rather than defaulted, so all four call sites pass it instead of inheriting the old
  behaviour by omission.
- The failure notice covers **both** of the picker's shapes: in place of the dead-end
  panel where the caller cannot add a model, and in place of the saved-model disclosure
  where it can — a control that quietly is not there reads as the product not having it.
- `useModelProviders` exposes its existing invalidation as `refetchProfiles`, which is
  what the Retry calls. The picker already consumed the hook for `deleteProfile`.
- Callers updated: the Builder page, `specialist-list.tsx`, `ingestion-settings.tsx`
  (`chat-model-picker.tsx`, named in the issue, consumes the hook but not this
  component — it has no such empty state).

## Testing

`model-profile-picker.test.tsx` — five new cases:

- a failed read makes no claim about the organization, names the failure, and Retry
  calls `refetchProfiles`;
- the add-capable shape says so where the saved-model disclosure would be, with the add
  form still there;
- a pending read claims nothing and blames nothing — it waits (both shapes);
- a list already on screen survives a later failed read — stale rows somebody can choose
  from beat a red panel instead of them.

`use-model-providers.test.tsx` — `pending`, `failed` and `loaded` each pinned, including
a read that has not resolved.

`model-panel.integration.test.tsx` — the "could not be read" case now asserts the
failure notice and the absence of both false claims. It previously asserted the false
claim was present, which is how this defect passed review one element above its own fix.
The successful-empty-read case there is unchanged and still asserts the old copy.

From the repository root:

- `make lint-frontend` — eslint, prettier, tsc, i18n guard all clean.
- `make test-frontend-cov` — 313 files, 4682 tests passed; 100% statements
  (8020/8020), 100% functions (2578/2578), 100% lines (7164/7164), 97.62% branches
  (5872/6015).
- `make build-frontend` — green.

## Notes for reviewers

The second commit answers Codex's P2: `profilesLoaded` (`isSuccess`) was false while the
initial read was in flight too, so the failure panel fired on every cold render of the
Builder — a false alarm on the ordinary path, which is worse than the wrong sentence it
replaced. Hence three states rather than two, and the pending-window case that would
have caught it.
