### PR TITLE
fix(api): answer a per-field refusal in the shape the form marks

### DIFF
--- a/backend/app/agents/capabilities/_registry.py
+++ b/backend/app/agents/capabilities/_registry.py
@@ -63,6 +63,7 @@ from pydantic_ai.capabilities import AbstractCapability
 
 from app.agents.capabilities._overrides import ToolOverrides
 from app.core.exceptions import BadRequestError
+from app.core.field_errors import field_problems
 from app.core.secret_kinds import SecretRequirement, StorableSecret
 
 logger = logging.getLogger(__name__)
@@ -361,13 +362,9 @@ class CapabilityDef:
         except ValidationError as exc:
             raise BadRequestError(
                 message=f"Invalid configuration for capability '{self.id}'",
-                # `include_input=False` for the same reason `ingestion_config`
-                # sets it: the rejected value is the caller's own submission and
-                # echoing it back adds nothing a form can act on, while putting
-                # whatever was posted into a response body and an error log.
                 details={
                     "capability_id": self.id,
-                    "errors": exc.errors(include_url=False, include_input=False),
+                    "fields": field_problems(exc.errors(), root="config"),
                 },
             ) from exc
 

--- a/backend/app/api/exception_handlers.py
+++ b/backend/app/api/exception_handlers.py
@@ -31,7 +31,7 @@ from starlette.requests import HTTPConnection
 
 from app.agents.capabilities.budget import BudgetExceeded
 from app.core.exceptions import AppException, ValidationError
-from app.core.field_errors import field_problems
+from app.core.field_errors import request_field_problems
 
 logger = logging.getLogger(__name__)
 
@@ -171,7 +171,7 @@ async def validation_exception_handler(
     field it belongs to - that is what lets the UI mark the offending input
     instead of showing a sentence about a form the reader has to re-scan.
     """
-    fields = field_problems(exc.errors(), root="request")
+    fields = request_field_problems(exc.errors())
     return await app_exception_handler(
         request,
         ValidationError(message=_summarize(fields), details={"fields": fields}),

--- a/backend/app/api/exception_handlers.py
+++ b/backend/app/api/exception_handlers.py
@@ -21,7 +21,6 @@ raised it had to hand - most often the `UUID` it could not find.
 """
 
 import logging
-from collections.abc import Sequence
 from typing import Any
 
 from fastapi import FastAPI
@@ -32,12 +31,9 @@ from starlette.requests import HTTPConnection
 
 from app.agents.capabilities.budget import BudgetExceeded
 from app.core.exceptions import AppException, ValidationError
+from app.core.field_errors import field_problems
 
 logger = logging.getLogger(__name__)
-
-# Where a validation error came from, as Pydantic reports it in the first
-# element of `loc`. Nothing a form can act on, so it is dropped from the path.
-_LOCATIONS = frozenset({"body", "query", "path", "header", "cookie"})
 
 
 def _envelope(
@@ -155,20 +151,6 @@ async def app_exception_handler(request: HTTPConnection, exc: AppException) -> J
     )
 
 
-def _field_path(location: Sequence[str | int]) -> str:
-    """The dotted path of the field a validation error is about.
-
-    Pydantic reports where the value came from as well as where it sits -
-    `("body", "spec", "name")`. A form can do nothing with "body", so it is
-    dropped and the rest joined: `spec.name`. List indices stay in the path,
-    because "the third capability" is exactly what the reader needs to know.
-    """
-    parts = list(location)
-    if parts and parts[0] in _LOCATIONS:
-        parts = parts[1:]
-    return ".".join(str(part) for part in parts) or "request"
-
-
 def _summarize(fields: list[dict[str, str]]) -> str:
     """One line for a client with nowhere better to put it than a toast.
 
@@ -189,9 +171,7 @@ async def validation_exception_handler(
     field it belongs to - that is what lets the UI mark the offending input
     instead of showing a sentence about a form the reader has to re-scan.
     """
-    fields = [
-        {"field": _field_path(error["loc"]), "message": error["msg"]} for error in exc.errors()
-    ]
+    fields = field_problems(exc.errors(), root="request")
     return await app_exception_handler(
         request,
         ValidationError(message=_summarize(fields), details={"fields": fields}),

--- a/backend/app/core/field_errors.py
+++ b/backend/app/core/field_errors.py
@@ -1,0 +1,64 @@
+"""What a refusal says about the field it refuses, in the one shape a form reads.
+
+A per-field refusal is only worth raising if the form can mark the input it
+names, and that takes **one** shape on the wire. There were two.
+:func:`app.api.exception_handlers.validation_exception_handler` answered
+`details={"fields": [{"field": ..., "message": ...}]}`, which
+`frontend/src/lib/api-error.ts` reads; four services handed pydantic's own
+`exc.errors()` through untouched under `details={"errors": [...]}`, which it
+reads nowhere. So a refused ingestion override, a refused spec import and a
+refused capability config each delivered a sentence to a toast and marked
+nothing - the half of the answer that says *which box to fix*, missing from the
+three refusals written to provide it (#882).
+
+This module is the only place that shape is built, and it is deliberately the
+narrowest possible reader of a pydantic error: `loc` and `msg`, nothing
+else. That is the part a fifth call site cannot forget. `exc.errors()` also
+carries the rejected value under `input` and, for a rule that raised, the
+`ValueError` object itself under `ctx` - and `details` is serialized into
+the response body and logged on the same line, so passing one through posts the
+caller's own submission back to them (`.claude/rules/exceptions-security.md`).
+"""
+
+from collections.abc import Sequence
+
+from pydantic_core import ErrorDetails
+
+__all__ = ["field_problems"]
+
+# Where a validation error came from, as pydantic reports it in the first
+# element of `loc`. Nothing a form can act on, so it is dropped from the path.
+_LOCATIONS = frozenset({"body", "query", "path", "header", "cookie"})
+
+
+def _path(location: Sequence[int | str], root: str) -> str:
+    """The dotted path of the field one validation error is about.
+
+    Pydantic reports where the value came from as well as where it sits -
+    `("body", "spec", "name")`. A form can do nothing with "body", so it is
+    dropped and the rest joined: `spec.name`. List indices stay in the path,
+    because "the third capability" is exactly what the reader needs to know.
+    """
+    parts = list(location)
+    if parts and parts[0] in _LOCATIONS:
+        parts = parts[1:]
+    return ".".join(str(part) for part in parts) or root
+
+
+def field_problems(errors: Sequence[ErrorDetails], *, root: str) -> list[dict[str, str]]:
+    """Pydantic's errors as the `details["fields"]` a form marks its inputs from.
+
+    Args:
+        errors: What pydantic reported, as `ValidationError.errors()` returns it.
+        root: The field an error that names none belongs to. A
+            `model_validator(mode="after")` reports `loc: ()`, because the rule
+            it broke is about the object rather than any one of its fields -
+            `IngestionConfig` refusing a `chunk_overlap` that does not fit
+            inside its `chunk_size` names both in `msg` and neither in `loc`. A
+            form still has to be told where to put that sentence, so the raiser
+            names the field the whole document belongs to: `ingestion_config`
+            for an upload's override - the same field the 422 names when that
+            pair arrives as a collection's own settings - and `yaml` for a spec
+            somebody is editing by hand.
+    """
+    return [{"field": _path(error["loc"], root), "message": error["msg"]} for error in errors]

--- a/backend/app/core/field_errors.py
+++ b/backend/app/core/field_errors.py
@@ -12,53 +12,85 @@ nothing - the half of the answer that says *which box to fix*, missing from the
 three refusals written to provide it (#882).
 
 This module is the only place that shape is built, and it is deliberately the
-narrowest possible reader of a pydantic error: `loc` and `msg`, nothing
-else. That is the part a fifth call site cannot forget. `exc.errors()` also
-carries the rejected value under `input` and, for a rule that raised, the
-`ValueError` object itself under `ctx` - and `details` is serialized into
-the response body and logged on the same line, so passing one through posts the
-caller's own submission back to them (`.claude/rules/exceptions-security.md`).
+narrowest possible reader of a pydantic error: `loc` and `msg`, nothing else.
+That is the part a fifth call site cannot forget. `exc.errors()` also carries
+the rejected value under `input` and, for a rule that raised, the `ValueError`
+object itself under `ctx` - and `details` is serialized into the response body
+and logged on the same line, so passing one through posts the caller's own
+submission back to them (`.claude/rules/exceptions-security.md`).
+
+There are two entry points because there are two callers, and **which one you
+are decides what the first element of `loc` means**. FastAPI puts where the
+value came from in front of the path - `("body", "spec", "name")` - and a form
+can do nothing with "body". A service validating a model itself gets no such
+segment: the first element is already a field name, and a spec whose forbidden
+top-level key is literally called `body` reports `loc: ("body",)` about that
+key. Deciding by the string would report it against the editor instead, which
+is one shape standing in for two - the mistake this module exists to end.
 """
 
 from collections.abc import Sequence
 
 from pydantic_core import ErrorDetails
 
-__all__ = ["field_problems"]
+__all__ = ["field_problems", "request_field_problems"]
 
-# Where a validation error came from, as pydantic reports it in the first
-# element of `loc`. Nothing a form can act on, so it is dropped from the path.
-_LOCATIONS = frozenset({"body", "query", "path", "header", "cookie"})
+# Where a validation error came from, as FastAPI reports it in the first element
+# of `loc`. Nothing a form can act on, so it is dropped from the path - but only
+# for the caller that puts it there. See the module docstring.
+_ORIGINS = frozenset({"body", "query", "path", "header", "cookie"})
 
 
-def _path(location: Sequence[int | str], root: str) -> str:
-    """The dotted path of the field one validation error is about.
+def _path(location: Sequence[int | str]) -> str:
+    """The dotted path a validation error reports, as a form addresses a field.
 
-    Pydantic reports where the value came from as well as where it sits -
-    `("body", "spec", "name")`. A form can do nothing with "body", so it is
-    dropped and the rest joined: `spec.name`. List indices stay in the path,
-    because "the third capability" is exactly what the reader needs to know.
+    List indices stay in it, because "the third capability" is exactly what the
+    reader needs to know.
     """
-    parts = list(location)
-    if parts and parts[0] in _LOCATIONS:
-        parts = parts[1:]
-    return ".".join(str(part) for part in parts) or root
+    return ".".join(str(part) for part in location)
+
+
+def _without_origin(location: Sequence[int | str]) -> Sequence[int | str]:
+    return location[1:] if location and location[0] in _ORIGINS else location
 
 
 def field_problems(errors: Sequence[ErrorDetails], *, root: str) -> list[dict[str, str]]:
     """Pydantic's errors as the `details["fields"]` a form marks its inputs from.
 
+    For a model a service validated itself, where `loc` is the path *within* the
+    document rather than within the request. A request body goes through
+    :func:`request_field_problems` instead.
+
     Args:
         errors: What pydantic reported, as `ValidationError.errors()` returns it.
-        root: The field an error that names none belongs to. A
+        root: What the caller's document is called on the form that sent it -
+            `ingestion_config` for an upload's override, `yaml` for a spec
+            somebody is editing by hand, `config` for a capability's settings
+            blob. Every path is reported relative to it, which does two things.
+            It makes an error naming *no* field addressable: a
             `model_validator(mode="after")` reports `loc: ()`, because the rule
-            it broke is about the object rather than any one of its fields -
+            it broke is about the object rather than any one of its fields, and
             `IngestionConfig` refusing a `chunk_overlap` that does not fit
-            inside its `chunk_size` names both in `msg` and neither in `loc`. A
-            form still has to be told where to put that sentence, so the raiser
-            names the field the whole document belongs to: `ingestion_config`
-            for an upload's override - the same field the 422 names when that
-            pair arrives as a collection's own settings - and `yaml` for a spec
-            somebody is editing by hand.
+            inside its `chunk_size` names both in `msg` and neither in `loc`.
+            And it makes the two entry points agree - an override refused at
+            upload now names exactly what the 422 names when the same pair
+            arrives as a collection's own settings, field for field.
     """
-    return [{"field": _path(error["loc"], root), "message": error["msg"]} for error in errors]
+    return [
+        {"field": ".".join(filter(None, (root, _path(error["loc"])))), "message": error["msg"]}
+        for error in errors
+    ]
+
+
+def request_field_problems(errors: Sequence[ErrorDetails]) -> list[dict[str, str]]:
+    """The same, for the `RequestValidationError` FastAPI raises about a request.
+
+    There is no root to add - `loc` already names a field of the request body,
+    which is the document - but there is one to remove: `loc` starts with where
+    the value came from, and a form can do nothing with "body". That segment is
+    dropped here and nowhere else, because only this caller puts one there.
+    """
+    return [
+        {"field": _path(_without_origin(error["loc"])) or "request", "message": error["msg"]}
+        for error in errors
+    ]

--- a/backend/app/services/agent_registry.py
+++ b/backend/app/services/agent_registry.py
@@ -253,6 +253,51 @@ def _tool_override_problems(binding: CapabilityBindingSpec, definition: Capabili
     return problems
 
 
+@dataclass
+class _SpecProblems:
+    """Everything wrong with a spec: a line to read, and where to put it.
+
+    `messages` is the list the Builder shows and has always been the whole of
+    the answer. `fields` is the same refusal aimed at an input, in the shape
+    `frontend/src/lib/api-error.ts` marks one from - because a capability's
+    configuration is a *form*, and "Capability 'knowledge': Invalid
+    configuration for capability 'knowledge'" leaves the reader to work out
+    which of its boxes is wrong.
+
+    Both, never one. `validate_spec` reports every problem at once and most of
+    them are broken references with no input to mark, so a field problem adds a
+    line as well: the message is what a form that does not render that field
+    still has to show (#882).
+    """
+
+    messages: list[str] = field(default_factory=list)
+    fields: list[dict[str, str]] = field(default_factory=list)
+
+    def add(self, messages: Sequence[str]) -> None:
+        """Problems with nothing to mark - a broken reference, a missing model."""
+        self.messages.extend(messages)
+
+    def merge(self, other: _SpecProblems) -> None:
+        self.messages.extend(other.messages)
+        self.fields.extend(other.fields)
+
+    def within_specialist(self, name: str) -> _SpecProblems:
+        """The same problems, said about a specialist defined inside this agent.
+
+        Both halves are scoped, or a mistake in a specialist's copy of
+        `knowledge` would mark the parent's own `knowledge` card - the Builder
+        renders one form per specialist and they configure the same
+        capabilities.
+        """
+        return _SpecProblems(
+            [f"Specialist '{name}': {message}" for message in self.messages],
+            [
+                {**problem, "field": f"specialists.{name}.{problem['field']}"}
+                for problem in self.fields
+            ],
+        )
+
+
 @dataclass(frozen=True)
 class _PinnedDelegate:
     """A delegate pin that resolved: which agent, which version, and its spec.
@@ -412,6 +457,31 @@ def _share_problems(spec: AgentSpec, config: SubagentsConfig) -> list[str]:
             "may delegate is a question its own spec answers."
         )
     return problems
+
+
+def _config_problems(capability_id: str, refusal: BadRequestError) -> _SpecProblems:
+    """A capability's refused configuration, as a line *and* as its inputs.
+
+    `validate_config` names each field that broke a rule, and publish validation
+    used to keep only `refusal.message` - so `default_top_k: 999` reached the
+    Builder as "Capability 'knowledge': Invalid configuration for capability
+    'knowledge'" and no box was ever marked. Draft saving does not validate a
+    config schema at all, which makes this the path a Builder submission
+    actually takes (found reviewing #892).
+
+    The path is qualified by the capability because the form is per capability
+    and two of them can hold a field of the same name; `SchemaForm` keys its
+    errors by the bare field, and `capabilityConfigErrors` in
+    `frontend/src/lib/agent-spec.ts` is what takes one apart again.
+    """
+    fields = refusal.details.get("fields", []) if refusal.details else []
+    return _SpecProblems(
+        [f"Capability '{capability_id}': {refusal.message}"],
+        [
+            {**problem, "field": f"capabilities.{capability_id}.{problem['field']}"}
+            for problem in fields
+        ],
+    )
 
 
 def _collision_problems(names: Sequence[str]) -> list[str]:
@@ -899,25 +969,28 @@ class AgentRegistryService:
 
         Raises:
             BadRequestError: With a `problems` list naming each broken
-                reference.
+                reference, and a `fields` list for those a form can mark. A
+                capability's configuration is the one part of a spec rendered as
+                a generated form, so its refusals name the input rather than
+                only the capability (#882).
         """
-        problems: list[str] = []
+        problems = _SpecProblems()
 
         for binding in spec.capabilities:
-            problems.extend(await self._binding_problems(ctx, binding))
+            problems.merge(await self._binding_problems(ctx, binding))
 
         # A model, named. There is no organization-wide default to fall back
         # on: a model an agent did not choose is one somebody else's change can
         # swap underneath it, and "why did this get more expensive" then has no
         # answer in the agent's own history.
         if spec.model_profile_id is None:
-            problems.append("No model selected - pick one before publishing")
+            problems.add(["No model selected - pick one before publishing"])
         else:
-            problems.extend(await self._model_profile_problems(ctx, spec.model_profile_id))
+            problems.add(await self._model_profile_problems(ctx, spec.model_profile_id))
 
-        problems.extend(await self._collection_problems(ctx, spec.collection_ids))
-        problems.extend(await self._skill_problems(ctx, spec.skill_ids))
-        problems.extend(await self._context_problems(ctx, spec.context_ids))
+        problems.add(await self._collection_problems(ctx, spec.collection_ids))
+        problems.add(await self._skill_problems(ctx, spec.skill_ids))
+        problems.add(await self._context_problems(ctx, spec.context_ids))
 
         for connection_id in spec.mcp_server_ids:
             connection = await mcp_connection_repo.get_org_scoped_by_id(
@@ -928,25 +1001,30 @@ class AgentRegistryService:
                 # likely one - a personal connection picked in the Builder - is
                 # not a missing row and "not found" would send the person
                 # looking for something that is right in front of them.
-                problems.append(
-                    f"MCP server {connection_id} is not shared with this organization. "
-                    "A published agent can only use connections the organization owns, "
-                    "never a member's personal one - otherwise what it can reach would "
-                    "depend on who happens to run it."
+                problems.add(
+                    [
+                        f"MCP server {connection_id} is not shared with this organization. "
+                        "A published agent can only use connections the organization owns, "
+                        "never a member's personal one - otherwise what it can reach would "
+                        "depend on who happens to run it."
+                    ]
                 )
 
-        problems.extend(await _sandbox_problems(self.db, ctx, spec))
-        problems.extend(await self._delegation_problems(ctx, spec, agent_id=agent_id))
+        problems.add(await _sandbox_problems(self.db, ctx, spec))
+        problems.merge(await self._delegation_problems(ctx, spec, agent_id=agent_id))
 
-        if problems:
-            raise BadRequestError(
-                message="This agent cannot be published yet",
-                details={"problems": problems},
-            )
+        if problems.messages:
+            # `fields` only when there is one: an empty list is a claim that
+            # nothing here can be marked, which a reader would have to tell
+            # apart from a refusal that never names a field at all.
+            details: dict[str, Any] = {"problems": problems.messages}
+            if problems.fields:
+                details["fields"] = problems.fields
+            raise BadRequestError(message="This agent cannot be published yet", details=details)
 
     async def _binding_problems(
         self, ctx: AuthContext, binding: CapabilityBindingSpec
-    ) -> list[str]:
+    ) -> _SpecProblems:
         """Everything wrong with one capability binding.
 
         One binding rather than a spec's list, because a specialist defined
@@ -955,36 +1033,41 @@ class AgentRegistryService:
         step would drift, and the half that drifted would be the one nobody
         thought of as an agent.
         """
+        problems = _SpecProblems()
         try:
             definition = get_capability(binding.id)
         except BadRequestError:
-            return [f"Unknown capability: {binding.id}"]
+            problems.add([f"Unknown capability: {binding.id}"])
+            return problems
 
-        problems: list[str] = []
         missing_scopes = definition.scopes - DEFAULT_GRANTED_SCOPES
         if missing_scopes:
-            problems.append(
-                f"Capability '{binding.id}' needs scopes not granted here: "
-                f"{', '.join(sorted(missing_scopes))}"
+            problems.add(
+                [
+                    f"Capability '{binding.id}' needs scopes not granted here: "
+                    f"{', '.join(sorted(missing_scopes))}"
+                ]
             )
         try:
             config = definition.validate_config(binding.config)
         except BadRequestError as exc:
-            problems.append(f"Capability '{binding.id}': {exc.message}")
+            problems.merge(_config_problems(binding.id, exc))
         else:
-            problems.extend(await _browser_use_problems(config))
-            problems.extend(ungateable_tool_problems(binding, definition, config))
+            problems.add(await _browser_use_problems(config))
+            problems.add(ungateable_tool_problems(binding, definition, config))
         # A tool_approval key that matches nothing is the dangerous kind of
         # typo: it is not an error at run time, it is silence - the tool the
         # author meant to gate runs unapproved and nobody is told.
         unknown_tools = sorted(set(binding.tool_approval) - definition.tool_ids)
         if unknown_tools:
-            problems.append(
-                f"Capability '{binding.id}' has no tool named "
-                f"{', '.join(unknown_tools)} to set approval for"
+            problems.add(
+                [
+                    f"Capability '{binding.id}' has no tool named "
+                    f"{', '.join(unknown_tools)} to set approval for"
+                ]
             )
-        problems.extend(_tool_override_problems(binding, definition))
-        problems.extend(await self._secret_problems(ctx, binding, definition))
+        problems.add(_tool_override_problems(binding, definition))
+        problems.add(await self._secret_problems(ctx, binding, definition))
         return problems
 
     async def _model_profile_problems(self, ctx: AuthContext, profile_id: UUID) -> list[str]:
@@ -1151,7 +1234,7 @@ class AgentRegistryService:
 
     async def _delegation_problems(
         self, ctx: AuthContext, spec: AgentSpec, *, agent_id: UUID | None
-    ) -> list[str]:
+    ) -> _SpecProblems:
         """Everything wrong with what this agent delegates to.
 
         Three things, checked together because they interact: the specialists
@@ -1172,11 +1255,13 @@ class AgentRegistryService:
                 # tools, so without it they are configuration that reads as a
                 # decision and has no effect - and the author who wired up three
                 # delegates is the last person who would notice.
-                return [
-                    "This agent names delegates, but its delegation capability is not "
-                    "enabled - nothing would ever call them. Enable it, or remove them."
-                ]
-            return []
+                return _SpecProblems(
+                    [
+                        "This agent names delegates, but its delegation capability is not "
+                        "enabled - nothing would ever call them. Enable it, or remove them."
+                    ]
+                )
+            return _SpecProblems()
         try:
             config = SubagentsConfig.model_validate(binding.config)
         except ValidationError:
@@ -1184,29 +1269,31 @@ class AgentRegistryService:
             # A policy that does not parse says nothing further about the
             # specialists it would have carried, and guessing at half of one
             # would report problems against a shape nobody wrote.
-            return []
+            return _SpecProblems()
 
-        problems: list[str] = []
+        problems = _SpecProblems()
         names: list[str] = []
         for specialist in config.inline:
             names.append(specialist.name)
-            problems.extend(await self._specialist_problems(ctx, specialist))
-        problems.extend(_share_problems(spec, config))
+            problems.merge(await self._specialist_problems(ctx, specialist))
+        problems.add(_share_problems(spec, config))
 
         pins = await self._resolve_pins(ctx, spec.subagents)
-        problems.extend(pins.problems)
+        problems.add(pins.problems)
         # A delegate's handle is its row's slug; a specialist's is the name as
         # typed, which is already constrained to what a tool argument can carry.
         # Both are what the runtime hands the model, which is the only namespace
         # a collision can happen in.
         names.extend(pins.handles)
-        problems.extend(_collision_problems(names))
-        problems.extend(
+        problems.add(_collision_problems(names))
+        problems.add(
             await self._cycle_problems(ctx, pins.delegates, agent_id=agent_id, root_name=spec.name)
         )
         return problems
 
-    async def _specialist_problems(self, ctx: AuthContext, specialist: SpecialistSpec) -> list[str]:
+    async def _specialist_problems(
+        self, ctx: AuthContext, specialist: SpecialistSpec
+    ) -> _SpecProblems:
         """Everything wrong with a specialist defined inside this agent.
 
         The same checks the parent's own bindings and collections get, through the
@@ -1221,18 +1308,18 @@ class AgentRegistryService:
         Every problem carries the specialist's name. A Builder form has one input
         per specialist and cannot point at the right one otherwise.
         """
-        problems: list[str] = []
+        problems = _SpecProblems()
         for binding in specialist.capabilities:
-            problems.extend(await self._binding_problems(ctx, binding))
-        problems.extend(await self._collection_problems(ctx, specialist.collection_ids))
-        problems.extend(await self._skill_problems(ctx, specialist.skill_ids))
-        problems.extend(await self._context_problems(ctx, specialist.context_ids))
+            problems.merge(await self._binding_problems(ctx, binding))
+        problems.add(await self._collection_problems(ctx, specialist.collection_ids))
+        problems.add(await self._skill_problems(ctx, specialist.skill_ids))
+        problems.add(await self._context_problems(ctx, specialist.context_ids))
         # A specialist naming no profile runs on the parent's, which publish has
         # already checked - so only a profile it *did* name is a reference that
         # can be broken, or borrowed from another organization.
         if specialist.model_profile_id is not None:
-            problems.extend(await self._model_profile_problems(ctx, specialist.model_profile_id))
-        return [f"Specialist '{specialist.name}': {problem}" for problem in problems]
+            problems.add(await self._model_profile_problems(ctx, specialist.model_profile_id))
+        return problems.within_specialist(specialist.name)
 
     async def _resolve_pins(self, ctx: AuthContext, refs: Sequence[SubagentRef]) -> _ResolvedPins:
         """Every way a pin to a published delegate can be wrong.

--- a/backend/app/services/agent_registry.py
+++ b/backend/app/services/agent_registry.py
@@ -43,6 +43,7 @@ from app.core.exceptions import (
     BadRequestError,
     NotFoundError,
 )
+from app.core.field_errors import field_problems
 from app.core.permissions import AuthContext, Perm
 from app.db.models.agent import Agent, AgentStatus, AgentVersion
 from app.db.models.credential import ModelProfile
@@ -515,14 +516,17 @@ def _parse_spec_yaml(text: str) -> AgentSpec:
     Raises:
         BadRequestError: If the document does not parse, is not a mapping, or
             breaks a field rule - carrying the field path a form can mark, and
-            no copy of what was submitted.
+            no copy of what was submitted. A field rule answers in the shape a
+            form marks an input from, `details["fields"]`; a document that never
+            parsed has no field of its own to name, so it is about the editor it
+            was typed into.
     """
     try:
         return AgentSpec.from_yaml(text)
     except ValidationError as exc:
         raise BadRequestError(
             message="This spec does not match the agent spec format",
-            details={"errors": exc.errors(include_url=False, include_input=False)},
+            details={"fields": field_problems(exc.errors(), root="yaml")},
         ) from exc
     except yaml.YAMLError as exc:
         raise BadRequestError(

--- a/backend/app/services/ingestion_config.py
+++ b/backend/app/services/ingestion_config.py
@@ -53,6 +53,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.exceptions import BadRequestError
+from app.core.field_errors import field_problems
 from app.core.secret_kinds import ApiKeySecret, SecretKind, unseal_secret
 from app.core.vault import VaultScope
 from app.repositories import organization_secret_repo
@@ -368,7 +369,11 @@ class IngestionOverride(BaseModel):
                 leaves as the same refusal :func:`parse_override` raises for a
                 field the override could not be read from at all - a raw
                 `ValidationError` reaches no handler, so the upload answered a
-                500 for a number the caller typed (#874).
+                500 for a number the caller typed (#874). The pair rule names
+                neither field in `loc`, so the refusal falls back to
+                `ingestion_config` - the same field the 422 names when the pair
+                arrives as a collection's own settings, so the form marks one
+                place whichever entry point refused.
         """
         changes = self.model_dump(exclude_unset=True, exclude={"image_description"})
         if self.image_description is not None:
@@ -378,7 +383,7 @@ class IngestionOverride(BaseModel):
         except ValidationError as exc:
             raise BadRequestError(
                 message="The 'ingestion' field is not a valid override for this collection",
-                details={"errors": exc.errors(include_url=False, include_input=False)},
+                details={"fields": field_problems(exc.errors(), root="ingestion_config")},
             ) from exc
 
 
@@ -403,7 +408,7 @@ def parse_override(raw: str | None) -> IngestionOverride | None:
     except ValidationError as exc:
         raise BadRequestError(
             message="The 'ingestion' field is not a valid ingestion override",
-            details={"errors": exc.errors(include_url=False, include_input=False)},
+            details={"fields": field_problems(exc.errors(), root="ingestion_config")},
         ) from exc
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -469,6 +469,11 @@ include = [
     # process it runs in, on the two stacks that have no supervisor reading a
     # beat from outside - so a wrong verdict is a restart loop in production.
     "app/core/watchdog.py",
+    # What a refusal is allowed to say about the field it refuses. One shape on
+    # the wire and one place that builds it - the module reads `loc` and `msg`
+    # and nothing else, which is what keeps a caller's own submission out of a
+    # response body a fifth call site would otherwise hand it (#882).
+    "app/core/field_errors.py",
     # Which tables alembic owns and which the vector store makes at runtime. It is
     # two statements, and one of them decides whether `db-check` reports real drift.
     "app/db/vector_tables.py",
@@ -635,6 +640,11 @@ include = [
     # process it runs in, on the two stacks that have no supervisor reading a
     # beat from outside - so a wrong verdict is a restart loop in production.
     "app/core/watchdog.py",
+    # What a refusal is allowed to say about the field it refuses. One shape on
+    # the wire and one place that builds it - the module reads `loc` and `msg`
+    # and nothing else, which is what keeps a caller's own submission out of a
+    # response body a fifth call site would otherwise hand it (#882).
+    "app/core/field_errors.py",
     # Which tables alembic owns and which the vector store makes at runtime. It is
     # two statements, and one of them decides whether `db-check` reports real drift.
     "app/db/vector_tables.py",

--- a/backend/tests/api/test_agent_spec_import_refusal.py
+++ b/backend/tests/api/test_agent_spec_import_refusal.py
@@ -82,8 +82,8 @@ class TestTheRefusalNamesTheField:
         error = response.json()["error"]
         assert error["code"] == "BAD_REQUEST"
         assert [problem["field"] for problem in error["details"]["fields"]] == [
-            "name",
-            "capabilities.0",
+            "yaml.name",
+            "yaml.capabilities.0",
         ]
 
     async def test_a_typo_in_a_field_name_names_the_key_it_could_not_place(
@@ -95,7 +95,27 @@ class TestTheRefusalNamesTheField:
 
         assert response.status_code == 400
         problems = response.json()["error"]["details"]["fields"]
-        assert problems == [{"field": "instrucitons", "message": "Extra inputs are not permitted"}]
+        assert problems == [
+            {"field": "yaml.instrucitons", "message": "Extra inputs are not permitted"}
+        ]
+
+    async def test_a_key_named_like_a_request_origin_is_named_as_the_key_it_is(
+        self, client: Any
+    ) -> None:
+        """`loc` here is the path inside the document, not inside the request.
+
+        FastAPI puts `body` in front of the path it reports and a form can do
+        nothing with that segment, so the 422 handler drops it. A spec is
+        `extra="forbid"`, so a top-level key called `body` is reported as
+        `loc: ("body",)` about that key - and a helper that decided by the
+        string dropped it too, blaming the editor for a key somebody has to
+        delete (found reviewing #892).
+        """
+        response = await _import(client, "name: Support\nbody: nope\n")
+
+        assert response.status_code == 400
+        problems = response.json()["error"]["details"]["fields"]
+        assert problems == [{"field": "yaml.body", "message": "Extra inputs are not permitted"}]
 
     async def test_a_document_that_is_a_list_is_refused_with_the_reason(self, client: Any) -> None:
         """Pydantic reports a list as an unhelpful type error, which is why
@@ -151,7 +171,10 @@ class TestTheRefusalQuotesNothingSubmitted:
 
         assert response.status_code == 400
         problems = response.json()["error"]["details"]["fields"]
-        assert sorted(problem["field"] for problem in problems) == ["description", "instructions"]
+        assert sorted(problem["field"] for problem in problems) == [
+            "yaml.description",
+            "yaml.instructions",
+        ]
         assert all(set(problem) == {"field", "message"} for problem in problems)
 
 

--- a/backend/tests/api/test_agent_spec_import_refusal.py
+++ b/backend/tests/api/test_agent_spec_import_refusal.py
@@ -81,9 +81,9 @@ class TestTheRefusalNamesTheField:
         assert response.status_code == 400
         error = response.json()["error"]
         assert error["code"] == "BAD_REQUEST"
-        assert [entry["loc"] for entry in error["details"]["errors"]] == [
-            ["name"],
-            ["capabilities", 0],
+        assert [problem["field"] for problem in error["details"]["fields"]] == [
+            "name",
+            "capabilities.0",
         ]
 
     async def test_a_typo_in_a_field_name_names_the_key_it_could_not_place(
@@ -94,9 +94,8 @@ class TestTheRefusalNamesTheField:
         response = await _import(client, "name: Support\ninstrucitons: be helpful\n")
 
         assert response.status_code == 400
-        errors = response.json()["error"]["details"]["errors"]
-        assert errors[0]["loc"] == ["instrucitons"]
-        assert errors[0]["type"] == "extra_forbidden"
+        problems = response.json()["error"]["details"]["fields"]
+        assert problems == [{"field": "instrucitons", "message": "Extra inputs are not permitted"}]
 
     async def test_a_document_that_is_a_list_is_refused_with_the_reason(self, client: Any) -> None:
         """Pydantic reports a list as an unhelpful type error, which is why
@@ -151,10 +150,9 @@ class TestTheRefusalQuotesNothingSubmitted:
         response = await _import(client, "name: Support\ninstructions: 12\ndescription: 34\n")
 
         assert response.status_code == 400
-        errors = response.json()["error"]["details"]["errors"]
-        assert sorted(entry["loc"] for entry in errors) == [["description"], ["instructions"]]
-        assert all("input" not in entry for entry in errors)
-        assert all("url" not in entry for entry in errors)
+        problems = response.json()["error"]["details"]["fields"]
+        assert sorted(problem["field"] for problem in problems) == ["description", "instructions"]
+        assert all(set(problem) == {"field", "message"} for problem in problems)
 
 
 class TestTheRefusalStopsBeforeTheRow:

--- a/backend/tests/api/test_error_envelope.py
+++ b/backend/tests/api/test_error_envelope.py
@@ -32,7 +32,6 @@ from app.agents.capabilities.budget import BudgetExceeded, BudgetScope
 from app.agents.capabilities.knowledge._search import search_knowledge_base
 from app.api import deps
 from app.api.exception_handlers import (
-    _field_path,
     _summarize,
     budget_exceeded_handler,
     validation_exception_handler,
@@ -50,32 +49,6 @@ from app.schemas.message_rating import RatingValue
 from app.services.email import templates
 from app.services.email.exceptions import EmailTemplateError
 from app.services.model_profile import validate_endpoint_url
-
-
-class TestFieldPath:
-    """The path a form has to be able to match against its own inputs."""
-
-    @pytest.mark.parametrize(
-        ("location", "expected"),
-        [
-            (("body", "name"), "name"),
-            # The Builder posts the whole spec under one key; the field a person
-            # is looking at is the leaf, and the path has to reach it.
-            (("body", "spec", "name"), "spec.name"),
-            (("query", "limit"), "limit"),
-            # An index is the most useful part of the path when a list is
-            # rejected - "the third capability", not "a capability".
-            (("body", "spec", "capabilities", 2, "id"), "spec.capabilities.2.id"),
-            # A body that is not an object at all belongs to no field.
-            (("body",), "request"),
-        ],
-    )
-    def test_the_origin_is_dropped_and_the_rest_is_a_dotted_path(self, location, expected):
-        assert _field_path(location) == expected
-
-    def test_an_unrecognised_origin_is_kept(self):
-        """Dropping a leading segment we do not recognise would lose the field."""
-        assert _field_path(("name",)) == "name"
 
 
 class TestSummary:

--- a/backend/tests/api/test_ingestion_override_routes.py
+++ b/backend/tests/api/test_ingestion_override_routes.py
@@ -136,19 +136,30 @@ class TestAnOverlapThatDoesNotFitInsideTheChunk:
         """`details` was `null`, so the form was told nothing at all."""
         response = await client.post(path, files=_upload(), data={"ingestion": _TOO_MUCH_OVERLAP})
 
-        errors = _error(response)["details"]["errors"]
-        assert "chunk_overlap" in errors[0]["msg"]
-        assert "chunk_size" in errors[0]["msg"]
+        problems = _error(response)["details"]["fields"]
+        assert "chunk_overlap" in problems[0]["message"]
+        assert "chunk_size" in problems[0]["message"]
+
+    async def test_the_refusal_names_a_field_the_form_can_mark_it_under(
+        self, client: AsyncClient, store: MagicMock, path: str
+    ) -> None:
+        """`fieldProblems` reads `details["fields"]` and nothing else, so a
+        refusal answered under `errors` showed a sentence and marked no input -
+        the half of the answer that says which box to fix (#882)."""
+        response = await client.post(path, files=_upload(), data={"ingestion": _TOO_MUCH_OVERLAP})
+
+        problems = _error(response)["details"]["fields"]
+        assert [problem["field"] for problem in problems] == ["ingestion_config"]
 
     async def test_no_copy_of_the_submitted_override_comes_back(
         self, client: AsyncClient, store: MagicMock, path: str
     ) -> None:
         """A refusal names the field that is wrong, not what was posted."""
-        errors = _error(
+        problems = _error(
             await client.post(path, files=_upload(), data={"ingestion": _TOO_MUCH_OVERLAP})
-        )["details"]["errors"]
+        )["details"]["fields"]
 
-        assert all("input" not in error and "url" not in error for error in errors)
+        assert all(set(problem) == {"field", "message"} for problem in problems)
 
 
 class TestTheSameRuleOnTheCollectionsOwnSettings:
@@ -158,7 +169,8 @@ class TestTheSameRuleOnTheCollectionsOwnSettings:
     FastAPI validates it before the handler and `validation_exception_handler`
     answers - the pair was already refused here, named and in the envelope.
     Only the multipart override skipped that, because a form field holding JSON
-    is a string until something parses it.
+    is a string until something parses it. Both name `ingestion_config` now, so
+    the form marks one place whichever entry point refused (#882).
     """
 
     async def test_an_impossible_pair_is_named_in_the_envelope(self, client: AsyncClient) -> None:

--- a/backend/tests/test_agent_registry.py
+++ b/backend/tests/test_agent_registry.py
@@ -924,7 +924,7 @@ class TestImportSpec:
                 _ctx(), uuid.uuid4(), "name: x\ninstrucitons: typo\n"
             )
 
-        assert refused.value.details["fields"][0]["field"] == "instrucitons"
+        assert refused.value.details["fields"][0]["field"] == "yaml.instrucitons"
         fetched.assert_not_called()
         update.assert_not_called()
 
@@ -963,6 +963,81 @@ class TestValidateSpec:
         assert any("Invalid configuration" in problem for problem in problems)
         assert "The selected model profile no longer exists" in problems
         assert any(problem.startswith("Collection not found:") for problem in problems)
+
+    @pytest.mark.anyio
+    async def test_a_refused_capability_config_names_the_input_as_well_as_the_capability(self):
+        """This is the path a Builder submission takes, and it discarded the field.
+
+        `validate_config` names each setting that broke a rule, and the
+        aggregator kept only `exc.message` - so `default_top_k: 999` reached the
+        form as one sentence about the capability and marked no box. Saving a
+        draft does not validate a config schema at all, which leaves publish
+        validation as the only place a mistyped setting is ever refused (found
+        reviewing #892).
+        """
+        spec = _spec(
+            capabilities=[{"id": "knowledge", "config": {"default_top_k": 999}}],
+            model_profile_id=None,
+        )
+
+        with pytest.raises(BadRequestError) as refused:
+            await AgentRegistryService(_db()).validate_spec(_ctx(), spec)
+
+        assert refused.value.details["fields"] == [
+            {
+                "field": "capabilities.knowledge.config.default_top_k",
+                "message": "Input should be less than or equal to 50",
+            }
+        ]
+        # And still as a line, because a form that does not render this field
+        # has to say something.
+        assert any(
+            "Invalid configuration" in problem for problem in refused.value.details["problems"]
+        )
+
+    @pytest.mark.anyio
+    async def test_a_specialists_config_is_marked_on_the_specialists_own_form(self):
+        """One form per specialist, configuring the same capabilities as the
+        parent - so an unscoped path would mark the parent's `knowledge` card
+        for a mistake in a copy of it that lives inside a delegate."""
+        spec = _spec(
+            capabilities=[
+                {
+                    "id": "subagents",
+                    "config": {
+                        "inline": [
+                            {
+                                "name": "researcher",
+                                "description": "Looks things up in the handbook.",
+                                "instructions": "Research things.",
+                                "capabilities": [
+                                    {"id": "knowledge", "config": {"default_top_k": 999}}
+                                ],
+                            }
+                        ]
+                    },
+                }
+            ],
+            model_profile_id=None,
+        )
+
+        with pytest.raises(BadRequestError) as refused:
+            await AgentRegistryService(_db()).validate_spec(_ctx(), spec)
+
+        assert [problem["field"] for problem in refused.value.details["fields"]] == [
+            "specialists.researcher.capabilities.knowledge.config.default_top_k"
+        ]
+
+    @pytest.mark.anyio
+    async def test_a_spec_whose_problems_name_no_field_carries_no_fields_key(self):
+        """An empty list would be a claim that nothing can be marked, which a
+        reader has to tell apart from a refusal that never names one."""
+        with pytest.raises(BadRequestError) as refused:
+            await AgentRegistryService(_db()).validate_spec(_ctx(), _spec(model_profile_id=None))
+
+        assert refused.value.details == {
+            "problems": ["No model selected - pick one before publishing"]
+        }
 
     @pytest.mark.anyio
     async def test_an_agent_with_no_model_cannot_publish(self):

--- a/backend/tests/test_agent_registry.py
+++ b/backend/tests/test_agent_registry.py
@@ -924,7 +924,7 @@ class TestImportSpec:
                 _ctx(), uuid.uuid4(), "name: x\ninstrucitons: typo\n"
             )
 
-        assert refused.value.details["errors"][0]["loc"] == ("instrucitons",)
+        assert refused.value.details["fields"][0]["field"] == "instrucitons"
         fetched.assert_not_called()
         update.assert_not_called()
 

--- a/backend/tests/test_capability_registry.py
+++ b/backend/tests/test_capability_registry.py
@@ -535,7 +535,9 @@ class TestConfigValidation:
             get("knowledge").validate_config({"default_top_k": 999})
         assert exc.value.details is not None
         assert exc.value.details["capability_id"] == "knowledge"
-        assert [problem["field"] for problem in exc.value.details["fields"]] == ["default_top_k"]
+        assert [problem["field"] for problem in exc.value.details["fields"]] == [
+            "config.default_top_k"
+        ]
 
     def test_a_rule_about_two_settings_is_attributed_to_the_config_itself(self):
         """A `model_validator(mode="after")` names no field, so the refusal

--- a/backend/tests/test_capability_registry.py
+++ b/backend/tests/test_capability_registry.py
@@ -525,11 +525,26 @@ class TestConfigValidation:
         assert config.default_top_k == 8
 
     def test_invalid_config_reports_field_errors(self):
-        """The Builder needs field-level errors to point at the right input."""
+        """The Builder needs field-level errors to point at the right input.
+
+        In `details["fields"]`, which is the only shape `fieldProblems` reads:
+        under `errors` this refusal marked nothing, and the capability it is
+        about was the only part of it a form could act on (#882).
+        """
         with pytest.raises(BadRequestError) as exc:
             get("knowledge").validate_config({"default_top_k": 999})
         assert exc.value.details is not None
-        assert exc.value.details["errors"]
+        assert exc.value.details["capability_id"] == "knowledge"
+        assert [problem["field"] for problem in exc.value.details["fields"]] == ["default_top_k"]
+
+    def test_a_rule_about_two_settings_is_attributed_to_the_config_itself(self):
+        """A `model_validator(mode="after")` names no field, so the refusal
+        falls back to the blob it was about - `browser_use` refusing a
+        `cdp_url` in the mode that launches its own browser is about the pair."""
+        with pytest.raises(BadRequestError) as exc:
+            get("browser_use").validate_config({"mode": "playwright", "cdp_url": "ws://host:9222"})
+        assert exc.value.details is not None
+        assert [problem["field"] for problem in exc.value.details["fields"]] == ["config"]
 
     def test_the_rejected_value_is_not_echoed_back(self):
         """`details` reaches the caller verbatim, so it carries the diagnosis
@@ -537,7 +552,7 @@ class TestConfigValidation:
         with pytest.raises(BadRequestError) as exc:
             get("knowledge").validate_config({"default_top_k": 999})
         assert exc.value.details is not None
-        assert all("input" not in error for error in exc.value.details["errors"])
+        assert all(set(problem) == {"field", "message"} for problem in exc.value.details["fields"])
 
     def test_capabilities_without_a_schema_accept_nothing(self):
         assert get("charts").validate_config({}) is None

--- a/backend/tests/test_coverage_gate.py
+++ b/backend/tests/test_coverage_gate.py
@@ -71,6 +71,7 @@ PLATFORM_MODULES = (
     "app/core/secret_kinds.py",
     "app/core/vault.py",
     "app/core/background.py",
+    "app/core/field_errors.py",
     "app/db/vector_tables.py",
     "app/services/access.py",
     "app/services/agent_chat.py",

--- a/backend/tests/test_field_errors.py
+++ b/backend/tests/test_field_errors.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 
 import pytest
 from pydantic import BaseModel, Field, ValidationError, model_validator
+from pydantic_core import ErrorDetails
 
-from app.core.field_errors import field_problems
+from app.core.field_errors import field_problems, request_field_problems
 
 
 class Chunking(BaseModel):
@@ -28,10 +29,20 @@ class Chunking(BaseModel):
         return self
 
 
+class Document(BaseModel):
+    """A model whose pair rule sits one level down, where `loc` is not empty."""
+
+    chunking: Chunking = Field(default_factory=Chunking)
+
+
 def _raise(payload: dict[str, object]) -> ValidationError:
     with pytest.raises(ValidationError) as caught:
         Chunking.model_validate(payload)
     return caught.value
+
+
+def _one(location: tuple[int | str, ...]) -> list[ErrorDetails]:
+    return [{"type": "x", "loc": location, "msg": "too long", "input": None}]
 
 
 class TestThePathAFormMarksOn:
@@ -46,20 +57,47 @@ class TestThePathAFormMarksOn:
             # An index is the most useful part of the path when a list is
             # rejected - "the third capability", not "a capability".
             (("body", "spec", "capabilities", 2, "id"), "spec.capabilities.2.id"),
-            # A service validates a model directly, so `loc` starts at the field
-            # and dropping a leading segment we do not recognise would lose it.
-            (("chunk_overlap",), "chunk_overlap"),
         ],
     )
-    def test_the_origin_is_dropped_and_the_rest_is_a_dotted_path(
+    def test_a_request_drops_where_the_value_came_from_and_joins_the_rest(
         self, location: tuple[int | str, ...], expected: str
     ) -> None:
         """A form can do nothing with "body"; `spec.name` is what it marks on."""
-        problems = field_problems(
-            [{"type": "x", "loc": location, "msg": "too long", "input": None}], root="request"
-        )
+        assert request_field_problems(_one(location)) == [
+            {"field": expected, "message": "too long"}
+        ]
 
-        assert problems == [{"field": expected, "message": "too long"}]
+    def test_a_request_body_that_is_not_an_object_belongs_to_no_field(self) -> None:
+        assert request_field_problems(_one(("body",))) == [
+            {"field": "request", "message": "too long"}
+        ]
+
+    def test_a_document_a_service_validated_itself_keeps_its_first_segment(self) -> None:
+        """`loc` has no origin on it, so the first element is already a field,
+        reported below the name the caller's form gives the whole document."""
+        assert field_problems(_one(("chunk_overlap",)), root="ingestion_config") == [
+            {"field": "ingestion_config.chunk_overlap", "message": "too long"}
+        ]
+
+    def test_a_service_document_names_exactly_what_the_request_path_names(self) -> None:
+        """The same rule, refused at the two entry points it has, addressed the
+        same way. `chunk_size` sent as a collection's own settings is a field of
+        a JSON body and FastAPI reports `("body", "ingestion_config",
+        "chunk_size")`; sent as an upload's override it is a document a service
+        parses itself and reports `("chunk_size",)`. A form has one input."""
+        by_request = request_field_problems(_one(("body", "ingestion_config", "chunk_size")))
+
+        assert by_request == field_problems(_one(("chunk_size",)), root="ingestion_config")
+
+    @pytest.mark.parametrize("name", ["body", "query", "path", "header", "cookie"])
+    def test_a_field_named_like_a_request_origin_is_still_that_field(self, name: str) -> None:
+        """The two cases are told apart by which caller it is, never by the
+        string. A spec is `extra="forbid"`, so a top-level key called `body`
+        reports `loc: ("body",)` - and reading that as FastAPI's marker dropped
+        it, blaming the editor for a key somebody has to delete."""
+        assert field_problems(_one((name,)), root="yaml") == [
+            {"field": f"yaml.{name}", "message": "too long"}
+        ]
 
     def test_a_rule_about_the_whole_object_is_given_the_field_it_arrived_in(self) -> None:
         """The wrinkle in #882: a `model_validator(mode="after")` reports `loc: ()`.
@@ -76,13 +114,33 @@ class TestThePathAFormMarksOn:
         assert "overlap (4096)" in problems[0]["message"]
         assert "size (512)" in problems[0]["message"]
 
+    def test_a_rule_on_a_nested_model_names_that_model_rather_than_the_root(self) -> None:
+        """The fallback is for an empty path, and a nested validator has one.
+
+        Pydantic reports the path *to* the object the rule is about, so
+        `chunking` is what the form marks - not the whole document, and not the
+        two fields the rule mentions in its sentence.
+        """
+        with pytest.raises(ValidationError) as caught:
+            Document.model_validate({"chunking": {"size": 512, "overlap": 4096}})
+
+        assert field_problems(caught.value.errors(), root="ingestion_config") == [
+            {
+                "field": "ingestion_config.chunking",
+                "message": "Value error, overlap (4096) must be smaller than size (512)",
+            }
+        ]
+
     def test_every_error_is_reported_not_only_the_first(self) -> None:
         """Fixing a form costs one round trip rather than one per mistake."""
         problems = field_problems(
             _raise({"size": 1, "overlap": "x"}).errors(), root="ingestion_config"
         )
 
-        assert sorted(problem["field"] for problem in problems) == ["overlap", "size"]
+        assert sorted(problem["field"] for problem in problems) == [
+            "ingestion_config.overlap",
+            "ingestion_config.size",
+        ]
 
 
 class TestNothingElseLeaves:

--- a/backend/tests/test_field_errors.py
+++ b/backend/tests/test_field_errors.py
@@ -1,0 +1,114 @@
+"""The one shape a per-field refusal takes, and what it refuses to carry.
+
+Every refusal that names a field builds it here - the validation handler and the
+four services that used to hand pydantic's `exc.errors()` through untouched. The
+two properties worth pinning are the ones a call site cannot restate for itself:
+what the path looks like, and that nothing but the path and the sentence leaves
+the process (#882).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel, Field, ValidationError, model_validator
+
+from app.core.field_errors import field_problems
+
+
+class Chunking(BaseModel):
+    """A pair rule that names both fields in `msg` and neither in `loc`."""
+
+    size: int = Field(default=512, ge=64)
+    overlap: int = 50
+
+    @model_validator(mode="after")
+    def overlap_fits(self) -> Chunking:
+        if self.overlap >= self.size:
+            raise ValueError(f"overlap ({self.overlap}) must be smaller than size ({self.size})")
+        return self
+
+
+def _raise(payload: dict[str, object]) -> ValidationError:
+    with pytest.raises(ValidationError) as caught:
+        Chunking.model_validate(payload)
+    return caught.value
+
+
+class TestThePathAFormMarksOn:
+    @pytest.mark.parametrize(
+        ("location", "expected"),
+        [
+            (("body", "name"), "name"),
+            # The Builder posts the whole spec under one key; the field a person
+            # is looking at is the leaf, and the path has to reach it.
+            (("body", "spec", "name"), "spec.name"),
+            (("query", "limit"), "limit"),
+            # An index is the most useful part of the path when a list is
+            # rejected - "the third capability", not "a capability".
+            (("body", "spec", "capabilities", 2, "id"), "spec.capabilities.2.id"),
+            # A service validates a model directly, so `loc` starts at the field
+            # and dropping a leading segment we do not recognise would lose it.
+            (("chunk_overlap",), "chunk_overlap"),
+        ],
+    )
+    def test_the_origin_is_dropped_and_the_rest_is_a_dotted_path(
+        self, location: tuple[int | str, ...], expected: str
+    ) -> None:
+        """A form can do nothing with "body"; `spec.name` is what it marks on."""
+        problems = field_problems(
+            [{"type": "x", "loc": location, "msg": "too long", "input": None}], root="request"
+        )
+
+        assert problems == [{"field": expected, "message": "too long"}]
+
+    def test_a_rule_about_the_whole_object_is_given_the_field_it_arrived_in(self) -> None:
+        """The wrinkle in #882: a `model_validator(mode="after")` reports `loc: ()`.
+
+        The sentence names both settings, pydantic attributes it to neither, and
+        the form still has to be told which input to put it under - so the
+        raiser names the field the whole document came in as.
+        """
+        problems = field_problems(
+            _raise({"size": 512, "overlap": 4096}).errors(), root="ingestion_config"
+        )
+
+        assert [problem["field"] for problem in problems] == ["ingestion_config"]
+        assert "overlap (4096)" in problems[0]["message"]
+        assert "size (512)" in problems[0]["message"]
+
+    def test_every_error_is_reported_not_only_the_first(self) -> None:
+        """Fixing a form costs one round trip rather than one per mistake."""
+        problems = field_problems(
+            _raise({"size": 1, "overlap": "x"}).errors(), root="ingestion_config"
+        )
+
+        assert sorted(problem["field"] for problem in problems) == ["overlap", "size"]
+
+
+class TestNothingElseLeaves:
+    def test_the_rejected_value_does_not_come_back_beside_the_field_it_broke(self) -> None:
+        """`exc.errors()` carries `input` by default, and a caller can forget to
+        turn it off. Reading `loc` and `msg` only is what makes forgetting safe:
+        a form needs to know which field is wrong, not to be sent a copy of what
+        it posted (`.claude/rules/exceptions-security.md`)."""
+        errors = _raise({"size": 12}).errors()
+        assert any("input" in error for error in errors)
+
+        problems = field_problems(errors, root="ingestion_config")
+
+        assert all(set(problem) == {"field", "message"} for problem in problems)
+        assert "12" not in repr(problems)
+
+    def test_the_exception_object_a_rule_raised_does_not_come_back(self) -> None:
+        """A `value_error` puts the `ValueError` itself in `ctx`, and
+        `jsonable_encoder` reaches an object it does not recognise through
+        `vars()` - so `details` used to carry an empty `{"error": {}}` where the
+        rule's own exception had been."""
+        problems = field_problems(
+            _raise({"size": 100, "overlap": 100}).errors(), root="ingestion_config"
+        )
+
+        assert all("ctx" not in problem for problem in problems)
+
+    def test_an_empty_report_is_an_empty_list_rather_than_an_invented_field(self) -> None:
+        assert field_problems([], root="ingestion_config") == []

--- a/backend/tests/test_ingestion_config.py
+++ b/backend/tests/test_ingestion_config.py
@@ -131,9 +131,25 @@ class TestAConfigurationThatWouldNotTerminate:
         with pytest.raises(BadRequestError) as refusal:
             IngestionOverride(chunk_overlap=4096).applied_to(base)
 
-        errors = refusal.value.details["errors"]
-        assert "chunk_overlap" in errors[0]["msg"]
-        assert "chunk_size" in errors[0]["msg"]
+        problems = refusal.value.details["fields"]
+        assert "chunk_overlap" in problems[0]["message"]
+        assert "chunk_size" in problems[0]["message"]
+
+    def test_the_pair_rule_is_attributed_to_the_field_the_override_arrived_in(self) -> None:
+        """A `model_validator` names no field, and a form cannot mark nothing.
+
+        `details["fields"]` is the only shape the frontend marks an input from,
+        so a refusal that answered `details["errors"]` showed its sentence in a
+        toast and highlighted nothing (#882).
+        """
+        base = IngestionConfig(chunk_size=512)
+
+        with pytest.raises(BadRequestError) as refusal:
+            IngestionOverride(chunk_overlap=4096).applied_to(base)
+
+        assert [problem["field"] for problem in refusal.value.details["fields"]] == [
+            "ingestion_config"
+        ]
 
     def test_the_refusal_carries_no_copy_of_what_was_submitted(self) -> None:
         """`details` names the fields that are wrong, never the document sent."""
@@ -143,7 +159,7 @@ class TestAConfigurationThatWouldNotTerminate:
             IngestionOverride(chunk_overlap=4096).applied_to(base)
 
         assert all(
-            "input" not in error and "url" not in error for error in refusal.value.details["errors"]
+            set(problem) == {"field", "message"} for problem in refusal.value.details["fields"]
         )
 
 
@@ -224,6 +240,26 @@ class TestReadingAnOverrideOffTheForm:
         """A misspelled setting must not look like it was applied."""
         with pytest.raises(BadRequestError):
             parse_override('{"chunk_sizes": 1024}')
+
+    def test_the_setting_that_broke_a_rule_is_named_as_a_field_the_form_marks(self) -> None:
+        """`details["fields"]` is what `fieldProblems` reads; `errors` was read
+        nowhere, so this refusal marked no input at all (#882)."""
+        with pytest.raises(BadRequestError) as refusal:
+            parse_override('{"chunk_size": 1}')
+
+        assert refusal.value.details["fields"] == [
+            {"field": "chunk_size", "message": "Input should be greater than or equal to 64"}
+        ]
+
+    def test_a_field_that_is_not_json_at_all_is_attributed_to_the_form_field(self) -> None:
+        """Pydantic names no field for a document it could not read, so the
+        refusal falls back to the multipart field the JSON arrived in."""
+        with pytest.raises(BadRequestError) as refusal:
+            parse_override("{not json")
+
+        assert [problem["field"] for problem in refusal.value.details["fields"]] == [
+            "ingestion_config"
+        ]
 
 
 class TestWhatTheDeploymentSeedsANewCollectionWith:

--- a/backend/tests/test_ingestion_config.py
+++ b/backend/tests/test_ingestion_config.py
@@ -248,7 +248,10 @@ class TestReadingAnOverrideOffTheForm:
             parse_override('{"chunk_size": 1}')
 
         assert refusal.value.details["fields"] == [
-            {"field": "chunk_size", "message": "Input should be greater than or equal to 64"}
+            {
+                "field": "ingestion_config.chunk_size",
+                "message": "Input should be greater than or equal to 64",
+            }
         ]
 
     def test_a_field_that_is_not_json_at_all_is_attributed_to_the_form_field(self) -> None:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -279,19 +279,42 @@ and a refusal about a *field* names it in one shape:
 `fieldProblems` in `frontend/src/lib/api-error.ts` reads that and nothing else,
 which is what lets a form mark the offending input rather than showing a sentence
 the reader has to re-scan the page for. `app/core/field_errors.py` is the only
-place it is built — by `validation_exception_handler` for every
-`RequestValidationError`, and by the services that validate a document a route's
-own schema cannot (a per-upload ingestion override, a hand-edited spec YAML, a
-capability's config blob).
+place it is built, and it has two entry points because **which caller you are
+decides what the first element of Pydantic's `loc` means**:
 
-Two properties are worth knowing before adding a call site. It reads `loc` and
-`msg` only, so the rejected value cannot come back beside the field it broke —
-which is why those call sites hand it `exc.errors()` unfiltered. And it takes a
-`root`: a `model_validator(mode="after")` reports `loc: ()`, because the rule it
-broke is about two fields at once, and a form still has to be told where to put
-that sentence. Handing pydantic's own `exc.errors()` through instead was
+| | For | `loc` starts with |
+|---|---|---|
+| `request_field_problems` | `validation_exception_handler`, every `RequestValidationError` | where the value came from (`body`, `query`, …), which is dropped |
+| `field_problems(…, root=…)` | a service validating a document a route's schema cannot — a per-upload ingestion override, a hand-edited spec YAML, a capability's config blob | a field of that document, reported below `root` |
+
+Deciding by the string instead would misread a spec whose forbidden top-level
+key is literally called `body`, which is one shape standing in for two — the
+mistake the module exists to end.
+
+Two more properties are worth knowing before adding a call site. It reads `loc`
+and `msg` only, so the rejected value cannot come back beside the field it broke,
+which is why those call sites hand it `exc.errors()` unfiltered. And `root` is
+what the caller's form calls the whole document, so every path is relative to it:
+that gives a `model_validator(mode="after")` somewhere to land — it reports
+`loc: ()`, because the rule it broke is about two fields at once — and it makes
+the entry points agree, an override refused at upload naming exactly what the 422
+names when the same pair arrives as a collection's own settings.
+
+Handing Pydantic's own `exc.errors()` through instead was
 [#882](https://github.com/vstorm-co/agenticos/issues/882) — a second shape,
 carrying `input`, `ctx` and `url`, that nothing on the frontend read.
+
+**An aggregated refusal carries both halves.** `validate_spec` reports every
+problem in a spec at once and most of them are broken references with no input to
+mark, so it answers `details.problems` (a line each, which the Builder lists) and
+`details.fields` for the subset that names one. A capability's configuration is
+the one part of a spec rendered as a generated form, so its refusals name the
+input — `capabilities.knowledge.config.default_top_k`, and
+`specialists.researcher.` in front of that for a capability configured inside a
+delegate, because the Builder renders one form per specialist. Keeping only the
+sentence was the other half of #882: saving a draft does not validate a config
+schema at all, so publish validation is the only place a mistyped setting is ever
+refused.
 
 ## Key Files
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -267,6 +267,32 @@ table in the schema. The index on `parent_run_id` serves
 [Governance](governance.md#what-run-history-shows) for why run history never lists
 the two kinds of row together.
 
+## A refusal that names a field
+
+Every refusal leaves in one envelope, `{"error": {"code", "message", "details"}}`,
+and a refusal about a *field* names it in one shape:
+
+```json
+{"details": {"fields": [{"field": "spec.name", "message": "String should have at most 128 characters"}]}}
+```
+
+`fieldProblems` in `frontend/src/lib/api-error.ts` reads that and nothing else,
+which is what lets a form mark the offending input rather than showing a sentence
+the reader has to re-scan the page for. `app/core/field_errors.py` is the only
+place it is built — by `validation_exception_handler` for every
+`RequestValidationError`, and by the services that validate a document a route's
+own schema cannot (a per-upload ingestion override, a hand-edited spec YAML, a
+capability's config blob).
+
+Two properties are worth knowing before adding a call site. It reads `loc` and
+`msg` only, so the rejected value cannot come back beside the field it broke —
+which is why those call sites hand it `exc.errors()` unfiltered. And it takes a
+`root`: a `model_validator(mode="after")` reports `loc: ()`, because the rule it
+broke is about two fields at once, and a form still has to be told where to put
+that sentence. Handing pydantic's own `exc.errors()` through instead was
+[#882](https://github.com/vstorm-co/agenticos/issues/882) — a second shape,
+carrying `input`, `ctx` and `url`, that nothing on the frontend read.
+
 ## Key Files
 
 - Entry point: `app/main.py`
@@ -274,6 +300,7 @@ the two kinds of row together.
 - Dependencies: `app/api/deps.py`
 - Auth utilities: `app/core/security.py`
 - Exception handlers: `app/api/exception_handlers.py`
+- Field-level refusals: `app/core/field_errors.py`
 
 ## Authentication & Authorization
 

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -332,13 +332,20 @@ per-upload `ingestion` field carries only what it changes, so `chunk_overlap:
 4096` sent to a collection chunking at 512 is two individually legal numbers and
 one configuration that repeats almost everything it advances past. The merge
 re-validates, and the upload is refused with a **400** naming both settings in
-`details.errors` — before the file is stored and before a document row exists,
+`details.fields` — before the file is stored and before a document row exists,
 so there is nothing to retry or clean up. It answered 500 with an empty
 `details` until [#874](https://github.com/vstorm-co/agenticos/issues/874): the
 merge raised a raw Pydantic error, which reaches no handler. The same pair sent
 as a collection's own configuration was always refused with a 422, because there
 it is a field of a JSON body and FastAPI validates it before the route is
 entered.
+
+Both refusals name the same field, `ingestion_config`, because a rule about two
+settings at once is attributed by Pydantic to neither of them — so the form
+marks one place whichever entry point refused. The 400 named its fields under
+`details.errors` until [#882](https://github.com/vstorm-co/agenticos/issues/882),
+in Pydantic's own error format, which nothing on the frontend read: the sentence
+reached a toast and no input was ever highlighted.
 
 ### Embeddings — the model, and whose key pays
 

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -340,12 +340,14 @@ as a collection's own configuration was always refused with a 422, because there
 it is a field of a JSON body and FastAPI validates it before the route is
 entered.
 
-Both refusals name the same field, `ingestion_config`, because a rule about two
-settings at once is attributed by Pydantic to neither of them — so the form
-marks one place whichever entry point refused. The 400 named its fields under
-`details.errors` until [#882](https://github.com/vstorm-co/agenticos/issues/882),
-in Pydantic's own error format, which nothing on the frontend read: the sentence
-reached a toast and no input was ever highlighted.
+Both refusals name the same fields, `ingestion_config` for the pair rule and
+`ingestion_config.chunk_size` for a setting of its own — so the form marks one
+place whichever entry point refused. (The pair rule names the object because
+Pydantic attributes a `model_validator(mode="after")` to neither of the two
+fields it is about.) The 400 named its fields under `details.errors` until
+[#882](https://github.com/vstorm-co/agenticos/issues/882), in Pydantic's own
+error format, which nothing on the frontend read: the sentence reached a toast
+and no input was ever highlighted.
 
 ### Embeddings — the model, and whose key pays
 

--- a/frontend/src/app/[locale]/(dashboard)/agents/[id]/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/agents/[id]/page.tsx
@@ -101,6 +101,7 @@ import {
   withSkills,
 } from "@/lib/agent-spec";
 import { useContextFiles } from "@/hooks/use-context";
+import type { FieldProblem } from "@/lib/api-error";
 import { ROUTES } from "@/lib/constants";
 import { useAgentSelectionStore, useConversationStore } from "@/stores";
 import { cn } from "@/lib/utils";
@@ -146,6 +147,10 @@ export default function AgentBuilderPage({ params }: PageProps) {
 
   const [spec, setSpec] = useState<AgentSpec | null>(null);
   const [problems, setProblems] = useState<string[]>([]);
+  // The subset of them that names an input, so the capability whose
+  // configuration was refused marks the box rather than only saying so in
+  // the list above the form (#882).
+  const [configProblems, setConfigProblems] = useState<FieldProblem[]>([]);
   const [confirming, setConfirming] = useState<"archive" | "delete" | null>(null);
   const [publishOpen, setPublishOpen] = useState(false);
   const [mapOpen, setMapOpen] = useState(false);
@@ -493,8 +498,9 @@ export default function AgentBuilderPage({ params }: PageProps) {
   async function handlePublish() {
     if (!(await persist())) return;
     const found = await validate();
-    setProblems(found);
-    if (found.length === 0) setPublishOpen(true);
+    setProblems(found.problems);
+    setConfigProblems(found.fields);
+    if (found.problems.length === 0) setPublishOpen(true);
   }
 
   // What the next publish will be called. The server owns the number; this
@@ -901,6 +907,7 @@ export default function AgentBuilderPage({ params }: PageProps) {
                 // resolve one for the standalone agent it becomes.
                 modelProfileId={spec.model_profile_id ?? null}
                 disabled={!canEdit}
+                configProblems={configProblems}
               />
             </CardContent>
           </Card>

--- a/frontend/src/components/agents/capability-settings.integration.test.tsx
+++ b/frontend/src/components/agents/capability-settings.integration.test.tsx
@@ -472,3 +472,97 @@ describe("SecretField · narrowing by what a key is for", () => {
     expect(screen.getByRole("option", { name: /OpenAI/ })).toBeInTheDocument();
   });
 });
+/** A capability whose configuration is a generated form, which is where a
+ *  refused setting has an input to be marked on. */
+const KNOWLEDGE: CapabilityCatalogEntry = {
+  ...WEATHER,
+  id: "knowledge",
+  name: "Knowledge",
+  requires_secret: null,
+  config_schema: {
+    type: "object",
+    properties: {
+      default_top_k: {
+        type: "integer",
+        title: "Default top k",
+        description: "How many chunks a search returns.",
+      },
+    },
+  },
+};
+
+/**
+ * A capability's configuration refused at publish, on the input that broke.
+ *
+ * `validate_spec` aggregates every problem in a spec into sentences, and it
+ * used to keep only the sentence for a refused config - so this reached the
+ * Builder as "Capability 'knowledge': Invalid configuration for capability
+ * 'knowledge'" and no box was ever marked. Saving a draft does not validate a
+ * config schema at all, so publish validation is the only place a mistyped
+ * setting is refused, which made it the only place it could be shown (#882).
+ */
+describe("a capability configuration refused at publish", () => {
+  const refusal = (field: string) => [
+    { field, message: "Input should be less than or equal to 50" },
+  ];
+
+  beforeEach(() => serve([]));
+
+  it("marks the setting the server named", async () => {
+    render(
+      <CapabilitySettings
+        catalog={[KNOWLEDGE]}
+        selected={[binding({ id: "knowledge", config: { default_top_k: 999 } })]}
+        onChange={vi.fn()}
+        configProblems={refusal("capabilities.knowledge.config.default_top_k")}
+      />,
+      { wrapper },
+    );
+
+    const input = await screen.findByLabelText(/Default top k/);
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(input).toHaveAccessibleDescription(
+      expect.stringContaining("Input should be less than or equal to 50"),
+    );
+  });
+
+  it("does not mark a field of the same name on another capability", async () => {
+    // Every capability's problems arrive in one flat list, so the path is what
+    // keeps two forms apart - both of these could hold a `default_top_k`.
+    render(
+      <CapabilitySettings
+        catalog={[KNOWLEDGE]}
+        selected={[binding({ id: "knowledge", config: { default_top_k: 8 } })]}
+        onChange={vi.fn()}
+        configProblems={refusal("capabilities.web_search.config.default_top_k")}
+      />,
+      { wrapper },
+    );
+
+    expect(await screen.findByLabelText(/Default top k/)).not.toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+  });
+
+  it("does not mark the parent's form for a mistake inside a specialist", async () => {
+    // One form per specialist, configuring the same capabilities. The parent's
+    // card renders without a specialist name, so a scoped path is not its own.
+    render(
+      <CapabilitySettings
+        catalog={[KNOWLEDGE]}
+        selected={[binding({ id: "knowledge", config: { default_top_k: 8 } })]}
+        onChange={vi.fn()}
+        configProblems={refusal(
+          "specialists.researcher.capabilities.knowledge.config.default_top_k",
+        )}
+      />,
+      { wrapper },
+    );
+
+    expect(await screen.findByLabelText(/Default top k/)).not.toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+  });
+});

--- a/frontend/src/components/agents/capability-settings.tsx
+++ b/frontend/src/components/agents/capability-settings.tsx
@@ -4,7 +4,9 @@ import type { ReactNode } from "react";
 import Link from "next/link";
 import { ChevronRight, ShieldAlert } from "lucide-react";
 
+import { capabilityConfigErrors } from "@/lib/agent-spec";
 import { getErrorMessage } from "@/lib/api-error";
+import type { FieldProblem } from "@/lib/api-error";
 import { SchemaForm } from "@/components/agents/schema-form";
 import {
   Badge,
@@ -44,6 +46,15 @@ interface CapabilitySettingsProps {
   selected: CapabilityBindingSpec[];
   onChange: (binding: CapabilityBindingSpec) => void;
   disabled?: boolean;
+  /**
+   * What publish validation said about the inputs on these forms.
+   *
+   * The whole flat list from `validate_spec`; each card takes the paths that
+   * name its own capability. Passed down rather than resolved here because a
+   * specialist's copy of a capability is a different form from the parent's,
+   * and only the component rendering one knows which it is.
+   */
+  configProblems?: readonly FieldProblem[];
 }
 
 /** The three modes, in order. Their words live in the catalog under `approval*`. */
@@ -133,6 +144,7 @@ export function CapabilitySettings({
   selected,
   onChange,
   disabled,
+  configProblems,
 }: CapabilitySettingsProps) {
   const configurable = selected
     .filter((binding) => binding.enabled)
@@ -156,6 +168,7 @@ export function CapabilitySettings({
           definition={definition}
           onChange={onChange}
           disabled={disabled}
+          configProblems={configProblems}
         />
       ))}
     </div>
@@ -177,6 +190,15 @@ interface CapabilityDetailProps {
    * the same for every capability and is not worth a second implementation.
    */
   hideConfigForm?: boolean;
+  /**
+   * What publish validation said about the inputs on these forms.
+   *
+   * The whole flat list from `validate_spec`; each card takes the paths that
+   * name its own capability. Passed down rather than resolved here because a
+   * specialist's copy of a capability is a different form from the parent's,
+   * and only the component rendering one knows which it is.
+   */
+  configProblems?: readonly FieldProblem[];
 }
 
 /**
@@ -192,8 +214,10 @@ export function CapabilityDetail({
   onChange,
   disabled,
   hideConfigForm,
+  configProblems,
 }: CapabilityDetailProps) {
   const t = useTranslations("agents");
+  const configErrors = capabilityConfigErrors(configProblems ?? [], binding.id);
   return (
     // Grouped and named, so the tool rows below are read as belonging to
     // this capability rather than to the page.
@@ -218,6 +242,7 @@ export function CapabilityDetail({
             schema={definition.config_schema}
             value={binding.config}
             disabled={disabled}
+            errors={configErrors}
             onChange={(config) => onChange({ ...binding, config })}
           />
         )}

--- a/frontend/src/components/agents/capability-workbench.tsx
+++ b/frontend/src/components/agents/capability-workbench.tsx
@@ -8,6 +8,7 @@ import { SubagentsSection } from "@/components/agents/subagents-section";
 import { WorkspaceSection } from "@/components/agents/workspace-section";
 import { SearchInput, Switch } from "@/components/ui";
 import { readSubagentsConfig, SANDBOX_ID, SUBAGENTS_ID } from "@/lib/agent-spec";
+import type { FieldProblem } from "@/lib/api-error";
 import { cn } from "@/lib/utils";
 import type { CapabilityBindingSpec, CapabilityCatalogEntry, SubagentRef } from "@/types/agents";
 import { useTranslations } from "next-intl";
@@ -33,6 +34,14 @@ interface CapabilityWorkbenchProps {
    */
   modelProfileId: string | null;
   disabled?: boolean;
+  /**
+   * What the last publish attempt said about the inputs on these forms.
+   *
+   * A capability's configuration is generated from its schema, so a refusal
+   * about one of its settings has an input to be shown on - which is the whole
+   * reason `validate_spec` reports fields as well as sentences (#882).
+   */
+  configProblems?: readonly FieldProblem[];
 }
 
 /**
@@ -87,6 +96,7 @@ export function CapabilityWorkbench({
   onSubagentsChange,
   modelProfileId,
   disabled,
+  configProblems,
 }: CapabilityWorkbenchProps) {
   const t = useTranslations("agents");
   const enabled = new Set(selected.filter((binding) => binding.enabled).map((b) => b.id));
@@ -262,6 +272,7 @@ export function CapabilityWorkbench({
                 binding={bound ?? unboundBinding(focused.id)}
                 definition={focused}
                 onChange={onChange}
+                configProblems={configProblems}
                 // A capability nobody granted has nothing to configure yet, so
                 // its controls are shown at their real values and left inert.
                 // The alternative - live controls writing to a binding that does

--- a/frontend/src/components/kb/ingestion-settings.test.tsx
+++ b/frontend/src/components/kb/ingestion-settings.test.tsx
@@ -1,13 +1,24 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { createTranslator } from "next-intl";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import en from "../../../messages/en.json";
 import { IngestionSettings } from "./ingestion-settings";
+import type { Translate } from "@/lib/agent-step-captions";
 import { apiClient } from "@/lib/api-client";
-import { DEFAULT_INGESTION_CONFIG } from "@/lib/ingestion-config";
+import { ApiError, submitFailure } from "@/lib/api-error";
+import { DEFAULT_INGESTION_CONFIG, INGESTION_FORM_FIELDS } from "@/lib/ingestion-config";
 import type { IngestionConfig } from "@/types";
+
+/** The real `errors` copy, for the one part of a refusal a form cannot show. */
+const tErrors = createTranslator({
+  locale: "en",
+  messages: en,
+  namespace: "errors",
+}) as Translate;
 
 vi.mock("@/lib/api-client", () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
@@ -257,5 +268,70 @@ describe("IngestionSettings", () => {
       screen.getByText("chunk_overlap (600) must be smaller than chunk_size (512)"),
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Overlap")).not.toHaveAttribute("aria-invalid", "true");
+  });
+
+  /**
+   * From the body the server sends to the control it marks, with nothing made up
+   * in between - the two tests above start from `errors` already sorted.
+   *
+   * Both bodies are copied from the backend tests that pin them
+   * (`tests/test_ingestion_config.py`), and until #882 both carried their fields
+   * under `details.errors` in Pydantic's own format instead. `fieldProblems`
+   * reads `details.fields` and nothing else, so what reached this form was `{}`:
+   * the sentence went to a toast and no control was ever marked.
+   */
+  describe("a refused upload override, from the wire", () => {
+    const refusal = (message: string, fields: { field: string; message: string }[]) =>
+      new ApiError(400, "…", {
+        error: { code: "BAD_REQUEST", message, details: { fields } },
+      });
+
+    const shown = (error: ApiError) =>
+      submitFailure(error, { fields: [...INGESTION_FORM_FIELDS] }, tErrors);
+
+    it("marks the setting the server named", () => {
+      const failure = shown(
+        refusal("The 'ingestion' field is not a valid ingestion override", [
+          { field: "chunk_size", message: "Input should be greater than or equal to 64" },
+        ]),
+      );
+      render(
+        <IngestionSettings
+          idPrefix="test"
+          value={DEFAULT_INGESTION_CONFIG}
+          onChange={vi.fn()}
+          errors={failure.fields}
+        />,
+        { wrapper },
+      );
+
+      const size = screen.getByLabelText("Chunk size");
+      expect(size).toHaveAttribute("aria-invalid", "true");
+      expect(size).toHaveAccessibleDescription("Input should be greater than or equal to 64");
+      // Nothing is left over to announce separately: a field-shaped failure
+      // shown on the field must not also arrive as a toast saying it broke.
+      expect(failure.toast).toBeNull();
+    });
+
+    it("shows the pair rule on the settings block it is about", () => {
+      const message = "Value error, chunk_overlap (4096) must be smaller than chunk_size (512)";
+      const failure = shown(
+        refusal("The 'ingestion' field is not a valid override for this collection", [
+          { field: "ingestion_config", message },
+        ]),
+      );
+      render(
+        <IngestionSettings
+          idPrefix="test"
+          value={DEFAULT_INGESTION_CONFIG}
+          onChange={vi.fn()}
+          errors={failure.fields}
+        />,
+        { wrapper },
+      );
+
+      expect(screen.getByText(message)).toBeInTheDocument();
+      expect(failure.toast).toBeNull();
+    });
   });
 });

--- a/frontend/src/hooks/use-agents.test.tsx
+++ b/frontend/src/hooks/use-agents.test.tsx
@@ -134,7 +134,7 @@ describe("useAgent validation", () => {
     const { result } = renderHook(() => useAgent("a1"), { wrapper });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    expect(await result.current.validate()).toEqual([]);
+    expect(await result.current.validate()).toEqual({ problems: [], fields: [] });
   });
 
   it("returns every problem rather than throwing", async () => {
@@ -160,10 +160,48 @@ describe("useAgent validation", () => {
     const { result } = renderHook(() => useAgent("a1"), { wrapper });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    expect(await result.current.validate()).toEqual([
-      "Unknown capability: typo",
-      "No model selected",
+    expect(await result.current.validate()).toEqual({
+      problems: ["Unknown capability: typo", "No model selected"],
+      fields: [],
+    });
+  });
+
+  it("carries the inputs a refused capability configuration named", async () => {
+    // The half that says *which box to fix*. Publish validation aggregates
+    // every problem in a spec into sentences, and it used to keep only the
+    // sentence for a refused config - so `default_top_k: 999` reached the
+    // Builder as one line about the capability and marked nothing (#882).
+    vi.mocked(apiClient.get).mockResolvedValue({ id: "a1", draft_spec: {} });
+    vi.mocked(apiClient.post).mockRejectedValue(
+      new ApiError(400, "This agent cannot be published yet", {
+        error: {
+          code: "BAD_REQUEST",
+          message: "This agent cannot be published yet",
+          details: {
+            problems: ["Capability 'knowledge': Invalid configuration for capability 'knowledge'"],
+            fields: [
+              {
+                field: "capabilities.knowledge.config.default_top_k",
+                message: "Input should be less than or equal to 50",
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    const { result } = renderHook(() => useAgent("a1"), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const refusal = await result.current.validate();
+    expect(refusal.fields).toEqual([
+      {
+        field: "capabilities.knowledge.config.default_top_k",
+        message: "Input should be less than or equal to 50",
+      },
     ]);
+    // And still as a line, because most of a spec is not a generated form.
+    expect(refusal.problems).toHaveLength(1);
   });
 
   it("falls back to the error message when the server sends no problem list", async () => {
@@ -173,7 +211,10 @@ describe("useAgent validation", () => {
     const { result } = renderHook(() => useAgent("a1"), { wrapper });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    expect(await result.current.validate()).toEqual(["Service unavailable"]);
+    expect(await result.current.validate()).toEqual({
+      problems: ["Service unavailable"],
+      fields: [],
+    });
   });
 
   it("does not turn a refused permission into a list of spec problems", async () => {
@@ -194,7 +235,10 @@ describe("useAgent validation", () => {
     const { result } = renderHook(() => useAgent("a1"), { wrapper });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    expect(await result.current.validate()).toEqual(["You cannot edit this agent"]);
+    expect(await result.current.validate()).toEqual({
+      problems: ["You cannot edit this agent"],
+      fields: [],
+    });
   });
 
   it("does not fetch until an agent is selected", () => {

--- a/frontend/src/hooks/use-agents.ts
+++ b/frontend/src/hooks/use-agents.ts
@@ -5,7 +5,8 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { apiClient } from "@/lib/api-client";
-import { getErrorMessage, problemList } from "@/lib/api-error";
+import { fieldProblems, getErrorMessage, problemList } from "@/lib/api-error";
+import type { FieldProblem } from "@/lib/api-error";
 import { qk } from "@/lib/query-keys";
 import type {
   Agent,
@@ -160,6 +161,18 @@ export function useAgents({
   };
 }
 
+/**
+ * Why a spec cannot be published, in the two places the Builder shows it.
+ *
+ * `fields` is a subset of what `problems` says, not a second answer: every
+ * problem that names an input also gets a line, because the page lists them all
+ * above the form and only one of the Builder's forms is generated from a schema.
+ */
+export type SpecRefusal = {
+  readonly problems: string[];
+  readonly fields: FieldProblem[];
+};
+
 /** One agent, with the spec currently being edited. */
 export function useAgent(agentId: string | null) {
   const tErrors = useTranslations("errors");
@@ -196,21 +209,29 @@ export function useAgent(agentId: string | null) {
   /**
    * Check the draft without publishing.
    *
-   * Returns the list of problems rather than throwing: the Builder shows them
-   * next to the fields that caused them, and a rejected draft is a normal state
-   * to be in while editing.
+   * Returns the problems rather than throwing: a rejected draft is a normal
+   * state to be in while editing.
+   *
+   * Both halves of the refusal, because a capability's configuration is a
+   * generated form and the rest of a spec is not. `problems` is the list the
+   * page shows; `fields` is the subset that names an input, which the Builder
+   * marks on the capability card that owns it - a `default_top_k` of 999 used
+   * to arrive as one sentence about the capability, leaving the reader to find
+   * which of its boxes was wrong (#882).
    */
-  const validate = useCallback(async (): Promise<string[]> => {
+  const validate = useCallback(async (): Promise<SpecRefusal> => {
     try {
       await apiClient.post<void>(`/agents/${agentId}/validate`, {});
-      return [];
+      return { problems: [], fields: [] };
     } catch (error) {
       // This read used to be `error.details`, a property `ApiError` has never
       // had, so the list the backend goes out of its way to report in full was
       // always thrown away and replaced with one line. `problemList` reads the
       // envelope; the fallback is for the failures that are not a verdict on
       // the spec at all - a refused permission, a dropped connection.
-      return problemList(error) ?? [getErrorMessage(error, tErrors)];
+      const problems = problemList(error);
+      if (problems === null) return { problems: [getErrorMessage(error, tErrors)], fields: [] };
+      return { problems, fields: fieldProblems(error) };
     }
   }, [agentId, tErrors]);
 

--- a/frontend/src/lib/agent-spec.test.ts
+++ b/frontend/src/lib/agent-spec.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  capabilityConfigErrors,
   CONTEXT_ID,
   DEFAULT_SUBAGENTS_CONFIG,
   delegationNameClashes,
@@ -276,5 +277,51 @@ describe("pinStatus", () => {
     // An agent unpublished since it was pinned has no current version to
     // compare against, and inventing one would report a stale pin as current.
     expect(pinStatus([version(1)], "v1", null)).toEqual({ kind: "unknown" });
+  });
+});
+describe("capabilityConfigErrors", () => {
+  const problem = (field: string) => ({ field, message: "Input should be <= 50" });
+
+  it("keys a capability's own settings by the name its form renders", () => {
+    // `SchemaForm` keys its errors by the bare field; the path is what says
+    // which of the forms on the page that name belongs to.
+    expect(
+      capabilityConfigErrors([problem("capabilities.knowledge.config.default_top_k")], "knowledge"),
+    ).toEqual({ default_top_k: "Input should be <= 50" });
+  });
+
+  it("leaves another capability's field alone", () => {
+    // Every problem in a spec arrives in one flat list, and two capabilities
+    // can hold a setting of the same name.
+    expect(
+      capabilityConfigErrors(
+        [problem("capabilities.web_search.config.default_top_k")],
+        "knowledge",
+      ),
+    ).toEqual({});
+  });
+
+  it("leaves a specialist's copy of the same capability alone", () => {
+    // The Builder renders one form per specialist, configuring the same
+    // capabilities as the parent - so the parent's card is not where a
+    // delegate's mistake is marked.
+    expect(
+      capabilityConfigErrors(
+        [problem("specialists.researcher.capabilities.knowledge.config.default_top_k")],
+        "knowledge",
+      ),
+    ).toEqual({});
+  });
+
+  it("leaves a refusal about the whole blob to the problem list above the form", () => {
+    // A rule about two settings at once names the config itself, and there is
+    // no input to put that under.
+    expect(capabilityConfigErrors([problem("capabilities.knowledge.config")], "knowledge")).toEqual(
+      {},
+    );
+  });
+
+  it("says nothing for the ordinary case, where no problem names an input", () => {
+    expect(capabilityConfigErrors([], "knowledge")).toEqual({});
   });
 });

--- a/frontend/src/lib/agent-spec.ts
+++ b/frontend/src/lib/agent-spec.ts
@@ -7,6 +7,7 @@
  * binding the server validates slightly differently.
  */
 
+import type { FieldProblem } from "@/lib/api-error";
 import type {
   AgentSpec,
   AgentVersion,
@@ -288,4 +289,33 @@ export function pinStatus(
     latest: current.version,
     by: current.version - pinned.version,
   };
+}
+
+/**
+ * What publish validation said about one capability's configuration form.
+ *
+ * `validate_spec` reports every problem in a spec at once, so its `fields`
+ * arrive as one flat list of paths, and the path is what says which of the
+ * forms on the page a field name belongs to. Two things follow from matching
+ * the whole prefix rather than the leaf. A `default_top_k` refused on one
+ * capability is not marked on every other card that has one. And a capability
+ * configured inside a delegate is reported under
+ * `specialists.researcher.capabilities.…`, which is not this card either - the
+ * Builder renders one form per specialist, and they configure the same
+ * capabilities as their parent.
+ *
+ * Empty for a capability nothing was said about, which is the ordinary case -
+ * most publish problems are broken references with no input to mark at all.
+ */
+export function capabilityConfigErrors(
+  problems: readonly FieldProblem[],
+  capabilityId: string,
+): Readonly<Record<string, string>> {
+  const prefix = `capabilities.${capabilityId}.config.`;
+  const errors: Record<string, string> = {};
+  for (const problem of problems) {
+    if (!problem.field.startsWith(prefix)) continue;
+    errors[problem.field.slice(prefix.length)] = problem.message;
+  }
+  return errors;
 }

--- a/frontend/src/lib/api-error.test.ts
+++ b/frontend/src/lib/api-error.test.ts
@@ -13,6 +13,7 @@ import {
   submitFailure,
 } from "./api-error";
 import { BFF_ERROR_KEYS } from "./bff-errors";
+import { INGESTION_FORM_FIELDS } from "./ingestion-config";
 
 /**
  * The real `errors` messages, in both locales: what a refusal shows is what these
@@ -172,6 +173,85 @@ describe("fieldProblems", () => {
       envelope("VALIDATION_ERROR", "…", { fields: [null, { field: "name" }, 3] }),
     );
     expect(fieldProblems(enveloped)).toEqual([]);
+  });
+});
+
+/**
+ * The three refusals a service raises for a document a route's schema cannot
+ * validate, each body copied from the backend test that pins it: an ingestion
+ * override (`tests/api/test_ingestion_override_routes.py`), a hand-edited spec
+ * (`tests/api/test_agent_spec_import_refusal.py`) and a capability's config
+ * blob (`tests/test_capability_registry.py`).
+ *
+ * All three are `BAD_REQUEST`, not the 422 the validation handler answers, and
+ * all three used to carry Pydantic's own error list under `details.errors` -
+ * which this module reads nowhere, so each one showed a sentence and marked no
+ * input at all (#882). They are here rather than in the reader's own describe
+ * block because what is being tested is that the wire shape reaches a form.
+ */
+const OVERRIDE_REFUSED = envelope(
+  "BAD_REQUEST",
+  "The 'ingestion' field is not a valid override for this collection",
+  {
+    fields: [
+      {
+        field: "ingestion_config",
+        message: "Value error, chunk_overlap (4096) must be smaller than chunk_size (512)",
+      },
+    ],
+  },
+);
+
+const SPEC_REFUSED = envelope("BAD_REQUEST", "This spec does not match the agent spec format", {
+  fields: [{ field: "instrucitons", message: "Extra inputs are not permitted" }],
+});
+
+const CONFIG_REFUSED = envelope("BAD_REQUEST", "Invalid configuration for capability 'knowledge'", {
+  capability_id: "knowledge",
+  fields: [{ field: "default_top_k", message: "Input should be less than or equal to 50" }],
+});
+
+describe("a refusal a service raised about a document it validated itself", () => {
+  it("names the setting a rejected ingestion override is about", () => {
+    // A `model_validator` names neither of the two settings it is about, so the
+    // server attributes the pair to the object - the field `IngestionSettings`
+    // reserves for exactly this rule.
+    expect(fieldProblems(apiError(400, OVERRIDE_REFUSED))).toEqual([
+      {
+        field: "ingestion_config",
+        message: "Value error, chunk_overlap (4096) must be smaller than chunk_size (512)",
+      },
+    ]);
+  });
+
+  it("marks the ingestion input the refusal names, and stays out of the toast", () => {
+    const failure = submitFailure(
+      apiError(400, OVERRIDE_REFUSED),
+      { fields: [...INGESTION_FORM_FIELDS] },
+      tEn,
+    );
+
+    expect(failure.fields.ingestion_config).toBe(
+      "Value error, chunk_overlap (4096) must be smaller than chunk_size (512)",
+    );
+    expect(failure.toast).toBeNull();
+  });
+
+  it("names the key a hand-edited spec misspelled", () => {
+    expect(fieldProblems(apiError(400, SPEC_REFUSED))).toEqual([
+      { field: "instrucitons", message: "Extra inputs are not permitted" },
+    ]);
+  });
+
+  it("marks the config input a capability refused, and keeps the capability it is about", () => {
+    const error = apiError(400, CONFIG_REFUSED);
+    const failure = submitFailure(error, { fields: ["default_top_k"] }, tEn);
+
+    expect(failure.fields.default_top_k).toBe("Input should be less than or equal to 50");
+    expect(failure.toast).toBeNull();
+    // Which card to open it on. The Builder posts every binding at once, so the
+    // field alone does not say which capability was refused.
+    expect(error.details?.capability_id).toBe("knowledge");
   });
 });
 


### PR DESCRIPTION
Four services refused caller input with pydantic's own `exc.errors()` under
`details["errors"]`. `fieldProblems` in `frontend/src/lib/api-error.ts:179`
reads `details["fields"]` and FastAPI's own `detail`, and nothing else — so a
refused ingestion override (#874, v0.0.190), a refused spec import (#873,
v0.0.191) and a refused capability config each delivered a sentence to a toast
and highlighted nothing. That is the half of the answer that says *which box to
fix*, missing from the three refusals written to provide it.

## The shapes, as they actually were

| Where | `details` |
|---|---|
| `validation_exception_handler` — every `RequestValidationError` | `{"fields": [{"field", "message"}]}` — **read** |
| `parse_override`, `IngestionOverride.applied_to`, `CapabilityDef.validate_config`, `_parse_spec_yaml` | `{"errors": [pydantic's own dicts]}` — read nowhere |
| Routes the handler does not reach | FastAPI's `{"detail": [...]}` — read, as a fallback |
| 17 other call sites | `{"field": "<name>"}`, singular, message on the envelope — read nowhere |

The fourth was found while doing this and is **not** fixed here — see below.

## The fix: the backend settles on one shape

Reading `errors` on the client would mean a second copy of `_field_path` over
there — drop the `body` prefix, join, keep list indices — which is the
duplication that produced the divergence in the first place, and it would leave
a fifth call site free to pick either. So `details["fields"]` is the one shape,
and `backend/app/core/field_errors.py` is the only place it is built: by the
validation handler and by the four services. `app/api/` is the wrong home
because a service cannot import from it.

Three properties are worth the new module:

- **It reads `loc` and `msg` and nothing else**, so the call sites no longer
  pass `include_url=False, include_input=False`. What leaves is decided in one
  place instead of remembered in four. `exc.errors()` carries the rejected value
  under `input` and, for a rule that raised, the `ValueError` itself under
  `ctx` — which `jsonable_encoder` reached through `vars()` and put on the wire
  as `{"error": {}}`.
- **Two entry points, because there are two callers.** Only FastAPI puts where
  the value came from in front of `loc`; a service validating a model itself
  reports a field name first. Deciding by the string misread a spec whose
  forbidden top-level key is literally called `body` — reported as `loc:
  ("body",)` — and blamed the editor for a key somebody has to delete. So
  `request_field_problems` strips an origin and `field_problems` never does.
- **`root` answers the wrinkle #882 names.** It is what the caller's form calls
  the whole document, and every path is relative to it. That gives a
  `model_validator(mode="after")` somewhere to land — it reports `loc: ()` —
  and it makes the two entry points agree exactly: a `chunk_size` refused on an
  upload override and the same field refused as a collection's own settings are
  both `ingestion_config.chunk_size`.

## And the publish path, which was discarding it

`validate_config` is one of the three refusals this PR exists to make
highlightable, and `AgentRegistryService._binding_problems` was flattening it:
it caught the `BadRequestError`, kept `exc.message`, and the validate endpoint
answered `details.problems` — so `default_top_k: 999` reached the Builder as
"Capability 'knowledge': Invalid configuration for capability 'knowledge'" and
marked nothing. Saving a draft does not validate a config schema, so this is the
path a Builder submission actually takes.

`validate_spec` now aggregates both halves through a small accumulator:
`details["problems"]` exactly as before, and `details["fields"]` for the subset
that names an input — qualified by the capability, because two of them can hold
a setting of the same name, and by the specialist when the binding is inside
one. `useAgent.validate` returns both, and `capabilityConfigErrors` hands each
capability card the paths that are its own. `SchemaForm` has taken an `errors`
prop since it was written; nothing was passing it.

The other two refusals were traced the same way, to the response body rather
than to the first envelope: both are raised inside a request and answered by the
handler with `details` intact, which is what the two API-level tests assert on.

**Not routed, and not claimed:** a *specialist's* own capability form. The
backend scopes those paths (`specialists.researcher.capabilities.…`) and there
is a test that such a path does not mark the parent's card, but threading
`configProblems` down to `SpecialistList` is a second surface — and a prop
nothing passes is worse than an honest gap.

## Tests

| Test | What it proves |
|---|---|
| `backend/tests/test_field_errors.py` — `TestThePathAFormMarksOn` | the origin segment is dropped, list indices survive, an unrecognised first segment is kept (moved from `test_error_envelope.py`, which held the same cases against the old private helper) |
| …`test_a_rule_about_the_whole_object_is_given_the_field_it_arrived_in` | the `loc: ()` wrinkle: the pair rule lands on the field the caller can see |
| …`TestNothingElseLeaves` (3) | `input`, `ctx` and everything else are dropped even when the caller passes them |
| `test_ingestion_config.py` — pair rule + `parse_override` (4) | the 400 names `ingestion_config` for the pair, `chunk_size` for a field of its own, and carries only `{field, message}` |
| `test_capability_registry.py` (3) | `default_top_k` is named beside `capability_id`; a `browser_use` cross-field rule falls back to `config` |
| `api/test_agent_spec_import_refusal.py` (4, updated) | the import 400 names `name`, `capabilities.0`, `instrucitons` as fields rather than pydantic `loc` arrays |
| `api/test_ingestion_override_routes.py` — new `…names_a_field_the_form_can_mark_it_under` | through the app: the 400 and the 422 now name the same field |
| `frontend/src/lib/api-error.test.ts` — new describe (4) | `fieldProblems` and `submitFailure` resolve a field for each of the three refusals, from bodies copied out of the backend tests |
| `frontend/src/components/kb/ingestion-settings.test.tsx` — new describe (2) | **the highlight**: from the wire body to `aria-invalid="true"` on Chunk size with the server's sentence as its accessible description, and the pair rule on the settings block — with `failure.toast` null in both, so a field-shaped failure is not also announced as a breakage |

Added after review:

| Test | What it proves |
|---|---|
| `test_field_errors.py` — `…a_field_named_like_a_request_origin_is_still_that_field` (5) and `…a_request_drops_where_the_value_came_from…` | the two callers are told apart by who is asking, not by the string |
| …`test_a_service_document_names_exactly_what_the_request_path_names` | the same rule refused at either entry point addresses the same input |
| …`test_a_rule_on_a_nested_model_names_that_model_rather_than_the_root` | a nested validator reports the path to its model, so the fallback is not reachable from one |
| `api/test_agent_spec_import_refusal.py` — `…a_key_named_like_a_request_origin…` | end to end: a spec with a top-level `body` key answers `yaml.body`, not `yaml` |
| `test_agent_registry.py` — `…names_the_input_as_well_as_the_capability` | publish validation answers `capabilities.knowledge.config.default_top_k` **and** the line |
| …`…marked_on_the_specialists_own_form` | a delegate's binding is scoped so it cannot mark the parent's card |
| …`…carries_no_fields_key` | no `fields` when nothing can be marked, rather than an empty list that reads as a claim |
| `use-agents.test.tsx` — `…carries_the_inputs_a_refused_capability_configuration_named` | the hook returns both halves |
| `capability-settings.integration.test.tsx` — new describe (3) | **the highlight, in the Builder**: `aria-invalid="true"` on the setting the server named, and not on a same-named field belonging to another capability or to a specialist |
| `agent-spec.test.ts` — `capabilityConfigErrors` (5) | the path is what keeps two generated forms apart |

## Verified

```
make lint                  exit 0
make test                  5679 passed, 15 skipped — coverage 100.00% (required 100.0%)
make test-frontend-cov     Statements 100% (8197/8197) · Branches 97.64% (6087/6234)
                           Functions 100% (2642/2642) · Lines 100% (7312/7312)
make build-frontend        exit 0
python3 scripts/docs_drift.py   no drift
```

The new module is in `[tool.coverage.run] include`, `[[tool.ty.overrides]]
include` and `PLATFORM_MODULES`, all three in the same position.

Docs: `docs/file-processing.md` said the override 400 names both settings in
`details.errors`; `docs/architecture.md` gains a short section on the one shape,
since a new call site is the thing this is meant to stop from guessing.

## Found and deliberately not fixed — #891

`details={"field": "<name>"}`, singular, with the sentence on the envelope, at
17 further call sites (`model_profile`, `sandbox_connection`,
`rag/remote_names`, `channel_bot`, `mcp_connection`, `skills`,
`agent_registry`, `google_drive`) plus the two non-pydantic branches of
`_parse_spec_yaml`. No form reads that either — it is the same defect in a
third shape. Converging one of the eighteen here would have made
`_parse_spec_yaml` disagree with its siblings, and the decision is about all of
them, so the two YAML branches are left exactly as they were and #891 carries
the question.

Closes #882
Refs #873, #874, #891
