### PR TITLE
chore: cut 0.0.195

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,35 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.195] - 2026-08-18
+
+A refusal that names a field marks that field.
+
+### Fixed
+
+- **A per-field refusal highlights the input it names.** The forms mark an
+  offending field from `details.fields`, and four refusals answered with
+  `details.errors` instead — so an ingestion override, a spec import and a
+  capability setting each showed a sentence and left every box unmarked. That is
+  the half that says *which one to fix*, and it was missing from three fixes
+  released earlier today. One module builds the shape now, reading `loc` and
+  `msg` only, so what is left out is decided once rather than remembered at four
+  call sites. (#882)
+- **A capability setting refused at publish reaches the Builder.** Saving a draft
+  does not validate a config schema, so publish is the only place a mistyped
+  setting is refused — and the accumulator kept the message and dropped the
+  path. Paths are qualified by capability, and by specialist where one applies,
+  because two capabilities can hold a setting of the same name and the Builder
+  draws a form per specialist over the same set. `SchemaForm` has accepted an
+  `errors` prop since it was written; nothing had ever passed it. (#882)
+- **A field genuinely called `body` is no longer mistaken for FastAPI's
+  transport marker.** The two are told apart by which entry point is asking, not
+  by the string: a spec whose top-level key is `body` now says so. (#882)
+- **The same field refused two ways answers with the same path.** An upload's
+  ingestion override and a collection's own settings both name
+  `ingestion_config.chunk_size`, where only the cross-field rule used to line
+  up. (#882)
+
 ## [0.0.194] - 2026-08-18
 
 MCP OAuth connects to the address it checked, at every hop.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.194"
+version = "0.0.195"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.194"
+version = "0.0.195"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.194",
+  "version": "0.0.195",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.195. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json` to 0.0.195 and adds the CHANGELOG entry.

Releases the half that was missing from three fixes released earlier today (#892, closing #882): a refusal that names a field now marks it. Four refusals answered with a shape the forms do not read, and the capability path lost its field one layer above where it was built — so `SchemaForm`'s `errors` prop, present since the component was written, had never been passed anything.

The review round found the second of those, which is the one that mattered: publish validation is the only place a mistyped capability setting is ever refused, and the accumulator was keeping the message and dropping the path.

## Verified

CI green on #892 after the review round. `make test` 5679 passed at 100% platform coverage; `make test-frontend-cov` 100% statements/functions/lines, 97.64% branches. Three Builder integration tests assert `aria-invalid` lands on the right card and not on a same-named field elsewhere.