### PR TITLE
chore: cut 0.0.206

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,33 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.206] - 2026-08-20
+
+Storing a long document's chunks cost one database round trip per chunk.
+
+### Changed
+
+- **A document's chunks are written a batch of rows to a statement, not one
+  statement each.** `insert_document` issued one `INSERT` per chunk in a Python
+  loop inside one open transaction, so at the default `chunk_size` of 512 a
+  200-page PDF was one to three thousand *sequential* asyncpg round trips: a
+  second or two on a local socket, five to fifteen seconds against a managed
+  Postgres at 3-5ms - spent holding a connection while it waited. The rows now go
+  200 at a time through an `executemany`, which asyncpg pipelines. The statement
+  itself is unchanged, `ON CONFLICT (id) DO UPDATE` included, and it still behaves
+  per row: a re-ingest of an unchanged document updates its rows rather than
+  duplicating them. (#950)
+- **Each batch's rows are built where its statement runs.** Batching the
+  statements alone would have bounded what asyncpg receives while leaving the
+  worker's memory where it was: the embedding is rendered as text in these rows,
+  tens of kilobytes each at 3072 dimensions, so materialising a
+  three-thousand-chunk document first meant better than 100MB of live strings on
+  top of the float vectors already in hand - an OOM kill rather than a slow
+  ingest. 200 rather than one statement per document is the same reason. (#950)
+- **`docs/file-processing.md`** says how many round trips storing a document costs
+  and why the batch is bounded, in the chunking section where `chunk_size` is set.
+  (#950)
+
 ## [0.0.205] - 2026-08-20
 
 Ingesting a large batch of documents exhausted the worker's database

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.205"
+version = "0.0.206"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.205"
+version = "0.0.206"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.205",
+  "version": "0.0.206",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.206. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.206 and adds the CHANGELOG entry.

One performance change, in two halves, and the second half is the one worth
recording. `insert_document` wrote a document's chunks one `INSERT` at a time,
so a 200-page PDF was one to three thousand sequential round trips - five to
fifteen seconds against a managed Postgres before a single embedding was paid
for. The rows now go 200 to a statement through an `executemany`.

The first attempt batched the statements and left the rows: it built every
row - each carrying its embedding rendered as text, tens of kilobytes at 3072
dimensions - before the first statement ran, which bounds what asyncpg
receives while leaving the worker holding better than 100MB of live strings
for a long document. The reviewer caught it, and the code's own comment had
already said why it was wrong. Each batch's rows are now built where its
statement runs, and a test counts them per statement rather than trusting the
comment.

## Verified

`make lint` and `make test` locally: 6136 passed, 15 skipped, 100% on the
platform layer. CI green on #962 end to end on its final commit. Ten new
tests: six count statements against a recording session, three ask a real
`pgvector/pgvector:pg16` what only a driver can answer - that SQLAlchemy
accepts a list of parameter dictionaries for a `text()` DML statement, that
250 chunks across a batch of 100 are 250 rows, that the upsert still holds per
row - and one pins the per-batch row construction. Five of the nine original
tests fail against the loop this replaces.

What the verification does not reach: the latency itself. The arithmetic is
the issue's, and what these tests pin is the round-trip count rather than the
seconds - nothing here was measured against a remote database.

Found and not fixed: #963, the float vectors `embed_document` returns for a
whole document at once, which for a 3,000-chunk document at 3072 dimensions
is a few hundred megabytes. Pre-existing, unchanged here, and the larger of
the two by the time it matters.

Refs #950