### PR TITLE
chore: cut 0.0.211

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,63 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.211] - 2026-08-20
+
+The last second mechanism for secrets at rest is gone.
+
+### Upgrading
+
+**A sync source's credential is no longer a `config` field.** Migration `0042`
+handles it, and it is not silent:
+
+- A source holding an encrypted credential has it **removed** from `config` and is
+  **named in the migration's output**. Nothing readable is lost - the value was a
+  Fernet token over `SECRET_KEY`, and the release that could read it is the one
+  being replaced - and leaving it would leave a credential at rest under a
+  deployment-wide key, which is the whole point of the change. Each named source
+  then has no credential and refuses to sync until one is attached.
+- **Add the credential to the organization's Vault** - a `gcp_service_account` for
+  Drive, an `aws_credentials` pair for S3, both now offered under a new *Document
+  source* group - and point each source at it.
+- **A source with no organization stops the upgrade.** `sync_sources.organization_id`
+  is `NOT NULL` now, and anything `rag-source-add` created before #707 has none.
+  Set it or delete the row, then upgrade.
+- **API callers** posting `service_account_json`, `access_key_id` or
+  `secret_access_key` under `config` get a 400 naming the field. `rag-source-add`
+  takes `--secret-id`.
+
+### Changed
+
+- **A sync source references a vault secret by id.** `sync_sources.config` held the
+  credential, encrypted by `app/core/crypto.py`: one deployment-wide Fernet key
+  over every tenant's secret, which is the weakness the vault exists to remove and
+  the one place `CLAUDE.md`'s "there is no second mechanism" was untrue. That module
+  is **deleted**. `config` now says only how to *find* the documents, and each
+  connector declares the kind of credential it takes. A credential is added once and
+  reused - five collections fed from one Drive folder used to mean the same JSON
+  pasted five times and rotated in five places - and it appears on the Vault page
+  like everything else. (#937)
+- **The sync wizard asks for a credential as its own step**, offering the
+  organization's matching secrets and linking to the Vault when there are none. It
+  distinguishes a vault that holds nothing from one that could not be read. (#937)
+- **`app/worker/background/rag.py` is deleted.** Its three in-process handlers had no
+  caller in `app/` at all, and the connector interface change made them
+  uncompilable. `IngestionService.from_settings` went with them. (#959)
+
+### Fixed
+
+- **Binding a sync credential checks that the binder can see it.** A secret can be
+  private to a member, and a sync runs for everyone who can reach the collection -
+  so binding one is lending it. A Builder with `connections:manage` but shared-only
+  secret visibility could post the id of another member's private credential and
+  have the worker unseal it. The row now goes through
+  `resolve_access(..., Perm.SECRETS_VIEW, resource_type=SECRET)`, refused in the
+  same words as an id that does not exist so the refusal cannot enumerate the
+  vault - the same fix #918 made for embedding keys. (#937)
+- **A nullable sync-source column can be cleared.** The repository skipped every
+  `None`, so `{"secret_id": null}` answered 200 and left the old credential
+  attached, and a source that recovered kept its previous `last_error`. (#937)
+
 ## [0.0.210] - 2026-08-20
 
 `rag-source-add` accepted any collection name, including another tenant's.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.210"
+version = "0.0.211"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.210"
+version = "0.0.211"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.210",
+  "version": "0.0.211",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.211. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.211 and adds the CHANGELOG entry.

The largest change in this series, and the one with operator steps.
`sync_sources.config` held a Google service account JSON or an AWS key pair,
encrypted by `app/core/crypto.py` - one deployment-wide Fernet key over every
tenant's credential, and the one table where "there is no second mechanism" was
untrue. A source now references a vault secret by id, and that module is gone.

**Operators: read the Upgrading section.** Migration `0042` strips an encrypted
credential out of `config` and names the sources it did that to; each needs its
credential added to the Vault and attached. A source with no organization stops
the upgrade, because the column is now NOT NULL.

## What the review changed

Worth recording, because it was most of the work. The reviewer found seven
things and all seven were real, three of them release-breaking: every
configured-source sync would have raised on a re-parsed UUID; a Builder with
shared-only secret visibility could bind another member's *private* credential,
which is the exact hole class this change exists to close; and the migration
refused to run while telling the operator to do something the pre-migration
schema made impossible. The rest were a nullable column that could not be
cleared, a CLI with no way to attach a credential, a Vault that had no purpose
for either credential shape, and a credential step that read a failed vault as
an empty one.

The honest lesson is that this branch was too large to get right in one pass.

## Verified

`make lint`, `make test` (6178 passed, 15 skipped, 100% on the platform layer)
and `make test-frontend-cov` (5244 passed, 100%/97.67%) locally. CI green on
#974 end to end on its final commit, including `e2e` - which is what caught the
integration spec still filling a field that no longer exists.

The migration was exercised by hand against a scratch database: an encrypted
source keeps `folder_id` and `include_subfolders`, loses the ciphertext, ends
with `secret_id` null; the org-less refusal fires and names the row; and
`alembic check` plus a full downgrade/upgrade cycle are clean.

Not verified: no sync was run against a real Drive folder or S3 bucket with a
vault-held credential. The tests assert which rows are refused and which
credential reaches a connector, not that Google or AWS then accepts it.

Refs #937
Refs #959