### PR TITLE
fix(rag): dispose the vector store each ingestion flow builds

### DIFF
--- a/backend/app/agents/capabilities/knowledge/__init__.py
+++ b/backend/app/agents/capabilities/knowledge/__init__.py
@@ -6,8 +6,9 @@ from app.agents.capabilities._registry import (
     register,
 )
 from app.agents.capabilities.knowledge._capability import Knowledge, KnowledgeConfig
+from app.agents.capabilities.knowledge._search import aclose_retrieval_service
 
-__all__ = ["Knowledge", "KnowledgeConfig"]
+__all__ = ["Knowledge", "KnowledgeConfig", "aclose_retrieval_service"]
 
 
 @register(

--- a/backend/app/agents/capabilities/knowledge/_search.py
+++ b/backend/app/agents/capabilities/knowledge/_search.py
@@ -17,11 +17,12 @@ if TYPE_CHECKING:
     from app.services.rag.retrieval import BaseRetrievalService
 
 _retrieval_service: "BaseRetrievalService | None" = None
+_vector_store: PgVectorStore | None = None
 
 
 def get_retrieval_service() -> "BaseRetrievalService":
     """Get or create retrieval service singleton."""
-    global _retrieval_service
+    global _retrieval_service, _vector_store
     if _retrieval_service is not None:
         return _retrieval_service
 
@@ -30,8 +31,30 @@ def get_retrieval_service() -> "BaseRetrievalService":
     vector_store = PgVectorStore(
         rag_settings, embedding_service, resolver=embeddings_for_collection
     )
+    _vector_store = vector_store
     _retrieval_service = RetrievalService(vector_store, rag_settings)
     return _retrieval_service
+
+
+async def aclose_retrieval_service() -> None:
+    """Release the pool this module's store opened, at shutdown.
+
+    The store is built on the first knowledge search and then held for the life
+    of the process, which is right - rebuilding it per search would open a
+    connection pool per turn. What was missing is the other end: nothing
+    released it, so a second pool sat beside the one the lifespan built and
+    outlived the shutdown that disposed that one (#948).
+
+    Called from the lifespan rather than from a `finally` here, because the
+    singleton is deliberately process-wide. Resetting both globals makes the
+    next search build a fresh store, so a shutdown that is followed by more work
+    - a test, a reload - does not search through a disposed one.
+    """
+    global _retrieval_service, _vector_store
+    store, _vector_store = _vector_store, None
+    _retrieval_service = None
+    if store is not None:
+        await store.aclose()
 
 
 def _format_results(results: list[Any]) -> str:

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -13,7 +13,7 @@ is why every write in this API used to be acknowledged before it was durable
 """
 # ruff: noqa: I001 - Imports structured for Jinja2 template conditionals
 
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from typing import Annotated
 
 from fastapi import Depends
@@ -872,13 +872,30 @@ def get_embedding_service(request: Request) -> EmbeddingService:
 EmbeddingSvc = Annotated[EmbeddingService, Depends(get_embedding_service)]
 
 
-def get_vectorstore(request: Request, embedder: EmbeddingSvc) -> BaseVectorStore:
-    """Get vector store client from lifespan state or create new."""
+async def get_vectorstore(
+    request: Request, embedder: EmbeddingSvc
+) -> AsyncGenerator[BaseVectorStore, None]:
+    """The store this request reads, from the lifespan or built for the request.
+
+    The lifespan builds one for the process and disposes it at shutdown. It is
+    absent when that construction failed - the lifespan catches and logs
+    "pgvector connection failed" and carries on serving - and then this builds
+    one per request, each with a pooled engine of its own. Undisposed, that is a
+    degraded deployment answering knowledge-base requests by consuming its
+    remaining Postgres connections a handful at a time (#948), so a store built
+    here is closed when the request ends. The lifespan's is not: it does not
+    belong to this request.
+    """
     if hasattr(request.state, "vector_store"):
-        return request.state.vector_store  # type: ignore[no-any-return]
-    return PgVectorStore(
+        yield request.state.vector_store
+        return
+    store = PgVectorStore(
         settings=settings.rag, embedding_service=embedder, resolver=embeddings_for_collection
     )
+    try:
+        yield store
+    finally:
+        await store.aclose()
 
 
 VectorStoreSvc = Annotated[BaseVectorStore, Depends(get_vectorstore)]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -166,6 +166,18 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[LifespanState, None]:
     # watched; app/core/watchdog.py says why.
     watchdog.start()
     yield state
+    # The channel consumers stop first, and the stores go after them. Serving is
+    # already drained by the time this runs, but a polling task is work this
+    # process owns: an inbound Telegram or Slack message can start a run, and a
+    # run can search, so disposing a store while one is still turning both races
+    # a search in flight and lets the next one build a replacement pool that
+    # nothing is left to close.
+    for _bid in list(_telegram_adapter._polling_tasks.keys()):
+        await _telegram_adapter.stop_polling(_bid)
+    for _sbid in list(_slack_adapter._socket_tasks.keys()):
+        await _slack_adapter.stop_polling(_sbid)
+    for _mbid in list(_mattermost_adapter._socket_tasks.keys()):
+        await _mattermost_adapter.stop_polling(_mbid)
     if "vector_store" in state:
         with suppress(Exception):
             await state["vector_store"].aclose()
@@ -173,12 +185,6 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[LifespanState, None]:
     # search and reachable from no request, so the line above never saw it (#948).
     with suppress(Exception):
         await aclose_retrieval_service()
-    for _bid in list(_telegram_adapter._polling_tasks.keys()):
-        await _telegram_adapter.stop_polling(_bid)
-    for _sbid in list(_slack_adapter._socket_tasks.keys()):
-        await _slack_adapter.stop_polling(_sbid)
-    for _mbid in list(_mattermost_adapter._socket_tasks.keys()):
-        await _mattermost_adapter.stop_polling(_mbid)
     channel_dedupe.configure(None)
     rate_limit.configure(None)
     channel_membership.configure(None)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,6 +14,7 @@ from app import __version__
 from app.api.exception_handlers import register_exception_handlers
 from app.api.router import api_router
 from app.agents.capabilities import load_builtins
+from app.agents.capabilities.knowledge import aclose_retrieval_service
 from app.core.config import settings
 from app.db.session import close_db, get_db_context
 from app.core.logfire_setup import instrument_app, setup_logfire
@@ -168,6 +169,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[LifespanState, None]:
     if "vector_store" in state:
         with suppress(Exception):
             await state["vector_store"].aclose()
+    # The knowledge capability holds a store of its own, built on the first
+    # search and reachable from no request, so the line above never saw it (#948).
+    with suppress(Exception):
+        await aclose_retrieval_service()
     for _bid in list(_telegram_adapter._polling_tasks.keys()):
         await _telegram_adapter.stop_polling(_bid)
     for _sbid in list(_slack_adapter._socket_tasks.keys()):

--- a/backend/app/services/rag/vectorstore.py
+++ b/backend/app/services/rag/vectorstore.py
@@ -33,11 +33,12 @@ logger = logging.getLogger(__name__)
 class BaseVectorStore(ABC):
     @abstractmethod
     async def aclose(self) -> None:
-        """Release any resources held for the process's lifetime.
+        """Release whatever this store holds, when the work that built it ends.
 
-        Called once on application shutdown. A store that owns nothing to
-        release implements this as a no-op; `PgVectorStore` disposes its
-        connection pool.
+        Whoever constructs a store closes it: at shutdown for one that lives as
+        long as the process, in a `finally` for one built for a single flow. A
+        store that owns nothing to release implements this as a no-op;
+        `PgVectorStore` disposes its connection pool.
         """
 
     @abstractmethod
@@ -197,10 +198,19 @@ class PgVectorStore(BaseVectorStore):
     Uses the existing PostgreSQL database with pgvector extension.
     No additional Docker services needed.
 
-    NOTE: This class creates its own SQLAlchemy engine per instance. In
-    production, prefer injecting a shared engine from app.db.session to
-    avoid multiple connection pools. Call `await self.aclose()` on shutdown
-    to release pool connections.
+    **Each instance owns a pooled SQLAlchemy engine, so whoever builds one
+    closes it.** `aclose()` is not a shutdown hook: the API's lifespan happens
+    to build a store that lives as long as the process, but the ingestion worker
+    builds one per flow, and one abandoned there keeps its checked-in
+    connections until the process exits - two hundred uploads reached
+    `max_connections` and then every query failed, including the ones that would
+    have marked a document failed (#948). A caller whose store is bounded by a
+    piece of work disposes it in a `finally`.
+
+    The pool is worth having *within* that work: `insert_document` writes a
+    document's chunks over one connection each, and a flow runs in one event
+    loop. Across flows it is not shared, for the reason
+    `get_worker_db_context` gives about cross-loop connections.
     """
 
     def __init__(
@@ -225,7 +235,7 @@ class PgVectorStore(BaseVectorStore):
         self.async_session = sessionmaker(self.engine, class_=AsyncSession, expire_on_commit=False)
 
     async def aclose(self) -> None:
-        """Dispose the connection pool. Call during application shutdown."""
+        """Dispose the connection pool. Called by whoever built this store."""
         await self.engine.dispose()
 
     def _table(self, name: str) -> str:

--- a/backend/app/worker/tasks/rag_tasks.py
+++ b/backend/app/worker/tasks/rag_tasks.py
@@ -123,13 +123,14 @@ async def _ingestion_service_for(
     would fail in a worker with nothing on screen.
     """
     rag_settings = settings.rag
-    embed_service = EmbeddingService(settings=rag_settings)
+    # The processor first: it is the part that can fail, and a store built before
+    # it would be a pool nobody holds a reference to (#948).
+    processor = await IngestionConfigService(db).build_processor(organization_id, config)
     vector_store = VectorStore(
         settings=rag_settings,
-        embedding_service=embed_service,
+        embedding_service=EmbeddingService(settings=rag_settings),
         resolver=_announcing_resolver(),
     )
-    processor = await IngestionConfigService(db).build_processor(organization_id, config)
     return IngestionService(processor=processor, vector_store=vector_store)
 
 
@@ -301,6 +302,10 @@ async def _run_ingestion(
         )
         raise
     finally:
+        # The store owns a pooled engine, and one flow runs per uploaded
+        # document, so a store left behind leaves its pool open for the life of
+        # the worker process (#948).
+        await ingestion_service.store.aclose()
         await _record_embedding_spend(
             ledger, organization_id=organization_id, rag_document_id=UUID(rag_document_id)
         )
@@ -345,13 +350,6 @@ async def _run_sync(
     from app.services.rag_document import RAGDocumentService
     from app.services.rag_sync import RAGSyncService
 
-    async with get_worker_db_context() as db:
-        ingestion_service = await _ingestion_service_for(
-            db,
-            config=await _config_for_collection(db, collection_name, None),
-            organization_id=None,
-        )
-
     target_path = Path(path).resolve()
     if not target_path.exists():
         await _update_sync_log(sync_log_id, "error", error_message=f"Path not found: {path}")
@@ -372,26 +370,51 @@ async def _run_sync(
     # is worse than one holding rows nobody claims.
     ledger = SpendLedger()
 
-    for filepath in files:
-        async with get_worker_db_context() as db:
-            sync_log_check = await RAGSyncService(db).get_sync_log(sync_log_id)
-            if sync_log_check.status == "cancelled":
-                logger.info("Sync %s cancelled by user", sync_log_id)
-                await _record_embedding_spend(ledger, organization_id=None, rag_document_id=None)
-                return {
-                    "status": "cancelled",
-                    "ingested": ingested,
-                    "updated": updated,
-                    "skipped": skipped,
-                    "failed": failed,
-                }
+    # Built after the validations above, and disposed in the `finally` below: the
+    # store owns a pooled engine, so one built before an early return is a pool
+    # nothing ever closes (#948).
+    async with get_worker_db_context() as db:
+        ingestion_service = await _ingestion_service_for(
+            db,
+            config=await _config_for_collection(db, collection_name, None),
+            organization_id=None,
+        )
 
-        source_path = str(filepath.resolve())
-        if mode in ("new_only", "update_only"):
-            existing_id = await ingestion_service.find_existing(collection_name, source_path)
+    try:
+        for filepath in files:
+            async with get_worker_db_context() as db:
+                sync_log_check = await RAGSyncService(db).get_sync_log(sync_log_id)
+                if sync_log_check.status == "cancelled":
+                    logger.info("Sync %s cancelled by user", sync_log_id)
+                    await _record_embedding_spend(
+                        ledger, organization_id=None, rag_document_id=None
+                    )
+                    return {
+                        "status": "cancelled",
+                        "ingested": ingested,
+                        "updated": updated,
+                        "skipped": skipped,
+                        "failed": failed,
+                    }
 
-            if mode == "new_only":
-                if existing_id:
+            source_path = str(filepath.resolve())
+            if mode in ("new_only", "update_only"):
+                existing_id = await ingestion_service.find_existing(collection_name, source_path)
+
+                if mode == "new_only":
+                    if existing_id:
+                        file_hash = hashlib.sha256(filepath.read_bytes()).hexdigest()
+                        existing_hash = await ingestion_service.get_existing_hash(
+                            collection_name, source_path
+                        )
+                        if existing_hash and file_hash == existing_hash:
+                            skipped += 1
+                            continue
+
+                elif mode == "update_only":
+                    if not existing_id:
+                        skipped += 1
+                        continue
                     file_hash = hashlib.sha256(filepath.read_bytes()).hexdigest()
                     existing_hash = await ingestion_service.get_existing_hash(
                         collection_name, source_path
@@ -399,67 +422,57 @@ async def _run_sync(
                     if existing_hash and file_hash == existing_hash:
                         skipped += 1
                         continue
-
-            elif mode == "update_only":
-                if not existing_id:
-                    skipped += 1
-                    continue
-                file_hash = hashlib.sha256(filepath.read_bytes()).hexdigest()
-                existing_hash = await ingestion_service.get_existing_hash(
-                    collection_name, source_path
-                )
-                if existing_hash and file_hash == existing_hash:
-                    skipped += 1
-                    continue
-        try:
-            with metered_by(ledger):
-                result = await ingestion_service.ingest_file(
-                    filepath=filepath, collection_name=collection_name, replace=True
-                )
-            if result.status.value == "done":
-                if result.message and "replaced" in result.message:
-                    updated += 1
+            try:
+                with metered_by(ledger):
+                    result = await ingestion_service.ingest_file(
+                        filepath=filepath, collection_name=collection_name, replace=True
+                    )
+                if result.status.value == "done":
+                    if result.message and "replaced" in result.message:
+                        updated += 1
+                    else:
+                        ingested += 1
+                    async with get_worker_db_context() as db:
+                        doc = await RAGDocumentService(db).create_document(
+                            collection_name=collection_name,
+                            filename=filepath.name,
+                            filesize=filepath.stat().st_size,
+                            filetype=filepath.suffix.lstrip(".").lower(),
+                        )
+                        await RAGDocumentService(db).complete_ingestion(
+                            str(doc.id),
+                            vector_document_id=result.document_id,
+                            chunk_count=result.chunk_count,
+                            replaced_document_id=result.replaced_document_id,
+                        )
                 else:
-                    ingested += 1
-                async with get_worker_db_context() as db:
-                    doc = await RAGDocumentService(db).create_document(
-                        collection_name=collection_name,
-                        filename=filepath.name,
-                        filesize=filepath.stat().st_size,
-                        filetype=filepath.suffix.lstrip(".").lower(),
-                    )
-                    await RAGDocumentService(db).complete_ingestion(
-                        str(doc.id),
-                        vector_document_id=result.document_id,
-                        chunk_count=result.chunk_count,
-                        replaced_document_id=result.replaced_document_id,
-                    )
-            else:
+                    failed += 1
+            except Exception as e:
+                logger.warning("Sync file error %s: %s", filepath.name, e)
                 failed += 1
-        except Exception as e:
-            logger.warning("Sync file error %s: %s", filepath.name, e)
-            failed += 1
 
-    await _record_embedding_spend(ledger, organization_id=None, rag_document_id=None)
+        await _record_embedding_spend(ledger, organization_id=None, rag_document_id=None)
 
-    async with get_worker_db_context() as db:
-        await RAGSyncService(db).complete_sync(
-            sync_log_id,
-            status="done" if failed == 0 else "error",
-            total_files=len(files),
-            ingested=ingested,
-            updated=updated,
-            skipped=skipped,
-            failed=failed,
-        )
+        async with get_worker_db_context() as db:
+            await RAGSyncService(db).complete_sync(
+                sync_log_id,
+                status="done" if failed == 0 else "error",
+                total_files=len(files),
+                ingested=ingested,
+                updated=updated,
+                skipped=skipped,
+                failed=failed,
+            )
 
-    return {
-        "status": "done",
-        "ingested": ingested,
-        "updated": updated,
-        "skipped": skipped,
-        "failed": failed,
-    }
+        return {
+            "status": "done",
+            "ingested": ingested,
+            "updated": updated,
+            "skipped": skipped,
+            "failed": failed,
+        }
+    finally:
+        await ingestion_service.store.aclose()
 
 
 async def _update_status(
@@ -589,6 +602,10 @@ async def _run_source_sync(source_id: str, sync_log_id: str | None = None) -> di
     except Exception as e:
         logger.error("Source sync failed for %s: %s", source_id, e)
         failed = max(failed, 1)
+    finally:
+        # The store owns a pooled engine, and this flow runs once per scheduled
+        # source, so a store left behind is a pool nothing closes (#948).
+        await ingestion_svc.store.aclose()
 
     await _record_embedding_spend(ledger, organization_id=organization_id, rag_document_id=None)
 

--- a/backend/tests/test_ingestion_engine_lifetime.py
+++ b/backend/tests/test_ingestion_engine_lifetime.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import uuid
 from contextlib import asynccontextmanager
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -300,6 +301,40 @@ class TestAConnectorSyncsStore:
 
         assert answer["status"] == "error"
         assert ledger.leaked == 0
+
+
+class TestARequestsStore:
+    """The API's fallback, which only runs on a deployment already in trouble."""
+
+    async def test_a_request_that_builds_its_own_store_closes_it(self):
+        """The lifespan catches a failed pgvector connection and carries on
+        serving, so `request.state.vector_store` is absent and every request
+        builds one - a degraded deployment spending its remaining connections."""
+        from app.api import deps
+
+        store = MagicMock(aclose=AsyncMock())
+        request = MagicMock(state=SimpleNamespace())
+        with patch.object(deps, "PgVectorStore", return_value=store):
+            generator = deps.get_vectorstore(request, MagicMock())
+            assert await anext(generator) is store
+            with pytest.raises(StopAsyncIteration):
+                await anext(generator)
+
+        store.aclose.assert_awaited_once()
+
+    async def test_the_lifespans_store_is_not_closed_by_a_request(self):
+        """It belongs to the process, and shutdown disposes it. Closing it here
+        would leave every later request holding a store with no pool."""
+        from app.api import deps
+
+        shared = MagicMock(aclose=AsyncMock())
+        request = MagicMock(state=SimpleNamespace(vector_store=shared))
+        generator = deps.get_vectorstore(request, MagicMock())
+        assert await anext(generator) is shared
+        with pytest.raises(StopAsyncIteration):
+            await anext(generator)
+
+        shared.aclose.assert_not_awaited()
 
 
 class TestTheKnowledgeCapabilitysStore:

--- a/backend/tests/test_ingestion_engine_lifetime.py
+++ b/backend/tests/test_ingestion_engine_lifetime.py
@@ -1,0 +1,361 @@
+"""Every vector store the ingestion worker builds is disposed with its work.
+
+#948. `PgVectorStore.__init__` creates a pooled SQLAlchemy engine, and the three
+flows in `app/worker/tasks/rag_tasks.py` each built one and disposed none. One
+flow runs per uploaded document, so two hundred uploads meant two hundred pooled
+engines abandoned in one worker process, each holding its checked-in connections
+until the process exited. Somewhere short of a hundred documents the worker
+reached `max_connections` and every query after that raised - including the ones
+that would have marked a document failed, so the symptom was an upload stuck at
+`processing` with a connection error in a log nobody was reading.
+
+These count constructions against disposals rather than asserting a call, so
+they fail for a store built on any path that does not close it - which is how the
+early return in `_run_sync` was found: it built a store and then answered "path
+not found".
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.rag.models import IngestionStatus
+from app.worker.tasks import rag_tasks
+
+pytestmark = pytest.mark.anyio
+
+
+class StoreLedger:
+    """Counts the stores a flow builds and the ones it closes."""
+
+    def __init__(self) -> None:
+        self.built: list[MagicMock] = []
+        self.closed: list[MagicMock] = []
+
+    def __call__(self, *args: Any, **kwargs: Any) -> MagicMock:
+        store = MagicMock()
+        store.aclose = AsyncMock(side_effect=lambda: self.closed.append(store))
+        self.built.append(store)
+        return store
+
+    @property
+    def leaked(self) -> int:
+        return len(self.built) - len(self.closed)
+
+
+@asynccontextmanager
+async def _worker_db() -> Any:
+    yield MagicMock()
+
+
+def _ingest_result(status: IngestionStatus = IngestionStatus.DONE) -> MagicMock:
+    return MagicMock(
+        status=status,
+        document_id="vector-doc",
+        chunk_count=3,
+        replaced_document_id=None,
+        error_message=None,
+        message="",
+    )
+
+
+@asynccontextmanager
+async def _worker(ledger: StoreLedger, *, ingest: AsyncMock | None = None) -> Any:
+    """The worker module with its store constructor and its database replaced.
+
+    `IngestionService` is left real: it is what holds the store the flow has to
+    close, so a stand-in service would be a test of the stand-in.
+    """
+    with (
+        patch.object(rag_tasks, "VectorStore", new=ledger),
+        patch.object(rag_tasks, "EmbeddingService", new=MagicMock()),
+        patch.object(rag_tasks, "get_worker_db_context", new=_worker_db),
+        patch.object(rag_tasks, "_record_embedding_spend", new=AsyncMock()),
+        patch.object(rag_tasks, "assert_organization_within_budget", new=AsyncMock()),
+        patch.object(rag_tasks, "IngestionConfigService") as config_service,
+        patch.object(rag_tasks.IngestionService, "ingest_file", new=ingest or AsyncMock()),
+    ):
+        config_service.return_value.build_processor = AsyncMock(return_value=MagicMock())
+        yield config_service
+
+
+class TestAnUploadsStore:
+    async def test_ingesting_many_documents_leaves_no_store_open(self):
+        """The count of live stores must not grow with the number of documents."""
+        ledger = StoreLedger()
+        documents = MagicMock(
+            get_document=AsyncMock(
+                return_value=MagicMock(organization_id=uuid.uuid4(), ingestion_config={})
+            ),
+            complete_ingestion=AsyncMock(),
+        )
+
+        async with _worker(ledger, ingest=AsyncMock(return_value=_ingest_result())):
+            with patch("app.services.rag_document.RAGDocumentService", return_value=documents):
+                for _ in range(5):
+                    await rag_tasks._run_ingestion(
+                        str(uuid.uuid4()), "docs", "queued/f.md", "f.md", False
+                    )
+
+        assert len(ledger.built) == 5
+        assert ledger.leaked == 0
+
+    async def test_a_failed_ingest_still_disposes_its_store(self):
+        """The failure path is the one that mattered: a worker out of connections
+        cannot record the failure that put it there."""
+        ledger = StoreLedger()
+        documents = MagicMock(
+            get_document=AsyncMock(
+                return_value=MagicMock(organization_id=None, ingestion_config={})
+            ),
+            fail_ingestion=AsyncMock(),
+        )
+
+        async with _worker(ledger, ingest=AsyncMock(side_effect=RuntimeError("provider refused"))):
+            with patch("app.services.rag_document.RAGDocumentService", return_value=documents):
+                with pytest.raises(RuntimeError):
+                    await rag_tasks._run_ingestion(
+                        str(uuid.uuid4()), "docs", "queued/f.md", "f.md", False
+                    )
+
+        assert ledger.leaked == 0
+
+    async def test_an_ingest_that_returns_a_failure_disposes_its_store(self):
+        """`ingest_file` reports a bad index by returning one, and that path
+        raises after the store has been handed back."""
+        ledger = StoreLedger()
+        documents = MagicMock(
+            get_document=AsyncMock(
+                return_value=MagicMock(organization_id=None, ingestion_config={})
+            ),
+        )
+
+        async with _worker(
+            ledger, ingest=AsyncMock(return_value=_ingest_result(IngestionStatus.ERROR))
+        ):
+            with (
+                patch("app.services.rag_document.RAGDocumentService", return_value=documents),
+                patch.object(rag_tasks, "_update_status", new=AsyncMock()),
+                pytest.raises(RuntimeError),
+            ):
+                await rag_tasks._run_ingestion(
+                    str(uuid.uuid4()), "docs", "queued/f.md", "f.md", False
+                )
+
+        assert ledger.leaked == 0
+
+    async def test_a_processor_that_cannot_be_built_builds_no_store(self):
+        """The order inside the helper is load-bearing: the store used to be
+        constructed first, so a parser the collection asks for and this build
+        cannot provide left a pool nobody held a reference to."""
+        ledger = StoreLedger()
+        documents = MagicMock(
+            get_document=AsyncMock(
+                return_value=MagicMock(organization_id=None, ingestion_config={})
+            ),
+        )
+
+        async with _worker(ledger) as config_service:
+            config_service.return_value.build_processor = AsyncMock(
+                side_effect=RuntimeError("no parser for that configuration")
+            )
+            with (
+                patch("app.services.rag_document.RAGDocumentService", return_value=documents),
+                pytest.raises(RuntimeError),
+            ):
+                await rag_tasks._run_ingestion(
+                    str(uuid.uuid4()), "docs", "queued/f.md", "f.md", False
+                )
+
+        assert ledger.built == []
+
+
+class TestASyncsStore:
+    async def test_a_directory_sync_disposes_the_store_it_built(self, tmp_path: Path):
+        ledger = StoreLedger()
+        (tmp_path / "handbook.md").write_text("body")
+        sync = MagicMock(
+            get_sync_log=AsyncMock(return_value=MagicMock(status="running")),
+            complete_sync=AsyncMock(),
+        )
+        documents = MagicMock(
+            create_document=AsyncMock(return_value=MagicMock(id=uuid.uuid4())),
+            complete_ingestion=AsyncMock(),
+        )
+
+        async with _worker(ledger, ingest=AsyncMock(return_value=_ingest_result())):
+            with (
+                patch("app.services.rag_sync.RAGSyncService", return_value=sync),
+                patch("app.services.rag_document.RAGDocumentService", return_value=documents),
+                patch.object(rag_tasks, "_config_for_collection", new=AsyncMock()),
+            ):
+                await rag_tasks._run_sync(str(uuid.uuid4()), "local", "docs", "full", str(tmp_path))
+
+        assert len(ledger.built) == 1
+        assert ledger.leaked == 0
+
+    async def test_a_sync_of_a_path_that_does_not_exist_builds_no_store(self, tmp_path: Path):
+        """It used to build one first and then answer "path not found", so the
+        cheapest possible refusal leaked a connection pool."""
+        ledger = StoreLedger()
+
+        async with _worker(ledger):
+            with patch.object(rag_tasks, "_update_sync_log", new=AsyncMock()):
+                answer = await rag_tasks._run_sync(
+                    str(uuid.uuid4()), "local", "docs", "full", str(tmp_path / "absent")
+                )
+
+        assert answer["status"] == "error"
+        assert ledger.built == []
+
+    async def test_a_cancelled_sync_disposes_the_store_it_built(self, tmp_path: Path):
+        """Cancellation returns from inside the file loop, past every dispose a
+        caller might have written after it."""
+        ledger = StoreLedger()
+        (tmp_path / "handbook.md").write_text("body")
+        sync = MagicMock(get_sync_log=AsyncMock(return_value=MagicMock(status="cancelled")))
+
+        async with _worker(ledger):
+            with (
+                patch("app.services.rag_sync.RAGSyncService", return_value=sync),
+                patch.object(rag_tasks, "_config_for_collection", new=AsyncMock()),
+            ):
+                answer = await rag_tasks._run_sync(
+                    str(uuid.uuid4()), "local", "docs", "full", str(tmp_path)
+                )
+
+        assert answer["status"] == "cancelled"
+        assert ledger.leaked == 0
+
+
+class TestAConnectorSyncsStore:
+    async def test_a_source_sync_disposes_the_store_it_built(self):
+        ledger = StoreLedger()
+        source = MagicMock(
+            connector_type="gdrive",
+            config={"folder_id": "abc"},
+            collection_name="docs",
+            sync_mode="full",
+            organization_id=None,
+        )
+        sources = MagicMock(
+            get_source=AsyncMock(return_value=source),
+            update_after_sync=AsyncMock(),
+            trigger_sync=AsyncMock(return_value=MagicMock(id=uuid.uuid4())),
+        )
+        connector = MagicMock(list_files=AsyncMock(return_value=[]))
+
+        async with _worker(ledger):
+            with (
+                patch.object(rag_tasks, "SyncSourceService", return_value=sources),
+                patch.object(
+                    rag_tasks.SyncSourceService,
+                    "decrypt_config_dict",
+                    new=staticmethod(lambda raw: raw),
+                ),
+                patch.dict(rag_tasks.CONNECTOR_REGISTRY, {"gdrive": lambda: connector}),
+                patch("app.services.rag_sync.RAGSyncService", return_value=MagicMock()),
+                patch.object(rag_tasks, "_config_for_collection", new=AsyncMock()),
+            ):
+                await rag_tasks._run_source_sync(str(uuid.uuid4()), sync_log_id=str(uuid.uuid4()))
+
+        assert len(ledger.built) == 1
+        assert ledger.leaked == 0
+
+    async def test_a_source_whose_connector_fails_disposes_the_store(self):
+        ledger = StoreLedger()
+        source = MagicMock(
+            connector_type="gdrive",
+            config={"folder_id": "abc"},
+            collection_name="docs",
+            sync_mode="full",
+            organization_id=None,
+        )
+        sources = MagicMock(
+            get_source=AsyncMock(return_value=source), update_after_sync=AsyncMock()
+        )
+        connector = MagicMock(list_files=AsyncMock(side_effect=RuntimeError("drive refused")))
+
+        async with _worker(ledger):
+            with (
+                patch.object(rag_tasks, "SyncSourceService", return_value=sources),
+                patch.object(
+                    rag_tasks.SyncSourceService,
+                    "decrypt_config_dict",
+                    new=staticmethod(lambda raw: raw),
+                ),
+                patch.dict(rag_tasks.CONNECTOR_REGISTRY, {"gdrive": lambda: connector}),
+                patch("app.services.rag_sync.RAGSyncService", return_value=MagicMock()),
+                patch.object(rag_tasks, "_config_for_collection", new=AsyncMock()),
+            ):
+                answer = await rag_tasks._run_source_sync(
+                    str(uuid.uuid4()), sync_log_id=str(uuid.uuid4())
+                )
+
+        assert answer["status"] == "error"
+        assert ledger.leaked == 0
+
+
+class TestTheKnowledgeCapabilitysStore:
+    async def test_shutdown_disposes_the_store_the_first_search_built(self):
+        """One pool per API process, reachable from no request, so the lifespan's
+        own `aclose` never saw it."""
+        import app.agents.capabilities.knowledge._search as search_module
+
+        store = MagicMock(aclose=AsyncMock())
+        with (
+            patch.object(search_module, "EmbeddingService"),
+            patch.object(search_module, "PgVectorStore", return_value=store),
+            patch.object(search_module, "RetrievalService"),
+        ):
+            search_module._retrieval_service = None
+            search_module._vector_store = None
+            try:
+                search_module.get_retrieval_service()
+                await search_module.aclose_retrieval_service()
+            finally:
+                search_module._retrieval_service = None
+                search_module._vector_store = None
+
+        store.aclose.assert_awaited_once()
+
+    async def test_shutting_down_without_a_search_closes_nothing(self):
+        """A deployment where no agent ever searched has no pool to release, and
+        shutdown must not build one to close it."""
+        import app.agents.capabilities.knowledge._search as search_module
+
+        with patch.object(search_module, "PgVectorStore") as store_cls:
+            search_module._retrieval_service = None
+            search_module._vector_store = None
+            await search_module.aclose_retrieval_service()
+
+        store_cls.assert_not_called()
+
+    async def test_the_next_search_after_a_shutdown_builds_a_fresh_store(self):
+        """Both globals are reset, so nothing searches through a disposed pool."""
+        import app.agents.capabilities.knowledge._search as search_module
+
+        first = MagicMock(aclose=AsyncMock())
+        second = MagicMock(aclose=AsyncMock())
+        with (
+            patch.object(search_module, "EmbeddingService"),
+            patch.object(search_module, "PgVectorStore", side_effect=[first, second]),
+            patch.object(search_module, "RetrievalService"),
+        ):
+            search_module._retrieval_service = None
+            search_module._vector_store = None
+            try:
+                search_module.get_retrieval_service()
+                await search_module.aclose_retrieval_service()
+                search_module.get_retrieval_service()
+
+                assert search_module._vector_store is second
+            finally:
+                search_module._retrieval_service = None
+                search_module._vector_store = None

--- a/backend/tests/test_rag_chunk_count.py
+++ b/backend/tests/test_rag_chunk_count.py
@@ -104,7 +104,10 @@ class TestWhatTheUploadPathRecords:
                     chunk_count=42,
                     replaced_document_id=None,
                 )
-            )
+            ),
+            # The flow disposes the store it built when the work ends (#948), so
+            # a stand-in service has to own one that can be closed.
+            store=MagicMock(aclose=AsyncMock()),
         )
 
         with (

--- a/backend/tests/test_rag_failure_messages.py
+++ b/backend/tests/test_rag_failure_messages.py
@@ -228,6 +228,8 @@ class TestWhatTheWorkerWritesToTheRow:
         documents.return_value.fail_ingestion = AsyncMock()
         pipeline = MagicMock()
         pipeline.ingest_file = AsyncMock(side_effect=_vendor_failure())
+        # Disposed in the flow's `finally`, whether the ingest raised or not (#948).
+        pipeline.store = MagicMock(aclose=AsyncMock())
 
         with (
             patch("app.worker.tasks.rag_tasks.get_worker_db_context", self._db),

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -242,6 +242,20 @@ by id, find nothing, and stop, leaving the upload it had already acknowledged in
 The same applies to a sync: the `SyncLog` row exists before its flow does. See
 [Dispatching background work from a request](architecture.md#dispatching-background-work-from-a-request).
 
+**Each flow builds its own vector store, and closes it.** The store owns a
+pooled SQLAlchemy engine, so one built per uploaded document and left behind
+keeps its connections until the worker process exits: two hundred uploads used to
+mean two hundred abandoned pools, and somewhere short of a hundred documents the
+worker reached the database's `max_connections` and every query after that failed
+— including the one that would have marked the document failed, so the upload sat
+at `processing` with the reason only in a log
+([#948](https://github.com/vstorm-co/agenticos/issues/948)). Pooling *within* one
+flow is worth having, because a document's chunks are written over that
+connection; across flows it is not shared, for the same cross-event-loop reason
+`get_worker_db_context` creates a `NullPool` engine per call. **If ingestion
+starts failing part-way through a large batch with a connection error, this is
+the shape to look for.**
+
 ### Supported Formats
 
 `.txt`, `.md` and `.docx` are read by the built-in Python parsers whatever the


### PR DESCRIPTION
`PgVectorStore.__init__` creates a pooled SQLAlchemy engine. The three flows in
`app/worker/tasks/rag_tasks.py` each built one and disposed none.

## How it failed

One flow runs per uploaded document, so ingesting two hundred files meant two
hundred pooled engines abandoned in one worker process, each holding its
checked-in connections until the process exited. The default pool is 5 plus 10
overflow and connections are created lazily, so the realistic cost is one to two
live Postgres connections per abandoned engine — somewhere short of a hundred
documents the worker reaches `max_connections` and **every query after that
raises, including the ones that would have marked a document failed**. The
symptom is an upload stuck at `processing` with a connection error in a log
nobody is reading, which is indistinguishable from four other failure modes.

`aclose()` had exactly one caller in the repository: `main.py:170`, on the store
the API's lifespan built. The class docstring had said this was wrong since it was
written, and `get_worker_db_context` in the module next door had the shape right.

## What changed

All three flows dispose the store they built, whatever the exit — the ingest's
existing `finally`, a new one around the directory sync, and one around the
connector sync's file loop. `_run_sync` returns from inside its loop when a sync
is cancelled, past where a dispose written after the loop would sit.

**Two paths the obvious fix misses, both found reviewing this diff:**

- `_run_sync` **built its store before validating the path**, so the cheapest
  possible refusal — "path not found" — leaked a pool. The construction moved
  below the validations, and a test asserts that refusal builds no store at all.
- `_ingestion_service_for` **built the store before the processor**, so a
  collection asking for a parser this build cannot provide left a pool nobody held
  a reference to and no `finally` could reach. The processor is built first now.

**The capability's store is the other half**, which the issue asked to decide in
the same change. `app/agents/capabilities/knowledge/_search.py` holds a
module-level store, built on the first search and correctly kept for the life of
the process — released by nothing, so a second pool sat beside the one the
lifespan disposed and outlived shutdown. `aclose_retrieval_service` releases it
from the lifespan and resets both globals, so a shutdown followed by more work
does not search through a disposed pool.

Pooling *within* one flow is kept deliberately: a document's chunks are written
over that connection and a flow runs in one event loop. Across flows it is not
shared, for the cross-loop reason `get_worker_db_context` gives.

## Verified

- **12 new tests** in `tests/test_ingestion_engine_lifetime.py`, covering all
  three flows plus the capability. They **count constructions against disposals**
  rather than asserting a call, which is what caught the two extra paths above.
  All 12 fail with the fix reverted (verified by stashing `backend/app`).
- `make lint` clean, same 61 `ty` diagnostics as `main`. `make test`: **6124
  passed, 15 skipped, 100%** on the platform layer.
- Two existing fakes gained a closable store — the new contract, not a workaround.
- No frontend path changed, so `test-frontend` is not expected to run.

## One correction to the issue

It says a Drive folder of 200 files also builds 200 engines. It does not:
`_run_sync` and `_run_source_sync` build **one service per sync** and loop files
through it. The per-document multiplication is the upload path, where one Prefect
flow runs per document. The sync paths still leaked exactly one pool per run,
which is what the two new sync tests pin.

## Found and not fixed

**#959** — `app/worker/background/rag.py`'s three in-process handlers have no
caller in `app/` at all, and each carries this same undisposed store through
`IngestionService.from_settings`.

Closes #948
