### PR TITLE
chore: cut 0.0.193

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.193] - 2026-08-18
+
+### Fixed
+
+- **The model picker stops telling an organization it has no models when the
+  request failed.** It made that claim from an array a refused or failed read
+  degrades to `[]` — the ambiguity 0.0.186 fixed one element above it, on the
+  page — and it made it in both of the picker's shapes, so an `allowAdd` panel
+  also dropped its saved-model disclosure silently. A failed read now says so and
+  offers a retry. (#863)
+- **And it says nothing at all while the answer is still coming.** The flag
+  behind the distinction is the query's success, which is equally false before
+  the first answer as after a failure, so the first version of this fix showed a
+  destructive failure panel on **every cold render of the Builder** — a false
+  alarm on the ordinary path, which is worse than the wrong sentence it replaced.
+  The hook answers with three states now, not two, and 0.0.186's page-level
+  consumer reads the same one, so there is no second vocabulary to drift. (#863)
+
 ## [0.0.192] - 2026-08-18
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.192"
+version = "0.0.193"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.192"
+version = "0.0.193"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.192",
+  "version": "0.0.193",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.193. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json` to 0.0.193 and adds the CHANGELOG entry.

Releases the model picker distinguishing "this organization has none" from "we could not find out" (#876, closing #863) — and, after the review round, from "we have not finished asking". The first version of the fix showed a destructive failure panel on every cold render of the Builder, which is a false alarm on the ordinary path and worse than the wrong sentence it replaced.

## Verified

CI green on #876, `make test-frontend-cov` at 100% statements/functions/lines and 97.62% branches. The existing integration test had been asserting the false claim was *present* — which is how this survived review one element above 0.0.186's own fix.