### PR TITLE
chore: cut 0.0.202

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,26 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.202] - 2026-08-19
+
+One test-only release: a `catch` the frontend suite reported as covered had
+never run.
+
+### Fixed
+
+- **The onboarding resume stash is tested against the storage the code reaches.**
+  Node 22+ ships its own `sessionStorage` — enabled on v26.3.0 — which shadows
+  jsdom's, so `vi.spyOn(Storage.prototype, "getItem")` patched a different object
+  than `takeStashedFlow` called: `getItem` never threw, the test passed through
+  the `raw === null` early return, and the `catch` at `resume.ts:45` never ran.
+  It read as covered in CI and as uncovered under `make test-frontend-cov` on a
+  newer Node. `vitest.setup.ts` now normalizes `sessionStorage` the way it already
+  did `localStorage` (one `StorageMock`, installed on both `globalThis` and
+  `window`), and both throw-path tests spy the instance and assert an outcome only
+  the `catch` produces — a stashed flow that comes back `null`, a write that left
+  nothing stored — so a spy that misses fails loudly instead of silently
+  uncovering the branch. No product code changed. (#919)
+
 ## [0.0.201] - 2026-08-19
 
 An agent is configured in one place, a deployment can brand and close itself,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.201"
+version = "0.0.202"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.201"
+version = "0.0.202"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.201",
+  "version": "0.0.202",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.202. Bumps `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json` to 0.0.202 and adds the CHANGELOG entry.

One change since 0.0.201, and it is test-only. The `catch` at `resume.ts:45` had
never run despite reading as covered: Node 22+ ships its own `sessionStorage` —
enabled on v26.3.0 — which shadows jsdom's, so
`vi.spyOn(Storage.prototype, "getItem")` patched an object the code did not
reach. `getItem` never threw, the test passed through the `raw === null` early
return, and the branch read as covered in CI and uncovered under
`make test-frontend-cov` on a newer Node. `vitest.setup.ts` now normalizes
`sessionStorage` the way it already did `localStorage`, and both throw-path tests
spy the instance and assert an outcome only the `catch` produces, so a spy that
misses fails loudly. No product code changed.

## Verified

`make lint` and `make test-frontend-cov` locally: 100%
statements/functions/lines, 97.67% branches, `resume.ts` at 100%. The backend
suite is untouched by this release and was green on #919, where CI skipped the
`test` job because no backend path changed.

Refs #919
