### PR TITLE
chore: cut 0.0.200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,27 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.200] - 2026-08-18
+
+### Fixed
+
+- **A refused model id is no longer posted back.** `details` is serialized into
+  the response body *and* written to the log line beside it, so refusing a bare
+  OpenRouter id sent the caller's own submission into the deployment's logs. It
+  names the `model` field now and the id is gone. (#898)
+- **Two provider refusals name the input they are about.** "This provider is
+  keyless so it needs an endpoint" and "this provider needs a key" both answered
+  with the provider, which is neither `base_url` nor `secret_id` — so the sentence
+  arrived with nothing marked. (#898)
+- **A stale key refusal is cleared when the key changes.** Both routes to a new
+  key only set the value, so the sentence survived under a key the reader had
+  already replaced — a refusal that accuses the current value is worse than
+  none. (#898)
+- **The mark and its reason are associated.** The model combobox announced
+  "invalid" to a screen reader and never why; it goes through the same
+  `FormField` the endpoint already used, so the bespoke `invalid` prop that would
+  have been a second convention is gone. (#898)
+
 ## [0.0.199] - 2026-08-18
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.199"
+version = "0.0.200"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.199"
+version = "0.0.200"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.199",
+  "version": "0.0.200",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.200. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json` to 0.0.200 and adds the CHANGELOG entry.

Releases a refused model id kept out of the response body and the log line (#901, closing #898), two provider refusals naming the input they are actually about, and the two halves of a mark the review round showed were missing: clearing it when the value changes, and associating it with its reason.

Worth recording from the reconciliation with #891: that branch's test `leaves a refusal that names no field where it always was` asserted on the exact body this change deletes, so it would have survived the merge pinning a state that no longer exists. It now uses a 403, which genuinely names no field.

## Verified

CI green on #901 after the review round and the merge with #891. `make test` 5728 passed at 100% platform coverage; `make test-frontend-cov` 100% statements/functions/lines, 97.64% branches.