### PR TITLE
fix(rag): a document row says which file it tracks

### DIFF
--- a/backend/alembic/versions/0043_rag_document_source_path.py
+++ b/backend/alembic/versions/0043_rag_document_source_path.py
@@ -7,10 +7,11 @@ is the collision `0042`'s successor removed on the *vector* side (#990), reached
 from the other direction: retiring "the previous row for this file" by name would
 delete the other file's row.
 
-So the address the ingest used is stored: `gdrive://<id>`, `s3://bucket/key`, an
-absolute path for a local-directory sync, and the filename itself for an upload,
-which has no address of its own. With it, a file that failed to parse on one sync
-and succeeded on the next stops leaving both rows behind (#996).
+So the address the ingest used is stored: `gdrive://<id>`, `s3://bucket/key`, or
+an absolute path for a local or CLI sync. An upload stores none - its only name
+is a basename, and two people can upload different files sharing one. With it, a
+file that failed to parse on one sync and succeeded on the next stops leaving
+both rows behind (#996).
 
 **Nullable, and nothing is backfilled.** A row written before this column is a
 row whose address nobody recorded, and inventing one from its filename is exactly
@@ -38,8 +39,21 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    op.add_column("rag_documents", sa.Column("source_path", sa.String(length=1024), nullable=True))
-    op.create_index("rag_documents_source_path_idx", "rag_documents", ["source_path"], unique=False)
+    # `Text`, not `String(n)`: an S3 key alone reaches 1024 bytes before the
+    # scheme and the bucket are added, and a filesystem path reaches 4096, so any
+    # length picked here is a truncation error on a file that used to ingest fine.
+    op.add_column("rag_documents", sa.Column("source_path", sa.Text(), nullable=True))
+    # A hash index for the same reason. Equality is the only way this column is
+    # ever read - `discard_failed` and nothing else - and a btree refuses a key
+    # over about 2700 bytes at insert time, which would reintroduce the error the
+    # `Text` avoids.
+    op.create_index(
+        "rag_documents_source_path_idx",
+        "rag_documents",
+        ["source_path"],
+        unique=False,
+        postgresql_using="hash",
+    )
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/0043_rag_document_source_path.py
+++ b/backend/alembic/versions/0043_rag_document_source_path.py
@@ -1,0 +1,47 @@
+"""A tracking row says which file it tracks.
+
+`rag_documents` held a `filename` and nothing else identifying, so a row could
+only be found again by name - and two objects with the same basename in one
+bucket, `a/readme.md` beside `b/readme.md`, are indistinguishable that way. That
+is the collision `0042`'s successor removed on the *vector* side (#990), reached
+from the other direction: retiring "the previous row for this file" by name would
+delete the other file's row.
+
+So the address the ingest used is stored: `gdrive://<id>`, `s3://bucket/key`, an
+absolute path for a local-directory sync, and the filename itself for an upload,
+which has no address of its own. With it, a file that failed to parse on one sync
+and succeeded on the next stops leaving both rows behind (#996).
+
+**Nullable, and nothing is backfilled.** A row written before this column is a
+row whose address nobody recorded, and inventing one from its filename is exactly
+the guess this column exists to avoid: it would claim `readme.md` is the same
+file as some other `readme.md`. Those rows keep `NULL` and are simply never
+matched by address, which is the truthful answer - they are still matched by the
+vector document they point at, which is how a replacement has always retired one.
+
+Revision ID: 0043_rag_document_source_path
+Revises: 0042_sync_source_secret_id
+Create Date: 2026-08-20
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0043_rag_document_source_path"
+down_revision: str | None = "0042_sync_source_secret_id"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("rag_documents", sa.Column("source_path", sa.String(length=1024), nullable=True))
+    op.create_index("rag_documents_source_path_idx", "rag_documents", ["source_path"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("rag_documents_source_path_idx", table_name="rag_documents")
+    op.drop_column("rag_documents", "source_path")

--- a/backend/app/commands/rag.py
+++ b/backend/app/commands/rag.py
@@ -207,12 +207,24 @@ async def ingest_path_async(
                     filename=filepath.name,
                     filesize=filepath.stat().st_size,
                     filetype=filepath.suffix.lstrip(".").lower(),
+                    # The address this command already looks documents up by, a
+                    # few lines above. Omitted, the row got `NULL` and a repeated
+                    # failure here kept inflating the collection's count - the
+                    # defect #996 fixed for the two worker flows and not for this
+                    # one.
+                    source_path=source_path,
                 )
                 doc_id = str(rag_doc.id)
 
             try:
                 result = await ingestion.ingest_file(
-                    filepath=filepath, collection_name=collection, replace=replace
+                    filepath=filepath,
+                    collection_name=collection,
+                    replace=replace,
+                    # So the stored document identifies itself the way this
+                    # command's own `existing_document` call asks for it, and the
+                    # row and the vector agree on which file this is.
+                    source_path=source_path,
                 )
                 if result.status.value == "done":
                     success_count += 1

--- a/backend/app/db/models/rag_document.py
+++ b/backend/app/db/models/rag_document.py
@@ -4,7 +4,7 @@ import enum
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text, func
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.orm import Mapped, mapped_column
@@ -42,15 +42,24 @@ class RAGDocument(TimestampMixin, Base):
     filetype: Mapped[str] = mapped_column(String(20), nullable=False)
     storage_path: Mapped[str | None] = mapped_column(String(500), nullable=True)
     # Which file this row tracks, as the ingest addressed it: `gdrive://<id>`,
-    # `s3://bucket/key`, an absolute path for a local sync, and the filename
-    # itself for an upload, which has no address of its own.
+    # `s3://bucket/key`, or an absolute path for a local or CLI sync. An upload
+    # has no address - its only name is a basename, which two different files can
+    # share - so it stores none (#996).
     #
-    # Indexed because it is how a row is found again. Without it a row could only
-    # be matched by `filename`, and two keys of one basename in a bucket are
-    # indistinguishable that way - so retiring "the previous row for this file"
-    # deleted the other file's (#996), which is the collision #990 removed on the
-    # vector side. Nullable for every row written before this column existed.
-    source_path: Mapped[str | None] = mapped_column(String(1024), nullable=True, index=True)
+    # `Text`, because an address has no length this can promise: an S3 key alone
+    # reaches 1024 bytes before the scheme and bucket are added, and a filesystem
+    # path reaches 4096. A `String(n)` here is a truncation error on a file that
+    # used to ingest fine.
+    #
+    # The index is a **hash** index for the same reason. Equality is the only way
+    # this column is ever read - `discard_failed` and nothing else - and a btree
+    # refuses a key over about 2700 bytes at insert time, which would turn a long
+    # path into the error the `Text` was chosen to avoid.
+    source_path: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    __table_args__ = (
+        Index("rag_documents_source_path_idx", "source_path", postgresql_using="hash"),
+    )
     status: Mapped[str] = mapped_column(
         String(20), nullable=False, default=DocumentStatus.PROCESSING
     )

--- a/backend/app/db/models/rag_document.py
+++ b/backend/app/db/models/rag_document.py
@@ -41,6 +41,16 @@ class RAGDocument(TimestampMixin, Base):
     filesize: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     filetype: Mapped[str] = mapped_column(String(20), nullable=False)
     storage_path: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    # Which file this row tracks, as the ingest addressed it: `gdrive://<id>`,
+    # `s3://bucket/key`, an absolute path for a local sync, and the filename
+    # itself for an upload, which has no address of its own.
+    #
+    # Indexed because it is how a row is found again. Without it a row could only
+    # be matched by `filename`, and two keys of one basename in a bucket are
+    # indistinguishable that way - so retiring "the previous row for this file"
+    # deleted the other file's (#996), which is the collision #990 removed on the
+    # vector side. Nullable for every row written before this column existed.
+    source_path: Mapped[str | None] = mapped_column(String(1024), nullable=True, index=True)
     status: Mapped[str] = mapped_column(
         String(20), nullable=False, default=DocumentStatus.PROCESSING
     )

--- a/backend/app/repositories/rag_document.py
+++ b/backend/app/repositories/rag_document.py
@@ -165,20 +165,22 @@ async def get_superseded(
     return list(result.scalars().all())
 
 
-async def discard_unindexed(db: AsyncSession, *, collection_name: str, source_path: str) -> int:
-    """Drop rows for this file that point at no vector document, and count them.
+async def discard_failed(db: AsyncSession, *, collection_name: str, source_path: str) -> int:
+    """Drop this file's *failed* attempts, and count them.
 
     A failed parse writes no vectors, so the row it leaves has no
     `vector_document_id` - and `complete_ingestion`'s retirement matches on
     exactly that, which is why a file failing one sync and succeeding the next
     used to leave both rows and inflate the collection's count for good (#996).
-    A stale `processing` row from a run that died mid-ingest is the same shape and
-    goes the same way.
 
-    **Only rows with no vector document.** One that has vectors is retired by
-    `complete_ingestion` after the replacement is written, and deleting it here -
-    before an ingest that may fail - would drop the only record of a document the
-    store still holds.
+    **`ERROR`, not "has no vector id".** Those are not the same set, and treating
+    them as one is a race: a `PROCESSING` row belongs to an attempt that is still
+    running, and two overlapping ingestions of one source - two manual triggers,
+    nothing serialising them - would have the second delete the first's live row.
+    The first would then finish, replace the vectors, and find no row to complete,
+    leaving one row pointing at deleted vectors and the new vectors tracked by
+    nothing. A row left `PROCESSING` by a run that died is a different problem
+    with a different fix, and it may describe vectors that exist.
 
     Matched on `source_path` rather than `filename`, which is the whole reason
     the column exists: `a/readme.md` and `b/readme.md` in one bucket share a
@@ -188,6 +190,7 @@ async def discard_unindexed(db: AsyncSession, *, collection_name: str, source_pa
         sql_delete(RAGDocument).where(
             RAGDocument.collection_name == collection_name,
             RAGDocument.source_path == source_path,
+            RAGDocument.status == DocumentStatus.ERROR,
             RAGDocument.vector_document_id.is_(None),
         )
     )

--- a/backend/app/repositories/rag_document.py
+++ b/backend/app/repositories/rag_document.py
@@ -84,6 +84,7 @@ async def create(
     filesize: int,
     filetype: str,
     storage_path: str,
+    source_path: str | None = None,
     status: DocumentStatus = DocumentStatus.PROCESSING,
     organization_id: UUID | None = None,
     knowledge_base_id: UUID | None = None,
@@ -99,6 +100,7 @@ async def create(
         filesize=filesize,
         filetype=filetype,
         storage_path=storage_path,
+        source_path=source_path,
         status=status,
         organization_id=organization_id,
         knowledge_base_id=knowledge_base_id,
@@ -161,6 +163,36 @@ async def get_superseded(
         )
     )
     return list(result.scalars().all())
+
+
+async def discard_unindexed(db: AsyncSession, *, collection_name: str, source_path: str) -> int:
+    """Drop rows for this file that point at no vector document, and count them.
+
+    A failed parse writes no vectors, so the row it leaves has no
+    `vector_document_id` - and `complete_ingestion`'s retirement matches on
+    exactly that, which is why a file failing one sync and succeeding the next
+    used to leave both rows and inflate the collection's count for good (#996).
+    A stale `processing` row from a run that died mid-ingest is the same shape and
+    goes the same way.
+
+    **Only rows with no vector document.** One that has vectors is retired by
+    `complete_ingestion` after the replacement is written, and deleting it here -
+    before an ingest that may fail - would drop the only record of a document the
+    store still holds.
+
+    Matched on `source_path` rather than `filename`, which is the whole reason
+    the column exists: `a/readme.md` and `b/readme.md` in one bucket share a
+    basename, and matching by name would delete the other file's row.
+    """
+    result = await db.execute(
+        sql_delete(RAGDocument).where(
+            RAGDocument.collection_name == collection_name,
+            RAGDocument.source_path == source_path,
+            RAGDocument.vector_document_id.is_(None),
+        )
+    )
+    await db.flush()
+    return int(result.rowcount or 0)
 
 
 async def delete(db: AsyncSession, doc_id: UUID) -> bool:

--- a/backend/app/services/rag/ingestion.py
+++ b/backend/app/services/rag/ingestion.py
@@ -177,8 +177,26 @@ class IngestionService:
             )
 
             if existing_id:
-                await self.store.delete_document(collection_name, existing_id)
-                logger.info("Replaced existing document %s for '%s'", existing_id, filepath.name)
+                try:
+                    await self.store.delete_document(collection_name, existing_id)
+                except Exception:
+                    # The ingest *succeeded*: the document asked for is stored.
+                    # Failing here used to be reported as a failed ingest, which
+                    # made the tracking row say `error` with no vector id while
+                    # the vectors existed - and the next attempt at the file then
+                    # retired that row as a failure and orphaned them (#996).
+                    # What is wrong is that an old document lingers, which is a
+                    # duplicate somebody can see and delete.
+                    logger.exception(
+                        "Stored %s but could not remove the document it replaces (%s)",
+                        filepath.name,
+                        existing_id,
+                    )
+                    existing_id = None
+                else:
+                    logger.info(
+                        "Replaced existing document %s for '%s'", existing_id, filepath.name
+                    )
 
             action = "replaced" if existing_id else "ingested"
             chunk_count = len(document.chunked_pages or [])

--- a/backend/app/services/rag_document.py
+++ b/backend/app/services/rag_document.py
@@ -118,6 +118,7 @@ class RAGDocumentService:
         filesize: int,
         filetype: str,
         storage_path: str | None = None,
+        source_path: str | None = None,
         organization_id: UUID | None = None,
         knowledge_base_id: UUID | None = None,
         ingestion_config: IngestionConfig | None = None,
@@ -125,7 +126,17 @@ class RAGDocumentService:
         image_description_model: str | None = None,
         embedding_model: str | None = None,
     ) -> RAGDocument:
-        """Create a new RAG document tracking record."""
+        """Create a new RAG document tracking record.
+
+        `source_path` is how the ingest addressed the file, and it is what lets a
+        later run find this row again - `discard_unindexed` retires a previous
+        attempt at the *same file* rather than at the same basename, which two
+        keys in one bucket share (#996).
+        """
+        if source_path:
+            await rag_document_repo.discard_unindexed(
+                self.db, collection_name=collection_name, source_path=source_path
+            )
         return await rag_document_repo.create(
             self.db,
             collection_name=collection_name,
@@ -133,6 +144,7 @@ class RAGDocumentService:
             filesize=filesize,
             filetype=filetype,
             storage_path=storage_path or "",
+            source_path=source_path,
             organization_id=organization_id,
             knowledge_base_id=knowledge_base_id,
             ingestion_config=(
@@ -223,6 +235,12 @@ class RAGDocumentService:
             filesize=len(file_data),
             filetype=ext.lstrip("."),
             storage_path=storage_path,
+            # The same value `ingest_document_flow` is dispatched with below, so
+            # the row and the stored document agree on which file this is. An
+            # upload has no address of its own, which is why it is the filename -
+            # and why a document uploaded once and later synced from the folder it
+            # came from is still reachable by name (`_unaddressed`).
+            source_path=filename,
             organization_id=organization_id,
             knowledge_base_id=knowledge_base_id,
             ingestion_config=config,

--- a/backend/app/services/rag_document.py
+++ b/backend/app/services/rag_document.py
@@ -129,12 +129,19 @@ class RAGDocumentService:
         """Create a new RAG document tracking record.
 
         `source_path` is how the ingest addressed the file, and it is what lets a
-        later run find this row again - `discard_unindexed` retires a previous
+        later run find this row again - `discard_failed` retires a previous
         attempt at the *same file* rather than at the same basename, which two
         keys in one bucket share (#996).
+
+        An **upload passes none**, and that is the point of the argument being
+        optional. A browser upload's only name is its basename, which is not an
+        address: two people can upload different `report.pdf`s and, with
+        `replace=false`, mean both to exist. Retiring by that name would delete
+        the first one's failed row - its diagnosis, its retry and its stored file
+        - for a caller who asked for no such thing.
         """
         if source_path:
-            await rag_document_repo.discard_unindexed(
+            await rag_document_repo.discard_failed(
                 self.db, collection_name=collection_name, source_path=source_path
             )
         return await rag_document_repo.create(
@@ -235,12 +242,6 @@ class RAGDocumentService:
             filesize=len(file_data),
             filetype=ext.lstrip("."),
             storage_path=storage_path,
-            # The same value `ingest_document_flow` is dispatched with below, so
-            # the row and the stored document agree on which file this is. An
-            # upload has no address of its own, which is why it is the filename -
-            # and why a document uploaded once and later synced from the folder it
-            # came from is still reachable by name (`_unaddressed`).
-            source_path=filename,
             organization_id=organization_id,
             knowledge_base_id=knowledge_base_id,
             ingestion_config=config,

--- a/backend/app/worker/tasks/rag_tasks.py
+++ b/backend/app/worker/tasks/rag_tasks.py
@@ -459,6 +459,9 @@ async def _run_sync(
                     filename=filepath.name,
                     filesize=filepath.stat().st_size,
                     collection_name=collection_name,
+                    # The same address it hands `existing_document` above, so the
+                    # row and the lookup name one file (#996).
+                    source_path=source_path,
                     # A path on the server belongs to no tenant and to no
                     # knowledge base; `POST /rag/sync/local` is the one route
                     # that still carries `is_app_admin` for exactly that reason.
@@ -471,7 +474,16 @@ async def _run_sync(
 
                 with metered_by(ledger):
                     result = await ingestion_service.ingest_file(
-                        filepath=filepath, collection_name=collection_name, replace=True
+                        filepath=filepath,
+                        collection_name=collection_name,
+                        replace=True,
+                        # The address this flow already looks documents up by. It
+                        # was omitted, so the stored document identified itself by
+                        # filename while the lookup asked for a path - the
+                        # `existing_document` call above only ever matched through
+                        # the filename fallback, and the row and the vector would
+                        # now disagree about which file this is (#996).
+                        source_path=source_path,
                     )
 
                 # Either way, which is the other half of #997: a file that failed
@@ -604,6 +616,7 @@ async def _open_document_row(
     filename: str,
     filesize: int,
     collection_name: str,
+    source_path: str,
     organization_id: UUID | None,
     knowledge_base_id: UUID | None,
     ingestion_config: IngestionConfig,
@@ -635,6 +648,7 @@ async def _open_document_row(
             filename=filename,
             filesize=filesize,
             filetype=Path(filename).suffix.lstrip(".").lower(),
+            source_path=source_path,
             organization_id=organization_id,
             knowledge_base_id=knowledge_base_id,
             ingestion_config=ingestion_config,
@@ -807,6 +821,7 @@ async def _run_source_sync(source_id: str, sync_log_id: str | None = None) -> di
                         filename=remote_file.name,
                         filesize=local_path.stat().st_size,
                         collection_name=collection_name,
+                        source_path=remote_file.source_path,
                         organization_id=organization_id,
                         knowledge_base_id=knowledge_base_id,
                         ingestion_config=ingestion_config,

--- a/backend/tests/integration/test_document_row_retirement.py
+++ b/backend/tests/integration/test_document_row_retirement.py
@@ -1,0 +1,183 @@
+"""Which tracking rows a new attempt at a file retires, asked of a real Postgres.
+
+#996. A file that failed to parse on one sync and succeeded on the next left
+*both* rows: `complete_ingestion`'s retirement matches on `vector_document_id`
+and a failed parse writes none, so the succeeding run had nothing to name. Every
+repeated failure added another permanent row, and each one counted toward the
+collection's `document_count`.
+
+The obvious fix is the trap, which is why these are here rather than in the unit
+suite: retiring "the previous row for this file" by **filename** deletes the
+other file's row when a bucket holds `a/readme.md` beside `b/readme.md`. That is
+the collision #990 removed on the vector side, reached from the other direction,
+and only a real `DELETE ... WHERE` answers whether the predicate keeps them
+apart.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models.rag_document import DocumentStatus, RAGDocument
+from app.repositories import rag_document_repo
+
+pytestmark = pytest.mark.anyio
+
+COLLECTION = "org_handbook"
+
+
+async def _row(
+    db: AsyncSession,
+    *,
+    filename: str,
+    source_path: str | None,
+    vector_document_id: str | None,
+    status: DocumentStatus = DocumentStatus.ERROR,
+) -> RAGDocument:
+    doc = RAGDocument(
+        id=uuid.uuid4(),
+        collection_name=COLLECTION,
+        filename=filename,
+        filesize=4,
+        filetype="md",
+        storage_path="",
+        source_path=source_path,
+        status=status,
+        vector_document_id=vector_document_id,
+        chunk_count=0,
+        ingestion_config={},
+    )
+    db.add(doc)
+    await db.flush()
+    return doc
+
+
+async def _surviving(db: AsyncSession) -> set[str]:
+    result = await db.execute(
+        select(RAGDocument.filename, RAGDocument.source_path).where(
+            RAGDocument.collection_name == COLLECTION
+        )
+    )
+    return {f"{name}@{path}" for name, path in result.all()}
+
+
+class TestWhatANewAttemptRetires:
+    async def test_a_failed_attempt_at_the_same_file_goes(self, db: AsyncSession):
+        await _row(
+            db,
+            filename="readme.md",
+            source_path="s3://bucket/a/readme.md",
+            vector_document_id=None,
+        )
+
+        discarded = await rag_document_repo.discard_unindexed(
+            db, collection_name=COLLECTION, source_path="s3://bucket/a/readme.md"
+        )
+
+        assert discarded == 1
+        assert await _surviving(db) == set()
+
+    async def test_another_key_of_the_same_basename_stays(self, db: AsyncSession):
+        """The trap. Matching by `filename` would take this row out, and a first
+        sync of a bucket holding both files could then never keep both."""
+        await _row(
+            db,
+            filename="readme.md",
+            source_path="s3://bucket/a/readme.md",
+            vector_document_id=None,
+        )
+        await _row(
+            db,
+            filename="readme.md",
+            source_path="s3://bucket/b/readme.md",
+            vector_document_id=None,
+        )
+
+        discarded = await rag_document_repo.discard_unindexed(
+            db, collection_name=COLLECTION, source_path="s3://bucket/a/readme.md"
+        )
+
+        assert discarded == 1
+        assert await _surviving(db) == {"readme.md@s3://bucket/b/readme.md"}
+
+    async def test_a_row_that_points_at_vectors_stays(self, db: AsyncSession):
+        """It describes a document the store still holds, and the replacement
+        that supersedes it has not been written yet - this runs *before* an
+        ingest that may fail. `complete_ingestion` retires that one, after."""
+        await _row(
+            db,
+            filename="readme.md",
+            source_path="s3://bucket/a/readme.md",
+            vector_document_id="vector-doc-1",
+            status=DocumentStatus.DONE,
+        )
+
+        discarded = await rag_document_repo.discard_unindexed(
+            db, collection_name=COLLECTION, source_path="s3://bucket/a/readme.md"
+        )
+
+        assert discarded == 0
+        assert await _surviving(db) == {"readme.md@s3://bucket/a/readme.md"}
+
+    async def test_a_row_with_no_address_stays(self, db: AsyncSession):
+        """Written before the column existed. Its address is unknown, not equal to
+        whatever is being ingested now, and a `NULL` matches no comparison - which
+        is the behaviour wanted rather than one to work around."""
+        await _row(db, filename="readme.md", source_path=None, vector_document_id=None)
+
+        discarded = await rag_document_repo.discard_unindexed(
+            db, collection_name=COLLECTION, source_path="s3://bucket/a/readme.md"
+        )
+
+        assert discarded == 0
+        assert await _surviving(db) == {"readme.md@None"}
+
+    async def test_another_collections_row_stays(self, db: AsyncSession):
+        """Two organizations can hold the same object in collections of their own,
+        and one sync must not reach into the other's rows."""
+        theirs = RAGDocument(
+            id=uuid.uuid4(),
+            collection_name="someone_elses",
+            filename="readme.md",
+            filesize=4,
+            filetype="md",
+            storage_path="",
+            source_path="s3://bucket/a/readme.md",
+            status=DocumentStatus.ERROR,
+            chunk_count=0,
+            ingestion_config={},
+        )
+        db.add(theirs)
+        await db.flush()
+
+        discarded = await rag_document_repo.discard_unindexed(
+            db, collection_name=COLLECTION, source_path="s3://bucket/a/readme.md"
+        )
+
+        assert discarded == 0
+        remaining = await db.execute(
+            select(RAGDocument.id).where(RAGDocument.collection_name == "someone_elses")
+        )
+        assert remaining.scalar_one() == theirs.id
+
+    async def test_every_failed_attempt_goes_at_once(self, db: AsyncSession):
+        """Rows accumulated one per failed sync, so a file failing nightly for a
+        week left seven before the run that finally parsed it."""
+        for _ in range(3):
+            await _row(
+                db,
+                filename="readme.md",
+                source_path="s3://bucket/a/readme.md",
+                vector_document_id=None,
+            )
+
+        discarded = await rag_document_repo.discard_unindexed(
+            db, collection_name=COLLECTION, source_path="s3://bucket/a/readme.md"
+        )
+
+        assert discarded == 3
+        assert await _surviving(db) == set()

--- a/backend/tests/integration/test_document_row_retirement.py
+++ b/backend/tests/integration/test_document_row_retirement.py
@@ -74,7 +74,7 @@ class TestWhatANewAttemptRetires:
             vector_document_id=None,
         )
 
-        discarded = await rag_document_repo.discard_unindexed(
+        discarded = await rag_document_repo.discard_failed(
             db, collection_name=COLLECTION, source_path="s3://bucket/a/readme.md"
         )
 
@@ -97,7 +97,7 @@ class TestWhatANewAttemptRetires:
             vector_document_id=None,
         )
 
-        discarded = await rag_document_repo.discard_unindexed(
+        discarded = await rag_document_repo.discard_failed(
             db, collection_name=COLLECTION, source_path="s3://bucket/a/readme.md"
         )
 
@@ -116,7 +116,28 @@ class TestWhatANewAttemptRetires:
             status=DocumentStatus.DONE,
         )
 
-        discarded = await rag_document_repo.discard_unindexed(
+        discarded = await rag_document_repo.discard_failed(
+            db, collection_name=COLLECTION, source_path="s3://bucket/a/readme.md"
+        )
+
+        assert discarded == 0
+        assert await _surviving(db) == {"readme.md@s3://bucket/a/readme.md"}
+
+    async def test_an_attempt_still_running_stays(self, db: AsyncSession):
+        """The race the predicate used to have. Two overlapping ingestions of one
+        source - two manual triggers, nothing serialising them - and the second
+        deleted the first's live `PROCESSING` row. The first then finished,
+        replaced the vectors, and found no row to complete: one row pointing at
+        deleted vectors, and the new vectors tracked by nothing."""
+        await _row(
+            db,
+            filename="readme.md",
+            source_path="s3://bucket/a/readme.md",
+            vector_document_id=None,
+            status=DocumentStatus.PROCESSING,
+        )
+
+        discarded = await rag_document_repo.discard_failed(
             db, collection_name=COLLECTION, source_path="s3://bucket/a/readme.md"
         )
 
@@ -129,7 +150,7 @@ class TestWhatANewAttemptRetires:
         is the behaviour wanted rather than one to work around."""
         await _row(db, filename="readme.md", source_path=None, vector_document_id=None)
 
-        discarded = await rag_document_repo.discard_unindexed(
+        discarded = await rag_document_repo.discard_failed(
             db, collection_name=COLLECTION, source_path="s3://bucket/a/readme.md"
         )
 
@@ -154,7 +175,7 @@ class TestWhatANewAttemptRetires:
         db.add(theirs)
         await db.flush()
 
-        discarded = await rag_document_repo.discard_unindexed(
+        discarded = await rag_document_repo.discard_failed(
             db, collection_name=COLLECTION, source_path="s3://bucket/a/readme.md"
         )
 
@@ -175,7 +196,7 @@ class TestWhatANewAttemptRetires:
                 vector_document_id=None,
             )
 
-        discarded = await rag_document_repo.discard_unindexed(
+        discarded = await rag_document_repo.discard_failed(
             db, collection_name=COLLECTION, source_path="s3://bucket/a/readme.md"
         )
 

--- a/backend/tests/test_flow_dispatch.py
+++ b/backend/tests/test_flow_dispatch.py
@@ -134,9 +134,6 @@ async def test_an_uploaded_document_is_parsed_after_its_row_is_committed(
 
     monkeypatch.setattr(settings, "MEDIA_DIR", str(tmp_path))
     monkeypatch.setattr(rag_document_repo, "create", AsyncMock(return_value=document))
-    # An upload's row now retires a previous unindexed attempt at the same file
-    # before writing its own (#996), so this boundary is mocked like `create`.
-    monkeypatch.setattr(rag_document_repo, "discard_unindexed", AsyncMock(return_value=0))
     monkeypatch.setattr(
         IngestionConfigService, "resolved_image_model", AsyncMock(return_value=None)
     )

--- a/backend/tests/test_flow_dispatch.py
+++ b/backend/tests/test_flow_dispatch.py
@@ -134,6 +134,9 @@ async def test_an_uploaded_document_is_parsed_after_its_row_is_committed(
 
     monkeypatch.setattr(settings, "MEDIA_DIR", str(tmp_path))
     monkeypatch.setattr(rag_document_repo, "create", AsyncMock(return_value=document))
+    # An upload's row now retires a previous unindexed attempt at the same file
+    # before writing its own (#996), so this boundary is mocked like `create`.
+    monkeypatch.setattr(rag_document_repo, "discard_unindexed", AsyncMock(return_value=0))
     monkeypatch.setattr(
         IngestionConfigService, "resolved_image_model", AsyncMock(return_value=None)
     )

--- a/backend/tests/test_synced_document_delete.py
+++ b/backend/tests/test_synced_document_delete.py
@@ -119,3 +119,65 @@ class TestTheRouteThatTheDocumentsTabUses:
             )
 
         documents.delete_document.assert_not_awaited()
+
+
+class TestRetiringAPreviousAttempt:
+    """A file that failed one sync and succeeded the next left both rows (#996).
+
+    `complete_ingestion`'s retirement matches on `vector_document_id`, and a
+    failed parse writes none - so the succeeding run had nothing to name, both
+    rows survived, and the collection's `document_count` was inflated for good by
+    every repeated failure.
+
+    It cannot be matched by filename instead, which is why `rag_documents` gained
+    a `source_path`: `a/readme.md` and `b/readme.md` in one bucket share a
+    basename, and matching by name would delete the other file's row - the
+    collision #990 removed on the vector side.
+    """
+
+    async def test_a_previous_attempt_at_the_same_file_is_discarded(self, monkeypatch):
+        discard = AsyncMock(return_value=1)
+        monkeypatch.setattr(rag_document_repo, "discard_unindexed", discard)
+        monkeypatch.setattr(rag_document_repo, "create", AsyncMock(return_value=MagicMock()))
+
+        await RAGDocumentService(MagicMock()).create_document(
+            collection_name="docs",
+            filename="readme.md",
+            filesize=4,
+            filetype="md",
+            source_path="s3://bucket/a/readme.md",
+        )
+
+        assert discard.await_args.kwargs == {
+            "collection_name": "docs",
+            "source_path": "s3://bucket/a/readme.md",
+        }
+
+    async def test_a_row_with_no_address_discards_nothing(self, monkeypatch):
+        """One written before the column existed, or by a path that has no
+        address to give. Guessing an address from its filename is the guess the
+        column exists to avoid."""
+        discard = AsyncMock()
+        monkeypatch.setattr(rag_document_repo, "discard_unindexed", discard)
+        monkeypatch.setattr(rag_document_repo, "create", AsyncMock(return_value=MagicMock()))
+
+        await RAGDocumentService(MagicMock()).create_document(
+            collection_name="docs", filename="readme.md", filesize=4, filetype="md"
+        )
+
+        discard.assert_not_awaited()
+
+    async def test_the_address_is_recorded_on_the_row(self, monkeypatch):
+        monkeypatch.setattr(rag_document_repo, "discard_unindexed", AsyncMock(return_value=0))
+        created = AsyncMock(return_value=MagicMock())
+        monkeypatch.setattr(rag_document_repo, "create", created)
+
+        await RAGDocumentService(MagicMock()).create_document(
+            collection_name="docs",
+            filename="readme.md",
+            filesize=4,
+            filetype="md",
+            source_path="gdrive://file-1",
+        )
+
+        assert created.await_args.kwargs["source_path"] == "gdrive://file-1"

--- a/backend/tests/test_synced_document_delete.py
+++ b/backend/tests/test_synced_document_delete.py
@@ -17,6 +17,8 @@ half.
 from __future__ import annotations
 
 import uuid
+from contextlib import asynccontextmanager
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -137,7 +139,7 @@ class TestRetiringAPreviousAttempt:
 
     async def test_a_previous_attempt_at_the_same_file_is_discarded(self, monkeypatch):
         discard = AsyncMock(return_value=1)
-        monkeypatch.setattr(rag_document_repo, "discard_unindexed", discard)
+        monkeypatch.setattr(rag_document_repo, "discard_failed", discard)
         monkeypatch.setattr(rag_document_repo, "create", AsyncMock(return_value=MagicMock()))
 
         await RAGDocumentService(MagicMock()).create_document(
@@ -153,12 +155,36 @@ class TestRetiringAPreviousAttempt:
             "source_path": "s3://bucket/a/readme.md",
         }
 
+    async def test_an_upload_retires_nothing(self, monkeypatch):
+        """An upload's only name is a basename, which is not an address: two
+        people can upload different `report.pdf`s and, with `replace=false`, mean
+        both to exist. Retiring by that name would delete the first one's failed
+        row - its diagnosis, its retry and its stored file - for a caller who
+        asked for no such thing."""
+        discard = AsyncMock()
+        monkeypatch.setattr(rag_document_repo, "discard_failed", discard)
+        monkeypatch.setattr(rag_document_repo, "create", AsyncMock(return_value=MagicMock()))
+        monkeypatch.setattr(
+            "app.services.rag_document.get_file_storage",
+            lambda: MagicMock(save=AsyncMock(return_value="rag/docs/report.pdf")),
+        )
+
+        await RAGDocumentService(MagicMock()).create_document(
+            collection_name="docs",
+            filename="report.pdf",
+            filesize=4,
+            filetype="pdf",
+            storage_path="rag/docs/report.pdf",
+        )
+
+        discard.assert_not_awaited()
+
     async def test_a_row_with_no_address_discards_nothing(self, monkeypatch):
         """One written before the column existed, or by a path that has no
         address to give. Guessing an address from its filename is the guess the
         column exists to avoid."""
         discard = AsyncMock()
-        monkeypatch.setattr(rag_document_repo, "discard_unindexed", discard)
+        monkeypatch.setattr(rag_document_repo, "discard_failed", discard)
         monkeypatch.setattr(rag_document_repo, "create", AsyncMock(return_value=MagicMock()))
 
         await RAGDocumentService(MagicMock()).create_document(
@@ -168,7 +194,7 @@ class TestRetiringAPreviousAttempt:
         discard.assert_not_awaited()
 
     async def test_the_address_is_recorded_on_the_row(self, monkeypatch):
-        monkeypatch.setattr(rag_document_repo, "discard_unindexed", AsyncMock(return_value=0))
+        monkeypatch.setattr(rag_document_repo, "discard_failed", AsyncMock(return_value=0))
         created = AsyncMock(return_value=MagicMock())
         monkeypatch.setattr(rag_document_repo, "create", created)
 
@@ -181,3 +207,68 @@ class TestRetiringAPreviousAttempt:
         )
 
         assert created.await_args.kwargs["source_path"] == "gdrive://file-1"
+
+
+class TestTheCLISync:
+    """`agenticos cmd rag-ingest` is the third ingest path, and it was the one
+    left out. Its rows got `NULL` for an address, so a file failing there
+    repeatedly kept inflating the collection's count - the defect #996 fixed for
+    the two worker flows (found reviewing #1001)."""
+
+    async def test_it_records_the_address_it_already_looks_documents_up_by(
+        self, monkeypatch, tmp_path
+    ):
+        from app.commands import rag as rag_command
+
+        (tmp_path / "handbook.md").write_text("body")
+        created = AsyncMock(return_value=MagicMock(id=uuid.uuid4()))
+        documents = MagicMock(
+            create_document=created,
+            complete_ingestion=AsyncMock(),
+            fail_ingestion=AsyncMock(),
+        )
+        ingestion = MagicMock(
+            existing_document=AsyncMock(
+                return_value=MagicMock(document_id=None, content_hash=None)
+            ),
+            ingest_file=AsyncMock(
+                return_value=MagicMock(
+                    status=MagicMock(value="done"),
+                    document_id="vector-doc-1",
+                    chunk_count=2,
+                    replaced_document_id=None,
+                    message="Successfully ingested 'handbook.md'",
+                    error_message=None,
+                )
+            ),
+        )
+
+        @asynccontextmanager
+        async def _db() -> Any:
+            yield MagicMock()
+
+        monkeypatch.setattr(rag_command, "get_db_context", _db)
+        monkeypatch.setattr(rag_command, "RAGDocumentService", lambda _db: documents)
+        monkeypatch.setattr(
+            rag_command,
+            "RAGSyncService",
+            lambda _db: MagicMock(
+                create_sync_log=AsyncMock(return_value=MagicMock(id=uuid.uuid4())),
+                complete_sync=AsyncMock(),
+            ),
+        )
+
+        await rag_command.ingest_path_async(
+            path=str(tmp_path),
+            collection="docs",
+            recursive=True,
+            vector_store=MagicMock(create_collection=AsyncMock()),
+            processor=MagicMock(),
+            ingestion=ingestion,
+        )
+
+        expected = str((tmp_path / "handbook.md").resolve())
+        assert created.await_args.kwargs["source_path"] == expected
+        # And the stored document identifies itself the same way, so the row and
+        # the vector agree on which file this is.
+        assert ingestion.ingest_file.await_args.kwargs["source_path"] == expected

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -608,12 +608,23 @@ local-directory one in
 locally-synced file that fails to parse a row and a reason — it had neither, so a
 sync log saying four of forty failed named none of them.
 
-One row per file is not yet an invariant. A file that fails to parse on one sync
-and succeeds on the next leaves both rows, because retirement matches on
-`vector_document_id` and a failed parse wrote no vectors — and it cannot be
-matched by filename instead, since `rag_documents` has no `source_path` column
-and two keys of one basename would delete each other's rows. That column is
-[#996](https://github.com/vstorm-co/agenticos/issues/996).
+**A row says which file it tracks**, in `source_path`: `gdrive://<id>`,
+`s3://bucket/key`, an absolute path for a local sync, and the filename itself for
+an upload, which has no address of its own. That is what retires a previous
+attempt at the *same file* — a failed parse writes no vectors, so
+`complete_ingestion`'s retirement has nothing to match and both rows used to
+survive, one more per failure, each counting toward the collection's
+`document_count` ([#996](https://github.com/vstorm-co/agenticos/issues/996)).
+
+Retiring by **filename** instead is the trap, and it is the collision
+[#990](https://github.com/vstorm-co/agenticos/issues/990) removed on the vector
+side reached from the other direction: `a/readme.md` and `b/readme.md` in one
+bucket share a basename, so a name match would delete the other file's row. Only
+rows with no `vector_document_id` are retired this way — one that has vectors
+describes a document the store still holds, and this runs *before* an ingest that
+may fail. Rows written before the column exists keep `NULL` and are matched by
+address never and by vector document as before; inventing an address from a
+filename is the guess the column exists to avoid.
 
 The connector sync wrote no row at all until
 [#992](https://github.com/vstorm-co/agenticos/issues/992) — the sentence above

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -608,23 +608,39 @@ local-directory one in
 locally-synced file that fails to parse a row and a reason — it had neither, so a
 sync log saying four of forty failed named none of them.
 
-**A row says which file it tracks**, in `source_path`: `gdrive://<id>`,
-`s3://bucket/key`, an absolute path for a local sync, and the filename itself for
-an upload, which has no address of its own. That is what retires a previous
-attempt at the *same file* — a failed parse writes no vectors, so
-`complete_ingestion`'s retirement has nothing to match and both rows used to
+**A synced row says which file it tracks**, in `source_path`: `gdrive://<id>`,
+`s3://bucket/key`, or an absolute path for a local or CLI sync. That is what
+retires a previous attempt at the *same file* — a failed parse writes no vectors,
+so `complete_ingestion`'s retirement has nothing to match and both rows used to
 survive, one more per failure, each counting toward the collection's
 `document_count` ([#996](https://github.com/vstorm-co/agenticos/issues/996)).
 
-Retiring by **filename** instead is the trap, and it is the collision
-[#990](https://github.com/vstorm-co/agenticos/issues/990) removed on the vector
-side reached from the other direction: `a/readme.md` and `b/readme.md` in one
-bucket share a basename, so a name match would delete the other file's row. Only
-rows with no `vector_document_id` are retired this way — one that has vectors
-describes a document the store still holds, and this runs *before* an ingest that
-may fail. Rows written before the column exists keep `NULL` and are matched by
-address never and by vector document as before; inventing an address from a
-filename is the guess the column exists to avoid.
+**An upload stores no address**, and so retires nothing. Its only name is a
+basename, which is not an address: two people can upload different `report.pdf`s
+and, with `replace=false`, mean both to exist. Retiring by that name would delete
+the first one's failed row — its diagnosis, its retry and its stored file — for a
+caller who asked for no such thing. A `NULL` address matches no comparison, which
+is the answer wanted rather than one to work around, and it is what every row
+written before the column has.
+
+Three things decide what a retirement may take, and each of them was got wrong
+first:
+
+- **By address, never by filename.** That is the collision
+  [#990](https://github.com/vstorm-co/agenticos/issues/990) removed on the vector
+  side reached from the other direction: `a/readme.md` and `b/readme.md` in one
+  bucket share a basename, so a name match deletes the other file's row.
+- **`ERROR`, not "has no vector id".** Those are different sets, and treating
+  them as one is a race: a `PROCESSING` row belongs to an attempt still running,
+  and two overlapping ingestions of one source would have the second delete the
+  first's live row — after which the first finishes, replaces the vectors and
+  finds no row to complete.
+- **A failed *supersede* is not a failed ingest.** `ingest_file` inserts the new
+  document before deleting the one it replaces, so a delete that raises used to
+  return an error while the vectors were sitting there — an `ERROR` row with no
+  vector id, which the next attempt would retire and orphan them. The insert
+  having succeeded is the whole answer: the lingering old document is logged, and
+  a duplicate somebody can see and delete is not a failure to report.
 
 The connector sync wrote no row at all until
 [#992](https://github.com/vstorm-co/agenticos/issues/992) — the sentence above


### PR DESCRIPTION
A file that failed to parse on one sync and succeeded on the next left
*both* rows. `complete_ingestion`'s retirement matches on
`vector_document_id`, and a failed parse writes none - so the succeeding
run had nothing to name, both rows survived, and every repeated failure
added another that counted toward the collection's `document_count` for
good.

It could not be fixed where it was found. `rag_documents` held a `filename`
and nothing else identifying, and retiring "the previous row for this file"
by name deletes the other file's row when a bucket holds `a/readme.md`
beside `b/readme.md` - the collision #990 removed on the vector side,
reached from the other direction. So `source_path` is a column now
(`0043`), holding the address the ingest used: `gdrive://<id>`,
`s3://bucket/key`, an absolute path for a local sync, and the filename
itself for an upload, which has no address of its own.

`discard_unindexed` retires by that address, and **only rows with no
vector document**. One that has vectors describes a document the store
still holds, and this runs *before* an ingest that may fail - deleting it
there would drop the only record of something searchable. A stale
`processing` row from a run that died mid-ingest is the same shape and goes
the same way.

Nothing is backfilled and the column is nullable. A row written before it
is a row whose address nobody recorded, and deriving one from its filename
is precisely the guess this column exists to avoid; those rows are matched
by address never and by vector document as before.

One thing came out of wiring it that was wrong on its own account: the
local-directory sync called `ingest_file` **without** `source_path`, so the
stored document identified itself by filename while the flow's own
`existing_document` lookup asked for a path. That lookup only ever matched
through the filename fallback, and the row would now have disagreed with
the vector about which file it was. It passes the address it already uses.

## Verified

Six integration tests against a real Postgres, because the naive fix is the
trap and only a real `DELETE ... WHERE` answers whether the predicate keeps
two same-named keys apart: swapping the match to `filename` fails exactly
the two that should fail, and passes the four that are about something else.
Three unit tests cover the wiring. `make lint`, `make docs-build`, the
backend suite (6228 passed) and the integration suite (577 passed).

`alembic check` cannot run in this checkout - its database is stamped at a
migration renumbered before merge, which fails the same way on `main` - so
the migration is verified against the model by inspection: the index the
metadata convention generates is `rag_documents_source_path_idx` and the
column is `VARCHAR(1024)`, both of which the migration creates. CI's
`db-check` and `test-migrations` are the real answer.

Closes #996