### PR TITLE
fix(rag): record who bound a credential to a collection

### DIFF
--- a/backend/app/api/routes/v1/knowledge_bases.py
+++ b/backend/app/api/routes/v1/knowledge_bases.py
@@ -378,9 +378,7 @@ async def clone_kb_sync_source(
     kb = await service.get_for_write(kb_id, ctx=ctx)
     source = await access.sync_source(ctx, str(source_id))
     clone_data = data.model_copy(update={"collection_name": kb.collection_name})
-    return await sync_source_svc.clone_source(
-        str(source.id), clone_data, organization_id=ctx.organization_id
-    )
+    return await sync_source_svc.clone_source(str(source.id), clone_data, ctx=ctx)
 
 
 @router.post(
@@ -460,4 +458,4 @@ async def delete_kb_sync_source(
             message="Sync source not found in this knowledge base",
             details={"kb_id": str(kb_id), "source_id": str(source_id)},
         )
-    await sync_source_svc.delete_source(str(source_id))
+    await sync_source_svc.delete_source(str(source_id), ctx=ctx)

--- a/backend/app/api/routes/v1/org_integrations.py
+++ b/backend/app/api/routes/v1/org_integrations.py
@@ -109,7 +109,7 @@ async def delete_org_integration(
 ) -> None:
     """Delete an org integration by ID."""
     source = await access.sync_source(ctx, str(source_id))
-    await sync_source_svc.delete_source(str(source.id))
+    await sync_source_svc.delete_source(str(source.id), ctx=ctx)
 
 
 @router.post(

--- a/backend/app/api/routes/v1/rag.py
+++ b/backend/app/api/routes/v1/rag.py
@@ -550,9 +550,7 @@ async def clone_sync_source(
     """
     source = await access.sync_source(ctx, source_id)
     await access.writable(ctx, data.collection_name)
-    return await sync_source_svc.clone_source(
-        str(source.id), data, organization_id=ctx.organization_id
-    )
+    return await sync_source_svc.clone_source(str(source.id), data, ctx=ctx)
 
 
 @router.patch(
@@ -588,7 +586,7 @@ async def delete_sync_source(
 ) -> None:
     """Delete a sync source configuration."""
     source = await access.sync_source(ctx, source_id)
-    await sync_source_svc.delete_source(str(source.id))
+    await sync_source_svc.delete_source(str(source.id), ctx=ctx)
 
 
 @router.post(

--- a/backend/app/commands/rag.py
+++ b/backend/app/commands/rag.py
@@ -729,7 +729,14 @@ def rag_source_remove(source_id: str, yes: bool) -> None:
         async with get_db_context() as db:
             svc = SyncSourceService(db)
             try:
-                await svc.delete_source(source_id)
+                # The row's own organization, because this command is
+                # deployment-wide and a shell prompt has no active one. The
+                # context carries no subject either, which is what the audit
+                # entry records: removed, by nobody a session can name (#983).
+                source = await svc.get_source(source_id)
+                await svc.delete_source(
+                    source_id, ctx=AuthContext.anonymous(source.organization_id)
+                )
                 success(f"Sync source '{source_id}' removed.")
             except Exception as e:
                 error(f"Failed to remove source: {e}")

--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -379,11 +379,13 @@ class AuthContext:
         says rather than assumes.
 
         Raises:
-            AuthorizationError: If there is no subject. Loudly, and here: the
-                audit actor column is `NOT NULL`, so letting the absence
-                travel surfaces several layers down as an `IntegrityError`
-                naming a constraint, by which point the audit entry is lost and
-                the request has half happened.
+            AuthorizationError: If there is no subject. Loudly, and here: an
+                authenticated path that reached this far has a person, and
+                letting the absence travel writes an entry naming nobody -
+                indistinguishable from the two writers that legitimately name
+                nobody, and by then the request has half happened. A caller
+                that genuinely has no session reads :attr:`user_id` instead,
+                deliberately.
         """
         if self.user_id is None:
             raise AuthorizationError(

--- a/backend/app/db/models/audit_log.py
+++ b/backend/app/db/models/audit_log.py
@@ -16,9 +16,11 @@ class AppAdminAuditLog(Base, TimestampMixin):
     __tablename__ = "app_admin_audit_logs"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    # Null is "the platform, on a schedule" - an approval the expiry sweep
-    # settled because nobody decided it. That is the only thing it can mean:
-    # every authenticated path has a subject and passes it.
+    # Null is "no session behind it", which two writers can mean: the approval
+    # expiry sweep, settling what nobody decided, and an operator command at the
+    # deployment's shell (`rag-source-add`, `rag-source-remove`). The `action`
+    # is what tells them apart; every authenticated path has a subject and
+    # passes it.
     actor_user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), nullable=True, index=True
     )

--- a/backend/app/services/sync_source.py
+++ b/backend/app/services/sync_source.py
@@ -8,6 +8,7 @@ from uuid import UUID
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.updates import writable
+from app.core.audit import record_audit
 from app.core.exceptions import BadRequestError, NotFoundError
 from app.core.field_errors import refused_field
 from app.core.permissions import AuthContext, Perm
@@ -243,7 +244,54 @@ class SyncSourceService:
             sync_mode=data.sync_mode,
             schedule_minutes=data.schedule_minutes,
         )
+        await self._record(source, "created", ctx=ctx)
         return self._to_read(source, secret_hint=hint)
+
+    async def _record(
+        self,
+        source: SyncSource,
+        event: str,
+        *,
+        ctx: AuthContext,
+        extra: dict[str, object] | None = None,
+    ) -> None:
+        """Leave a trail for the decision this row *is*.
+
+        A sync source binds a credential to a collection, which is the platform's
+        authorization decision for everything it ingests: access is decided at
+        the collection and the credential's reach is the source's reach
+        (`docs/file-processing.md#who-ends-up-able-to-read-what-a-source-ingested`).
+        Nothing recorded it, so "who made this credential's reach searchable by
+        this collection's readers" had no answer after the fact, and neither did
+        "when did it start pointing at the org collection instead of my personal
+        one" (#983).
+
+        What lands in `details` is the decision and not the payload: the
+        connector, the collection, and the *id* of the secret. Never the config
+        document - a place a credential has been posted before (#937) - and never
+        the row.
+
+        `ctx.user_id` rather than `ctx.subject_id`, which raises: `rag-source-add`
+        and `rag-source-remove` are operator commands with nobody at a keyboard,
+        and an entry naming no actor is a truer record of one than no entry at
+        all. The action is what tells such an entry from the approval expiry
+        sweep's, the other writer that names nobody.
+        """
+        await record_audit(
+            self.db,
+            actor_user_id=ctx.user_id,
+            organization_id=source.organization_id,
+            action=f"sync_source.{event}",
+            target_type="sync_source",
+            target_id=str(source.id),
+            details={
+                "name": source.name,
+                "connector_type": source.connector_type,
+                "collection_name": source.collection_name,
+                "secret_id": str(source.secret_id) if source.secret_id else None,
+                **(extra or {}),
+            },
+        )
 
     async def _checked_secret(
         self, secret_id: UUID | None, connector_type: str, ctx: AuthContext
@@ -303,7 +351,7 @@ class SyncSourceService:
         return row.hint
 
     async def clone_source(
-        self, source_id: str, data: SyncSourceClone, *, organization_id: UUID
+        self, source_id: str, data: SyncSourceClone, *, ctx: AuthContext
     ) -> SyncSourceRead:
         """Clone an existing integration into a different knowledge base.
 
@@ -311,6 +359,11 @@ class SyncSourceService:
         credential. That is the point of the id: one Drive credential feeding
         five collections is one secret, rotated once, and revoking it stops all
         five - where five encrypted copies had to be found first (#937).
+
+        Which makes a clone the very decision #983 is about, and the one most
+        easily missed: it points a credential somebody already scoped at a
+        *different* collection, so its audience changes while nothing about the
+        credential does. The entry says which row it was cloned from.
         """
         existing = await self.get_source(source_id)
         raw = _raw_config(existing)
@@ -322,13 +375,14 @@ class SyncSourceService:
             self.db,
             name=data.name or f"{existing.name} (copy)",
             connector_type=existing.connector_type,
-            organization_id=organization_id,
+            organization_id=ctx.organization_id,
             collection_name=data.collection_name,
             config=raw,
             secret_id=existing.secret_id,
             sync_mode=existing.sync_mode,
             schedule_minutes=existing.schedule_minutes,
         )
+        await self._record(source, "created", ctx=ctx, extra={"cloned_from": source_id})
         return self._to_read(source)
 
     async def update_source(
@@ -368,19 +422,31 @@ class SyncSourceService:
             await _refuse_an_invalid_config(merged, existing.connector_type)
             updates["config"] = merged
 
+        previous_collection = existing.collection_name
         source = await sync_source_repo.update(self.db, UUID(source_id), **updates)
         if source is None:
             raise NotFoundError(message="Sync source not found", details={"source_id": source_id})
+        repointed = (
+            {"previous_collection_name": previous_collection}
+            if source.collection_name != previous_collection
+            else {}
+        )
+        # The field names, never their values: one of them is `config`, and a
+        # patch is a place a credential has been posted before (#937, #412).
+        await self._record(
+            source, "updated", ctx=ctx, extra={"fields": sorted(updates), **repointed}
+        )
         return self._to_read(source, secret_hint=hint)
 
-    async def delete_source(self, source_id: str) -> None:
+    async def delete_source(self, source_id: str, *, ctx: AuthContext) -> None:
         """Delete a sync source.
 
         Raises:
             NotFoundError: If sync source does not exist.
         """
-        await self.get_source(source_id)
+        source = await self.get_source(source_id)
         await sync_source_repo.delete(self.db, UUID(source_id))
+        await self._record(source, "deleted", ctx=ctx)
 
     async def trigger_sync(self, source_id: str) -> object:
         """Trigger a manual sync - persists a SyncLog and dispatches the task.

--- a/backend/tests/test_sync_source_audit.py
+++ b/backend/tests/test_sync_source_audit.py
@@ -1,0 +1,283 @@
+"""A sync source's life is recorded, because the row *is* an access decision.
+
+#983. A source binds a credential to a collection, and access to what it
+ingests is decided at the collection - so the row decides who ends up able to
+read whatever that credential can reach
+(`docs/file-processing.md#who-ends-up-able-to-read-what-a-source-ingested`).
+Nothing wrote an audit entry for creating, repointing or deleting one, so a
+broad credential pointed at an `org` collection weeks ago had no answer to who
+did it, when, or whether it had originally been pointed somewhere narrower.
+
+Two things every test here holds shut, and the second is why the first is not
+enough:
+
+* **The entry exists**, on all four paths that write such a row - create,
+  clone, update, delete.
+* **`details` carries the decision and not the payload.** The connector, the
+  collection and the secret's *id*; never the config document, which is a place
+  a credential has been posted before (#937), and never the row.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.core.permissions import AuthContext, OrgRoleName
+from app.schemas.sync_source import SyncSourceClone, SyncSourceCreate, SyncSourceUpdate
+from app.services import sync_source as sync_source_module
+from app.services.sync_source import SyncSourceService
+
+pytestmark = pytest.mark.anyio
+
+_ORG = uuid.uuid4()
+_CALLER = uuid.uuid4()
+_SECRET = uuid.uuid4()
+
+# The value a reader of the trail must never be handed back: `config` is what a
+# connector needs to *find* the documents, and the field names in it have held a
+# credential within this repository's memory.
+_CONFIG = {"folder_id": "1AbC_-secret-looking-folder"}
+
+
+def _ctx(*, anonymous: bool = False) -> AuthContext:
+    if anonymous:
+        return AuthContext.anonymous(_ORG)
+    return AuthContext(user_id=_CALLER, organization_id=_ORG, role=OrgRoleName.OWNER.value)
+
+
+def _row(**overrides) -> SimpleNamespace:
+    """A stored source. `SimpleNamespace` because `name` is MagicMock's own kwarg."""
+    fields = {
+        "id": uuid.uuid4(),
+        "organization_id": _ORG,
+        "name": "Legal docs",
+        "connector_type": "gdrive",
+        "collection_name": "legal",
+        "config": dict(_CONFIG),
+        "secret_id": _SECRET,
+        "sync_mode": "new_only",
+        "schedule_minutes": None,
+        "is_active": True,
+        "last_sync_at": None,
+        "last_sync_status": None,
+        "last_error": None,
+        "created_at": None,
+    }
+    return SimpleNamespace(**{**fields, **overrides})
+
+
+def _service(monkeypatch: pytest.MonkeyPatch, *, stored=None, updated=None) -> AsyncMock:
+    """The real service with its repositories and its checks mocked at the edge.
+
+    Returns the `record_audit` mock, because that is what every test here reads.
+    The credential check is `resolve_access`, which has its own tests and needs a
+    real grant table; what matters here is only that a source reaches the trail.
+    """
+    monkeypatch.setattr(sync_source_module, "resolve_access", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        sync_source_module.organization_secret_repo,
+        "get",
+        AsyncMock(
+            return_value=SimpleNamespace(id=_SECRET, kind="gcp_service_account", hint="9f3c")
+        ),
+    )
+    monkeypatch.setattr(
+        sync_source_module.sync_source_repo,
+        "create",
+        AsyncMock(
+            side_effect=lambda db, **kwargs: _row(
+                organization_id=kwargs["organization_id"],
+                name=kwargs["name"],
+                collection_name=kwargs["collection_name"],
+                config=kwargs["config"],
+                secret_id=kwargs["secret_id"],
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        sync_source_module.sync_source_repo, "get_by_id", AsyncMock(return_value=stored)
+    )
+    monkeypatch.setattr(
+        sync_source_module.sync_source_repo, "update", AsyncMock(return_value=updated)
+    )
+    monkeypatch.setattr(sync_source_module.sync_source_repo, "delete", AsyncMock())
+    audit = AsyncMock()
+    monkeypatch.setattr(sync_source_module, "record_audit", audit)
+    return audit
+
+
+def _create(**overrides) -> SyncSourceCreate:
+    return SyncSourceCreate(
+        name="Legal docs",
+        connector_type="gdrive",
+        collection_name="legal",
+        config=dict(_CONFIG),
+        secret_id=_SECRET,
+        **overrides,
+    )
+
+
+def _entry(audit: AsyncMock) -> dict:
+    assert audit.await_count == 1, f"expected one audit entry, got {audit.await_count}"
+    return audit.await_args.kwargs
+
+
+class TestEveryWritePathLeavesAnEntry:
+    async def test_creating_a_source_names_the_actor_the_collection_and_the_secret(
+        self, monkeypatch
+    ):
+        audit = _service(monkeypatch)
+
+        await SyncSourceService(MagicMock()).create_source(_create(), ctx=_ctx())
+
+        entry = _entry(audit)
+        assert entry["action"] == "sync_source.created"
+        assert entry["actor_user_id"] == _CALLER
+        assert entry["organization_id"] == _ORG
+        assert entry["target_type"] == "sync_source"
+        assert entry["details"]["collection_name"] == "legal"
+        assert entry["details"]["secret_id"] == str(_SECRET)
+        assert entry["details"]["connector_type"] == "gdrive"
+
+    async def test_a_clone_says_which_row_it_was_cloned_from(self, monkeypatch):
+        """The decision most easily missed: the credential is unchanged and its
+        audience is not. A clone references the same secret and names a different
+        collection, so it widens who can read what that credential reaches
+        without touching the credential at all."""
+        stored = _row()
+        audit = _service(monkeypatch, stored=stored)
+
+        await SyncSourceService(MagicMock()).clone_source(
+            str(stored.id), SyncSourceClone(collection_name="everyone"), ctx=_ctx()
+        )
+
+        entry = _entry(audit)
+        assert entry["action"] == "sync_source.created"
+        assert entry["details"]["cloned_from"] == str(stored.id)
+        assert entry["details"]["collection_name"] == "everyone"
+        assert entry["details"]["secret_id"] == str(_SECRET)
+
+    async def test_an_update_names_the_fields_and_not_their_values(self, monkeypatch):
+        stored = _row()
+        audit = _service(
+            monkeypatch, stored=stored, updated=_row(id=stored.id, sync_mode="update_only")
+        )
+
+        await SyncSourceService(MagicMock()).update_source(
+            str(stored.id), SyncSourceUpdate(sync_mode="update_only"), ctx=_ctx()
+        )
+
+        entry = _entry(audit)
+        assert entry["action"] == "sync_source.updated"
+        assert entry["details"]["fields"] == ["sync_mode"]
+
+    async def test_repointing_a_source_says_where_it_used_to_point(self, monkeypatch):
+        """A rename and a repoint are both `updated`, and only one of them
+        changes who can read what has already been ingested. The entry has to
+        say which happened, or the trail answers "something changed"."""
+        stored = _row(collection_name="my_notes")
+        audit = _service(
+            monkeypatch, stored=stored, updated=_row(id=stored.id, collection_name="everyone")
+        )
+
+        await SyncSourceService(MagicMock()).update_source(
+            str(stored.id), SyncSourceUpdate(collection_name="everyone"), ctx=_ctx()
+        )
+
+        entry = _entry(audit)
+        assert entry["details"]["previous_collection_name"] == "my_notes"
+        assert entry["details"]["collection_name"] == "everyone"
+
+    async def test_a_rename_records_no_previous_collection(self, monkeypatch):
+        stored = _row()
+        audit = _service(
+            monkeypatch, stored=stored, updated=_row(id=stored.id, name="Legal docs (EU)")
+        )
+
+        await SyncSourceService(MagicMock()).update_source(
+            str(stored.id), SyncSourceUpdate(name="Legal docs (EU)"), ctx=_ctx()
+        )
+
+        assert "previous_collection_name" not in _entry(audit)["details"]
+
+    async def test_deleting_a_source_records_what_was_deleted(self, monkeypatch):
+        stored = _row()
+        audit = _service(monkeypatch, stored=stored)
+
+        await SyncSourceService(MagicMock()).delete_source(str(stored.id), ctx=_ctx())
+
+        entry = _entry(audit)
+        assert entry["action"] == "sync_source.deleted"
+        assert entry["target_id"] == str(stored.id)
+        assert entry["details"]["collection_name"] == "legal"
+        assert entry["details"]["secret_id"] == str(_SECRET)
+
+    async def test_a_source_that_does_not_exist_leaves_no_entry(self, monkeypatch):
+        audit = _service(monkeypatch, stored=None)
+
+        with pytest.raises(sync_source_module.NotFoundError):
+            await SyncSourceService(MagicMock()).delete_source(str(uuid.uuid4()), ctx=_ctx())
+
+        assert audit.await_count == 0
+
+
+class TestWhatMayNotReachTheTrail:
+    @pytest.mark.parametrize(
+        "act",
+        [
+            pytest.param("create", id="create"),
+            pytest.param("clone", id="clone"),
+            pytest.param("update", id="update"),
+            pytest.param("delete", id="delete"),
+        ],
+    )
+    async def test_no_config_value_reaches_details(self, monkeypatch, act: str):
+        """`details` is a stored JSONB column with a longer life than a response
+        body, and the rule that governs a refusal governs it too: the field that
+        explains the decision, never the payload that was submitted (#412)."""
+        stored = _row()
+        audit = _service(monkeypatch, stored=stored, updated=_row(id=stored.id))
+        service = SyncSourceService(MagicMock())
+
+        if act == "create":
+            await service.create_source(_create(), ctx=_ctx())
+        elif act == "clone":
+            await service.clone_source(
+                str(stored.id), SyncSourceClone(collection_name="everyone"), ctx=_ctx()
+            )
+        elif act == "update":
+            await service.update_source(
+                str(stored.id), SyncSourceUpdate(config=dict(_CONFIG)), ctx=_ctx()
+            )
+        else:
+            await service.delete_source(str(stored.id), ctx=_ctx())
+
+        written = json.dumps(_entry(audit)["details"])
+        assert _CONFIG["folder_id"] not in written
+        assert "folder_id" not in written
+
+
+class TestAnOperatorCommandStillLeavesOne:
+    async def test_a_context_with_no_subject_records_no_actor_rather_than_refusing(
+        self, monkeypatch
+    ):
+        """`rag-source-add` and `rag-source-remove` have nobody at a keyboard,
+        and `ctx.subject_id` raises for such a context - so reading it here
+        would have turned two working operator commands into an
+        `AuthorizationError`. An entry naming no actor is a truer record of the
+        removal than no entry at all, and the action is what tells it from the
+        approval expiry sweep, the only other writer that names nobody."""
+        stored = _row()
+        audit = _service(monkeypatch, stored=stored)
+
+        await SyncSourceService(MagicMock()).delete_source(str(stored.id), ctx=_ctx(anonymous=True))
+
+        entry = _entry(audit)
+        assert entry["actor_user_id"] is None
+        assert entry["action"] == "sync_source.deleted"
+        assert entry["organization_id"] == _ORG

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -891,14 +891,22 @@ the source cannot widen. Pointing a broad credential at a `personal` collection
 narrows the readers but not what was ingested; a narrow credential on an `org`
 collection is the shape to aim for.
 
-Two things this rule owes and does not yet have, each filed:
-[#982](https://github.com/vstorm-co/agenticos/issues/982) states the consequence
-in the wizard where the collection is chosen, and re-asks when a source is
-repointed at a different one; [#983](https://github.com/vstorm-co/agenticos/issues/983)
-records creating and repointing a source in the audit log, which is what gives
-"who decided this collection gets that credential's reach" an answer after the
-fact. Today both are silent, which is exactly the implicitness this section
-exists to name.
+**Who decided it is recorded.** Creating, cloning, repointing and deleting a
+source each write an audit entry - `sync_source.created`, `.updated`,
+`.deleted` - naming the actor, the connector, the collection and the *id* of the
+secret, never the config document. An update that moves the source to a
+different collection also records the one it left, because a rename and a change
+of audience are otherwise the same entry. A clone is recorded as a creation
+naming the row it came from: it points a credential somebody already scoped at a
+different collection, so its audience changes while nothing about the credential
+does (#983).
+
+What this rule still owes, and does not yet have, is the other half - saying the
+consequence *before* the fact rather than after it:
+[#982](https://github.com/vstorm-co/agenticos/issues/982) states it in the
+wizard where the collection is chosen, and re-asks when a source is repointed at
+a different one. Today that step is silent, which is exactly the implicitness
+this section exists to name.
 
 ### What a new connector owes
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -950,9 +950,15 @@ ended must not fail again because SMTP was down.
 
 ## Audit
 
-Actions that change access or spend money are recorded with an actor, and the
-actor column is `NOT NULL` - which is why a context with no subject raises rather
-than letting the absence travel. A privileged bulk read is recorded too: each CSV
+Actions that change access or spend money are recorded with an actor, and a
+context with no subject raises rather than letting the absence travel - so an
+entry naming nobody means exactly two things, and the `action` says which: the
+approval expiry sweep, and an operator command at the deployment's shell.
+Binding a credential to a collection is one of those actions: `sync_source`
+entries record creating, cloning, repointing and deleting a source, because the
+row decides who ends up able to read what it ingests
+([File processing](file-processing.md#who-ends-up-able-to-read-what-a-source-ingested)).
+A privileged bulk read is recorded too: each CSV
 export writes a `runs.export`, `approvals.export` or `spend.export` entry naming
 the window and the row count, because who took the whole table off the screen is a
 question that is cheap to answer now and impossible to reconstruct later.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -326,10 +326,11 @@ trail and the approval gate all key on one.
 - `.permissions` returns `{}` when there is no subject - checked on the subject
   rather than on the role string, because a subject-less context built with
   `"owner"` would otherwise reach every row in the organization.
-- `.subject_id` raises `AuthorizationError` rather than returning `None`, because
-  the audit actor column is `NOT NULL` and letting the absence travel surfaces
-  several layers down as an `IntegrityError` - by which point the audit entry is
-  lost and the request has half happened.
+- `.subject_id` raises `AuthorizationError` rather than returning `None`: an
+  authenticated path that got this far has a person, and letting the absence
+  travel writes an entry naming nobody - indistinguishable from the two writers
+  that legitimately do, and by then the request has half happened. A caller with
+  no session at all reads `.user_id` and says so.
 
 The surfaces open to people this deployment cannot name do not use that
 constructor. A hosted page, a widget and a channel each run the turn under


### PR DESCRIPTION
`grep -n record_audit app/services/sync_source.py` returned nothing. Every other
service that decides who can reach what writes an entry — and this one binds a
**credential** to a **collection**, which is the platform's authorization
decision for everything it ingests: access is decided at the collection, and the
credential's reach is the source's reach.

So the sequence in the issue had no answer after the fact. A member creates a
source on an `org` collection with a broad credential, it syncs, the documents
are searchable org-wide, somebody notices weeks later — and nothing recorded who
created it, when, which credential it named, or whether it had originally been
pointed somewhere narrower.

## What is recorded

`sync_source.created`, `.updated` and `.deleted`, on all four paths that write
such a row, with `actor_user_id`, the row's `organization_id`,
`target_type="sync_source"` and `target_id`.

`details` carries the decision and not the payload — the connector, the
collection, the *id* of the secret, and the source's name. Never the config
document, which is a place a credential has been posted before (#937), and never
the row.

- **A clone is one of the four**, and the one most easily missed: it points a
  credential somebody already scoped at a *different* collection, so the audience
  changes while nothing about the credential does. Recorded as a creation naming
  the row it came from.
- **An update names the fields, never their values.** One of those fields is
  `config`. Same rule audit entries already take (#412).
- **A repoint says where it used to point.** A rename and a change of audience are
  otherwise the same entry.

## Two things worth a reviewer's attention

**`ctx.user_id`, not `ctx.subject_id`.** `subject_id` *raises* for a context with
no subject, and `rag-source-add` / `rag-source-remove` are operator commands with
nobody at a keyboard — reading it would have turned two working CLI commands into
an `AuthorizationError`. An entry naming no actor is a truer record of a removal
than no entry at all. That does widen what a null actor means: the approval
expiry sweep used to be the only writer producing one, so the `action` is now
what tells them apart, and the model comment says so. Push back if you would
rather the CLI paths simply recorded nothing.

**Three sentences were wrong and are corrected.** `docs/permissions.md`,
`docs/governance.md` and `AuthContext.subject_id`'s docstring each said the audit
actor column is `NOT NULL`. It is nullable, and has been since the sweep needed
it (`backend/app/db/models/audit_log.py:22`). The behaviour does not change —
`subject_id` still raises — but the reason given was a constraint the database
does not have, and this change leans on the column being nullable, so leaving
them would have been confidently wrong about exactly that.

## Signatures

`delete_source` takes a `ctx`, and `clone_source` takes one instead of a bare
`organization_id`. All five call sites already had `ctx: Auth`; the CLI builds
`AuthContext.anonymous(source.organization_id)` — the row's organization, because
that command is deployment-wide and a shell prompt has no active one.

## How it was verified

- `tests/test_sync_source_audit.py` — 12 new tests: one per path, the repoint,
  the rename that is not one, a missing row leaving no entry, plus the two the
  issue asks for by name — **no config value reaches `details`** on any of the
  four paths, and an anonymous context records a null actor rather than raising.
- Backend suite: 6244 passed. Integration suite: 578 passed.
- `make check` green — every CI job except e2e — and `make docs-build`.

## Docs

`docs/file-processing.md` named #983 as owed and unbuilt. It now describes what
is recorded, and still names #982 as the half that is missing: saying the
consequence in the wizard *before* the fact rather than after it.

Closes #983
