### PR TITLE
fix(rag): record a document row for what a connector sync ingests

### DIFF
--- a/backend/app/api/routes/v1/knowledge_bases.py
+++ b/backend/app/api/routes/v1/knowledge_bases.py
@@ -14,6 +14,7 @@ from fastapi.responses import FileResponse
 from app.api.deps import (
     Auth,
     CollectionAccessSvc,
+    IngestionSvc,
     KnowledgeBaseSvc,
     RAGDocumentSvc,
     SyncSourceSvc,
@@ -257,6 +258,7 @@ async def delete_kb_document(
     doc_id: UUID,
     service: KnowledgeBaseSvc,
     rag_doc_service: RAGDocumentSvc,
+    ingestion_service: IngestionSvc,
     ctx: Auth,
 ) -> None:
     """Remove a document from the KB (cascades to vectors + file storage).
@@ -264,6 +266,13 @@ async def delete_kb_document(
     Verifies the doc actually belongs to this KB's collection - without that
     check a KB owner could pass any doc_id and remove docs from KBs they
     don't own.
+
+    The ingestion service is what removes the *vectors*, and this route did not
+    take one: it deleted the tracking row and left the content searchable, so a
+    collection held a document nobody could see, delete or re-ingest - the next
+    `new_only` sync matched its unchanged hash and skipped it (#992). The
+    argument has no default on the service any more, which is what stops a third
+    route repeating it.
     """
     kb = await service.get_for_write(kb_id, ctx=ctx)
     doc = await rag_doc_service.get_document(str(doc_id))
@@ -272,7 +281,7 @@ async def delete_kb_document(
             message="Document not found in this knowledge base",
             details={"kb_id": str(kb_id), "doc_id": str(doc_id)},
         )
-    await rag_doc_service.delete_document(str(doc_id))
+    await rag_doc_service.delete_document(str(doc_id), ingestion_service)
 
 
 @router.get("/{kb_id}/sync-sources", response_model=SyncSourceList)

--- a/backend/app/services/rag_document.py
+++ b/backend/app/services/rag_document.py
@@ -17,6 +17,7 @@ from app.db.models.knowledge_base import KnowledgeBase
 from app.db.models.rag_document import DocumentStatus, RAGDocument
 from app.services.rag.config import get_supported_formats
 from app.services.rag.documents import has_indexable_text
+from app.services.rag.ingestion import IngestionService
 from app.services.rag.vectorstore import BaseVectorStore
 from app.repositories import rag_document_repo
 from app.schemas.rag import (
@@ -418,17 +419,26 @@ class RAGDocumentService:
     async def delete_document(
         self,
         doc_id: str,
-        ingestion_service: Any = None,
+        ingestion_service: IngestionService,
     ) -> None:
         """Delete a document with cascading cleanup.
 
-        Removes the record from the database and attempts to clean up
-        the vector store entry and stored file. Failures in cleanup
-        are logged but do not prevent the DB deletion.
+        Removes the record from the database and attempts to clean up the vector
+        store entry and stored file. Failures in cleanup are logged but do not
+        prevent the DB deletion.
+
+        **`ingestion_service` has no default, and that is the whole of it.** It
+        was `Any = None`, and the vector cleanup ran only when a caller happened
+        to pass one - so `DELETE /kb/{kb_id}/documents/{doc_id}`, which did not,
+        removed the row and left the content searchable. A collection then held a
+        document nobody could see, delete or re-ingest, because the next
+        `new_only` sync matched its unchanged hash and skipped it (#992). That is
+        the same trap `complete_ingestion` describes one method down: an argument
+        the caller may omit is an argument some caller will.
         """
         doc = await self.get_document(doc_id)
 
-        if doc.vector_document_id and ingestion_service:
+        if doc.vector_document_id:
             try:
                 await ingestion_service.remove_document(doc.collection_name, doc.vector_document_id)
             except Exception as e:

--- a/backend/app/worker/tasks/rag_tasks.py
+++ b/backend/app/worker/tasks/rag_tasks.py
@@ -18,6 +18,7 @@ from app.agents.capabilities.budget import BudgetExceeded, SpendLedger, metered_
 from app.core.config import settings
 from app.core.secret_kinds import SecretKind, StorableSecret, unseal_secret
 from app.core.vault import VaultScope
+from app.db.models.knowledge_base import KnowledgeBase
 from app.db.session import get_worker_db_context
 from app.repositories import ingestion_spend_repo, knowledge_base_repo, organization_secret_repo
 from app.repositories import sync_source as sync_source_repo
@@ -35,7 +36,7 @@ from app.services.rag.connectors import CONNECTOR_REGISTRY
 from app.services.rag.embeddings import EmbeddingService
 from app.services.rag.failures import IngestionStage, failure_summary
 from app.services.rag.ingestion import IngestionService, StoredDocument
-from app.services.rag.models import IngestionStatus
+from app.services.rag.models import IngestionResult, IngestionStatus
 from app.services.rag.vectorstore import EmbeddingResolver
 from app.services.rag.vectorstore import PgVectorStore as VectorStore
 from app.services.spend import assert_organization_within_budget
@@ -165,6 +166,26 @@ async def _record_embedding_spend(
             )
 
 
+async def _knowledge_base_for(
+    db: AsyncSession, collection_name: str | None, organization_id: UUID | None
+) -> KnowledgeBase | None:
+    """The knowledge base behind a collection name, or `None` if none claims it.
+
+    The organization narrows the candidates because `collection_name` is not
+    unique across tenants. Two callers reach `None`: a local-directory sync,
+    which names a path on the server rather than a collection somebody
+    configured, and a sync source with no collection at all - an org-level
+    integration template that exists to be cloned and should never have been
+    run.
+    """
+    if collection_name is None:
+        return None
+    for kb in await knowledge_base_repo.list_by_collection_name(db, collection_name):
+        if organization_id is None or kb.organization_id == organization_id:
+            return kb
+    return None
+
+
 async def _config_for_collection(
     db: AsyncSession, collection_name: str | None, organization_id: UUID | None
 ) -> IngestionConfig:
@@ -173,21 +194,15 @@ async def _config_for_collection(
     A sync writes into a collection the same way an upload does, so it has to
     read documents the same way too - a collection set to LiteParse that gets
     PyMuPDF whenever the file arrives from Google Drive is configured in name
-    only. The organization narrows the candidates because `collection_name` is
-    not unique across tenants.
+    only.
 
     Falls back to the deployment defaults when no knowledge base claims the
-    name. Two cases reach that: a local-directory sync, which names a path on
-    the server rather than a collection somebody configured, and a sync source
-    with no collection at all - an org-level integration template that exists to
-    be cloned and should never have been run.
+    name; `_knowledge_base_for` says which callers that is.
     """
-    if collection_name is None:
-        return deployment_defaults()
-    for kb in await knowledge_base_repo.list_by_collection_name(db, collection_name):
-        if organization_id is None or kb.organization_id == organization_id:
-            return IngestionConfig.model_validate(kb.ingestion_config)
-    return deployment_defaults()
+    kb = await _knowledge_base_for(db, collection_name, organization_id)
+    return (
+        deployment_defaults() if kb is None else IngestionConfig.model_validate(kb.ingestion_config)
+    )
 
 
 @flow(name="ingest-document", log_prints=True)
@@ -559,6 +574,59 @@ async def _connector_credential(
         return None
 
 
+async def _track_synced_document(
+    result: IngestionResult,
+    *,
+    filename: str,
+    filesize: int,
+    collection_name: str,
+    organization_id: UUID | None,
+    knowledge_base_id: UUID | None,
+    ingestion_config: IngestionConfig,
+) -> None:
+    """Record what a sync ingested, the way an upload records it.
+
+    A connector sync used to create no `rag_documents` row at all, so its
+    documents were searchable and invisible: absent from the knowledge base's
+    Documents tab, from a collection's own `document_count`, and from delete -
+    a file ingested from a Drive folder could be removed only by dropping the
+    whole collection (#992). A failure was counted in the sync log and recorded
+    nowhere per-file, so "which four of the forty failed, and why" had no answer.
+
+    No original is stored, unlike an upload: a synced file's bytes live in the
+    system it was synced from, and mirroring every one of them onto this
+    deployment's disk to make a retry button work is a cost per corpus rather
+    than per failure. `has_file` is false for these, and re-running the sync is
+    the retry - which since #990 skips everything unchanged and re-fetches
+    exactly what has no document.
+    """
+    from app.services.rag_document import RAGDocumentService
+
+    async with get_worker_db_context() as db:
+        documents = RAGDocumentService(db)
+        row = await documents.create_document(
+            collection_name=collection_name,
+            filename=filename,
+            filesize=filesize,
+            filetype=Path(filename).suffix.lstrip(".").lower(),
+            organization_id=organization_id,
+            knowledge_base_id=knowledge_base_id,
+            ingestion_config=ingestion_config,
+        )
+        if result.status is IngestionStatus.DONE and result.document_id:
+            await documents.complete_ingestion(
+                str(row.id),
+                vector_document_id=result.document_id,
+                chunk_count=result.chunk_count,
+                replaced_document_id=result.replaced_document_id,
+            )
+        else:
+            # The row is created either way, because a document that failed to
+            # parse is the one a reader most needs to see - and its reason is a
+            # `failure_summary` already, built by `ingest_file` (#423).
+            await documents.fail_ingestion(str(row.id), result.error_message or "Ingestion failed")
+
+
 async def _run_source_sync(source_id: str, sync_log_id: str | None = None) -> dict[str, Any]:
     """Core sync logic for connector-based sources (shared between all task frameworks).
 
@@ -613,10 +681,20 @@ async def _run_source_sync(source_id: str, sync_log_id: str | None = None) -> di
                 await source_svc.update_after_sync(source_id, status="error", error=reason)
                 return {"status": "error", "message": reason}
 
+        # One lookup for both answers, in the session that is already open: the
+        # collection's parser settings, and the knowledge base id every document
+        # this sync creates has to carry. Without the second, a synced document
+        # was absent from the knowledge base's Documents tab, from delete and
+        # from a collection's own stats, while search over it worked (#992).
+        knowledge_base = await _knowledge_base_for(db, collection_name, organization_id)
+        ingestion_config = (
+            deployment_defaults()
+            if knowledge_base is None
+            else IngestionConfig.model_validate(knowledge_base.ingestion_config)
+        )
+        knowledge_base_id = None if knowledge_base is None else knowledge_base.id
         ingestion_svc = await _ingestion_service_for(
-            db,
-            config=await _config_for_collection(db, collection_name, organization_id),
-            organization_id=organization_id,
+            db, config=ingestion_config, organization_id=organization_id
         )
 
     connector = connector_cls()
@@ -680,6 +758,17 @@ async def _run_source_sync(source_id: str, sync_log_id: str | None = None) -> di
                             replace=True,
                             source_path=remote_file.source_path,
                         )
+
+                    await _track_synced_document(
+                        result,
+                        filename=remote_file.name,
+                        filesize=local_path.stat().st_size,
+                        collection_name=collection_name,
+                        organization_id=organization_id,
+                        knowledge_base_id=knowledge_base_id,
+                        ingestion_config=ingestion_config,
+                    )
+
                     # On `replaced_document_id`, not on the result's sentence:
                     # `sync_local_flow` reads its own message for the word
                     # "replaced", which is a string it has to keep agreeing with.

--- a/backend/app/worker/tasks/rag_tasks.py
+++ b/backend/app/worker/tasks/rag_tasks.py
@@ -172,18 +172,29 @@ async def _knowledge_base_for(
     """The knowledge base behind a collection name, or `None` if none claims it.
 
     The organization narrows the candidates because `collection_name` is not
-    unique across tenants. Two callers reach `None`: a local-directory sync,
-    which names a path on the server rather than a collection somebody
-    configured, and a sync source with no collection at all - an org-level
-    integration template that exists to be cloned and should never have been
-    run.
+    unique across tenants - and the caller's own row wins over a deployment-wide
+    one of the same name, which is the reason for two passes rather than one
+    condition.
+
+    An `app`-scoped collection belongs to no organization, so it is matched on
+    the second pass rather than skipped. Skipping it meant a source pointed at
+    one was parsed with the deployment defaults instead of the settings that
+    collection had chosen, and - once a sync started recording documents - filed
+    them under no knowledge base, which is the invisibility this was fixing
+    (#992).
+
+    Two callers still reach `None`: a local-directory sync, which names a path on
+    the server rather than a collection somebody configured, and a sync source
+    with no collection at all - an org-level integration template that exists to
+    be cloned and should never have been run.
     """
     if collection_name is None:
         return None
-    for kb in await knowledge_base_repo.list_by_collection_name(db, collection_name):
+    candidates = await knowledge_base_repo.list_by_collection_name(db, collection_name)
+    for kb in candidates:
         if organization_id is None or kb.organization_id == organization_id:
             return kb
-    return None
+    return next((kb for kb in candidates if kb.organization_id is None), None)
 
 
 async def _config_for_collection(
@@ -574,8 +585,7 @@ async def _connector_credential(
         return None
 
 
-async def _track_synced_document(
-    result: IngestionResult,
+async def _open_document_row(
     *,
     filename: str,
     filesize: int,
@@ -583,8 +593,10 @@ async def _track_synced_document(
     organization_id: UUID | None,
     knowledge_base_id: UUID | None,
     ingestion_config: IngestionConfig,
-) -> None:
-    """Record what a sync ingested, the way an upload records it.
+    image_description_model: str | None,
+    embedding_model: str | None,
+) -> str:
+    """Record a document a sync is about to ingest, and answer its row id.
 
     A connector sync used to create no `rag_documents` row at all, so its
     documents were searchable and invisible: absent from the knowledge base's
@@ -603,8 +615,7 @@ async def _track_synced_document(
     from app.services.rag_document import RAGDocumentService
 
     async with get_worker_db_context() as db:
-        documents = RAGDocumentService(db)
-        row = await documents.create_document(
+        row = await RAGDocumentService(db).create_document(
             collection_name=collection_name,
             filename=filename,
             filesize=filesize,
@@ -612,19 +623,33 @@ async def _track_synced_document(
             organization_id=organization_id,
             knowledge_base_id=knowledge_base_id,
             ingestion_config=ingestion_config,
+            image_description_model=image_description_model,
+            embedding_model=embedding_model,
         )
+        return str(row.id)
+
+
+async def _settle_document_row(row_id: str, result: IngestionResult) -> None:
+    """Move an open row to what the ingest actually did.
+
+    The failure branch is not an afterthought: a document that failed to parse
+    is the one a reader most needs to see, and its reason is a `failure_summary`
+    already, built by `ingest_file` rather than by a caller stringifying a
+    vendor's exception (#423).
+    """
+    from app.services.rag_document import RAGDocumentService
+
+    async with get_worker_db_context() as db:
+        documents = RAGDocumentService(db)
         if result.status is IngestionStatus.DONE and result.document_id:
             await documents.complete_ingestion(
-                str(row.id),
+                row_id,
                 vector_document_id=result.document_id,
                 chunk_count=result.chunk_count,
                 replaced_document_id=result.replaced_document_id,
             )
         else:
-            # The row is created either way, because a document that failed to
-            # parse is the one a reader most needs to see - and its reason is a
-            # `failure_summary` already, built by `ingest_file` (#423).
-            await documents.fail_ingestion(str(row.id), result.error_message or "Ingestion failed")
+            await documents.fail_ingestion(row_id, result.error_message or "Ingestion failed")
 
 
 async def _run_source_sync(source_id: str, sync_log_id: str | None = None) -> dict[str, Any]:
@@ -693,6 +718,14 @@ async def _run_source_sync(source_id: str, sync_log_id: str | None = None) -> di
             else IngestionConfig.model_validate(knowledge_base.ingestion_config)
         )
         knowledge_base_id = None if knowledge_base is None else knowledge_base.id
+        # Both models, resolved once for the collection rather than per file, and
+        # recorded on every row this sync writes - the provenance the documents
+        # page reads. An upload has carried them since it started tracking; a
+        # sync reported neither.
+        embedding_model = None if knowledge_base is None else knowledge_base.embedding_model
+        image_description_model = await IngestionConfigService(db).resolved_image_model(
+            organization_id, ingestion_config
+        )
         ingestion_svc = await _ingestion_service_for(
             db, config=ingestion_config, organization_id=organization_id
         )
@@ -748,6 +781,24 @@ async def _run_source_sync(source_id: str, sync_log_id: str | None = None) -> di
                         skipped += 1
                         continue
 
+                    # Opened before the ingest, which is the order the upload
+                    # path uses and the only one that cannot leave the state this
+                    # removes: a row written afterwards and failing - a database
+                    # blip, a remote name longer than the column - left the
+                    # vector document stored and untracked, and the next
+                    # `new_only` run then matched its hash and skipped the file
+                    # before reaching the write, for good.
+                    row_id = await _open_document_row(
+                        filename=remote_file.name,
+                        filesize=local_path.stat().st_size,
+                        collection_name=collection_name,
+                        organization_id=organization_id,
+                        knowledge_base_id=knowledge_base_id,
+                        ingestion_config=ingestion_config,
+                        image_description_model=image_description_model,
+                        embedding_model=embedding_model,
+                    )
+
                     with metered_by(ledger):
                         result = await ingestion_svc.ingest_file(
                             filepath=local_path,
@@ -759,15 +810,7 @@ async def _run_source_sync(source_id: str, sync_log_id: str | None = None) -> di
                             source_path=remote_file.source_path,
                         )
 
-                    await _track_synced_document(
-                        result,
-                        filename=remote_file.name,
-                        filesize=local_path.stat().st_size,
-                        collection_name=collection_name,
-                        organization_id=organization_id,
-                        knowledge_base_id=knowledge_base_id,
-                        ingestion_config=ingestion_config,
-                    )
+                    await _settle_document_row(row_id, result)
 
                     # On `replaced_document_id`, not on the result's sentence:
                     # `sync_local_flow` reads its own message for the word

--- a/backend/tests/test_connector_sync_modes.py
+++ b/backend/tests/test_connector_sync_modes.py
@@ -40,6 +40,9 @@ BODY = b"the handbook, unchanged since last night"
 BODY_HASH = hashlib.sha256(BODY).hexdigest()
 SOURCE_PATH = "gdrive://file-1"
 KB_ID = uuid.uuid4()
+ROW_ID = uuid.uuid4()
+IMAGE_MODEL = "openai:gpt-4o-mini"
+EMBEDDING_MODEL = "openai:text-embedding-3-small"
 
 
 def _stored(*, content_hash: str, source_path: str = SOURCE_PATH) -> MagicMock:
@@ -121,7 +124,7 @@ async def _syncing(
     )
     ingest = AsyncMock(return_value=_result(replaced=replaced))
     documents = MagicMock(
-        create_document=AsyncMock(return_value=MagicMock(id=uuid.uuid4())),
+        create_document=AsyncMock(return_value=MagicMock(id=ROW_ID)),
         complete_ingestion=AsyncMock(),
         fail_ingestion=AsyncMock(),
     )
@@ -140,7 +143,11 @@ async def _syncing(
         patch.object(
             rag_tasks,
             "_knowledge_base_for",
-            new=AsyncMock(return_value=MagicMock(id=KB_ID, ingestion_config={})),
+            new=AsyncMock(
+                return_value=MagicMock(
+                    id=KB_ID, ingestion_config={}, embedding_model=EMBEDDING_MODEL
+                )
+            ),
         ),
         patch.object(rag_tasks, "IngestionConfigService") as config_service,
         patch.object(rag_tasks.IngestionService, "ingest_file", new=ingest),
@@ -149,6 +156,7 @@ async def _syncing(
         patch("app.services.rag_document.RAGDocumentService", return_value=documents),
     ):
         config_service.return_value.build_processor = AsyncMock(return_value=MagicMock())
+        config_service.return_value.resolved_image_model = AsyncMock(return_value=IMAGE_MODEL)
         yield ingest, documents
 
 
@@ -165,6 +173,61 @@ async def _sync(
     ):
         answer = await rag_tasks._run_source_sync(str(uuid.uuid4()), sync_log_id=str(uuid.uuid4()))
     return answer, ingest, documents
+
+
+class TestWhichKnowledgeBaseOwnsTheCollection:
+    """`_knowledge_base_for` decides two things at once: which parser settings a
+    sync reads documents with, and which knowledge base its documents are filed
+    under. Getting it wrong is invisible both times."""
+
+    @staticmethod
+    def _kbs(*rows: MagicMock) -> Any:
+        return patch.object(
+            rag_tasks.knowledge_base_repo,
+            "list_by_collection_name",
+            new=AsyncMock(return_value=list(rows)),
+        )
+
+    @staticmethod
+    def _kb(*, organization_id: uuid.UUID | None) -> MagicMock:
+        return MagicMock(id=uuid.uuid4(), organization_id=organization_id, ingestion_config={})
+
+    async def test_the_callers_own_collection_is_found(self):
+        org = uuid.uuid4()
+        mine = self._kb(organization_id=org)
+
+        with self._kbs(self._kb(organization_id=uuid.uuid4()), mine):
+            assert await rag_tasks._knowledge_base_for(MagicMock(), "docs", org) is mine
+
+    async def test_an_app_scoped_collection_belongs_to_no_organization(self):
+        """It has `organization_id=None`, so the equality test skipped it - and a
+        source pointed at one was parsed with the deployment defaults instead of
+        that collection's own settings, then filed under no knowledge base at
+        all."""
+        shared = self._kb(organization_id=None)
+
+        with self._kbs(shared):
+            found = await rag_tasks._knowledge_base_for(MagicMock(), "docs", uuid.uuid4())
+
+        assert found is shared
+
+    async def test_the_organizations_own_row_wins_over_a_deployment_wide_one(self):
+        """Two passes rather than one condition, because `collection_name` is not
+        unique and the caller's own collection is the one they meant."""
+        org = uuid.uuid4()
+        mine = self._kb(organization_id=org)
+
+        with self._kbs(self._kb(organization_id=None), mine):
+            assert await rag_tasks._knowledge_base_for(MagicMock(), "docs", org) is mine
+
+    async def test_another_tenants_collection_is_not_borrowed(self):
+        with self._kbs(self._kb(organization_id=uuid.uuid4())):
+            found = await rag_tasks._knowledge_base_for(MagicMock(), "docs", uuid.uuid4())
+
+        assert found is None
+
+    async def test_a_source_with_no_collection_asks_nothing(self):
+        assert await rag_tasks._knowledge_base_for(MagicMock(), None, uuid.uuid4()) is None
 
 
 class TestAnIngestAlwaysReplaces:
@@ -339,6 +402,36 @@ class TestWhatASyncedDocumentLeavesBehind:
 
         documents.create_document.assert_not_awaited()
 
+    async def test_the_row_is_opened_before_the_file_is_indexed(self):
+        """The order that cannot leave the state this issue is about. Written
+        after the ingest and failing, the row left a vector document stored and
+        untracked - and the next `new_only` run matched its hash and skipped the
+        file before reaching the write, so it stayed searchable, invisible and
+        undeletable for good."""
+        order: list[str] = []
+        connector = _connector()
+        async with _syncing(mode="new_only", listing=[], connector=connector) as (
+            ingest,
+            documents,
+        ):
+            documents.create_document = AsyncMock(
+                side_effect=lambda **_: order.append("create") or MagicMock(id=ROW_ID)
+            )
+            ingest.side_effect = lambda **_: order.append("ingest") or _result()
+            await rag_tasks._run_source_sync(str(uuid.uuid4()), sync_log_id=str(uuid.uuid4()))
+
+        assert order == ["create", "ingest"]
+
+    async def test_the_row_records_which_models_read_the_document(self):
+        """An upload has carried both since it started tracking; a sync reported
+        neither, so the documents page showed a synced file as parsed by nothing
+        and embedded by nothing."""
+        _, _, documents = await _sync(mode="new_only", listing=[], connector=_connector())
+
+        created = documents.create_document.await_args.kwargs
+        assert created["image_description_model"] == IMAGE_MODEL
+        assert created["embedding_model"] == EMBEDDING_MODEL
+
     async def test_a_file_that_failed_to_parse_keeps_its_own_reason(self):
         """The count in the sync log said four of forty failed and nothing said
         which four, or why."""
@@ -430,13 +523,14 @@ class TestAListingTheStoreCannotAnswer:
             patch(
                 "app.services.rag_document.RAGDocumentService",
                 return_value=MagicMock(
-                    create_document=AsyncMock(return_value=MagicMock(id=uuid.uuid4())),
+                    create_document=AsyncMock(return_value=MagicMock(id=ROW_ID)),
                     complete_ingestion=AsyncMock(),
                     fail_ingestion=AsyncMock(),
                 ),
             ),
         ):
             config_service.return_value.build_processor = AsyncMock(return_value=MagicMock())
+            config_service.return_value.resolved_image_model = AsyncMock(return_value=None)
             answer = await rag_tasks._run_source_sync(
                 str(uuid.uuid4()), sync_log_id=str(uuid.uuid4())
             )

--- a/backend/tests/test_connector_sync_modes.py
+++ b/backend/tests/test_connector_sync_modes.py
@@ -31,6 +31,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.services.rag.connectors import RemoteFile
+from app.services.rag.models import IngestionStatus
 from app.worker.tasks import rag_tasks
 
 pytestmark = pytest.mark.anyio
@@ -38,6 +39,7 @@ pytestmark = pytest.mark.anyio
 BODY = b"the handbook, unchanged since last night"
 BODY_HASH = hashlib.sha256(BODY).hexdigest()
 SOURCE_PATH = "gdrive://file-1"
+KB_ID = uuid.uuid4()
 
 
 def _stored(*, content_hash: str, source_path: str = SOURCE_PATH) -> MagicMock:
@@ -50,9 +52,19 @@ def _stored(*, content_hash: str, source_path: str = SOURCE_PATH) -> MagicMock:
 
 
 def _result(*, replaced: str | None = None) -> MagicMock:
-    """What `ingest_file` answers. `replaced_document_id` is what the flow reads
-    to tell an update from a first ingestion, so it is never a bare mock here."""
-    return MagicMock(replaced_document_id=replaced)
+    """What `ingest_file` answers.
+
+    Never a bare mock: the flow reads `replaced_document_id` to tell an update
+    from a first ingestion, and `status` to decide whether the document it just
+    recorded succeeded - both of which a mock answers truthily.
+    """
+    return MagicMock(
+        status=IngestionStatus.DONE,
+        document_id="vector-doc-new",
+        chunk_count=3,
+        replaced_document_id=replaced,
+        error_message=None,
+    )
 
 
 def _connector(*, written: bytes = BODY) -> MagicMock:
@@ -108,6 +120,11 @@ async def _syncing(
         trigger_sync=AsyncMock(return_value=MagicMock(id=uuid.uuid4())),
     )
     ingest = AsyncMock(return_value=_result(replaced=replaced))
+    documents = MagicMock(
+        create_document=AsyncMock(return_value=MagicMock(id=uuid.uuid4())),
+        complete_ingestion=AsyncMock(),
+        fail_ingestion=AsyncMock(),
+    )
 
     @asynccontextmanager
     async def _db() -> Any:
@@ -120,14 +137,19 @@ async def _syncing(
         patch.object(rag_tasks, "_record_embedding_spend", new=AsyncMock()),
         patch.object(rag_tasks, "assert_organization_within_budget", new=AsyncMock()),
         patch.object(rag_tasks, "SyncSourceService", return_value=sources),
-        patch.object(rag_tasks, "_config_for_collection", new=AsyncMock()),
+        patch.object(
+            rag_tasks,
+            "_knowledge_base_for",
+            new=AsyncMock(return_value=MagicMock(id=KB_ID, ingestion_config={})),
+        ),
         patch.object(rag_tasks, "IngestionConfigService") as config_service,
         patch.object(rag_tasks.IngestionService, "ingest_file", new=ingest),
         patch.dict(rag_tasks.CONNECTOR_REGISTRY, {"gdrive": lambda: connector}),
         patch("app.services.rag_sync.RAGSyncService", return_value=MagicMock()),
+        patch("app.services.rag_document.RAGDocumentService", return_value=documents),
     ):
         config_service.return_value.build_processor = AsyncMock(return_value=MagicMock())
-        yield ingest
+        yield ingest, documents
 
 
 async def _sync(
@@ -137,11 +159,12 @@ async def _sync(
     connector: MagicMock,
     replaced: str | None = None,
 ) -> Any:
-    async with _syncing(
-        mode=mode, listing=listing, connector=connector, replaced=replaced
-    ) as ingest:
+    async with _syncing(mode=mode, listing=listing, connector=connector, replaced=replaced) as (
+        ingest,
+        documents,
+    ):
         answer = await rag_tasks._run_source_sync(str(uuid.uuid4()), sync_log_id=str(uuid.uuid4()))
-    return answer, ingest
+    return answer, ingest, documents
 
 
 class TestAnIngestAlwaysReplaces:
@@ -155,7 +178,7 @@ class TestAnIngestAlwaysReplaces:
     async def test_whatever_the_mode_a_file_that_is_ingested_replaces_its_document(self, mode: str):
         # A listing whose hash differs, so every mode reaches the ingest: what is
         # under test is the argument it is reached with, not whether it is.
-        answer, ingest = await _sync(
+        answer, ingest, _ = await _sync(
             mode=mode,
             listing=[_stored(content_hash="a-different-file-entirely")],
             connector=_connector(),
@@ -170,7 +193,7 @@ class TestAnUnchangedFile:
     async def test_it_is_skipped_rather_than_embedded_again(self):
         """The cost this exists to avoid. Before the fix a nightly sync
         re-embedded every unchanged file and inserted a second copy of it."""
-        answer, ingest = await _sync(
+        answer, ingest, _ = await _sync(
             mode="new_only",
             listing=[_stored(content_hash=BODY_HASH)],
             connector=_connector(),
@@ -181,7 +204,7 @@ class TestAnUnchangedFile:
         assert answer["ingested"] == 0
 
     async def test_update_only_skips_it_too(self):
-        answer, ingest = await _sync(
+        answer, ingest, _ = await _sync(
             mode="update_only",
             listing=[_stored(content_hash=BODY_HASH)],
             connector=_connector(),
@@ -191,7 +214,7 @@ class TestAnUnchangedFile:
         assert answer["skipped"] == 1
 
     async def test_full_re_ingests_it_because_that_is_what_full_means(self):
-        answer, ingest = await _sync(
+        answer, ingest, _ = await _sync(
             mode="full",
             listing=[_stored(content_hash=BODY_HASH)],
             connector=_connector(),
@@ -208,7 +231,7 @@ class TestAChangedFile:
         """Which is what `sync_local_flow` does with the same mode - the name
         says otherwise, and the two flows agreeing matters more than the name,
         because one column feeds both."""
-        answer, ingest = await _sync(
+        answer, ingest, _ = await _sync(
             mode="new_only",
             listing=[_stored(content_hash="what-it-was-yesterday")],
             connector=_connector(),
@@ -226,7 +249,7 @@ class TestWhatTheSyncLogIsTold:
     that replaces was unreachable before #990, so nothing had ever noticed."""
 
     async def test_a_replacement_counts_as_an_update_not_an_ingestion(self):
-        answer, _ = await _sync(
+        answer, _, _docs = await _sync(
             mode="new_only",
             listing=[_stored(content_hash="what-it-was-yesterday")],
             connector=_connector(),
@@ -236,14 +259,14 @@ class TestWhatTheSyncLogIsTold:
         assert (answer["updated"], answer["ingested"]) == (1, 0)
 
     async def test_a_first_ingestion_counts_as_one(self):
-        answer, _ = await _sync(mode="new_only", listing=[], connector=_connector())
+        answer, _, _docs = await _sync(mode="new_only", listing=[], connector=_connector())
 
         assert (answer["updated"], answer["ingested"]) == (0, 1)
 
 
 class TestAFileNeverSeenBefore:
     async def test_new_only_ingests_it(self):
-        answer, ingest = await _sync(mode="new_only", listing=[], connector=_connector())
+        answer, ingest, _ = await _sync(mode="new_only", listing=[], connector=_connector())
 
         assert answer["ingested"] == 1
         assert ingest.await_args.kwargs["source_path"] == SOURCE_PATH
@@ -254,11 +277,92 @@ class TestAFileNeverSeenBefore:
         new file in the folder, on every run."""
         connector = _connector()
 
-        answer, ingest = await _sync(mode="update_only", listing=[], connector=connector)
+        answer, ingest, _ = await _sync(mode="update_only", listing=[], connector=connector)
 
         connector.download_file.assert_not_awaited()
         ingest.assert_not_awaited()
         assert answer["skipped"] == 1
+
+
+class TestWhatASyncedDocumentLeavesBehind:
+    """A `rag_documents` row, which it did not before (#992).
+
+    Without one a synced document was searchable and invisible: absent from the
+    knowledge base's Documents tab, from a collection's `document_count`, and
+    from delete - a file ingested from a Drive folder could be removed only by
+    dropping the whole collection.
+    """
+
+    async def test_a_row_is_created_and_completed(self):
+        answer, _, documents = await _sync(mode="new_only", listing=[], connector=_connector())
+
+        assert answer["ingested"] == 1
+        documents.create_document.assert_awaited_once()
+        documents.complete_ingestion.assert_awaited_once()
+        documents.fail_ingestion.assert_not_awaited()
+
+    async def test_the_row_names_the_knowledge_base_that_owns_the_collection(self):
+        """`GET /kb/{kb_id}/documents` reads `get_for_kb`, so a row without it is
+        a document in the right collection and the wrong tab - which is to say no
+        tab at all."""
+        _, _, documents = await _sync(mode="new_only", listing=[], connector=_connector())
+
+        created = documents.create_document.await_args.kwargs
+        assert created["knowledge_base_id"] == KB_ID
+        assert created["collection_name"] == "docs"
+        assert created["filename"] == "handbook.md"
+        assert created["filesize"] == len(BODY)
+        assert created["filetype"] == "md"
+
+    async def test_a_replacement_retires_the_row_it_superseded(self):
+        """Otherwise the tab grows a row per sync the way the store grew a
+        document per sync. `complete_ingestion` retires it, given the id."""
+        _, _, documents = await _sync(
+            mode="new_only",
+            listing=[_stored(content_hash="what-it-was-yesterday")],
+            connector=_connector(),
+            replaced="vector-doc-1",
+        )
+
+        assert documents.complete_ingestion.await_args.kwargs["replaced_document_id"] == (
+            "vector-doc-1"
+        )
+
+    async def test_a_skipped_file_creates_nothing(self):
+        """It already has a row from the sync that ingested it. Creating another
+        is the duplication this issue is about, arrived at from the other side."""
+        _, _, documents = await _sync(
+            mode="new_only",
+            listing=[_stored(content_hash=BODY_HASH)],
+            connector=_connector(),
+        )
+
+        documents.create_document.assert_not_awaited()
+
+    async def test_a_file_that_failed_to_parse_keeps_its_own_reason(self):
+        """The count in the sync log said four of forty failed and nothing said
+        which four, or why."""
+        connector = _connector()
+        async with _syncing(mode="new_only", listing=[], connector=connector, replaced=None) as (
+            ingest,
+            documents,
+        ):
+            ingest.return_value = MagicMock(
+                status=IngestionStatus.ERROR,
+                document_id=None,
+                chunk_count=0,
+                replaced_document_id=None,
+                error_message="The parser gave up on page 4",
+            )
+            answer = await rag_tasks._run_source_sync(
+                str(uuid.uuid4()), sync_log_id=str(uuid.uuid4())
+            )
+
+        assert answer["failed"] == 0 and answer["ingested"] == 1
+        documents.create_document.assert_awaited_once()
+        documents.fail_ingestion.assert_awaited_once()
+        assert "page 4" in documents.fail_ingestion.await_args.args[1]
+        documents.complete_ingestion.assert_not_awaited()
 
 
 class TestAStoredDocumentWithNoHash:
@@ -266,7 +370,7 @@ class TestAStoredDocumentWithNoHash:
         """A document ingested before the hash was recorded, or by a path that
         did not record one. Skipping it would be a decision nothing later
         corrects; re-embedding it costs once."""
-        answer, ingest = await _sync(
+        answer, ingest, _ = await _sync(
             mode="new_only",
             listing=[_stored(content_hash="")],
             connector=_connector(),
@@ -314,11 +418,23 @@ class TestAListingTheStoreCannotAnswer:
             patch.object(rag_tasks, "_record_embedding_spend", new=AsyncMock()),
             patch.object(rag_tasks, "assert_organization_within_budget", new=AsyncMock()),
             patch.object(rag_tasks, "SyncSourceService", return_value=sources),
-            patch.object(rag_tasks, "_config_for_collection", new=AsyncMock()),
+            patch.object(
+                rag_tasks,
+                "_knowledge_base_for",
+                new=AsyncMock(return_value=MagicMock(id=KB_ID, ingestion_config={})),
+            ),
             patch.object(rag_tasks, "IngestionConfigService") as config_service,
             patch.object(rag_tasks.IngestionService, "ingest_file", new=ingest),
             patch.dict(rag_tasks.CONNECTOR_REGISTRY, {"gdrive": lambda: connector}),
             patch("app.services.rag_sync.RAGSyncService", return_value=MagicMock()),
+            patch(
+                "app.services.rag_document.RAGDocumentService",
+                return_value=MagicMock(
+                    create_document=AsyncMock(return_value=MagicMock(id=uuid.uuid4())),
+                    complete_ingestion=AsyncMock(),
+                    fail_ingestion=AsyncMock(),
+                ),
+            ),
         ):
             config_service.return_value.build_processor = AsyncMock(return_value=MagicMock())
             answer = await rag_tasks._run_source_sync(

--- a/backend/tests/test_ingestion_engine_lifetime.py
+++ b/backend/tests/test_ingestion_engine_lifetime.py
@@ -83,6 +83,9 @@ async def _worker(ledger: StoreLedger, *, ingest: AsyncMock | None = None) -> An
         patch.object(rag_tasks.IngestionService, "ingest_file", new=ingest or AsyncMock()),
     ):
         config_service.return_value.build_processor = AsyncMock(return_value=MagicMock())
+        # A connector sync asks for the image model to record on each document's
+        # row (#992), so the stand-in service has to answer awaitably.
+        config_service.return_value.resolved_image_model = AsyncMock(return_value=None)
         yield config_service
 
 

--- a/backend/tests/test_ingestion_engine_lifetime.py
+++ b/backend/tests/test_ingestion_engine_lifetime.py
@@ -262,7 +262,7 @@ class TestAConnectorSyncsStore:
                 patch.object(rag_tasks, "SyncSourceService", return_value=sources),
                 patch.dict(rag_tasks.CONNECTOR_REGISTRY, {"gdrive": lambda: connector}),
                 patch("app.services.rag_sync.RAGSyncService", return_value=MagicMock()),
-                patch.object(rag_tasks, "_config_for_collection", new=AsyncMock()),
+                patch.object(rag_tasks, "_knowledge_base_for", new=AsyncMock(return_value=None)),
             ):
                 await rag_tasks._run_source_sync(str(uuid.uuid4()), sync_log_id=str(uuid.uuid4()))
 
@@ -293,7 +293,7 @@ class TestAConnectorSyncsStore:
                 patch.object(rag_tasks, "SyncSourceService", return_value=sources),
                 patch.dict(rag_tasks.CONNECTOR_REGISTRY, {"gdrive": lambda: connector}),
                 patch("app.services.rag_sync.RAGSyncService", return_value=MagicMock()),
-                patch.object(rag_tasks, "_config_for_collection", new=AsyncMock()),
+                patch.object(rag_tasks, "_knowledge_base_for", new=AsyncMock(return_value=None)),
             ):
                 answer = await rag_tasks._run_source_sync(
                     str(uuid.uuid4()), sync_log_id=str(uuid.uuid4())

--- a/backend/tests/test_synced_document_delete.py
+++ b/backend/tests/test_synced_document_delete.py
@@ -1,0 +1,121 @@
+"""Deleting a tracked document removes its vectors, whichever route asked.
+
+#992. `RAGDocumentService.delete_document` took `ingestion_service: Any = None`
+and removed vectors only when a caller happened to pass one. `DELETE
+/rag/documents/{doc_id}` did; `DELETE /kb/{kb_id}/documents/{doc_id}` - the one
+the Documents tab uses - did not. So deleting a document from the tab removed its
+row and left the content searchable, and for a *synced* document that was
+permanent: the next `new_only` run matched its unchanged hash and skipped it, so
+the row never came back. The document became searchable, invisible and
+undeletable again, through the delete button.
+
+The argument has no default now, which is the structural half: a third route
+cannot repeat this without the type checker saying so. These are the behavioural
+half.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.repositories import rag_document_repo
+from app.services.rag_document import RAGDocumentService
+
+pytestmark = pytest.mark.anyio
+
+
+def _row(*, vector_document_id: str | None, storage_path: str = "") -> MagicMock:
+    return MagicMock(
+        id=uuid.uuid4(),
+        collection_name="docs",
+        vector_document_id=vector_document_id,
+        storage_path=storage_path,
+    )
+
+
+class TestDeletingATrackedDocument:
+    async def test_the_vectors_go_with_the_row(self, monkeypatch):
+        row = _row(vector_document_id="vector-doc-1")
+        monkeypatch.setattr(rag_document_repo, "get_by_id", AsyncMock(return_value=row))
+        monkeypatch.setattr(rag_document_repo, "delete", AsyncMock(return_value=True))
+        ingestion = MagicMock(remove_document=AsyncMock(return_value=True))
+
+        await RAGDocumentService(MagicMock()).delete_document(str(row.id), ingestion)
+
+        ingestion.remove_document.assert_awaited_once_with("docs", "vector-doc-1")
+
+    async def test_a_document_with_no_vectors_asks_for_nothing(self, monkeypatch):
+        """One that failed to index. There is nothing in the store to remove, and
+        asking would be a query about a document that was never written."""
+        row = _row(vector_document_id=None)
+        monkeypatch.setattr(rag_document_repo, "get_by_id", AsyncMock(return_value=row))
+        monkeypatch.setattr(rag_document_repo, "delete", AsyncMock(return_value=True))
+        ingestion = MagicMock(remove_document=AsyncMock())
+
+        await RAGDocumentService(MagicMock()).delete_document(str(row.id), ingestion)
+
+        ingestion.remove_document.assert_not_awaited()
+
+    async def test_a_store_that_refuses_still_removes_the_row(self, monkeypatch):
+        """The cleanup is best-effort by design: a row kept because the store was
+        briefly unreachable is a document a reader cannot delete at all."""
+        row = _row(vector_document_id="vector-doc-1")
+        monkeypatch.setattr(rag_document_repo, "get_by_id", AsyncMock(return_value=row))
+        deleted = AsyncMock(return_value=True)
+        monkeypatch.setattr(rag_document_repo, "delete", deleted)
+        ingestion = MagicMock(remove_document=AsyncMock(side_effect=RuntimeError("no such table")))
+
+        await RAGDocumentService(MagicMock()).delete_document(str(row.id), ingestion)
+
+        deleted.assert_awaited_once()
+
+
+class TestTheRouteThatTheDocumentsTabUses:
+    async def test_the_kb_delete_route_hands_over_an_ingestion_service(self):
+        """The route signature is the fix, so this asserts on the wiring: a
+        `DELETE` through the knowledge base reaches `delete_document` with a
+        service that can remove vectors, not with `None`."""
+        from app.api.routes.v1 import knowledge_bases
+
+        kb = MagicMock(collection_name="docs")
+        doc = MagicMock(id=uuid.uuid4(), collection_name="docs")
+        service = MagicMock(get_for_write=AsyncMock(return_value=kb))
+        documents = MagicMock(get_document=AsyncMock(return_value=doc), delete_document=AsyncMock())
+        ingestion = MagicMock(remove_document=AsyncMock())
+
+        await knowledge_bases.delete_kb_document(
+            kb_id=uuid.uuid4(),
+            doc_id=doc.id,
+            service=service,
+            rag_doc_service=documents,
+            ingestion_service=ingestion,
+            ctx=MagicMock(),
+        )
+
+        documents.delete_document.assert_awaited_once_with(str(doc.id), ingestion)
+
+    async def test_a_document_from_another_knowledge_base_is_not_deleted(self):
+        """The check that was already here, kept under test because the signature
+        around it moved: without it a KB owner could pass any doc_id."""
+        from app.api.routes.v1 import knowledge_bases
+        from app.core.exceptions import NotFoundError
+
+        doc = MagicMock(id=uuid.uuid4(), collection_name="somebody_elses")
+        documents = MagicMock(get_document=AsyncMock(return_value=doc), delete_document=AsyncMock())
+
+        with pytest.raises(NotFoundError):
+            await knowledge_bases.delete_kb_document(
+                kb_id=uuid.uuid4(),
+                doc_id=doc.id,
+                service=MagicMock(
+                    get_for_write=AsyncMock(return_value=MagicMock(collection_name="docs"))
+                ),
+                rag_doc_service=documents,
+                ingestion_service=MagicMock(),
+                ctx=MagicMock(),
+            )
+
+        documents.delete_document.assert_not_awaited()

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -595,6 +595,21 @@ since [#990](https://github.com/vstorm-co/agenticos/issues/990) it skips
 everything unchanged and re-fetches exactly what has no document, so retrying
 four failures out of forty costs four transfers rather than forty.
 
+**The row is opened before the file is indexed**, on every path. Written
+afterwards, a row whose write failed — a database blip, a remote name longer than
+the column — left the vector document stored and untracked, and the next
+`new_only` run then matched its hash and *skipped* the file before reaching the
+write, so it stayed searchable, invisible and undeletable for good. This order's
+worst case is a row that says `processing` beside a document that finished, which
+is visible and can be deleted.
+
+One row per file is not yet an invariant. A file that fails to parse on one sync
+and succeeds on the next leaves both rows, because retirement matches on
+`vector_document_id` and a failed parse wrote no vectors — and it cannot be
+matched by filename instead, since `rag_documents` has no `source_path` column
+and two keys of one basename would delete each other's rows. That column is
+[#996](https://github.com/vstorm-co/agenticos/issues/996).
+
 The connector sync wrote no row at all until
 [#992](https://github.com/vstorm-co/agenticos/issues/992) — the sentence above
 was true of the upload, the CLI and the *local* sync only. A document from a

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -595,13 +595,20 @@ since [#990](https://github.com/vstorm-co/agenticos/issues/990) it skips
 everything unchanged and re-fetches exactly what has no document, so retrying
 four failures out of forty costs four transfers rather than forty.
 
-**The row is opened before the file is indexed**, on every path. Written
-afterwards, a row whose write failed — a database blip, a remote name longer than
-the column — left the vector document stored and untracked, and the next
-`new_only` run then matched its hash and *skipped* the file before reaching the
-write, so it stayed searchable, invisible and undeletable for good. This order's
-worst case is a row that says `processing` beside a document that finished, which
-is visible and can be deleted.
+**An upload and a connector sync open the row before the file is indexed.**
+Written afterwards, a row whose write failed — a database blip, a remote name
+longer than the column — left the vector document stored and untracked, and the
+next `new_only` run then matched its hash and *skipped* the file before reaching
+the write, so it stayed searchable, invisible and undeletable for good. This
+order's worst case is a row that says `processing` beside a document that
+finished, which is visible and can be deleted.
+
+The **local-directory** sync still writes its row after the ingest, and only when
+the ingest succeeded — so it carries the same exposure, and a file that failed to
+parse leaves no row and no reason at all.
+[#997](https://github.com/vstorm-co/agenticos/issues/997) is that reorder; it is
+a narrower path (an app admin naming a directory on the server) which is why it
+is not folded in here.
 
 One row per file is not yet an invariant. A file that fails to parse on one sync
 and succeeds on the next leaves both rows, because retirement matches on

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -585,11 +585,30 @@ vector document it replaced, along with their stored copies of the file. Without
 that a directory synced nightly reported a collection growing by its own size
 every night.
 
+**A synced document keeps no original, and says so.** The upload path stores a
+copy under `rag/{collection}` and a sync does not: a synced file's bytes live in
+the system it came from, and mirroring every one of them onto this deployment's
+disk to make one button work is a cost per corpus rather than per failure. So
+`storage_path` is empty for these and `has_file` is false, which is what a
+surface offering a download has to read. **Re-running the sync is the retry** —
+since [#990](https://github.com/vstorm-co/agenticos/issues/990) it skips
+everything unchanged and re-fetches exactly what has no document, so retrying
+four failures out of forty costs four transfers rather than forty.
+
+The connector sync wrote no row at all until
+[#992](https://github.com/vstorm-co/agenticos/issues/992) — the sentence above
+was true of the upload, the CLI and the *local* sync only. A document from a
+Drive folder was searchable and invisible: absent from the knowledge base's
+Documents tab (`GET /kb/{kb_id}/documents` reads `get_for_kb`), absent from the
+collection's own `document_count`, unreachable by delete, and a failure was a
+number in the sync log with no per-file reason anywhere.
+
 Failed ingestions can be retried via `POST /rag/documents/{id}/retry`. It
 re-reads `storage_path` — the copy the upload kept for exactly this — and
 dispatches the parse again, replacing whatever the failed attempt indexed. A
-document that did not fail, or that predates uploads keeping their file, is
-refused with a 400 rather than moved to `processing`
+document that did not fail, or that has no stored file — one that predates
+uploads keeping theirs, or one a sync ingested — is refused with a 400 rather
+than moved to `processing`
 ([#441](https://github.com/vstorm-co/agenticos/issues/441)).
 
 ### What a failed ingest says


### PR DESCRIPTION
A synced document was searchable and invisible. `GET /kb/{kb_id}/documents`
reads `rag_documents` through `get_for_kb`, and `_run_source_sync` created
no row there - so a Drive folder synced into a knowledge base reported
"ingested: 40" and left the Documents tab empty, the collection's own
`document_count` at zero, and the documents unreachable by delete: one
ingested from a folder could be removed only by dropping the whole
collection. A failure was a number in the sync log and a reason nowhere,
so "which four of the forty failed, and why" had no answer.

The bookkeeping is `sync_local_flow`'s, as the mode logic was: a row per
file, `complete_ingestion` with the chunk count and the id it replaced,
`fail_ingestion` with the reason on the other branch. `complete_ingestion`
already retires the superseded row, so the tab does not grow a row per
sync the way the store grew a document per sync before #990. A *skipped*
file creates nothing - it has a row from the run that ingested it.

The knowledge base id is resolved once, in the session that is already
open, rather than per file: `_config_for_collection` was already finding
that row to read its parser settings, so `_knowledge_base_for` now answers
both questions from one lookup and the config helper is written on top of
it.

One thing deliberately not done. A synced document keeps **no original**:
an upload stores a copy under `rag/{collection}` for its retry button, and
mirroring every synced file onto this deployment's disk is a cost per
corpus rather than per failure. `storage_path` is empty and `has_file` is
false, which is what a surface offering a download reads, and `retry`
refuses with the message it already had. Re-running the sync is the retry -
since #990 that skips everything unchanged and re-fetches exactly what has
no document, so four failures out of forty cost four transfers.

No backfill either, and this is the reason rather than an omission: no
deployment carries synced documents, so a migration for rows that do not
exist is a branch written for nobody. If one ever does, the store's own
listing is the source - `existing_document` already reads it, and each
entry carries the `source_path`, the hash and a filename.

## Verified

Eighteen tests in `tests/test_connector_sync_modes.py`, all eighteen of
which fail against the unfixed flow. Five are new and about this: a row is
created and completed, it names the knowledge base that owns the
collection, a replacement retires what it superseded, a skipped file
creates nothing, and a file that failed to parse keeps its own reason.
`make lint`, `make docs-build`, and the backend suite - 6205 passed.

`docs/file-processing.md` already claimed every ingest path writes a
tracking row, which was true of the upload, the CLI and the local sync
only. It now says what a synced document does and does not keep.

Closes #992