### PR TITLE
test(frontend): size the suite's two deadlines for a loaded machine

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -280,3 +280,8 @@ and most of `src/components`, so a suite where every test passes can still be re
 dead branch is easier to delete than to cover: a `?? ""` behind a check that already
 proved the value, or an optional prop two callers always pass, is one the gate is
 right to notice.
+
+**A red spec that says "timed out" is usually the machine.** `testTimeout` is 15s and
+`asyncUtilTimeout` 5s, both measured rather than guessed - `docs/testing.md#two-deadlines-both-sized-for-a-loaded-machine`
+has the four runs behind them (#862). Neither is a reason to keep a spec that mounts
+more than its assertions read.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -85,9 +85,14 @@ Traps, each of which has cost a red job here:
   before the response goes out (#353) - but #230 is a browser-side staleness nobody has
   closed, so the polling stays until it is. One step read once instead and took all 87
   specs down three times in a day (#335).
-- **Coverage instrumentation slows tests enough to trip a 5s `testTimeout`.** A
-  heavy spec that passes under `test:run` can time out under `test:coverage`; re-run
-  before believing it.
+- **A frontend spec that times out is usually the machine, and the deadlines are set
+  for that.** `testTimeout` is 15s in `vitest.config.ts` and `asyncUtilTimeout` 5s in
+  `vitest.setup.ts`, both raised from defaults sized for a quiet machine: measured over
+  all 4941 tests, the slowest is 1.7s bare and 2.9s instrumented on ten idle cores, and
+  5.4s bare and 6.1s instrumented with 32 busy loops beside it - where the 5s default
+  reddened three tests a run, a different three each time, bare and under coverage
+  alike (#862). Do not lower either to make a hang fail faster, and do not raise one
+  to rescue a spec doing more work than its assertions need.
 
 ## The four layers
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -158,6 +158,37 @@ bun run test:e2e --headed                                  # ...with a browser t
 `test-frontend` job will pass: the gate wants 100% lines, statements and functions and
 97.5% branches over `src/{app/api,lib,stores,hooks}` and most of `src/components`.
 
+### Two deadlines, both sized for a loaded machine
+
+A render-heavy spec is not slow because it is badly written; it is slow because
+several thousand of them share ten cores with whatever else is running.
+`testTimeout` in `vitest.config.ts` is **15s** and Testing Library's
+`asyncUtilTimeout` in `vitest.setup.ts` is **5s**, both raised from defaults that
+only hold on an idle machine.
+
+The numbers come from running the whole suite four ways
+([#862](https://github.com/vstorm-co/agenticos/issues/862)):
+
+| Slowest single test | Bare | Under `--coverage` |
+|---|---|---|
+| Ten idle cores | 1.7s | 2.9s |
+| 32 busy loops beside it | 5.4s | 6.1s |
+
+Under that load the old 5s default failed three tests a run — a *different* three
+each time, because which files share a worker is decided on timing, and in the bare
+run as well as the instrumented one. Instrumentation costs about 1.6x of total test
+time on a quiet machine and is the smaller multiplier; scheduling latency is the
+rest. That is why neither deadline is conditional on `--coverage`: a limit the fast
+loop and the gate disagree about is one that cannot reproduce the gate.
+
+`asyncUtilTimeout` stays well under `testTimeout` on purpose. An element that is
+never coming should lose the race, so the failure says *"Unable to find an element
+with the text: …"* and names it, rather than *"Test timed out"* and names nothing.
+
+Neither number is a licence for a spec that does more work than its assertions need:
+mounting forty table rows twice to prove a count cost about two seconds in
+`rag/[id]/counts.integration.test.tsx` before its fixture was cut to three.
+
 Playwright starts what the suite needs: the frontend, and an OpenAI-compatible
 **stub model server** (`frontend/e2e/stub-model-server.ts`) on `127.0.0.1:4010`
 by default. The backend and its database have to be up already — the seeded

--- a/frontend/src/app/[locale]/(dashboard)/rag/[id]/counts.integration.test.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/rag/[id]/counts.integration.test.tsx
@@ -87,9 +87,10 @@ function document_(index: number, chunks: number): KBDocument {
  * Deliberately not the twenty `DOCS_PAGE_SIZE` really asks for
  * (`src/hooks/use-knowledge-bases.ts` - it is the frontend's constant, and the
  * route itself caps `limit` at 100). What the assertions need is a page
- * *shorter than the total*, and forty table rows to mount twice was 39% of the
- * 5s `testTimeout` for one test - which is how a spec starts flaking under
- * coverage instrumentation.
+ * *shorter than the total*, and forty table rows to mount twice cost about two
+ * seconds for one test - a spec that does more work than its assertions need is
+ * the first to flake under coverage instrumentation, whatever `testTimeout` is
+ * (#862).
  */
 const FIRST_PAGE = Array.from({ length: 3 }, (_, i) => document_(i, 4));
 const SECOND_PAGE = Array.from({ length: 3 }, (_, i) => document_(3 + i, 4));

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -10,6 +10,27 @@ export default defineConfig({
     setupFiles: ["./vitest.setup.ts"],
     include: ["**/*.{test,spec}.{ts,tsx}"],
     exclude: ["node_modules", ".next", "e2e"],
+    /*
+     * Raised from vitest's 5s default, because 5s is not a deadline this suite
+     * can hold and the machine decides which spec misses it.
+     *
+     * Measured over all 4941 tests, on ten cores (#862). Quiet, the slowest
+     * test is 1.7s bare and 2.9s under v8 instrumentation. At 32 busy loops
+     * beside it — the load the issue was filed from — the slowest is 5.4s bare
+     * and 6.1s instrumented, and both runs went red: three tests each, and a
+     * different three, because which files share a worker is decided on
+     * timing. Instrumentation is one multiplier of several and the smaller
+     * one; scheduling latency is the rest, which is why this is not
+     * conditional on `--coverage`. A timeout the fast loop and the gate
+     * disagree about is one that cannot reproduce the gate.
+     *
+     * 15s is 2.5x the worst duration measured under that load, and the number
+     * `playwright.config.ts` already writes down for the same class of
+     * problem. A test that genuinely hangs still fails — ten seconds later
+     * than it used to, on the one run where that is the answer rather than a
+     * lie about the diff.
+     */
+    testTimeout: 15_000,
     server: {
       deps: {
         // `next-intl/middleware` imports `next/server` bare, which Node's ESM

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,6 +1,25 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup } from "@testing-library/react";
+import { cleanup, configure } from "@testing-library/react";
 import { afterEach, vi } from "vitest";
+
+/**
+ * How long `findBy*` and `waitFor` keep looking, raised from Testing Library's
+ * 1s default.
+ *
+ * The second deadline in this suite, and the one `testTimeout` cannot cover: a
+ * `findByText` that gives up at 1s fails the test at 1s, whatever vitest's
+ * limit is. Under the load #862 was filed from it is the deadline that bites
+ * most often — two of the three failures in each loaded run, bare and
+ * instrumented alike, and the same specs that pass in about a second on a
+ * quiet machine.
+ *
+ * 5s rather than vitest's 15s on purpose: an element that is never coming has
+ * to lose the race to `testTimeout`, so the failure reads "Unable to find an
+ * element with the text: …" and names it, rather than "Test timed out in
+ * 15000ms" and names nothing. It costs nothing when a wait succeeds, which is
+ * every passing test — only a genuine failure waits the whole 5s.
+ */
+configure({ asyncUtilTimeout: 5_000 });
 
 /**
  * Whether this file runs in a browser-shaped environment.


### PR DESCRIPTION
`test-frontend` is a required check, and under load it went red on whichever
render-heavy spec happened to miss vitest's 5s `testTimeout` — naming a file the
branch had not touched. `.claude/rules/testing.md` carried a note telling people to
distrust that red rather than a fix for it.

## What I measured

Four whole-suite runs, all 4941 tests, ten cores, per-test durations from vitest's
JSON reporter. Slowest single test in each:

| | bare (`test:run`) | `--coverage` |
|---|---|---|
| ten idle cores | 1.7s | 2.9s |
| 32 busy loops beside it | **5.4s** | **6.1s** |

Both loaded runs went red — three tests each, and a *different* three, because which
files share a worker is decided on timing. The two the issue names reproduced
exactly: `file-render` at 6102ms and `dashboard.integration` at 5254ms.

Two things fell out of that, and they decided the shape of the fix.

**The bare run failed too.** So this is not a coverage defect. Instrumentation costs
about 1.6x of total test time on a quiet machine and 3.6x under load; scheduling
latency is the larger multiplier, and load alone crosses 5s. Making the deadline
conditional on `--coverage` — which the config can see — would leave the fast loop
unable to reproduce the gate, so both numbers are unconditional.

**There is a second deadline.** Two of the three failures in each loaded run were not
`testTimeout` at all but Testing Library's own 1s `asyncUtilTimeout` — including
`approvals-count`, which #862 names. Raising `testTimeout` alone would have left that
one reproducible, since a `findByText` that gives up at 1s fails the test at 1s
whatever vitest's limit is.

## What I changed

- **`testTimeout: 15_000`** (`vitest.config.ts`) — 2.5x the worst duration measured
  under that load, and the number `playwright.config.ts` already justifies for the
  same class of problem. A genuine hang still fails, ten seconds later.
- **`asyncUtilTimeout: 5_000`** (`vitest.setup.ts`) — deliberately well under
  `testTimeout`, so an element that is never coming loses the race and the failure
  says *"Unable to find an element with the text: …"* rather than *"Test timed out"*.
  It costs nothing when a wait succeeds, which is every passing test.
- Docs: `docs/testing.md` gains "Two deadlines, both sized for a loaded machine" with
  the table above; `.claude/rules/testing.md` and `.claude/rules/frontend.md` record
  the resolution in place of the "re-run before believing it" note.

## The other half of the issue

Whether some specs are simply doing more work than they need. Twelve of 322 files are
a third of the suite's test time, but no *single* test is pathological — the slowest,
`file-render`'s five-hundred-row table, is heavy because the cap is what it asserts.
So a blanket raise is not hiding one bad spec here; the cost is broad and per-test.
One spec had already bent itself around the old number
(`rag/[id]/counts.integration.test.tsx` serves three documents a page rather than
twenty); it keeps its short fixture, and its comment no longer cites a limit that has
moved.

## Verification

- Re-ran the same 32-busy-loop coverage run with the change: **0 failed**, worst test
  6.2s against the new 15s budget.
- `make lint-frontend`, `make test-frontend-cov` **three times** (322 files, 4941
  tests, 100% statements/functions/lines, 97.63% branches), `make build-frontend` —
  all green. The third coverage run was on a machine busy enough to take it from 126s
  to 348s, and stayed green.
- `make check` is untouched: CI's `test-frontend` job still runs
  `make test-frontend-cov`, so `test_ci_parity` has nothing to disagree with.

Nothing is red.

Closes #862
