### PR TITLE
chore: cut 0.0.207

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,29 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.207] - 2026-08-20
+
+The two addresses an upload can arrive at answered with different shapes.
+
+### Fixed
+
+- **Both upload routes serialize `RAGIngestResponse` identically.**
+  `POST /rag/collections/{name}/ingest` carried `response_model_exclude_none=True`
+  and `POST /kb/{kb_id}/documents` did not - same schema, same operation, both
+  feeding the same upload UI. `document_id` is `str | None` and is `None` on every
+  accepted upload, because the vector store's id does not exist until the worker
+  has indexed the file, so one address omitted the key and the other sent it as
+  `null`: a client normalising the answer got a different shape depending on which
+  it had called. The flag is gone rather than added to the other route - `null` is
+  the honest answer, the id is pending rather than absent, and it was the only use
+  of `response_model_exclude_none` in the tree. No client is affected: nothing in
+  the frontend reads `document_id` from an upload response. (#560)
+
+### Changed
+
+- **`docs/file-processing.md`** names both upload addresses and says they answer
+  202 with every field of the schema, `"document_id": null` included. (#560)
+
 ## [0.0.206] - 2026-08-20
 
 Storing a long document's chunks cost one database round trip per chunk.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.206"
+version = "0.0.207"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.206"
+version = "0.0.207"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.206",
+  "version": "0.0.207",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.207. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.207 and adds the CHANGELOG entry.

One consistency fix. The two addresses an upload can arrive at returned the
same schema through different serialization: `response_model_exclude_none` on
one route and not the other, so `document_id` - null on every accepted upload,
because the id exists only once the worker has indexed the file - was absent
from one answer and `null` in the other. The flag is gone; it was the only use
of it in the tree.

The test asserts the response's keys against `RAGIngestResponse.model_fields`
rather than against the other route's answer, so it fails at whichever address
drifts instead of only when the two disagree.

## Verified

`make lint` and `make test` locally: 6140 passed, 15 skipped, 100% on the
platform layer. CI green on #965 end to end, and the Codex reviewer came back
clean on that commit - the first pass it has managed today, the earlier ones
having answered "usage limits".

No client is affected: nothing in the frontend reads `document_id` from an
upload response - `grep` finds only `vector_document_id`, a different field on
a different schema - so `make test-frontend-cov` was not re-run. No frontend
path has changed since 0.0.202, where it was green.

Refs #560