### PR TITLE
fix(agents): answer a broken spec YAML with the field, not a 500

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -21,7 +21,11 @@
 #   falied     The misspelling is the subject of a test: `?status=falied` must
 #              be refused rather than answered with an empty 200 that reads as
 #              "no failures". Correcting it would delete what it proves.
-ignore-words-list = dependant,nam,adres,ue,couldn,re-use,re-declaring,selectin,ans,oraz,jest,informacji,falied
+#   instrucitons
+#              The same: a typo'd key in an imported spec must come back named
+#              in `loc` rather than as a 500 (#873), so the tests assert on the
+#              misspelling. Correcting it would assert nothing.
+ignore-words-list = dependant,nam,adres,ue,couldn,re-use,re-declaring,selectin,ans,oraz,jest,informacji,falied,instrucitons
 
 # Lockfiles, generated code, uploaded media and the Polish message catalog are
 # not English prose. `messages/pl.json` in particular is a translation file:

--- a/backend/app/api/routes/v1/agents.py
+++ b/backend/app/api/routes/v1/agents.py
@@ -321,7 +321,7 @@ async def import_spec(
     agent_id: UUID, data: AgentSpecImport, service: AgentRegistrySvc, ctx: Auth
 ) -> Any:
     """Replace the draft with a hand-written or externally-managed spec."""
-    return await service.save_draft(ctx, agent_id, AgentSpec.from_yaml(data.yaml))
+    return await service.import_spec(ctx, agent_id, data.yaml)
 
 
 @router.post(

--- a/backend/app/services/agent_registry.py
+++ b/backend/app/services/agent_registry.py
@@ -21,8 +21,10 @@ import re
 from collections import Counter
 from collections.abc import Sequence
 from dataclasses import dataclass, field
+from typing import Any
 from uuid import UUID
 
+import yaml
 from pydantic import BaseModel, ValidationError
 from pydantic_ai_harness.compaction import resolve_context_window
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -520,6 +522,54 @@ def _window_of(profile: ModelProfile | None) -> int | None:
     return resolve_context_window(f"{profile.provider}:{profile.model}")
 
 
+def _yaml_location(exc: yaml.YAMLError) -> dict[str, Any]:
+    """Where the document stopped parsing, without quoting any of it.
+
+    `str()` on a marked YAML error includes the offending source line, and the
+    document is somebody's spec - instructions, a `secret_id`, whatever they
+    were editing when it broke. So the position is reported and the text is not:
+    it is already in front of the person who wrote it
+    (`.claude/rules/exceptions-security.md`). A `ReaderError` - a control
+    character in the file - carries a byte offset and no mark, which is why the
+    line is optional rather than assumed.
+    """
+    mark = getattr(exc, "problem_mark", None)
+    if mark is None:
+        return {"field": "yaml"}
+    return {"field": "yaml", "line": mark.line + 1, "column": mark.column + 1}
+
+
+def _parse_spec_yaml(text: str) -> AgentSpec:
+    """Read a spec written or edited outside the Builder.
+
+    Every field rule in `AgentSpec` exists to explain what is wrong with a spec,
+    and none of those explanations used to reach the person who wrote one: a
+    pydantic `ValidationError` is a `ValueError` but not a
+    `RequestValidationError`, so nothing between the parse and the ASGI boundary
+    mapped it and a typo answered 500 with a traceback in the log, as though the
+    platform had broken rather than the file (#873). Bad input is this path's
+    ordinary case - somebody is editing YAML by hand and iterating.
+
+    Raises:
+        BadRequestError: If the document does not parse, is not a mapping, or
+            breaks a field rule - carrying the field path a form can mark, and
+            no copy of what was submitted.
+    """
+    try:
+        return AgentSpec.from_yaml(text)
+    except ValidationError as exc:
+        raise BadRequestError(
+            message="This spec does not match the agent spec format",
+            details={"errors": exc.errors(include_url=False, include_input=False)},
+        ) from exc
+    except yaml.YAMLError as exc:
+        raise BadRequestError(
+            message="This spec is not valid YAML", details=_yaml_location(exc)
+        ) from exc
+    except ValueError as exc:
+        raise BadRequestError(message=str(exc), details={"field": "yaml"}) from exc
+
+
 class AgentRegistryService:
     """Manage an organization's agents."""
 
@@ -840,6 +890,20 @@ class AgentRegistryService:
                 "description": spec.description,
             },
         )
+
+    async def import_spec(self, ctx: AuthContext, agent_id: UUID, text: str) -> Agent:
+        """Replace the draft with a spec exported into a client's own repository.
+
+        The parse happens before the agent is read. What it refuses depends only
+        on the document the caller sent, so putting it first leaks nothing about
+        which agents exist and answers somebody iterating on a file without
+        opening a transaction against a row they were never going to write.
+
+        Raises:
+            BadRequestError: If the document does not parse, is not a mapping, or
+                breaks a field rule.
+        """
+        return await self.save_draft(ctx, agent_id, _parse_spec_yaml(text))
 
     async def validate_spec(
         self, ctx: AuthContext, spec: AgentSpec, *, agent_id: UUID | None = None

--- a/backend/tests/api/test_agent_spec_import_refusal.py
+++ b/backend/tests/api/test_agent_spec_import_refusal.py
@@ -1,0 +1,170 @@
+"""A hand-edited spec YAML, through the app.
+
+What the spec's own field rules say is covered by `tests/test_agent_spec_and_factory.py`;
+what is asserted here is how a mistake in a spec *arrives*. A pydantic
+`ValidationError` is a `ValueError` but not a `RequestValidationError`, and
+`app/api/exception_handlers.py` maps neither `ValueError` nor `yaml.YAMLError` - so
+every kind of mistake in an imported file used to answer 500 "An unexpected error
+occurred" with `details: null` and a traceback in the log, for the endpoint whose
+ordinary case is somebody editing YAML by hand and iterating (#873).
+
+The service is the real one; only the session and Redis are mocked. The parse
+refuses before the agent is read, so nothing here reaches the database.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.api import deps
+from app.core.config import settings
+from app.core.permissions import AuthContext, OrgRoleName
+from app.main import app
+
+pytestmark = pytest.mark.anyio
+
+_AGENT_ID = uuid.uuid4()
+
+# A spec carrying the two things a spec carries that must never come back in a
+# refusal: a block of instructions and a reference somebody named.
+_SECRETIVE_YAML = """
+name: Support
+instructions: |
+  Escalate to legal@example.com and quote contract ACME-9981.
+capabilities:
+  - id: clock
+    secret_id: 3f7c2c58-0000-4000-8000-000000000001
+  bad indent here
+"""
+
+
+@pytest.fixture
+def client(mock_db_session: Any, mock_redis: MagicMock) -> Iterator[Any]:
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    context = AuthContext(user_id=user.id, organization_id=uuid.uuid4(), role=OrgRoleName.OWNER)
+    app.dependency_overrides[deps.get_db_session] = lambda: mock_db_session
+    app.dependency_overrides[deps.get_redis] = lambda: mock_redis
+    app.dependency_overrides[deps.get_current_user] = lambda: user
+    app.dependency_overrides[deps.get_auth_context] = lambda: context
+
+    @asynccontextmanager
+    async def open_client() -> AsyncIterator[AsyncClient]:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as opened:
+            yield opened
+
+    yield open_client
+    app.dependency_overrides.clear()
+
+
+async def _import(client: Any, text: str) -> Any:
+    async with client() as opened:
+        return await opened.post(
+            f"{settings.API_V1_STR}/agents/{_AGENT_ID}/spec.yaml", json={"yaml": text}
+        )
+
+
+class TestTheRefusalNamesTheField:
+    async def test_a_field_that_breaks_a_rule_is_refused_with_a_400_naming_it(
+        self, client: Any
+    ) -> None:
+        """The example from #873, which answered 500 on `main`."""
+        response = await _import(client, "capabilities: [not_a_capability]\n")
+
+        assert response.status_code == 400
+        error = response.json()["error"]
+        assert error["code"] == "BAD_REQUEST"
+        assert [entry["loc"] for entry in error["details"]["errors"]] == [
+            ["name"],
+            ["capabilities", 0],
+        ]
+
+    async def test_a_typo_in_a_field_name_names_the_key_it_could_not_place(
+        self, client: Any
+    ) -> None:
+        """`extra="forbid"` is what makes a spec strict; the caller has to be
+        told *which* key it refused, or strictness is just a rejection."""
+        response = await _import(client, "name: Support\ninstrucitons: be helpful\n")
+
+        assert response.status_code == 400
+        errors = response.json()["error"]["details"]["errors"]
+        assert errors[0]["loc"] == ["instrucitons"]
+        assert errors[0]["type"] == "extra_forbidden"
+
+    async def test_a_document_that_is_a_list_is_refused_with_the_reason(self, client: Any) -> None:
+        """Pydantic reports a list as an unhelpful type error, which is why
+        `from_yaml` refuses it itself - and that message is ours to surface."""
+        response = await _import(client, "- a\n- b\n")
+
+        assert response.status_code == 400
+        error = response.json()["error"]
+        assert error["code"] == "BAD_REQUEST"
+        assert error["message"] == "An agent spec must be a YAML mapping"
+        assert error["details"] == {"field": "yaml"}
+
+    async def test_yaml_that_does_not_parse_is_refused_with_the_position(self, client: Any) -> None:
+        response = await _import(client, "name: Support\n  description: adrift\n")
+
+        assert response.status_code == 400
+        error = response.json()["error"]
+        assert error["code"] == "BAD_REQUEST"
+        assert error["details"] == {"field": "yaml", "line": 2, "column": 14}
+
+    async def test_a_character_yaml_cannot_read_has_no_position_to_report(
+        self, client: Any
+    ) -> None:
+        """A `ReaderError` carries a byte offset and no mark, so the field is
+        named and nothing is invented for the line."""
+        response = await _import(client, "name: Sup\x00port\n")
+
+        assert response.status_code == 400
+        assert response.json()["error"]["details"] == {"field": "yaml"}
+
+
+class TestTheRefusalQuotesNothingSubmitted:
+    async def test_neither_the_instructions_nor_a_secret_reference_come_back(
+        self, client: Any
+    ) -> None:
+        """A spec is a file somebody is editing: it carries instructions and
+        `secret_id` references, and a YAML error's own text quotes the line it
+        failed on (`.claude/rules/exceptions-security.md`)."""
+        response = await _import(client, _SECRETIVE_YAML)
+
+        assert response.status_code == 400
+        assert "legal@example.com" not in response.text
+        assert "ACME-9981" not in response.text
+        assert "3f7c2c58" not in response.text
+        assert "bad indent here" not in response.text
+
+    async def test_a_rejected_value_is_not_echoed_beside_the_field_it_broke(
+        self, client: Any
+    ) -> None:
+        """`include_input=False`: a form needs to know which field is wrong, not
+        to be sent a copy of what it posted."""
+        response = await _import(client, "name: Support\ninstructions: 12\ndescription: 34\n")
+
+        assert response.status_code == 400
+        errors = response.json()["error"]["details"]["errors"]
+        assert sorted(entry["loc"] for entry in errors) == [["description"], ["instructions"]]
+        assert all("input" not in entry for entry in errors)
+        assert all("url" not in entry for entry in errors)
+
+
+class TestTheRefusalStopsBeforeTheRow:
+    async def test_nothing_is_read_or_written_when_the_spec_does_not_parse(
+        self, client: Any, mock_db_session: Any
+    ) -> None:
+        """The parse is the first thing `import_spec` does, so a spec nobody
+        could have saved never opens a transaction against an agent."""
+        response = await _import(client, "- a\n- b\n")
+
+        assert response.status_code == 400
+        mock_db_session.execute.assert_not_called()
+        mock_db_session.flush.assert_not_called()

--- a/backend/tests/test_agent_registry.py
+++ b/backend/tests/test_agent_registry.py
@@ -886,6 +886,49 @@ class TestSaveDraft:
         }
 
 
+class TestImportSpec:
+    """The round trip the export feature exists for: a spec committed to a
+    client's own repository, edited there, and posted back (#873)."""
+
+    @pytest.mark.anyio
+    async def test_a_valid_document_replaces_the_draft(self):
+        ctx = _ctx()
+        agent = _agent(ctx)
+        spec = _spec("Support", description="Answers billing questions")
+
+        with (
+            patch(f"{REGISTRY_PATH}.agent_repo.get", new=AsyncMock(return_value=agent)),
+            patch(
+                f"{REGISTRY_PATH}.agent_repo.update", new=AsyncMock(return_value=agent)
+            ) as update,
+        ):
+            await AgentRegistryService(_db()).import_spec(ctx, agent.id, spec.to_yaml())
+
+        assert update.call_args.kwargs["update_data"] == {
+            "draft_spec": spec.model_dump(mode="json"),
+            "name": "Support",
+            "description": "Answers billing questions",
+        }
+
+    @pytest.mark.anyio
+    async def test_a_document_that_does_not_parse_never_reaches_the_row(self):
+        """The refusal is a `BadRequestError`, not the `ValidationError` nothing
+        in `app/api/exception_handlers.py` maps - and it is raised before the
+        agent is read, so a spec nobody could have saved opens no transaction."""
+        with (
+            patch(f"{REGISTRY_PATH}.agent_repo.get", new=AsyncMock()) as fetched,
+            patch(f"{REGISTRY_PATH}.agent_repo.update", new=AsyncMock()) as update,
+            pytest.raises(BadRequestError) as refused,
+        ):
+            await AgentRegistryService(_db()).import_spec(
+                _ctx(), uuid.uuid4(), "name: x\ninstrucitons: typo\n"
+            )
+
+        assert refused.value.details["errors"][0]["loc"] == ("instrucitons",)
+        fetched.assert_not_called()
+        update.assert_not_called()
+
+
 class TestValidateSpec:
     @pytest.mark.anyio
     async def test_a_broken_spec_reports_every_problem_at_once(self, ungranted_capability):

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,6 +79,13 @@ type rather than as data access.
 - Input validation via Pydantic schemas
 - Authentication and authorization checks
 - **Never** contains direct DB calls — always delegates to a service
+- **Never** parses untrusted input in the route expression. A `ValidationError`
+  raised there is a `ValueError` but not a `RequestValidationError`, so no
+  handler maps it and the caller is answered 500 with `details: null` — which is
+  how every mistake in a hand-edited spec YAML was reported as a crash (#873).
+  Parsing is the owning service's job, and so is the refusal: `import_spec` on
+  `AgentRegistryService` answers a broken document with a 400 that names the
+  field, and never quotes what was submitted back at the caller.
 
 ### Services (`services/`)
 - Business logic and validation


### PR DESCRIPTION
## What this fixes

Importing a hand-edited spec YAML answered **500 "An unexpected error occurred"**
with `details: null` for every kind of mistake it could contain — a typo in a
field name, a document that is a list instead of a mapping, YAML that does not
parse — and left a traceback in the log as though the platform had broken.

The endpoint exists to take a file somebody edited by hand, so bad input is its
*ordinary* case. Every field rule in `AgentSpec` was written to explain what is
wrong with a spec, and on this route not one of those explanations reached the
person who wrote it. A spec exported into a client's own git repository and
edited there comes back through exactly this endpoint, so this is the round trip
the feature is for.

`AgentSpec.from_yaml` was called **inline in the route expression**, and a
pydantic `ValidationError` is a `ValueError` but not a `RequestValidationError`.
`register_exception_handlers` maps `AppException`, `BudgetExceeded`,
`RequestValidationError` and bare `Exception` — nothing in between — so the
parse fell through to `unhandled_exception_handler`. Same family as #861, fixed
in #872; different code path.

## The change

The parse leaves the route expression, which is where it should not have been
anyway (`.claude/rules/architecture.md`, "a route module holds routers, not
helpers"). `AgentRegistryService.import_spec` owns it, and owns the refusal:

```python
except ValidationError as exc:
    raise BadRequestError(
        message="This spec does not match the agent spec format",
        details={"errors": exc.errors(include_url=False, include_input=False)},
    ) from exc
```

the same shape `CapabilityDef.validate_config` and `parse_override` already use.
All three refusals a broken document can produce are covered: a field rule
(`400`, the pydantic field paths), a non-mapping document (`400`, `from_yaml`'s
own message, which is written in this repository), and YAML that does not parse
(`400`, the line and column).

**`details` names the field and quotes nothing submitted**, which here is more
than `include_input=False`. `str()` on a marked YAML error includes the
**offending source line**, and the document being refused is somebody's spec —
instructions, a `secret_id`, whatever they were editing when it broke. So a
syntax error reports where it stopped and not what it read. A `ReaderError` (a
control character in the file) carries a byte offset and no mark, which is why
the line is optional rather than assumed.

The parse also runs *before* the agent is read. What it refuses depends only on
the caller's own document, so ordering it first leaks nothing about which agents
exist and opens no transaction against a row that was never going to be written.

## The sibling, checked

Only one entry point parses spec YAML. `from_yaml` had exactly one non-test
caller (this route), and `yaml.safe_load` appears nowhere else on a request path
— `skill_library.py` reads the shipped catalog off disk. The three
`AgentSpec.model_validate(agent.draft_spec)` calls still in the route module
read a **stored** spec, where a 500 is the honest answer: a stored spec that no
longer validates is a platform defect, not a caller mistake.

## What is asserted

`backend/tests/api/test_agent_spec_import_refusal.py` (new) — through the app,
real service, only the session and Redis mocked. **All eight fail on `main`,
five of them with a 500.**

- a field that breaks a rule → 400, `BAD_REQUEST`, `loc` naming `capabilities.0`
- a typo'd key → 400 with `extra_forbidden` on the key it could not place
- a list document → 400 carrying `An agent spec must be a YAML mapping`
- YAML that does not parse → 400 with `{"field": "yaml", "line": 2, "column": 14}`
- a character YAML cannot read → 400 with the field named and no invented line
- a spec carrying instructions, an email, a contract number and a `secret_id`
  → none of them appear anywhere in the response body
- two rejected values → the field paths come back, `input` and `url` do not
- a document that does not parse → `execute` and `flush` are never called

`backend/tests/test_agent_registry.py::TestImportSpec` — a valid document
replaces the draft; a broken one raises `BadRequestError` with the field path
and touches neither `agent_repo.get` nor `agent_repo.update`.

## Verification

From the repository root:

```
make lint       -> exit 0 (ruff, ty, vulture, deptry, the guard scripts,
                   eslint, prettier, tsc, codespell)
make test       -> 5593 passed, 15 skipped in 125.11s
                   TOTAL 10652 stmts, 0 miss, 2356 branch, 0 brpart, 100%
                   Required test coverage of 100.0% reached.
```

One line of `.codespellrc`: `instrucitons` joins `falied` on the ignore list.
The typo is the *subject* of two tests — a misplaced key has to come back named
in `loc` — so correcting it would assert nothing. The file already documents
each entry for exactly this reason.

Closes #873
