### PR TITLE
fix(api): make the storage-root check a barrier the query applies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,31 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+### Fixed
+
+- **The storage-root check is a barrier the query actually applies.** 0.0.184
+  rewrote it into the `realpath` + `startswith` idiom `py/path-injection` models
+  and closed one of the three alerts it claimed; #14 and #15, both sinks in
+  `LocalFileStorage.load`, survived on `main` for thirteen releases. The idiom
+  was right and the *shape* was wrong: the query clears a normalised path only
+  where the `startswith` call alone decides the branch, and the check was written
+  `if candidate != base and not candidate.startswith(prefix)`. Falling through
+  `A and B` proves neither conjunct, so the guard never applied. The root is
+  answered in its own branch above, leaving `startswith` as the whole condition
+  of its own — same refusals, same message, same tests. Established by running
+  CodeQL 2.26.3 with `codeql/python-queries` over this tree rather than by
+  predicting it: two results before, none after. (#903)
+- **What 0.0.184 claimed about those alerts is corrected in its own entry**, so a
+  reader who goes looking there finds what happened rather than the claim. (#903)
+
+### Added
+
+- **A test that fails if the containment check stops being one condition.** It
+  reads `_resolve_safe_path`'s AST and asserts the `startswith` call is the whole
+  test of its branch — the property 0.0.184 lost, which every behavioural test in
+  the file passed straight through. It pins the shape; only CodeQL answers the
+  verdict, and the pull request's own scan is where that is read. (#903)
+
 ## [0.0.197] - 2026-08-18
 
 The `e2e` job stopped stalling for twenty-five minutes on an apt mirror.
@@ -406,10 +431,13 @@ Three places where the code said something about itself that was not true.
 
 ### Fixed
 
-- **The storage-root check is written so a static analyser can follow it**, which
-  is what closes three CodeQL `py/path-injection` alerts — a `Path.parents`
-  membership test is correct and invisible to the query, and an alert nobody can
-  close is an alert everybody learns to ignore. (#841)
+- **The storage-root check is written so a static analyser can follow it** — a
+  `Path.parents` membership test is correct and invisible to the query, and an
+  alert nobody can close is an alert everybody learns to ignore. (#841)
+  **Correction:** this said it closed three CodeQL `py/path-injection` alerts. It
+  closed one. #14 and #15 stayed open on `main` because the check was written as
+  a conjunction, which is not a shape the query accepts as a barrier; see
+  Unreleased and (#903).
 - **A filesystem root can be the storage root again.** The rewritten check built
   its prefix as `base + os.sep` unconditionally, so with `MEDIA_DIR=/` the prefix
   was `//` — which nothing under `/` starts with. `load`, `delete` and

--- a/backend/app/services/file_storage.py
+++ b/backend/app/services/file_storage.py
@@ -125,13 +125,22 @@ class LocalFileStorage(BaseFileStorage):
         rather than a `Path.parents` membership test: both refuse the same paths,
         but only the first is a barrier static analysis recognises, so the second
         read as an unguarded path expression (CodeQL `py/path-injection`).
+
+        It has to be the *whole* condition of its branch, which is why the root
+        itself is answered before it rather than beside it. `py/path-injection`
+        clears a normalised path where `startswith` alone decides the branch;
+        written as `candidate != base and not candidate.startswith(prefix)`, the
+        fall-through proves neither conjunct, so the guard stopped counting and
+        both sinks in `load` stayed flagged (#903).
         """
         base = os.path.realpath(self.base_dir)
+        candidate = os.path.realpath(Path(base) / storage_path)
+        if candidate == base:
+            return Path(base)
         # A filesystem root already ends in the separator, and `/` + `/` is a prefix
         # no descendant of it has.
         prefix = base if base.endswith(os.sep) else base + os.sep
-        candidate = os.path.realpath(Path(base) / storage_path)
-        if candidate != base and not candidate.startswith(prefix):
+        if not candidate.startswith(prefix):
             raise ValueError(f"Path escapes storage root: {storage_path}")
         return Path(candidate)
 

--- a/backend/tests/test_file_storage.py
+++ b/backend/tests/test_file_storage.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import ast
+import inspect
 import os
+import textwrap
 from pathlib import Path
 
 import pytest
@@ -62,3 +65,35 @@ async def test_a_sibling_of_the_root_sharing_its_prefix_is_refused(storage: Loca
 
     with pytest.raises(ValueError, match="escapes storage root"):
         await storage.load(f"../{sibling.name}/secrets.env")
+
+
+async def test_the_storage_root_itself_resolves_to_the_storage_root(storage: LocalFileStorage):
+    """An empty path names the root, which is inside itself and not an escape."""
+    assert storage.get_full_path("") == storage.base_dir.resolve()
+
+
+def test_the_containment_check_is_the_whole_condition_of_its_branch():
+    """What `py/path-injection` accepts as a barrier, and what #903 was.
+
+    The query clears a normalised path only where the `startswith` call alone
+    decides the branch. `candidate != base and not candidate.startswith(prefix)`
+    refuses exactly the same paths and reads to a person as the same guard, but
+    its fall-through proves neither conjunct, so the barrier never applied and
+    both sinks in `load` stayed flagged through a release that said otherwise.
+
+    This pins the shape, not the verdict - only CodeQL answers the verdict.
+    """
+    source = textwrap.dedent(inspect.getsource(LocalFileStorage._resolve_safe_path))
+    branches = [
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.If) and "startswith" in ast.dump(node.test)
+    ]
+
+    assert len(branches) == 1
+    test = branches[0].test
+    if isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not):
+        test = test.operand
+    assert isinstance(test, ast.Call)
+    assert isinstance(test.func, ast.Attribute)
+    assert test.func.attr == "startswith"


### PR DESCRIPTION
Alerts **#14** and **#15** — `file_path.exists()` and `file_path.read_bytes()` in `LocalFileStorage.load` — have been open on `main` since v0.0.184 said they were closed.

## What the query actually objects to

Not the idiom. #841 was right that `Path.resolve()` is a filesystem access to CodeQL and `base in candidate.parents` is not a sanitiser it knows, and moving to `os.path.realpath` + `startswith` is exactly the shape `py/path-injection` models. That part worked: alert #13 closed.

It was the **shape of the branch**. The query runs two flow states — a source is `NotNormalized`, `os.path.realpath` moves it to `NormalizedUnchecked`, and only a `Path::SafeAccessCheck` clears it from there. The one that applies here is:

```ql
private class StartswithCall extends Path::SafeAccessCheck::Range {
  StartswithCall() { this.(CallNode).getFunction().(AttrNode).getName() = "startswith" }

  override predicate checks(ControlFlowNode node, boolean branch) {
    node = this.(CallNode).getFunction().(AttrNode).getObject() and
    branch = true
  }
}
```

It sanitises its own object, and only where the call decides the branch. The check was written

```python
if candidate != base and not candidate.startswith(prefix):
    raise ValueError(...)
return Path(candidate)
```

and falling through `A and B` proves neither conjunct — `candidate == base` is enough to reach the `return` with `startswith` never having been true. So the barrier never applied, the taint carried on through `Path(candidate)`, and both sinks in `load` stayed flagged. A person reads that line as one guard; the query does not.

## How I established it, rather than predicting it

Three independent pieces, because a second guess was the one thing this issue could not afford:

1. **The SARIF for the analysis on `main`** (`code-scanning/analyses/1633754456`, the run on `c178fbdf`) names the whole flow, not just the sink: `generated_media.py:24` (the `filename` path parameter) → `services/generated_media.py:90` → `file_storage.py:147/148` → into `_resolve_safe_path` at 121 → `realpath` at 133 → `Path()` at 136 → back out to 149 / 151. The flow walks *through* the guard, which is the answer.

2. **CodeQL run locally**, CLI **2.26.3** with `codeql/python-queries` **1.8.8** — the same version CI's default setup runs — over a database built from `backend/`:

   | tree | `Security/CWE-022/PathInjection.ql` |
   |---|---|
   | `main` as it stands | **2 results** — `file_storage.py:149`, `file_storage.py:151` |
   | conjunct removed, nothing else changed | **0 results** |
   | this branch | **0 results** |

   The middle row is the control: it isolates the conjunct as the cause, rather than the sink kinds, the `Path(candidate)` conversion, or the interprocedural hop the issue also asked about.

3. **The clue from the issue resolves to something else entirely.** `delete()` and `get_full_path()` are not flagged for a reason unrelated to the barrier — no tainted source reaches them. `load()` is the only one of the three called with a value from a path parameter. `exists()` *is* a sink; it is a sink in `get_full_path` too, and sits there unflagged for want of a source.

## The change

```python
base = os.path.realpath(self.base_dir)
candidate = os.path.realpath(Path(base) / storage_path)
if candidate == base:
    return Path(base)
prefix = base if base.endswith(os.sep) else base + os.sep
if not candidate.startswith(prefix):
    raise ValueError(f"Path escapes storage root: {storage_path}")
return Path(candidate)
```

The root case is answered in a branch above, leaving `startswith` as the whole condition of its own. Same refusals, same `ValueError`, same message. The `not` is fine — the control run in the table above keeps it and reports zero.

## Tests

`test_the_containment_check_is_the_whole_condition_of_its_branch` reads `_resolve_safe_path`'s AST and asserts the `startswith` call is the entire test of its `if`. That is the property v0.0.184 lost, and every behavioural test in the file passed straight through the loss of it — which is the whole reason this issue exists.

It pins the **shape, not the verdict**, and that limit is worth stating plainly: no unit test can tell you what CodeQL accepts. A future CodeQL release could stop clearing this shape with the file untouched and the suite would stay green. The scan is the only thing that answers that, and this PR's own run is where it is read.

`test_the_storage_root_itself_resolves_to_the_storage_root` covers the branch that was previously the conjunct, so the equality case is no longer untested.

## Correcting the record

The v0.0.184 CHANGELOG entry stated the three-alert claim as fact. Its bullet now carries the correction inline — what it closed, what it did not, and why — because that is where a reader goes looking. The Unreleased entry says what actually happened and how it was established.

## Verified

- `make test` — 5727 passed, 15 skipped, 100% on the platform layer.
- `make lint-backend` — clean.
- `backend/tests/test_file_storage.py` — 6 tests, filesystem-root and sibling-prefix cases included, none changed, all passing.
- `python3 scripts/docs_drift.py` — nothing owed; `file_storage.py` is not on the trigger map and no described behaviour changed.

Not verified: whether GitHub's own analysis agrees with the local one. It should — same CLI version, same pack, same query — but this PR's `python` scan is the evidence that counts, and it touches `file_storage.py` so the diff-informed run will actually look at it.

Closes #903
