### PR TITLE
chore: cut 0.0.208

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,35 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.208] - 2026-08-20
+
+Ingesting one changed file read the whole collection four times.
+
+### Changed
+
+- **One document lookup, one scan, both answers.** Three lookups walked the same
+  document listing with three predicates - `source_path`-then-`filename`, content
+  hash, and two public methods each projecting one field from the first - and every
+  one of them read the whole collection. So ingesting a changed file in `new_only`
+  mode read it four times (the sync asked for an id, then a hash, and `ingest_file`
+  asked for both again) and an unchanged one twice; it is now once for the sync's
+  decision and once inside the ingest. Both sync callers, the worker flow and
+  `rag-sync` in the CLI, did the identical two-call dance and now do one. (#566)
+- **The id and the hash come back together, so they cannot disagree.**
+  `IngestionService.existing_document` answers with a frozen `StoredDocument`
+  carrying both, and `find_existing` / `get_existing_hash` are gone rather than
+  kept as wrappers. While the two were computed separately they *could* name
+  different documents - the id lookup checked every document for a `source_path`
+  match before falling back to `filename` while the hash lookup interleaved the
+  two - so a sync compared a live file's hash against a different document's and
+  either re-embedded an unchanged file every night or skipped a changed one as
+  current. That was fixed in #548; a caller that cannot ask for one answer without
+  the other cannot write it again. (#566)
+- **`docs/file-processing.md`** states the precedence, the read count, and that a
+  store which cannot answer the listing is treated as "no match" - a failed query
+  is not evidence a document is absent, and acting as though one were present
+  would delete it. (#566)
+
 ## [0.0.207] - 2026-08-20
 
 The two addresses an upload can arrive at answered with different shapes.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.207"
+version = "0.0.208"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.207"
+version = "0.0.208"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.207",
+  "version": "0.0.208",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.208. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.208 and adds the CHANGELOG entry.

One refactor, and the count is the smaller half of it. Three lookups read the
same document listing with three predicates, so ingesting one changed file read
the whole collection four times and an unchanged one twice - now once for the
sync's decision and once inside the ingest.

What the change is actually for is that the id and the hash are answers about
one document, and while two methods computed them separately they could name
two. That was #548, fixed once already; `existing_document` returning both in
a frozen `StoredDocument` is what stops it being written a second time, and the
two half-answer methods are deleted rather than kept as wrappers.

## Verified

`make lint` and `make test` locally: 6144 passed, 15 skipped, 100% on the
platform layer. CI green on #967 end to end, and the Codex reviewer came back
clean on that commit.

The five precedence tests #548 left are rewritten onto the one call, and three
are new: the hash fallback sitting behind the filename match, an unhashed file
not matching a document that has no hash either, and two counting
`get_documents` awaits - which is what stops a fourth lookup being added later.

Behaviour is unchanged, precedence included, so there is nothing here a
deployment has to do. What this release does *not* fix is that reading the
listing at all is a full scan: #27 is the pagination, and one read per file is
still one too many on a collection of thousands.

Refs #566