### PR TITLE
fix(rag): count the status the pipeline writes, not one nothing writes

### DIFF
--- a/backend/app/db/models/rag_document.py
+++ b/backend/app/db/models/rag_document.py
@@ -1,5 +1,6 @@
 """RAGDocument model - tracks documents ingested into RAG collections."""
 
+import enum
 import uuid
 from datetime import datetime
 
@@ -9,6 +10,22 @@ from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base, TimestampMixin
+
+
+class DocumentStatus(enum.StrEnum):
+    """Where a tracked document is in its ingestion.
+
+    Three values, and the column holds nothing else: a row is created
+    `PROCESSING` by the upload, and the pipeline moves it to `DONE` or `ERROR`.
+    It is an enum because it was not one - the listing's `indexed` count
+    filtered on a fourth value, `"completed"`, that nothing has ever written, so
+    every knowledge base in the product reported `indexed_count: 0` however many
+    documents had finished (#148).
+    """
+
+    PROCESSING = "processing"
+    DONE = "done"
+    ERROR = "error"
 
 
 class RAGDocument(TimestampMixin, Base):
@@ -24,7 +41,9 @@ class RAGDocument(TimestampMixin, Base):
     filesize: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     filetype: Mapped[str] = mapped_column(String(20), nullable=False)
     storage_path: Mapped[str | None] = mapped_column(String(500), nullable=True)
-    status: Mapped[str] = mapped_column(String(20), nullable=False, default="processing")
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, default=DocumentStatus.PROCESSING
+    )
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
     vector_document_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
     chunk_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)

--- a/backend/app/repositories/rag_document.py
+++ b/backend/app/repositories/rag_document.py
@@ -11,7 +11,7 @@ from sqlalchemy import delete as sql_delete
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.db.models.rag_document import RAGDocument
+from app.db.models.rag_document import DocumentStatus, RAGDocument
 
 
 @dataclass(frozen=True)
@@ -84,7 +84,7 @@ async def create(
     filesize: int,
     filetype: str,
     storage_path: str,
-    status: str = "processing",
+    status: DocumentStatus = DocumentStatus.PROCESSING,
     organization_id: UUID | None = None,
     knowledge_base_id: UUID | None = None,
     ingestion_config: dict[str, object] | None = None,
@@ -116,7 +116,7 @@ async def update_status(
     db: AsyncSession,
     doc_id: UUID,
     *,
-    status: str,
+    status: DocumentStatus,
     error_message: str | None = None,
     vector_document_id: str | None = None,
     chunk_count: int | None = None,
@@ -200,7 +200,7 @@ async def counts_by_collection(
             RAGDocument.collection_name,
             func.count(),
             func.coalesce(func.sum(RAGDocument.chunk_count), 0),
-            func.count().filter(RAGDocument.status == "completed"),
+            func.count().filter(RAGDocument.status == DocumentStatus.DONE),
         )
         .where(RAGDocument.collection_name.in_(collections))
         .group_by(RAGDocument.collection_name)

--- a/backend/app/services/rag_document.py
+++ b/backend/app/services/rag_document.py
@@ -14,7 +14,7 @@ from app.core.config import settings
 from app.core.exceptions import BadRequestError, NotFoundError
 from app.core.permissions import AuthContext
 from app.db.models.knowledge_base import KnowledgeBase
-from app.db.models.rag_document import RAGDocument
+from app.db.models.rag_document import DocumentStatus, RAGDocument
 from app.services.rag.config import get_supported_formats
 from app.services.rag.documents import has_indexable_text
 from app.services.rag.vectorstore import BaseVectorStore
@@ -243,7 +243,7 @@ class RAGDocumentService:
 
         return RAGIngestResponse(
             id=str(doc_id),
-            status="processing",
+            status=DocumentStatus.PROCESSING,
             filename=filename,
             collection=collection_name,
             message="File accepted. Processing in background.",
@@ -311,7 +311,7 @@ class RAGDocumentService:
         await rag_document_repo.update_status(
             self.db,
             doc.id,
-            status="done",
+            status=DocumentStatus.DONE,
             vector_document_id=vector_document_id,
             chunk_count=chunk_count,
             completed_at=datetime.now(UTC),
@@ -360,7 +360,7 @@ class RAGDocumentService:
         await rag_document_repo.update_status(
             self.db,
             doc.id,
-            status="error",
+            status=DocumentStatus.ERROR,
             error_message=error_message,
             completed_at=datetime.now(UTC),
         )
@@ -386,7 +386,7 @@ class RAGDocumentService:
                 before uploads kept their file and so has nothing to re-read.
         """
         doc = await self.get_document(doc_id)
-        if doc.status != "error":
+        if doc.status != DocumentStatus.ERROR:
             raise BadRequestError(
                 message="Only failed documents can be retried",
                 details={"doc_id": doc_id, "status": doc.status},
@@ -400,7 +400,7 @@ class RAGDocumentService:
         updated = await rag_document_repo.update_status(
             self.db,
             doc.id,
-            status="processing",
+            status=DocumentStatus.PROCESSING,
             error_message="",
             completed_at=None,
         )
@@ -470,7 +470,7 @@ class RAGDocumentService:
                 parsed content to show.
         """
         doc = await self.get_document(doc_id)
-        if doc.status != "done" or not doc.vector_document_id:
+        if doc.status != DocumentStatus.DONE or not doc.vector_document_id:
             raise NotFoundError(
                 message="No parsed content for this document",
                 details={"doc_id": doc_id, "status": doc.status},

--- a/backend/tests/integration/test_platform_flows.py
+++ b/backend/tests/integration/test_platform_flows.py
@@ -55,7 +55,7 @@ from app.db.models.knowledge_base import KBScope, KnowledgeBase
 from app.db.models.mcp_connection import McpConnection
 from app.db.models.organization import Organization, OrganizationMember
 from app.db.models.organization_secret import OrganizationSecret
-from app.db.models.rag_document import RAGDocument
+from app.db.models.rag_document import DocumentStatus, RAGDocument
 from app.db.models.resource_grant import GrantLevel, Visibility
 from app.db.models.skill import Skill
 from app.db.models.sync_log import SyncLog
@@ -533,7 +533,7 @@ async def _rag_document(db, *, collection_name: str, filename: str) -> RAGDocume
         filename=filename,
         filesize=12,
         filetype="txt",
-        status="done",
+        status=DocumentStatus.DONE,
         vector_document_id=str(uuid.uuid4()),
     )
     db.add(doc)
@@ -1739,24 +1739,30 @@ class TestWhatACollectionReportsItHolds:
 
         assert collection.collection_name not in counts
 
-    async def test_only_completed_documents_count_as_indexed(self, db) -> None:
+    async def test_only_finished_documents_count_as_indexed(self, db) -> None:
         """A failed upload stays in `documents` and drops out of `indexed`.
 
         This is what makes a half-broken collection legible on a listing: the
         two numbers disagreeing is the only signal that something died, since
         the vectors it never wrote leave no trace anywhere else.
+
+        The statuses are `DocumentStatus` members rather than strings, and that
+        is the whole of #148: this test used to set `"completed"` and
+        `"failed"`, neither of which anything in the product writes, so it
+        agreed with the query instead of with the pipeline and passed while
+        every knowledge base reported `indexed_count: 0`.
         """
         tenant = await _tenant(db, name="Partial")
         collection = await _collection_with(db, tenant, name="partial", config=IngestionConfig())
         done = await _rag_document(
             db, collection_name=collection.collection_name, filename="ok.txt"
         )
-        done.status = "completed"
+        done.status = DocumentStatus.DONE
         done.chunk_count = 7
         broken = await _rag_document(
             db, collection_name=collection.collection_name, filename="dead.txt"
         )
-        broken.status = "failed"
+        broken.status = DocumentStatus.ERROR
         broken.chunk_count = 0
         await db.flush()
 
@@ -1767,6 +1773,38 @@ class TestWhatACollectionReportsItHolds:
         assert counts[collection.collection_name].documents == 2
         assert counts[collection.collection_name].indexed == 1
         assert counts[collection.collection_name].chunks == 7
+
+    async def test_the_pipeline_marking_a_document_done_makes_it_count_as_indexed(self, db) -> None:
+        """The writer and the reader, in one test, with no status written by hand.
+
+        `complete_ingestion` is the only thing that finishes a document, and
+        `counts_by_collection` is what the listing reads - so a filter on a
+        value the pipeline does not write can only be caught by running both.
+        Nothing here names a status literal, which is the point: the two agree
+        or this fails.
+        """
+        tenant = await _tenant(db, name="Finished")
+        collection = await _collection_with(db, tenant, name="finished", config=IngestionConfig())
+        doc = await _rag_document(
+            db, collection_name=collection.collection_name, filename="handbook.md"
+        )
+        doc.status = DocumentStatus.PROCESSING
+        await db.flush()
+
+        await RAGDocumentService(db).complete_ingestion(
+            str(doc.id),
+            vector_document_id=doc.vector_document_id,
+            chunk_count=4,
+            replaced_document_id=None,
+        )
+
+        counts = await rag_document_repo.counts_by_collection(
+            db, collections=[collection.collection_name]
+        )
+
+        assert counts[collection.collection_name].documents == 1
+        assert counts[collection.collection_name].indexed == 1
+        assert counts[collection.collection_name].chunks == 4
 
     async def test_re_ingesting_a_document_does_not_count_it_twice(self, db) -> None:
         """The vector store keeps one document; `rag_documents` gained a second row.

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -524,7 +524,7 @@ Ingested documents are tracked in the SQL database via the `RAGDocument` model:
 | `filename` | Original filename |
 | `filesize` | File size in bytes |
 | `filetype` | File extension (without dot) |
-| `status` | `processing`, `done`, or `error` |
+| `status` | `processing`, `done`, or `error` — the `DocumentStatus` members, and the only three values the column holds. A collection's *indexed* count filters on `done`; it filtered on a fourth value nothing has ever written until [#148](https://github.com/vstorm-co/agenticos/issues/148), so every knowledge base reported `indexed_count: 0` however many documents had finished |
 | `error_message` | What failed, if `status` is `error` — see below |
 | `vector_document_id` | ID in the vector store |
 | `chunk_count` | Number of chunks created. Recorded since [#147](https://github.com/vstorm-co/agenticos/issues/147); a document ingested before it holds `0` and its collection's card under-reports until it is re-ingested |


### PR DESCRIPTION
`indexed_count` was `0` on every knowledge base in the product, however many
documents had finished ingesting.

## What was wrong

The listing's aggregation filtered on a status value nothing writes —
`repositories/rag_document.py:203`:

```python
func.count().filter(RAGDocument.status == "completed"),
```

The pipeline writes `processing`, `done` and `error`, which is what the model
default, `docs/file-processing.md` and the frontend's `rag-status.ts` all say.
The `FILTER` clause therefore could not match a row: `documents` and `indexed`
disagreed on every collection, and a collection where everything succeeded read
as entirely unindexed.

## What changed

The literal is now an enum. `DocumentStatus` lives beside the column in
`app/db/models/rag_document.py` — the shape `RunStatus`, `AgentStatus` and
`InvitationStatus` already take — and the writer (`RAGDocumentService`) and the
reader (`counts_by_collection`) name the same member rather than two strings
that were free to drift. `create` and `update_status` take `DocumentStatus`
instead of `str`, so the next typo is a type error rather than a count that
silently reports nothing.

`docs/file-processing.md`'s status row now says the three values are the
`DocumentStatus` members and that the indexed count filters on `done`.

## Why it survived

The test that asserted this behaviour set the statuses by hand, and it set
`"completed"` and `"failed"` — neither of which anything in the product writes.
It agreed with the query instead of with the pipeline, so it passed for as long
as the bug existed.

It now sets `DocumentStatus` members, and a second test names no status at all:
it runs `complete_ingestion` and then reads `counts_by_collection`, so the writer
and the reader have to agree or it fails. Both fail against the old filter —
verified by putting `"completed"` back and re-running (`2 failed, 4 passed`).

## Verified

- `tests/integration/test_platform_flows.py -k WhatACollectionReportsItHolds` —
  6 passed, against a real `pgvector/pgvector:pg16`.
- Every unit and API test touching `rag_documents` — 268 passed, 2 skipped.
- `make lint-backend` clean, with the same 61 `ty` diagnostics `main` reports.
- `make db-check` **fails identically on `main`** in this checkout: the dev
  database is stamped at a migration renumbered before merge
  (`0047_trigger_fire_in_flight`). It says nothing about this change; CI runs it
  against a fresh database. No DDL changed here — the enum is a Python-side
  default.
- No frontend path changed, so `test-frontend` is not expected to run.

## Found and not fixed

`_update_status` in `app/worker/tasks/rag_tasks.py` branches on `"error"` and
`"done"`, and all four callers pass `"error"` — so the `done` branch is a `pass`
that cannot be reached. Filed as **#956** rather than folded in here.

Closes #148
