### PR TITLE
chore: cut 0.0.192

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,28 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.192] - 2026-08-18
+
+### Fixed
+
+- **A network blip no longer fails the dependency audit.** `pip-audit` asks
+  pypi.org once per locked distribution with no retry, so one slow answer ended
+  the run and turned `Security Scan` — a required check — red on a pull request
+  whose dependencies were fine. Every run that reaches no verdict is retried now,
+  unconditionally: re-running a deterministic failure costs seconds and the same
+  answer, while not re-running a transient one is the false red this fixes. (#855)
+- **The audit says which of four things happened, in a line a job can read.**
+  `make audit` ends on `AUDIT: CLEAN|VULNERABLE|NETWORK|FAILED — detail`, mirrored
+  into the job summary. The exit code cannot carry that: GNU Make turns any failed
+  recipe status into its own 2, and GitHub Actions never surfaces a step's exit
+  code anyway — so a code was the wrong place for a verdict, whether or not `make`
+  was in the way. The script keeps 0/1/75 for a human at a terminal, and
+  `docs/commands.md` now says which interface delivers which. (#855)
+- **An audit that did not happen is never green.** The verdict comes from the JSON
+  report, which `pip-audit` writes on both the clean and the vulnerable path and
+  only after every distribution has been queried — so its presence means the audit
+  finished, whatever the process exited with. (#855)
+
 ## [0.0.191] - 2026-08-18
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.191"
+version = "0.0.192"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.191"
+version = "0.0.192"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.191",
+  "version": "0.0.192",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.192. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json` to 0.0.192 and adds the CHANGELOG entry.

Releases an audit that survives a network blip (#877, closing #855). The review round moved the design: the three-way exit code the first version relied on could never have been read — GNU Make collapses a failed recipe status to its own 2, and GitHub Actions does not surface a step's exit code at all — so the verdict is a line, and retrying no longer depends on matching an error's wording.

## Verified

CI green on #877. Exercised against real tooling: a clean run, a genuinely vulnerable dependency, a feed pointed at a closed port, a flaky feed answering 503 once, and `uv` itself unable to fetch `pip-audit` — the reviewer's case, reproduced. 12 of the 26 tests fail against the previous commit's script.