### PR TITLE
test: cover the resume catch by normalizing sessionStorage

### DIFF
--- a/frontend/src/lib/onboarding/resume.test.ts
+++ b/frontend/src/lib/onboarding/resume.test.ts
@@ -60,14 +60,21 @@ describe("stashFlow / takeStashedFlow", () => {
   it("survives storage refusing to hold it", () => {
     // Private mode, or a full quota. Losing the walk is what already happened
     // without this; it must not also break the navigation that was under way.
-    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+    // Spy the instance, not `Storage.prototype`: on a Node that ships its own
+    // storage the two are different objects. Asserting nothing was stored fails
+    // a spy that missed, where asserting only "did not throw" would not.
+    vi.spyOn(sessionStorage, "setItem").mockImplementation(() => {
       throw new Error("QuotaExceededError");
     });
     expect(() => stashFlow(RUNNING)).not.toThrow();
+    expect(takeStashedFlow()).toBeNull();
   });
 
   it("survives storage refusing to be read", () => {
-    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+    // A real flow is present, so a missed spy would return it rather than null -
+    // which is what let this `catch` read as covered while never running (#915).
+    stashFlow(RUNNING);
+    vi.spyOn(sessionStorage, "getItem").mockImplementation(() => {
       throw new Error("SecurityError");
     });
     expect(takeStashedFlow()).toBeNull();

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -58,9 +58,10 @@ vi.mock("next/navigation", () => ({
   permanentRedirect: vi.fn(),
 }));
 
-// Node 22+ ships a built-in localStorage that is disabled (undefined) without
-// --localstorage-file and shadows jsdom's, breaking zustand persist. Provide one.
-class LocalStorageMock {
+// Node 22+ ships built-in localStorage and sessionStorage that are disabled
+// (undefined) without --localstorage-file and shadow jsdom's, breaking zustand
+// persist and the onboarding resume stash. Provide both.
+class StorageMock {
   private store = new Map<string, string>();
   get length(): number {
     return this.store.size;
@@ -81,16 +82,23 @@ class LocalStorageMock {
     return Array.from(this.store.keys())[index] ?? null;
   }
 }
-Object.defineProperty(globalThis, "localStorage", {
-  configurable: true,
-  writable: true,
-  value: new LocalStorageMock(),
-});
+for (const name of ["localStorage", "sessionStorage"] as const) {
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    writable: true,
+    value: new StorageMock(),
+  });
+}
 if (inBrowser) {
   Object.defineProperty(window, "localStorage", {
     configurable: true,
     writable: true,
     value: globalThis.localStorage,
+  });
+  Object.defineProperty(window, "sessionStorage", {
+    configurable: true,
+    writable: true,
+    value: globalThis.sessionStorage,
   });
 
   // Mock matchMedia for responsive components


### PR DESCRIPTION
## Summary

`make test-frontend-cov` was red on Node 26 while the CI `test-frontend` job stayed green: `resume.ts:45`, the `catch` in `takeStashedFlow`, reported uncovered.

Node 22+ ships a built-in `sessionStorage` (enabled on v26.3.0) that shadows jsdom's, so `vi.spyOn(Storage.prototype, "getItem")` patched a different object than the code reached — `getItem` never threw, the test passed through the `raw === null` early return, and the `catch` never ran. Both throw-path tests asserted the same observable (`null`) on the throw and no-throw paths, which let the miss stay silent.

## Changed

- `vitest.setup.ts` normalizes `sessionStorage` the way it already did `localStorage` (generalized `LocalStorageMock` → `StorageMock`, installed for both on `globalThis` and `window`).
- Both throw-path tests in `resume.test.ts` now spy the instance the code reaches and assert an outcome only the `catch` produces — a stashed flow that comes back `null`, a write that left nothing stored — so a spy that misses fails loudly instead of silently uncovering the branch.

No product code changed.

## Testing

- `bun run test:coverage` passes in full (Statements/Functions/Lines 100%, Branches 97.64%), `resume.ts` at 100%.
- Removing the `catch` fails "survives storage refusing to be read" — the miss is no longer silent.

Closes #915
