### PR TITLE
fix(rag): refuse an impossible ingestion override at the form

### DIFF
--- a/backend/app/services/ingestion_config.py
+++ b/backend/app/services/ingestion_config.py
@@ -361,11 +361,25 @@ class IngestionOverride(BaseModel):
         be legal: a collection with `chunk_size=512` and an override setting
         `chunk_overlap=600` is two individually valid numbers and one
         configuration that does not terminate.
+
+        Raises:
+            BadRequestError: If the merged configuration is not legal. The
+                refusal is about the form field the override arrived in, so it
+                leaves as the same refusal :func:`parse_override` raises for a
+                field the override could not be read from at all - a raw
+                `ValidationError` reaches no handler, so the upload answered a
+                500 for a number the caller typed (#874).
         """
         changes = self.model_dump(exclude_unset=True, exclude={"image_description"})
         if self.image_description is not None:
             changes["image_description"] = self.image_description.applied_to(base.image_description)
-        return IngestionConfig.model_validate({**base.model_dump(), **changes})
+        try:
+            return IngestionConfig.model_validate({**base.model_dump(), **changes})
+        except ValidationError as exc:
+            raise BadRequestError(
+                message="The 'ingestion' field is not a valid override for this collection",
+                details={"errors": exc.errors(include_url=False, include_input=False)},
+            ) from exc
 
 
 def parse_override(raw: str | None) -> IngestionOverride | None:

--- a/backend/tests/api/test_ingestion_override_routes.py
+++ b/backend/tests/api/test_ingestion_override_routes.py
@@ -1,0 +1,175 @@
+"""What an upload answers when its per-file ingestion override is not legal.
+
+The pair rule on `IngestionConfig` refuses an overlap that is not smaller than
+the chunk it repeats, and its docstring says where the refusal is meant to
+land: "the form is what says so". The form got `500 An unexpected error
+occurred` with `details: null`, because the merge raised a raw pydantic
+`ValidationError` and `register_exception_handlers` maps no such thing (#874).
+
+Routes rather than the service alone, because the defect was route-shaped: the
+service test underneath asserted the merge raised, which it always did. What
+was wrong was what that raise became on the wire - and it became it twice, at
+both addresses an upload can arrive at.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import AsyncClient
+
+from app.api import deps
+from app.core.config import settings
+from app.core.permissions import AuthContext, OrgRoleName
+from app.db.models.knowledge_base import KBScope, KnowledgeBase
+from app.db.models.resource_grant import Visibility
+from app.main import app
+from app.services import rag_document
+
+pytestmark = pytest.mark.anyio
+
+_ORGANIZATION = uuid.uuid4()
+_CALLER = uuid.uuid4()
+# Fixed, because it is part of a parametrized route and so part of a test id:
+# a fresh one per process makes xdist workers disagree about what was collected.
+_KB_ID = uuid.UUID("6a3f0b6e-9d1f-4a52-9c0b-2f5f6c1d84a7")
+
+_TOO_MUCH_OVERLAP = json.dumps({"chunk_overlap": 4096})
+
+
+@pytest.fixture(autouse=True)
+def caller() -> None:
+    """An owner, so a 400 here is a statement about the override.
+
+    Which permission each route gates on is `tests/api/test_platform_routes.py`
+    and the knowledge-base service's own tests; holding all of them keeps that
+    out of the way.
+    """
+    app.dependency_overrides[deps.get_auth_context] = lambda: AuthContext(
+        user_id=_CALLER,
+        organization_id=_ORGANIZATION,
+        role=OrgRoleName.OWNER.value,
+        is_app_admin=False,
+    )
+
+
+@pytest.fixture(autouse=True)
+def collection(monkeypatch: pytest.MonkeyPatch) -> KnowledgeBase:
+    """A collection chunking at 512, reachable through both routes' resolvers.
+
+    Both resolvers are stubbed rather than driven, because who may write here
+    is settled before the override is read and is not what these tests are
+    about. The budget check in front of the merge is stubbed for the same
+    reason: it queries a session that is an `AsyncMock` in this suite.
+    """
+    row = KnowledgeBase(
+        id=_KB_ID,
+        name="Handbook",
+        collection_name="handbook",
+        scope=KBScope.ORG.value,
+        organization_id=_ORGANIZATION,
+        owner_user_id=None,
+        visibility=Visibility.ORG.value,
+        ingestion_config={"chunk_size": 512},
+        embedding_model="text-embedding-3-large",
+        embedding_dim=3072,
+    )
+    access = MagicMock()
+    access.writable = AsyncMock(return_value=row)
+    app.dependency_overrides[deps.get_collection_access_service] = lambda: access
+
+    knowledge_bases = MagicMock()
+    knowledge_bases.get_for_write = AsyncMock(return_value=row)
+    app.dependency_overrides[deps.get_knowledge_base_service] = lambda: knowledge_bases
+
+    monkeypatch.setattr(rag_document, "assert_organization_within_budget", AsyncMock())
+    return row
+
+
+@pytest.fixture
+def store() -> MagicMock:
+    """A stand-in for the vector store, so "never reached" is assertable."""
+    stub = MagicMock()
+    stub.create_collection = AsyncMock()
+    app.dependency_overrides[deps.get_vectorstore] = lambda: stub
+    return stub
+
+
+def _upload() -> dict[str, Any]:
+    return {"file": ("handbook.pdf", b"%PDF-1.4", "application/pdf")}
+
+
+def _error(response: Any) -> dict[str, Any]:
+    body: dict[str, Any] = response.json()["error"]
+    return body
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        f"{settings.API_V1_STR}/rag/collections/handbook/ingest",
+        f"{settings.API_V1_STR}/kb/{_KB_ID}/documents",
+    ],
+)
+class TestAnOverlapThatDoesNotFitInsideTheChunk:
+    async def test_the_upload_is_refused_rather_than_crashing(
+        self, client: AsyncClient, store: MagicMock, path: str
+    ) -> None:
+        """It was a 500, which reads as the platform being broken.
+
+        4096 and 512 are each legal on their own; it is the pair that never
+        advances, and the caller chose one half of it.
+        """
+        response = await client.post(path, files=_upload(), data={"ingestion": _TOO_MUCH_OVERLAP})
+
+        assert response.status_code == 400
+        assert _error(response)["code"] == "BAD_REQUEST"
+        store.create_collection.assert_not_called()
+
+    async def test_the_refusal_names_the_two_numbers_that_disagree(
+        self, client: AsyncClient, store: MagicMock, path: str
+    ) -> None:
+        """`details` was `null`, so the form was told nothing at all."""
+        response = await client.post(path, files=_upload(), data={"ingestion": _TOO_MUCH_OVERLAP})
+
+        errors = _error(response)["details"]["errors"]
+        assert "chunk_overlap" in errors[0]["msg"]
+        assert "chunk_size" in errors[0]["msg"]
+
+    async def test_no_copy_of_the_submitted_override_comes_back(
+        self, client: AsyncClient, store: MagicMock, path: str
+    ) -> None:
+        """A refusal names the field that is wrong, not what was posted."""
+        errors = _error(
+            await client.post(path, files=_upload(), data={"ingestion": _TOO_MUCH_OVERLAP})
+        )["details"]["errors"]
+
+        assert all("input" not in error and "url" not in error for error in errors)
+
+
+class TestTheSameRuleOnTheCollectionsOwnSettings:
+    """The other entry point the rule guards, checked rather than assumed.
+
+    A collection's configuration arrives as a schema field of a JSON body, so
+    FastAPI validates it before the handler and `validation_exception_handler`
+    answers - the pair was already refused here, named and in the envelope.
+    Only the multipart override skipped that, because a form field holding JSON
+    is a string until something parses it.
+    """
+
+    async def test_an_impossible_pair_is_named_in_the_envelope(self, client: AsyncClient) -> None:
+        response = await client.post(
+            f"{settings.API_V1_STR}/kb",
+            json={
+                "name": "Handbook",
+                "ingestion_config": {"chunk_size": 512, "chunk_overlap": 512},
+            },
+        )
+
+        assert response.status_code == 422
+        assert _error(response)["code"] == "VALIDATION_ERROR"
+        assert _error(response)["details"]["fields"][0]["field"] == "ingestion_config"

--- a/backend/tests/test_ingestion_config.py
+++ b/backend/tests/test_ingestion_config.py
@@ -117,8 +117,34 @@ class TestAConfigurationThatWouldNotTerminate:
         """Two individually legal numbers, one configuration that does not terminate."""
         base = IngestionConfig(chunk_size=4096, chunk_overlap=2048)
 
-        with pytest.raises(ValueError, match="chunk_overlap"):
+        with pytest.raises(BadRequestError, match="ingestion"):
             IngestionOverride(chunk_size=1024).applied_to(base)
+
+    def test_the_merged_pair_is_refused_as_a_form_error_and_names_both_numbers(self) -> None:
+        """It was a raw `ValidationError`, which reaches no handler and is a 500.
+
+        The rule's own docstring says the form is what refuses this pair, and
+        the form was being told the server had broken (#874).
+        """
+        base = IngestionConfig(chunk_size=512)
+
+        with pytest.raises(BadRequestError) as refusal:
+            IngestionOverride(chunk_overlap=4096).applied_to(base)
+
+        errors = refusal.value.details["errors"]
+        assert "chunk_overlap" in errors[0]["msg"]
+        assert "chunk_size" in errors[0]["msg"]
+
+    def test_the_refusal_carries_no_copy_of_what_was_submitted(self) -> None:
+        """`details` names the fields that are wrong, never the document sent."""
+        base = IngestionConfig(chunk_size=512)
+
+        with pytest.raises(BadRequestError) as refusal:
+            IngestionOverride(chunk_overlap=4096).applied_to(base)
+
+        assert all(
+            "input" not in error and "url" not in error for error in refusal.value.details["errors"]
+        )
 
 
 class TestWhatAnOverrideChanges:

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -327,6 +327,19 @@ Chunk boundaries are what a search matches against, so a collection ingested
 before that change keeps the chunks it was ingested with. Re-upload a document,
 or re-run `uv run agenticos cmd rag-ingest`, to re-chunk it.
 
+**An override is checked against the merged pair, not against its own value.** A
+per-upload `ingestion` field carries only what it changes, so `chunk_overlap:
+4096` sent to a collection chunking at 512 is two individually legal numbers and
+one configuration that repeats almost everything it advances past. The merge
+re-validates, and the upload is refused with a **400** naming both settings in
+`details.errors` — before the file is stored and before a document row exists,
+so there is nothing to retry or clean up. It answered 500 with an empty
+`details` until [#874](https://github.com/vstorm-co/agenticos/issues/874): the
+merge raised a raw Pydantic error, which reaches no handler. The same pair sent
+as a collection's own configuration was always refused with a 422, because there
+it is a field of a JSON body and FastAPI validates it before the route is
+entered.
+
 ### Embeddings — the model, and whose key pays
 
 Embeddings go out through OpenRouter to an OpenAI embedding model. Both halves


### PR DESCRIPTION
## What changed

An upload whose per-file `ingestion` override sets `chunk_overlap` at or above the
collection's `chunk_size` now answers **400** naming both settings, instead of
`500 "An unexpected error occurred"` with `details: null`.

`parse_override` accepts the field — 4096 and 512 are each inside
`IngestionOverride`'s bounds — so the pair is only refused when the merge
re-validates it in `IngestionOverride.applied_to`. That raised a raw pydantic
`ValidationError`, which is not a `RequestValidationError`, so no handler mapped it
and `unhandled_exception_handler` answered: a traceback in the log for a number
somebody typed, and an operator reading a refusal as a broken platform.

The rule's own docstring already said where the refusal belongs — *"Refusing the
pair here means the form is what says so"* — so `applied_to` now raises
`BadRequestError` with `exc.errors(include_url=False, include_input=False)` in
`details`.

## On the shape, and #873

Deliberately the **existing local idiom, not a new mechanism**. `parse_override`
uses exactly this twenty lines above in the same module, and
`CapabilityDef.validate_config` uses it for the same reason. #873 is the same
defect on the spec-YAML endpoint and its issue names the same two call sites as
the shape to copy; it had no branch or PR open when this was written
(`gh pr list --search 873` found only #872, the #861 fix this was swept out of).
So there is one answer here, and a general handler for raw `ValidationError` stays
available as a single deliberate decision later rather than two half-made ones a
week apart.

## The sibling entry points

- **`POST /rag/collections/{name}/ingest`** and **`POST /kb/{kb_id}/documents`** both
  reach the same merge. Both are covered.
- **A collection's own `ingestion_config`** (`POST /kb`, `PATCH /kb/{id}`) was checked
  and is **already correct**: it arrives as a schema field of a JSON body, so FastAPI
  refuses the same pair with a 422 naming `ingestion_config` before the route is
  entered. A test pins that, so the two halves cannot drift apart unnoticed.
- **The stored-row validation immediately above the merge**
  (`IngestionConfig.model_validate(collection.ingestion_config)`) is left raising on
  purpose. A collection whose saved configuration no longer parses is a corrupt row,
  not caller input — reporting it as a bad request would blame the person uploading.
  The worker paths that read the same rows have no client waiting at all.

## Tests

| Test | What it proves |
|---|---|
| `test_the_upload_is_refused_rather_than_crashing` (both routes) | 400, `code: BAD_REQUEST`, and the vector collection is never created — the refusal lands before anything is stored |
| `test_the_refusal_names_the_two_numbers_that_disagree` (both routes) | `details.errors[0].msg` names `chunk_overlap` and `chunk_size`; `details` was `null` |
| `test_no_copy_of_the_submitted_override_comes_back` (both routes) | no `input` and no `url` key in any error entry |
| `test_an_impossible_pair_is_named_in_the_envelope` | the collection-settings sibling still answers 422 with `details.fields[0].field == "ingestion_config"` |
| `test_the_merged_pair_is_refused_as_a_form_error_and_names_both_numbers` | the service-level refusal is a `BadRequestError` |
| `test_the_refusal_carries_no_copy_of_what_was_submitted` | same, at the service level |
| `test_an_override_is_checked_against_the_merged_pair_not_its_own_value` | updated: it asserted `ValueError`, which is what the defect was |

The three route tests fail on `main` with the raw `ValidationError` they were
written for — checked by reverting the fix and re-running.

## Verification

```
make lint          green
make test          5592 passed, 15 skipped — platform layer at 100.00%
make docs-build    built, --strict
python3 scripts/docs_drift.py   no drift
```

## Docs

`docs/file-processing.md` (Chunking Configuration) now says that an override is
checked against the merged pair, what the refusal is, that it lands before the file
is stored, and how the collection-settings path differs.

## Found and not fixed

The frontend marks an offending input from `details.fields` (`fieldProblems` in
`src/lib/api-error.ts`); all three call sites of this idiom — `parse_override`,
`CapabilityDef.validate_config` and now `applied_to` — answer with
`details.errors`, so the message is shown and no input is highlighted.
Pre-existing, cross-cutting, and shared with #873, so it is filed separately rather
than folded in here.

Closes #874
