### PR TITLE
chore: cut 0.0.204

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,34 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.204] - 2026-08-20
+
+Every knowledge base in the product reported nothing indexed, however many
+documents had finished ingesting.
+
+### Fixed
+
+- **A collection's indexed count filters on the status the pipeline writes.**
+  `counts_by_collection` counted rows whose `status` was `"completed"`, and
+  nothing has ever written that value: an upload creates a row `processing` and
+  the pipeline moves it to `done` or `error`, which is what the model default,
+  `docs/file-processing.md` and the frontend's status map all say. The `FILTER`
+  clause therefore could not match a row, so `indexed_count` was `0` on every
+  knowledge base and a collection where everything succeeded read as entirely
+  unindexed. The literal is now an enum: `DocumentStatus` sits beside the column
+  in `app/db/models/rag_document.py` - the shape `RunStatus`, `AgentStatus` and
+  `InvitationStatus` already take - and the writer (`RAGDocumentService`) and the
+  reader name the same member rather than two strings free to drift.
+  `rag_document_repo.create` and `update_status` take `DocumentStatus` instead of
+  `str`, so the next typo is a type error rather than a count that silently
+  reports nothing. (#148)
+
+### Changed
+
+- **`docs/file-processing.md`** says the three status values are the
+  `DocumentStatus` members and that the indexed count filters on `done`, so a
+  reader of that table knows where the vocabulary lives.
+
 ## [0.0.203] - 2026-08-19
 
 A Member could pay for a collection's embeddings with another member's private

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.203"
+version = "0.0.204"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.203"
+version = "0.0.204"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.203",
+  "version": "0.0.204",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.204. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.204 and adds the CHANGELOG entry.

One fix, and it made a number in the product a lie rather than breaking a
path. `counts_by_collection` counted documents whose `status` was
`"completed"` - a value nothing has ever written, since an upload creates a
row `processing` and the pipeline moves it to `done` or `error`. The `FILTER`
clause could not match a row, so `indexed_count` was `0` on every knowledge
base however many documents had finished, and a collection where everything
succeeded read as entirely unindexed.

The literal became a `DocumentStatus` enum beside the column, so the writer
and the reader name one member instead of two strings free to drift, and the
repository's `status` parameters are typed rather than `str`.

Worth recording why it survived: the test asserting this behaviour set the
statuses by hand, and set `"completed"` and `"failed"` - neither of which
anything in the product writes. It agreed with the query rather than with the
pipeline, so it passed for as long as the bug existed. Its replacement runs
`complete_ingestion` and then reads the count, naming no status at all.

## Verified

`make lint` and `make test` locally: 6112 passed, 15 skipped, 100% on the
platform layer. CI green on #957 end to end - `test`, `e2e`, `lint`, `docs`,
`Security Scan` and all three CodeQL analyses. `make test-frontend-cov` was
not re-run: no frontend path has changed since 0.0.202, where it was green.

The Codex reviewer answered "You have reached your Codex usage limits" to
both the automatic run and an explicit `@codex review`, so the only review
before this merge was a human sweep of the diff and of the siblings of what
it touched - the one other status filter in `app/repositories`
(`AgentRun.status == "completed"`, correct: that value is written) and the
sync-log vocabulary, which has no aggregation filtering on it.

Refs #148