### PR TITLE
chore: cut 0.0.189

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,27 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.189] - 2026-08-18
+
+### Fixed
+
+- **The frontend suite has deadlines it can actually meet.** `test-frontend`
+  went red on specs that pass in about a second alone, and the diagnosis in the
+  issue was half right: measured over four whole-suite runs, coverage
+  instrumentation is a 1.6x multiplier on an idle machine but 3.6x on a busy
+  one, and **the bare run failed under load too** — so this was never a coverage
+  defect, and a deadline that differed between the fast loop and the gate could
+  not have reproduced the gate. `testTimeout` moves to 15s, which is 2.5x the
+  worst duration measured under load and the figure `playwright.config.ts`
+  already justifies for the same class of problem. (#862)
+- **The second deadline nobody had noticed.** Two of the three failures in each
+  loaded run were Testing Library's own 1s `asyncUtilTimeout`, not
+  `testTimeout` — including one of the two specs the issue named, so raising
+  `testTimeout` alone would have left the reported symptom reproducible. It goes
+  to 5s, deliberately well under `testTimeout`, so an element that is never
+  coming loses the race and the failure names it rather than blaming the test.
+  (#862)
+
 ## [0.0.188] - 2026-08-18
 
 An approval nobody was ever asked for is refused rather than assumed.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.188"
+version = "0.0.189"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.188"
+version = "0.0.189"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.188",
+  "version": "0.0.189",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.189. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json` to 0.0.189 and adds the CHANGELOG entry.

Releases deadlines the frontend suite can actually meet (#880, closing #862). Both numbers come from four measured whole-suite runs rather than from taste, and the measurement corrected the issue's own diagnosis twice: the bare run failed under load as well, so this was never a coverage defect; and two of three failures per loaded run were Testing Library's 1s `asyncUtilTimeout`, a second deadline nobody had noticed, which raising `testTimeout` alone would have left in place.

## Verified

CI green on #880, and `make test-frontend-cov` run three times locally — the third on a machine loaded enough to stretch it from 126s to 348s.