### PR TITLE
chore: cut 0.0.220

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,30 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.220] - 2026-08-20
+
+A status parameter with one value stops pretending to be a choice.
+
+### Changed
+
+- **`_update_status` in the ingestion flow is `_fail_document`, and takes no
+  status.** It branched on two values and all four callers passed `"error"`; the
+  `elif status == "done"` was a `pass` whose comment explained why nothing takes
+  it - reaching `DONE` needs the vector document's id, which only
+  `_run_ingestion` holds, so it calls `complete_ingestion` itself. The name now
+  says what the function does: record the *first* failure and refuse to overwrite
+  it (#423). `vulture` could not see the dead branch, because the parameter was
+  read. (#956)
+- **The guard compares `DocumentStatus.ERROR`, not the string.** Two spellings of
+  one value set is how #148 happened - a fourth status nothing had ever written,
+  filtered on by the listing, so every knowledge base reported `indexed_count:
+  0`. (#956)
+
+### Added
+
+- A test for the guard's other half: a row that has not failed yet does take the
+  failure. It was covered only incidentally, through `_run_ingestion`. (#956)
+
 ## [0.0.219] - 2026-08-20
 
 A tracking row says which file it tracks, so a failed attempt stops piling up.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.219"
+version = "0.0.220"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.219"
+version = "0.0.220"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.219",
+  "version": "0.0.220",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.220. Bumps `backend/pyproject.toml`,
`backend/uv.lock` and `frontend/package.json` to 0.0.220 and adds the
CHANGELOG entry.

One issue, #956, and no behaviour change: `_update_status` in the
ingestion flow took a status and branched on two values, and all four
callers passed `"error"`. The `elif status == "done"` was a `pass` whose
comment explained why nothing takes it - reaching `DONE` needs the vector
document's id, which only `_run_ingestion` holds, so it calls
`complete_ingestion` itself. So the branch could not be reached, the `if`
was always true, and the parameter was a constant dressed as a choice
that `vulture` cannot report, because the parameter is read.

It is `_fail_document(rag_document_id, *, error_message)` now, which is
what it does: record the first failure and refuse to overwrite it (#423).
The guard compares `DocumentStatus.ERROR` rather than the string, because
two spellings of one value set is how #148 happened.

## Verified

`make check` green on the branch - every CI job except e2e - and CI green
end to end on #1003 including `e2e`. The #423 behaviour keeps its test,
and the guard's other half - a row that has not failed yet does take the
failure - has one now rather than being covered incidentally through
`_run_ingestion`.

Closes #956