### PR TITLE
chore: cut 0.0.218

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,35 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.218] - 2026-08-20
+
+Every ingest path writes its tracking row before the file is indexed.
+
+### Fixed
+
+- **The local-directory sync opens its document row before the ingest**, and
+  writes one whether or not the ingest succeeded. It created the row afterwards
+  and only on success, so a row whose write failed - a database blip, a name
+  longer than the 255-character column - left the vector document stored and
+  untracked, and the next `new_only` run then matched its unchanged hash and
+  skipped the file before reaching the write: searchable, invisible and
+  undeletable for good. This was the last path still doing it; the connector sync
+  stopped in #992. (#997)
+- **A locally-synced file that failed to parse keeps its own reason.** `failed`
+  was incremented in the sync log and nothing anywhere said which file or why, so
+  a run reporting four of forty failures named none of the four. (#997)
+- **A locally-synced document's row says which parser read it.** The rows carried
+  no `ingestion_config` at all, so `parser` read `null` for every one of them
+  while the setting that chose it sat resolved a few lines above. (#997)
+
+### Changed
+
+- `updated` is counted off `replaced_document_id` rather than by searching the
+  ingest result's own message for the word "replaced" - the string dependency
+  #990's review removed from the connector flow. Equivalent today, since
+  `ingest_file` writes that word exactly when it replaced something; one of the
+  two is a fact and the other is a sentence. (#997)
+
 ## [0.0.217] - 2026-08-20
 
 What a connector sync ingests is visible, and deleting it deletes it.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.217"
+version = "0.0.218"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.217"
+version = "0.0.218"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.217",
+  "version": "0.0.218",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.218. Bumps `backend/pyproject.toml`,
`backend/uv.lock` and `frontend/package.json` to 0.0.218 and adds the
CHANGELOG entry.

One issue, #997, and it closes a note the previous release had to leave in
`docs/file-processing.md`: the local-directory sync was the last path
writing its tracking row after the ingest, so the page could only claim the
order for the upload and the connector sync. It now claims every path,
which is true.

Two smaller things came in the same lines and are worth the release note:
a locally-synced file that failed to parse left no row and no reason at
all, and the rows carried no `ingestion_config`, so `parser` read `null`
for every locally-synced document while the setting that chose it sat
resolved a few lines above.

## Verified

`make lint`, `make docs-build` and the backend suite - 6219 passed. Two new
tests, both failing without the change. CI green end to end on #999,
`test-frontend` skipped by the path filter.

Codex has answered "usage limits" since before that PR opened and reviewed
neither commit, so the review was a read of the diff - which found the
shared helper's docstring justifying "no original is stored" with a reason
true only of the connector sync.

Closes #997