### PR TITLE
refactor(rag): _update_status is _fail_document, and takes no status

### DIFF
--- a/backend/app/worker/tasks/rag_tasks.py
+++ b/backend/app/worker/tasks/rag_tasks.py
@@ -19,6 +19,7 @@ from app.core.config import settings
 from app.core.secret_kinds import SecretKind, StorableSecret, unseal_secret
 from app.core.vault import VaultScope
 from app.db.models.knowledge_base import KnowledgeBase
+from app.db.models.rag_document import DocumentStatus
 from app.db.session import get_worker_db_context
 from app.repositories import ingestion_spend_repo, knowledge_base_repo, organization_secret_repo
 from app.repositories import sync_source as sync_source_repo
@@ -238,9 +239,8 @@ async def ingest_document_flow(
         )
     except Exception as exc:
         logger.exception("Ingestion failed for %s", source_path)
-        await _update_status(
+        await _fail_document(
             rag_document_id,
-            "error",
             error_message=failure_summary(exc, stage=IngestionStage.INGEST),
         )
         raise
@@ -323,9 +323,8 @@ async def _run_ingestion(
         # budget, or the pipeline itself. Which stage it was is not knowable
         # from here, and the stage below says so.
         logger.exception("Ingestion failed for %s", source_path)
-        await _update_status(
+        await _fail_document(
             rag_document_id,
-            "error",
             error_message=failure_summary(exc, stage=IngestionStage.INGEST),
         )
         raise
@@ -348,7 +347,7 @@ async def _run_ingestion(
     # held zero rows.
     if result.status is not IngestionStatus.DONE:
         reason = result.error_message or result.message
-        await _update_status(rag_document_id, "error", error_message=reason)
+        await _fail_document(rag_document_id, error_message=reason)
         raise RuntimeError(f"Ingestion failed for {source_path}: {reason}")
 
     try:
@@ -361,9 +360,8 @@ async def _run_ingestion(
             )
     except Exception as exc:
         logger.exception("Indexed %s but could not record it", source_path)
-        await _update_status(
+        await _fail_document(
             rag_document_id,
-            "error",
             error_message=failure_summary(exc, stage=IngestionStage.RECORD),
         )
         raise
@@ -526,10 +524,8 @@ async def _run_sync(
         await ingestion_service.store.aclose()
 
 
-async def _update_status(
-    rag_document_id: str, status: str, error_message: str | None = None
-) -> None:
-    """Put a status on the document row, and let the first failure keep it.
+async def _fail_document(rag_document_id: str, *, error_message: str | None) -> None:
+    """Put a failure on the document row, and let the first one keep it.
 
     One collapse is reported by up to three handlers here: the stage that
     raised, the check that a *returned* failure is not `done`, and the flow's
@@ -538,24 +534,23 @@ async def _update_status(
     the outermost only knows the ingest failed. Overwriting therefore replaces
     the useful sentence with the vague one, which mattered from the moment the
     column stopped holding the same `str(exc)` at every level (#423).
+
+    Failure is the only status this records. Reaching `DONE` needs the vector
+    document's id, which only `_run_ingestion` holds, so it calls
+    `complete_ingestion` itself.
     """
     from app.services.rag_document import RAGDocumentService
 
     try:
         async with get_worker_db_context() as db:
             doc_svc = RAGDocumentService(db)
-            if status == "error":
-                if (await doc_svc.get_document(rag_document_id)).status == "error":
-                    return
-                await doc_svc.fail_ingestion(
-                    rag_document_id, error_message=error_message or "Unknown error"
-                )
-            elif status == "done":
-                # vector_document_id required for complete_ingestion; callers
-                # set status="done" directly in _run_ingestion with the ID.
-                pass
+            if (await doc_svc.get_document(rag_document_id)).status == DocumentStatus.ERROR:
+                return
+            await doc_svc.fail_ingestion(
+                rag_document_id, error_message=error_message or "Unknown error"
+            )
     except Exception as e:
-        logger.warning("Failed to update RAGDocument status: %s", e)
+        logger.warning("Failed to record the ingestion failure: %s", e)
 
 
 async def _update_sync_log(sync_log_id: str, status: str, error_message: str | None = None) -> None:

--- a/backend/tests/test_ingestion_engine_lifetime.py
+++ b/backend/tests/test_ingestion_engine_lifetime.py
@@ -145,7 +145,7 @@ class TestAnUploadsStore:
         ):
             with (
                 patch("app.services.rag_document.RAGDocumentService", return_value=documents),
-                patch.object(rag_tasks, "_update_status", new=AsyncMock()),
+                patch.object(rag_tasks, "_fail_document", new=AsyncMock()),
                 pytest.raises(RuntimeError),
             ):
                 await rag_tasks._run_ingestion(

--- a/backend/tests/test_rag_failure_messages.py
+++ b/backend/tests/test_rag_failure_messages.py
@@ -28,10 +28,11 @@ import pytest
 
 from app.agents.capabilities.budget import BudgetExceeded, BudgetScope
 from app.core.exceptions import ConfigurationError
+from app.db.models.rag_document import DocumentStatus
 from app.services.rag.failures import IngestionStage, failure_summary
 from app.services.rag.ingestion import IngestionService
 from app.services.rag.models import IngestionStatus
-from app.worker.tasks.rag_tasks import _run_ingestion, _update_status
+from app.worker.tasks.rag_tasks import _fail_document, _run_ingestion
 
 pytestmark = pytest.mark.anyio
 
@@ -222,7 +223,9 @@ class TestWhatTheWorkerWritesToTheRow:
         """
         documents = MagicMock()
         documents.return_value.get_document = AsyncMock(
-            return_value=MagicMock(organization_id=None, ingestion_config={}, status="processing")
+            return_value=MagicMock(
+                organization_id=None, ingestion_config={}, status=DocumentStatus.PROCESSING
+            )
         )
         documents.return_value.fail_ingestion = AsyncMock()
         pipeline = MagicMock()
@@ -256,13 +259,34 @@ class TestWhatTheWorkerWritesToTheRow:
         with the vague one.
         """
         documents = MagicMock()
-        documents.return_value.get_document = AsyncMock(return_value=MagicMock(status="error"))
+        documents.return_value.get_document = AsyncMock(
+            return_value=MagicMock(status=DocumentStatus.ERROR)
+        )
         documents.return_value.fail_ingestion = AsyncMock()
 
         with (
             patch("app.worker.tasks.rag_tasks.get_worker_db_context", self._db),
             patch("app.services.rag_document.RAGDocumentService", documents),
         ):
-            await _update_status(str(uuid.uuid4()), "error", error_message="the vague one")
+            await _fail_document(str(uuid.uuid4()), error_message="the vague one")
 
         documents.return_value.fail_ingestion.assert_not_awaited()
+
+    async def test_a_row_that_has_not_failed_yet_takes_the_failure(self):
+        """The other half of the guard above: the first handler does write."""
+        documents = MagicMock()
+        documents.return_value.get_document = AsyncMock(
+            return_value=MagicMock(status=DocumentStatus.PROCESSING)
+        )
+        documents.return_value.fail_ingestion = AsyncMock()
+
+        with (
+            patch("app.worker.tasks.rag_tasks.get_worker_db_context", self._db),
+            patch("app.services.rag_document.RAGDocumentService", documents),
+        ):
+            await _fail_document(str(uuid.uuid4()), error_message="the specific one")
+
+        assert (
+            documents.return_value.fail_ingestion.await_args.kwargs["error_message"]
+            == "the specific one"
+        )


### PR DESCRIPTION
`_update_status` in the ingestion flow took a `status` and branched on two
values. All four callers passed `"error"`.

## What was wrong

The `elif status == "done"` branch was a `pass`, and its comment explained why
nothing takes it — reaching `DONE` needs the vector document's id, which only
`_run_ingestion` holds, so it calls `complete_ingestion` itself. So the branch
could not be reached, the `if` was always true, and the parameter was a constant
dressed as a choice. `vulture` does not see it, because the parameter is read.

Two smaller things came with it. The function's real job is narrower than its
name: it records the **first** failure and refuses to overwrite it (#423). And
the guard compared `.status` against the string `"error"` while the column's
vocabulary is `DocumentStatus` — two spellings of one value set is how #148
happened.

## What changed

- `_update_status` → `_fail_document(rag_document_id, *, error_message)`, taking
  no status; the dead branch is gone and the reason it existed moved into the
  docstring.
- The four call sites (`:242`, `:326`, `:350`, `:363`) drop their `"error"`.
- The guard compares `DocumentStatus.ERROR`, and the two tests that stubbed a row
  now use the enum rather than string literals.

No behaviour change, and no migration: the column's values are untouched.

## How it was verified

- `tests/test_rag_failure_messages.py` and `tests/test_ingestion_engine_lifetime.py`
  — 25 passed.
- `uv run pytest tests -k "rag or ingest or sync or document"` — 448 passed.
- `make check` — green, every CI job except e2e.

The #423 behaviour ("the first handler to report a failure is the one that is
kept") keeps its test. The guard's other half — a row that has not failed yet
does take the failure — had no test of its own and now has one, so both branches
are covered by name rather than incidentally through `_run_ingestion`.

## Not fixed here

`_update_sync_log` one function below takes a `status` too, and that one is
genuinely two-valued (`"error"` from the flow's backstop, `"cancelled"`
elsewhere) — left alone. The nearest open siblings named in the issue, #566 and
#948, do not touch this function.

Closes #956
