### PR TITLE
fix(mcp): refuse an OAuth URL httpx will not parse, rather than crash

### DIFF
--- a/backend/app/agents/mcp_oauth.py
+++ b/backend/app/agents/mcp_oauth.py
@@ -64,6 +64,40 @@ class OAuthError(Exception):
     """A recoverable failure in the OAuth flow (surfaced to the user)."""
 
 
+def _unusable_url(exc: httpx.InvalidURL, what: str) -> OAuthError:
+    """The refusal for an endpoint no request can be built for.
+
+    `httpx.InvalidURL` derives from `Exception` rather than from
+    `httpx.HTTPError`, so a catch written for a request that failed does not see
+    one that was never made - and a discovery document naming
+    `https://host:client_secret=sh-key/token` answered 500 with an empty body
+    instead of the refusal every other malformed document gets (#889). No check
+    written here could have reached it: `httpx` gives up while parsing the URL,
+    above both `PinnedAsyncClient` and `app.core.sanitize`.
+
+    Deliberately not the blocked-address refusal :func:`_send` raises, the same
+    separation #875 made: that one says this server aimed the flow somewhere the
+    deployment will not go, and this one that it wrote an address nothing can
+    dial. Reporting either as the other is a confident claim about whose fault a
+    failure was.
+
+    `InvalidURL` quotes what it could not parse - `Invalid port:
+    'client_secret=sh-key'`, `Invalid IDNA hostname: ...` - and on this flow that
+    text was written by the server being refused, so it stays in the log line
+    here and what is shown names only which endpoint was unusable.
+    """
+    logger.warning("MCP OAuth: %s cannot be requested: %s", what, exc)
+    return OAuthError(f"This server named {what} that cannot be requested - it is malformed.")
+
+
+_DISCOVERY_FAILURES = (httpx.HTTPError, httpx.InvalidURL, OAuthError)
+"""What ends one discovery candidate rather than the whole flow.
+
+`httpx.InvalidURL` is named because it is not an `httpx.HTTPError` and a catch
+that omits it is #889 again - see :func:`_unusable_url`.
+"""
+
+
 def _flow_failed(exc: Exception, *, summary: str, advice: str) -> str:
     """The sentence a failed OAuth step may show, for an exception it may not.
 
@@ -186,6 +220,11 @@ async def discover(server_url: str) -> DiscoveredServer:
     Follows the SEP-985 / RFC 9728 discovery chain: read the protected-resource
     metadata (from the `WWW-Authenticate` header if present, else well-known
     URIs), then the authorization-server metadata (RFC 8414, OIDC fallbacks).
+
+    A candidate the server named so badly that no request can be built for it
+    ends that candidate rather than the flow, like a candidate that answered
+    404: the `WWW-Authenticate` hint is the first of three, and the well-known
+    URIs after it are derived from the URL an operator typed (#889).
     """
     async with _client() as client:
         # 1. Probe the server unauthenticated to surface the WWW-Authenticate hint.
@@ -210,7 +249,7 @@ async def discover(server_url: str) -> DiscoveredServer:
                 ),
             )
             www_auth_url = extract_resource_metadata_from_www_auth(probe)
-        except (httpx.HTTPError, OAuthError):
+        except _DISCOVERY_FAILURES:
             # Probe failed or was blocked - fall back to well-known discovery below.
             pass
 
@@ -222,7 +261,7 @@ async def discover(server_url: str) -> DiscoveredServer:
                 prm = await handle_protected_resource_response(
                     await _send(client, create_oauth_metadata_request(url))
                 )
-            except (httpx.HTTPError, OAuthError):
+            except _DISCOVERY_FAILURES:
                 continue
             if prm and prm.authorization_servers:
                 auth_server_url = str(prm.authorization_servers[0])
@@ -240,7 +279,7 @@ async def discover(server_url: str) -> DiscoveredServer:
                 keep_going, candidate = await handle_auth_metadata_response(
                     await _send(client, create_oauth_metadata_request(url))
                 )
-            except (httpx.HTTPError, OAuthError):
+            except _DISCOVERY_FAILURES:
                 continue
             if candidate is not None:
                 asm = candidate
@@ -285,9 +324,12 @@ async def register_client(server: DiscoveredServer, redirect_uri: str) -> tuple[
     secret and use PKCE alone.
     """
     metadata = client_metadata(redirect_uri, server.scope)
-    request = create_client_registration_request(
-        server.metadata, metadata, server.authorization_endpoint
-    )
+    try:
+        request = create_client_registration_request(
+            server.metadata, metadata, server.authorization_endpoint
+        )
+    except httpx.InvalidURL as exc:
+        raise _unusable_url(exc, "a registration endpoint") from exc
     async with _client() as client:
         try:
             info = await handle_registration_response(await _send(client, request))
@@ -390,15 +432,16 @@ async def refresh_tokens(
 async def _token_request(token_endpoint: str, data: dict[str, str]) -> OAuthToken:
     async with _client() as client:
         try:
-            response = await _send(
-                client,
-                client.build_request(
-                    "POST",
-                    token_endpoint,
-                    data=data,
-                    headers={"Content-Type": "application/x-www-form-urlencoded"},
-                ),
+            request = client.build_request(
+                "POST",
+                token_endpoint,
+                data=data,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
             )
+        except httpx.InvalidURL as exc:
+            raise _unusable_url(exc, "a token endpoint") from exc
+        try:
+            response = await _send(client, request)
         except httpx.HTTPError as exc:
             logger.exception("MCP token request to %s failed", token_endpoint)
             raise OAuthError(

--- a/backend/tests/test_mcp_connections.py
+++ b/backend/tests/test_mcp_connections.py
@@ -2116,6 +2116,187 @@ class TestOAuthRefusalsDoNotQuoteTheServer:
         assert "at-secret-9f2c" in caplog.text
 
 
+class TestAUrlNoRequestCanBeBuiltFor:
+    """A discovery document may name a URL `httpx` will not parse at all, and
+    that is the third-party server being malformed rather than this platform
+    being broken - so it answers the 400 every other bad document answers.
+
+    `httpx.InvalidURL` derives from `Exception` rather than from
+    `httpx.HTTPError`, so it escaped all three of this module's catches and
+    reached the unhandled-exception handler as a 500 with an empty body (#889).
+    Neither `app.core.sanitize` nor `PinnedAsyncClient` could have stopped it:
+    both need a request, and this is the failure to build one.
+
+    Two shapes reach here, and both are the remote server's text. A bad port
+    survives `urlparse` and is quoted back by `InvalidURL` - `Invalid port:
+    'client_secret=…'` - which is what decides the wording. An endpoint over
+    64 KiB survives `AnyHttpUrl` too, so it is the shape that reaches a stored
+    `token_endpoint` and a `registration_endpoint` after discovery has already
+    accepted the document.
+    """
+
+    _SERVER = "https://93.184.216.34/mcp"
+    _BAD_PORT = (
+        "https://auth.example.com:client_secret=sh-9f2c/.well-known/oauth-protected-resource"
+    )
+    _TOO_LONG = "https://93.184.216.35/token?p=" + "p" * 70_000
+
+    @staticmethod
+    def _serving(monkeypatch, handler) -> None:
+        """Point every client `discover` opens at *handler* instead of a network."""
+        real = mcp_oauth._client
+        monkeypatch.setattr(mcp_oauth, "_client", lambda: real(httpx.MockTransport(handler)))
+
+    @classmethod
+    def _hinting_at_the_bad_port(cls, request: httpx.Request) -> httpx.Response:
+        if request.method == "POST":
+            return httpx.Response(
+                401,
+                headers={"WWW-Authenticate": f'Bearer resource_metadata="{cls._BAD_PORT}"'},
+                json={},
+            )
+        return httpx.Response(404, json={})
+
+    @staticmethod
+    def _metadata(token_endpoint: str) -> dict[str, object]:
+        return {
+            "issuer": "https://93.184.216.35",
+            "authorization_endpoint": "https://93.184.216.35/authorize",
+            "token_endpoint": token_endpoint,
+            "response_types_supported": ["code"],
+        }
+
+    @pytest.mark.anyio
+    async def test_a_www_authenticate_hint_with_an_unusable_port_does_not_crash_discovery(
+        self, monkeypatch
+    ):
+        """The header is remote-controlled text that reaches `httpx.Request`
+        before anything here sees it. It used to raise `InvalidURL` out of
+        `discover`; now the candidate is skipped and the flow gives the answer
+        it gives for a server with no metadata."""
+        seen: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(str(request.url))
+            return self._hinting_at_the_bad_port(request)
+
+        self._serving(monkeypatch, handler)
+        with pytest.raises(mcp_oauth.OAuthError) as exc_info:
+            await mcp_oauth.discover(self._SERVER)
+
+        assert "did not advertise OAuth metadata" in str(exc_info.value)
+        assert "sh-9f2c" not in str(exc_info.value)
+        # The hint was never requested; the well-known URIs after it still were.
+        assert seen == [
+            self._SERVER,
+            "https://93.184.216.34/.well-known/oauth-protected-resource/mcp",
+            "https://93.184.216.34/.well-known/oauth-protected-resource",
+            "https://93.184.216.34/.well-known/oauth-authorization-server",
+        ]
+
+    @pytest.mark.anyio
+    async def test_an_unusable_hint_ends_that_candidate_and_not_the_flow(self, monkeypatch):
+        """The hint is the first of three candidates and the other two are
+        derived from the URL an operator typed, so a server that writes its
+        `WWW-Authenticate` header badly and its well-known documents correctly
+        still connects."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/.well-known/oauth-protected-resource":
+                return httpx.Response(
+                    200,
+                    json={
+                        "resource": "https://93.184.216.34/mcp",
+                        "authorization_servers": ["https://93.184.216.35"],
+                    },
+                )
+            if request.url.path == "/.well-known/oauth-authorization-server":
+                return httpx.Response(200, json=self._metadata("https://93.184.216.35/token"))
+            return self._hinting_at_the_bad_port(request)
+
+        self._serving(monkeypatch, handler)
+        server = await mcp_oauth.discover(self._SERVER)
+
+        assert server.token_endpoint == "https://93.184.216.35/token"
+        assert server.authorization_endpoint == "https://93.184.216.35/authorize"
+
+    @pytest.mark.anyio
+    async def test_a_token_endpoint_discovery_accepted_but_httpx_will_not_build(
+        self, monkeypatch, caplog
+    ):
+        """`AnyHttpUrl` has no length limit and `httpx` stops at 64 KiB, which
+        is how an endpoint the metadata document was validated with reaches the
+        vault and comes back at every refresh. The refresh path answers `None`
+        on an `OAuthError` and a 500 on anything else."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/.well-known/oauth-protected-resource":
+                return httpx.Response(
+                    200,
+                    json={
+                        "resource": "https://93.184.216.34/mcp",
+                        "authorization_servers": ["https://93.184.216.35"],
+                    },
+                )
+            if request.url.path == "/.well-known/oauth-authorization-server":
+                return httpx.Response(200, json=self._metadata(self._TOO_LONG))
+            return httpx.Response(404, json={})
+
+        self._serving(monkeypatch, handler)
+        server = await mcp_oauth.discover(self._SERVER)
+        assert server.token_endpoint == self._TOO_LONG
+
+        with (
+            caplog.at_level(logging.WARNING, logger="app.agents.mcp_oauth"),
+            pytest.raises(mcp_oauth.OAuthError) as exc_info,
+        ):
+            await mcp_oauth._token_request(server.token_endpoint, {"grant_type": "refresh_token"})
+
+        assert "a token endpoint" in str(exc_info.value)
+        assert "URL too long" in caplog.text
+
+    @pytest.mark.anyio
+    async def test_a_registration_endpoint_no_request_can_be_built_for_is_refused(self):
+        """`create_client_registration_request` sits above the client, so this
+        one raised before the flow's `except httpx.HTTPError` was even entered."""
+        metadata = OAuthMetadata(
+            issuer=AnyUrl("https://auth.example.com"),
+            authorization_endpoint=AnyUrl("https://auth.example.com/authorize"),
+            token_endpoint=AnyUrl("https://auth.example.com/token"),
+            registration_endpoint=AnyUrl(self._TOO_LONG),
+            response_types_supported=["code"],
+        )
+        server = mcp_oauth.DiscoveredServer(
+            authorization_endpoint=str(metadata.authorization_endpoint),
+            token_endpoint=str(metadata.token_endpoint),
+            registration_endpoint=str(metadata.registration_endpoint),
+            resource="https://mcp.example.com/",
+            scope=None,
+            metadata=metadata,
+        )
+        with pytest.raises(mcp_oauth.OAuthError) as exc_info:
+            await mcp_oauth.register_client(server, "https://app.example.com/oauth/callback")
+
+        assert "a registration endpoint" in str(exc_info.value)
+
+    @pytest.mark.anyio
+    async def test_the_refusal_does_not_quote_the_port_it_could_not_parse(self, caplog):
+        """`InvalidURL` says `Invalid port: 'client_secret=sh-9f2c'`, and on this
+        flow that string was written by the server being refused. It stays in
+        the log; the browser is told which endpoint was unusable and no more."""
+        endpoint = "https://auth.example.com:client_secret=sh-9f2c/token"
+        with (
+            caplog.at_level(logging.WARNING, logger="app.agents.mcp_oauth"),
+            pytest.raises(mcp_oauth.OAuthError) as exc_info,
+        ):
+            await mcp_oauth._token_request(endpoint, {"grant_type": "authorization_code"})
+
+        shown = str(exc_info.value)
+        assert "sh-9f2c" not in shown
+        assert "auth.example.com" not in shown
+        assert "sh-9f2c" in caplog.text
+
+
 class TestReadSchema:
     def test_token_never_leaves_backend(self):
         conn = _connection()

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -144,6 +144,22 @@ browser; a pydantic error over an unreadable token response echoes the payload i
 rejected, which is the tokens. Both stay in the server log, which is where an
 operator already looks.
 
+**A discovery document naming a URL that cannot be requested at all is the same
+kind of answer** — a **400** saying which endpoint was unusable, and that it is
+malformed. It is a distinct refusal from "this server pointed the flow at a
+blocked address": one says the server aimed us somewhere this deployment will
+not go, the other that it wrote an address nothing can dial, and reporting
+either as the other would be a confident claim about whose fault a failure was.
+An unusable `WWW-Authenticate` hint ends that discovery candidate rather than
+the flow, because the well-known URIs after it are derived from the URL an
+operator typed and may well answer. This was a 500 with an empty body until
+[#889](https://github.com/vstorm-co/agenticos/issues/889): `httpx.InvalidURL`
+does not derive from `httpx.HTTPError`, so none of the flow's catches saw it,
+and no check here could have — the URL is refused while the request is being
+built, above both the SSRF check and the pinned client. What the parser could
+not read (`Invalid port: 'client_secret=…'`) is the remote server's own text
+and stays in the log with everything else.
+
 !!! warning "An organization's OAuth connection is still someone's grant"
 
     `POST /mcp-connections/oauth/start` produces a connection the organization


### PR DESCRIPTION
`httpx.InvalidURL` derives from `Exception`, not from `httpx.HTTPError`, so none of
the three catches in the MCP OAuth flow saw it. A discovery document naming
`https://auth.example.com:client_secret=sh-key/token` answered **500** with an empty
`details` and a traceback in the log, where every other malformed document answers a
**400** — connecting a third-party server that is merely broken read as the platform
being broken.

It is #861 one layer further out, and #872's fix cannot reach it: the URL never gets to
`app.core.sanitize`, because `httpx` gives up while the request is still being built —
above both the SSRF check and `PinnedAsyncClient`.

## What changed

- **Discovery** catches `InvalidURL` alongside `HTTPError`, through one named tuple
  (`_DISCOVERY_FAILURES`) so the next catch written in that module cannot omit it. An
  unusable candidate ends *that candidate*, not the flow: the `WWW-Authenticate` hint is
  the first of three, and the well-known URIs after it are derived from the URL an
  operator typed — so a server that writes its header badly and its documents correctly
  still connects.
- **`register_client` and `_token_request`** raise `_unusable_url`, a refusal kept
  separate from the blocked-address one `_send` raises. #875 narrowed those catches
  precisely so a library failure is not reported as "this server pointed us at a blocked
  address"; a URL the server got wrong and a URL it aimed somewhere we will not go stay
  two different claims about whose fault a failure is.
- **Nothing remote-written goes out.** `InvalidURL` quotes what it could not cast
  (`Invalid port: 'client_secret=sh-key'`), which on this flow is the refused server's
  own text — it stays in the `logger.warning`, and the refusal names only which endpoint
  was unusable. No field is named: the malformed input is the remote server's, not
  anything the person reading the toast can fix (#892's rule).
- `docs/mcp.md` gains the refusal beside the existing "what a failed step may say"
  section.

## Both shapes are reachable, and that decided the tests

- A **bad port** survives `urlparse` and reaches discovery straight off the
  `WWW-Authenticate` header, unvalidated.
- An endpoint **over 64 KiB** survives `AnyHttpUrl` as well, so it passes the metadata
  document's own validation and reaches a stored `token_endpoint` and a
  `registration_endpoint`. That is what makes the two sites *below* discovery reachable
  at all — pydantic rejects every bad-port form before it can be stored, so the length
  divergence between `AnyHttpUrl` (no limit) and `httpx` (65536) is the live path there.

Five tests, in `TestAUrlNoRequestCanBeBuiltFor`, all five failing without the fix — each
drives a discovery document or a stored endpoint rather than calling a validator,
because the whole point is that `httpx` raises before this project's code runs:

| Test | Proves |
|---|---|
| `test_a_www_authenticate_hint_with_an_unusable_port_does_not_crash_discovery` | The issue's own criterion: `OAuthError`, not `InvalidURL`, and the well-known candidates after the hint are still requested |
| `test_an_unusable_hint_ends_that_candidate_and_not_the_flow` | A server with a broken hint and working well-knowns still discovers — the `continue` is behaviour, not a swallow |
| `test_a_token_endpoint_discovery_accepted_but_httpx_will_not_build` | End to end: `discover` stores an over-long `token_endpoint`, and every refresh on it refuses instead of 500ing |
| `test_a_registration_endpoint_no_request_can_be_built_for_is_refused` | `create_client_registration_request` sat *above* the client, so it raised before the flow's `except httpx.HTTPError` was entered |
| `test_the_refusal_does_not_quote_the_port_it_could_not_parse` | The secret in `Invalid port: 'client_secret=sh-9f2c'` is in the log and not in the body |

## The sweep

`CookieConflict` and the `StreamError` family (`RequestNotRead`, `ResponseNotRead`,
`StreamClosed`, `StreamConsumed`) are the only other `httpx` exceptions outside
`HTTPError` — enumerated by walking `dir(httpx)` for `BaseException` subclasses and
checking each against `issubclass(..., httpx.HTTPError)`. Neither family is reachable on
this path: no cookie jar is read, and every response goes through `client.send` rather
than a stream. `backend/app/` has no other `except httpx.HTTPError` — the five in
`mcp_oauth.py` are all of them.

## Verification

- `make lint` — green
- `make test` — 5719 passed, 15 skipped, 100.00% on the platform layer
- `make docs-build` — green (`--strict`)
- `python3 scripts/docs_drift.py` — no drift

Closes #889
