### PR TITLE
fix(chat): spin only the thumb whose rating request is in flight

### DIFF
--- a/frontend/src/components/chat/rating-buttons.test.tsx
+++ b/frontend/src/components/chat/rating-buttons.test.tsx
@@ -426,4 +426,42 @@ describe("rating an answer", () => {
 
     release({ ok: true, status: 200, json: () => Promise.resolve({}) });
   });
+
+  it("spins one thumb on a message nobody has rated yet", async () => {
+    // An unrated message has currentRating === null, the case a spinner keyed
+    // on the rating cannot tell apart - and the normal one.
+    let release: (value: unknown) => void = () => {};
+    fetchMock = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve;
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    mount();
+
+    await userEvent.click(up());
+
+    await waitFor(() => expect(up().querySelector(".animate-spin")).not.toBeNull());
+    expect(down().querySelector(".animate-spin")).toBeNull();
+
+    release({ ok: true, status: 200, json: () => Promise.resolve({}) });
+  });
+
+  it("spins one thumb when a rating is being removed", async () => {
+    let release: (value: unknown) => void = () => {};
+    fetchMock = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve;
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    mount({ currentRating: RatingValue.DISLIKE });
+
+    await userEvent.click(down());
+
+    await waitFor(() => expect(down().querySelector(".animate-spin")).not.toBeNull());
+    expect(up().querySelector(".animate-spin")).toBeNull();
+
+    release({ ok: true, status: 200, json: () => Promise.resolve({}) });
+  });
 });

--- a/frontend/src/components/chat/rating-buttons.tsx
+++ b/frontend/src/components/chat/rating-buttons.tsx
@@ -39,7 +39,9 @@ export function RatingButtons({
   const [showCommentDialog, setShowCommentDialog] = useState(false);
   const [pendingRating, setPendingRating] = useState<RatingValue>(RatingValue.DISLIKE);
   const [comment, setComment] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
+  // Which button's request is in flight, not what the rating is: keying the
+  // spinner on currentRating (null on an unrated message) spins both thumbs.
+  const [inFlight, setInFlight] = useState<RatingValue | null>(null);
 
   const calculateNewCounts = useMemo(
     () =>
@@ -63,7 +65,7 @@ export function RatingButtons({
   // submitRating must be declared before handleRate since handleRate uses it
   const submitRating = useCallback(
     async (rating: RatingValue, commentText: string | null) => {
-      setIsLoading(true);
+      setInFlight(rating);
       try {
         const response = await fetch(
           `/api/conversations/${conversationId}/messages/${messageId}/rate`,
@@ -91,7 +93,7 @@ export function RatingButtons({
       } catch (error) {
         toast.error(error instanceof Error ? error.message : t("ratingFailed"));
       } finally {
-        setIsLoading(false);
+        setInFlight(null);
       }
     },
     [conversationId, messageId, currentRating, calculateNewCounts, onRatingChange, t],
@@ -104,7 +106,7 @@ export function RatingButtons({
   const handleRate = useCallback(
     async (rating: RatingValue) => {
       if (currentRating === rating) {
-        setIsLoading(true);
+        setInFlight(rating);
         try {
           const response = await fetch(
             `/api/conversations/${conversationId}/messages/${messageId}/rate`,
@@ -125,7 +127,7 @@ export function RatingButtons({
         } catch (error) {
           toast.error(error instanceof Error ? error.message : t("failedRemoveRating"));
         } finally {
-          setIsLoading(false);
+          setInFlight(null);
         }
       } else {
         setPendingRating(rating);
@@ -154,7 +156,7 @@ export function RatingButtons({
       <div className="flex items-center gap-1">
         <button
           onClick={() => handleRate(RatingValue.LIKE)}
-          disabled={isLoading || isMissingConversationId}
+          disabled={inFlight !== null || isMissingConversationId}
           className={cn(
             "inline-flex items-center rounded-md p-1.5 transition-colors",
             "hover:bg-muted/80",
@@ -164,7 +166,7 @@ export function RatingButtons({
           )}
           title={isMissingConversationId ? t("saveConversationToRate") : t("helpful")}
         >
-          {isLoading && currentRating !== RatingValue.DISLIKE ? (
+          {inFlight === RatingValue.LIKE ? (
             <Loader2 className="h-4 w-4 animate-spin" />
           ) : (
             <ThumbsUp className="h-4 w-4" />
@@ -176,7 +178,7 @@ export function RatingButtons({
 
         <button
           onClick={() => handleRate(RatingValue.DISLIKE)}
-          disabled={isLoading || isMissingConversationId}
+          disabled={inFlight !== null || isMissingConversationId}
           className={cn(
             "inline-flex items-center rounded-md p-1.5 transition-colors",
             "hover:bg-muted/80",
@@ -186,7 +188,7 @@ export function RatingButtons({
           )}
           title={isMissingConversationId ? t("saveConversationToRate") : t("notHelpful")}
         >
-          {isLoading && currentRating !== RatingValue.LIKE ? (
+          {inFlight === RatingValue.DISLIKE ? (
             <Loader2 className="h-4 w-4 animate-spin" />
           ) : (
             <ThumbsDown className="h-4 w-4" />
@@ -214,22 +216,22 @@ export function RatingButtons({
           <div className="flex items-center justify-between">
             <span className="text-muted-foreground text-xs">{comment.length} / 2000</span>
             <div className="flex gap-2">
-              <Button variant="ghost" onClick={handleCloseDialog} disabled={isLoading}>
+              <Button variant="ghost" onClick={handleCloseDialog} disabled={inFlight !== null}>
                 {tc("cancel")}
               </Button>
               <Button
                 variant="outline"
                 onClick={() => submitRating(pendingRating, null)}
-                disabled={isLoading}
+                disabled={inFlight !== null}
               >
-                {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                {inFlight !== null ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
                 {t("skipComment")}
               </Button>
               <Button
                 onClick={() => submitRating(pendingRating, comment.trim() || null)}
-                disabled={isLoading}
+                disabled={inFlight !== null}
               >
-                {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                {inFlight !== null ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
                 {tc("submit")}
               </Button>
             </div>


### PR DESCRIPTION
## What changed

Clicking 👍 (or 👎) on a chat message put a spinner on **both** thumbs. The spinner was keyed on the *current* rating rather than on the button clicked:

```tsx
isLoading && currentRating !== RatingValue.DISLIKE  // thumbs-up
isLoading && currentRating !== RatingValue.LIKE     // thumbs-down
```

`currentRating` is `null` on every message nobody has rated yet — the normal case — and `null !== DISLIKE` and `null !== LIKE` are both true, so a single `isLoading` lit both. The expressions only behaved on a message that already carried a rating, which is why it survived. The un-rate `DELETE` path had no notion of which button at all.

## Fix

Track **which button's request is in flight** rather than what the rating is: one `inFlight: RatingValue | null`, set before every request (POST and DELETE) and cleared in `finally`. Each thumb spins iff `inFlight` is its own value; both stay `disabled` while `inFlight !== null`, since a second rating mid-flight is still wrong.

## Verification

- The existing spinner test used an already-rated message — the case the buggy expressions happened to get right. Added the **unrated (`null`)** case (fails against the old code: both thumbs spin) and the **un-rate** case.
- Full suite: 27 tests pass. `make lint-frontend` clean; frontend coverage gate green.

Out of scope, noted on their issues: #563 (this file should move to a lib client + `useMutation`, which carries `variables` and would make "which rating is in flight" free) and #655 (`error.message` read against the `{error:{message}}` envelope).

Closes #928