### PR TITLE
fix(rag): open a local sync's document row before indexing too

### DIFF
--- a/backend/app/worker/tasks/rag_tasks.py
+++ b/backend/app/worker/tasks/rag_tasks.py
@@ -619,12 +619,13 @@ async def _open_document_row(
     whole collection (#992). A failure was counted in the sync log and recorded
     nowhere per-file, so "which four of the forty failed, and why" had no answer.
 
-    No original is stored, unlike an upload: a synced file's bytes live in the
-    system it was synced from, and mirroring every one of them onto this
-    deployment's disk to make a retry button work is a cost per corpus rather
-    than per failure. `has_file` is false for these, and re-running the sync is
-    the retry - which since #990 skips everything unchanged and re-fetches
-    exactly what has no document.
+    No original is stored, unlike an upload, and that holds for both callers:
+    a connector's file lives in the system it was synced from and a local one is
+    already on this host's disk at the path the sync named, so keeping a second
+    copy to make a retry button work is a cost per corpus rather than per
+    failure. `has_file` is false for these, and **re-running the sync is the
+    retry** - which since #990 skips everything unchanged and re-fetches exactly
+    what has no document.
     """
     from app.services.rag_document import RAGDocumentService
 

--- a/backend/app/worker/tasks/rag_tasks.py
+++ b/backend/app/worker/tasks/rag_tasks.py
@@ -375,7 +375,6 @@ async def _run_ingestion(
 async def _run_sync(
     sync_log_id: str, source: str, collection_name: str, mode: str, path: str
 ) -> dict[str, Any]:
-    from app.services.rag_document import RAGDocumentService
     from app.services.rag_sync import RAGSyncService
 
     target_path = Path(path).resolve()
@@ -402,10 +401,12 @@ async def _run_sync(
     # store owns a pooled engine, so one built before an early return is a pool
     # nothing ever closes (#948).
     async with get_worker_db_context() as db:
+        # Kept, not just passed through: every row this sync writes records which
+        # parser read the document, and the rows used to carry no configuration at
+        # all - so `parser` read `null` for every locally-synced file (#997).
+        ingestion_config = await _config_for_collection(db, collection_name, None)
         ingestion_service = await _ingestion_service_for(
-            db,
-            config=await _config_for_collection(db, collection_name, None),
-            organization_id=None,
+            db, config=ingestion_config, organization_id=None
         )
 
     try:
@@ -448,28 +449,41 @@ async def _run_sync(
                         skipped += 1
                         continue
             try:
+                # Opened before the ingest, as the upload and the connector sync
+                # do (#992). Written afterwards it could fail afterwards - a
+                # database blip, a name longer than the column - leaving the
+                # vector document stored and untracked, and the next `new_only`
+                # run then matched its unchanged hash and skipped the file before
+                # reaching the write, for good (#997).
+                row_id = await _open_document_row(
+                    filename=filepath.name,
+                    filesize=filepath.stat().st_size,
+                    collection_name=collection_name,
+                    # A path on the server belongs to no tenant and to no
+                    # knowledge base; `POST /rag/sync/local` is the one route
+                    # that still carries `is_app_admin` for exactly that reason.
+                    organization_id=None,
+                    knowledge_base_id=None,
+                    ingestion_config=ingestion_config,
+                    image_description_model=None,
+                    embedding_model=None,
+                )
+
                 with metered_by(ledger):
                     result = await ingestion_service.ingest_file(
                         filepath=filepath, collection_name=collection_name, replace=True
                     )
-                if result.status.value == "done":
-                    if result.message and "replaced" in result.message:
+
+                # Either way, which is the other half of #997: a file that failed
+                # to parse used to leave no row and no reason, so a sync log
+                # saying four of forty failed named none of the four.
+                await _settle_document_row(row_id, result)
+
+                if result.status is IngestionStatus.DONE:
+                    if result.replaced_document_id:
                         updated += 1
                     else:
                         ingested += 1
-                    async with get_worker_db_context() as db:
-                        doc = await RAGDocumentService(db).create_document(
-                            collection_name=collection_name,
-                            filename=filepath.name,
-                            filesize=filepath.stat().st_size,
-                            filetype=filepath.suffix.lstrip(".").lower(),
-                        )
-                        await RAGDocumentService(db).complete_ingestion(
-                            str(doc.id),
-                            vector_document_id=result.document_id,
-                            chunk_count=result.chunk_count,
-                            replaced_document_id=result.replaced_document_id,
-                        )
                 else:
                     failed += 1
             except Exception as e:

--- a/backend/tests/test_connector_sync_modes.py
+++ b/backend/tests/test_connector_sync_modes.py
@@ -537,3 +537,81 @@ class TestAListingTheStoreCannotAnswer:
 
         assert answer["ingested"] == 1
         assert answer["skipped"] == 0
+
+
+class TestTheLocalDirectorySync:
+    """The same two guarantees, on the flow that names a path on the server.
+
+    One `sync_mode` column feeds both flows and both now write their rows the
+    same way round - which is the point: the local sync kept the exposure #992
+    removed from the connector path, and a file that failed to parse there left
+    no row and no reason at all (#997).
+    """
+
+    @staticmethod
+    @asynccontextmanager
+    async def _syncing(*, result: MagicMock) -> Any:
+        store = MagicMock(aclose=AsyncMock(), get_documents=AsyncMock(return_value=[]))
+        documents = MagicMock(
+            create_document=AsyncMock(return_value=MagicMock(id=ROW_ID)),
+            complete_ingestion=AsyncMock(),
+            fail_ingestion=AsyncMock(),
+        )
+
+        @asynccontextmanager
+        async def _db() -> Any:
+            yield MagicMock()
+
+        with (
+            patch.object(rag_tasks, "VectorStore", return_value=store),
+            patch.object(rag_tasks, "EmbeddingService", new=MagicMock()),
+            patch.object(rag_tasks, "get_worker_db_context", new=_db),
+            patch.object(rag_tasks, "_record_embedding_spend", new=AsyncMock()),
+            patch.object(rag_tasks, "_config_for_collection", new=AsyncMock()),
+            patch.object(rag_tasks, "IngestionConfigService") as config_service,
+            patch.object(
+                rag_tasks.IngestionService, "ingest_file", new=AsyncMock(return_value=result)
+            ),
+            patch(
+                "app.services.rag_sync.RAGSyncService",
+                # The loop asks whether the run was cancelled before each file,
+                # so the stand-in has to answer awaitably and say it was not.
+                return_value=MagicMock(
+                    get_sync_log=AsyncMock(return_value=MagicMock(status="running")),
+                    complete_sync=AsyncMock(),
+                ),
+            ),
+            patch("app.services.rag_document.RAGDocumentService", return_value=documents),
+        ):
+            config_service.return_value.build_processor = AsyncMock(return_value=MagicMock())
+            yield documents
+
+    async def test_a_file_that_failed_to_parse_keeps_its_own_reason(self, tmp_path: Path):
+        (tmp_path / "handbook.md").write_text("body")
+        failure = MagicMock(
+            status=IngestionStatus.ERROR,
+            document_id=None,
+            chunk_count=0,
+            replaced_document_id=None,
+            error_message="The parser gave up on page 4",
+        )
+
+        async with self._syncing(result=failure) as documents:
+            answer = await rag_tasks._run_sync(
+                str(uuid.uuid4()), "local", "docs", "full", str(tmp_path)
+            )
+
+        assert answer["failed"] == 1
+        documents.create_document.assert_awaited_once()
+        assert "page 4" in documents.fail_ingestion.await_args.args[1]
+
+    async def test_the_row_says_which_parser_read_the_document(self, tmp_path: Path):
+        """The rows carried no configuration at all, so `parser` read `null` for
+        every locally-synced file while the setting that chose it was right
+        there."""
+        (tmp_path / "handbook.md").write_text("body")
+
+        async with self._syncing(result=_result()) as documents:
+            await rag_tasks._run_sync(str(uuid.uuid4()), "local", "docs", "full", str(tmp_path))
+
+        assert documents.create_document.await_args.kwargs["ingestion_config"] is not None

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -595,20 +595,18 @@ since [#990](https://github.com/vstorm-co/agenticos/issues/990) it skips
 everything unchanged and re-fetches exactly what has no document, so retrying
 four failures out of forty costs four transfers rather than forty.
 
-**An upload and a connector sync open the row before the file is indexed.**
-Written afterwards, a row whose write failed — a database blip, a remote name
-longer than the column — left the vector document stored and untracked, and the
-next `new_only` run then matched its hash and *skipped* the file before reaching
-the write, so it stayed searchable, invisible and undeletable for good. This
-order's worst case is a row that says `processing` beside a document that
-finished, which is visible and can be deleted.
-
-The **local-directory** sync still writes its row after the ingest, and only when
-the ingest succeeded — so it carries the same exposure, and a file that failed to
-parse leaves no row and no reason at all.
-[#997](https://github.com/vstorm-co/agenticos/issues/997) is that reorder; it is
-a narrower path (an app admin naming a directory on the server) which is why it
-is not folded in here.
+**Every path opens the row before the file is indexed.** Written afterwards, a
+row whose write failed — a database blip, a name longer than the column — left the
+vector document stored and untracked, and the next `new_only` run then matched
+its hash and *skipped* the file before reaching the write, so it stayed
+searchable, invisible and undeletable for good. This order's worst case is a row
+that says `processing` beside a document that finished, which is visible and can
+be deleted. The connector sync stopped writing afterwards in
+[#992](https://github.com/vstorm-co/agenticos/issues/992) and the
+local-directory one in
+[#997](https://github.com/vstorm-co/agenticos/issues/997), which also gave a
+locally-synced file that fails to parse a row and a reason — it had neither, so a
+sync log saying four of forty failed named none of them.
 
 One row per file is not yet an invariant. A file that fails to parse on one sync
 and succeeds on the next leaves both rows, because retirement matches on


### PR DESCRIPTION
The last path still writing its row afterwards, and the one the previous
change had to leave a note about in the docs.

`sync_local_flow` created its row after `ingest_file` returned, and only
when it returned `done`. Two consequences, both of which the connector sync
stopped having in #992:

- **A row written after the ingest can fail after it.** A database blip, or
  a name longer than the 255-character column, and the vector document is
  stored with nothing tracking it - then the next `new_only` run matches its
  unchanged hash and skips the file before reaching the write, so it stays
  searchable, invisible and undeletable for good.
- **A file that failed to parse left no row and no reason.** `failed` was
  incremented in the sync log and nothing anywhere said which file or why.

Both fixed by the two helpers the connector path already uses -
`_open_document_row` before, `_settle_document_row` after - with
`organization_id` and `knowledge_base_id` at `None`, because a path on the
server belongs to no tenant and no knowledge base. That is also why
`POST /rag/sync/local` is the one route still carrying `is_app_admin`.

Two smaller things came with it, both in the same lines:

- **The rows now say which parser read the document.** They carried no
  `ingestion_config` at all, so `parser` read `null` for every
  locally-synced file while the setting that chose it sat a few lines above,
  already resolved to build the ingestion service.
- **`updated` is counted off `replaced_document_id`** rather than by
  searching the result's own message for the word "replaced" - the string
  dependency #990's review removed from the connector flow. Equivalent
  today, since `ingest_file` writes that word exactly when it replaced
  something; one of the two is a fact and the other is a sentence.

## Verified

Two tests, both failing without the change: a locally-synced file that fails
to parse keeps its own reason, and its row says which parser read it.
`make lint`, `make docs-build`, and the backend suite - 6219 passed.

`docs/file-processing.md` said the row-before-index order held for the
upload and the connector sync, and named this path as the exception. It now
says every path, which is true.

Closes #997