### PR TITLE
fix(rag): implement sync_mode in the connector sync

### DIFF
--- a/backend/app/services/rag/ingestion.py
+++ b/backend/app/services/rag/ingestion.py
@@ -36,6 +36,27 @@ def _stored(doc: DocumentInfo) -> StoredDocument:
     )
 
 
+def _unaddressed(doc: DocumentInfo) -> bool:
+    """Whether this document may be matched by its *name* alone.
+
+    Only one that does not already claim an address of its own. A file uploaded
+    through the browser stores its filename as its `source_path`, so the two
+    agree and it stays reachable by name - which is what the fallback is for: a
+    document uploaded once and later synced from the folder it came from should
+    be replaced rather than duplicated.
+
+    A document that names a *different* address is a different document, and
+    matching it by basename loses one of them. An S3 bucket holding
+    `a/readme.md` and `b/readme.md` is the case: the second key found the
+    first's document by name, so equal contents skipped it and unequal contents
+    replaced the first - either way a first sync could not keep both, silently
+    (#990). The same collision existed for two local files of the same name in
+    different directories.
+    """
+    stored_path = str((doc.additional_info or {}).get("source_path") or "")
+    return not stored_path or stored_path == doc.filename
+
+
 class IngestionService:
     """File → Parse/Chunk → Deduplicate → Embed/Store → Query-Ready."""
 
@@ -97,9 +118,10 @@ class IngestionService:
         by_hash: DocumentInfo | None = None
         for doc in docs:
             meta = doc.additional_info or {}
-            if source_path and meta.get("source_path") == source_path:
+            stored_path = str(meta.get("source_path") or "")
+            if source_path and stored_path == source_path:
                 return _stored(doc)
-            if by_filename is None and filename and doc.filename == filename:
+            if by_filename is None and filename and doc.filename == filename and _unaddressed(doc):
                 by_filename = doc
             if by_hash is None and content_hash and meta.get("content_hash") == content_hash:
                 by_hash = doc
@@ -142,14 +164,21 @@ class IngestionService:
                     )
                 ).document_id
 
-            if existing_id:
-                await self.store.delete_document(collection_name, existing_id)
-                logger.info("Replaced existing document %s for '%s'", existing_id, filepath.name)
-
+            # Inserted before the old one is removed, not after. `insert_document`
+            # is where the embeddings are computed, so a provider that refuses
+            # between the two statements used to leave the collection with
+            # *neither* document - permanently, since the failure is returned
+            # rather than raised and nothing retries it. In this order the worst
+            # case is both for as long as the insert takes, which a search
+            # survives and a reader can see (#990).
             await self.store.insert_document(
                 collection_name=collection_name,
                 document=document,
             )
+
+            if existing_id:
+                await self.store.delete_document(collection_name, existing_id)
+                logger.info("Replaced existing document %s for '%s'", existing_id, filepath.name)
 
             action = "replaced" if existing_id else "ingested"
             chunk_count = len(document.chunked_pages or [])

--- a/backend/app/services/rag/ingestion.py
+++ b/backend/app/services/rag/ingestion.py
@@ -118,8 +118,7 @@ class IngestionService:
         by_hash: DocumentInfo | None = None
         for doc in docs:
             meta = doc.additional_info or {}
-            stored_path = str(meta.get("source_path") or "")
-            if source_path and stored_path == source_path:
+            if source_path and meta.get("source_path") == source_path:
                 return _stored(doc)
             if by_filename is None and filename and doc.filename == filename and _unaddressed(doc):
                 by_filename = doc
@@ -168,9 +167,10 @@ class IngestionService:
             # is where the embeddings are computed, so a provider that refuses
             # between the two statements used to leave the collection with
             # *neither* document - permanently, since the failure is returned
-            # rather than raised and nothing retries it. In this order the worst
-            # case is both for as long as the insert takes, which a search
-            # survives and a reader can see (#990).
+            # rather than raised and nothing retries it. This order fails the
+            # other way: a delete that does not happen leaves both, which is
+            # visible, searchable and fixable, where neither was none of those
+            # (#990).
             await self.store.insert_document(
                 collection_name=collection_name,
                 document=document,

--- a/backend/app/worker/tasks/rag_tasks.py
+++ b/backend/app/worker/tasks/rag_tasks.py
@@ -34,7 +34,7 @@ from app.services.rag.config import DocumentExtensions
 from app.services.rag.connectors import CONNECTOR_REGISTRY
 from app.services.rag.embeddings import EmbeddingService
 from app.services.rag.failures import IngestionStage, failure_summary
-from app.services.rag.ingestion import IngestionService
+from app.services.rag.ingestion import IngestionService, StoredDocument
 from app.services.rag.models import IngestionStatus
 from app.services.rag.vectorstore import EmbeddingResolver
 from app.services.rag.vectorstore import PgVectorStore as VectorStore
@@ -631,14 +631,52 @@ async def _run_source_sync(source_id: str, sync_log_id: str | None = None) -> di
         with tempfile.TemporaryDirectory() as tmp_dir:
             for remote_file in files:
                 try:
+                    # `sync_mode` used to reach one argument here and nothing
+                    # else, so a scheduled source re-embedded every file every
+                    # night - and on the default `new_only` it passed
+                    # `replace=False`, which skips the lookup, leaves the old
+                    # document in place and inserts a second copy. A week of
+                    # nightly syncs was seven copies of every chunk, ranked
+                    # against each other in every search (#990). The modes are
+                    # `sync_local_flow`'s, deliberately: one column feeds both
+                    # flows and they must mean the same thing.
+                    existing = StoredDocument()
+                    if sync_mode in ("new_only", "update_only"):
+                        existing = await ingestion_svc.existing_document(
+                            collection_name, remote_file.source_path
+                        )
+                        # Before the transfer, where the answer allows it:
+                        # `update_only` has nothing to do with a file it has
+                        # never seen, and downloading one to find that out is a
+                        # transfer per new file, every run.
+                        if sync_mode == "update_only" and not existing.document_id:
+                            skipped += 1
+                            continue
+
                     local_path = await connector.download_file(
                         remote_file, Path(tmp_dir), config=config, credential=credential
                     )
+
+                    # After it, because a hash needs the bytes and no remote
+                    # system on this list offers one. A stored document with no
+                    # hash is re-ingested rather than assumed current: the
+                    # embedding is the cost worth avoiding, and skipping a file
+                    # that may have changed is the answer that cannot be
+                    # corrected later.
+                    if existing.content_hash and (
+                        hashlib.sha256(local_path.read_bytes()).hexdigest() == existing.content_hash
+                    ):
+                        skipped += 1
+                        continue
+
                     with metered_by(ledger):
                         await ingestion_svc.ingest_file(
                             filepath=local_path,
                             collection_name=collection_name,
-                            replace=(sync_mode == "full"),
+                            # Unconditional, as in `sync_local_flow`: once this
+                            # has decided to ingest, whatever it matched has to
+                            # go, or the collection grows a copy.
+                            replace=True,
                             source_path=remote_file.source_path,
                         )
                     ingested += 1

--- a/backend/app/worker/tasks/rag_tasks.py
+++ b/backend/app/worker/tasks/rag_tasks.py
@@ -621,7 +621,8 @@ async def _run_source_sync(source_id: str, sync_log_id: str | None = None) -> di
 
     connector = connector_cls()
 
-    ingested = skipped = failed = total = 0
+    ingested = updated = skipped = failed = 0
+    total = 0
     ledger = SpendLedger(organization_id=organization_id)
 
     try:
@@ -670,7 +671,7 @@ async def _run_source_sync(source_id: str, sync_log_id: str | None = None) -> di
                         continue
 
                     with metered_by(ledger):
-                        await ingestion_svc.ingest_file(
+                        result = await ingestion_svc.ingest_file(
                             filepath=local_path,
                             collection_name=collection_name,
                             # Unconditional, as in `sync_local_flow`: once this
@@ -679,7 +680,13 @@ async def _run_source_sync(source_id: str, sync_log_id: str | None = None) -> di
                             replace=True,
                             source_path=remote_file.source_path,
                         )
-                    ingested += 1
+                    # On `replaced_document_id`, not on the result's sentence:
+                    # `sync_local_flow` reads its own message for the word
+                    # "replaced", which is a string it has to keep agreeing with.
+                    if result.replaced_document_id:
+                        updated += 1
+                    else:
+                        ingested += 1
                 except Exception as e:
                     logger.warning("Failed to sync %s: %s", remote_file.name, e)
                     failed += 1
@@ -702,6 +709,7 @@ async def _run_source_sync(source_id: str, sync_log_id: str | None = None) -> di
                 status="done" if not failed else "error",
                 total_files=total,
                 ingested=ingested,
+                updated=updated,
                 skipped=skipped,
                 failed=failed,
             )
@@ -714,10 +722,11 @@ async def _run_source_sync(source_id: str, sync_log_id: str | None = None) -> di
             logger.error("Failed to update sync status for source %s", source_id)
 
     logger.info(
-        "Source sync complete: %s - total=%d, ingested=%d, skipped=%d, failed=%d",
+        "Source sync complete: %s - total=%d, ingested=%d, updated=%d, skipped=%d, failed=%d",
         source_id,
         total,
         ingested,
+        updated,
         skipped,
         failed,
     )
@@ -725,6 +734,7 @@ async def _run_source_sync(source_id: str, sync_log_id: str | None = None) -> di
         "status": "done" if not failed else "error",
         "total": total,
         "ingested": ingested,
+        "updated": updated,
         "skipped": skipped,
         "failed": failed,
     }

--- a/backend/tests/test_connector_sync_modes.py
+++ b/backend/tests/test_connector_sync_modes.py
@@ -49,6 +49,12 @@ def _stored(*, content_hash: str, source_path: str = SOURCE_PATH) -> MagicMock:
     )
 
 
+def _result(*, replaced: str | None = None) -> MagicMock:
+    """What `ingest_file` answers. `replaced_document_id` is what the flow reads
+    to tell an update from a first ingestion, so it is never a bare mock here."""
+    return MagicMock(replaced_document_id=replaced)
+
+
 def _connector(*, written: bytes = BODY) -> MagicMock:
     """A connector answering one file, whose download writes real bytes.
 
@@ -72,7 +78,13 @@ def _connector(*, written: bytes = BODY) -> MagicMock:
 
 
 @asynccontextmanager
-async def _syncing(*, mode: str, listing: list[MagicMock], connector: MagicMock) -> Any:
+async def _syncing(
+    *,
+    mode: str,
+    listing: list[MagicMock],
+    connector: MagicMock,
+    replaced: str | None = None,
+) -> Any:
     """The connector flow with its store, database and ingest replaced.
 
     `IngestionService` stays real: `existing_document` is what decides whether a
@@ -95,7 +107,7 @@ async def _syncing(*, mode: str, listing: list[MagicMock], connector: MagicMock)
         update_after_sync=AsyncMock(),
         trigger_sync=AsyncMock(return_value=MagicMock(id=uuid.uuid4())),
     )
-    ingest = AsyncMock()
+    ingest = AsyncMock(return_value=_result(replaced=replaced))
 
     @asynccontextmanager
     async def _db() -> Any:
@@ -118,8 +130,16 @@ async def _syncing(*, mode: str, listing: list[MagicMock], connector: MagicMock)
         yield ingest
 
 
-async def _sync(*, mode: str, listing: list[MagicMock], connector: MagicMock) -> Any:
-    async with _syncing(mode=mode, listing=listing, connector=connector) as ingest:
+async def _sync(
+    *,
+    mode: str,
+    listing: list[MagicMock],
+    connector: MagicMock,
+    replaced: str | None = None,
+) -> Any:
+    async with _syncing(
+        mode=mode, listing=listing, connector=connector, replaced=replaced
+    ) as ingest:
         answer = await rag_tasks._run_source_sync(str(uuid.uuid4()), sync_log_id=str(uuid.uuid4()))
     return answer, ingest
 
@@ -139,9 +159,10 @@ class TestAnIngestAlwaysReplaces:
             mode=mode,
             listing=[_stored(content_hash="a-different-file-entirely")],
             connector=_connector(),
+            replaced="vector-doc-1",
         )
 
-        assert answer["ingested"] == 1
+        assert answer["updated"] == 1
         assert ingest.await_args.kwargs["replace"] is True
 
 
@@ -174,10 +195,11 @@ class TestAnUnchangedFile:
             mode="full",
             listing=[_stored(content_hash=BODY_HASH)],
             connector=_connector(),
+            replaced="vector-doc-1",
         )
 
         ingest.assert_awaited_once()
-        assert answer["ingested"] == 1
+        assert answer["updated"] == 1
         assert answer["skipped"] == 0
 
 
@@ -190,11 +212,33 @@ class TestAChangedFile:
             mode="new_only",
             listing=[_stored(content_hash="what-it-was-yesterday")],
             connector=_connector(),
+            replaced="vector-doc-1",
         )
 
         ingest.assert_awaited_once()
-        assert answer["ingested"] == 1
+        assert answer["updated"] == 1
         assert answer["skipped"] == 0
+
+
+class TestWhatTheSyncLogIsTold:
+    """A replacement is an update. Every successful sync used to be reported as a
+    first ingestion, with `updated` left at zero in the history - and the mode
+    that replaces was unreachable before #990, so nothing had ever noticed."""
+
+    async def test_a_replacement_counts_as_an_update_not_an_ingestion(self):
+        answer, _ = await _sync(
+            mode="new_only",
+            listing=[_stored(content_hash="what-it-was-yesterday")],
+            connector=_connector(),
+            replaced="vector-doc-1",
+        )
+
+        assert (answer["updated"], answer["ingested"]) == (1, 0)
+
+    async def test_a_first_ingestion_counts_as_one(self):
+        answer, _ = await _sync(mode="new_only", listing=[], connector=_connector())
+
+        assert (answer["updated"], answer["ingested"]) == (0, 1)
 
 
 class TestAFileNeverSeenBefore:
@@ -226,9 +270,10 @@ class TestAStoredDocumentWithNoHash:
             mode="new_only",
             listing=[_stored(content_hash="")],
             connector=_connector(),
+            replaced="vector-doc-1",
         )
 
-        assert answer["ingested"] == 1
+        assert answer["updated"] == 1
         assert ingest.await_args.kwargs["replace"] is True
 
 
@@ -256,7 +301,7 @@ class TestAListingTheStoreCannotAnswer:
             update_after_sync=AsyncMock(),
             trigger_sync=AsyncMock(return_value=MagicMock(id=uuid.uuid4())),
         )
-        ingest = AsyncMock()
+        ingest = AsyncMock(return_value=_result())
 
         @asynccontextmanager
         async def _db() -> Any:

--- a/backend/tests/test_connector_sync_modes.py
+++ b/backend/tests/test_connector_sync_modes.py
@@ -1,0 +1,284 @@
+"""What `sync_mode` means when the files come from a connector.
+
+#990. It meant nothing. `_run_source_sync` listed, downloaded and ingested every
+file a connector answered with, and the mode reached exactly one argument -
+`ingest_file`'s `replace` - while `ingest_file` itself never skips anything. So
+on the default `new_only` the previous document was neither found nor deleted and
+a *second copy* was inserted on every run: a nightly sync of a folder was a
+seventh copy of every chunk by the end of the week, all of them ranked against
+each other in every search, each one paid for in embeddings.
+
+`sync_local_flow` in the same module had implemented the modes properly the whole
+time. These are therefore written as *comparisons between the two flows* wherever
+they can be: one `sync_mode` column feeds both, so a mode that means one thing
+for a directory on the server and another for a Drive folder is the defect
+whatever either one does in isolation.
+
+`existing_document` is left real, because it is the thing being relied on - it
+reads the collection's own listing and answers a precedence (#548). What the
+tests control is the listing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.rag.connectors import RemoteFile
+from app.worker.tasks import rag_tasks
+
+pytestmark = pytest.mark.anyio
+
+BODY = b"the handbook, unchanged since last night"
+BODY_HASH = hashlib.sha256(BODY).hexdigest()
+SOURCE_PATH = "gdrive://file-1"
+
+
+def _stored(*, content_hash: str, source_path: str = SOURCE_PATH) -> MagicMock:
+    """One row of a collection's document listing, as the store answers it."""
+    return MagicMock(
+        id="vector-doc-1",
+        filename="handbook.md",
+        additional_info={"source_path": source_path, "content_hash": content_hash},
+    )
+
+
+def _connector(*, written: bytes = BODY) -> MagicMock:
+    """A connector answering one file, whose download writes real bytes.
+
+    Real bytes because the flow hashes what landed on disk - a stand-in that
+    wrote nothing would make the comparison this is about vacuous.
+    """
+
+    async def download(remote_file: RemoteFile, dest_dir: Path, **_: Any) -> Path:
+        dest = dest_dir / remote_file.name
+        dest.write_bytes(written)
+        return dest
+
+    return MagicMock(
+        list_files=AsyncMock(
+            return_value=[
+                RemoteFile(id="file-1", name="handbook.md", source_path=SOURCE_PATH),
+            ]
+        ),
+        download_file=AsyncMock(side_effect=download),
+    )
+
+
+@asynccontextmanager
+async def _syncing(*, mode: str, listing: list[MagicMock], connector: MagicMock) -> Any:
+    """The connector flow with its store, database and ingest replaced.
+
+    `IngestionService` stays real: `existing_document` is what decides whether a
+    file is skipped, so a stand-in service would be a test of the stand-in.
+    """
+    store = MagicMock()
+    store.aclose = AsyncMock()
+    store.get_documents = AsyncMock(return_value=listing)
+
+    source = MagicMock(
+        connector_type="gdrive",
+        config={"folder_id": "abc"},
+        collection_name="docs",
+        sync_mode=mode,
+        organization_id=uuid.uuid4(),
+        secret_id=None,
+    )
+    sources = MagicMock(
+        get_source=AsyncMock(return_value=source),
+        update_after_sync=AsyncMock(),
+        trigger_sync=AsyncMock(return_value=MagicMock(id=uuid.uuid4())),
+    )
+    ingest = AsyncMock()
+
+    @asynccontextmanager
+    async def _db() -> Any:
+        yield MagicMock()
+
+    with (
+        patch.object(rag_tasks, "VectorStore", return_value=store),
+        patch.object(rag_tasks, "EmbeddingService", new=MagicMock()),
+        patch.object(rag_tasks, "get_worker_db_context", new=_db),
+        patch.object(rag_tasks, "_record_embedding_spend", new=AsyncMock()),
+        patch.object(rag_tasks, "assert_organization_within_budget", new=AsyncMock()),
+        patch.object(rag_tasks, "SyncSourceService", return_value=sources),
+        patch.object(rag_tasks, "_config_for_collection", new=AsyncMock()),
+        patch.object(rag_tasks, "IngestionConfigService") as config_service,
+        patch.object(rag_tasks.IngestionService, "ingest_file", new=ingest),
+        patch.dict(rag_tasks.CONNECTOR_REGISTRY, {"gdrive": lambda: connector}),
+        patch("app.services.rag_sync.RAGSyncService", return_value=MagicMock()),
+    ):
+        config_service.return_value.build_processor = AsyncMock(return_value=MagicMock())
+        yield ingest
+
+
+async def _sync(*, mode: str, listing: list[MagicMock], connector: MagicMock) -> Any:
+    async with _syncing(mode=mode, listing=listing, connector=connector) as ingest:
+        answer = await rag_tasks._run_source_sync(str(uuid.uuid4()), sync_log_id=str(uuid.uuid4()))
+    return answer, ingest
+
+
+class TestAnIngestAlwaysReplaces:
+    """The half of #990 that produced the duplicates.
+
+    `replace=(sync_mode == "full")` meant the two commonest modes told
+    `ingest_file` not to look for what it was about to insert beside.
+    """
+
+    @pytest.mark.parametrize("mode", ["full", "new_only", "update_only"])
+    async def test_whatever_the_mode_a_file_that_is_ingested_replaces_its_document(self, mode: str):
+        # A listing whose hash differs, so every mode reaches the ingest: what is
+        # under test is the argument it is reached with, not whether it is.
+        answer, ingest = await _sync(
+            mode=mode,
+            listing=[_stored(content_hash="a-different-file-entirely")],
+            connector=_connector(),
+        )
+
+        assert answer["ingested"] == 1
+        assert ingest.await_args.kwargs["replace"] is True
+
+
+class TestAnUnchangedFile:
+    async def test_it_is_skipped_rather_than_embedded_again(self):
+        """The cost this exists to avoid. Before the fix a nightly sync
+        re-embedded every unchanged file and inserted a second copy of it."""
+        answer, ingest = await _sync(
+            mode="new_only",
+            listing=[_stored(content_hash=BODY_HASH)],
+            connector=_connector(),
+        )
+
+        ingest.assert_not_awaited()
+        assert answer["skipped"] == 1
+        assert answer["ingested"] == 0
+
+    async def test_update_only_skips_it_too(self):
+        answer, ingest = await _sync(
+            mode="update_only",
+            listing=[_stored(content_hash=BODY_HASH)],
+            connector=_connector(),
+        )
+
+        ingest.assert_not_awaited()
+        assert answer["skipped"] == 1
+
+    async def test_full_re_ingests_it_because_that_is_what_full_means(self):
+        answer, ingest = await _sync(
+            mode="full",
+            listing=[_stored(content_hash=BODY_HASH)],
+            connector=_connector(),
+        )
+
+        ingest.assert_awaited_once()
+        assert answer["ingested"] == 1
+        assert answer["skipped"] == 0
+
+
+class TestAChangedFile:
+    async def test_new_only_re_ingests_it(self):
+        """Which is what `sync_local_flow` does with the same mode - the name
+        says otherwise, and the two flows agreeing matters more than the name,
+        because one column feeds both."""
+        answer, ingest = await _sync(
+            mode="new_only",
+            listing=[_stored(content_hash="what-it-was-yesterday")],
+            connector=_connector(),
+        )
+
+        ingest.assert_awaited_once()
+        assert answer["ingested"] == 1
+        assert answer["skipped"] == 0
+
+
+class TestAFileNeverSeenBefore:
+    async def test_new_only_ingests_it(self):
+        answer, ingest = await _sync(mode="new_only", listing=[], connector=_connector())
+
+        assert answer["ingested"] == 1
+        assert ingest.await_args.kwargs["source_path"] == SOURCE_PATH
+
+    async def test_update_only_skips_it_without_paying_for_the_download(self):
+        """`update_only` means "do not add anything", so the answer is known
+        before the bytes are fetched - and fetching them anyway is a transfer per
+        new file in the folder, on every run."""
+        connector = _connector()
+
+        answer, ingest = await _sync(mode="update_only", listing=[], connector=connector)
+
+        connector.download_file.assert_not_awaited()
+        ingest.assert_not_awaited()
+        assert answer["skipped"] == 1
+
+
+class TestAStoredDocumentWithNoHash:
+    async def test_it_is_re_ingested_rather_than_assumed_current(self):
+        """A document ingested before the hash was recorded, or by a path that
+        did not record one. Skipping it would be a decision nothing later
+        corrects; re-embedding it costs once."""
+        answer, ingest = await _sync(
+            mode="new_only",
+            listing=[_stored(content_hash="")],
+            connector=_connector(),
+        )
+
+        assert answer["ingested"] == 1
+        assert ingest.await_args.kwargs["replace"] is True
+
+
+class TestAListingTheStoreCannotAnswer:
+    async def test_a_failed_lookup_ingests_rather_than_skips(self):
+        """`existing_document` answers "no match" when the store refuses, and
+        that has to mean *ingest*: a failed query is not evidence a document is
+        unchanged, and the sync that believed it would leave the collection
+        stale with nothing said."""
+        store_error = MagicMock()
+        store_error.aclose = AsyncMock()
+        store_error.get_documents = AsyncMock(side_effect=RuntimeError("no such table"))
+
+        connector = _connector()
+        source = MagicMock(
+            connector_type="gdrive",
+            config={"folder_id": "abc"},
+            collection_name="docs",
+            sync_mode="new_only",
+            organization_id=uuid.uuid4(),
+            secret_id=None,
+        )
+        sources = MagicMock(
+            get_source=AsyncMock(return_value=source),
+            update_after_sync=AsyncMock(),
+            trigger_sync=AsyncMock(return_value=MagicMock(id=uuid.uuid4())),
+        )
+        ingest = AsyncMock()
+
+        @asynccontextmanager
+        async def _db() -> Any:
+            yield MagicMock()
+
+        with (
+            patch.object(rag_tasks, "VectorStore", return_value=store_error),
+            patch.object(rag_tasks, "EmbeddingService", new=MagicMock()),
+            patch.object(rag_tasks, "get_worker_db_context", new=_db),
+            patch.object(rag_tasks, "_record_embedding_spend", new=AsyncMock()),
+            patch.object(rag_tasks, "assert_organization_within_budget", new=AsyncMock()),
+            patch.object(rag_tasks, "SyncSourceService", return_value=sources),
+            patch.object(rag_tasks, "_config_for_collection", new=AsyncMock()),
+            patch.object(rag_tasks, "IngestionConfigService") as config_service,
+            patch.object(rag_tasks.IngestionService, "ingest_file", new=ingest),
+            patch.dict(rag_tasks.CONNECTOR_REGISTRY, {"gdrive": lambda: connector}),
+            patch("app.services.rag_sync.RAGSyncService", return_value=MagicMock()),
+        ):
+            config_service.return_value.build_processor = AsyncMock(return_value=MagicMock())
+            answer = await rag_tasks._run_source_sync(
+                str(uuid.uuid4()), sync_log_id=str(uuid.uuid4())
+            )
+
+        assert answer["ingested"] == 1
+        assert answer["skipped"] == 0

--- a/backend/tests/test_rag_document_lookup.py
+++ b/backend/tests/test_rag_document_lookup.py
@@ -146,6 +146,63 @@ class TestOnePrecedenceForBothAnswers:
         assert existing == StoredDocument(document_id="doc-a", content_hash=None)
 
 
+class TestADocumentThatNamesItsOwnAddress:
+    """The filename fallback may not claim one (#990).
+
+    It exists so a file uploaded through the browser and later synced from the
+    folder it came from is replaced rather than duplicated - an upload stores its
+    filename as its `source_path`, so the two agree and it stays reachable by
+    name. A document naming a *different* address is a different document, and
+    matching it by basename loses one of the two.
+    """
+
+    async def test_two_keys_with_the_same_basename_are_two_documents(self):
+        """An S3 bucket holding `a/readme.md` and `b/readme.md`. The second key
+        found the first's document by name, so under `new_only` equal contents
+        skipped it and unequal contents *replaced* the first - either way a
+        first sync could not keep both, and said nothing."""
+        service = _service(
+            [
+                _doc(
+                    "doc-a",
+                    filename="readme.md",
+                    source_path="s3://bucket/a/readme.md",
+                    content_hash="hash-a",
+                )
+            ]
+        )
+
+        existing = await service.existing_document("kb", "s3://bucket/b/readme.md")
+
+        assert existing == StoredDocument()
+
+    async def test_two_local_files_of_the_same_name_in_different_folders_are_two(self):
+        """The same collision on the flow that had the modes right all along."""
+        service = _service(
+            [
+                _doc(
+                    "doc-a",
+                    filename="notes.md",
+                    source_path="/srv/docs/one/notes.md",
+                    content_hash="hash-a",
+                )
+            ]
+        )
+
+        assert await service.existing_document("kb", "/srv/docs/two/notes.md") == StoredDocument()
+
+    async def test_an_uploaded_document_is_still_replaced_by_its_sync(self):
+        """The case the fallback is for, and the reason it is narrowed rather
+        than removed: an upload's `source_path` is its filename."""
+        service = _service(
+            [_doc("doc-a", filename="handbook.md", source_path="handbook.md", content_hash="h")]
+        )
+
+        existing = await service.existing_document("kb", "gdrive://file-1/handbook.md")
+
+        assert existing == StoredDocument(document_id="doc-a", content_hash="h")
+
+
 class TestHowManyTimesTheCollectionIsRead:
     """#566. Three lookups over one listing, and a sync asked for two of them."""
 
@@ -200,6 +257,71 @@ class TestHowManyTimesTheCollectionIsRead:
 
         assert result.status is IngestionStatus.DONE
         assert store.get_documents.await_count == 1
+
+
+class TestReplacingADocument:
+    """The new one is written before the old one is removed (#990).
+
+    `insert_document` is where the embeddings are computed, so a provider that
+    refuses between the two statements used to leave the collection holding
+    *neither* - permanently, because `ingest_file` returns the failure rather
+    than raising it and nothing retries. Both for the length of an insert is a
+    state a search survives; neither is not.
+    """
+
+    @staticmethod
+    def _replacing(insert: AsyncMock) -> tuple[MagicMock, IngestionService]:
+        store = MagicMock(
+            get_documents=AsyncMock(
+                return_value=[
+                    _doc(
+                        "doc-old",
+                        filename="handbook.pdf",
+                        source_path="/srv/sync/handbook.pdf",
+                        content_hash="hash-old",
+                    )
+                ]
+            ),
+            insert_document=insert,
+            delete_document=AsyncMock(),
+        )
+        document = Document(
+            pages=[DocumentPage(page_num=1, content="body")],
+            metadata=DocumentMetadata(filename="handbook.pdf", filesize=4, filetype="pdf"),
+        )
+        document.chunked_pages = [
+            DocumentPageChunk(chunk_content="body", chunk_num=0, page_num=1, content="body")
+        ]
+        document.metadata.content_hash = "hash-new"
+        processor = MagicMock(process_file=AsyncMock(return_value=document))
+        return store, IngestionService(processor=processor, vector_store=store)
+
+    async def test_a_failed_embedding_leaves_the_old_document_in_place(self):
+        store, service = self._replacing(AsyncMock(side_effect=RuntimeError("provider refused")))
+
+        result = await service.ingest_file(
+            filepath=Path("handbook.pdf"),
+            collection_name="kb",
+            replace=True,
+            source_path="/srv/sync/handbook.pdf",
+        )
+
+        assert result.status is IngestionStatus.ERROR
+        store.delete_document.assert_not_awaited()
+
+    async def test_a_successful_replacement_still_removes_the_old_one(self):
+        store, service = self._replacing(AsyncMock())
+
+        result = await service.ingest_file(
+            filepath=Path("handbook.pdf"),
+            collection_name="kb",
+            replace=True,
+            source_path="/srv/sync/handbook.pdf",
+        )
+
+        assert result.status is IngestionStatus.DONE
+        assert result.replaced_document_id == "doc-old"
+        store.delete_document.assert_awaited_once_with("kb", "doc-old")
 
 
 class TestGetDocumentsIsDeterministic:

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -684,7 +684,26 @@ seen, so that answer is given before the download; a hash needs them, so an
 unchanged file is recognised after one and before the embedding, which is the
 expensive half. A stored document carrying no `content_hash` is re-ingested
 rather than assumed current: skipping a file that may have changed is the answer
-nothing later corrects.
+nothing later corrects. A file that was replaced is counted as an **update**
+rather than an ingestion, read off `replaced_document_id` rather than off the
+result's own sentence.
+
+**Two things about matching, both of which decide whether a document survives.**
+`existing_document`'s last-but-one resort is a *filename* match, and it exists so
+a file uploaded through the browser and later synced from the folder it came from
+is replaced rather than duplicated — an upload stores its filename as its
+`source_path`, so the two agree and it stays reachable by name. A document naming
+a **different** address is not a candidate for it: a bucket holding
+`a/readme.md` beside `b/readme.md` had the second key find the first's document
+by name, so equal contents skipped it and unequal contents replaced the first —
+either way a first sync could not keep both, and said nothing. The same
+collision applied to two local files of one name in different directories.
+
+And a replacement **inserts before it deletes**. `insert_document` is where the
+embeddings are computed, so a provider that refused between the two statements
+used to leave the collection holding neither document — permanently, because a
+failed ingest is returned rather than raised and nothing retries it. Both for the
+length of an insert is a state a search survives; neither is not.
 
 One source's own history is `GET /kb/{kb_id}/sync-sources/{source_id}/logs`. The
 source is resolved against that knowledge base first, so a source belonging to

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -667,14 +667,24 @@ matches. A store that cannot answer the listing is treated as "no match" rather
 than as a match: a failed query is not evidence that a document is absent, but
 acting on it as though a document *were* present would delete one.
 
-**That is the local-directory sync. A connector sync implements none of it**
-([#990](https://github.com/vstorm-co/agenticos/issues/990)): `sync_source_flow`
-downloads and ingests every file the connector lists, `sync_mode` reaches only
-`ingest_file`'s `replace` argument, and `ingest_file` never skips — so on the
-default `new_only` the previous document is neither found nor deleted and a
-duplicate is inserted on every run. The `skipped` counter beside it is
-initialised and never incremented, which is what a sync log truthfully reporting
-`skipped=0` every night has been saying all along.
+**Both flows, and they have to agree** — one `sync_mode` column feeds a local
+directory and a connector alike, so a mode meaning one thing for each is the
+defect whatever either does alone. A connector sync implemented none of it until
+[#990](https://github.com/vstorm-co/agenticos/issues/990): `sync_mode` reached
+only `ingest_file`'s `replace` argument and `ingest_file` never skips, so on the
+default `new_only` the previous document was neither found nor deleted and a
+*second copy* was inserted every run — a week of nightly syncs was seven copies
+of every chunk, ranked against each other in every search and each one paid for
+in embeddings. The `skipped` counter beside it was initialised and never
+incremented, which is a sync log truthfully reporting `skipped=0` every night.
+
+Where the decision is taken differs between them, because a remote file's bytes
+cost something to fetch. `update_only` needs no bytes to skip a file it has never
+seen, so that answer is given before the download; a hash needs them, so an
+unchanged file is recognised after one and before the embedding, which is the
+expensive half. A stored document carrying no `content_hash` is re-ingested
+rather than assumed current: skipping a file that may have changed is the answer
+nothing later corrects.
 
 One source's own history is `GET /kb/{kb_id}/sync-sources/{source_id}/logs`. The
 source is resolved against that knowledge base first, so a source belonging to
@@ -811,19 +821,16 @@ A connector is `list_files` + `_fetch` + a `CONFIG_SCHEMA`, and the API calls ar
 the cheap part. Three things are not, and a connector without them is a bill or a
 surprise rather than a feature:
 
-- **A change signal** — and, today, the sync path that would use it.
-  `sync_source_flow` lists, downloads and ingests every file unconditionally:
-  `sync_mode` reaches one argument and `ingest_file` never skips, so a scheduled
-  source re-embeds everything nightly and, on the default `new_only`, inserts a
-  *second copy* each run
-  ([#990](https://github.com/vstorm-co/agenticos/issues/990)). Naming a signal
-  therefore buys nothing on its own, which is why #990 comes before the
-  connectors are worth having: it is the comparison step, and the local-directory
-  flow already has one to copy. Name the signal in the connector's docstring
-  anyway — a Graph `delta` token, a page's `version.number`, a commit sha, an
-  HTTP `ETag` — because which one a connector can offer is what decides whether
-  that comparison happens before the download or after it, and fall back to
-  `content_hash` only where the remote system genuinely offers none.
+- **A change signal.** The sync path compares one since
+  [#990](https://github.com/vstorm-co/agenticos/issues/990), and what it compares
+  is a `content_hash` of the bytes — which means it downloads a file to find out
+  it was unchanged. That saves the embedding and not the transfer. A connector
+  that can answer "changed?" *without* the bytes should say so in its docstring —
+  a Graph `delta` token, a page's `version.number`, a commit sha, an HTTP `ETag` —
+  because a signal the flow can read before the download is the difference
+  between a nightly sync that costs a listing and one that costs the whole
+  folder. `content_hash` is the fallback where the remote system genuinely offers
+  none.
 - **A credential scoped at the source.** See the section above. A connector's
   `SECRET_KIND` says what shape the credential is; nothing in the platform can
   say how wide it was issued, which is why the guidance belongs where the source
@@ -841,10 +848,7 @@ question to answer before writing one is which half is being built — see
 [mcp](mcp.md).
 
 Which connectors are being built, and in what order, is decided in
-[#938](https://github.com/vstorm-co/agenticos/issues/938). First
-[#990](https://github.com/vstorm-co/agenticos/issues/990), because every
-connector below names a change signal and the sync path consults none of them:
-then a web crawler
+[#938](https://github.com/vstorm-co/agenticos/issues/938): a web crawler
 ([#984](https://github.com/vstorm-co/agenticos/issues/984)), SharePoint and
 OneDrive ([#985](https://github.com/vstorm-co/agenticos/issues/985)), Confluence
 ([#986](https://github.com/vstorm-co/agenticos/issues/986)), a git repository's


### PR DESCRIPTION
A scheduled Google Drive or S3 source inserted a second copy of every
document on every run, and re-embedded all of them to do it.

`sync_mode` reached exactly one argument in `_run_source_sync` -
`ingest_file`'s `replace` - and `ingest_file` never skips anything: it
parses, embeds and inserts, and `replace` only decides whether the
document it matched is deleted first. So `replace=(sync_mode == "full")`
meant the two commonest modes told it not to look. On the default
`new_only` the previous document was neither found nor deleted and a new
one was inserted beside it, so a week of nightly syncs was seven copies of
every chunk, ranked against each other in every search, each paid for in
embeddings on the organization's own key. `skipped` was initialised beside
the loop and never incremented, which is a sync log truthfully reporting
`skipped=0` every night.

`sync_local_flow` in the same module had implemented the modes properly
the whole time, so this is that logic rather than a new design - one
`sync_mode` column feeds both flows and a mode meaning one thing for a
directory and another for a Drive folder is the defect whatever either
does alone. `replace=True` unconditionally, as there: once the flow has
decided to ingest, whatever it matched has to go.

Where the decision is taken differs, because remote bytes cost something.
`update_only` needs none to skip a file it has never seen, so that answer
is given before the download - otherwise it is a transfer per new file in
the folder, every run. A hash needs them, so an unchanged file is
recognised after the download and before the embedding, which is the
expensive half. A stored document carrying no `content_hash` is
re-ingested rather than assumed current: skipping a file that may have
changed is the answer nothing later corrects, and re-embedding costs once.

## Verified

`tests/test_connector_sync_modes.py`, eleven tests, six of which fail
without this change - including both duplication cases and the
before-download skip. They leave `existing_document` real and control the
listing it reads, because that lookup and its precedence (#548) are the
thing being relied on. `make lint` and the backend suite: 6193 passed.

Not fixed here, and filed: #992, that a connector sync creates no
`rag_documents` row at all, so its documents are invisible to the
Documents tab, to download, delete and retry, and to a collection's own
stats. Same root cause - the connector flow does not do the per-file work
the local flow does - and a different symptom. It has an ordering
consequence worth knowing: with this change a second sync ingests nothing,
so #992 will need a backfill for documents already synced rather than only
a new call site.

`docs/file-processing.md` is updated: the `sync_mode` paragraph said the
connector flow implemented none of this, and "what a new connector owes"
now asks for a signal readable *before* the download, since a
`content_hash` comparison saves the embedding and not the transfer.

Closes #990