### PR TITLE
chore: cut 0.0.205

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,51 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.205] - 2026-08-20
+
+Ingesting a large batch of documents exhausted the worker's database
+connections, and the failure that followed could not be recorded.
+
+### Fixed
+
+- **Every vector store the ingestion worker builds is disposed with the work
+  that built it.** `PgVectorStore.__init__` creates a pooled SQLAlchemy engine,
+  and the three flows in `app/worker/tasks/rag_tasks.py` each built one and
+  disposed none. One flow runs per uploaded document, so two hundred uploads
+  meant two hundred pooled engines abandoned in one worker process, each holding
+  its checked-in connections until the process exited - and somewhere short of a
+  hundred documents the worker reached `max_connections`, after which every
+  query raised, including the ones that would have marked a document failed. The
+  symptom was an upload stuck at `processing` with a connection error in a log
+  nobody reads, indistinguishable from four other failure modes. Two further
+  paths went with it: `_run_sync` built its store *before* validating the path,
+  so the cheapest refusal - "path not found" - leaked a pool, and
+  `_ingestion_service_for` built the store *before* the processor, so a
+  collection asking for a parser this build cannot provide left a pool no
+  `finally` could reach. (#948)
+- **A store built for one request is closed when the request ends.**
+  `get_vectorstore` reads the store the lifespan built and, when there is none,
+  builds one - and there is none whenever that construction failed, because the
+  lifespan logs "Vector store will not be available" and carries on serving. A
+  degraded deployment therefore answered every knowledge-base request by building
+  a pooled engine and abandoning it, at request rate. The lifespan's own store is
+  passed through untouched: it belongs to the process. (#948)
+- **The knowledge capability's store is released at shutdown**, and the channel
+  consumers stop before either store is disposed. The capability holds a
+  process-wide store built on the first search an agent runs, reachable from no
+  request, so the lifespan's `aclose` never saw it. Disposing it while the
+  Telegram, Slack and Mattermost polling loops were still turning raced a search
+  in flight and let the next one rebuild a pool nothing was left to close, so the
+  three stop loops now run first. (#948)
+
+### Changed
+
+- **`docs/file-processing.md` states the rule for all three stores** - the
+  worker's per flow, the request's, and the capability's per process - and says
+  what to look for when ingestion starts failing part-way through a large batch.
+  Pooling *within* one flow is kept deliberately: a document's chunks are written
+  over that connection, and a flow runs in one event loop. (#948)
+
 ## [0.0.204] - 2026-08-20
 
 Every knowledge base in the product reported nothing indexed, however many

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.204"
+version = "0.0.205"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.204"
+version = "0.0.205"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.204",
+  "version": "0.0.205",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.205. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.205 and adds the CHANGELOG entry.

One issue, and three sites of it. `PgVectorStore` owns a pooled SQLAlchemy
engine, and almost nothing disposed one: the ingestion worker built one per
uploaded document, the API's dependency built one per request whenever the
lifespan's own construction had failed, and the knowledge capability's
process-wide store was released by nothing at all. The worker was the one
that bites: two hundred uploads meant two hundred abandoned pools, and past
`max_connections` every query raised - including the one that would have
marked the document failed, so the upload sat at `processing` with the reason
only in a log.

Two of the three, and two of the extra paths, were found reviewing the diff
rather than in the issue: `_run_sync` built its store before validating the
path, `_ingestion_service_for` built it before the processor that can fail,
and the shutdown disposed both stores while the channel polling loops were
still turning - which the reviewer caught, and which was already true for the
lifespan's store before this branch touched it.

## Verified

`make lint` and `make test` locally: 6126 passed, 15 skipped, 100% on the
platform layer. 14 new tests in `tests/test_ingestion_engine_lifetime.py`
count constructions against disposals rather than asserting a call, which is
what found the two extra paths; all of them fail with the fix reverted. CI
green on #960 end to end - `test`, `e2e`, `lint`, `docs`, `Security Scan` and
all three CodeQL analyses, on the final commit. `make test-frontend-cov` was
not re-run: no frontend path has changed since 0.0.202, where it was green.

What the verification does not reach: no test drives the lifespan's shutdown
order, because doing so imports the channel SDKs that #520 removed from the
unit suite - so the ordering is held by review and by the comment above it,
not by a test. Nothing here was exercised against a worker actually running
out of connections; the tests assert the disposal, not the exhaustion.

Refs #948