### PR TITLE
chore: cut 0.0.209

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,60 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.209] - 2026-08-20
+
+A chat attachment was refused by a 10 MiB limit no operator could see or raise.
+
+### Added
+
+- **`CHAT_MAX_UPLOAD_SIZE_MB`, default 10** - what may be attached in chat, and a
+  *different* setting from the knowledge base's `MAX_UPLOAD_SIZE_MB` rather than the
+  same one. A knowledge-base document is chunked, embedded and read back through
+  retrieval; an attachment to an agent with no workspace is pasted whole into the
+  prompt, so the same size fails differently on each surface and one ceiling cannot
+  be right for both. The default is what the hardcoded limit already enforced, so
+  nothing changes on upgrade except that it can now be raised. `GET /health`
+  publishes both ceilings, because a client that reads one cannot know the other.
+  (#498)
+
+### Fixed
+
+- **The chat upload limit is a setting rather than a literal.** Three numbers
+  claimed to be it and they disagreed: `MAX_UPLOAD_SIZE` (10 MiB in
+  `file_storage.py`) was what refused, `MAX_UPLOAD_SIZE_MB` (50) was what `/health`
+  published and what RAG ingestion used, and the frontend defaulted its own check to
+  50. So a 20MB attachment passed the client check, was read into memory, crossed
+  the wire in full and came back refused by a number that appeared in no
+  configuration file - while `frontend/README.md` told the operator to keep the
+  client value "at or below the backend's", which was advice they could not follow.
+  (#498)
+- **The whole-request body ceiling follows the largest upload limit, not the first
+  one.** `BodySizeLimitMiddleware` is global and derived its cap from
+  `MAX_UPLOAD_SIZE_MB` alone, so a chat limit configured above the knowledge base's
+  would have been unreachable - a 413 before the code that enforces it ran. It now
+  takes the largest of the three, including the embed ceiling, which is the smallest
+  today and would have been the same latent defect for whoever raised it next.
+  (#498)
+- **A `sonner` mock in `chat-input.test.tsx` was never reset**, so a toast asserted
+  in one test was still recorded in the next one asserting none. Found because it
+  would have made a new test lie. (#498)
+
+### Changed
+
+- **The composer's own ceiling is `NEXT_PUBLIC_CHAT_MAX_UPLOAD_SIZE_MB`**, defaulting
+  to 10 and named for its surface. It was `MAX_UPLOAD_SIZE_MB` defaulting to 50 - and
+  it is the only reader of that value in the frontend, so it was already the chat
+  limit by usage with the wrong number in it. The three compose files, the frontend
+  `Dockerfile`, `.env.example` and the `vercel-deploy` recipe all named the old
+  variable; each now passes the configured value through. **An operator setting
+  `NEXT_PUBLIC_MAX_UPLOAD_SIZE_MB` must rename it**, or the composer silently takes
+  the 10MB default. (#498)
+- **Four pages described the old split** - `configuration.md`, `channels.md`,
+  `architecture.md` and `file-processing.md` - and each now names the setting for the
+  surface it describes. `file-processing.md`'s "Size Limits" sits under a chat
+  heading and led with the knowledge base's number; it leads with the chat one now.
+  (#498)
+
 ## [0.0.208] - 2026-08-20
 
 Ingesting one changed file read the whole collection four times.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.208"
+version = "0.0.209"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.208"
+version = "0.0.209"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.208",
+  "version": "0.0.209",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.209. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.209 and adds the CHANGELOG entry.

One fix with an operator-visible rename in it. Three numbers claimed to be the
chat upload limit; the one that refused was a literal nobody could configure,
while `/health` published a different one and the composer checked against that
same wrong one. A 20MB attachment therefore passed the client, crossed the wire
and was refused by a number in no configuration file.

#498 asked for a decision as well as a fix, and the decision is two settings:
`CHAT_MAX_UPLOAD_SIZE_MB` (10) for chat, `MAX_UPLOAD_SIZE_MB` (50) for
knowledge-base documents. An attachment to an agent with no workspace is pasted
whole into the prompt while a document is chunked and embedded, so one ceiling
cannot be right for both. The chat default is what was already enforced, so
behaviour is unchanged on upgrade.

**Operators upgrading: `NEXT_PUBLIC_MAX_UPLOAD_SIZE_MB` is now
`NEXT_PUBLIC_CHAT_MAX_UPLOAD_SIZE_MB`.** Left unrenamed, the composer takes the
10MB default and disagrees with a backend configured higher.

The reviewer found four things, and the first was a hole in the fix's own
claim: the global body-size middleware derived its cap from
`MAX_UPLOAD_SIZE_MB` alone, so a chat limit raised above 50 would have been
refused with a 413 before the code enforcing it ran. It follows the largest of
the three ceilings now. The other three were the same mistake in three
deployment surfaces - the Vercel recipe, the local compose file and the docs
section - each of which would have left a configured value unread.

## Verified

`make lint`, `make test` (6152 passed, 15 skipped, 100% on the platform layer)
and `make test-frontend-cov` (5238 passed, 100%/97.67%) locally. CI green on
#969 end to end on its final commit, including `test-frontend` and
`build-frontend`, which this branch is the first in this series to exercise.

Ten new backend tests and two frontend ones. The one that matters most refuses
and then accepts the same 30MB file with nothing changed but the setting -
which is the thing that could not be done before - and the body-limit test
fails against the old derivation.

Not verified: no real upload was pushed through a deployment at a raised
ceiling. The tests assert the decision each limit makes, not the transfer.

Refs #498