### PR TITLE
chore: cut 0.0.196

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,27 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.196] - 2026-08-18
+
+### Fixed
+
+- **An MCP server that writes an address nothing can dial is refused, not
+  crashed on.** `httpx.InvalidURL` does not subclass `httpx.HTTPError`, so it
+  escaped all three catches in the OAuth flow and answered 500 — one layer
+  further out than 0.0.190's fix could reach, because `httpx` refuses to build
+  the URL before this project's validator is ever called. Discovery treats an
+  unusable candidate as ending *that candidate*: a server with a broken
+  `WWW-Authenticate` hint and correct well-known documents still connects. The
+  two sites below it raise a refusal of their own. (#889)
+- **"Nothing can dial this" and "we will not go there" stay two different
+  claims.** The refusal for an unbuildable address is deliberately distinct from
+  the blocked-address one, so a failure never misattributes whose fault it was.
+  The address itself goes to the log: `InvalidURL`'s message quotes the text it
+  could not cast, and on this flow that text is written by the server being
+  refused. (#889)
+- **`create_client_registration_request` is guarded at all** — it sat outside the
+  try it appeared to be inside. (#889)
+
 ## [0.0.195] - 2026-08-18
 
 A refusal that names a field marks that field.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.195"
+version = "0.0.196"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.195"
+version = "0.0.196"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.195",
+  "version": "0.0.196",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.196. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json` to 0.0.196 and adds the CHANGELOG entry.

Releases an unbuildable OAuth address refused rather than answered with a 500 (#894, closing #889) — `httpx.InvalidURL` sits outside `httpx.HTTPError`, so it escaped all three catches, and `create_client_registration_request` turned out to sit outside the try it appeared to be inside.

Worth recording: the headline shape in the issue reaches only one of the three sites. Pydantic's `AnyHttpUrl` rejects a bad port in a metadata document, so what actually reaches the other two is *length* — `AnyHttpUrl` has no limit and `httpx` stops at 65536. The tests use the shape that reaches each site rather than the one the issue named.

## Verified

CI green on #894, no review findings. `make test` 5719 passed with the platform gate at 100%; all five new tests confirmed failing with the source change stashed.