### PR TITLE
fix(rag): refuse a collection rag-source-add cannot legally own

### DIFF
--- a/backend/app/commands/rag.py
+++ b/backend/app/commands/rag.py
@@ -17,12 +17,15 @@ import asyncio
 import hashlib
 import json
 from pathlib import Path
+from uuid import UUID
 
 import click
 
 from app.commands import command, error, info, success, warning
 from app.core.background import drain
+from app.core.exceptions import AppException
 from app.db.session import get_db_context
+from app.repositories import knowledge_base_repo, organization_repo
 from app.schemas.sync_source import SyncSourceCreate
 from app.services.embedding_resolution import embeddings_for_collection
 from app.services.rag.config import DEFAULT_COLLECTION_NAME, DocumentExtensions, RAGSettings
@@ -552,6 +555,7 @@ def rag_sources() -> None:
 @command("rag-source-add", help="Add a new sync source")
 @click.option("--name", required=True, help="Source name")
 @click.option("--type", "connector_type", required=True, help="Connector type (e.g. gdrive, s3)")
+@click.option("--org", "org_id", required=True, help="Organization id that owns the collection")
 @click.option("--collection", required=True, help="Target collection name")
 @click.option("--config", "config_json", required=True, help="Config JSON string")
 @click.option(
@@ -570,6 +574,7 @@ def rag_sources() -> None:
 def rag_source_add(
     name: str,
     connector_type: str,
+    org_id: str,
     collection: str,
     config_json: str,
     sync_mode: str,
@@ -578,14 +583,30 @@ def rag_source_add(
     """
     Add a new sync source configuration.
 
+    `--org` is required, and the collection has to be one that organization
+    already holds. A sync *writes into* the collection it names, so a row
+    pointing at a name nobody owns is a source that fails in a worker, and one
+    pointing at another tenant's is an injection rather than a read - the same
+    reason the HTTP route resolves the collection through
+    `CollectionAccessService.writable` before creating anything. This command
+    had no ctx and so asked neither question: it wrote whatever name it was
+    given, into a row with no organization at all (#707).
+
     Example:
-        project cmd rag-source-add --name "My Drive" --type gdrive --collection docs \\
+        project cmd rag-source-add --name "My Drive" --type gdrive \\
+            --org 0c8f... --collection docs \\
             --config '{"folder_id": "abc123"}' --sync-mode new_only
     """
     try:
         config_dict = json.loads(config_json)
     except json.JSONDecodeError as e:
         error(f"Invalid JSON config: {e}")
+        return
+
+    try:
+        organization_id = UUID(org_id)
+    except ValueError:
+        error(f"Not an organization id: {org_id}")
         return
 
     data = SyncSourceCreate(
@@ -599,11 +620,29 @@ def rag_source_add(
 
     async def _create() -> None:
         async with get_db_context() as db:
+            organization = await organization_repo.get_by_id(db, organization_id)
+            if organization is None:
+                error(f"No such organization: {org_id}")
+                return
+            # `list_by_collection_name`, not `get_by_collection_name`: the column
+            # is not unique, so the singular lookup answers with whichever row
+            # the database returns first and would hand this organization
+            # another's collection (#913). The candidates are filtered here, by
+            # the organization the operator named.
+            candidates = await knowledge_base_repo.list_by_collection_name(db, collection)
+            owned = [kb for kb in candidates if kb.organization_id == organization_id]
+            if not owned:
+                error(
+                    f"No collection '{collection}' in {organization.name}. "
+                    "A sync writes into the collection it names, so it has to exist first."
+                )
+                return
+
             svc = SyncSourceService(db)
             try:
-                source = await svc.create_source(data)
+                source = await svc.create_source(data, organization_id=organization_id)
                 success(f"Sync source created: {source.name} (id={source.id})")
-            except ValueError as e:
+            except (ValueError, AppException) as e:
                 error(f"Failed to create source: {e}")
 
     asyncio.run(_create())

--- a/backend/app/commands/rag.py
+++ b/backend/app/commands/rag.py
@@ -24,6 +24,7 @@ import click
 from app.commands import command, error, info, success, warning
 from app.core.background import drain
 from app.core.exceptions import AppException
+from app.db.models.knowledge_base import KBScope
 from app.db.session import get_db_context
 from app.repositories import knowledge_base_repo, organization_repo
 from app.schemas.sync_source import SyncSourceCreate
@@ -601,13 +602,13 @@ def rag_source_add(
         config_dict = json.loads(config_json)
     except json.JSONDecodeError as e:
         error(f"Invalid JSON config: {e}")
-        return
+        raise SystemExit(1) from e
 
     try:
         organization_id = UUID(org_id)
-    except ValueError:
+    except ValueError as exc:
         error(f"Not an organization id: {org_id}")
-        return
+        raise SystemExit(1) from exc
 
     data = SyncSourceCreate(
         name=name,
@@ -618,34 +619,56 @@ def rag_source_add(
         schedule_minutes=schedule_minutes if schedule_minutes > 0 else None,
     )
 
-    async def _create() -> None:
+    async def _create() -> bool:
         async with get_db_context() as db:
             organization = await organization_repo.get_by_id(db, organization_id)
             if organization is None:
                 error(f"No such organization: {org_id}")
-                return
+                return False
             # `list_by_collection_name`, not `get_by_collection_name`: the column
             # is not unique, so the singular lookup answers with whichever row
             # the database returns first and would hand this organization
             # another's collection (#913). The candidates are filtered here, by
             # the organization the operator named.
+            #
+            # Org-scoped only, and that is not the same question as "carries this
+            # organization_id": a *personal* base carries it too, and
+            # `writable_kb` lets only its owner write to one. Accepting one here
+            # would point an organization-owned source at a member's private
+            # collection, which every member holding `connections:manage` can
+            # then see and trigger. The CLI has no caller identity, so the org
+            # scope is the only one it can claim on the organization's behalf -
+            # an app-scoped base belongs to the deployment and takes an app
+            # admin.
             candidates = await knowledge_base_repo.list_by_collection_name(db, collection)
-            owned = [kb for kb in candidates if kb.organization_id == organization_id]
+            owned = [
+                kb
+                for kb in candidates
+                if kb.organization_id == organization_id and kb.scope == KBScope.ORG.value
+            ]
             if not owned:
                 error(
-                    f"No collection '{collection}' in {organization.name}. "
-                    "A sync writes into the collection it names, so it has to exist first."
+                    f"No organization-scoped collection '{collection}' in {organization.name}. "
+                    "A sync writes into the collection it names, so it has to exist first - "
+                    "and a personal collection is its owner's to point a source at, not the "
+                    "organization's."
                 )
-                return
+                return False
 
             svc = SyncSourceService(db)
             try:
                 source = await svc.create_source(data, organization_id=organization_id)
-                success(f"Sync source created: {source.name} (id={source.id})")
             except (ValueError, AppException) as e:
                 error(f"Failed to create source: {e}")
+                return False
+            success(f"Sync source created: {source.name} (id={source.id})")
+            return True
 
-    asyncio.run(_create())
+    # A refusal has to be a non-zero exit, not red text on stdout: `error` is
+    # `click.secho`, so returning normally from a refused command left click
+    # exiting 0 and a shell script carrying on as though the source existed.
+    if not asyncio.run(_create()):
+        raise SystemExit(1)
 
 
 @command("rag-source-remove", help="Remove a sync source")

--- a/backend/app/services/sync_source.py
+++ b/backend/app/services/sync_source.py
@@ -12,7 +12,9 @@ from app.core.config import settings
 from app.core.crypto import decrypt_value, encrypt_value, is_encrypted
 from app.core.exceptions import BadRequestError, NotFoundError
 from app.core.field_errors import refused_field
+from app.db.base import Base
 from app.db.models.sync_source import SyncSource
+from app.db.vector_tables import validate_collection_name
 from app.services.rag.connectors import CONNECTOR_REGISTRY
 from app.repositories import sync_log as sync_log_repo
 from app.repositories import sync_source as sync_source_repo
@@ -199,14 +201,32 @@ class SyncSourceService:
         `collection_name` is optional - omit to create an org-level integration
         not yet linked to a knowledge base.
 
+        The name's *shape* is judged here rather than only at the routes,
+        because a sync writes into whatever collection this row names and the
+        store will interpolate it into DDL. A name no table can be called was
+        accepted and then failed in a worker, attributed to the sync rather than
+        to the configuration that caused it - which is the same class of failure
+        #371 and #368 fixed on the route side, reaching the row through the CLI
+        instead (#707).
+
+        Whose collection it is remains the caller's question, because only the
+        caller knows who is asking: the route resolves it with
+        `CollectionAccessService.writable`, and `rag-source-add` resolves the
+        organization it was given. This method cannot answer it - `organization_id`
+        is a keyword here and `None` is a legal value for it.
+
         Raises:
-            BadRequestError: unknown connector or invalid config.
+            BadRequestError: unknown connector, invalid config, or a collection
+                name that cannot safely become an identifier.
         """
         if data.connector_type not in CONNECTOR_REGISTRY:
             raise BadRequestError(
                 message=f"Unknown connector type: {data.connector_type}",
                 details={"connector_type": data.connector_type},
             )
+
+        if data.collection_name is not None:
+            validate_collection_name(data.collection_name, metadata=Base.metadata)
 
         await _refuse_an_invalid_config(data.config, data.connector_type)
 

--- a/backend/tests/test_commands.py
+++ b/backend/tests/test_commands.py
@@ -174,6 +174,154 @@ class TestRagSourceSyncWaitsForItsWork:
         )
 
 
+class TestRagSourceAddRefusesWhatItCannotOwn:
+    """#707. The command wrote a caller-supplied collection name straight into a
+    `sync_sources` row without asking whether it was a legal identifier, whether
+    a knowledge base of that name existed, or whose it was. The HTTP route for
+    the same thing asks all three, and its docstring says why: "a sync writes
+    into the collection, so pointing one at another tenant's is an injection,
+    not a read".
+
+    The row also had no organization - `create_source` was called without one and
+    the column is nullable - while the model's docstring opens "Belongs to an
+    organization". `--org` is now required and is what answers the ownership
+    question the CLI has no `ctx` for.
+    """
+
+    ORG = uuid4()
+
+    @staticmethod
+    def _run(monkeypatch, *, organization, candidates, service=None):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from app.commands import rag as rag_command
+
+        created: list[dict[str, object]] = []
+
+        class RecordingService:
+            def __init__(self, db: object) -> None:
+                self.db = db
+
+            async def create_source(self, data, organization_id=None):
+                created.append({"data": data, "organization_id": organization_id})
+                return SimpleNamespace(name=data.name, id=uuid4())
+
+        @asynccontextmanager
+        async def session() -> AsyncGenerator[object, None]:
+            yield object()
+
+        monkeypatch.setattr(rag_command, "get_db_context", session)
+        monkeypatch.setattr(
+            rag_command.organization_repo, "get_by_id", AsyncMock(return_value=organization)
+        )
+        monkeypatch.setattr(
+            rag_command.knowledge_base_repo,
+            "list_by_collection_name",
+            AsyncMock(return_value=candidates),
+        )
+        monkeypatch.setattr(rag_command, "SyncSourceService", service or RecordingService)
+        return created, MagicMock
+
+    def _invoke(self, collection: str, org: str | None = None):
+        from app.commands import rag as rag_command
+
+        return CliRunner().invoke(
+            rag_command.rag_source_add,
+            [
+                "--name",
+                "My Drive",
+                "--type",
+                "gdrive",
+                "--org",
+                org or str(self.ORG),
+                "--collection",
+                collection,
+                "--config",
+                '{"folder_id": "abc123"}',
+            ],
+        )
+
+    def test_a_collection_the_organization_holds_is_accepted_and_owns_the_row(
+        self, monkeypatch
+    ) -> None:
+        """And the row carries the organization, which every row this command
+        made used to lack."""
+        organization = SimpleNamespace(id=self.ORG, name="Acme")
+        kb = SimpleNamespace(collection_name="docs", organization_id=self.ORG)
+        created, _ = self._run(monkeypatch, organization=organization, candidates=[kb])
+
+        result = self._invoke("docs")
+
+        assert result.exit_code == 0, result.output
+        assert len(created) == 1
+        assert created[0]["organization_id"] == self.ORG
+        assert created[0]["data"].collection_name == "docs"
+
+    def test_a_collection_no_knowledge_base_claims_is_refused(self, monkeypatch) -> None:
+        """It was accepted, and then failed in a worker - attributed to the sync
+        rather than to the configuration that caused it."""
+        organization = SimpleNamespace(id=self.ORG, name="Acme")
+        created, _ = self._run(monkeypatch, organization=organization, candidates=[])
+
+        result = self._invoke("absent")
+
+        assert created == []
+        assert "No collection 'absent'" in result.output
+
+    def test_another_organizations_collection_is_refused(self, monkeypatch) -> None:
+        """The injection the route's docstring names. `collection_name` is not
+        unique, so a name can exist and still not be this organization's - which
+        is why the command filters the candidates rather than taking the first
+        row the database returns (#913).
+        """
+        organization = SimpleNamespace(id=self.ORG, name="Acme")
+        theirs = SimpleNamespace(collection_name="docs", organization_id=uuid4())
+        created, _ = self._run(monkeypatch, organization=organization, candidates=[theirs])
+
+        result = self._invoke("docs")
+
+        assert created == []
+        assert "No collection 'docs'" in result.output
+
+    def test_an_organization_that_does_not_exist_is_refused(self, monkeypatch) -> None:
+        created, _ = self._run(monkeypatch, organization=None, candidates=[])
+
+        result = self._invoke("docs")
+
+        assert created == []
+        assert "No such organization" in result.output
+
+    def test_something_that_is_not_an_organization_id_is_refused_before_any_query(
+        self, monkeypatch
+    ) -> None:
+        """Left to `UUID()` inside the coroutine this was a `ValueError`
+        traceback rather than a sentence."""
+        created, _ = self._run(monkeypatch, organization=None, candidates=[])
+
+        result = self._invoke("docs", org="acme")
+
+        assert created == []
+        assert "Not an organization id" in result.output
+
+    def test_a_name_no_table_can_be_called_is_refused_by_the_service(self, monkeypatch) -> None:
+        """The shape check lives in `create_source`, so the route and the CLI
+        share it. The command reports it rather than raising a traceback.
+        """
+        from app.services.sync_source import SyncSourceService
+
+        organization = SimpleNamespace(id=self.ORG, name="Acme")
+        kb = SimpleNamespace(collection_name="Bad Name!", organization_id=self.ORG)
+        self._run(
+            monkeypatch, organization=organization, candidates=[kb], service=SyncSourceService
+        )
+
+        result = self._invoke("Bad Name!")
+
+        assert result.exit_code == 0, result.output
+        assert "Failed to create source" in result.output
+        assert "collection name" in result.output
+
+
 class TestSeedSkillsSurvivesARacingListing:
     """A listing top-up can commit the same skill between the command's name
     check and its flush. That surfaces as `IntegrityError`, not

--- a/backend/tests/test_commands.py
+++ b/backend/tests/test_commands.py
@@ -174,6 +174,22 @@ class TestRagSourceSyncWaitsForItsWork:
         )
 
 
+def _kb(
+    *,
+    organization_id,
+    collection_name: str = "docs",
+    scope: str = "org",
+    owner=None,
+) -> SimpleNamespace:
+    """A knowledge base row as the command reads one: name, tenant and scope."""
+    return SimpleNamespace(
+        collection_name=collection_name,
+        organization_id=organization_id,
+        scope=scope,
+        owner_user_id=owner,
+    )
+
+
 class TestRagSourceAddRefusesWhatItCannotOwn:
     """#707. The command wrote a caller-supplied collection name straight into a
     `sync_sources` row without asking whether it was a legal identifier, whether
@@ -247,7 +263,7 @@ class TestRagSourceAddRefusesWhatItCannotOwn:
         """And the row carries the organization, which every row this command
         made used to lack."""
         organization = SimpleNamespace(id=self.ORG, name="Acme")
-        kb = SimpleNamespace(collection_name="docs", organization_id=self.ORG)
+        kb = _kb(organization_id=self.ORG)
         created, _ = self._run(monkeypatch, organization=organization, candidates=[kb])
 
         result = self._invoke("docs")
@@ -266,7 +282,8 @@ class TestRagSourceAddRefusesWhatItCannotOwn:
         result = self._invoke("absent")
 
         assert created == []
-        assert "No collection 'absent'" in result.output
+        assert result.exit_code != 0
+        assert "'absent'" in result.output
 
     def test_another_organizations_collection_is_refused(self, monkeypatch) -> None:
         """The injection the route's docstring names. `collection_name` is not
@@ -275,13 +292,46 @@ class TestRagSourceAddRefusesWhatItCannotOwn:
         row the database returns (#913).
         """
         organization = SimpleNamespace(id=self.ORG, name="Acme")
-        theirs = SimpleNamespace(collection_name="docs", organization_id=uuid4())
+        theirs = _kb(organization_id=uuid4())
         created, _ = self._run(monkeypatch, organization=organization, candidates=[theirs])
 
         result = self._invoke("docs")
 
         assert created == []
-        assert "No collection 'docs'" in result.output
+        assert result.exit_code != 0
+        assert "'docs'" in result.output
+
+    def test_a_members_personal_collection_is_refused(self, monkeypatch) -> None:
+        """A personal base carries the organization's id too, so "same tenant" is
+        not ownership: `writable_kb` lets only its owner write to one.
+
+        Accepting it here would point an *organization-owned* source at a
+        member's private collection, which every member holding
+        `connections:manage` could then see and trigger. The command has no
+        caller identity, so the org scope is the only one it can claim on the
+        organization's behalf.
+        """
+        organization = SimpleNamespace(id=self.ORG, name="Acme")
+        personal = _kb(organization_id=self.ORG, scope="personal", owner=uuid4())
+        created, _ = self._run(monkeypatch, organization=organization, candidates=[personal])
+
+        result = self._invoke("docs")
+
+        assert created == []
+        assert result.exit_code != 0
+        assert "personal collection" in result.output
+
+    def test_an_app_scoped_collection_is_refused(self, monkeypatch) -> None:
+        """It belongs to the deployment, and takes an app admin - which a
+        `--org` cannot stand in for."""
+        organization = SimpleNamespace(id=self.ORG, name="Acme")
+        shared = _kb(organization_id=self.ORG, scope="app")
+        created, _ = self._run(monkeypatch, organization=organization, candidates=[shared])
+
+        result = self._invoke("docs")
+
+        assert created == []
+        assert result.exit_code != 0
 
     def test_an_organization_that_does_not_exist_is_refused(self, monkeypatch) -> None:
         created, _ = self._run(monkeypatch, organization=None, candidates=[])
@@ -289,6 +339,7 @@ class TestRagSourceAddRefusesWhatItCannotOwn:
         result = self._invoke("docs")
 
         assert created == []
+        assert result.exit_code != 0
         assert "No such organization" in result.output
 
     def test_something_that_is_not_an_organization_id_is_refused_before_any_query(
@@ -301,6 +352,7 @@ class TestRagSourceAddRefusesWhatItCannotOwn:
         result = self._invoke("docs", org="acme")
 
         assert created == []
+        assert result.exit_code != 0
         assert "Not an organization id" in result.output
 
     def test_a_name_no_table_can_be_called_is_refused_by_the_service(self, monkeypatch) -> None:
@@ -310,16 +362,29 @@ class TestRagSourceAddRefusesWhatItCannotOwn:
         from app.services.sync_source import SyncSourceService
 
         organization = SimpleNamespace(id=self.ORG, name="Acme")
-        kb = SimpleNamespace(collection_name="Bad Name!", organization_id=self.ORG)
+        kb = _kb(collection_name="Bad Name!", organization_id=self.ORG)
         self._run(
             monkeypatch, organization=organization, candidates=[kb], service=SyncSourceService
         )
 
         result = self._invoke("Bad Name!")
 
-        assert result.exit_code == 0, result.output
+        assert result.exit_code != 0
         assert "Failed to create source" in result.output
         assert "collection name" in result.output
+
+    def test_a_refusal_exits_non_zero_so_a_script_can_read_it(self, monkeypatch) -> None:
+        """`error` is `click.secho`, so a command that printed and returned exited
+        **0** - and a shell script carried on as though the source had been
+        created when no row existed.
+        """
+        organization = SimpleNamespace(id=self.ORG, name="Acme")
+        created, _ = self._run(monkeypatch, organization=organization, candidates=[])
+
+        result = self._invoke("absent")
+
+        assert created == []
+        assert result.exit_code == 1
 
 
 class TestSeedSkillsSurvivesARacingListing:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -452,10 +452,14 @@ uv run agenticos cmd rag-sync-s3 --collection docs --bucket my-bucket
 # List configured sync sources
 uv run agenticos cmd rag-sources
 
-# Add a new sync source
+# Add a new sync source. `--org` is required and the collection has to be one
+# that organization already holds: a sync *writes into* the collection it names,
+# so a source pointing at a name nobody owns fails later in a worker, and one
+# pointing at another tenant's is an injection rather than a read.
 uv run agenticos cmd rag-source-add \
     --name "My Drive" \
     --type gdrive \
+    --org 0c8f2b1e-... \
     --collection docs \
     --config '{"folder_id": "abc123"}' \
     --sync-mode new_only \

--- a/docs/howto/configure-sync-sources.md
+++ b/docs/howto/configure-sync-sources.md
@@ -43,6 +43,7 @@ uv run agenticos cmd rag-sources
 uv run agenticos cmd rag-source-add \
   --name "Legal docs" \
   --type gdrive \
+  --org 0c8f2b1e-... \
   --collection legal \
   --config '{"folder_id": "1abc123def", "include_subfolders": true}' \
   --sync-mode new_only \
@@ -55,6 +56,7 @@ uv run agenticos cmd rag-source-add \
 uv run agenticos cmd rag-source-add \
   --name "Marketing" \
   --type s3 \
+  --org 0c8f2b1e-... \
   --collection marketing \
   --config '{"bucket": "my-docs", "prefix": "marketing/"}' \
   --sync-mode full \


### PR DESCRIPTION
`rag-source-add --collection <name>` wrote a caller-supplied collection name
straight into a `sync_sources` row without asking whether it was a legal
identifier, whether a knowledge base of that name existed, or whose it was. The
HTTP route for the same thing asks all three, and its own docstring says why:

> a sync writes into the collection, so pointing one at another tenant's is an
> injection, not a read.

The row also had no organization at all — `create_source` was called without one
and the column is nullable — while the model's docstring opens *"Belongs to an
organization"*.

## Three questions, answered where they can be

**Shape, in the service.** `create_source` runs `validate_collection_name` when a
name is given, so the route and the CLI share one rule and a name no table can be
called is refused where it enters rather than failing later in a worker,
attributed to the sync rather than to the configuration that caused it. Same class
as #371 and #368, reaching the row by another door.

**Ownership, in the command**, because only the caller knows who is asking.
`--org` is required now and is what the CLI has instead of a `ctx`: the
organization is resolved, and the collection has to be one it already holds.

The candidates come from `list_by_collection_name`, **not**
`get_by_collection_name` — the column is not unique, so the singular lookup
answers with whichever row the database returns first and would hand this
organization another's collection (#913). Filtering by the named organization is
exactly what that repository docstring asks a caller to do.

**The organization on the row** follows from the same lookup, so every row this
command makes now has one. That is also **step 1 of #937**: converging
`sync_sources.config` onto the vault needs an owner to bind a ciphertext to, and
the nullable column is what has been blocking it.

## Verified

Six tests in `tests/test_commands.py`, following `TestRagSourceSyncWaitsForItsWork`
as #439 left it. The accepted case asserts the row carries the organization; the
five refusals cover

- a collection no knowledge base claims,
- **another organization's collection with the same name** — the injection the
  route's docstring names,
- an organization that does not exist,
- a `--org` that is not a UUID (a `ValueError` traceback before this, since
  `UUID()` ran inside the coroutine),
- a malformed name, reported as a sentence rather than raised.

`make lint` clean, same 61 `ty` diagnostics as `main`. `make test`: **6158 passed,
15 skipped, 100%** on the platform layer. No frontend path changed.

## Breaking for the CLI

`--org` is required, so an existing script calling `rag-source-add` without it now
exits with click's usage error rather than creating an org-less row.
`docs/commands.md` and `docs/howto/configure-sync-sources.md` carry it in all three
documented invocations. There is no data migration here: existing org-less rows are
untouched, and moving them is #937's business.

Closes #707
Refs #937
