### PR TITLE
ci(e2e): a cancelled job is a job that ran out of its bound

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,9 +530,25 @@ jobs:
           key: playwright-${{ runner.os }}-${{ hashFiles('frontend/bun.lock') }}
 
       - name: Install Playwright browsers
-        # `--with-deps` still runs: the apt packages Chromium links against live
-        # outside the cached directory, and installing them on a hit is seconds.
-        run: bunx playwright install --with-deps chromium
+        # **No `--with-deps`, and #879 is why.** It shells out to `apt-get`, which
+        # on a hosted runner resolves through `azure.archive.ubuntu.com` - and when
+        # that mirror is unreachable apt falls back to the public archive and
+        # stalls there with no bound of its own. Fourteen e2e runs between 14 and
+        # 18 August died exactly that way, every one of them in this step, every
+        # one at 25 minutes on the nose: the job's `timeout-minutes` ended it, and
+        # a job ended by its bound is recorded as `cancelled` - which reads as a
+        # superseded run, is not treated as a pass by the ruleset, and blocks the
+        # merge until somebody re-runs the slowest job in CI.
+        #
+        # It was buying nothing. On a healthy run apt reports every library
+        # Chromium links against as "already the newest version" - the runner
+        # image ships all of them - and installs 21 MB of CJK, Cyrillic and emoji
+        # fonts no spec renders. An image that does drop a library fails at
+        # browser launch, with Playwright naming the package, which is louder
+        # than this was. The step keeps a bound of its own so that a stall in the
+        # CDN download fails *this step* by name rather than the job by timeout.
+        run: bunx playwright install chromium
+        timeout-minutes: 10
         working-directory: frontend
 
       - name: Run E2E tests

--- a/Makefile
+++ b/Makefile
@@ -391,8 +391,13 @@ test-cov:
 # Everything, including template-inherited subsystems. Informational: those are
 # not held to the platform bar, because mock-heavy tests over code we did not
 # design buy a number rather than confidence.
+#
+# It runs across workers like every other suite here. It was the one that did not,
+# which made it the longest step in the `test` job - 14m46s of the 25 that job is
+# allowed, against 8m39s for the gated suite beside it - so a runner about three
+# times slower than usual took the whole job past its bound (#879).
 coverage-all:
-	uv run --directory backend pytest tests/ -q --cov=app --cov-report=term-missing --cov-fail-under=0
+	uv run --directory backend pytest tests/ -q --cov=app --cov-report=term-missing --cov-fail-under=0 -n auto --maxprocesses 4
 
 test-frontend:
 	cd frontend && bun run test:run

--- a/backend/tests/test_ci_workflow.py
+++ b/backend/tests/test_ci_workflow.py
@@ -10,12 +10,17 @@ whether it is bounded when it does.
     reads as *starting* rather than *absent* - and four pull requests merged that
     way in one day (#359).
   - `changes` was the only job declaring `timeout-minutes`, so every other job
-    inherited GitHub's default of 360 minutes. Nothing has been observed to stall;
-    the point is that if one did, its required check would be held for six hours
-    and nothing in this repository would end it sooner (#364).
+    inherited GitHub's default of 360 minutes, and a stalled required check would
+    have been held for six hours with nothing in this repository ending it sooner
+    (#364). That bound was written against a stall nobody had seen yet; fourteen
+    e2e runs then hit it in four days (#879).
+  - Which is how the third property arrived. A job ended by its own bound reports
+    `cancelled`, indistinguishable at a glance from a run somebody superseded - so
+    a step reaching a third-party apt mirror on every run is a step that can put a
+    green diff behind a conclusion that reads as somebody else's doing.
 
-Neither is testable by running CI, which is the whole difficulty: a workflow that
-does not trigger produces no evidence at all, and a bound is only exercised by the
+None is testable by running CI, which is the whole difficulty: a workflow that does
+not trigger produces no evidence at all, and a bound is only exercised by the
 incident it exists to shorten.
 """
 
@@ -119,4 +124,35 @@ class TestEveryJobBoundsItsOwnRuntime:
         assert not excessive, (
             f"{excessive} allow more than {MAX_TIMEOUT_MINUTES} minutes, which is several "
             "times the slowest job this workflow has ever run."
+        )
+
+
+class TestNoStepInstallsSystemPackages:
+    """The one stall this workflow has actually had, and the shape of it.
+
+    `playwright install --with-deps` runs `apt-get` against the runner's Azure
+    mirror. When that mirror is unreachable apt falls back to the public archive
+    and stalls with no bound of its own - fourteen `e2e` runs between 14 and 18
+    August, every one in that step, every one ended at 25 minutes by the job's
+    `timeout-minutes` and reported as `cancelled` (#879).
+
+    It is worth a test rather than a comment because re-adding the flag is the
+    obvious thing to do: it is what Playwright's own documentation recommends, it
+    is what the step said for months, and on a runner whose mirror answers it
+    costs seconds and looks harmless.
+    """
+
+    def test_no_step_shells_out_to_apt(self, workflow: dict[str, Any]) -> None:
+        offenders = [
+            f"{job_name}/{step.get('name', step['run'].splitlines()[0])}"
+            for job_name, job in workflow["jobs"].items()
+            for step in job.get("steps", [])
+            if "run" in step and ("--with-deps" in step["run"] or "apt-get" in step["run"])
+        ]
+        assert not offenders, (
+            f"{offenders} install system packages during the run. apt reaches a mirror this "
+            "repository does not control and stalls unbounded when it is unavailable, which "
+            "ends the job at its `timeout-minutes` and reports `cancelled` rather than a "
+            "failure naming the step - #879. The runner image already carries every library "
+            "Chromium links against."
         )

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -125,10 +125,12 @@ this repository, so whether it reads a stacked pull request is not ours to decid
 
 `changes` was the only job in `ci.yml` carrying a `timeout-minutes`, so the other
 seven inherited GitHub's default of **360 minutes**
-([#364](https://github.com/vstorm-co/agenticos/issues/364)). Nothing has ever been
-observed to stall here — this bounds the tail rather than fixing something seen — but
-if one did, its required status check would be held for six hours and nothing in this
-repository would end it sooner.
+([#364](https://github.com/vstorm-co/agenticos/issues/364)), so a stalled job would
+have held its required status check for six hours with nothing in this repository
+ending it sooner. That was written as a precaution against something nobody had
+seen. Fourteen `e2e` runs hit the bound in the four days to 18 August
+([#879](https://github.com/vstorm-co/agenticos/issues/879)) — and what a job looks
+like when it does is below.
 
 | Job | Bound | Observed |
 |---|---|---|
@@ -166,6 +168,38 @@ minute `main` run, two merges inside one window is not a rare shape.
 So the group carries `github.run_id` on a push, which is unique per run: every
 merge gets a group of its own and collides with nothing. Pull requests all resolve
 to the same suffix and go on cancelling each other per `github.ref`.
+
+### Two things report `cancelled`, and only one of them is that
+
+The section above is the cancellation that is working as designed, and it is the
+explanation everybody reaches for. **The other one is a job that ran out of its
+`timeout-minutes`** — GitHub records a job it ended on the bound as `cancelled`,
+not as a failure — and a `cancelled` required check is *not* treated as a pass the
+way a `skipped` one is, so the merge stays blocked on a diff that is fine.
+
+Telling them apart takes one look:
+
+| | Superseded (#317) | Ended on its bound (#879) |
+|---|---|---|
+| What else is in the run | every in-flight job cancelled together | **one** job; the rest are green |
+| The run's own conclusion | `cancelled` | `success`, less the one job |
+| Duration of the cancelled job | whatever it had reached | its `timeout-minutes`, to the second |
+| A newer push on the branch | yes — that is the cause | no |
+| The log's last line | `The operation was canceled.` | the same line, which is the trap |
+
+The duration is the tell. `gh api repos/vstorm-co/agenticos/actions/runs/<id>/attempts/<n>/jobs`
+gives `started_at`, `completed_at` and per-step conclusions — **and it must be the
+`attempts/<n>` form**, because a re-run rewrites what the plain `runs/<id>/jobs`
+endpoint answers, so a job re-run into the green reports `success` there and the
+original conclusion is gone.
+
+What the fourteen had in common was one step: `playwright install --with-deps`
+shelling out to `apt-get`, which stalls unbounded when the runner's Azure mirror is
+unreachable. The e2e job no longer installs system packages at all, and
+`backend/tests/test_ci_workflow.py` refuses a step that would. The general lesson
+outlives that step, though: **a step reaching a third party is a step that can hang
+without a bound of its own**, and one that does spends the job's whole budget and
+then reports as somebody else's cancellation.
 
 ## Squash, and why the pull request title matters
 


### PR DESCRIPTION
**Nothing cancelled them. GitHub records a job it ended on its own
`timeout-minutes` as `cancelled`, not as a failure** — and a `cancelled` required
check is not treated as a pass the way a `skipped` one is, so the merge stays
blocked on a diff that is fine.

That is the whole mystery. It is not concurrency, not a reclaimed runner, and not
Playwright's project dependencies. All three hypotheses in the issue are ruled out
below.

## The evidence

300 CI runs since 14 August carry **82 cancelled jobs**. Splitting them by whether
the job's duration sits within a minute of its own bound:

| | Count | Shape |
|---|---|---|
| Ended on `timeout-minutes` | **15** | one job of the run; the rest green; no newer push |
| The deliberate supersede (#317) | 67 | several jobs of one run, at mixed durations |

Of the 15, **14 are `e2e`**, and the jobs API names the same cancelled step in all
fourteen:

```
95588162891  e2e  main                                Install Playwright browsers
95587279021  e2e  main                                Install Playwright browsers
95587139193  e2e  main                                Install Playwright browsers
95586375310  e2e  main                                Install Playwright browsers
95581096125  e2e  fix/860-pin-oauth-discovery-addr…   Install Playwright browsers
95580933470  e2e  fix/863-picker-empty-state          Install Playwright browsers
95579192849  e2e  main                                Install Playwright browsers
95574935730  e2e  ci/855-audit-survives-a-network-…   Install Playwright browsers
95570203039  e2e  fix/861-blocked-url-names-the-re…   Install Playwright browsers
95561047899  e2e  feat/onboarding                     Install Playwright browsers
95559005464  e2e  main                                Install Playwright browsers
95558885590  e2e  main                                Install Playwright browsers
95520072636  e2e  main                                Install Playwright browsers
95510055850  e2e  feat/onboarding                     Install Playwright browsers
95549633162  test chore/claims-that-do-not-hold       (ran out; a slow runner — below)
```

Durations: 25.2, 25.2, 25.2, 25.2, 25.3, 25.2, 25.2, 25.3, 25.2, 25.3, 25.2, 25.3,
25.2, 25.2 minutes — against `timeout-minutes: 25`. Fourteen for fourteen, to
within twenty seconds.

**Read them per attempt.** `runs/<id>/jobs` answers with the *latest* attempt, so
every one of these reports `success` there now that the job was re-run — the
original conclusion only exists under `runs/<id>/attempts/<n>/jobs`. That is why
the pattern was hard to see, and it is now in `docs/branching.md`.

## What the step was doing for 22 minutes

`bunx playwright install --with-deps chromium`. `--with-deps` shells out to
`apt-get`, and on job `95561047899` the log reads:

```
01:06:31  Ign:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
01:06:32  Ign:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
01:06:38  Ign:5 http://azure.archive.ubuntu.com/ubuntu noble-security InRelease
01:06:39  Hit:2 https://archive.ubuntu.com/ubuntu noble InRelease
01:06:40  Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
01:29:04  ##[error]The operation was canceled.
```

The runner's Azure mirror answers `Ign` for every index, apt falls back to the
public archive, and then **stops dead for 22 minutes 24 seconds** with no bound of
its own. Job `95574935730` stalls at the identical line, 22m41s. On that one the
Playwright browser cache was a **hit**, so the browser download is not involved at
all — the stall is entirely apt.

And the flag was buying nothing. A run where the mirror answers finishes
`apt-get update` in 8 seconds and then reports *every* library Chromium links
against as `already the newest version` — `libnss3`, `libgbm1`, `libatk1.0-0t64`,
all of them; the `ubuntu-24.04` image ships them. The only thing it installs is
**9 font packages, 21.1 MB** of CJK, Cyrillic and emoji glyphs that no spec in this
suite renders, and that cost 70 seconds even on the healthy run.

## Hypotheses ruled out, and on what

- **A `concurrency` group colliding across runs.** The group is
  `ci-${{ github.ref }}-…`, and a supersede cancels every in-flight job of the run
  and sets the *run's* conclusion to `cancelled`. All fifteen have exactly one
  cancelled job, the rest of the run green, the run's own conclusion `success`, and
  no newer push on the branch. The 67 in the other bucket are what a real supersede
  looks like.
- **A runner going away.** A reclaimed runner does not stop at 25.2 minutes
  fourteen times running. `runner_name` differs on every occurrence, and the
  reclamation hypothesis has no explanation for the same step being named each time.
- **Playwright's `[setup]`/`[seed]` project dependencies.** Step 17, `Run E2E
  tests`, never started on any of the fourteen — the job died two steps earlier.
  Playwright was never invoked.

## The change

**`ci.yml`** — the e2e job installs the browser and no longer calls apt. An image
that does drop a library fails at browser launch with Playwright naming the
package, which is louder than a step that hangs. The step also carries a
`timeout-minutes` of its own now, well above the ~40s a cold cache costs: that is
the legibility half of the ask, so a stall in the CDN download fails *this step by
name* rather than consuming the job's budget and reporting as a cancellation.

**`backend/tests/test_ci_workflow.py`** — refuses a step that installs system
packages. Re-adding the flag is the obvious thing to do: it is what Playwright's
own documentation recommends, it is what the step said for months, and on a runner
whose mirror answers it costs seconds and looks harmless. Checked against the
pre-change workflow, where it names `e2e/Install Playwright browsers`.

**`Makefile`** — the fifteenth occurrence is a different failure with the same
conclusion, and worth its own fix. Nothing stalled in `95549633162`: every step
succeeded, the log carries `Required test coverage of 100.0% reached` and `5474
passed`, and the cancellation landed on the skipped Codecov upload at the end —
exactly the shape the issue flagged. The runner was about three times slower than
usual (`make test` 8m39s, against 3m08s for the re-run of the same commit). What
made 25 minutes reachable is that `coverage-all` was the one suite here running in
a single process — 14m46s of the job for an informational number, against 8m39s for
the gated suite beside it. It now runs `-n auto --maxprocesses 4` like `test` and
`test-fast` already do: 3m51s locally, same 85% total. Not a raised bound — a bound
raised to survive a slow runner is a bound that no longer ends a stall, which is
what #364 put it there for.

**`docs/branching.md`** — the page taught only the deliberate cancellation, so it
now carries the five ways the two differ (one job vs. every in-flight job, the run's
own conclusion, whether anything was pushed, the duration, and that the log's last
line is `The operation was canceled.` either way), plus the per-attempt endpoint.
It also corrects "nothing has ever been observed to stall here", written when the
bounds went in under #364. Something has now.

## Verified

`make lint-backend` green (frontend half not runnable in this worktree; no frontend
file is touched). `make docs-build --strict` clean.
`pytest tests/test_ci_workflow.py tests/test_ci_parity.py` — 24 passed, so the
gating-job/`make check` parity still holds. `make coverage-all` run end to end with
the new flags: 5715 passed, 85% total, 3m51s.

## What this does not settle

The apt stall itself is GitHub's infrastructure, not ours — this removes our
exposure to it rather than fixing it. If a step here ever stalls again, it will now
report `failure` and name the step instead of `cancelled`, which is the part that
cost the reading time. The issue's own bar is a week of ordinary merges with no
`cancelled` conclusion on a run nothing pushed over, so it stays open until that
week has passed.

Refs #879

---

### CI on this branch, run 32121556614 — every job green

The step timings are the point:

| Step | Before | Now |
|---|---|---|
| `Install Playwright browsers` | 70s healthy · 23m stalled | **1s** |
| `Report coverage of template-inherited code` | 4m31s healthy · 14m46s slow runner | **2m41s** |
| `e2e` job | ~6–8m | 4m56s |
| `test` job | ~9–10m | 6m32s |

`Run E2E tests` ran the full suite in 2m44s and passed, so dropping `--with-deps`
costs the browser nothing on the current runner image.
