### PR TITLE
chore: cut 0.0.213

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,41 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.213] - 2026-08-20
+
+Both RAG pages get tabs, and the tab is in the URL.
+
+### Changed
+
+- **Integrations is `/rag`'s third tab.** `ReusableIntegrations` sat under the base
+  grid - the right relationship, since the collections are fed from it, and the
+  wrong placement: on an organization with a dozen bases it was below a grid three
+  rows deep, and reachable *only* from the Knowledge bases tab, which makes a
+  page-level concern something you find by first choosing one of two tabs. (#939)
+- **A knowledge base has three tabs** - Documents, How documents are read, Sync
+  sources. Each section carried a comment justifying its place under the one above,
+  and each argument was about reading order on a first visit, which is not where
+  somebody returns to: adjusting a parser meant scrolling past every document. The
+  stats strip and the override banner stay above the tabs, because they describe
+  the collection rather than any one section. (#939)
+- **Both pages carry `?tab=`**, read through the SSR-aware `useUrlState` rather
+  than a `useState` initializer touching `window` - which renders one value on the
+  server and another in the browser, so the default tab flashed before the named
+  one arrived. A link can name a section and a reload keeps it. (#939)
+- **The onboarding walk selects a tab before spotlighting what is inside it.** Four
+  steps gained `activate`; without it a stop waits four seconds for an element that
+  never mounts. (#939)
+
+### Fixed
+
+- **Each tab shows only its own section.** The base list rendered for every value
+  that was not `search`, so choosing Integrations appended the panel *below* the
+  grid rather than replacing it - the placement the tab exists to escape. (#939)
+- **A tab's panel lives inside its `Tabs` root**, on both RAG pages. A
+  `TabsTrigger` points at its panel with `aria-controls`, and a root that closed
+  after the trigger list left those references dangling and the visible section
+  with no `role="tabpanel"`. Pre-existing on `/rag`; fixed there too. (#939)
+
 ## [0.0.212] - 2026-08-20
 
 The RAG dialogs: a real editor for a model prompt, one width scale, and a mark on

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.212"
+version = "0.0.213"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.212"
+version = "0.0.213"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.212",
+  "version": "0.0.213",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.213. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.213 and adds the CHANGELOG entry.

Frontend only, and the last of the RAG page work. Both pages get tabs, the tab
goes in the URL through the SSR-aware hook, and the onboarding walk selects a
tab before spotlighting a control inside it.

Two of the entries are fixes to this branch's own first attempt, found in
review: the base grid still rendered in the Integrations tab, which is the
placement the tab exists to escape, and the panels sat outside the `Tabs` root
so every trigger's `aria-controls` pointed at nothing. The second was
pre-existing on `/rag` and is fixed there as well.

## Verified

`make lint-frontend`, `make test-frontend-cov` (5253 passed, 100%/97.67%) and
`make build-frontend` locally. CI green on #978 end to end on its final commit,
including `e2e` - which is what caught four specs reaching for sections that are
now behind tabs, and is the only place that could: the dev database in this
checkout is stamped at a renumbered migration, so a local run fails its queries
before reaching a locator.

One test came out rather than going in. "Opens the section the URL names"
passed while the page was showing its default - `useSearchParams` is mocked
empty in `vitest.setup.ts`, so the URL never reached the page - and substituting
that mock per file did not take effect. The read direction is covered by
`src/hooks/use-url-state.test.tsx`, the hook's own suite; what the page suites
assert is what they can assert honestly. A test that passes for the wrong reason
is worse than not having it.

`make test` was not re-run and CI skipped it: no backend path changed since
0.0.212.

Refs #939