### PR TITLE
refactor(rag): one document lookup, one scan, both answers

### DIFF
--- a/backend/app/commands/rag.py
+++ b/backend/app/commands/rag.py
@@ -176,25 +176,23 @@ async def ingest_path_async(
 
             source_path = str(filepath.resolve())
             if sync_mode in ("new_only", "update_only"):
-                existing_id: str | None = await ingestion.find_existing(collection, source_path)
+                # One scan for both answers - see `existing_document` for why
+                # they are not two calls (#548, #566).
+                existing = await ingestion.existing_document(collection, source_path)
 
                 if sync_mode == "new_only":
-                    if existing_id:
+                    if existing.document_id:
                         file_hash: str = hashlib.sha256(filepath.read_bytes()).hexdigest()
-                        existing_hash: str | None = await ingestion.get_existing_hash(
-                            collection, source_path
-                        )
-                        if existing_hash and file_hash == existing_hash:
+                        if existing.content_hash and file_hash == existing.content_hash:
                             skipped_count += 1
                             continue
 
                 elif sync_mode == "update_only":
-                    if not existing_id:
+                    if not existing.document_id:
                         skipped_count += 1
                         continue
                     file_hash = hashlib.sha256(filepath.read_bytes()).hexdigest()
-                    existing_hash = await ingestion.get_existing_hash(collection, source_path)
-                    if existing_hash and file_hash == existing_hash:
+                    if existing.content_hash and file_hash == existing.content_hash:
                         skipped_count += 1
                         continue
 

--- a/backend/app/services/rag/ingestion.py
+++ b/backend/app/services/rag/ingestion.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from pathlib import Path
 
 from app.core.config import settings
@@ -14,6 +15,29 @@ from app.services.rag.vectorstore import BaseVectorStore
 from app.services.rag.vectorstore import PgVectorStore as VectorStore
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class StoredDocument:
+    """What a collection already holds for the file being ingested.
+
+    Both fields or neither: they are facts about one document, and returning
+    them together is what stops a caller pairing one document's id with
+    another's hash (#548). Absent means no match, not an empty document - a
+    stored hash of `""` is reported as `None` for the same reason every caller
+    gates on truthiness.
+    """
+
+    document_id: str | None = None
+    content_hash: str | None = None
+
+
+def _stored(doc: DocumentInfo) -> StoredDocument:
+    meta = doc.additional_info or {}
+    return StoredDocument(
+        document_id=doc.document_id,
+        content_hash=meta.get("content_hash") or None,
+    )
 
 
 class IngestionService:
@@ -51,46 +75,55 @@ class IngestionService:
             except Exception as e:
                 logger.warning("Webhook event dispatch failed: %s", e)
 
-    async def _existing_by_source(
-        self, collection_name: str, source_path: str
-    ) -> tuple[str | None, str | None]:
-        """The stored document `source_path` refers to, as `(document_id, content_hash)`.
+    async def existing_document(
+        self, collection_name: str, source_path: str, *, content_hash: str = ""
+    ) -> StoredDocument:
+        """The stored document this file refers to, found in one pass.
 
-        One precedence for both answers: a `source_path` match anywhere in the
-        collection beats a `filename` match anywhere in it. The id lookup and
-        the hash lookup used to walk the documents with different rules, so the
-        sync modes compared a live file's hash against a different document's
-        `content_hash` than the one they were about to replace (#548).
+        **One scan, one precedence, both answers.** A `source_path` match
+        anywhere in the collection beats a `filename` match anywhere in it, and
+        a `content_hash` match is the last resort - the order the ingest already
+        applied by calling two helpers in sequence, each walking the whole
+        collection with a predicate of its own.
+
+        There were three lookups over one listing before this, and they cost two
+        things. The obvious one is the scans: the sync modes asked for an id and
+        then for a hash, and `ingest_file` then asked twice more, so ingesting
+        one changed file read the entire collection four times (#566, and #27
+        for why reading it once is still not cheap).
+
+        The other is the reason those two answers are returned together rather
+        than by two methods. They are answers about *one document*, and when
+        they were computed separately they disagreed: the id lookup checked every
+        document for a `source_path` match before falling back to `filename`
+        while the hash lookup interleaved the two, so a caller compared a live
+        file's hash against a different document's `content_hash` than the one it
+        was about to replace - an unchanged file re-embedded on every sync, or a
+        changed one skipped as current (#548). A caller that cannot ask for one
+        without the other cannot reintroduce that.
+
+        A store that refuses answers "no match", as it did before: a listing this
+        cannot read is not evidence that the document is absent, but treating it
+        as a match would delete a document on the strength of a failed query.
         """
         try:
             docs = await self.store.get_documents(collection_name)
         except Exception as exc:
             logger.warning("Could not check for existing document: %s", exc, exc_info=True)
-            return None, None
-        filename = Path(source_path).name
-        fallback: DocumentInfo | None = None
+            return StoredDocument()
+        filename = Path(source_path).name if source_path else ""
+        by_filename: DocumentInfo | None = None
+        by_hash: DocumentInfo | None = None
         for doc in docs:
             meta = doc.additional_info or {}
-            if meta.get("source_path") == source_path:
-                return doc.document_id, meta.get("content_hash") or None
-            if fallback is None and doc.filename and doc.filename == filename:
-                fallback = doc
-        if fallback is None:
-            return None, None
-        meta = fallback.additional_info or {}
-        return fallback.document_id, meta.get("content_hash") or None
-
-    async def _find_existing_by_hash(self, collection_name: str, content_hash: str) -> str | None:
-        """Find an existing document by content hash (exact duplicate check)."""
-        try:
-            docs = await self.store.get_documents(collection_name)
-            for doc in docs:
-                meta = doc.additional_info or {}
-                if meta.get("content_hash") == content_hash:
-                    return doc.document_id
-        except Exception as exc:
-            logger.warning("Could not check for existing document: %s", exc, exc_info=True)
-        return None
+            if source_path and meta.get("source_path") == source_path:
+                return _stored(doc)
+            if by_filename is None and filename and doc.filename == filename:
+                by_filename = doc
+            if by_hash is None and content_hash and meta.get("content_hash") == content_hash:
+                by_hash = doc
+        matched = by_filename or by_hash
+        return _stored(matched) if matched is not None else StoredDocument()
 
     async def ingest_file(
         self,
@@ -120,14 +153,13 @@ class IngestionService:
 
             existing_id = None
             if replace:
-                if document.metadata.source_path:
-                    existing_id, _ = await self._existing_by_source(
-                        collection_name, document.metadata.source_path
+                existing_id = (
+                    await self.existing_document(
+                        collection_name,
+                        document.metadata.source_path or "",
+                        content_hash=document.metadata.content_hash or "",
                     )
-                if not existing_id and document.metadata.content_hash:
-                    existing_id = await self._find_existing_by_hash(
-                        collection_name, document.metadata.content_hash
-                    )
+                ).document_id
 
             if existing_id:
                 await self.store.delete_document(collection_name, existing_id)
@@ -181,14 +213,6 @@ class IngestionService:
             error_message=failure_summary(exc, stage=stage),
             message=f"Failed to process {filename}",
         )
-
-    async def find_existing(self, collection_name: str, source_path: str) -> str | None:
-        document_id, _ = await self._existing_by_source(collection_name, source_path)
-        return document_id
-
-    async def get_existing_hash(self, collection_name: str, source_path: str) -> str | None:
-        _, content_hash = await self._existing_by_source(collection_name, source_path)
-        return content_hash
 
     async def remove_document(self, collection_name: str, document_id: str) -> bool:
         """Wipes all traces of a document from the vector store."""

--- a/backend/app/worker/tasks/rag_tasks.py
+++ b/backend/app/worker/tasks/rag_tasks.py
@@ -399,27 +399,24 @@ async def _run_sync(
 
             source_path = str(filepath.resolve())
             if mode in ("new_only", "update_only"):
-                existing_id = await ingestion_service.find_existing(collection_name, source_path)
+                # One scan for both answers. They are facts about the same
+                # document, and asking for them separately is what let a live
+                # file's hash be compared against a different document's (#548).
+                existing = await ingestion_service.existing_document(collection_name, source_path)
 
                 if mode == "new_only":
-                    if existing_id:
+                    if existing.document_id:
                         file_hash = hashlib.sha256(filepath.read_bytes()).hexdigest()
-                        existing_hash = await ingestion_service.get_existing_hash(
-                            collection_name, source_path
-                        )
-                        if existing_hash and file_hash == existing_hash:
+                        if existing.content_hash and file_hash == existing.content_hash:
                             skipped += 1
                             continue
 
                 elif mode == "update_only":
-                    if not existing_id:
+                    if not existing.document_id:
                         skipped += 1
                         continue
                     file_hash = hashlib.sha256(filepath.read_bytes()).hexdigest()
-                    existing_hash = await ingestion_service.get_existing_hash(
-                        collection_name, source_path
-                    )
-                    if existing_hash and file_hash == existing_hash:
+                    if existing.content_hash and file_hash == existing.content_hash:
                         skipped += 1
                         continue
             try:

--- a/backend/tests/test_rag_document_lookup.py
+++ b/backend/tests/test_rag_document_lookup.py
@@ -1,4 +1,4 @@
-"""One precedence for "which stored document is this source_path" (#548).
+"""One precedence, one scan, for "which stored document is this file" (#548, #566).
 
 `find_existing` and `get_existing_hash` used to walk the collection with
 different rules: the id lookup checked every document for a `source_path`
@@ -10,18 +10,31 @@ different document's `content_hash` than the one they were about to replace:
 an unchanged file re-embedded on every sync, or a changed one skipped as
 already current.
 
+Both answers now come from one call, which is the structural half of that fix:
+a caller cannot pair one document's id with another's hash if it cannot ask for
+one without the other. It is also one full-collection read per file rather than
+the two the sync modes did and the two more `ingest_file` added (#566).
+
 This module is template-inherited and outside the coverage gate, which is why
 the precedence is pinned by name rather than trusted to a percentage.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from app.services.rag.ingestion import IngestionService
-from app.services.rag.models import DocumentInfo
+from app.services.rag.ingestion import IngestionService, StoredDocument
+from app.services.rag.models import (
+    Document,
+    DocumentInfo,
+    DocumentMetadata,
+    DocumentPage,
+    DocumentPageChunk,
+    IngestionStatus,
+)
 from app.services.rag.vectorstore import PgVectorStore
 
 pytestmark = pytest.mark.anyio
@@ -62,8 +75,9 @@ class TestOnePrecedenceForBothAnswers:
             ]
         )
 
-        assert await service.find_existing("kb", "/srv/sync/handbook.pdf") == "doc-b"
-        assert await service.get_existing_hash("kb", "/srv/sync/handbook.pdf") == "hash-b"
+        existing = await service.existing_document("kb", "/srv/sync/handbook.pdf")
+
+        assert existing == StoredDocument(document_id="doc-b", content_hash="hash-b")
 
     async def test_a_filename_match_answers_when_no_source_path_does(self):
         service = _service(
@@ -73,21 +87,53 @@ class TestOnePrecedenceForBothAnswers:
             ]
         )
 
-        assert await service.find_existing("kb", "/srv/sync/handbook.pdf") == "doc-b"
-        assert await service.get_existing_hash("kb", "/srv/sync/handbook.pdf") == "hash-b"
+        existing = await service.existing_document("kb", "/srv/sync/handbook.pdf")
 
-    async def test_no_match_answers_none_on_both_paths(self):
+        assert existing == StoredDocument(document_id="doc-b", content_hash="hash-b")
+
+    async def test_a_hash_match_is_the_last_resort_behind_the_filename(self):
+        """The order `ingest_file` used to get by calling two helpers in turn.
+
+        A document whose hash matches is the same content under another name, so
+        it is a match - but only where neither the path nor the name found one,
+        because a file that moved keeps its identity and a file that was copied
+        does not take over the original's.
+        """
+        service = _service(
+            [
+                _doc("doc-a", filename="copy.pdf", content_hash="hash-x"),
+                _doc("doc-b", filename="handbook.pdf", content_hash="hash-y"),
+            ]
+        )
+
+        by_name = await service.existing_document(
+            "kb", "/srv/sync/handbook.pdf", content_hash="hash-x"
+        )
+        by_hash = await service.existing_document(
+            "kb", "/srv/sync/absent.pdf", content_hash="hash-x"
+        )
+
+        assert by_name.document_id == "doc-b"
+        assert by_hash.document_id == "doc-a"
+
+    async def test_a_hash_is_only_matched_when_one_was_offered(self):
+        """An unhashed file must not match the first document that has no hash."""
+        service = _service([_doc("doc-a", filename="other.pdf")])
+
+        assert await service.existing_document("kb", "/srv/sync/handbook.pdf") == StoredDocument()
+
+    async def test_no_match_answers_neither_id_nor_hash(self):
         service = _service([_doc("doc-a", filename="other.pdf", content_hash="hash-a")])
 
-        assert await service.find_existing("kb", "/srv/sync/handbook.pdf") is None
-        assert await service.get_existing_hash("kb", "/srv/sync/handbook.pdf") is None
+        assert await service.existing_document("kb", "/srv/sync/handbook.pdf") == StoredDocument()
 
-    async def test_a_store_failure_answers_no_match_on_both_paths(self):
+    async def test_a_store_failure_answers_no_match(self):
+        """A listing that cannot be read is not evidence the document is absent -
+        but treating it as a match would delete one on a failed query."""
         store = MagicMock(get_documents=AsyncMock(side_effect=RuntimeError("connection refused")))
         service = IngestionService(processor=MagicMock(), vector_store=store)
 
-        assert await service.find_existing("kb", "/srv/sync/handbook.pdf") is None
-        assert await service.get_existing_hash("kb", "/srv/sync/handbook.pdf") is None
+        assert await service.existing_document("kb", "/srv/sync/handbook.pdf") == StoredDocument()
 
     async def test_a_document_without_a_stored_hash_answers_none_not_empty(self):
         """`_group_documents` fills an absent hash with "" — callers gate on truthiness."""
@@ -95,7 +141,65 @@ class TestOnePrecedenceForBothAnswers:
             [_doc("doc-a", filename="handbook.pdf", source_path="/srv/sync/handbook.pdf")]
         )
 
-        assert await service.get_existing_hash("kb", "/srv/sync/handbook.pdf") is None
+        existing = await service.existing_document("kb", "/srv/sync/handbook.pdf")
+
+        assert existing == StoredDocument(document_id="doc-a", content_hash=None)
+
+
+class TestHowManyTimesTheCollectionIsRead:
+    """#566. Three lookups over one listing, and a sync asked for two of them."""
+
+    async def test_both_answers_cost_one_read(self):
+        store = MagicMock(
+            get_documents=AsyncMock(
+                return_value=[
+                    _doc(
+                        "doc-a",
+                        filename="handbook.pdf",
+                        source_path="/srv/sync/handbook.pdf",
+                        content_hash="hash-a",
+                    )
+                ]
+            )
+        )
+        service = IngestionService(processor=MagicMock(), vector_store=store)
+
+        existing = await service.existing_document("kb", "/srv/sync/handbook.pdf")
+
+        assert existing.document_id and existing.content_hash
+        assert store.get_documents.await_count == 1
+
+    async def test_an_ingest_that_replaces_reads_the_collection_once(self):
+        """It read it twice: once for the path, then again for the hash.
+
+        Both are decided in one pass now, so the count is one whether the path
+        matched or the hash did.
+        """
+        store = MagicMock(
+            get_documents=AsyncMock(return_value=[]),
+            insert_document=AsyncMock(),
+            delete_document=AsyncMock(),
+        )
+        document = Document(
+            pages=[DocumentPage(page_num=1, content="body")],
+            metadata=DocumentMetadata(filename="handbook.pdf", filesize=4, filetype="pdf"),
+        )
+        document.chunked_pages = [
+            DocumentPageChunk(chunk_content="body", chunk_num=0, page_num=1, content="body")
+        ]
+        document.metadata.content_hash = "hash-a"
+        processor = MagicMock(process_file=AsyncMock(return_value=document))
+        service = IngestionService(processor=processor, vector_store=store)
+
+        result = await service.ingest_file(
+            filepath=Path("handbook.pdf"),
+            collection_name="kb",
+            replace=True,
+            source_path="/srv/sync/handbook.pdf",
+        )
+
+        assert result.status is IngestionStatus.DONE
+        assert store.get_documents.await_count == 1
 
 
 class TestGetDocumentsIsDeterministic:

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -634,6 +634,28 @@ Sync operations are tracked via the `SyncLog` model, recording source, mode,
 total files, ingested/updated/skipped/failed counts, and timing. View sync
 history via `GET /rag/sync/logs`.
 
+**Which stored document a file corresponds to is one question, asked once.**
+`IngestionService.existing_document` reads the collection's document listing a
+single time and answers with both the document's id and its stored
+`content_hash`, in one precedence: a `source_path` match beats a `filename`
+match, and a `content_hash` match is the last resort. The two answers come back
+together on purpose — they are facts about *one* document, and while they were
+computed by separate lookups they could disagree, so a sync compared a live
+file's hash against a different document's and either re-embedded an unchanged
+file every night or skipped a changed one as current
+([#548](https://github.com/vstorm-co/agenticos/issues/548)). That also made
+ingesting one changed file read the whole collection up to four times; it is now
+once for the decision and once inside the ingest
+([#566](https://github.com/vstorm-co/agenticos/issues/566)). Reading it at all is
+still a full scan — [#27](https://github.com/vstorm-co/agenticos/issues/27) is the
+pagination that would fix that.
+
+`new_only` skips a file whose stored hash matches, `update_only` skips one that
+is unchanged and ignores one that is new, and `full` replaces whatever it
+matches. A store that cannot answer the listing is treated as "no match" rather
+than as a match: a failed query is not evidence that a document is absent, but
+acting on it as though a document *were* present would delete one.
+
 One source's own history is `GET /kb/{kb_id}/sync-sources/{source_id}/logs`. The
 source is resolved against that knowledge base first, so a source belonging to
 another base answers **404** rather than an empty list — the two render the same


### PR DESCRIPTION
Three lookups walked the same document listing with three predicates —
`_existing_by_source` (source_path, then filename), `_find_existing_by_hash`
(content hash), and two public methods each projecting one field from the first.
Every one of them read the whole collection.

## The count

Ingesting one changed file in `new_only` mode read the collection **four times**:
the sync asked for an id, then for a hash, and `ingest_file` then asked for both
again. An unchanged file cost two. It is now **one** for the sync's decision and
**one** inside the ingest.

## The reason both answers come back together

That is the smaller half. While the id and the hash were computed separately they
could **disagree** — the id lookup checked every document for a `source_path`
match before falling back to `filename`, while the hash lookup interleaved the
two. A caller then compared a live file's hash against a different document's
`content_hash` than the one it was about to replace, and either re-embedded an
unchanged file every night or skipped a changed one as current (#548).

`existing_document` returns a frozen `StoredDocument` carrying both, so a caller
**cannot ask for one without the other** and cannot pair them wrongly. That makes
#548 unrepeatable rather than merely fixed.

`find_existing` and `get_existing_hash` are gone rather than kept as wrappers: two
methods whose whole purpose was to project half of one answer are how the answer
got split in the first place. Both sync callers — the worker flow and `rag-sync`
in the CLI — did the identical two-call dance and now do one.

## Behaviour is unchanged

Precedence included: `source_path`, then `filename`, then `content_hash`. A store
that refuses answers "no match", as before, and that is now stated where it
happens: a listing this cannot read is not evidence the document is absent, but
treating it as a match would delete a document on the strength of a failed query.

## Verified

`tests/test_rag_document_lookup.py` keeps the five precedence tests #548 left,
rewritten onto the one call, and adds three:

- the hash fallback sits **behind** the filename match — a file that moved keeps
  its identity, a file that was copied does not take over the original's;
- an unhashed file does not match a document that has no hash either;
- two count `get_documents` awaits, which is what stops a fourth lookup being
  added later.

10 passed. `make lint` clean, same 61 `ty` diagnostics as `main`. `make test`:
**6144 passed, 15 skipped, 100%** on the platform layer. No frontend path changed.

## Not addressed

**#27** — paginating `get_documents`. One read per file is still one read too many
on a collection of thousands, and this change does not pretend otherwise.

Closes #566
