### PR TITLE
chore: cut 0.0.212

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,33 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.212] - 2026-08-20
+
+The RAG dialogs: a real editor for a model prompt, one width scale, and a mark on
+each parser.
+
+### Changed
+
+- **The image-description prompt is a `MarkdownEditor`.** It is a model prompt,
+  several sentences long, and it was a bare three-row textarea - while the product
+  already has the control for that, the one the Builder uses for an agent's
+  instructions, an exposure prompt and a capability's generated form. The editor
+  gained `maxLength` so the swap did not quietly drop the hard cap: a field whose
+  length the API refuses should not let somebody write past it and find out on
+  submit. `IngestionSettings` is embedded whole in the create dialog, so both
+  dialogs get it. (#940)
+- **The four RAG dialogs agree on a width scale.** The same `IngestionSettings` was
+  given 768px in two of them and 512px in the one that also carries four fields
+  above it - not a judgement call but a disagreement, since nobody had decided and
+  each had picked. `src/lib/dialog-widths.ts` holds the three sizes with the rule on
+  each, so the create dialog is no longer the narrowest thing holding the widest
+  form. (#940)
+- **Each PDF parser choice draws a mark.** Three lines of text where every other
+  picker in the product draws one. Only LlamaParse is a product, so it takes
+  LlamaIndex's own mark - a row in `scripts/gen-brand-icons.ts`, generated, never a
+  hand-authored path - and PyMuPDF and liteparse take a lucide icon rather than one
+  row getting special treatment and two getting blanks. (#940)
+
 ## [0.0.211] - 2026-08-20
 
 The last second mechanism for secrets at rest is gone.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.211"
+version = "0.0.212"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.211"
+version = "0.0.212"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.211",
+  "version": "0.0.212",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.212. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.212 and adds the CHANGELOG entry.

Frontend only: the RAG dialogs. A model prompt gets the control the rest of the
product uses for a model prompt, the four dialogs stop disagreeing about how
wide `IngestionSettings` should be, and the parser picker draws a mark on each
of its three choices instead of one on none.

The width scale is the part worth a file: the same component was given 768px in
two dialogs and 512px in the one carrying four fields above it, which is a
disagreement rather than a decision. `src/lib/dialog-widths.ts` is where the
fifth dialog looks.

## Verified

`make lint-frontend`, `make test-frontend-cov` (5248 passed, 100%/97.67%) and
`make build-frontend` locally. CI green on #976 end to end, and the Codex
reviewer came back clean.

Four new tests, two of them the regression that matters - the editor's
source/preview toggle and the length cap, since the field is easy to swap back
to a textarea. `make test` was not re-run: no backend path changed since
0.0.211, and CI skipped that job for the same reason.

Refs #940