### PR TITLE
chore: cut 0.0.197

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,35 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.197] - 2026-08-18
+
+The `e2e` job stopped stalling for twenty-five minutes on an apt mirror.
+
+### Fixed
+
+- **Nothing was cancelling those jobs.** GitHub records a job it ends on its own
+  `timeout-minutes` as `cancelled` rather than as a failure, and a `cancelled`
+  required check is not a pass the way a `skipped` one is — so the merge stayed
+  blocked on a diff that was fine. Across 300 runs, 15 jobs ended that way, and
+  the jobs API names the same step in fourteen of them: `Install Playwright
+  browsers`. `--with-deps` shells out to `apt-get`, the runner's mirror answers
+  `Ign` for every index, and apt stops dead on the fallback — 22 minutes of
+  silence. The flag bought nothing: on a healthy run every library Chromium
+  links against is already the newest version, and the 21 MB it does install is
+  fonts no spec renders. It is gone, and the full suite still passes. (#879)
+- **A stall now fails the step that stalled, by name.** Step-level bounds sit
+  under the job's, so a residual hang says which step rather than ending the job
+  at its outer limit with no explanation. `test_ci_workflow.py` refuses any step
+  that installs system packages, so the flag cannot come back quietly. (#879)
+
+### Changed
+
+- **`make coverage-all` runs across worker processes**, like `test` and
+  `test-fast` already did. It was the one suite still single-process, which is
+  what made 25 minutes reachable on a slow runner: 14m46s of a job for a number
+  that does not gate anything. Measured on the branch's own run, the step went
+  from 4m31s to 2m41s, and `Install Playwright browsers` from 70s to 1s. (#879)
+
 ## [0.0.196] - 2026-08-18
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.196"
+version = "0.0.197"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.196"
+version = "0.0.197"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.196",
+  "version": "0.0.197",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.197. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json` to 0.0.197 and adds the CHANGELOG entry.

Releases the end of the `cancelled` e2e job (#895, refs #879). Nothing was cancelling them: GitHub records a job it ends on its own `timeout-minutes` as cancelled rather than failed, and the step burning those 25 minutes was `--with-deps` stalling on an apt mirror to install fonts no spec renders.

Two things from the investigation worth carrying forward. The reason this read as infrastructure for so long is that `runs/&lt;id&gt;/jobs` answers with the *latest attempt*, so every job I re-ran now reports success and the original conclusions survive only under `runs/&lt;id&gt;/attempts/&lt;n&gt;/jobs`. And `make coverage-all` was the last single-process suite, which is what made 25 minutes reachable on a slow runner.

#879 stays open deliberately: its own acceptance bar is a week of clean merges.

## Verified

CI green on #895, no review findings. Measured on its own run: `Install Playwright browsers` 1s (was 70s healthy, 23m stalled), `coverage-all` 2m41s (was 4m31s), `e2e` 4m56s with the full suite passing — so dropping `--with-deps` costs the browser nothing on the current image.