### PR TITLE
ci(audit): tell a network failure from a vulnerability finding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -411,10 +411,19 @@ build-frontend:
 # virtualenv. The export is fully pinned, so `--no-deps --disable-pip` skips a
 # resolution round-trip pip-audit would otherwise do in a throwaway virtualenv.
 #
-# Needs the network: the advisory database is fetched, not vendored.
+# Needs the network: the advisory database is fetched, not vendored - one request
+# per locked distribution, 254 of them, none of which pip-audit retries and all of
+# which exit 1 the way a real advisory does. `scripts/audit_dependencies.py` is
+# what stops a single slow answer reading as a finding on a required check (#855):
+# it retries a network-shaped failure and exits 75 with the word NETWORK when the
+# feed never answered, so exit 1 keeps meaning "a locked dependency is vulnerable".
+AUDIT_ATTEMPTS ?= 3
+AUDIT_TIMEOUT ?= 30
+
 audit:
 	cd backend && uv export --frozen --no-emit-project --no-hashes -o requirements-audit.txt
-	cd backend && uv tool run pip-audit -r requirements-audit.txt --no-deps --disable-pip --progress-spinner=off
+	python3 scripts/audit_dependencies.py backend/requirements-audit.txt \
+		--attempts $(AUDIT_ATTEMPTS) --timeout $(AUDIT_TIMEOUT)
 
 # Playwright starts the frontend itself; the backend and its seed are on you.
 # Checked rather than assumed: against a backend that is not there the suite

--- a/Makefile
+++ b/Makefile
@@ -415,8 +415,15 @@ build-frontend:
 # per locked distribution, 254 of them, none of which pip-audit retries and all of
 # which exit 1 the way a real advisory does. `scripts/audit_dependencies.py` is
 # what stops a single slow answer reading as a finding on a required check (#855):
-# it retries a network-shaped failure and exits 75 with the word NETWORK when the
-# feed never answered, so exit 1 keeps meaning "a locked dependency is vulnerable".
+# it retries every run that reached no verdict, and says which of the four states
+# it ended in.
+#
+# It says so on its **last line**, not in its exit status, because make has no way
+# to carry one: a failed recipe becomes make's own exit 2, so a caller reaching
+# this through `make audit` - which the `Security Scan` job does - cannot tell 75
+# from 1. So the contract is `AUDIT: CLEAN|VULNERABLE|NETWORK|FAILED - detail`,
+# also appended to $GITHUB_STEP_SUMMARY inside a job. `make audit | tail -1` is
+# the whole of it; the script's own 0/1/75 is for callers that invoke it directly.
 AUDIT_ATTEMPTS ?= 3
 AUDIT_TIMEOUT ?= 30
 

--- a/backend/tests/test_audit_dependencies.py
+++ b/backend/tests/test_audit_dependencies.py
@@ -1,0 +1,194 @@
+"""What `make audit` may and may not conclude from a pip-audit run.
+
+`Security Scan` is a required check, and pip-audit exits 1 both when a locked
+dependency is vulnerable and when it never reached the feed at all — a
+`ReadTimeout` on one of 254 requests looked exactly like an advisory on #838,
+and a re-run of the same commit passed unchanged (#855).
+
+`scripts/audit_dependencies.py` is what keeps those two apart, so the tests here
+are about the distinction rather than about pip-audit: a verdict is the JSON
+report existing, a network-shaped failure is retried, and an incomplete run exits
+75 rather than 1 — never 0, because an unaudited dependency set reported green is
+the same defect facing the other way.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = REPO_ROOT / "scripts" / "audit_dependencies.py"
+_NAME = "audit_dependencies_under_test"
+_spec = importlib.util.spec_from_file_location(_NAME, _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+audit_dependencies = importlib.util.module_from_spec(_spec)
+# `@dataclass` resolves its annotations through `sys.modules[cls.__module__]`, so a
+# module executed without being registered there raises rather than defining `Attempt`.
+sys.modules[_NAME] = audit_dependencies
+_spec.loader.exec_module(audit_dependencies)
+
+
+TIMEOUT_TRACEBACK = (
+    "Traceback (most recent call last):\n"
+    "requests.exceptions.ReadTimeout: HTTPSConnectionPool(host='pypi.org', port=443): "
+    "Read timed out. (read timeout=15)\n"
+)
+
+
+def clean_report(*names: str) -> dict[str, Any]:
+    return {
+        "dependencies": [{"name": name, "version": "1.0.0", "vulns": []} for name in names],
+        "fixes": [],
+    }
+
+
+def vulnerable_report() -> dict[str, Any]:
+    return {
+        "dependencies": [
+            {
+                "name": "requests",
+                "version": "2.19.0",
+                "vulns": [
+                    {
+                        "id": "PYSEC-2018-28",
+                        "fix_versions": ["2.20.0"],
+                        "aliases": ["CVE-2018-18074"],
+                    }
+                ],
+            }
+        ],
+        "fixes": [],
+    }
+
+
+class FakePipAudit:
+    """A pip-audit that writes the reports it is given, in order, or fails."""
+
+    def __init__(self, *outcomes: dict[str, Any] | str) -> None:
+        self.outcomes = list(outcomes)
+        self.calls = 0
+
+    def __call__(self, command: list[str], report: Path) -> Any:
+        outcome = self.outcomes[self.calls]
+        self.calls += 1
+        if isinstance(outcome, str):
+            return audit_dependencies.Attempt(returncode=1, output=outcome, report=None)
+        report.write_text(json.dumps(outcome))
+        return audit_dependencies.Attempt(returncode=0, output="", report=outcome)
+
+
+@pytest.fixture
+def no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(audit_dependencies.time, "sleep", lambda _: None)
+
+
+def run(monkeypatch: pytest.MonkeyPatch, fake: FakePipAudit, *, attempts: int = 3) -> int:
+    monkeypatch.setattr(audit_dependencies, "run_pip_audit", fake)
+    return audit_dependencies.audit(
+        Path("requirements-audit.txt"), attempts=attempts, timeout=30, backoff=5, extra=[]
+    )
+
+
+def test_a_clean_audit_exits_zero(monkeypatch: pytest.MonkeyPatch, no_sleep: None) -> None:
+    assert run(monkeypatch, FakePipAudit(clean_report("anyio", "httpx"))) == 0
+
+
+def test_a_vulnerable_dependency_still_fails_the_audit(
+    monkeypatch: pytest.MonkeyPatch, no_sleep: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert run(monkeypatch, FakePipAudit(vulnerable_report())) == 1
+    assert "PYSEC-2018-28" in capsys.readouterr().out
+
+
+def test_a_timeout_on_one_request_is_retried_rather_than_reported(
+    monkeypatch: pytest.MonkeyPatch, no_sleep: None
+) -> None:
+    """The failure #855 is about: one slow answer, then a run that says nothing is wrong."""
+    fake = FakePipAudit(TIMEOUT_TRACEBACK, clean_report("anyio"))
+    assert run(monkeypatch, fake) == 0
+    assert fake.calls == 2
+
+
+def test_a_feed_that_never_answers_is_not_reported_as_a_finding(
+    monkeypatch: pytest.MonkeyPatch, no_sleep: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fake = FakePipAudit(TIMEOUT_TRACEBACK, TIMEOUT_TRACEBACK, TIMEOUT_TRACEBACK)
+    assert run(monkeypatch, fake) == audit_dependencies.EXIT_UNAVAILABLE
+    assert fake.calls == 3
+
+    err = capsys.readouterr().err
+    assert "NETWORK: the vulnerability feed was unreachable (ReadTimeout) after 3 attempts" in err
+    assert "not a finding" in err
+
+
+def test_a_failure_that_is_not_the_network_is_not_retried(
+    monkeypatch: pytest.MonkeyPatch, no_sleep: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Three tries at a rejected flag only delay the same answer, and it is not a blip."""
+    fake = FakePipAudit("pip-audit: error: unrecognized arguments: --nonsense")
+    assert run(monkeypatch, fake) == audit_dependencies.EXIT_UNAVAILABLE
+    assert fake.calls == 1
+    assert capsys.readouterr().err.startswith("NOT AUDITED:")
+
+
+def test_an_unauditable_dependency_is_named_rather_than_counted_as_clean(
+    monkeypatch: pytest.MonkeyPatch, no_sleep: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """pip-audit skips a distribution PyPI has no record of; the columns report says so."""
+    report = clean_report("anyio")
+    report["dependencies"].append({"name": "internal-lib", "skip_reason": "not found on PyPI"})
+    assert run(monkeypatch, FakePipAudit(report)) == 0
+
+    out = capsys.readouterr().out
+    assert "skipped: internal-lib" in out
+    assert "1 locked dependencies" in out
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        "requests.exceptions.ReadTimeout: Read timed out. (read timeout=15)",
+        "requests.exceptions.ConnectionError: Max retries exceeded with url: /pypi/x/json",
+        "ERROR:pip_audit._cli:Could not connect to PyPI's vulnerability feed",
+        "Tip: your network may be blocking this service.",
+        "pip_audit._service.interface.ServiceError",
+    ],
+)
+def test_the_shapes_a_blocked_feed_arrives_in(output: str) -> None:
+    assert audit_dependencies.network_marker(output) is not None
+
+
+def test_a_rejected_flag_is_not_mistaken_for_the_network() -> None:
+    assert audit_dependencies.network_marker("error: unrecognized arguments: --nope") is None
+
+
+def test_the_report_is_written_where_the_command_is_told_to_write_it(tmp_path: Path) -> None:
+    report = tmp_path / "report.json"
+    command = audit_dependencies.build_command(
+        Path("requirements-audit.txt"), report, timeout=30, extra=["-s", "osv"]
+    )
+    assert command[-2:] == ["-s", "osv"]
+    assert command[command.index("--output") + 1] == str(report)
+    assert command[command.index("--timeout") + 1] == "30"
+    assert command[command.index("--format") + 1] == "json"
+
+
+def test_a_report_that_was_never_written_is_not_a_verdict(tmp_path: Path) -> None:
+    """The whole discrimination rests on this: no file, no audit, whatever the exit code."""
+    attempt = audit_dependencies.run_pip_audit(
+        ["python3", "-c", "raise SystemExit(1)"], tmp_path / "report.json"
+    )
+    assert attempt.report is None
+
+
+def test_a_stale_report_from_an_earlier_attempt_is_not_reused(tmp_path: Path) -> None:
+    report = tmp_path / "report.json"
+    report.write_text(json.dumps(clean_report("anyio")))
+    attempt = audit_dependencies.run_pip_audit(["python3", "-c", "raise SystemExit(1)"], report)
+    assert attempt.report is None

--- a/backend/tests/test_audit_dependencies.py
+++ b/backend/tests/test_audit_dependencies.py
@@ -7,15 +7,24 @@ and a re-run of the same commit passed unchanged (#855).
 
 `scripts/audit_dependencies.py` is what keeps those two apart, so the tests here
 are about the distinction rather than about pip-audit: a verdict is the JSON
-report existing, a network-shaped failure is retried, and an incomplete run exits
-75 rather than 1 — never 0, because an unaudited dependency set reported green is
-the same defect facing the other way.
+report existing, an incomplete run is retried and exits 75 rather than 1 — never
+0, because an unaudited dependency set reported green is the same defect facing
+the other way.
+
+Two of them are about how far that distinction actually travels, both from the
+review of #877. `make` collapses every failed recipe into its own exit 2, so the
+exit code cannot reach the job that runs `make audit` and the verdict has to be a
+line of output; and uv fetches pip-audit before pip-audit fetches anything, so a
+cold tool cache against an unreachable host fails in a vocabulary pip-audit never
+uses. The second is why matching phrases no longer decides whether to retry.
 """
 
 from __future__ import annotations
 
 import importlib.util
 import json
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -39,6 +48,20 @@ TIMEOUT_TRACEBACK = (
     "requests.exceptions.ReadTimeout: HTTPSConnectionPool(host='pypi.org', port=443): "
     "Read timed out. (read timeout=15)\n"
 )
+
+# What a cold `uv tool run` says when the package host is unreachable. pip-audit
+# never runs at all, so none of its own vocabulary appears.
+UV_DOWNLOAD_FAILURE = (
+    "error: Failed to download `pip-audit==2.10.1`\n"
+    "  Caused by: Request failed after 3 retries\n"
+    "  Caused by: error sending request for url (https://files.pythonhosted.org/...)\n"
+    "  Caused by: client error (Connect)\n"
+)
+
+
+def verdict(captured: pytest.CaptureResult[str]) -> str:
+    """The one line every caller can read, whatever mangled the exit code."""
+    return captured.out.splitlines()[-1]
 
 
 def clean_report(*names: str) -> dict[str, Any]:
@@ -122,32 +145,111 @@ def test_a_feed_that_never_answers_is_not_reported_as_a_finding(
     assert run(monkeypatch, fake) == audit_dependencies.EXIT_UNAVAILABLE
     assert fake.calls == 3
 
-    err = capsys.readouterr().err
-    assert "NETWORK: the vulnerability feed was unreachable (ReadTimeout) after 3 attempts" in err
-    assert "not a finding" in err
+    captured = capsys.readouterr()
+    assert (
+        verdict(captured)
+        == "AUDIT: NETWORK — unreachable (ReadTimeout) after 3 attempts; no audit was performed"
+    )
+    assert "not a finding" in captured.err
 
 
-def test_a_failure_that_is_not_the_network_is_not_retried(
+def test_a_cold_uv_cache_against_a_dead_host_is_the_network_too(
     monkeypatch: pytest.MonkeyPatch, no_sleep: None, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """Three tries at a rejected flag only delay the same answer, and it is not a blip."""
-    fake = FakePipAudit("pip-audit: error: unrecognized arguments: --nonsense")
+    """uv fetches pip-audit first, and fails in reqwest's words rather than requests'.
+
+    A fresh runner or a cache miss makes this the *commonest* way the job meets an
+    unreachable host, and it used to skip the retry loop and read `NOT AUDITED`.
+    """
+    fake = FakePipAudit(UV_DOWNLOAD_FAILURE, clean_report("anyio"))
+    assert run(monkeypatch, fake) == 0
+    assert fake.calls == 2
+
+    assert audit_dependencies.network_marker(UV_DOWNLOAD_FAILURE) == "Failed to download"
+
+
+def test_a_failure_nobody_recognised_is_retried_anyway(
+    monkeypatch: pytest.MonkeyPatch, no_sleep: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """What happens the next time a phrase is missing: the wording dulls, nothing else.
+
+    Matching strings decides how the verdict reads, never whether to try again —
+    the two mistakes are not symmetric. Re-running a deterministic failure costs
+    seconds; not re-running a transient one is the false red #855 is about.
+    """
+    fake = FakePipAudit("segmentation fault", "segmentation fault", clean_report("anyio"))
+    assert run(monkeypatch, fake) == 0
+    assert fake.calls == 3
+
+
+def test_a_failure_nobody_recognised_says_so_rather_than_blaming_the_network(
+    monkeypatch: pytest.MonkeyPatch, no_sleep: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fake = FakePipAudit(*["pip-audit: error: unrecognized arguments: --nonsense"] * 3)
     assert run(monkeypatch, fake) == audit_dependencies.EXIT_UNAVAILABLE
-    assert fake.calls == 1
-    assert capsys.readouterr().err.startswith("NOT AUDITED:")
+    assert verdict(capsys.readouterr()).startswith("AUDIT: FAILED — pip-audit reached no verdict")
+
+
+def test_the_verdict_is_the_last_line_because_the_exit_code_does_not_survive_make(
+    monkeypatch: pytest.MonkeyPatch, no_sleep: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Every state ends on one grep-able line, which is what a caller through make gets."""
+    assert run(monkeypatch, FakePipAudit(clean_report("anyio"))) == 0
+    assert (
+        verdict(capsys.readouterr())
+        == "AUDIT: CLEAN — no known advisories against 1 locked dependencies"
+    )
+
+    assert run(monkeypatch, FakePipAudit(vulnerable_report())) == 1
+    assert verdict(capsys.readouterr()) == (
+        "AUDIT: VULNERABLE — 1 known advisory in 1 of 1 locked dependencies"
+    )
+
+
+def test_make_cannot_carry_the_exit_code_the_script_returns(tmp_path: Path) -> None:
+    """The constraint the verdict line exists for, asserted rather than assumed.
+
+    GNU Make prints `Error 75` and exits 2, so `Security Scan` — which runs
+    `make audit` — sees one status for a finding and for a feed that never
+    answered. Found reviewing #877.
+    """
+    (tmp_path / "Makefile").write_text("audit:\n\t@python3 -c 'raise SystemExit(75)'\n")
+    make = shutil.which("make")
+    assert make is not None
+    completed = subprocess.run(
+        [make, "-C", str(tmp_path), "audit"], capture_output=True, text=True, check=False
+    )
+    assert completed.returncode == 2
+
+
+def test_a_job_can_read_the_verdict_without_reading_the_log(
+    monkeypatch: pytest.MonkeyPatch, no_sleep: None, tmp_path: Path
+) -> None:
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    fake = FakePipAudit(TIMEOUT_TRACEBACK, TIMEOUT_TRACEBACK, TIMEOUT_TRACEBACK)
+    assert run(monkeypatch, fake) == audit_dependencies.EXIT_UNAVAILABLE
+    assert summary.read_text().startswith("AUDIT: NETWORK —")
+
+
+def test_nothing_is_written_when_the_run_is_not_inside_a_job(
+    monkeypatch: pytest.MonkeyPatch, no_sleep: None
+) -> None:
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    assert run(monkeypatch, FakePipAudit(clean_report("anyio"))) == 0
 
 
 def test_an_unauditable_dependency_is_named_rather_than_counted_as_clean(
     monkeypatch: pytest.MonkeyPatch, no_sleep: None, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """pip-audit skips a distribution PyPI has no record of; the columns report says so."""
+    """pip-audit skips a distribution PyPI has no record of, and it is not audited."""
     report = clean_report("anyio")
     report["dependencies"].append({"name": "internal-lib", "skip_reason": "not found on PyPI"})
     assert run(monkeypatch, FakePipAudit(report)) == 0
 
     out = capsys.readouterr().out
     assert "skipped: internal-lib" in out
-    assert "1 locked dependencies" in out
+    assert "against 1 locked dependencies" in out
 
 
 @pytest.mark.parametrize(
@@ -158,9 +260,14 @@ def test_an_unauditable_dependency_is_named_rather_than_counted_as_clean(
         "ERROR:pip_audit._cli:Could not connect to PyPI's vulnerability feed",
         "Tip: your network may be blocking this service.",
         "pip_audit._service.interface.ServiceError",
+        "error: Failed to download `pip-audit==2.10.1`",
+        "  Caused by: Request failed after 3 retries",
+        "  Caused by: error sending request for url (https://pypi.org/simple/pip-audit/)",
+        "  Caused by: client error (Connect)",
+        "  Caused by: dns error: failed to lookup address information",
     ],
 )
-def test_the_shapes_a_blocked_feed_arrives_in(output: str) -> None:
+def test_the_shapes_a_blocked_host_arrives_in(output: str) -> None:
     assert audit_dependencies.network_marker(output) is not None
 
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -29,7 +29,8 @@ Run these from the project root directory.
 | `make dead-code` | Unused functions and methods — vulture at a lower confidence than the `lint` gate, plus knip's full report on the frontend. A report to read, not a gate: on a registry-driven codebase it comes with false positives (a CLI command, a capability hook), so read each before deleting. The same role `dependency-freshness` plays for dependencies. Its one unambiguous half — a package in `package.json` that nothing imports — gates in `lint-frontend` instead (`bun run lint:deps`), because a dependency that survived being unused for months is what motivated it |
 | `make lint-spelling` | codespell over every tracked file. The pre-commit hook reads only the files a commit touches, so a misspelling that lands with its file waits there to refuse somebody else's unrelated commit |
 | `make build-frontend` | `next build`. Type-checks the route tree and fails on a server component that cannot render — which neither tsc nor vitest sees |
-| `make audit` | Audit the locked dependency set for known vulnerabilities (needs the network) |
+| `make audit` | Audit the locked dependency set for known vulnerabilities. Needs the network — one request per locked distribution — so a network failure is separated from a finding rather than sharing an exit code with it. See below |
+| `make sandbox-token` | Generate the sandbox service's own `SANDBOXD_TOKEN` into `backend/.env`, once. `make dev` runs it for you; it never regenerates, because a new token orphans every workspace the service is holding. The connection form offers to store the same value in the vault, so it does not have to be pasted anywhere |
 | `make clean` | Remove cache files (__pycache__, .pytest_cache, etc.) |
 
 ### Before a pull request
@@ -55,8 +56,36 @@ One gap no command can close: CI's `test` job has a Postgres beside it, so
 `tests/integration/` runs there, and locally it skips itself when nothing answers
 on 5432. `make check` says so at the end when that happens — `make docker-db`
 first if the change is anywhere near the database.
-| `make sandbox-token` | Generate the sandbox service's own `SANDBOXD_TOKEN` into `backend/.env`, once. `make dev` runs it for you; it never regenerates, because a new token orphans every workspace the service is holding. The connection form offers to store the same value in the vault, so it does not have to be pasted anywhere |
 
+### What a red `make audit` means
+
+`make audit` exports what the lockfile resolves to — which is what a deployment
+installs — and hands it to `pip-audit`, which asks the vulnerability feed about
+each of the 254 locked distributions in turn. It answers in three ways, and the
+third is why `scripts/audit_dependencies.py` stands between pip-audit and the job:
+
+| Exit | Means |
+|---|---|
+| `0` | Every locked dependency was audited and none has a known advisory |
+| `1` | A locked dependency has a known advisory. The ids, the fixed versions and the CVE aliases are printed |
+| `75` | **No audit happened.** The first line says `NETWORK:` or `NOT AUDITED:` and pip-audit's own output follows |
+
+`pip-audit` alone cannot make that third distinction: it exits 1 whether it found
+an advisory or died on a `ReadTimeout` reaching for one, and `Security Scan` is a
+required check, so one slow answer out of 254 blocks a merge while reading exactly
+like a real finding until somebody opens the log
+([#855](https://github.com/vstorm-co/agenticos/issues/855)). The verdict is
+therefore taken from pip-audit's JSON report rather than from its exit code —
+that file is written only once every dependency has been queried, so its absence
+means the run never reached a conclusion, whatever it exited. A failure that names
+the network is retried (`AUDIT_ATTEMPTS`, default 3, with a backoff); one that does
+not — a rejected flag, an unreadable requirements file — is reported straight away,
+because trying it twice more only delays the same answer.
+
+It never reports green on an audit that did not run. An unaudited dependency set
+called clean is the same defect facing the other way, so exit 75 still fails the
+job — it just cannot be mistaken for a finding. `AUDIT_TIMEOUT` (default 30s) is
+the per-request socket timeout, raised from pip-audit's own 15.
 
 ### Database
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -29,7 +29,7 @@ Run these from the project root directory.
 | `make dead-code` | Unused functions and methods — vulture at a lower confidence than the `lint` gate, plus knip's full report on the frontend. A report to read, not a gate: on a registry-driven codebase it comes with false positives (a CLI command, a capability hook), so read each before deleting. The same role `dependency-freshness` plays for dependencies. Its one unambiguous half — a package in `package.json` that nothing imports — gates in `lint-frontend` instead (`bun run lint:deps`), because a dependency that survived being unused for months is what motivated it |
 | `make lint-spelling` | codespell over every tracked file. The pre-commit hook reads only the files a commit touches, so a misspelling that lands with its file waits there to refuse somebody else's unrelated commit |
 | `make build-frontend` | `next build`. Type-checks the route tree and fails on a server component that cannot render — which neither tsc nor vitest sees |
-| `make audit` | Audit the locked dependency set for known vulnerabilities. Needs the network — one request per locked distribution — so a network failure is separated from a finding rather than sharing an exit code with it. See below |
+| `make audit` | Audit the locked dependency set for known vulnerabilities. Needs the network — one request per locked distribution — so its last line says which of four states it ended in rather than leaving a red run ambiguous. See below |
 | `make sandbox-token` | Generate the sandbox service's own `SANDBOXD_TOKEN` into `backend/.env`, once. `make dev` runs it for you; it never regenerates, because a new token orphans every workspace the service is holding. The connection form offers to store the same value in the vault, so it does not have to be pasted anywhere |
 | `make clean` | Remove cache files (__pycache__, .pytest_cache, etc.) |
 
@@ -61,31 +61,54 @@ first if the change is anywhere near the database.
 
 `make audit` exports what the lockfile resolves to — which is what a deployment
 installs — and hands it to `pip-audit`, which asks the vulnerability feed about
-each of the 254 locked distributions in turn. It answers in three ways, and the
-third is why `scripts/audit_dependencies.py` stands between pip-audit and the job:
+each of the 254 locked distributions in turn. `pip-audit` on its own cannot say
+which of two very different things went wrong: it exits 1 whether it found an
+advisory or died on a `ReadTimeout` reaching for one, and `Security Scan` is a
+required check, so one slow answer out of 254 blocks a merge while reading
+exactly like a real finding until somebody opens the log
+([#855](https://github.com/vstorm-co/agenticos/issues/855)).
 
-| Exit | Means |
-|---|---|
-| `0` | Every locked dependency was audited and none has a known advisory |
-| `1` | A locked dependency has a known advisory. The ids, the fixed versions and the CVE aliases are printed |
-| `75` | **No audit happened.** The first line says `NETWORK:` or `NOT AUDITED:` and pip-audit's own output follows |
+`scripts/audit_dependencies.py` stands between the two and **ends every run on
+one line**:
 
-`pip-audit` alone cannot make that third distinction: it exits 1 whether it found
-an advisory or died on a `ReadTimeout` reaching for one, and `Security Scan` is a
-required check, so one slow answer out of 254 blocks a merge while reading exactly
-like a real finding until somebody opens the log
-([#855](https://github.com/vstorm-co/agenticos/issues/855)). The verdict is
-therefore taken from pip-audit's JSON report rather than from its exit code —
-that file is written only once every dependency has been queried, so its absence
-means the run never reached a conclusion, whatever it exited. A failure that names
-the network is retried (`AUDIT_ATTEMPTS`, default 3, with a backoff); one that does
-not — a rejected flag, an unreadable requirements file — is reported straight away,
-because trying it twice more only delays the same answer.
+```
+AUDIT: CLEAN — no known advisories against 254 locked dependencies
+AUDIT: VULNERABLE — 6 known advisories in 1 of 254 locked dependencies
+AUDIT: NETWORK — unreachable (ReadTimeout) after 3 attempts; no audit was performed
+AUDIT: FAILED — pip-audit reached no verdict in 3 attempts and did not say why; no audit was performed
+```
 
-It never reports green on an audit that did not run. An unaudited dependency set
-called clean is the same defect facing the other way, so exit 75 still fails the
-job — it just cannot be mistaken for a finding. `AUDIT_TIMEOUT` (default 30s) is
-the per-request socket timeout, raised from pip-audit's own 15.
+| State | Means | What to do |
+|---|---|---|
+| `CLEAN` | Every locked dependency was audited, none has a known advisory | Nothing |
+| `VULNERABLE` | A locked dependency has a known advisory. Ids, fixed versions and CVE aliases are printed above the verdict | Upgrade it |
+| `NETWORK` | No audit happened, and the cause was recognisably the network | Re-run |
+| `FAILED` | No audit happened, and the cause was not recognised. pip-audit's own output is on stderr | Read that output |
+
+**A line, not an exit code, because make cannot carry one.** GNU Make turns any
+failed recipe into its own exit 2, so `make audit` returns 2 for both `VULNERABLE`
+and `NETWORK` and there is no target shape that changes that. Anything reading the
+result through this interface — the `Security Scan` job included — reads the line:
+`make audit | tail -1`, or `make audit 2>&1 | grep '^AUDIT:'`. Inside a GitHub job
+the same line is appended to `$GITHUB_STEP_SUMMARY`, so the run's summary page says
+which state it was without anyone opening the log.
+
+Invoked directly, `scripts/audit_dependencies.py` does carry it: `0` for `CLEAN`,
+`1` for `VULNERABLE`, `75` (`EX_TEMPFAIL`) for `NETWORK` and `FAILED` alike — an
+audit that did not happen is never reported green, because an unaudited dependency
+set called clean is the same defect facing the other way.
+
+**Every incomplete run is retried, whatever it said.** `AUDIT_ATTEMPTS` (default
+3) with a 5s/10s backoff, and `AUDIT_TIMEOUT` (default 30s) as the per-request
+socket timeout, raised from pip-audit's own 15. Matching a phrase in the output
+decides only whether the verdict reads `NETWORK` or `FAILED` — never whether to
+try again. The two mistakes are not symmetric: re-running a deterministic failure
+costs seconds and the same answer, while not re-running a transient one is the
+false red on a required check that this exists to prevent. So a failure phrased in
+words the list does not hold still gets its retries; it just gets a vaguer name.
+Two vocabularies are in that list, because two programs reach for the network —
+`uv`, fetching `pip-audit` itself on a cold tool cache, and then `pip-audit`,
+fetching the advisories.
 
 ### Database
 

--- a/scripts/audit_dependencies.py
+++ b/scripts/audit_dependencies.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Audit the locked dependency set, and tell a network failure from a finding.
+
+`pip-audit` issues one request per locked distribution and exits 1 whether it
+found a vulnerability or never reached the feed at all — a `ReadTimeout` on one
+of 254 requests ends the run with a traceback and the same exit code a real
+advisory produces. `Security Scan` is a required check, so that reads as "a
+locked dependency is vulnerable" until somebody opens the log (#855).
+
+Two things fix that, and this script is both of them:
+
+**A verdict is a file, not an exit code.** `--format json` is a *manifest*
+format, so pip-audit writes it on both the clean and the vulnerable path, and
+only after every dependency has been queried. The report existing therefore means
+the audit completed; the report missing means it did not, whatever the exit code
+said. Nothing here parses a summary line.
+
+**A failure that names the network is retried.** The feed answering slowly once
+is not information about the dependency set, so a network-shaped failure is tried
+again, twice, with a backoff. A failure that is *not* network-shaped — a flag the
+tool rejects, a requirements file it cannot read — is not retried, because trying
+it three times only delays the same answer.
+
+Whichever way that ends, an incomplete audit exits `EXIT_UNAVAILABLE` (75,
+`EX_TEMPFAIL`) and says so in its first line. Only a completed audit that found
+something exits 1. It never exits 0 on an audit that did not run: an unaudited
+dependency set reported green is the same defect facing the other way.
+
+Usage::
+
+    python3 scripts/audit_dependencies.py backend/requirements-audit.txt
+    python3 scripts/audit_dependencies.py backend/requirements-audit.txt \
+        --attempts 3 --timeout 30
+
+Arguments after `--` are passed to pip-audit, which is how the failure path is
+exercised for real: the PyPI service hardcodes its URL, but the OSV service takes
+one, so pointing it at a closed port makes the feed unreachable without touching
+the network the rest of the run needs::
+
+    python3 scripts/audit_dependencies.py backend/requirements-audit.txt \
+        -- -s osv --osv-url http://127.0.0.1:9/v1/query
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+EXIT_CLEAN = 0
+EXIT_VULNERABLE = 1
+# EX_TEMPFAIL. Distinct from 1 on purpose: the whole point is that a red job
+# whose cause is the network cannot be mistaken for one whose cause is a finding.
+EXIT_UNAVAILABLE = 75
+
+# `--no-deps --disable-pip` skips the resolution round-trip pip-audit would
+# otherwise do in a throwaway virtualenv; the export is already fully pinned.
+PIP_AUDIT = ("uv", "tool", "run", "pip-audit")
+BASE_FLAGS = ("--no-deps", "--disable-pip", "--progress-spinner=off", "--desc", "off")
+
+# Substrings that mean the run ended on the way to the feed rather than on what
+# it found there. Exception names as pip-audit lets them escape (`ReadTimeout`,
+# `ConnectionError`, `ServiceError` wrapping a 5xx) plus the two messages it
+# raises itself. Matched against stdout and stderr together, because a traceback
+# and pip-audit's own logging do not share a stream.
+NETWORK_MARKERS = (
+    "ConnectionError",
+    "ConnectTimeout",
+    "ReadTimeout",
+    "Timeout",
+    "TooManyRedirects",
+    "HTTPError",
+    "ServiceError",
+    "Max retries exceeded",
+    "Could not connect",
+    "not redirecting properly",
+    "network may be blocking",
+    "Name or service not known",
+    "Temporary failure in name resolution",
+)
+
+
+@dataclass(frozen=True)
+class Attempt:
+    """One pip-audit invocation: what it printed, and whether it reached a verdict."""
+
+    returncode: int
+    output: str
+    report: dict[str, Any] | None
+
+
+def build_command(requirements: Path, report: Path, timeout: int, extra: list[str]) -> list[str]:
+    """The pip-audit invocation, writing its verdict to `report`."""
+    return [
+        *PIP_AUDIT,
+        "-r",
+        str(requirements),
+        *BASE_FLAGS,
+        "--timeout",
+        str(timeout),
+        "--format",
+        "json",
+        "--output",
+        str(report),
+        *extra,
+    ]
+
+
+def run_pip_audit(command: list[str], report: Path) -> Attempt:
+    """Run pip-audit and read back the report, which exists only if it finished."""
+    report.unlink(missing_ok=True)
+    completed = subprocess.run(command, capture_output=True, text=True, check=False)
+    output = completed.stdout + completed.stderr
+
+    try:
+        parsed = json.loads(report.read_text())
+    except (OSError, json.JSONDecodeError):
+        return Attempt(completed.returncode, output, None)
+    return Attempt(completed.returncode, output, parsed)
+
+
+def network_marker(output: str) -> str | None:
+    """The first marker in `output` saying this failure was the network, if any."""
+    for marker in NETWORK_MARKERS:
+        if marker in output:
+            return marker
+    return None
+
+
+def report_findings(report: dict[str, Any]) -> int:
+    """Print what the completed audit found, and return the exit code it earns."""
+    dependencies = report.get("dependencies", [])
+    skipped = [dep for dep in dependencies if "skip_reason" in dep]
+    vulnerable = [dep for dep in dependencies if dep.get("vulns")]
+
+    for dep in skipped:
+        print(f"skipped: {dep['name']} — {dep['skip_reason']}")
+
+    audited = len(dependencies) - len(skipped)
+    if not vulnerable:
+        print(f"No known vulnerabilities in {audited} locked dependencies.")
+        return EXIT_CLEAN
+
+    count = sum(len(dep["vulns"]) for dep in vulnerable)
+    plural = "vulnerability" if count == 1 else "vulnerabilities"
+    print(f"Found {count} known {plural} in {len(vulnerable)} of {audited} locked dependencies:")
+    for dep in vulnerable:
+        for vuln in dep["vulns"]:
+            fixes = ", ".join(vuln["fix_versions"]) or "none"
+            aliases = " ".join(vuln.get("aliases", []))
+            print(f"  {dep['name']} {dep['version']}  {vuln['id']}  fix: {fixes}  {aliases}")
+    return EXIT_VULNERABLE
+
+
+def report_unavailable(attempt: Attempt, marker: str | None, tries: int) -> int:
+    """Print why no audit happened, in terms nobody can read as a finding."""
+    if marker is None:
+        headline = "NOT AUDITED: pip-audit failed before reaching the vulnerability feed."
+        advice = "Read its output below; re-running will not change it."
+    else:
+        plural = "attempt" if tries == 1 else "attempts"
+        headline = (
+            f"NETWORK: the vulnerability feed was unreachable ({marker}) after {tries} {plural}."
+        )
+        advice = "Re-run the job."
+
+    print(headline, file=sys.stderr)
+    print(
+        "No audit was performed, so this is not a finding: no locked dependency has "
+        f"been reported vulnerable, and none has been cleared either. {advice}",
+        file=sys.stderr,
+    )
+    print(f"\npip-audit exited {attempt.returncode}:\n{attempt.output}", file=sys.stderr)
+    return EXIT_UNAVAILABLE
+
+
+def audit(requirements: Path, attempts: int, timeout: int, backoff: int, extra: list[str]) -> int:
+    with tempfile.TemporaryDirectory() as workdir:
+        report = Path(workdir) / "pip-audit.json"
+        command = build_command(requirements, report, timeout, extra)
+
+        tries = 0
+        while True:
+            tries += 1
+            attempt = run_pip_audit(command, report)
+            if attempt.report is not None:
+                return report_findings(attempt.report)
+
+            marker = network_marker(attempt.output)
+            if marker is None or tries >= attempts:
+                return report_unavailable(attempt, marker, tries)
+
+            delay = backoff * tries
+            print(
+                f"attempt {tries}/{attempts} did not reach the feed ({marker}); "
+                f"retrying in {delay}s",
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Audit the locked dependency set for known vulnerabilities."
+    )
+    parser.add_argument("requirements", type=Path, help="the exported, fully pinned requirements")
+    parser.add_argument(
+        "--attempts", type=int, default=3, help="how many times to try the feed (default: 3)"
+    )
+    parser.add_argument(
+        "--timeout", type=int, default=30, help="socket timeout in seconds (default: 30)"
+    )
+    parser.add_argument(
+        "--backoff", type=int, default=5, help="seconds before the second attempt (default: 5)"
+    )
+    parser.add_argument("extra", nargs="*", help="arguments passed through to pip-audit")
+    args = parser.parse_args()
+
+    return audit(args.requirements, args.attempts, args.timeout, args.backoff, args.extra)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit_dependencies.py
+++ b/scripts/audit_dependencies.py
@@ -7,7 +7,7 @@ of 254 requests ends the run with a traceback and the same exit code a real
 advisory produces. `Security Scan` is a required check, so that reads as "a
 locked dependency is vulnerable" until somebody opens the log (#855).
 
-Two things fix that, and this script is both of them:
+Three things fix that, and this script is all of them:
 
 **A verdict is a file, not an exit code.** `--format json` is a *manifest*
 format, so pip-audit writes it on both the clean and the vulnerable path, and
@@ -15,16 +15,29 @@ only after every dependency has been queried. The report existing therefore mean
 the audit completed; the report missing means it did not, whatever the exit code
 said. Nothing here parses a summary line.
 
-**A failure that names the network is retried.** The feed answering slowly once
-is not information about the dependency set, so a network-shaped failure is tried
-again, twice, with a backoff. A failure that is *not* network-shaped — a flag the
-tool rejects, a requirements file it cannot read — is not retried, because trying
-it three times only delays the same answer.
+**An audit that did not complete is tried again.** The feed answering slowly once
+is not information about the dependency set. Every incomplete run is retried —
+*every* one, not only those whose output matches a phrase — because the two
+mistakes are not symmetric: re-running a deterministic failure costs seconds and
+the same answer, while not re-running a transient one puts a false red on a
+required check, which is the whole of #855. `NETWORK_MARKERS` therefore chooses
+the **wording** of the verdict and nothing else; a failure phrased in words the
+list does not hold is still retried, and merely reads `FAILED` rather than
+`NETWORK`. That distinction has to hold for two vocabularies, not one: uv fetches
+pip-audit before pip-audit fetches anything, so `Failed to download` is as much a
+network failure here as `ReadTimeout` is.
 
-Whichever way that ends, an incomplete audit exits `EXIT_UNAVAILABLE` (75,
-`EX_TEMPFAIL`) and says so in its first line. Only a completed audit that found
-something exits 1. It never exits 0 on an audit that did not run: an unaudited
-dependency set reported green is the same defect facing the other way.
+**The verdict is a line, because the exit code does not survive the caller.**
+GNU Make turns any failed recipe into its own exit 2, so a caller reaching this
+through `make audit` — which is what the `Security Scan` job does — cannot tell
+75 from 1. The last line of stdout is therefore always
+`AUDIT: <STATE> — <detail>`, with `STATE` one of `CLEAN`, `VULNERABLE`, `NETWORK`
+or `FAILED`, and it is mirrored into `$GITHUB_STEP_SUMMARY` when the run is inside
+a job. The exit codes below are still the contract for anything invoking this
+script directly, which is where they are readable.
+
+It never exits 0 on an audit that did not run: an unaudited dependency set
+reported green is the same defect facing the other way.
 
 Usage::
 
@@ -45,6 +58,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -55,21 +69,25 @@ from typing import Any
 
 EXIT_CLEAN = 0
 EXIT_VULNERABLE = 1
-# EX_TEMPFAIL. Distinct from 1 on purpose: the whole point is that a red job
-# whose cause is the network cannot be mistaken for one whose cause is a finding.
+# EX_TEMPFAIL. Distinct from 1 for a caller that can see it; the verdict line is
+# what says the same thing to one that cannot.
 EXIT_UNAVAILABLE = 75
+
+# The token every caller can read, whatever mangled the exit code on the way.
+VERDICT_PREFIX = "AUDIT:"
 
 # `--no-deps --disable-pip` skips the resolution round-trip pip-audit would
 # otherwise do in a throwaway virtualenv; the export is already fully pinned.
 PIP_AUDIT = ("uv", "tool", "run", "pip-audit")
 BASE_FLAGS = ("--no-deps", "--disable-pip", "--progress-spinner=off", "--desc", "off")
 
-# Substrings that mean the run ended on the way to the feed rather than on what
-# it found there. Exception names as pip-audit lets them escape (`ReadTimeout`,
-# `ConnectionError`, `ServiceError` wrapping a 5xx) plus the two messages it
-# raises itself. Matched against stdout and stderr together, because a traceback
-# and pip-audit's own logging do not share a stream.
+# Substrings that mean the run ended on the way to a feed rather than on what it
+# found there. Two vocabularies, because two programs reach for the network: uv,
+# fetching pip-audit itself on a cold tool cache, and then pip-audit, fetching the
+# advisories. Neither list is exhaustive and neither has to be — an unmatched
+# failure is retried exactly the same, and only reads `FAILED` instead.
 NETWORK_MARKERS = (
+    # pip-audit: exception names as it lets them escape, plus its own messages.
     "ConnectionError",
     "ConnectTimeout",
     "ReadTimeout",
@@ -83,6 +101,13 @@ NETWORK_MARKERS = (
     "network may be blocking",
     "Name or service not known",
     "Temporary failure in name resolution",
+    # uv, which speaks reqwest rather than requests.
+    "Failed to download",
+    "Failed to fetch",
+    "Request failed after",
+    "error sending request",
+    "client error (Connect)",
+    "dns error",
 )
 
 
@@ -126,11 +151,22 @@ def run_pip_audit(command: list[str], report: Path) -> Attempt:
 
 
 def network_marker(output: str) -> str | None:
-    """The first marker in `output` saying this failure was the network, if any."""
+    """The first marker in `output` naming this failure as the network, if any."""
     for marker in NETWORK_MARKERS:
         if marker in output:
             return marker
     return None
+
+
+def announce(state: str, detail: str) -> None:
+    """Emit the verdict where a caller can read it without an exit code."""
+    line = f"{VERDICT_PREFIX} {state} — {detail}"
+    print(line)
+
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with Path(summary).open("a", encoding="utf-8") as handle:
+            handle.write(f"{line}\n")
 
 
 def report_findings(report: dict[str, Any]) -> int:
@@ -144,39 +180,43 @@ def report_findings(report: dict[str, Any]) -> int:
 
     audited = len(dependencies) - len(skipped)
     if not vulnerable:
-        print(f"No known vulnerabilities in {audited} locked dependencies.")
+        announce("CLEAN", f"no known advisories against {audited} locked dependencies")
         return EXIT_CLEAN
 
     count = sum(len(dep["vulns"]) for dep in vulnerable)
-    plural = "vulnerability" if count == 1 else "vulnerabilities"
-    print(f"Found {count} known {plural} in {len(vulnerable)} of {audited} locked dependencies:")
+    plural = "advisory" if count == 1 else "advisories"
     for dep in vulnerable:
         for vuln in dep["vulns"]:
             fixes = ", ".join(vuln["fix_versions"]) or "none"
             aliases = " ".join(vuln.get("aliases", []))
             print(f"  {dep['name']} {dep['version']}  {vuln['id']}  fix: {fixes}  {aliases}")
+    announce(
+        "VULNERABLE",
+        f"{count} known {plural} in {len(vulnerable)} of {audited} locked dependencies",
+    )
     return EXIT_VULNERABLE
 
 
 def report_unavailable(attempt: Attempt, marker: str | None, tries: int) -> int:
     """Print why no audit happened, in terms nobody can read as a finding."""
+    plural = "attempt" if tries == 1 else "attempts"
     if marker is None:
-        headline = "NOT AUDITED: pip-audit failed before reaching the vulnerability feed."
-        advice = "Read its output below; re-running will not change it."
-    else:
-        plural = "attempt" if tries == 1 else "attempts"
-        headline = (
-            f"NETWORK: the vulnerability feed was unreachable ({marker}) after {tries} {plural}."
+        state = "FAILED"
+        detail = (
+            f"pip-audit reached no verdict in {tries} {plural} and did not say why; "
+            "no audit was performed"
         )
-        advice = "Re-run the job."
+    else:
+        state = "NETWORK"
+        detail = f"unreachable ({marker}) after {tries} {plural}; no audit was performed"
 
-    print(headline, file=sys.stderr)
     print(
         "No audit was performed, so this is not a finding: no locked dependency has "
-        f"been reported vulnerable, and none has been cleared either. {advice}",
+        "been reported vulnerable, and none has been cleared either.",
         file=sys.stderr,
     )
     print(f"\npip-audit exited {attempt.returncode}:\n{attempt.output}", file=sys.stderr)
+    announce(state, detail)
     return EXIT_UNAVAILABLE
 
 
@@ -193,13 +233,13 @@ def audit(requirements: Path, attempts: int, timeout: int, backoff: int, extra: 
                 return report_findings(attempt.report)
 
             marker = network_marker(attempt.output)
-            if marker is None or tries >= attempts:
+            if tries >= attempts:
                 return report_unavailable(attempt, marker, tries)
 
             delay = backoff * tries
             print(
-                f"attempt {tries}/{attempts} did not reach the feed ({marker}); "
-                f"retrying in {delay}s",
+                f"attempt {tries}/{attempts} reached no verdict "
+                f"({marker or 'cause not recognised'}); retrying in {delay}s",
                 file=sys.stderr,
             )
             time.sleep(delay)


### PR DESCRIPTION
`Security Scan` is a required check, and `pip-audit` exits 1 whether it found a
known advisory or never reached the vulnerability feed at all. So the `ReadTimeout`
on #838 (run 32073668049) blocked a merge while reading exactly like a finding
until somebody opened the log, and a re-run of the same commit passed unchanged.

`scripts/audit_dependencies.py` now stands between `pip-audit` and the job, and
does three things.

**It takes the verdict from the report, not the exit code.** `--format json` is a
*manifest* format in pip-audit, so it is written on both the clean and the
vulnerable path — and only after every one of the 254 locked distributions has
been queried. The report existing therefore means the audit completed; the report
missing means it did not, whatever the process exited. Nothing parses a summary
line.

**It retries every run that reached no verdict.** Three attempts (`AUDIT_ATTEMPTS`)
with a 5s/10s backoff, and the per-request socket timeout raised from pip-audit's
15s to 30s (`AUDIT_TIMEOUT`). Matching a phrase in the output decides only whether
the verdict reads `NETWORK` or `FAILED` — never whether to try again. The two
mistakes are not symmetric: re-running a deterministic failure costs seconds and
the same answer, while not re-running a transient one is the false red this exists
to prevent. Two vocabularies are in that list, because two programs reach for the
network — `uv`, fetching `pip-audit` itself on a cold tool cache, and then
`pip-audit`, fetching the advisories.

**It says which of four states it ended in, on a line.** GNU Make turns any failed
recipe into its own exit 2, so an exit code cannot reach a caller going through
`make audit` — which is what `Security Scan` does. Every run therefore ends on:

```
AUDIT: CLEAN — no known advisories against 254 locked dependencies
AUDIT: VULNERABLE — 6 known advisories in 1 of 254 locked dependencies
AUDIT: NETWORK — unreachable (ReadTimeout) after 3 attempts; no audit was performed
AUDIT: FAILED — pip-audit reached no verdict in 3 attempts and did not say why; no audit was performed
```

Last line of stdout, so `make audit | tail -1` is the whole contract, and the same
line is appended to `$GITHUB_STEP_SUMMARY` inside a job. Invoked directly the
script also carries `0` / `1` / `75` (`EX_TEMPFAIL` for both `NETWORK` and
`FAILED`), and `docs/commands.md` says plainly which interface gives which — an
exit contract nobody can read is worse than no contract.

It never reports green on an audit that did not run: an unaudited dependency set
called clean is the same defect facing the other way. So a `NETWORK` verdict still
fails the job — it just cannot be read as a finding, which is the requirement the
issue actually sets.

The workflow still calls `make audit`, so `tests/test_ci_parity.py` keeps its
premise. Calling the script directly from the job would have traded that premise
for nothing: GitHub records a step as passed or failed and never surfaces its exit
code, so the job sees no more with `make` out of the way than with it in.

## Why not the other two remedies

**`-s osv` — rejected, on the evidence.** The issue says OSV "answers in one
batched request rather than one per distribution". It does not:
`pip_audit/_service/osv.py` POSTs to `/v1/query` once per dependency inside
`query_all`, exactly like the PyPI service GETs once per dependency. It is also
*more* fragile at the point that matters — it catches `requests.ConnectTimeout`
only, so a `ReadTimeout` escapes as a traceback there too. Switching services
would have moved the single point of failure, not removed it.

**Caching the vulnerability database — rejected as a fix, though it helps.**
pip-audit already caches through `cachecontrol` into pip's HTTP cache, which is
why a warm local run answers in 1.3s. Persisting that across CI runs shortens the
job; it does not make an uncached or revalidated request survive a timeout, and it
cannot tell a network failure from a finding. Worth doing separately if the job's
duration ever becomes the complaint.

## Verified

All against real `pip-audit` 2.10.1 and real `uv`:

- **A clean run still passes.** `make audit` ends `AUDIT: CLEAN — no known
  advisories against 254 locked dependencies`, exit 0.
- **A real advisory still fails.** `requests==2.19.0` prints six advisories with
  ids, fix versions and CVE aliases, ends `AUDIT: VULNERABLE — 6 known advisories
  in 1 of 1 locked dependencies`, script exit 1.
- **An unreachable feed does not read as a finding.** The issue suggests pointing
  `--index-url` at a dead host; that would not have exercised the feed, because
  `PyPIService` hardcodes `https://pypi.org/pypi/…` and ignores the index URL. The
  OSV service does take its URL, so it was pointed at a closed port:

  ```
  attempt 1/3 reached no verdict (ConnectionError); retrying in 1s
  attempt 2/3 reached no verdict (ConnectionError); retrying in 2s
  AUDIT: NETWORK — unreachable (ConnectionError) after 3 attempts; no audit was performed
  ```

  Script exit 75, and the same line in `$GITHUB_STEP_SUMMARY`.
- **A cold uv cache against a dead host is recognised too.**
  `UV_NO_CACHE=1 UV_INDEX_URL=http://127.0.0.1:9/simple` reproduces the review's
  case: `attempt 1/2 reached no verdict (Failed to fetch); retrying in 1s`, then
  `AUDIT: NETWORK — unreachable (Failed to fetch) after 2 attempts`.
- **A transient failure recovers.** Against a local feed answering `503` once and
  then normally: `attempt 1/3 reached no verdict (HTTPError); retrying in 1s`
  followed by `AUDIT: CLEAN`, exit 0. That is the #838 shape, end to end, going
  green on its own.
- **`make` really does collapse the status.** A recipe exiting 75 prints
  `make: *** [audit] Error 75` and `make` exits 2 — asserted in the suite so the
  reason for the verdict line is not only in a commit message.

Twelve of the 26 tests in `backend/tests/test_audit_dependencies.py` fail against
the first commit's script.

What I could **not** exercise: a genuine pypi.org `ReadTimeout` in the real job.
It is a timing condition on somebody else's server, so #838's traceback is covered
as a recorded string rather than provoked. `make lint-frontend` could not run in
this worktree (no `frontend/node_modules`); nothing frontend is touched and CI's
path filters skip that job here. `make lint-backend`, `make test` (5609 passed,
100% coverage) and `make docs-build` are green.

## Also in the diff

`docs/commands.md` had an orphaned `make sandbox-token` table row stranded below a
paragraph, three rows away from the table it belongs to, rendering as literal
pipes. It sat in the lines this change edits, so it is moved back into the
`Development` table rather than filed.

Closes #855
