### PR TITLE
chore: cut 0.0.199

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -465,8 +465,8 @@ Three places where the code said something about itself that was not true.
   alert nobody can close is an alert everybody learns to ignore. (#841)
   **Correction:** this said it closed three CodeQL `py/path-injection` alerts. It
   closed one. #14 and #15 stayed open on `main` because the check was written as
-  a conjunction, which is not a shape the query accepts as a barrier; see
-  Unreleased and (#903).
+  a conjunction, which is not a shape the query accepts as a barrier; fixed in
+  0.0.199 (#903).
 - **A filesystem root can be the storage root again.** The rewritten check built
   its prefix as `base + os.sep` unconditionally, so with `MEDIA_DIR=/` the prefix
   was `//` — which nothing under `/` starts with. `load`, `delete` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.199] - 2026-08-18
+
 ### Fixed
 
 - **The storage-root check is a barrier the query actually applies.** 0.0.184

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.198"
+version = "0.0.199"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.198"
+version = "0.0.199"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.198",
+  "version": "0.0.199",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.199. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json` to 0.0.199 and adds the CHANGELOG entry.

Releases the storage-root check written so the query actually applies its barrier (#905, closing #903), and the correction of what 0.0.184 claimed about it.

0.0.184 said it closed three `py/path-injection` alerts and closed one; two survived on `main` for thirteen releases. The idiom it introduced was right and the *shape* was wrong: the query clears a normalised path only where the `startswith` call alone decides the branch, and the check was a conjunction — falling through `A and B` proves neither half, so the barrier never applied. A person reads it as one guard; the query does not.

Established by running CodeQL 2.26.3 with `codeql/python-queries` over the tree rather than by predicting it — two results before, none after, with a control run isolating the conjunct as the cause. That matters because 0.0.184 *did* predict, and named the wrong survivor.

## Verified

CI green on #905, no review findings. `make test` 5727 passed at 100% platform coverage. The new test reads the guard's AST and fails if the containment check stops being one condition — it pins the shape; only CodeQL answers the verdict.