### PR TITLE
fix(api): name the input in the one shape a form marks it from

### DIFF
--- a/.claude/rules/exceptions-security.md
+++ b/.claude/rules/exceptions-security.md
@@ -40,9 +40,37 @@ URL in the message and a URL carries a key in its query string - and an absolute
 path says where the container keeps its files. Neither is deleted: it goes in the
 `logger.exception` line beside the raise, and the refusal names what the reader
 can act on (#342). A URL the refusal is *about* is named by its field rather than
-repeated - `{"field": "base_url"}`, never the endpoint with the password still in
-it. An audit entry is `details` with a longer life and takes the same rule:
-`{"fields": sorted(update_data)}`, not the body that was submitted (#412).
+repeated - `refused_field("base_url", ...)`, never the endpoint with the password
+still in it. An audit entry is `details` with a longer life and takes the same
+rule: `{"fields": sorted(update_data)}`, not the body that was submitted (#412).
+
+**A refusal that names a field says so in one shape, and `app/core/field_errors.py`
+is the only place it is built.** `details={"fields": [{"field", "message"}]}` is
+what `fieldProblems` in `frontend/src/lib/api-error.ts` reads, and it is the
+whole reason for naming a field at all - a form marks the input rather than
+showing a sentence somebody has to re-scan the page for. Three entry points:
+
+```python
+# A rule stated in prose. The sentence is the envelope's and the field's - one
+# argument, so they cannot drift apart. Returns the exception; you raise it.
+raise refused_field("base_url", "A model endpoint must include a host")
+
+# A pydantic model a service validated itself, below what the form calls it.
+raise BadRequestError(message=..., details={"fields": field_problems(exc.errors(), root="yaml")})
+```
+
+`request_field_problems` is the third and belongs to
+`validation_exception_handler` alone. `field_details` builds the same `details`
+without the exception, for a raiser that needs another status or that may have
+no field to name.
+
+**Name a field only when the caller sent it in that request.** A refusal about a
+value nobody submitted - a remote file's name chosen by whoever shares the synced
+folder, a stored row a worker read back - names none. Nor does a conflict:
+`AlreadyExistsError` reports a fact about a row that exists, and which of a
+form's inputs produced the taken value is the form's to say, through
+`submitFailure`'s `identifiedBy` on the client. A singular `details={"field": ...}`
+is the shape #891 removed; do not bring it back.
 
 Exception handlers in `api/exception_handlers.py` automatically:
 - Map to HTTP status codes

--- a/backend/app/core/field_errors.py
+++ b/backend/app/core/field_errors.py
@@ -19,21 +19,39 @@ object itself under `ctx` - and `details` is serialized into the response body
 and logged on the same line, so passing one through posts the caller's own
 submission back to them (`.claude/rules/exceptions-security.md`).
 
-There are two entry points because there are two callers, and **which one you
-are decides what the first element of `loc` means**. FastAPI puts where the
-value came from in front of the path - `("body", "spec", "name")` - and a form
-can do nothing with "body". A service validating a model itself gets no such
-segment: the first element is already a field name, and a spec whose forbidden
-top-level key is literally called `body` reports `loc: ("body",)` about that
-key. Deciding by the string would report it against the editor instead, which
-is one shape standing in for two - the mistake this module exists to end.
+Two of the three entry points read pydantic, and **which one you are decides
+what the first element of `loc` means**. FastAPI puts where the value came from
+in front of the path - `("body", "spec", "name")` - and a form can do nothing
+with "body". A service validating a model itself gets no such segment: the first
+element is already a field name, and a spec whose forbidden top-level key is
+literally called `body` reports `loc: ("body",)` about that key. Deciding by the
+string would report it against the editor instead, which is one shape standing
+in for two - the mistake this module exists to end.
+
+The third is :func:`refused_field`, for a rule a service states in prose rather
+than in a model - an endpoint that carries a password, a Mattermost bot losing
+the server it is hosted on, a YAML document that never parsed. Eighteen of those
+answered `details={"field": "<name>"}`, singular, with the sentence on the
+envelope, and no form has ever read it (#891). They take the same shape as the
+rest now, and there is no other: a service that wants to name an input calls
+this, and one that cannot say which input is wrong names none.
+
+**A conflict is not a field refusal.** `AlreadyExistsError` reports a fact about
+a row that already exists, not about the shape of what was sent, and which input
+produced the taken value is a thing only the form knows - an agent's handle is
+derived from a name nobody typed as a handle. `submitFailure`'s `identifiedBy`
+in `frontend/src/lib/api-error.ts` is where that is claimed, which is why a 409
+carries the taken value and no field.
 """
 
 from collections.abc import Sequence
+from typing import Any
 
 from pydantic_core import ErrorDetails
 
-__all__ = ["field_problems", "request_field_problems"]
+from app.core.exceptions import BadRequestError
+
+__all__ = ["field_details", "field_problems", "refused_field", "request_field_problems"]
 
 # Where a validation error came from, as FastAPI reports it in the first element
 # of `loc`. Nothing a form can act on, so it is dropped from the path - but only
@@ -94,3 +112,35 @@ def request_field_problems(errors: Sequence[ErrorDetails]) -> list[dict[str, str
         {"field": _path(_without_origin(error["loc"])) or "request", "message": error["msg"]}
         for error in errors
     ]
+
+
+def field_details(field: str, message: str, **context: Any) -> dict[str, Any]:
+    """`details` for a refusal a service states itself, about one named input.
+
+    The sentence is the refusal's *and* the field's, because they are the same
+    sentence: the envelope's `message` is what a caller with no form to mark
+    reads, and `fields[0]["message"]` is what the form puts under the input. A
+    second, shorter one written for the field would be the copy that goes stale.
+
+    `context` is anything else the refusal is about - the platform, the provider
+    - and takes the rule in `.claude/rules/exceptions-security.md`: a value that
+    explains the refusal, never the caller's own submission and never a row.
+
+    Only :func:`refused_field` and a raiser that needs a status other than 400
+    should call this; everything else raises the exception directly.
+    """
+    return {**context, "fields": [{"field": field, "message": message}]}
+
+
+def refused_field(field: str, message: str, **context: Any) -> BadRequestError:
+    """A 400 about one input, in the shape the form that sent it marks from.
+
+    Args:
+        field: What the form calls the input, as it addresses it - `base_url`,
+            `api_base_url`, `yaml`. A dotted path where the document has a root,
+            the same way :func:`field_problems` reports one.
+        message: Why it is refused, as the reader sees it. Named in one place so
+            the envelope and the field cannot come to disagree.
+        context: Anything else the refusal is about.
+    """
+    return BadRequestError(message=message, details=field_details(field, message, **context))

--- a/backend/app/core/field_errors.py
+++ b/backend/app/core/field_errors.py
@@ -126,8 +126,11 @@ def field_details(field: str, message: str, **context: Any) -> dict[str, Any]:
     - and takes the rule in `.claude/rules/exceptions-security.md`: a value that
     explains the refusal, never the caller's own submission and never a row.
 
-    Only :func:`refused_field` and a raiser that needs a status other than 400
-    should call this; everything else raises the exception directly.
+    :func:`refused_field` is the shape to reach for. This one is for the raiser
+    that cannot: one needing a status other than 400, or one deciding at run
+    time whether it has a field to name at all - `_get_json` describes the same
+    five failures for a form testing an address and for a page reading a saved
+    connection, and only the first has an input to blame.
     """
     return {**context, "fields": [{"field": field, "message": message}]}
 

--- a/backend/app/services/agent_registry.py
+++ b/backend/app/services/agent_registry.py
@@ -570,10 +570,11 @@ def _yaml_refusal(exc: yaml.YAMLError) -> str:
     keys of its own, which nothing has ever read (#891), and a line number is
     only worth reporting to the reader who has the document open.
     """
+    refusal = "This spec is not valid YAML"
     mark = getattr(exc, "problem_mark", None)
     if mark is None:
-        return "This spec is not valid YAML"
-    return f"This spec is not valid YAML - line {mark.line + 1}, column {mark.column + 1}"
+        return refusal
+    return f"{refusal} - line {mark.line + 1}, column {mark.column + 1}"
 
 
 def _parse_spec_yaml(text: str) -> AgentSpec:

--- a/backend/app/services/agent_registry.py
+++ b/backend/app/services/agent_registry.py
@@ -43,7 +43,7 @@ from app.core.exceptions import (
     BadRequestError,
     NotFoundError,
 )
-from app.core.field_errors import field_problems
+from app.core.field_errors import field_problems, refused_field
 from app.core.permissions import AuthContext, Perm
 from app.db.models.agent import Agent, AgentStatus, AgentVersion
 from app.db.models.credential import ModelProfile
@@ -555,7 +555,7 @@ def _window_of(profile: ModelProfile | None) -> int | None:
     return resolve_context_window(f"{profile.provider}:{profile.model}")
 
 
-def _yaml_location(exc: yaml.YAMLError) -> dict[str, Any]:
+def _yaml_refusal(exc: yaml.YAMLError) -> str:
     """Where the document stopped parsing, without quoting any of it.
 
     `str()` on a marked YAML error includes the offending source line, and the
@@ -565,11 +565,15 @@ def _yaml_location(exc: yaml.YAMLError) -> dict[str, Any]:
     (`.claude/rules/exceptions-security.md`). A `ReaderError` - a control
     character in the file - carries a byte offset and no mark, which is why the
     line is optional rather than assumed.
+
+    In the sentence rather than beside it: the position used to be `details`
+    keys of its own, which nothing has ever read (#891), and a line number is
+    only worth reporting to the reader who has the document open.
     """
     mark = getattr(exc, "problem_mark", None)
     if mark is None:
-        return {"field": "yaml"}
-    return {"field": "yaml", "line": mark.line + 1, "column": mark.column + 1}
+        return "This spec is not valid YAML"
+    return f"This spec is not valid YAML - line {mark.line + 1}, column {mark.column + 1}"
 
 
 def _parse_spec_yaml(text: str) -> AgentSpec:
@@ -586,10 +590,10 @@ def _parse_spec_yaml(text: str) -> AgentSpec:
     Raises:
         BadRequestError: If the document does not parse, is not a mapping, or
             breaks a field rule - carrying the field path a form can mark, and
-            no copy of what was submitted. A field rule answers in the shape a
-            form marks an input from, `details["fields"]`; a document that never
-            parsed has no field of its own to name, so it is about the editor it
-            was typed into.
+            no copy of what was submitted. All three answer in the one shape,
+            `details["fields"]`: a field rule below `yaml`, and a document that
+            never parsed against `yaml` itself, since the editor it was typed
+            into is the only input there is to blame.
     """
     try:
         return AgentSpec.from_yaml(text)
@@ -599,11 +603,9 @@ def _parse_spec_yaml(text: str) -> AgentSpec:
             details={"fields": field_problems(exc.errors(), root="yaml")},
         ) from exc
     except yaml.YAMLError as exc:
-        raise BadRequestError(
-            message="This spec is not valid YAML", details=_yaml_location(exc)
-        ) from exc
+        raise refused_field("yaml", _yaml_refusal(exc)) from exc
     except ValueError as exc:
-        raise BadRequestError(message=str(exc), details={"field": "yaml"}) from exc
+        raise refused_field("yaml", str(exc)) from exc
 
 
 class AgentRegistryService:
@@ -781,11 +783,11 @@ class AgentRegistryService:
                     "is what an @mention resolves to, so it has to be unique and cannot be "
                     "changed later - give this agent a name that produces a different handle."
                 ),
-                # `field` names the input a person is looking at, which is not
-                # what the server calls it: they typed a *name*, and the thing
-                # that collided is the handle derived from it. Without this the
-                # form has to guess where to put the message.
-                details={"slug": slug, "field": "name"},
+                # The handle, not the input that produced it: a conflict is a
+                # fact about a row, and which of its own fields derived the
+                # taken value is the form's to say - `submitFailure`'s
+                # `identifiedBy`, in `frontend/src/lib/api-error.ts` (#891).
+                details={"slug": slug},
             )
 
         agent = await agent_repo.create(

--- a/backend/app/services/channel_bot.py
+++ b/backend/app/services/channel_bot.py
@@ -18,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.background import spawn_after_commit
 from app.core.exceptions import BadRequestError, NotFoundError
+from app.core.field_errors import refused_field
 from app.core.vault import SealedSecret, VaultScope, seal, unseal
 from app.db.models.channel_bot import ChannelBot
 from app.db.updates import writable
@@ -249,20 +250,18 @@ class ChannelBotService:
         field existed.
         """
         if platform == "mattermost" and api_base_url is None:
-            raise BadRequestError(
-                message=(
-                    "A Mattermost bot cannot lose its server URL - it is self-hosted, "
-                    "so there is no default address to fall back to"
-                ),
-                details={"field": "api_base_url", "platform": platform},
+            raise refused_field(
+                "api_base_url",
+                "A Mattermost bot cannot lose its server URL - it is self-hosted, "
+                "so there is no default address to fall back to",
+                platform=platform,
             )
         if platform != "mattermost" and api_base_url is not None:
-            raise BadRequestError(
-                message=(
-                    f"A server URL is for a self-hosted platform - a {platform} bot "
-                    "has one address for everybody"
-                ),
-                details={"field": "api_base_url", "platform": platform},
+            raise refused_field(
+                "api_base_url",
+                f"A server URL is for a self-hosted platform - a {platform} bot "
+                "has one address for everybody",
+                platform=platform,
             )
 
     @staticmethod

--- a/backend/app/services/mcp_connection.py
+++ b/backend/app/services/mcp_connection.py
@@ -53,6 +53,7 @@ from app.agents.mcp_oauth import McpOAuthPayload, OAuthError
 from app.core.audit import record_audit
 from app.core.config import settings
 from app.core.exceptions import AlreadyExistsError, BadRequestError, NotFoundError
+from app.core.field_errors import refused_field
 from app.core.permissions import AuthContext
 from app.core.sanitize import UrlRefusedError
 from app.core.vault import SealedSecret, VaultScope, seal, unseal
@@ -114,10 +115,7 @@ async def _checked_url(url: str) -> str:
     except UrlRefusedError as exc:
         # Ours to quote, in the log as much as in the body - see the docstring.
         logger.warning("MCP server URL refused: %s", exc)
-        raise BadRequestError(
-            message=f"This MCP server URL cannot be used: {exc}",
-            details={"field": "url"},
-        ) from exc
+        raise refused_field("url", f"This MCP server URL cannot be used: {exc}") from exc
 
 
 def _apply_token(payload: McpOAuthPayload, token: OAuthToken) -> McpOAuthPayload:

--- a/backend/app/services/model_profile.py
+++ b/backend/app/services/model_profile.py
@@ -21,6 +21,7 @@ from app.agents.model_resolver import (
 )
 from app.core.audit import record_audit
 from app.core.exceptions import AlreadyExistsError, BadRequestError, NotFoundError
+from app.core.field_errors import refused_field
 from app.core.permissions import AuthContext
 from app.core.secret_kinds import (
     NoSecret,
@@ -86,21 +87,14 @@ async def validate_endpoint_url(url: str) -> str:
     """
     parsed = urlparse(url)
     if parsed.scheme not in _ALLOWED_ENDPOINT_SCHEMES:
-        raise BadRequestError(
-            message="A model endpoint must be an http or https URL",
-            details={"field": "base_url"},
-        )
+        raise refused_field("base_url", "A model endpoint must be an http or https URL")
     if not parsed.hostname:
-        raise BadRequestError(
-            message="A model endpoint must include a host", details={"field": "base_url"}
-        )
+        raise refused_field("base_url", "A model endpoint must include a host")
     if parsed.username is not None or parsed.password is not None:
-        raise BadRequestError(
-            message=(
-                "A model endpoint must not carry credentials in the URL - store the key "
-                "on the credential instead"
-            ),
-            details={"field": "base_url"},
+        raise refused_field(
+            "base_url",
+            "A model endpoint must not carry credentials in the URL - store the key "
+            "on the credential instead",
         )
     return url
 
@@ -166,12 +160,11 @@ class ModelProfileService:
 
         if base_url is not None:
             if not spec.supports_base_url:
-                raise BadRequestError(
-                    message=(
-                        f"{spec.name} has no endpoint setting - its SDK always talks to the "
-                        "provider's own API, so a custom URL here would be ignored"
-                    ),
-                    details={"provider": provider, "field": "base_url"},
+                raise refused_field(
+                    "base_url",
+                    f"{spec.name} has no endpoint setting - its SDK always talks to the "
+                    "provider's own API, so a custom URL here would be ignored",
+                    provider=provider,
                 )
             base_url = await validate_endpoint_url(base_url)
         elif spec.keyless and secret_id is None:

--- a/backend/app/services/rag/connectors/google_drive.py
+++ b/backend/app/services/rag/connectors/google_drive.py
@@ -92,10 +92,8 @@ class GoogleDriveConnector(BaseSyncConnector):
         """
         sa_json = config.get("service_account_json")
         if not sa_json:
-            # No `details["fields"]`: this is read from a stored row inside a
-            # sync, so there is no request whose input to blame and no form
-            # open to mark. `CONFIG_SCHEMA` is what refuses it at the route
-            # (#891).
+            # No field: nothing was submitted here - the row is stored and a
+            # sync is reading it back. `CONFIG_SCHEMA` refuses it at the route.
             raise BadRequestError(
                 message=(
                     "This Google Drive source has no service account credential. "

--- a/backend/app/services/rag/connectors/google_drive.py
+++ b/backend/app/services/rag/connectors/google_drive.py
@@ -92,12 +92,15 @@ class GoogleDriveConnector(BaseSyncConnector):
         """
         sa_json = config.get("service_account_json")
         if not sa_json:
+            # No `details["fields"]`: this is read from a stored row inside a
+            # sync, so there is no request whose input to blame and no form
+            # open to mark. `CONFIG_SCHEMA` is what refuses it at the route
+            # (#891).
             raise BadRequestError(
                 message=(
                     "This Google Drive source has no service account credential. "
                     "Add the service account JSON to the source configuration."
-                ),
-                details={"field": "service_account_json"},
+                )
             )
         info = _json.loads(sa_json) if isinstance(sa_json, str) else sa_json
         creds = Credentials.from_service_account_info(info, scopes=SCOPES)

--- a/backend/app/services/rag/remote_names.py
+++ b/backend/app/services/rag/remote_names.py
@@ -9,6 +9,14 @@ and this module is the one place that promotion is refused.
 
 Kept outside `connectors/` because `sources/` needs the same two answers and
 must not import from its sibling.
+
+**Neither refusal names a field**, and that is the point of the paragraph above:
+what they refuse is not something a caller sent. A remote file's name is chosen
+by whoever can drop a file in the folder, and both checks run inside a sync,
+where the reader is a log rather than a form. The folder id *is* configured, but
+`SyncSourceConnector.validate_config` answers `(False, message)` - the details
+never reach the wire, and the route re-raises about the connector (#897). So
+these carry no `details["fields"]`, which the one shape is for (#891).
 """
 
 import re
@@ -42,8 +50,7 @@ def checked_drive_folder_id(folder_id: object) -> str:
     """
     if not isinstance(folder_id, str) or not _DRIVE_ID.fullmatch(folder_id):
         raise BadRequestError(
-            message="A Google Drive folder ID may contain only letters, digits, '-' and '_'.",
-            details={"field": "folder_id"},
+            message="A Google Drive folder ID may contain only letters, digits, '-' and '_'."
         )
     return folder_id
 
@@ -68,16 +75,12 @@ def destination_within(directory: Path, remote_name: str) -> Path:
         BadRequestError: the name does not name a file inside `directory`.
     """
     if "\x00" in remote_name:
-        raise BadRequestError(
-            message="A remote file name may not contain a NULL byte.",
-            details={"field": "name"},
-        )
+        raise BadRequestError(message="A remote file name may not contain a NULL byte.")
 
     base = directory.resolve()
     destination = (base / Path(remote_name).name).resolve()
     if destination.parent != base:
         raise BadRequestError(
-            message="A remote file name must name one file inside the sync directory.",
-            details={"field": "name"},
+            message="A remote file name must name one file inside the sync directory."
         )
     return destination

--- a/backend/app/services/sandbox_connection.py
+++ b/backend/app/services/sandbox_connection.py
@@ -25,6 +25,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.audit import record_audit
 from app.core.config import settings
 from app.core.exceptions import AlreadyExistsError, BadRequestError, NotFoundError
+from app.core.field_errors import field_details, refused_field
 from app.core.permissions import AuthContext
 from app.core.secret_kinds import ApiKeySecret
 from app.db.models.sandbox_connection import SandboxConnection
@@ -360,9 +361,8 @@ class SandboxConnectionService:
                 missing, is not an API key, or is refused.
         """
         if data.secret_id is None:
-            raise BadRequestError(
-                message="Pick the key this service was started with before testing it",
-                details={"field": "secret_id"},
+            raise refused_field(
+                "secret_id", "Pick the key this service was started with before testing it"
             )
         secrets = await self.secrets.resolve_for_bindings(ctx, [data.secret_id])
         secret = secrets.get(data.secret_id)
@@ -378,7 +378,8 @@ class SandboxConnectionService:
             # The field, not the address it was given - the same answer
             # `_check_shape` gives sixteen lines down, and for the reason in
             # agenticos#342: `details` is logged as well as serialized.
-            details={"field": "base_url"},
+            field="base_url",
+            context={},
         )
         payload["kind"] = "docker"
         return payload
@@ -407,9 +408,9 @@ class SandboxConnectionService:
                 details={"kind": kind, "expected": list(CONNECTION_KINDS)},
             )
         if kind == "docker" and not base_url:
-            raise BadRequestError(
-                message="A container connection needs the address its sandbox service answers on",
-                details={"field": "base_url"},
+            raise refused_field(
+                "base_url",
+                "A container connection needs the address its sandbox service answers on",
             )
 
     async def resolve(self, ctx: AuthContext, connection_id: UUID | None) -> ResolvedConnection:
@@ -664,12 +665,13 @@ class SandboxConnectionService:
             base_url=resolved.row.base_url,
             token=resolved.token,
             path=path,
-            details={"connection_id": str(connection_id)},
+            field=None,
+            context={"connection_id": str(connection_id)},
         )
 
     @staticmethod
     async def _get_json(
-        *, base_url: str | None, token: str, path: str, details: dict[str, str]
+        *, base_url: str | None, token: str, path: str, field: str | None, context: dict[str, str]
     ) -> dict[str, Any]:
         """One authenticated GET against a sandbox service.
 
@@ -677,31 +679,37 @@ class SandboxConnectionService:
         three failures have to be described the same way for an address nobody has
         saved yet - a form testing one before it exists is exactly when a clear
         answer is worth most.
+
+        Args:
+            field: The input to blame, for the caller that has a form open -
+                every one of these failures is something the address it was given
+                explains. `None` for a read against a saved connection, where the
+                reader is looking at a session rather than at a field.
+            context: What else the refusal is about, never the address itself
+                (agenticos#342: `details` is logged as well as serialized).
         """
         import httpx
+
+        def refusal(message: str) -> dict[str, Any]:
+            return context if field is None else field_details(field, message, **context)
 
         base = (base_url or "").rstrip("/")
         try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 response = await client.get(f"{base}{path}", headers={"X-Sandbox-Token": token})
         except Exception as exc:
-            raise BadRequestError(
-                message=f"The sandbox service at {base} did not answer",
-                details=details,
-            ) from exc
+            unanswered = f"The sandbox service at {base} did not answer"
+            raise BadRequestError(message=unanswered, details=refusal(unanswered)) from exc
 
         if response.status_code == 401:
-            raise BadRequestError(
-                message="The sandbox service refused this connection's credential",
-                details=details,
-            )
+            refused = "The sandbox service refused this connection's credential"
+            raise BadRequestError(message=refused, details=refusal(refused))
         if response.status_code == 404:
-            raise NotFoundError(message="Sandbox session not found", details=details)
+            missing = "Sandbox session not found"
+            raise NotFoundError(message=missing, details=refusal(missing))
         if response.status_code != 200:
-            raise BadRequestError(
-                message=f"The sandbox service answered {response.status_code}",
-                details=details,
-            )
+            answered = f"The sandbox service answered {response.status_code}"
+            raise BadRequestError(message=answered, details=refusal(answered))
         # Inside a guard, because a 200 is not a promise of JSON. The commonest
         # way to reach this is an address pointing at the wrong port: plenty of
         # things answer 200 with HTML, and an uncaught `JSONDecodeError` would
@@ -710,12 +718,10 @@ class SandboxConnectionService:
         try:
             payload: dict[str, Any] = response.json()
         except ValueError as exc:
-            raise BadRequestError(
-                message=(
-                    f"The service at {base} answered, but not with JSON. Check the "
-                    "address and the port - this is what a web server rather than a "
-                    "sandbox service looks like."
-                ),
-                details=details,
-            ) from exc
+            not_json = (
+                f"The service at {base} answered, but not with JSON. Check the "
+                "address and the port - this is what a web server rather than a "
+                "sandbox service looks like."
+            )
+            raise BadRequestError(message=not_json, details=refusal(not_json)) from exc
         return payload

--- a/backend/app/services/sandbox_connection.py
+++ b/backend/app/services/sandbox_connection.py
@@ -375,10 +375,8 @@ class SandboxConnectionService:
             base_url=data.base_url,
             token=secret.api_key.get_secret_value(),
             path="/policy",
-            # The field, not the address it was given - the same answer
-            # `_check_shape` gives sixteen lines down, and for the reason in
-            # agenticos#342: `details` is logged as well as serialized.
             field="base_url",
+            not_found="No sandbox service answers at this address - check the address and the port",
             context={},
         )
         payload["kind"] = "docker"
@@ -666,12 +664,19 @@ class SandboxConnectionService:
             token=resolved.token,
             path=path,
             field=None,
+            not_found="Sandbox session not found",
             context={"connection_id": str(connection_id)},
         )
 
     @staticmethod
     async def _get_json(
-        *, base_url: str | None, token: str, path: str, field: str | None, context: dict[str, str]
+        *,
+        base_url: str | None,
+        token: str,
+        path: str,
+        field: str | None,
+        not_found: str,
+        context: dict[str, str],
     ) -> dict[str, Any]:
         """One authenticated GET against a sandbox service.
 
@@ -685,8 +690,16 @@ class SandboxConnectionService:
                 every one of these failures is something the address it was given
                 explains. `None` for a read against a saved connection, where the
                 reader is looking at a session rather than at a field.
-            context: What else the refusal is about, never the address itself
-                (agenticos#342: `details` is logged as well as serialized).
+            not_found: What a 404 means to this caller, which is the one failure
+                the two do not share: a session that has ended, against a service
+                with no such endpoint. Marking a form's address with the first
+                would tell an operator their port is wrong about a session they
+                never asked for.
+            context: What else the refusal is about. The address is not withheld
+                from it - the sentence carries it and `field_details` copies the
+                sentence - because a `user:pass@` one is refused at the schema
+                (`SandboxConnectionCreate`), which is what keeps agenticos#342
+                shut here.
         """
         import httpx
 
@@ -705,8 +718,7 @@ class SandboxConnectionService:
             refused = "The sandbox service refused this connection's credential"
             raise BadRequestError(message=refused, details=refusal(refused))
         if response.status_code == 404:
-            missing = "Sandbox session not found"
-            raise NotFoundError(message=missing, details=refusal(missing))
+            raise NotFoundError(message=not_found, details=refusal(not_found))
         if response.status_code != 200:
             answered = f"The sandbox service answered {response.status_code}"
             raise BadRequestError(message=answered, details=refusal(answered))

--- a/backend/app/services/skills.py
+++ b/backend/app/services/skills.py
@@ -479,7 +479,7 @@ class SkillService:
                     f"'{skill.name}' already has a file called '{name}'. The name is how the "
                     "model asks for it, so it has to be unique within the skill."
                 ),
-                details={"name": name, "field": "name"},
+                details={"name": name},
             )
         resource = await skill_repo.create_resource(
             self.db,

--- a/backend/tests/api/test_agent_spec_import_refusal.py
+++ b/backend/tests/api/test_agent_spec_import_refusal.py
@@ -126,7 +126,7 @@ class TestTheRefusalNamesTheField:
         error = response.json()["error"]
         assert error["code"] == "BAD_REQUEST"
         assert error["message"] == "An agent spec must be a YAML mapping"
-        assert error["details"] == {"field": "yaml"}
+        assert error["details"]["fields"] == [{"field": "yaml", "message": error["message"]}]
 
     async def test_yaml_that_does_not_parse_is_refused_with_the_position(self, client: Any) -> None:
         response = await _import(client, "name: Support\n  description: adrift\n")
@@ -134,7 +134,10 @@ class TestTheRefusalNamesTheField:
         assert response.status_code == 400
         error = response.json()["error"]
         assert error["code"] == "BAD_REQUEST"
-        assert error["details"] == {"field": "yaml", "line": 2, "column": 14}
+        # The position is in the sentence the editor shows, not in keys of its
+        # own that nothing has ever read (#891).
+        assert error["message"] == "This spec is not valid YAML - line 2, column 14"
+        assert error["details"]["fields"] == [{"field": "yaml", "message": error["message"]}]
 
     async def test_a_character_yaml_cannot_read_has_no_position_to_report(
         self, client: Any
@@ -144,7 +147,9 @@ class TestTheRefusalNamesTheField:
         response = await _import(client, "name: Sup\x00port\n")
 
         assert response.status_code == 400
-        assert response.json()["error"]["details"] == {"field": "yaml"}
+        error = response.json()["error"]
+        assert error["message"] == "This spec is not valid YAML"
+        assert error["details"]["fields"] == [{"field": "yaml", "message": error["message"]}]
 
 
 class TestTheRefusalQuotesNothingSubmitted:

--- a/backend/tests/api/test_error_envelope.py
+++ b/backend/tests/api/test_error_envelope.py
@@ -451,5 +451,6 @@ class TestDetailsDescribeTheRefusalNotTheServer:
 
         response = await self._refusal_on_the_wire(client, refusal.value)
 
-        assert response.json()["error"]["details"] == {"field": "base_url"}
+        error = response.json()["error"]
+        assert error["details"] == {"fields": [{"field": "base_url", "message": error["message"]}]}
         assert "hunter2" not in response.text

--- a/backend/tests/api/test_mcp_connection_url_refusal.py
+++ b/backend/tests/api/test_mcp_connection_url_refusal.py
@@ -79,7 +79,7 @@ class TestTheRefusalReachesTheOperator:
         assert response.status_code == 400
         error = response.json()["error"]
         assert error["code"] == "BAD_REQUEST"
-        assert error["details"] == {"field": "url"}
+        assert [problem["field"] for problem in error["details"]["fields"]] == ["url"]
 
     async def test_an_organization_connection_to_a_loopback_url_is_refused_with_a_400(
         self, client
@@ -93,7 +93,7 @@ class TestTheRefusalReachesTheOperator:
         assert response.status_code == 400
         error = response.json()["error"]
         assert error["code"] == "BAD_REQUEST"
-        assert error["details"] == {"field": "url"}
+        assert [problem["field"] for problem in error["details"]["fields"]] == ["url"]
 
     async def test_starting_oauth_against_a_loopback_url_is_refused_with_a_400(
         self, client
@@ -140,7 +140,8 @@ class TestTheRefusalQuotesNoSecret:
         assert response.status_code == 400
         assert "hunter2" not in response.text
         assert "sh-secret-value" not in response.text
-        assert response.json()["error"]["details"] == {"field": "url"}
+        error = response.json()["error"]
+        assert error["details"]["fields"] == [{"field": "url", "message": error["message"]}]
 
     async def test_a_secret_parked_where_the_port_belongs_is_not_read_back(self, client) -> None:
         """The refusal for this one is written by `urlsplit`, not by us.
@@ -158,4 +159,5 @@ class TestTheRefusalQuotesNoSecret:
 
         assert response.status_code == 400
         assert "sh-port-secret" not in response.text
-        assert response.json()["error"]["details"] == {"field": "url"}
+        error = response.json()["error"]
+        assert error["details"]["fields"] == [{"field": "url", "message": error["message"]}]

--- a/backend/tests/test_agent_registry.py
+++ b/backend/tests/test_agent_registry.py
@@ -735,7 +735,7 @@ class TestCreate:
         ):
             await AgentRegistryService(_db()).create(ctx, _spec("Support!"))
 
-        assert refused.value.details == {"slug": "support", "field": "name"}
+        assert refused.value.details == {"slug": "support"}
         # The message has to tell them what to change. They typed a *name*; the
         # thing that collided is the handle derived from it, and a refusal that
         # only states the collision leaves them staring at an input that looks

--- a/backend/tests/test_field_errors.py
+++ b/backend/tests/test_field_errors.py
@@ -1,10 +1,11 @@
 """The one shape a per-field refusal takes, and what it refuses to carry.
 
-Every refusal that names a field builds it here - the validation handler and the
-four services that used to hand pydantic's `exc.errors()` through untouched. The
-two properties worth pinning are the ones a call site cannot restate for itself:
-what the path looks like, and that nothing but the path and the sentence leaves
-the process (#882).
+Every refusal that names a field builds it here - the validation handler, the
+four services that used to hand pydantic's `exc.errors()` through untouched
+(#882), and the eighteen that used to answer a singular `details["field"]` no
+form has ever read (#891). The two properties worth pinning are the ones a call
+site cannot restate for itself: what the path looks like, and that nothing but
+the path and the sentence leaves the process.
 """
 
 from __future__ import annotations
@@ -13,7 +14,13 @@ import pytest
 from pydantic import BaseModel, Field, ValidationError, model_validator
 from pydantic_core import ErrorDetails
 
-from app.core.field_errors import field_problems, request_field_problems
+from app.core.exceptions import BadRequestError
+from app.core.field_errors import (
+    field_details,
+    field_problems,
+    refused_field,
+    request_field_problems,
+)
 
 
 class Chunking(BaseModel):
@@ -170,3 +177,51 @@ class TestNothingElseLeaves:
 
     def test_an_empty_report_is_an_empty_list_rather_than_an_invented_field(self) -> None:
         assert field_problems([], root="ingestion_config") == []
+
+
+class TestARuleStatedInProse:
+    """A refusal a service writes itself, rather than one pydantic reported.
+
+    Eighteen of them answered `details={"field": "<name>"}` with the sentence on
+    the envelope, which `fieldProblems` reads nowhere - so each showed a toast
+    and marked nothing (#891). They take the same shape as everything else now,
+    and this is what keeps a nineteenth from inventing a second one.
+    """
+
+    def test_it_is_the_same_shape_the_validation_handler_answers_in(self) -> None:
+        refusal = refused_field("base_url", "A model endpoint must include a host")
+
+        assert refusal.details == {
+            "fields": [{"field": "base_url", "message": "A model endpoint must include a host"}]
+        }
+
+    def test_it_is_a_bad_request_carrying_the_sentence_it_names_the_field_with(self) -> None:
+        """One sentence, in both places. A shorter one written for the field is
+        the copy that goes stale."""
+        refusal = refused_field("yaml", "This spec is not valid YAML - line 2, column 14")
+
+        assert isinstance(refusal, BadRequestError)
+        assert refusal.details is not None
+        assert refusal.details["fields"][0]["message"] == refusal.message
+
+    def test_what_else_the_refusal_is_about_sits_beside_the_fields_rather_than_in_one(
+        self,
+    ) -> None:
+        """`platform` explains the refusal; it is not an input to mark."""
+        refusal = refused_field(
+            "api_base_url", "A server URL is for a self-hosted platform", platform="telegram"
+        )
+
+        assert refusal.details == {
+            "platform": "telegram",
+            "fields": [
+                {"field": "api_base_url", "message": "A server URL is for a self-hosted platform"}
+            ],
+        }
+
+    def test_a_raiser_that_needs_another_status_builds_the_same_details(self) -> None:
+        """`_get_json` answers 404 for a sandbox session that is not there, and
+        the address is still the input to blame for it."""
+        assert field_details("base_url", "Sandbox session not found") == {
+            "fields": [{"field": "base_url", "message": "Sandbox session not found"}]
+        }

--- a/backend/tests/test_field_errors.py
+++ b/backend/tests/test_field_errors.py
@@ -219,9 +219,10 @@ class TestARuleStatedInProse:
             ],
         }
 
-    def test_a_raiser_that_needs_another_status_builds_the_same_details(self) -> None:
-        """`_get_json` answers 404 for a sandbox session that is not there, and
-        the address is still the input to blame for it."""
-        assert field_details("base_url", "Sandbox session not found") == {
-            "fields": [{"field": "base_url", "message": "Sandbox session not found"}]
+    def test_a_raiser_deciding_its_field_at_run_time_builds_the_same_details(self) -> None:
+        """`_get_json` describes the same five failures for a form testing an
+        address and for a page reading a saved connection, so whether there is
+        an input to blame is not known where the sentence is written."""
+        assert field_details("base_url", "The sandbox service answered 502") == {
+            "fields": [{"field": "base_url", "message": "The sandbox service answered 502"}]
         }

--- a/backend/tests/test_mcp_connections.py
+++ b/backend/tests/test_mcp_connections.py
@@ -892,7 +892,9 @@ class TestMcpConnectionService:
         data = McpConnectionCreate(name="internal", url="http://127.0.0.1:8000/mcp")
         with pytest.raises(BadRequestError) as excinfo:
             await service.create(user_id=uuid4(), data=data)
-        assert excinfo.value.details == {"field": "url"}
+        assert excinfo.value.details == {
+            "fields": [{"field": "url", "message": excinfo.value.message}]
+        }
         assert excinfo.value.status_code == 400
         repo.create.assert_not_called()
 
@@ -1093,7 +1095,9 @@ class TestMcpConnectionService:
                 data=McpConnectionUpdate(url="http://169.254.169.254/mcp"),
             )
 
-        assert excinfo.value.details == {"field": "url"}
+        assert excinfo.value.details == {
+            "fields": [{"field": "url", "message": excinfo.value.message}]
+        }
         repo.update.assert_not_called()
 
     @pytest.mark.anyio
@@ -1255,7 +1259,9 @@ class TestMcpConnectionService:
             await service.oauth_start(
                 user_id=uuid4(), name="evil", url="http://169.254.169.254/mcp"
             )
-        assert excinfo.value.details == {"field": "url"}
+        assert excinfo.value.details == {
+            "fields": [{"field": "url", "message": excinfo.value.message}]
+        }
         repo.create.assert_not_called()
 
     @pytest.mark.anyio
@@ -1491,7 +1497,9 @@ class TestOrganizationConnections:
             await service.create_for_org(
                 ctx, OrgMcpConnectionCreate(name="internal", url="http://127.0.0.1:8000/mcp")
             )
-        assert excinfo.value.details == {"field": "url"}
+        assert excinfo.value.details == {
+            "fields": [{"field": "url", "message": excinfo.value.message}]
+        }
         repo.create_org_scoped.assert_not_called()
 
     @pytest.mark.anyio
@@ -1600,7 +1608,9 @@ class TestOrganizationConnections:
                 ctx, connection_id=conn.id, data=OrgMcpConnectionUpdate(url="http://[::1]/mcp")
             )
 
-        assert excinfo.value.details == {"field": "url"}
+        assert excinfo.value.details == {
+            "fields": [{"field": "url", "message": excinfo.value.message}]
+        }
         repo.update.assert_not_called()
 
     @pytest.mark.anyio

--- a/backend/tests/test_sandbox_connections.py
+++ b/backend/tests/test_sandbox_connections.py
@@ -735,9 +735,36 @@ class TestTestingAnAddressBeforeItIsSaved:
             )
 
         assert "http://typo:8080 did not answer" in refused.value.message
-        # The message names the address the operator typed; `details` names the
-        # field, because it is logged as well as returned (agenticos#342) - in
-        # the one shape the dialog marks an input from (#891).
+        # One sentence, in both places, so the dialog can mark the input rather
+        # than print a line under it (#891). It names the address the operator
+        # typed, and agenticos#342 stays shut because `SandboxProbeRequest`
+        # refuses a `user:pass@` one - see the test below.
+        assert refused.value.details == {
+            "fields": [{"field": "base_url", "message": refused.value.message}]
+        }
+
+    async def test_a_service_with_no_policy_endpoint_is_a_wrong_address_not_a_lost_session(
+        self, monkeypatch
+    ):
+        """The one failure the two callers of `_get_json` do not share.
+
+        A 404 reading a saved connection is a session that has ended. Here
+        nothing asked for a session: it is an address answering, but not as a
+        sandbox service - and marking the operator's Address box with "Sandbox
+        session not found" would be confident about the wrong thing.
+        """
+        secret_id = uuid.uuid4()
+        service = _service(monkeypatch, secret=(secret_id, ApiKeySecret(api_key="tok")))
+        _serve(monkeypatch, _Response(404))
+
+        with pytest.raises(NotFoundError) as refused:
+            await service.probe_policy(
+                _ctx(), SandboxProbeRequest(base_url="http://typo:8080", secret_id=secret_id)
+            )
+
+        assert refused.value.message == (
+            "No sandbox service answers at this address - check the address and the port"
+        )
         assert refused.value.details == {
             "fields": [{"field": "base_url", "message": refused.value.message}]
         }

--- a/backend/tests/test_sandbox_connections.py
+++ b/backend/tests/test_sandbox_connections.py
@@ -161,7 +161,9 @@ class TestRegistering:
         with pytest.raises(BadRequestError) as refused:
             await service.create(_ctx(), SandboxConnectionCreate(name="Big box", kind="docker"))
 
-        assert refused.value.details["field"] == "base_url"
+        assert refused.value.details == {
+            "fields": [{"field": "base_url", "message": refused.value.message}]
+        }
 
     async def test_daytona_needs_no_address_of_its_own(self, monkeypatch):
         """Their API has one, and asking an operator to type it invites a typo in
@@ -697,7 +699,9 @@ class TestTestingAnAddressBeforeItIsSaved:
         with pytest.raises(BadRequestError) as refused:
             await service.probe_policy(_ctx(), SandboxProbeRequest(base_url="http://s:8080"))
 
-        assert refused.value.details["field"] == "secret_id"
+        assert refused.value.details == {
+            "fields": [{"field": "secret_id", "message": refused.value.message}]
+        }
 
     async def test_a_credential_of_the_wrong_shape_cannot_authenticate_a_service(self, monkeypatch):
         secret_id = uuid.uuid4()
@@ -732,8 +736,11 @@ class TestTestingAnAddressBeforeItIsSaved:
 
         assert "http://typo:8080 did not answer" in refused.value.message
         # The message names the address the operator typed; `details` names the
-        # field, because it is logged as well as returned (agenticos#342).
-        assert refused.value.details == {"field": "base_url"}
+        # field, because it is logged as well as returned (agenticos#342) - in
+        # the one shape the dialog marks an input from (#891).
+        assert refused.value.details == {
+            "fields": [{"field": "base_url", "message": refused.value.message}]
+        }
 
     async def test_an_address_carrying_a_password_is_refused_before_it_is_stored(self):
         """A `user:pass@` here would be echoed back by every refusal below.

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -1067,7 +1067,7 @@ class TestSkillFiles:
                 ctx, skill.id, name="template.md", description=None, content="Dear {name},"
             )
 
-        assert refused.value.details == {"name": "template.md", "field": "name"}
+        assert refused.value.details == {"name": "template.md"}
         repo.create_resource.assert_not_awaited()
         repo.update.assert_not_awaited()
         audit.assert_not_awaited()

--- a/backend/tests/test_untrusted_remote_names.py
+++ b/backend/tests/test_untrusted_remote_names.py
@@ -75,7 +75,10 @@ class TestWhereARemoteFileMayBeWritten:
         """These resolve onto the directory itself, which is not a file to write."""
         with pytest.raises(BadRequestError) as exc:
             destination_within(tmp_path, name)
-        assert exc.value.details == {"field": "name"}
+        # No field, and no copy of the name: whoever can drop a file in the
+        # folder chose it, and this runs inside a sync where the reader is a
+        # log rather than a form (#891).
+        assert exc.value.details is None
 
     def test_a_name_with_a_null_byte_is_refused(self, tmp_path: Path) -> None:
         """`resolve()` raises `ValueError` on one, which is not an answer a caller can act on."""
@@ -175,7 +178,8 @@ class TestTheGoogleDriveConnector:
         with pytest.raises(BadRequestError) as exc:
             await connector.list_files({"folder_id": "x' in parents or name contains 'salary"})
 
-        assert exc.value.details == {"field": "folder_id"}
+        assert exc.value.details is None
+        assert "salary" not in exc.value.message
         service.files.return_value.list.assert_not_called()
 
     async def test_a_hostile_sub_folder_id_is_refused_too(
@@ -233,7 +237,7 @@ class TestTheGoogleDriveConnector:
         """There is no deployment-wide fallback for a tenant's query to run under."""
         with pytest.raises(BadRequestError) as exc:
             GoogleDriveConnector()._get_drive_service({})
-        assert exc.value.details == {"field": "service_account_json"}
+        assert exc.value.details is None
 
 
 class TestTheS3Connector:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -286,7 +286,7 @@ place it is built, and it has three entry points. Two of them read Pydantic, and
 |---|---|---|
 | `request_field_problems` | `validation_exception_handler`, every `RequestValidationError` | where the value came from (`body`, `query`, …), which is dropped |
 | `field_problems(…, root=…)` | a service validating a document a route's schema cannot — a per-upload ingestion override, a hand-edited spec YAML, a capability's config blob | a field of that document, reported below `root` |
-| `refused_field(field, message, **context)` | a rule a service states in prose rather than in a model — an endpoint carrying a password, a Mattermost bot losing its server, a YAML document that never parsed | — it raises the `BadRequestError` itself |
+| `refused_field(field, message, **context)` | a rule a service states in prose rather than in a model — an endpoint carrying a password, a Mattermost bot losing its server, a YAML document that never parsed | — it answers with the `BadRequestError` for the caller to raise |
 
 `refused_field` names the sentence once, because the envelope's `message` and the
 field's are the same sentence; a raiser needing another status builds the same
@@ -324,8 +324,8 @@ sentence was the other half of #882: saving a draft does not validate a config
 schema at all, so publish validation is the only place a mistyped setting is ever
 refused.
 
-**Two refusals deliberately name no field**, and the line between them and the
-rest is what stops the one shape from meaning two things again:
+**Two kinds of refusal deliberately name no field**, and the line between them
+and the rest is what stops the one shape from meaning two things again:
 
 - **A refusal about a value no caller sent.** A remote file's name is chosen by
   whoever can drop a file in the synced folder, and both checks in

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -279,13 +279,21 @@ and a refusal about a *field* names it in one shape:
 `fieldProblems` in `frontend/src/lib/api-error.ts` reads that and nothing else,
 which is what lets a form mark the offending input rather than showing a sentence
 the reader has to re-scan the page for. `app/core/field_errors.py` is the only
-place it is built, and it has two entry points because **which caller you are
-decides what the first element of Pydantic's `loc` means**:
+place it is built, and it has three entry points. Two of them read Pydantic, and
+**which caller you are decides what the first element of `loc` means**:
 
 | | For | `loc` starts with |
 |---|---|---|
 | `request_field_problems` | `validation_exception_handler`, every `RequestValidationError` | where the value came from (`body`, `query`, …), which is dropped |
 | `field_problems(…, root=…)` | a service validating a document a route's schema cannot — a per-upload ingestion override, a hand-edited spec YAML, a capability's config blob | a field of that document, reported below `root` |
+| `refused_field(field, message, **context)` | a rule a service states in prose rather than in a model — an endpoint carrying a password, a Mattermost bot losing its server, a YAML document that never parsed | — it raises the `BadRequestError` itself |
+
+`refused_field` names the sentence once, because the envelope's `message` and the
+field's are the same sentence; a raiser needing another status builds the same
+`details` with `field_details`. Eighteen call sites answered
+`details={"field": "<name>"}` instead, singular, with the sentence on the
+envelope, and no form has ever read it — the same defect in a third shape
+([#891](https://github.com/vstorm-co/agenticos/issues/891)).
 
 Deciding by the string instead would misread a spec whose forbidden top-level
 key is literally called `body`, which is one shape standing in for two — the
@@ -315,6 +323,22 @@ delegate, because the Builder renders one form per specialist. Keeping only the
 sentence was the other half of #882: saving a draft does not validate a config
 schema at all, so publish validation is the only place a mistyped setting is ever
 refused.
+
+**Two refusals deliberately name no field**, and the line between them and the
+rest is what stops the one shape from meaning two things again:
+
+- **A refusal about a value no caller sent.** A remote file's name is chosen by
+  whoever can drop a file in the synced folder, and both checks in
+  `app/services/rag/remote_names.py` run inside a background sync, where the
+  reader is a log rather than a form. Same for a Google Drive source read back
+  without its credential: the row is stored, and `CONFIG_SCHEMA` is what refuses
+  it at the route.
+- **A conflict.** `AlreadyExistsError` reports a fact about a row that already
+  exists, not about the shape of what was sent — and which of a form's own
+  inputs produced the taken value is a thing only the form knows, since an
+  agent's handle is derived from a name nobody typed as a handle. That is
+  claimed by `submitFailure`'s `identifiedBy` on the client, so a 409 carries the
+  taken value and no field.
 
 ## Key Files
 

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -130,7 +130,11 @@ except Exception as exc:
 `message` is held to the same bar - the envelope carries it and the handler logs
 it on the same line, so a sentence naming the endpoint leaks whatever the field
 was refused for carrying. A URL the refusal is *about* is named by its field:
-`{"field": "base_url"}`, never the endpoint with the password still in it.
+`refused_field("base_url", ...)`, never the endpoint with the password still in
+it. That helper is in `app/core/field_errors.py`, which is the only place the
+`details["fields"]` a form marks an input from is built - see
+[Architecture](architecture.md#a-refusal-that-names-a-field) for the three entry
+points and for which refusals deliberately name no field at all.
 
 The same applies to an audit entry, which is `details` with a longer life: record
 *which* fields an administrator changed, not the values they submitted.

--- a/frontend/src/components/agents/add-model.integration.test.tsx
+++ b/frontend/src/components/agents/add-model.integration.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AddModel } from "./add-model";
+import { ApiError } from "@/lib/api-error";
 import { Perm } from "@/types/permissions";
 import type { Permission } from "@/types/permissions";
 import type { SecretPurpose } from "@/types/secrets";
@@ -632,6 +633,84 @@ describe("pointing a model somewhere other than the provider's own API", () => {
     await userEvent.type(screen.getByLabelText("Endpoint"), "https://gateway.acme/v1");
 
     expect(screen.getByRole("button", { name: "Add model" })).toBeDisabled();
+  });
+
+  /**
+   * The half of the refusal that says *which box to fix*.
+   *
+   * `validate_endpoint_url` answers `details.fields` against `base_url` (#891),
+   * and this is where that stops being a sentence floating under the model id -
+   * an operator who mistyped a gateway address is looking at the field that
+   * holds it.
+   */
+  function refusedEndpoint(message: string) {
+    return new ApiError(400, message, {
+      error: {
+        code: "BAD_REQUEST",
+        message,
+        details: { fields: [{ field: "base_url", message }] },
+      },
+    });
+  }
+
+  async function submitWithEndpoint(url: string) {
+    state.secrets = [secret()];
+    mount();
+    await pickProvider("OpenAI");
+    await userEvent.click(screen.getByLabelText("Model"));
+    await userEvent.click(screen.getByRole("option", { name: /gpt-5/ }));
+    await userEvent.type(screen.getByLabelText("Endpoint"), url);
+    await userEvent.click(screen.getByRole("button", { name: "Add model" }));
+  }
+
+  it("marks the endpoint the server refused, and says why on it", async () => {
+    const message = "A model endpoint must be an http or https URL";
+    state.createProfile = {
+      mutateAsync: vi.fn().mockRejectedValue(refusedEndpoint(message)),
+      isPending: false,
+    };
+
+    await submitWithEndpoint("ftp://models.example");
+
+    const endpoint = screen.getByLabelText("Endpoint");
+    expect(endpoint).toHaveAttribute("aria-invalid", "true");
+    expect(endpoint).toHaveAccessibleDescription(message);
+  });
+
+  it("clears the mark as soon as the endpoint changes", async () => {
+    // The verdict was about the value that was sent; leaving it on a field
+    // somebody has since corrected is a form arguing with itself.
+    state.createProfile = {
+      mutateAsync: vi
+        .fn()
+        .mockRejectedValue(refusedEndpoint("A model endpoint must include a host")),
+      isPending: false,
+    };
+
+    await submitWithEndpoint("http://");
+    await userEvent.type(screen.getByLabelText("Endpoint"), "gateway.acme/v1");
+
+    expect(screen.getByLabelText("Endpoint")).not.toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("leaves a refusal that names no field where it always was", async () => {
+    // A bare OpenRouter id is refused about the model rather than the endpoint,
+    // and `submitFailure` hands back what it could not place rather than
+    // guessing at a box.
+    const message = "OpenRouter model ids are namespaced, e.g. 'openai/gpt-4.1'";
+    state.createProfile = {
+      mutateAsync: vi.fn().mockRejectedValue(
+        new ApiError(400, message, {
+          error: { code: "BAD_REQUEST", message, details: { model: "gpt-4.1" } },
+        }),
+      ),
+      isPending: false,
+    };
+
+    await submitWithEndpoint("https://gateway.acme/v1");
+
+    expect(screen.getByText(message)).toBeInTheDocument();
+    expect(screen.getByLabelText("Endpoint")).not.toHaveAttribute("aria-invalid", "true");
   });
 });
 

--- a/frontend/src/components/agents/add-model.tsx
+++ b/frontend/src/components/agents/add-model.tsx
@@ -3,12 +3,14 @@
 import { useState } from "react";
 import { Check, KeyRound, Plus } from "lucide-react";
 
-import { getErrorMessage } from "@/lib/api-error";
+import { submitFailure } from "@/lib/api-error";
+import type { SubmitFailure } from "@/lib/api-error";
 import { ModelCombobox } from "@/components/agents/model-combobox";
 import { InlineSecret } from "@/components/vault/inline-secret";
 import { ProviderRow } from "@/components/vault/provider-row";
 import {
   Button,
+  FormField,
   Input,
   Label,
   Select,
@@ -126,6 +128,20 @@ export function modelIdIsWellFormed(providerId: string, model: string): boolean 
   return providerId !== "openrouter" || model.includes("/");
 }
 
+/**
+ * What this form can mark, for `submitFailure`.
+ *
+ * The endpoint and nothing else, because it is the only input the API names:
+ * every `validate_endpoint_url` refusal and the "this provider has no endpoint
+ * setting" one answer `details.fields` against `base_url` (#891), and a 422 on
+ * the field says the same. Everything else the endpoint refuses - a bare
+ * OpenRouter id, a provider with no key - names no input, and `submitFailure`
+ * hands those back as one line rather than guessing at a box.
+ */
+const FORM = { fields: ["base_url"] } as const;
+
+const NOTHING_WRONG: SubmitFailure = { fields: {}, toast: null };
+
 export function AddModel({ onCreated, onCancel, disabled, selected }: AddModelProps) {
   const tErrors = useTranslations("errors");
   const t = useTranslations("agents");
@@ -149,7 +165,7 @@ export function AddModel({ onCreated, onCancel, disabled, selected }: AddModelPr
   const [label, setLabel] = useState("");
   const [secretId, setSecretId] = useState(selected?.secret_id ?? "");
   const [baseUrl, setBaseUrl] = useState(selected?.base_url ?? "");
-  const [failure, setFailure] = useState<string | null>(null);
+  const [failure, setFailure] = useState<SubmitFailure>(NOTHING_WRONG);
   const [naming, setNaming] = useState(false);
 
   const providers = purposes.filter((entry) => entry.category === "model_provider");
@@ -211,7 +227,7 @@ export function AddModel({ onCreated, onCancel, disabled, selected }: AddModelPr
   const submit = async () => {
     /* v8 ignore next -- the id comes from the list this select was built from */
     if (provider === undefined) return;
-    setFailure(null);
+    setFailure(NOTHING_WRONG);
     if (already !== undefined) {
       onCreated(already);
       return;
@@ -231,11 +247,11 @@ export function AddModel({ onCreated, onCancel, disabled, selected }: AddModelPr
       onCreated(profile);
     } catch (error) {
       // Caught, not left to reject: an unhandled rejection here is Next.js's
-      // full-screen error overlay for what is a typo in one field. Every
-      // refusal this endpoint gives is about the model id - a bare id where the
-      // provider namespaces them, an endpoint that is not a URL - so it belongs
-      // under the field, where it can be fixed.
-      setFailure(getErrorMessage(error, tErrors));
+      // full-screen error overlay for what is a typo in one field. An endpoint
+      // that is not a URL, or one for a provider that has no endpoint setting,
+      // is refused against `base_url` and marks that input; a bare OpenRouter
+      // id names no field and stays a line under the model.
+      setFailure(submitFailure(error, FORM, tErrors));
     }
   };
 
@@ -251,7 +267,7 @@ export function AddModel({ onCreated, onCancel, disabled, selected }: AddModelPr
               setSecretId("");
               setModel("");
               setBaseUrl("");
-              setFailure(null);
+              setFailure(NOTHING_WRONG);
             }}
           >
             <SelectTrigger id="add-model-provider">
@@ -301,7 +317,7 @@ export function AddModel({ onCreated, onCancel, disabled, selected }: AddModelPr
             value={model}
             onChange={(next) => {
               setModel(next);
-              setFailure(null);
+              setFailure(NOTHING_WRONG);
             }}
             options={suggestions}
             source={source}
@@ -309,7 +325,7 @@ export function AddModel({ onCreated, onCancel, disabled, selected }: AddModelPr
             disabled={provider === undefined}
             placeholder={placeholderWords(modelPlaceholder(provider?.id), tRoot)}
           />
-          {failure !== null && <p className="text-destructive text-xs">{failure}</p>}
+          {failure.toast !== null && <p className="text-destructive text-xs">{failure.toast}</p>}
         </div>
       </div>
 
@@ -383,14 +399,22 @@ export function AddModel({ onCreated, onCancel, disabled, selected }: AddModelPr
           for the rest would collect a URL the client drops, and the API refuses
           it - which is the right refusal and a pointless one to walk into. */}
       {provider !== undefined && acceptsEndpoint && (
-        <div className="space-y-1.5">
-          <Label htmlFor="add-model-endpoint">{t("endpoint")}</Label>
+        <FormField
+          htmlFor="add-model-endpoint"
+          label={t("endpoint")}
+          error={failure.fields.base_url}
+          description={
+            capabilities?.keyless === true
+              ? t("gatewayLitellmProxyModel")
+              : t("optionalPointModelAt")
+          }
+        >
           <Input
             id="add-model-endpoint"
             value={baseUrl}
             onChange={(event) => {
               setBaseUrl(event.target.value);
-              setFailure(null);
+              setFailure(NOTHING_WRONG);
             }}
             placeholder={
               capabilities?.keyless === true
@@ -400,12 +424,7 @@ export function AddModel({ onCreated, onCancel, disabled, selected }: AddModelPr
             autoComplete="off"
             spellCheck={false}
           />
-          <p className="text-muted-foreground text-xs">
-            {capabilities?.keyless === true
-              ? t("gatewayLitellmProxyModel")
-              : t("optionalPointModelAt")}
-          </p>
-        </div>
+        </FormField>
       )}
 
       {/* The name is derived and almost never worth changing - it exists so an

--- a/frontend/src/components/agents/add-model.tsx
+++ b/frontend/src/components/agents/add-model.tsx
@@ -3,8 +3,7 @@
 import { useState } from "react";
 import { Check, KeyRound, Plus } from "lucide-react";
 
-import { submitFailure } from "@/lib/api-error";
-import type { SubmitFailure } from "@/lib/api-error";
+import { NO_FAILURE, submitFailure } from "@/lib/api-error";
 import { ModelCombobox } from "@/components/agents/model-combobox";
 import { InlineSecret } from "@/components/vault/inline-secret";
 import { ProviderRow } from "@/components/vault/provider-row";
@@ -140,8 +139,6 @@ export function modelIdIsWellFormed(providerId: string, model: string): boolean 
  */
 const FORM = { fields: ["base_url"] } as const;
 
-const NOTHING_WRONG: SubmitFailure = { fields: {}, toast: null };
-
 export function AddModel({ onCreated, onCancel, disabled, selected }: AddModelProps) {
   const tErrors = useTranslations("errors");
   const t = useTranslations("agents");
@@ -165,7 +162,7 @@ export function AddModel({ onCreated, onCancel, disabled, selected }: AddModelPr
   const [label, setLabel] = useState("");
   const [secretId, setSecretId] = useState(selected?.secret_id ?? "");
   const [baseUrl, setBaseUrl] = useState(selected?.base_url ?? "");
-  const [failure, setFailure] = useState<SubmitFailure>(NOTHING_WRONG);
+  const [failure, setFailure] = useState(NO_FAILURE);
   const [naming, setNaming] = useState(false);
 
   const providers = purposes.filter((entry) => entry.category === "model_provider");
@@ -227,7 +224,7 @@ export function AddModel({ onCreated, onCancel, disabled, selected }: AddModelPr
   const submit = async () => {
     /* v8 ignore next -- the id comes from the list this select was built from */
     if (provider === undefined) return;
-    setFailure(NOTHING_WRONG);
+    setFailure(NO_FAILURE);
     if (already !== undefined) {
       onCreated(already);
       return;
@@ -267,7 +264,7 @@ export function AddModel({ onCreated, onCancel, disabled, selected }: AddModelPr
               setSecretId("");
               setModel("");
               setBaseUrl("");
-              setFailure(NOTHING_WRONG);
+              setFailure(NO_FAILURE);
             }}
           >
             <SelectTrigger id="add-model-provider">
@@ -317,7 +314,7 @@ export function AddModel({ onCreated, onCancel, disabled, selected }: AddModelPr
             value={model}
             onChange={(next) => {
               setModel(next);
-              setFailure(NOTHING_WRONG);
+              setFailure(NO_FAILURE);
             }}
             options={suggestions}
             source={source}
@@ -414,7 +411,7 @@ export function AddModel({ onCreated, onCancel, disabled, selected }: AddModelPr
             value={baseUrl}
             onChange={(event) => {
               setBaseUrl(event.target.value);
-              setFailure(NOTHING_WRONG);
+              setFailure(NO_FAILURE);
             }}
             placeholder={
               capabilities?.keyless === true

--- a/frontend/src/components/sandboxes/connection-dialog.test.tsx
+++ b/frontend/src/components/sandboxes/connection-dialog.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ConnectionDialog } from "./connection-dialog";
+import { ApiError } from "@/lib/api-error";
 import type { SandboxConnectionRecord } from "@/lib/sandbox-connections-api";
 import { providerMarkIn } from "@/test-utils/brand-marks";
 
@@ -284,6 +285,84 @@ describe("ConnectionDialog", () => {
 
     expect(screen.getByText("that name is taken")).toBeVisible();
     expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  /**
+   * Which box to fix, not just what went wrong.
+   *
+   * `_check_shape` and the probe both answer `details.fields` against
+   * `base_url`, and a duplicate name is a 409 this form places itself through
+   * `identifiedBy` (#891). Before that, all three were one red line at the
+   * bottom of a dialog with four inputs in it.
+   */
+  it("marks the address the service refused", async () => {
+    const message = "A container connection needs the address its sandbox service answers on";
+    const onSubmit = vi.fn().mockRejectedValue(
+      new ApiError(400, message, {
+        error: {
+          code: "BAD_REQUEST",
+          message,
+          details: { fields: [{ field: "base_url", message }] },
+        },
+      }),
+    );
+    render(<ConnectionDialog editing={connection()} onOpenChange={vi.fn()} onSubmit={onSubmit} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    const address = screen.getByLabelText("Address");
+    expect(address).toHaveAttribute("aria-invalid", "true");
+    expect(address).toHaveAccessibleDescription(message);
+    expect(screen.getByLabelText("Name")).not.toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("marks the name a duplicate is about, and does not repeat it below", async () => {
+    const message = "A sandbox connection by that name already exists";
+    const onSubmit = vi.fn().mockRejectedValue(
+      new ApiError(409, message, {
+        error: { code: "ALREADY_EXISTS", message, details: { name: "Local Docker" } },
+      }),
+    );
+    render(<ConnectionDialog editing={connection()} onOpenChange={vi.fn()} onSubmit={onSubmit} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(screen.getByLabelText("Name")).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getAllByText(message)).toHaveLength(1);
+  });
+
+  it("clears the mark as soon as the address changes", async () => {
+    const message = "The sandbox service at http://typo:8080 did not answer";
+    const onSubmit = vi.fn().mockRejectedValue(
+      new ApiError(400, message, {
+        error: {
+          code: "BAD_REQUEST",
+          message,
+          details: { fields: [{ field: "base_url", message }] },
+        },
+      }),
+    );
+    render(<ConnectionDialog editing={connection()} onOpenChange={vi.fn()} onSubmit={onSubmit} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+    await userEvent.type(screen.getByLabelText("Address"), "0");
+
+    expect(screen.getByLabelText("Address")).not.toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("clears the mark as soon as the name changes", async () => {
+    const message = "A sandbox connection by that name already exists";
+    const onSubmit = vi.fn().mockRejectedValue(
+      new ApiError(409, message, {
+        error: { code: "ALREADY_EXISTS", message, details: { name: "Local Docker" } },
+      }),
+    );
+    render(<ConnectionDialog editing={connection()} onOpenChange={vi.fn()} onSubmit={onSubmit} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+    await userEvent.type(screen.getByLabelText("Name"), "2");
+
+    expect(screen.getByLabelText("Name")).not.toHaveAttribute("aria-invalid", "true");
   });
 
   it("cancelling closes without saving", async () => {

--- a/frontend/src/components/sandboxes/connection-dialog.tsx
+++ b/frontend/src/components/sandboxes/connection-dialog.tsx
@@ -20,8 +20,7 @@ import {
   SelectValue,
   Switch,
 } from "@/components/ui";
-import { submitFailure } from "@/lib/api-error";
-import type { SubmitFailure } from "@/lib/api-error";
+import { NO_FAILURE, submitFailure } from "@/lib/api-error";
 import { InlineSecret } from "@/components/vault/inline-secret";
 import { ProviderRow } from "@/components/vault/provider-row";
 import { useLocalSandboxService, useSecrets } from "@/hooks";
@@ -113,8 +112,6 @@ function isComplete(form: FormState, baseUrl: string): boolean {
  */
 const FORM = { fields: ["base_url"], identifiedBy: "name" } as const;
 
-const NOTHING_WRONG: SubmitFailure = { fields: {}, toast: null };
-
 /**
  * Register or edit a place sandboxes run.
  *
@@ -136,7 +133,7 @@ export function ConnectionDialog({ editing, onOpenChange, onSubmit }: Connection
   const [storing, setStoring] = useState(false);
   const [testing, setTesting] = useState(false);
   const [allowed, setAllowed] = useState<SandboxRuntime[] | null>(null);
-  const [failure, setFailure] = useState<SubmitFailure>(NOTHING_WRONG);
+  const [failure, setFailure] = useState(NO_FAILURE);
 
   // Derived rather than written into state by an effect: what a service answered
   // is a default for a field nobody has touched, and an effect that filled the box
@@ -148,7 +145,7 @@ export function ConnectionDialog({ editing, onOpenChange, onSubmit }: Connection
 
   async function submit(): Promise<void> {
     setSaving(true);
-    setFailure(NOTHING_WRONG);
+    setFailure(NO_FAILURE);
     try {
       await onSubmit({
         name: form.name.trim(),
@@ -193,7 +190,7 @@ export function ConnectionDialog({ editing, onOpenChange, onSubmit }: Connection
               placeholder={t("namePlaceholder")}
               onChange={(event) => {
                 setForm({ ...form, name: event.target.value });
-                setFailure(NOTHING_WRONG);
+                setFailure(NO_FAILURE);
               }}
             />
           </FormField>
@@ -230,7 +227,7 @@ export function ConnectionDialog({ editing, onOpenChange, onSubmit }: Connection
                   placeholder="http://sandboxd:8080"
                   onChange={(event) => {
                     setForm({ ...form, baseUrl: event.target.value, urlTouched: true });
-                    setFailure(NOTHING_WRONG);
+                    setFailure(NO_FAILURE);
                   }}
                 />
               </FormField>
@@ -293,7 +290,7 @@ export function ConnectionDialog({ editing, onOpenChange, onSubmit }: Connection
                   disabled={storing}
                   onClick={async () => {
                     setStoring(true);
-                    setFailure(NOTHING_WRONG);
+                    setFailure(NO_FAILURE);
                     try {
                       const secretId = await storeCredential();
                       setForm((current) => ({ ...current, secretId }));
@@ -329,7 +326,7 @@ export function ConnectionDialog({ editing, onOpenChange, onSubmit }: Connection
                 baseUrl.trim() && form.secretId
                   ? async () => {
                       setTesting(true);
-                      setFailure(NOTHING_WRONG);
+                      setFailure(NO_FAILURE);
                       try {
                         const policy = await probe(baseUrl.trim(), form.secretId);
                         setAllowed(policy.runtimes);

--- a/frontend/src/components/sandboxes/connection-dialog.tsx
+++ b/frontend/src/components/sandboxes/connection-dialog.tsx
@@ -10,6 +10,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  FormField,
   Input,
   Label,
   Select,
@@ -19,7 +20,8 @@ import {
   SelectValue,
   Switch,
 } from "@/components/ui";
-import { getErrorMessage } from "@/lib/api-error";
+import { submitFailure } from "@/lib/api-error";
+import type { SubmitFailure } from "@/lib/api-error";
 import { InlineSecret } from "@/components/vault/inline-secret";
 import { ProviderRow } from "@/components/vault/provider-row";
 import { useLocalSandboxService, useSecrets } from "@/hooks";
@@ -102,6 +104,18 @@ function isComplete(form: FormState, baseUrl: string): boolean {
 }
 
 /**
+ * What this dialog can mark, for `submitFailure`.
+ *
+ * The address, because every refusal the service and the probe give about one -
+ * a shape that cannot work, a host that does not answer, a port answering HTML
+ * - names `base_url` (#891). And the name, through `identifiedBy`: a duplicate
+ * is a 409 about a row that exists, which only this form can place.
+ */
+const FORM = { fields: ["base_url"], identifiedBy: "name" } as const;
+
+const NOTHING_WRONG: SubmitFailure = { fields: {}, toast: null };
+
+/**
  * Register or edit a place sandboxes run.
  *
  * The credential is chosen from the vault or added inline; it is never typed into
@@ -122,7 +136,7 @@ export function ConnectionDialog({ editing, onOpenChange, onSubmit }: Connection
   const [storing, setStoring] = useState(false);
   const [testing, setTesting] = useState(false);
   const [allowed, setAllowed] = useState<SandboxRuntime[] | null>(null);
-  const [refusal, setRefusal] = useState<string | null>(null);
+  const [failure, setFailure] = useState<SubmitFailure>(NOTHING_WRONG);
 
   // Derived rather than written into state by an effect: what a service answered
   // is a default for a field nobody has touched, and an effect that filled the box
@@ -134,7 +148,7 @@ export function ConnectionDialog({ editing, onOpenChange, onSubmit }: Connection
 
   async function submit(): Promise<void> {
     setSaving(true);
-    setRefusal(null);
+    setFailure(NOTHING_WRONG);
     try {
       await onSubmit({
         name: form.name.trim(),
@@ -152,7 +166,7 @@ export function ConnectionDialog({ editing, onOpenChange, onSubmit }: Connection
       // Shown here rather than rethrown. The server refuses a duplicate name and
       // a shape it cannot use; both are about a field on this form, and a
       // rejection that escaped an onClick reached nobody at all.
-      setRefusal(getErrorMessage(error, tErrors));
+      setFailure(submitFailure(error, FORM, tErrors));
     } finally {
       setSaving(false);
     }
@@ -167,16 +181,22 @@ export function ConnectionDialog({ editing, onOpenChange, onSubmit }: Connection
         </DialogHeader>
 
         <div className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="connection-name">{t("name")}</Label>
+          <FormField
+            htmlFor="connection-name"
+            label={t("name")}
+            description={t("whatAgentAuthorsWill")}
+            error={failure.fields.name}
+          >
             <Input
               id="connection-name"
               value={form.name}
               placeholder={t("namePlaceholder")}
-              onChange={(event) => setForm({ ...form, name: event.target.value })}
+              onChange={(event) => {
+                setForm({ ...form, name: event.target.value });
+                setFailure(NOTHING_WRONG);
+              }}
             />
-            <p className="text-muted-foreground text-xs">{t("whatAgentAuthorsWill")}</p>
-          </div>
+          </FormField>
 
           <div className="space-y-2">
             <Label htmlFor="connection-kind">{t("kind")}</Label>
@@ -198,16 +218,22 @@ export function ConnectionDialog({ editing, onOpenChange, onSubmit }: Connection
 
           {form.kind === "docker" && (
             <div className="space-y-2">
-              <Label htmlFor="connection-url">{t("address")}</Label>
-              <Input
-                id="connection-url"
-                value={baseUrl}
-                placeholder="http://sandboxd:8080"
-                onChange={(event) =>
-                  setForm({ ...form, baseUrl: event.target.value, urlTouched: true })
-                }
-              />
-              <p className="text-muted-foreground text-xs">{t("whereSandboxServiceAnswers")}</p>
+              <FormField
+                htmlFor="connection-url"
+                label={t("address")}
+                description={t("whereSandboxServiceAnswers")}
+                error={failure.fields.base_url}
+              >
+                <Input
+                  id="connection-url"
+                  value={baseUrl}
+                  placeholder="http://sandboxd:8080"
+                  onChange={(event) => {
+                    setForm({ ...form, baseUrl: event.target.value, urlTouched: true });
+                    setFailure(NOTHING_WRONG);
+                  }}
+                />
+              </FormField>
               {local?.url != null && (
                 <p className="text-muted-foreground text-xs">
                   {local.registered_connection_id === null
@@ -267,12 +293,12 @@ export function ConnectionDialog({ editing, onOpenChange, onSubmit }: Connection
                   disabled={storing}
                   onClick={async () => {
                     setStoring(true);
-                    setRefusal(null);
+                    setFailure(NOTHING_WRONG);
                     try {
                       const secretId = await storeCredential();
                       setForm((current) => ({ ...current, secretId }));
                     } catch (error) {
-                      setRefusal(getErrorMessage(error, tErrors));
+                      setFailure(submitFailure(error, FORM, tErrors));
                     } finally {
                       setStoring(false);
                     }
@@ -303,12 +329,12 @@ export function ConnectionDialog({ editing, onOpenChange, onSubmit }: Connection
                 baseUrl.trim() && form.secretId
                   ? async () => {
                       setTesting(true);
-                      setRefusal(null);
+                      setFailure(NOTHING_WRONG);
                       try {
                         const policy = await probe(baseUrl.trim(), form.secretId);
                         setAllowed(policy.runtimes);
                       } catch (error) {
-                        setRefusal(getErrorMessage(error, tErrors));
+                        setFailure(submitFailure(error, FORM, tErrors));
                       } finally {
                         setTesting(false);
                       }
@@ -357,7 +383,10 @@ export function ConnectionDialog({ editing, onOpenChange, onSubmit }: Connection
           )}
         </div>
 
-        {refusal !== null && <p className="text-destructive text-sm">{refusal}</p>}
+        {/* What could not be placed under an input - a refused permission, a
+            vault write that failed, a server fault. A refusal that found its
+            field is not also announced here. */}
+        {failure.toast !== null && <p className="text-destructive text-sm">{failure.toast}</p>}
 
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)}>

--- a/frontend/src/lib/api-error.test.ts
+++ b/frontend/src/lib/api-error.test.ts
@@ -255,6 +255,69 @@ describe("a refusal a service raised about a document it validated itself", () =
   });
 });
 
+describe("a refusal a service states in prose about one input", () => {
+  /**
+   * Bodies copied out of the backend's own tests. Eighteen of these answered a
+   * singular `details.field` with the sentence on the envelope, which this
+   * module reads nowhere - so each showed a toast and marked nothing (#891).
+   */
+  const ENDPOINT_REFUSED = envelope(
+    "BAD_REQUEST",
+    "A model endpoint must be an http or https URL",
+    {
+      fields: [{ field: "base_url", message: "A model endpoint must be an http or https URL" }],
+    },
+  );
+
+  const MCP_URL_REFUSED = envelope(
+    "BAD_REQUEST",
+    "This MCP server URL cannot be used: loopback addresses are not reachable",
+    {
+      fields: [
+        {
+          field: "url",
+          message: "This MCP server URL cannot be used: loopback addresses are not reachable",
+        },
+      ],
+    },
+  );
+
+  const YAML_REFUSED = envelope("BAD_REQUEST", "This spec is not valid YAML - line 2, column 14", {
+    fields: [{ field: "yaml", message: "This spec is not valid YAML - line 2, column 14" }],
+  });
+
+  it("marks the endpoint a model profile was refused over", () => {
+    const failure = submitFailure(apiError(400, ENDPOINT_REFUSED), { fields: ["base_url"] }, tEn);
+
+    expect(failure.fields.base_url).toBe("A model endpoint must be an http or https URL");
+    expect(failure.toast).toBeNull();
+  });
+
+  it("marks the server URL an MCP connection was refused over", () => {
+    expect(fieldProblems(apiError(400, MCP_URL_REFUSED))).toEqual([
+      {
+        field: "url",
+        message: "This MCP server URL cannot be used: loopback addresses are not reachable",
+      },
+    ]);
+  });
+
+  it("carries the position of a spec that never parsed in the sentence it marks with", () => {
+    // The line and column used to be `details` keys of their own that nothing
+    // read; they are only worth reporting to the reader who has the document.
+    expect(fieldProblems(apiError(400, YAML_REFUSED))).toEqual([
+      { field: "yaml", message: "This spec is not valid YAML - line 2, column 14" },
+    ]);
+  });
+
+  it("says one thing once - the field, and no toast repeating it", () => {
+    const failure = submitFailure(apiError(400, ENDPOINT_REFUSED), { fields: ["base_url"] }, tEn);
+
+    expect(Object.keys(failure.fields)).toEqual(["base_url"]);
+    expect(failure.toast).toBeNull();
+  });
+});
+
 describe("submitFailure", () => {
   const form = { fields: ["name", "description"], identifiedBy: "name" } as const;
 

--- a/frontend/src/lib/api-error.ts
+++ b/frontend/src/lib/api-error.ts
@@ -234,6 +234,15 @@ export type FormShape = {
 };
 
 /**
+ * A submission with nothing wrong with it yet - the state a form opens in, and
+ * the one it returns to when the input the server named is edited.
+ *
+ * Here rather than in each form, because two spellings of "no failure" is how
+ * `fields: {}` and `toast: null` come to disagree about which means "clean".
+ */
+export const NO_FAILURE: SubmitFailure = { fields: {}, toast: null };
+
+/**
  * Split a rejected submission into what the form can show and what it cannot.
  *
  * Anything the server blames on a field the form renders is returned to be


### PR DESCRIPTION
Eighteen call sites answered a per-field refusal with a singular
`details={"field": "<name>"}` and the sentence on the envelope. `fieldProblems`
in `frontend/src/lib/api-error.ts:179` reads `details["fields"]` and FastAPI's
own `detail`, and nothing else — so a mistyped model endpoint, a blocked MCP
server URL and a spec YAML that would not parse each delivered a sentence to a
toast and marked no input. The same defect #882 fixed for `details["errors"]`,
in the third shape it deliberately did not touch.

## How the eighteen were enumerated

`rg -n '"field"' backend/app --glob '*.py'`, minus `field_errors.py` itself and
the three hits that build or read the *plural* shape (`agent_registry.py:295`
and `:481` qualify a path; `exception_handlers.py:162` summarises one). That
gives 19 raise statements at the 18 sites the issue lists — `_yaml_location`
returns the same `details` from two branches, which the issue counts as one.
The list matches the issue's table exactly, with line numbers shifted by #892.
`rg -n '"field"' backend/app` now returns only those three.

## The rule, so a nineteenth site cannot guess

`app/core/field_errors.py` gains a third entry point beside the two that read
pydantic. `refused_field(field, message, **context)` answers with the
`BadRequestError` for the caller to raise, taking the sentence **once** — which
is what stops the envelope's and the field's from drifting apart, since they are
the same sentence and a shorter one written for the field is the copy that goes
stale. `field_details` builds the same `details` without the exception, for the
raiser that cannot use it: another status, or a field decided at run time.

The line the shape must not cross, stated in the module docstring and in
`docs/architecture.md`: **a refusal names an input only when the caller sent it
in that request.** That decides both halves, and it does not depend on whether
a React form exists today — which is not a property the backend can know or keep
true.

### Converted (12 raises)

| Where | Field |
|---|---|
| `model_profile.validate_endpoint_url` ×3, `create_profile` | `base_url` |
| `sandbox_connection.probe_policy`, `_check_shape`, `_get_json` (5 raises, one shared `field`) | `secret_id`, `base_url` |
| `channel_bot._check_server_url` ×2 | `api_base_url` |
| `mcp_connection._checked_url` | `url` |
| `agent_registry._parse_spec_yaml`, both non-pydantic branches | `yaml` |

The YAML pair is why the issue exists: #892 converted the `ValidationError`
branch and stopped, because converging one of three would have made
`_parse_spec_yaml` disagree with itself. `_yaml_location` becomes
`_yaml_refusal` and puts the position **in the sentence** — `line` and `column`
were `details` keys nothing has ever read, and a line number is only worth
reporting to the reader who has the file open.

### Not converted (6 raises) — they lose the key instead

Not "left as they were": keeping `field` anywhere is the two-shapes problem
this change exists to end.

- **`rag/remote_names.py` (3)** refuses a *remote* file's name and a folder id
  inside a background sync. Nobody sent either — sharing a Drive folder outside
  the organization is what folder sharing is for, so whoever can drop a file in
  it names the next one — and the reader is a sync log, not a form. The folder
  id *is* configured, but `SyncSourceConnector.validate_config` answers
  `(False, message)` and `sync_source.py` re-raises about the connector, so the
  details are discarded two layers before the wire. Filed as **#897**, with the
  frontend half: `sync-source-configure-step.tsx` generates one input per
  `config_schema` entry and takes no error prop at all.
- **`rag/connectors/google_drive.py`** reads a stored row inside a sync. No
  request, no input to blame; `CONFIG_SCHEMA` is what refuses it at the route.
- **The two 409s** — `skills.add_resource` and `agent_registry.create` — report
  a fact about a row that already exists, not about the shape of what was sent.
  Which of a form's own inputs produced the taken value is the form's to say,
  because an agent's handle is derived from a name nobody typed as a handle.
  `submitFailure`'s `identifiedBy` is where that is claimed and it already
  worked; the `field` key beside it was a second mechanism for one job, and a
  dead one — `submitFailure`'s 409 branch returns before it ever reads `fields`.

## What now marks an input

- **`add-model.tsx`**, which the issue names. An endpoint that is not a URL,
  one carrying a password, one for a provider whose SDK would ignore it: all
  three mark the Endpoint field and describe it, instead of printing a line
  under the model id. A refusal that names no field stays exactly where it was.
- **The sandbox connection dialog**, the other one the issue names. The address
  for a shape that cannot work and for every way a probe fails; the name for a
  duplicate, through `identifiedBy`. All of them were one red line at the bottom
  of a dialog with four inputs in it.

Both inputs move to `FormField`, which wires `aria-invalid` and
`aria-describedby`, and both clear on the next keystroke — the verdict was about
the value that was sent.

**Not claimed:** the channel-bot `api_base_url` refusals convert and mark
nothing, because the PATCH route that raises them has no form — `use-channel-bots.ts`
has create, activate, deactivate and delete, and no update. Said plainly rather
than papered over with a prop nothing passes.

## Tests

| Test | What it proves |
|---|---|
| `test_field_errors.py` — `TestARuleStatedInProse` (4) | the shape matches the validation handler's; the envelope's sentence *is* the field's; `context` sits beside `fields` rather than inside one; `field_details` for a raiser that decides its field at run time |
| `test_sandbox_connections.py` (3 updated, 1 new) | address, credential and a probe that could not connect each answer `fields` with the message they were refused with — and a 404 on the probe is a wrong address, not a lost session |
| `test_mcp_connections.py` (5) · `api/test_mcp_connection_url_refusal.py` (4) | through the app: the field is named and neither `hunter2` nor a secret parked in the port is in the body |
| `api/test_error_envelope.py` | an endpoint with a password answers `base_url` and repeats nothing of it |
| `api/test_agent_spec_import_refusal.py` (3, updated) | all three YAML branches answer one shape, and the position is in the sentence: `line 2, column 14` |
| `test_untrusted_remote_names.py` (3, updated) | the sync refusals name no field, and the hostile folder id is not echoed |
| `test_skills.py`, `test_agent_registry.py` | a 409 carries the taken value and no field |
| `api-error.test.ts` — new describe (4) | `fieldProblems` and `submitFailure` resolve `base_url`, `url` and `yaml` from bodies copied out of the backend tests, with no toast repeating them |
| `add-model.integration.test.tsx` — new (3) | **the highlight**: `aria-invalid="true"` on Endpoint with the server's sentence as its accessible description; cleared on the next keystroke; a refusal naming no field left where it was |
| `connection-dialog.test.tsx` — new (4) | the address marked and the name not; a duplicate marked once, on the name; both cleared on the next keystroke |

## Verified

```
make lint                exit 0
make test                5718 passed, 15 skipped — coverage 100.00% (required 100.0%)
make test-frontend-cov   Statements 100% (8203/8203) · Branches 97.64% (6087/6234)
                         Functions 100% (2642/2642) · Lines 100% (7318/7318)
make build-frontend      exit 0
make docs-build          exit 0
make audit               CLEAN — no advisories against 254 locked dependencies
python3 scripts/docs_drift.py   no drift
```

**`make db-check` is red locally, and not from this change.** The dev database
is stamped at `0040_trigger_fire_in_flight`, a revision in no commit in this
repository — somebody's local branch. No model changed here, so there is nothing
for `alembic check` to find against the fresh database CI builds.

Docs: `docs/architecture.md`'s "A refusal that names a field" section gains the
third entry point and, at the end, the two kinds of refusal that deliberately
name none.

## Found and not fixed

`_validate_model_id` answers `details={"model": model}` — the caller's own
submission, serialized into the body and logged beside it, which
`.claude/rules/exceptions-security.md` refuses — and names a field in a shape no
form reads. Two neighbours in the same function answer `{"provider": provider}`
for refusals that are about `base_url` and `secret_id`. All three are **#898**;
none carried a `field` key, so none is in this change's sweep.

Closes #891
Refs #882, #897, #898


---

## Second commit — `adef5950`, from reviewing the first

Reviewing my own diff found the thing this PR exists to prevent, in the one file
that would have caused it again:

- **`.claude/rules/exceptions-security.md` still taught `{"field": "base_url"}`**
  as the way to name a URL a refusal is about, and never mentioned
  `field_errors.py` at all. It is the file an author reads before writing an
  exception in `core/` or `services/`, so as written it instructed call site
  nineteen to reproduce #891 exactly — the way `assistant.py`, `UserRole` and
  `CHANNEL_ENCRYPTION_KEY` outlived their code. It now carries the three entry
  points and the rule that decides between them. `docs/patterns.md` held the
  same sentence verbatim.
- **A 404 no longer marks an address about a session nobody asked for.** The
  404 is the one failure `_get_json`'s two callers do not share — a session that
  ended, against a service with no such endpoint — so giving the probe
  `field="base_url"` put *"Sandbox session not found"* under the operator's
  Address box. The sentence is the caller's now, and the probe's says what a
  wrong address looks like. New test.
- **Two comments claimed the opposite of what the code does**, both about
  agenticos#342: `field_details` copies the whole message into `details` and
  every `_get_json` message interpolates the address, so `details` does now carry
  it. That is safe for the reason the tests already assert and not the one the
  comments gave — `SandboxProbeRequest` refuses a `user:pass@` address at the
  schema.
- `field_details`' docstring named a rule its own caller already broke; two
  wordings in `docs/architecture.md` were wrong (`refused_field` returns rather
  than raises; "two refusals" is two *kinds*); the Drive comment was four lines
  explaining an absence documented twice elsewhere; `NO_FAILURE` was duplicated
  in both forms and now lives beside `SubmitFailure`; `_yaml_refusal` wrote its
  sentence twice.

Re-verified end to end: `make lint` 0 · `make test` 5719 passed, coverage
100.00% · `make test-frontend-cov` 100/97.64/100/100 · `make build-frontend` 0 ·
`make docs-build` 0 · no docs drift.
