### PR TITLE
chore: cut 0.0.191

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,28 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.191] - 2026-08-18
+
+### Fixed
+
+- **A hand-edited agent spec says which field is wrong.** `AgentSpec.from_yaml`
+  was called inline in the route expression, and a pydantic `ValidationError` is
+  a `ValueError` but not a `RequestValidationError` — so every mistake in an
+  imported spec answered 500 with no field path and left a traceback in the log,
+  on an endpoint whose ordinary case *is* somebody iterating on YAML by hand. The
+  parse moved into the service that owns the refusal: a rule broken answers 400
+  with the field path, YAML that will not parse answers 400 with the line and
+  column, and
+  a document that is not a mapping says so. (#873)
+- **A syntax error reports its position, never the line it read.** `str()` on a
+  marked YAML error includes the offending source, and the document being refused
+  is somebody's spec — instructions, a `secret_id`. Neither the failing text nor
+  the submitted values come back; a reader error with only a byte offset gets no
+  invented position. (#873)
+- **Nothing is read or written before the document is judged.** The parse runs
+  first, so a refusal depends only on the caller's own text: it opens no
+  transaction and says nothing about which agents exist. (#873)
+
 ## [0.0.190] - 2026-08-18
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.190"
+version = "0.0.191"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.190"
+version = "0.0.191"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.190",
+  "version": "0.0.191",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.191. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json` to 0.0.191 and adds the CHANGELOG entry.

Releases a hand-edited agent spec answering 400 with the field path rather than 500 with nothing (#883, closing #873) — on an endpoint whose ordinary case is somebody iterating on YAML by hand, which is what made a missing field path expensive.

One thing the issue did not anticipate: `str()` on a marked YAML error carries the offending source line, and the document being refused is somebody's spec. A syntax error therefore reports line and column and never the text.

## Verified

CI green on #883, no review findings. All eight new route tests fail on `main`, five of them with the 500 this fixes.