### PR TITLE
chore: cut 0.0.216

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,54 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.216] - 2026-08-20
+
+A scheduled sync stops duplicating everything it has already ingested.
+
+### Fixed
+
+- **`sync_mode` is implemented for a connector sync.** It reached exactly one
+  argument - `ingest_file`'s `replace` - and `ingest_file` never skips anything,
+  so a scheduled Google Drive or S3 source re-embedded every file every night;
+  and on the default `new_only` it passed `replace=False`, which skips the
+  lookup, leaves the old document in place and inserts a second copy. A week of
+  nightly syncs was seven copies of every chunk, ranked against each other in
+  every search and each one paid for on the organization's own embedding key.
+  `skipped` sat beside the loop, initialised and never incremented, which is a
+  sync log truthfully reporting `skipped=0` every night. The logic is
+  `sync_local_flow`'s, which had it right all along: one `sync_mode` column feeds
+  both flows and a mode meaning one thing for a server directory and another for
+  a Drive folder is the defect whatever either does alone. (#990)
+- **A basename no longer claims a document that names its own address.**
+  `existing_document` falls back from `source_path` to *filename*, so a bucket
+  holding `a/readme.md` beside `b/readme.md` had the second key find the first
+  key's document - equal contents skipped the second file, unequal contents
+  deleted the first, and either way a first sync could not keep both. The
+  fallback is narrowed rather than removed, because it is what stops a file
+  uploaded through the browser and later synced from its own folder being
+  duplicated: an upload stores its filename *as* its `source_path`, so the two
+  agree and it stays reachable by name. Same collision fixed for two local files
+  of one name in different directories. (#990)
+- **A replacement inserts before it deletes.** `insert_document` is where the
+  embeddings are computed, so a provider refusing between the two statements left
+  the collection holding *neither* document - permanently, since a failed ingest
+  is returned rather than raised and nothing retries it. This order fails the
+  recoverable way instead. (#990)
+- **A replaced file is counted as an update.** The connector loop reported every
+  success as a first ingestion and passed no `updated` to `complete_sync`, so the
+  sync history read zero updates forever - unnoticed, because the mode that
+  replaces was unreachable. Read off `replaced_document_id` rather than off the
+  result's own sentence. (#990)
+
+### Changed
+
+- Where a sync decides differs between the two flows, because remote bytes cost
+  something: `update_only` skips a file it has never seen *before* the download,
+  while an unchanged file is recognised after one and before the embedding. A
+  stored document with no `content_hash` is re-ingested rather than assumed
+  current - skipping a file that may have changed is the answer nothing later
+  corrects. (#990)
+
 ## [0.0.215] - 2026-08-20
 
 Which sync connectors come after Google Drive and S3, and who ends up able to

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.215"
+version = "0.0.216"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.215"
+version = "0.0.216"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.215",
+  "version": "0.0.216",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.216. Bumps `backend/pyproject.toml`,
`backend/uv.lock` and `frontend/package.json` to 0.0.216 and adds the
CHANGELOG entry.

One issue, #990, and it is the most expensive thing found in this run of
work. A scheduled connector source inserted a second copy of every
document on every run and re-embedded all of them to do it, on the default
mode, silently - `sync_mode` reached one argument and `ingest_file` never
skips. The fix is `sync_local_flow`'s own logic, because one column feeds
both flows.

Three more defects came out of reviewing that fix, and one of them was a
regression the branch would have shipped: with the modes implemented,
`existing_document`'s fallback from `source_path` to *filename* let a
bucket's `b/readme.md` find `a/readme.md`'s document, so equal contents
skipped the second file and unequal contents deleted the first. Also fixed
in the same place: a replacement now inserts before it deletes, where a
refused embedding used to leave the collection holding neither document
permanently; and a replaced file is counted as an update rather than as a
first ingestion.

Two of those three were pre-existing on `full` mode and unreachable on the
other two, which is why nothing had found them: the mode that replaces was
the mode that did not work.

## Verified

`make lint`, `make docs-build` and the backend suite - 6200 passed. Every
new test was checked against the unfixed code: eleven of nineteen fail
without their change, including both duplication cases, both basename
collisions and the failed-embedding case. CI green end to end on #993
including `e2e`; `test-frontend` skipped by the path filter, nothing under
`frontend/` changed.

Codex reviewed the branch once and found all three of the extra defects.
Its re-review answered "usage limits" for an hour and never reached the
last commit, which was reviewed by reading the diff - that found a comment
overstating what the new replacement order guarantees.

Not fixed, and filed: #992, that a connector sync creates no
`rag_documents` row, so its documents are invisible to the Documents tab,
to download, delete and retry, and to a collection's stats. Same root
cause, different symptom - and it now needs a backfill, because with #990
fixed a second sync ingests nothing.

Closes #990