### PR TITLE
fix(api): serialize both upload responses the same way

### DIFF
--- a/backend/app/api/routes/v1/rag.py
+++ b/backend/app/api/routes/v1/rag.py
@@ -299,7 +299,6 @@ async def delete_document(
 @router.post(
     "/collections/{name}/ingest",
     response_model=RAGIngestResponse,
-    response_model_exclude_none=True,
     status_code=status.HTTP_202_ACCEPTED,
     dependencies=[Depends(require(Perm.COLLECTIONS_EDIT))],
 )

--- a/backend/tests/api/test_ingestion_override_routes.py
+++ b/backend/tests/api/test_ingestion_override_routes.py
@@ -28,6 +28,7 @@ from app.core.permissions import AuthContext, OrgRoleName
 from app.db.models.knowledge_base import KBScope, KnowledgeBase
 from app.db.models.resource_grant import Visibility
 from app.main import app
+from app.schemas.rag import RAGIngestResponse
 from app.services import rag_document
 
 pytestmark = pytest.mark.anyio
@@ -160,6 +161,69 @@ class TestAnOverlapThatDoesNotFitInsideTheChunk:
         )["details"]["fields"]
 
         assert all(set(problem) == {"field", "message"} for problem in problems)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        f"{settings.API_V1_STR}/rag/collections/handbook/ingest",
+        f"{settings.API_V1_STR}/kb/{_KB_ID}/documents",
+    ],
+)
+class TestWhatBothUploadRoutesSerialize:
+    """The same schema, the same operation, the same keys on the wire.
+
+    #560. `ingest_file` carried `response_model_exclude_none=True` and
+    `upload_kb_document` did not, so `document_id` - `str | None`, and `None` on
+    every accepted upload, because the id exists only once the worker has indexed
+    the file - was absent from one answer and present as `null` in the other. A
+    client normalising the response got a different shape from each, and the flag
+    was the only use of it in the tree.
+
+    The service is stubbed here because the question is what the *route*
+    serializes: the two differed in a decorator argument, not in what they
+    computed.
+    """
+
+    @pytest.fixture(autouse=True)
+    def accepted_upload(self) -> MagicMock:
+        service = MagicMock()
+        service.dispatch_upload = AsyncMock(
+            return_value=RAGIngestResponse(
+                id=str(uuid.uuid4()),
+                status="processing",
+                filename="handbook.pdf",
+                collection="handbook",
+                message="File accepted. Processing in background.",
+            )
+        )
+        app.dependency_overrides[deps.get_rag_document_service] = lambda: service
+        return service
+
+    async def test_an_accepted_upload_names_document_id_even_when_it_has_none(
+        self, client: AsyncClient, store: MagicMock, path: str
+    ) -> None:
+        """`null` is the honest answer: the id does not exist yet."""
+        response = await client.post(path, files=_upload())
+
+        assert response.status_code == 202
+        body = response.json()
+        assert "document_id" in body
+        assert body["document_id"] is None
+
+    async def test_the_two_routes_answer_with_the_same_keys(
+        self, client: AsyncClient, store: MagicMock, path: str
+    ) -> None:
+        """Every field of the schema, from either address.
+
+        Asserted against the schema rather than against the other route's answer,
+        so this fails at whichever address drifts rather than only when they
+        disagree - and so adding a field to `RAGIngestResponse` that one route
+        drops is caught here too.
+        """
+        response = await client.post(path, files=_upload())
+
+        assert set(response.json()) == set(RAGIngestResponse.model_fields)
 
 
 class TestTheSameRuleOnTheCollectionsOwnSettings:

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -234,6 +234,13 @@ different pipeline handles parsing, chunking, and embedding.
 Over the API the order is the other way round: the `RAGDocument` row is written
 first and steps 2–5 run in a background task against a session of their own,
 which is why an upload answers `{"status": "processing"}` rather than waiting.
+There are two addresses an upload can arrive at — `POST /rag/collections/{name}/ingest`
+and `POST /kb/{kb_id}/documents` — and both answer **202** with the same
+`RAGIngestResponse`, every field of it, `"document_id": null` included: the vector
+store's id for the document does not exist until the worker has indexed it. One of
+the two used to omit the key rather than send it null, so a client normalising the
+answer got a different shape from each
+([#560](https://github.com/vstorm-co/agenticos/issues/560)).
 That task is started **after the request's transaction commits** — it is handed
 over with `spawn_after_commit`, not `spawn`, and started by the session itself
 once the row is durable. Dispatched any earlier it would look for the document


### PR DESCRIPTION
The same schema, the same operation, two shapes on the wire.

`POST /rag/collections/{name}/ingest` carried `response_model_exclude_none=True`
and `POST /kb/{kb_id}/documents` did not — both returning `RAGIngestResponse`,
both feeding the same upload UI. `document_id` is `str | None` and is `None` on
every accepted upload, because the vector store's id does not exist until the
worker has indexed the file. So one address omitted the key and the other sent it
as `null`, and a client normalising the answer got a different shape depending on
which it had called.

## The fix

The flag is gone rather than added to the other route. `null` is the honest answer
here — the id is pending, not absent — and it was the **only** use of
`response_model_exclude_none` in the tree, so keeping it would have meant
defending a convention with one member.

## Verified

Two tests at both addresses, in the file that already parametrizes over them:

- `document_id` is present and `null` on a 202.
- The response's keys are exactly `RAGIngestResponse.model_fields` — asserted
  against the **schema**, not against the other route's answer, so it fails at
  whichever address drifts rather than only when the two disagree, and a field
  added to the schema that one route drops is caught by it too.

Both fail with the flag put back, and only on the `/rag` path — which is the
asymmetry itself.

- `make lint` clean, same 61 `ty` diagnostics as `main`.
- `make test`: **6140 passed, 15 skipped, 100%** on the platform layer.
- **No client is affected.** The frontend never reads `document_id` from an
  upload response — `grep` finds only `vector_document_id` on tracked documents,
  a different field on a different schema — so the added key changes nothing on
  screen. No frontend path changed, so `test-frontend` is not expected to run.

`docs/file-processing.md` now names both addresses and says they answer 202 with
every field of the schema, `"document_id": null` included.

## Deliberately not fixed

The `Form(...)` description for `ingestion` still differs between the two routes.
#560 says that half belongs to the batched FE/BE cleanup in #545, not here.

Closes #560
