### PR TITLE
chore: cut 0.0.203

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,34 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.203] - 2026-08-19
+
+A Member could pay for a collection's embeddings with another member's private
+key by supplying its id.
+
+### Fixed
+
+- **Binding an embedding key checks that the chooser can see it.**
+  `KnowledgeBaseService._check_embedding_secret` looked the chosen key up scoped
+  only to the organization and never ran the caller's own secret-view check, so a
+  Member with `collections:edit` who supplied the UUID of another member's
+  **private** vault key bound a key `secrets:view` would have refused them — and
+  the collection's embeddings then billed it, for everyone who can write the
+  collection. The picker only ever offered keys the chooser can see, which is not
+  a check: the API takes an id and an id is guessable. The fetched row now goes
+  through `resolve_access(..., Perm.SECRETS_VIEW, resource_type=SECRET)`, exactly
+  as the agent secret bindings already did, and a key the caller cannot view is
+  refused as one the vault does not hold — so the refusal cannot enumerate
+  somebody else's private secrets. Creation is the only path that binds one:
+  `KnowledgeBaseUpdate` carries no `embedding_secret_id`. (#918)
+
+### Changed
+
+- **`docs/file-processing.md` says binding needs `secrets:view`**, and why —
+  binding a key is lending it. The page listed the two refusals creation already
+  made, another organization's key and the wrong purpose, so a reader acting on it
+  would have expected `collections:edit` alone to be enough. (#918)
+
 ## [0.0.202] - 2026-08-19
 
 One test-only release: a `catch` the frontend suite reported as covered had

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.202"
+version = "0.0.203"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.202"
+version = "0.0.203"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.202",
+  "version": "0.0.203",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.203. Bumps `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json` to 0.0.203 and adds the CHANGELOG entry.

One fix, and it is an isolation failure rather than a bug in the happy path.
`KnowledgeBaseService._check_embedding_secret` looked the chosen embedding key up
scoped only to the organization and never ran the caller's own secret-view check,
so a Member with `collections:edit` who supplied the UUID of another member's
**private** vault key bound a key `secrets:view` would have refused them — and the
collection's embeddings then billed it, for everyone who can write the collection.
The picker only ever offered keys the chooser can see, which is not a check: the
API takes an id and an id is guessable.

The docs half shipped with it: `docs/file-processing.md` listed the two refusals
creation already made — another organization's key, the wrong purpose — so a
reader acting on that page would have expected `collections:edit` alone to be
enough to bind a key.

## Verified

`make lint` and `make test` locally: 6111 passed, 15 skipped, 100% on the platform
layer. CI green on #918 end to end — `test`, `e2e`, `lint`, `docs` and all three
CodeQL analyses — after `main` was merged into the branch, so those jobs answered
about this tree rather than a four-commit older one. `make test-frontend-cov` was
not re-run for this release: no frontend path changed since 0.0.202, where it was
green.

Refs #918
