### PR TITLE
chore: cut 0.0.221

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,40 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.221] - 2026-08-20
+
+Who bound a credential to a collection is recorded.
+
+### Fixed
+
+- **Creating, cloning, repointing and deleting a sync source left no audit
+  entry.** A source binds a credential to a collection, and access to what it
+  ingests is decided at the collection - so the row is the platform's
+  authorization decision for everything that credential can reach, and nothing
+  recorded who made it. `sync_source.created`, `.updated` and `.deleted` name the
+  actor, the connector, the collection and the *id* of the secret. (#983)
+- **A clone is recorded as a creation naming the row it came from.** It points a
+  credential somebody already scoped at a different collection, so the audience
+  changes while nothing about the credential does - the decision in this set that
+  is easiest to miss. (#983)
+- **An update names the fields it changed, never their values**, one of them
+  being `config` - a place a credential has been posted before (#937). An update
+  that moves the source to another collection also records the one it left,
+  because a rename and a change of audience are otherwise the same entry. (#983)
+
+### Changed
+
+- **A null audit actor now means one of two things**, and the `action` says
+  which: the approval expiry sweep, and an operator command at the deployment's
+  shell (`rag-source-add`, `rag-source-remove`), which have nobody at a keyboard
+  to name. Reading `ctx.subject_id` there - as every HTTP path does - would have
+  turned two working commands into an `AuthorizationError`. (#983)
+- Three sentences said the audit actor column is `NOT NULL`
+  (`docs/permissions.md`, `docs/governance.md`, `AuthContext.subject_id`). It is
+  nullable, and has been since the expiry sweep needed it; the reason
+  `subject_id` raises is that an authenticated path has a person, not that the
+  database would refuse. (#983)
+
 ## [0.0.220] - 2026-08-20
 
 A status parameter with one value stops pretending to be a choice.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.220"
+version = "0.0.221"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.220"
+version = "0.0.221"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.220",
+  "version": "0.0.221",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.221. Bumps `backend/pyproject.toml`,
`backend/uv.lock` and `frontend/package.json` to 0.0.221 and adds the
CHANGELOG entry.

One issue, #983. `grep -n record_audit app/services/sync_source.py`
returned nothing, while every other service that decides who can reach
what writes an entry - and this one binds a credential to a collection,
which is the authorization decision for everything it ingests. So "who
made this credential's reach searchable by this collection's readers" had
no answer after the fact, and neither did "when did it start pointing at
the org collection instead of my personal one".

Four paths write such a row and all four are recorded now. The clone was
worth the extra one: it references the same vault secret and names a
different collection, so the audience changes while nothing about the
credential does, and it is the only way to change one from the product's
own UI.

Two decisions in it worth keeping visible. The entry carries the field
names an update changed and never their values, because one of those
fields is `config`. And it reads `ctx.user_id` rather than
`ctx.subject_id`, which raises: `rag-source-add` and `rag-source-remove`
have nobody at a keyboard, so the strict reading would have turned two
working operator commands into an `AuthorizationError`. That widens what
a null actor means - the expiry sweep used to be the only writer of one -
so the `action` is now what tells them apart.

Which is also why three sentences are corrected: `docs/permissions.md`,
`docs/governance.md` and `AuthContext.subject_id`'s docstring each said
the audit actor column is `NOT NULL`. It is nullable, and the true reason
`subject_id` raises is that an authenticated path has a person.

## Verified

12 new tests, including the two the issue asks for by name - no config
value reaches `details` on any of the four paths, and an anonymous
context records a null actor rather than raising. The backend suite (6244
passed), the integration suite (578 passed), `make check`, and CI green
end to end on #1007 including `e2e`.

Closes #983