### PR TITLE
perf(rag): write a document's chunks in batches, not one statement each

### DIFF
--- a/backend/app/services/rag/vectorstore.py
+++ b/backend/app/services/rag/vectorstore.py
@@ -164,6 +164,7 @@ class BaseVectorStore(ABC):
 
 import json
 from collections.abc import Awaitable, Callable
+from itertools import batched
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
@@ -190,6 +191,17 @@ EmbeddingResolver = Callable[[str], Awaitable[ResolvedEmbeddings | None]]
 # collection created with the default configuration would have failed on its
 # first upload, in a worker, with a 500 and no explanation on screen.
 _HNSW_MAX_VECTOR_DIM = 2000
+
+# How many chunks go into one `INSERT`. The statement used to run once per chunk,
+# so a 200-page PDF at the default `chunk_size` was one to three thousand
+# sequential round trips inside one open transaction - a second or two on a local
+# socket, five to fifteen against a managed Postgres at 3-5ms (#950).
+#
+# Batched rather than one statement for the whole document, because the parameter
+# list is held in memory and each row carries an embedding rendered as text: at
+# 3072 dimensions that is tens of kilobytes a row, so three thousand of them in
+# one statement is a parameter list measured in hundreds of megabytes.
+_CHUNK_INSERT_BATCH = 200
 
 
 class PgVectorStore(BaseVectorStore):
@@ -352,29 +364,40 @@ class PgVectorStore(BaseVectorStore):
             return result.scalar() is not None
 
     async def insert_document(self, collection_name: str, document: Document) -> None:
+        """Write a document's chunks, a batch of rows per statement.
+
+        One statement per `_CHUNK_INSERT_BATCH` chunks rather than one per chunk:
+        SQLAlchemy takes a list of parameter dictionaries and issues an
+        `executemany`, which asyncpg pipelines. What that replaces is a Python
+        loop of sequential round trips inside one open transaction, holding a
+        connection while it waited - and the number of them scaled with the
+        document, so the worst case was a long PDF against the slowest database
+        (#950).
+        """
         table = self._table(collection_name)
         await self._ensure_collection(collection_name)
         if not document.chunked_pages:
             raise ValueError("Document has no chunked pages.")
         embedder, _ = await self._for_collection(collection_name)
         vectors = embedder.embed_document(document)
+        statement = text(f"""
+            INSERT INTO {table} (id, parent_doc_id, content, embedding, metadata)
+            VALUES (:id, :parent_doc_id, :content, :embedding, :metadata)
+            ON CONFLICT (id) DO UPDATE SET content = :content, embedding = :embedding, metadata = :metadata
+        """)
+        rows = [
+            {
+                "id": chunk.chunk_id,
+                "parent_doc_id": chunk.parent_doc_id,
+                "content": chunk.chunk_content,
+                "embedding": str(vectors[i]),
+                "metadata": json.dumps(self._build_chunk_metadata(chunk, document)),
+            }
+            for i, chunk in enumerate(document.chunked_pages)
+        ]
         async with self.async_session() as session:
-            for i, chunk in enumerate(document.chunked_pages):
-                meta = self._build_chunk_metadata(chunk, document)
-                await session.execute(
-                    text(f"""
-                        INSERT INTO {table} (id, parent_doc_id, content, embedding, metadata)
-                        VALUES (:id, :parent_doc_id, :content, :embedding, :metadata)
-                        ON CONFLICT (id) DO UPDATE SET content = :content, embedding = :embedding, metadata = :metadata
-                    """),
-                    {
-                        "id": chunk.chunk_id,
-                        "parent_doc_id": chunk.parent_doc_id,
-                        "content": chunk.chunk_content,
-                        "embedding": str(vectors[i]),
-                        "metadata": json.dumps(meta),
-                    },
-                )
+            for batch in batched(rows, _CHUNK_INSERT_BATCH):
+                await session.execute(statement, list(batch))
             await session.commit()
 
     async def search(

--- a/backend/app/services/rag/vectorstore.py
+++ b/backend/app/services/rag/vectorstore.py
@@ -373,6 +373,14 @@ class PgVectorStore(BaseVectorStore):
         connection while it waited - and the number of them scaled with the
         document, so the worst case was a long PDF against the slowest database
         (#950).
+
+        **Each batch's rows are built inside the loop, not before it.** The
+        embedding is rendered as text here, and at 3072 dimensions that is tens
+        of kilobytes a row - so materialising every row first would hold a
+        three-thousand-chunk document's parameters, better than 100MB of live
+        strings, on top of the float vectors already in hand. Batching the
+        statements and not the rows would have bounded what asyncpg receives
+        while leaving the worker's memory exactly where it was.
         """
         table = self._table(collection_name)
         await self._ensure_collection(collection_name)
@@ -385,19 +393,21 @@ class PgVectorStore(BaseVectorStore):
             VALUES (:id, :parent_doc_id, :content, :embedding, :metadata)
             ON CONFLICT (id) DO UPDATE SET content = :content, embedding = :embedding, metadata = :metadata
         """)
-        rows = [
-            {
-                "id": chunk.chunk_id,
-                "parent_doc_id": chunk.parent_doc_id,
-                "content": chunk.chunk_content,
-                "embedding": str(vectors[i]),
-                "metadata": json.dumps(self._build_chunk_metadata(chunk, document)),
-            }
-            for i, chunk in enumerate(document.chunked_pages)
-        ]
         async with self.async_session() as session:
-            for batch in batched(rows, _CHUNK_INSERT_BATCH):
-                await session.execute(statement, list(batch))
+            for batch in batched(enumerate(document.chunked_pages), _CHUNK_INSERT_BATCH):
+                await session.execute(
+                    statement,
+                    [
+                        {
+                            "id": chunk.chunk_id,
+                            "parent_doc_id": chunk.parent_doc_id,
+                            "content": chunk.chunk_content,
+                            "embedding": str(vectors[i]),
+                            "metadata": json.dumps(self._build_chunk_metadata(chunk, document)),
+                        }
+                        for i, chunk in batch
+                    ],
+                )
             await session.commit()
 
     async def search(

--- a/backend/tests/integration/test_chunk_insert_batching.py
+++ b/backend/tests/integration/test_chunk_insert_batching.py
@@ -1,0 +1,127 @@
+"""A batched chunk insert, against a real pgvector Postgres.
+
+#950. The unit half (`tests/test_chunk_insert_batching.py`) counts statements
+against a recording session, which proves the loop batches and nothing else. Two
+facts it takes on trust come from the driver or not at all: that SQLAlchemy hands
+a list of parameter dictionaries for a `text()` DML statement to asyncpg as one
+`executemany` rather than refusing it, and that `ON CONFLICT (id) DO UPDATE`
+still behaves per row when it does. Both are asked here.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
+
+from app.services.rag import vectorstore as vectorstore_module
+from app.services.rag.models import (
+    Document,
+    DocumentMetadata,
+    DocumentPage,
+    DocumentPageChunk,
+)
+from app.services.rag.vectorstore import PgVectorStore
+
+pytestmark = pytest.mark.anyio
+
+_DIM = 3
+
+
+def _document(*, chunks: int, body: str = "chunk") -> Document:
+    document = Document(
+        pages=[DocumentPage(page_num=1, content="body")],
+        metadata=DocumentMetadata(filename="handbook.pdf", filesize=10, filetype="pdf"),
+    )
+    # `parent_doc_id` the way the splitter sets it (`documents.py:685`); the
+    # model validator only connects pages, not the chunks assigned after it.
+    document.chunked_pages = [
+        DocumentPageChunk(
+            chunk_content=f"{body} {index}",
+            chunk_num=index,
+            page_num=1,
+            content=f"{body} {index}",
+            parent_doc_id=document.id,
+        )
+        for index in range(chunks)
+    ]
+    return document
+
+
+def _store(engine: AsyncEngine) -> PgVectorStore:
+    """The real store on the suite's engine, with only the embedder stubbed.
+
+    `_ensure_collection` stays real - the table this writes into is the one it
+    creates, including the `vector({dim})` column the rows have to satisfy.
+    """
+    store = PgVectorStore.__new__(PgVectorStore)
+    store.async_session = async_sessionmaker(engine, expire_on_commit=False)
+    embedder = MagicMock(
+        embed_document=MagicMock(side_effect=lambda doc: [[0.25] * _DIM for _ in doc.chunked_pages])
+    )
+    store._for_collection = AsyncMock(return_value=(embedder, _DIM))  # ty: ignore[invalid-assignment]
+    return store
+
+
+async def _count(engine: AsyncEngine, table: str) -> int:
+    async with engine.connect() as connection:
+        result = await connection.execute(text(f"SELECT count(*) FROM {table}"))  # noqa: S608
+        return int(result.scalar_one())
+
+
+async def test_a_document_spanning_several_batches_writes_every_row(
+    engine: AsyncEngine, monkeypatch
+) -> None:
+    """250 chunks across a batch size of 100 must be 250 rows, not 100 and not 50."""
+    monkeypatch.setattr(vectorstore_module, "_CHUNK_INSERT_BATCH", 100)
+    collection = f"batched_{uuid.uuid4().hex[:8]}"
+    store = _store(engine)
+
+    await store.insert_document(collection, _document(chunks=250))
+
+    assert await _count(engine, f"rag_{collection}") == 250
+
+
+async def test_re_inserting_the_same_chunks_updates_rather_than_duplicates(
+    engine: AsyncEngine, monkeypatch
+) -> None:
+    """`ON CONFLICT (id) DO UPDATE` has to hold per row inside an `executemany`,
+    which is what makes a re-ingest of an unchanged document idempotent."""
+    monkeypatch.setattr(vectorstore_module, "_CHUNK_INSERT_BATCH", 4)
+    collection = f"upserted_{uuid.uuid4().hex[:8]}"
+    store = _store(engine)
+    document = _document(chunks=10)
+
+    await store.insert_document(collection, document)
+    for chunk in document.chunked_pages:
+        chunk.chunk_content = f"revised {chunk.chunk_num}"
+    await store.insert_document(collection, document)
+
+    table = f"rag_{collection}"
+    assert await _count(engine, table) == 10
+    async with engine.connect() as connection:
+        stored = await connection.execute(
+            text(f"SELECT content FROM {table} ORDER BY (metadata->>'chunk_num')::int")  # noqa: S608
+        )
+        assert [row[0] for row in stored] == [f"revised {index}" for index in range(10)]
+
+
+async def test_the_chunks_are_readable_back_in_document_order(
+    engine: AsyncEngine, monkeypatch
+) -> None:
+    """The store's own reader is the consumer of these rows, so it is what asserts
+    the batches did not scramble what the splitter produced."""
+    monkeypatch.setattr(vectorstore_module, "_CHUNK_INSERT_BATCH", 3)
+    collection = f"ordered_{uuid.uuid4().hex[:8]}"
+    store = _store(engine)
+    document = _document(chunks=8)
+    parent = document.chunked_pages[0].parent_doc_id
+
+    await store.insert_document(collection, document)
+
+    chunks = await store.get_document_chunks(collection, parent)
+    assert [chunk.content for chunk in chunks] == [f"chunk {index}" for index in range(8)]
+    assert [chunk.chunk_num for chunk in chunks] == list(range(8))

--- a/backend/tests/test_chunk_insert_batching.py
+++ b/backend/tests/test_chunk_insert_batching.py
@@ -1,0 +1,159 @@
+"""How many statements writing a document's chunks costs.
+
+#950. `insert_document` ran one `INSERT` per chunk in a Python loop, inside one
+open transaction. At the default `chunk_size` a 200-page PDF is on the order of
+one to three thousand chunks, so ingesting it was that many sequential asyncpg
+round trips: a second or two on a local socket, five to fifteen against a managed
+Postgres at 3-5ms - spent holding a connection while it waited.
+
+These count statements rather than time them, because the count is what the
+change is: it must not scale with the number of chunks. The integration half
+proves the `executemany` actually writes every row, which a counted mock cannot.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.rag import vectorstore as vectorstore_module
+from app.services.rag.models import (
+    Document,
+    DocumentMetadata,
+    DocumentPage,
+    DocumentPageChunk,
+)
+from app.services.rag.vectorstore import PgVectorStore
+
+pytestmark = pytest.mark.anyio
+
+
+def _document(*, chunks: int) -> Document:
+    document = Document(
+        pages=[DocumentPage(page_num=1, content="body")],
+        metadata=DocumentMetadata(filename="handbook.pdf", filesize=10, filetype="pdf"),
+    )
+    # `parent_doc_id` the way the splitter sets it (`documents.py:685`); the
+    # model validator only connects pages, not the chunks assigned after it.
+    document.chunked_pages = [
+        DocumentPageChunk(
+            chunk_content=f"chunk {index}",
+            chunk_num=index,
+            page_num=1,
+            content=f"chunk {index}",
+            parent_doc_id=document.id,
+        )
+        for index in range(chunks)
+    ]
+    return document
+
+
+class RecordingSession:
+    """A session that records the parameters each `execute` was given."""
+
+    def __init__(self) -> None:
+        self.calls: list[object] = []
+        self.commits = 0
+
+    async def __aenter__(self) -> RecordingSession:
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+    async def execute(self, statement: object, params: object = None) -> MagicMock:
+        self.calls.append(params)
+        return MagicMock()
+
+    async def commit(self) -> None:
+        self.commits += 1
+
+
+def _store(session: RecordingSession, *, dim: int = 3) -> PgVectorStore:
+    """The real `insert_document`, with only the collection and embedder stubbed.
+
+    `_ensure_collection` is replaced because it is DDL this is not about; what
+    stays real is the statement building and the loop over batches, which is the
+    whole of the change.
+    """
+    store = PgVectorStore.__new__(PgVectorStore)
+    store.async_session = lambda: session  # ty: ignore[invalid-assignment]
+    embedder = MagicMock(
+        embed_document=MagicMock(side_effect=lambda doc: [[0.0] * dim] * len(doc.chunked_pages))
+    )
+    store._ensure_collection = AsyncMock()  # ty: ignore[invalid-assignment]
+    store._for_collection = AsyncMock(return_value=(embedder, dim))  # ty: ignore[invalid-assignment]
+    return store
+
+
+class TestHowManyStatementsOneDocumentCosts:
+    async def test_a_document_of_many_chunks_is_written_in_batches(self, monkeypatch):
+        """The statement count follows the batch size, not the chunk count."""
+        monkeypatch.setattr(vectorstore_module, "_CHUNK_INSERT_BATCH", 100)
+        session = RecordingSession()
+
+        await _store(session).insert_document("docs", _document(chunks=250))
+
+        assert len(session.calls) == 3
+        assert [len(batch) for batch in session.calls] == [100, 100, 50]  # ty: ignore[invalid-argument-type]
+        assert session.commits == 1
+
+    async def test_a_document_within_one_batch_is_one_statement(self, monkeypatch):
+        """The common case - a short document - is a single round trip."""
+        monkeypatch.setattr(vectorstore_module, "_CHUNK_INSERT_BATCH", 200)
+        session = RecordingSession()
+
+        await _store(session).insert_document("docs", _document(chunks=7))
+
+        assert len(session.calls) == 1
+        assert len(session.calls[0]) == 7  # ty: ignore[invalid-argument-type]
+
+    async def test_the_statement_count_does_not_grow_with_the_chunk_count(self, monkeypatch):
+        """Ten times the chunks must not be ten times the statements, which is
+        the only thing distinguishing this from the loop it replaced."""
+        monkeypatch.setattr(vectorstore_module, "_CHUNK_INSERT_BATCH", 500)
+        small, large = RecordingSession(), RecordingSession()
+
+        await _store(small).insert_document("docs", _document(chunks=40))
+        await _store(large).insert_document("docs", _document(chunks=400))
+
+        assert len(small.calls) == len(large.calls) == 1
+
+    async def test_every_chunk_is_in_the_parameters_exactly_once(self, monkeypatch):
+        """Batching is only correct if nothing is dropped at a boundary."""
+        monkeypatch.setattr(vectorstore_module, "_CHUNK_INSERT_BATCH", 3)
+        session = RecordingSession()
+        document = _document(chunks=10)
+
+        await _store(session).insert_document("docs", document)
+
+        written = [row["id"] for batch in session.calls for row in batch]  # ty: ignore[invalid-argument-type]
+        assert written == [chunk.chunk_id for chunk in document.chunked_pages]
+
+    async def test_each_row_carries_its_own_metadata_and_vector(self, monkeypatch):
+        """The rows are built in a comprehension now, so a row taking the wrong
+        chunk's page number or the wrong embedding would be silent."""
+        monkeypatch.setattr(vectorstore_module, "_CHUNK_INSERT_BATCH", 200)
+        session = RecordingSession()
+        document = _document(chunks=4)
+        for index, chunk in enumerate(document.chunked_pages):
+            chunk.page_num = index + 1
+
+        await _store(session).insert_document("docs", document)
+
+        rows = session.calls[0]
+        assert [json.loads(row["metadata"])["page_num"] for row in rows] == [1, 2, 3, 4]  # ty: ignore[invalid-argument-type]
+        assert [json.loads(row["metadata"])["chunk_num"] for row in rows] == [0, 1, 2, 3]  # ty: ignore[invalid-argument-type]
+        assert {row["embedding"] for row in rows} == {"[0.0, 0.0, 0.0]"}  # ty: ignore[invalid-argument-type]
+
+    async def test_a_document_with_no_chunks_is_refused_before_any_statement(self):
+        """Unchanged, and worth pinning: an empty parameter list would make
+        `executemany` a silent no-op where the loop was a silent no-op too."""
+        session = RecordingSession()
+
+        with pytest.raises(ValueError, match="no chunked pages"):
+            await _store(session).insert_document("docs", _document(chunks=0))
+
+        assert session.calls == []

--- a/backend/tests/test_chunk_insert_batching.py
+++ b/backend/tests/test_chunk_insert_batching.py
@@ -14,6 +14,7 @@ proves the `executemany` actually writes every row, which a counted mock cannot.
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -56,6 +57,7 @@ class RecordingSession:
     def __init__(self) -> None:
         self.calls: list[object] = []
         self.commits = 0
+        self.on_execute: Callable[[], None] | None = None
 
     async def __aenter__(self) -> RecordingSession:
         return self
@@ -64,6 +66,8 @@ class RecordingSession:
         return None
 
     async def execute(self, statement: object, params: object = None) -> MagicMock:
+        if self.on_execute is not None:
+            self.on_execute()
         self.calls.append(params)
         return MagicMock()
 
@@ -147,6 +151,36 @@ class TestHowManyStatementsOneDocumentCosts:
         assert [json.loads(row["metadata"])["page_num"] for row in rows] == [1, 2, 3, 4]  # ty: ignore[invalid-argument-type]
         assert [json.loads(row["metadata"])["chunk_num"] for row in rows] == [0, 1, 2, 3]  # ty: ignore[invalid-argument-type]
         assert {row["embedding"] for row in rows} == {"[0.0, 0.0, 0.0]"}  # ty: ignore[invalid-argument-type]
+
+    async def test_each_batch_of_rows_is_built_when_its_statement_runs(self, monkeypatch):
+        """Batching the statements without batching the rows fixes nothing.
+
+        The embedding is rendered as text in these rows, tens of kilobytes each
+        at 3072 dimensions, so materialising all of them first would hold better
+        than 100MB of live strings for a long document - bounding what asyncpg
+        receives while leaving the worker's memory where it was. Counted through
+        `_build_chunk_metadata`, which runs once per row built: at each statement
+        only that batch's rows exist, so the counts step. Building the whole list
+        first reads as `[30, 30, 30]`.
+        """
+        monkeypatch.setattr(vectorstore_module, "_CHUNK_INSERT_BATCH", 10)
+        session = RecordingSession()
+        store = _store(session)
+        built = 0
+        original = store._build_chunk_metadata
+
+        def counting(chunk: object, document: object) -> dict[str, object]:
+            nonlocal built
+            built += 1
+            return original(chunk, document)  # ty: ignore[invalid-argument-type]
+
+        store._build_chunk_metadata = counting  # ty: ignore[invalid-assignment]
+        seen: list[int] = []
+        session.on_execute = lambda: seen.append(built)
+
+        await store.insert_document("docs", _document(chunks=30))
+
+        assert seen == [10, 20, 30]
 
     async def test_a_document_with_no_chunks_is_refused_before_any_statement(self):
         """Unchanged, and worth pinning: an empty parameter list would make

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -341,6 +341,17 @@ Chunk boundaries are what a search matches against, so a collection ingested
 before that change keeps the chunks it was ingested with. Re-upload a document,
 or re-run `uv run agenticos cmd rag-ingest`, to re-chunk it.
 
+**How many chunks a document has decides how long storing it takes, but no longer
+how many round trips.** `insert_document` writes them 200 rows to a statement
+(`executemany`, which asyncpg pipelines), where it used to issue one `INSERT` per
+chunk in a Python loop inside one open transaction — so a 200-page PDF at the
+default `chunk_size` was one to three thousand sequential round trips, five to
+fifteen seconds against a managed Postgres at 3-5ms before a single embedding was
+paid for ([#950](https://github.com/vstorm-co/agenticos/issues/950)). It is
+batched rather than one statement for the whole document because the parameter
+list is held in memory and each row carries its embedding rendered as text: at
+3072 dimensions that is tens of kilobytes a row.
+
 **An override is checked against the merged pair, not against its own value.** A
 per-upload `ingestion` field carries only what it changes, so `chunk_overlap:
 4096` sent to a collection chunking at 512 is two individually legal numbers and


### PR DESCRIPTION
`insert_document` issued one `INSERT` per chunk, in a Python loop, inside one open
transaction.

## The cost

At the default `chunk_size` of 512 a 200-page PDF is on the order of one to three
thousand chunks, so storing it was that many **sequential** asyncpg round trips: a
second or two on a local socket, five to fifteen seconds against a managed
Postgres at 3-5ms RTT — spent holding a connection from the pool while it waited,
which #948 was multiplying by every document in a batch.

## What changed

The rows are built first and handed to `session.execute` 200 at a time, which
SQLAlchemy issues as an `executemany` and asyncpg pipelines. The statement itself
is unchanged, `ON CONFLICT (id) DO UPDATE` included.

200 rather than one statement for the whole document because the parameter list is
held in memory and each row carries its embedding rendered as text — tens of
kilobytes a row at 3072 dimensions, so a three-thousand-chunk document in one
statement is a parameter list measured in hundreds of megabytes.

## Verified in two halves

A mock cannot answer the question that mattered, so both are here.

**Six unit tests** count statements against a recording session: the count follows
the batch size rather than the chunk count; ten times the chunks is not ten times
the statements; no chunk is dropped at a boundary; and each row still carries its
own page number and vector — that last one because the rows are built in a
comprehension now, where taking the wrong chunk's metadata would be silent.

**Three integration tests** ask a real `pgvector/pgvector:pg16` what only a driver
can answer: that SQLAlchemy accepts a list of parameter dictionaries for a
`text()` DML statement at all, that 250 chunks across a batch size of 100 are 250
rows, that the upsert still behaves **per row** inside an `executemany` (a
re-ingest updates ten rows rather than duplicating them), and that the store's own
reader gets them back in document order.

Five of the nine fail against the loop this replaces. The other four assert
correctness that held either way, which is why they are there.

- `make lint` clean, same 61 `ty` diagnostics as `main`.
- `make test`: **6135 passed, 15 skipped, 100%** on the platform layer.
- No frontend path changed, so `test-frontend` is not expected to run.

## Not measured

The actual latency improvement against a remote database. The arithmetic above is
the issue's; what these tests pin is the round-trip count, not the seconds.

Closes #950
