### PR TITLE
feat(chat): show which model a conversation runs on

### DIFF
--- a/backend/app/schemas/agent.py
+++ b/backend/app/schemas/agent.py
@@ -13,6 +13,20 @@ from app.core.secret_kinds import SecretRequirement
 from app.schemas.base import BaseSchema
 
 
+class PublishedModel(BaseSchema):
+    """The model an agent's published version runs on.
+
+    Enough for the chat's model picker to open showing what the conversation is
+    on and to offer a way back to it after an override: the profile's id (what an
+    override is set to), its provider, the model id, and the label a person reads.
+    """
+
+    profile_id: UUID
+    provider: str
+    model: str
+    label: str
+
+
 class AgentRead(BaseSchema):
     """An agent as the Builder lists it."""
 
@@ -74,6 +88,17 @@ class AgentRead(BaseSchema):
             "falling back to the pricing registry; null when neither can say, and a "
             "surface then draws no share rather than one against a guess. Filled by the "
             "listing, same bargain as shared_user_count."
+        ),
+    )
+    published_model: PublishedModel | None = Field(
+        default=None,
+        description=(
+            "The model the published version runs on, so the chat's model picker can "
+            "open showing what the conversation is on and offer a way back to it after "
+            "an override. Read off the frozen spec's profile, not the draft's, which may "
+            "name a different model than the agent runs; null for a draft agent and when "
+            "that profile has been deleted. Filled by the listing, same bargain as "
+            "shared_user_count."
         ),
     )
     created_at: datetime | None = None

--- a/backend/app/services/agent_registry.py
+++ b/backend/app/services/agent_registry.py
@@ -62,7 +62,13 @@ from app.repositories import (
     sandbox_connection_repo,
     skill_repo,
 )
-from app.schemas.agent import AgentRead, AgentVersionRead, DelegationTree, DelegationTreeNode
+from app.schemas.agent import (
+    AgentRead,
+    AgentVersionRead,
+    DelegationTree,
+    DelegationTreeNode,
+    PublishedModel,
+)
 from app.services.access import (
     AGENT,
     COLLECTION,
@@ -557,6 +563,27 @@ def _window_of(profile: ModelProfile | None) -> int | None:
     return resolve_context_window(f"{profile.provider}:{profile.model}")
 
 
+def _published_models(
+    profile_ids: dict[UUID, UUID], profiles: dict[UUID, ModelProfile]
+) -> dict[UUID, PublishedModel]:
+    """The model each published version runs on, by version id.
+
+    A version whose profile has been deleted is absent rather than a null entry:
+    the frozen spec still names an id, but nothing can say what it was, and a
+    picker prefilled from a gap would name a model the profile no longer is.
+    """
+    return {
+        version_id: PublishedModel(
+            profile_id=profile.id,
+            provider=profile.provider,
+            model=profile.model,
+            label=profile.label,
+        )
+        for version_id, profile_id in profile_ids.items()
+        if (profile := profiles.get(profile_id)) is not None
+    }
+
+
 def _yaml_refusal(exc: yaml.YAMLError) -> str:
     """Where the document stopped parsing, without quoting any of it.
 
@@ -692,7 +719,16 @@ class AgentRegistryService:
         )
         version_ids = [agent.current_version_id for agent in agents if agent.current_version_id]
         budget_caps = await agent_repo.published_budget_caps(self.db, version_ids=version_ids)
-        windows = await self._context_windows(ctx, version_ids)
+        profile_ids = await agent_repo.published_model_profiles(self.db, version_ids=version_ids)
+        profiles = (
+            await credential_repo.get_profiles_by_ids(
+                self.db, list(set(profile_ids.values())), organization_id=ctx.organization_id
+            )
+            if profile_ids
+            else {}
+        )
+        windows = await self._context_windows(version_ids, profile_ids, profiles)
+        published_models = _published_models(profile_ids, profiles)
         rows = [
             AgentRead(
                 id=agent.id,
@@ -713,6 +749,11 @@ class AgentRegistryService:
                 context_window_tokens=(
                     windows.get(agent.current_version_id) if agent.current_version_id else None
                 ),
+                published_model=(
+                    published_models.get(agent.current_version_id)
+                    if agent.current_version_id
+                    else None
+                ),
                 created_at=agent.created_at,
                 updated_at=agent.updated_at,
             )
@@ -721,7 +762,10 @@ class AgentRegistryService:
         return rows, total
 
     async def _context_windows(
-        self, ctx: AuthContext, version_ids: list[UUID]
+        self,
+        version_ids: list[UUID],
+        profile_ids: dict[UUID, UUID],
+        profiles: dict[UUID, ModelProfile],
     ) -> dict[UUID, int | None]:
         """How many tokens each published version's model accepts, by version id.
 
@@ -742,16 +786,12 @@ class AgentRegistryService:
 
         `None` where neither can say, and a surface then draws no share at all
         rather than one against a conservative guess.
+
+        `profile_ids` (version to its published profile) and `profiles` (profile
+        to its row) are loaded once by the caller, because the published-model
+        summary the listing also carries is read off the same two lookups.
         """
         overrides = await agent_repo.published_compaction_windows(self.db, version_ids=version_ids)
-        profile_ids = await agent_repo.published_model_profiles(self.db, version_ids=version_ids)
-        profiles = (
-            await credential_repo.get_profiles_by_ids(
-                self.db, list(set(profile_ids.values())), organization_id=ctx.organization_id
-            )
-            if profile_ids
-            else {}
-        )
         return {
             version_id: overrides.get(version_id) or _window_of(profiles.get(profile_id))
             for version_id, profile_id in profile_ids.items()

--- a/backend/tests/test_agent_registry.py
+++ b/backend/tests/test_agent_registry.py
@@ -412,6 +412,66 @@ class TestList:
         assert rows[1].budget_monthly_usd is None
 
     @pytest.mark.anyio
+    async def test_a_published_agents_model_rides_the_listing_and_a_drafts_does_not(self):
+        """What the chat's model picker prefills from - the published version's
+        model, read off the frozen spec, not the draft the Builder is editing and
+        which may name a different one than the conversation runs on."""
+        ctx = _ctx(OrgRoleName.OWNER)
+        version_id = uuid.uuid4()
+        profile_id = uuid.uuid4()
+        published = _agent(ctx, current_version_id=version_id)
+        draft = _agent(ctx)
+
+        with (
+            patch(
+                f"{REGISTRY_PATH}.agent_repo.list_visible",
+                new=AsyncMock(return_value=([published, draft], 2)),
+            ),
+            patch(
+                f"{REGISTRY_PATH}.resource_grant_repo.count_for_resources",
+                new=AsyncMock(return_value={}),
+            ),
+            patch(
+                f"{REGISTRY_PATH}.agent_exposure_repo.active_surfaces_for_agents",
+                new=AsyncMock(return_value={}),
+            ),
+            patch(
+                f"{REGISTRY_PATH}.agent_repo.published_budget_caps",
+                new=AsyncMock(return_value={}),
+            ),
+            patch(
+                f"{REGISTRY_PATH}.agent_repo.published_compaction_windows",
+                new=AsyncMock(return_value={}),
+            ),
+            patch(
+                f"{REGISTRY_PATH}.agent_repo.published_model_profiles",
+                new=AsyncMock(return_value={version_id: profile_id}),
+            ),
+            patch(
+                f"{REGISTRY_PATH}.credential_repo.get_profiles_by_ids",
+                new=AsyncMock(
+                    return_value={
+                        profile_id: MagicMock(
+                            id=profile_id,
+                            provider="anthropic",
+                            model="claude-sonnet-4-5",
+                            label="Claude Sonnet",
+                            context_length=200_000,
+                        )
+                    }
+                ),
+            ),
+        ):
+            rows, _total = await AgentRegistryService(_db()).list_agents(ctx)
+
+        assert rows[0].published_model is not None
+        assert rows[0].published_model.profile_id == profile_id
+        assert rows[0].published_model.provider == "anthropic"
+        assert rows[0].published_model.model == "claude-sonnet-4-5"
+        assert rows[0].published_model.label == "Claude Sonnet"
+        assert rows[1].published_model is None
+
+    @pytest.mark.anyio
     async def test_the_window_a_listed_agents_model_accepts_rides_along(self):
         """What a chat divides its context gauge by.
 
@@ -454,7 +514,11 @@ class TestList:
                 new=AsyncMock(
                     return_value={
                         profile_id: MagicMock(
-                            context_length=128_000, provider="openai", model="gpt-4o"
+                            id=profile_id,
+                            label="GPT-4o",
+                            context_length=128_000,
+                            provider="openai",
+                            model="gpt-4o",
                         )
                     }
                 ),
@@ -504,7 +568,11 @@ class TestList:
                 new=AsyncMock(
                     return_value={
                         profile_id: MagicMock(
-                            context_length=None, provider="openai", model="gpt-4o"
+                            id=profile_id,
+                            label="GPT-4o",
+                            context_length=None,
+                            provider="openai",
+                            model="gpt-4o",
                         )
                     }
                 ),
@@ -554,7 +622,11 @@ class TestList:
                 new=AsyncMock(
                     return_value={
                         profile_id: MagicMock(
-                            context_length=None, provider="ollama", model="llama3.3"
+                            id=profile_id,
+                            label="Llama 3.3",
+                            context_length=None,
+                            provider="ollama",
+                            model="llama3.3",
                         )
                     }
                 ),
@@ -610,7 +682,11 @@ class TestList:
                 new=AsyncMock(
                     return_value={
                         profile_id: MagicMock(
-                            context_length=1_050_000, provider="openrouter", model="openai/gpt-5.5"
+                            id=profile_id,
+                            label="GPT-5.5",
+                            context_length=1_050_000,
+                            provider="openrouter",
+                            model="openai/gpt-5.5",
                         )
                     }
                 ),
@@ -662,6 +738,9 @@ class TestList:
             rows, _total = await AgentRegistryService(_db()).list_agents(ctx)
 
         assert rows[0].context_window_tokens is None
+        # Same gap seen by the picker: a spec that names a deleted profile prefills
+        # from nothing rather than from a model the profile no longer is.
+        assert rows[0].published_model is None
 
     @pytest.mark.anyio
     async def test_the_listing_returns_the_page_and_the_total(self):

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -888,12 +888,14 @@
     "memberEmail": "Email address",
     "memberSuggestions": "Matching members",
     "modelPicker": {
+      "agentModel": "Agent's model",
       "chooseProvider": "Choose a provider",
       "model": "Model",
-      "needsConnectionsManage": "Choosing another model needs a permission you do not hold. This conversation runs on the agent's own model, and somebody who can manage this organization's connections can change that.",
+      "needsConnectionsManage": "Choosing another model needs a permission you do not hold. Somebody who can manage this organization's connections can change it.",
       "noProviderKey": "No {provider} key in the vault yet.",
       "provider": "Provider",
-      "runModel": "Run on this model"
+      "runModel": "Run on this model",
+      "thisChat": "Just this chat"
     },
     "newChat": "New Chat",
     "newConversation": "New conversation",

--- a/frontend/src/components/chat/chat-container.tsx
+++ b/frontend/src/components/chat/chat-container.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useLayoutEffect, useRef, useCallback, useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import type { ChatMessageFile } from "@/types";
+import type { PublishedModel } from "@/types/agents";
 import { useAgents, useChat, useConversationWorkspace, useModelProviders } from "@/hooks";
 import { AgentPicker } from "./agent-picker";
 import { ChatControls } from "./chat-controls";
@@ -75,6 +76,9 @@ export function ChatContainer() {
   // is a share of *its* window rather than of the agent's default.
   const [modelProfileId, setModelProfileId] = useState<string | null>(null);
   const contextWindow = useContextWindow(modelProfileId);
+  const { agents } = useAgents({ includeArchived: true });
+  const selectedAgentId = useAgentSelectionStore((state) => state.selectedAgentId);
+  const agentModel = agents.find((agent) => agent.id === selectedAgentId)?.published_model ?? null;
   // Deliberately unfiltered, which is what calling this with no arguments
   // means. The sidebar's copy of this list is narrowed by whatever is in its
   // search box, and reading the two facts below off *that* would flip the
@@ -270,6 +274,7 @@ export function ChatContainer() {
       // conversation somebody has just reopened instead of after their next message.
       lastUsage={lastUsage ?? latestUsage(currentMessages, currentConversationId)}
       contextWindow={contextWindow}
+      agentModel={agentModel}
       // Only for the thread that is actually open. The store keeps the transcript
       // it last loaded, so between clicking another conversation and its messages
       // arriving this figure belongs to the one just left - the same reason
@@ -324,6 +329,8 @@ interface ChatUIProps {
   conversationCost: ConversationCost | null;
   /** The window the context gauge is a share of, or null when nobody knows it. */
   contextWindow: number | null;
+  /** The selected agent's published model, shown as current in the model picker. */
+  agentModel: PublishedModel | null;
   /**
    * The turn's delegations, drawn under the transcript.
    *
@@ -376,6 +383,7 @@ function ChatUI({
   lastUsage,
   conversationCost,
   contextWindow,
+  agentModel,
   delegations,
   conversationId,
   turns,
@@ -534,6 +542,7 @@ function ChatUI({
                   <div data-tour="chat-model-picker">
                     <ChatControls
                       onModelProfileChange={onModelProfileChange}
+                      agentModel={agentModel}
                       onTemperatureChange={onTemperatureChange}
                       onThinkingEffortChange={onThinkingEffortChange}
                     />

--- a/frontend/src/components/chat/chat-controls.tsx
+++ b/frontend/src/components/chat/chat-controls.tsx
@@ -9,6 +9,7 @@ import { ChatModelPicker } from "./chat-model-picker";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui";
 import { useModelProviders } from "@/hooks";
 import { useConversationStore } from "@/stores";
+import type { PublishedModel } from "@/types/agents";
 import { cn } from "@/lib/utils";
 
 type ThinkingEffort = "off" | "low" | "medium" | "high";
@@ -25,6 +26,8 @@ const EFFORT_OPTIONS: { value: ThinkingEffort; key: string }[] = [
 interface ChatControlsProps {
   /** The model profile this conversation runs on, or null for the agent's own. */
   onModelProfileChange?: (profileId: string | null) => void;
+  /** The selected agent's published model, shown as current when there is no override. */
+  agentModel?: PublishedModel | null;
   onTemperatureChange?: (value: number | null) => void;
   onThinkingEffortChange?: (value: "low" | "medium" | "high" | null) => void;
 }
@@ -52,6 +55,7 @@ interface ChatControlsProps {
  */
 export function ChatControls({
   onModelProfileChange,
+  agentModel = null,
   onTemperatureChange,
   onThinkingEffortChange,
 }: ChatControlsProps) {
@@ -141,6 +145,7 @@ export function ChatControls({
               </p>
               <ChatModelPicker
                 value={profileId}
+                agentModel={agentModel}
                 onChange={(next) => {
                   setProfileId(next);
                   onModelProfileChange?.(next);

--- a/frontend/src/components/chat/chat-model-picker.integration.test.tsx
+++ b/frontend/src/components/chat/chat-model-picker.integration.test.tsx
@@ -98,7 +98,16 @@ async function mount(permissions: Permission[], onChange = vi.fn()) {
   });
   render(
     <QueryClientProvider client={client}>
-      <ChatModelPicker value={null} onChange={onChange} />
+      <ChatModelPicker
+        value={null}
+        agentModel={{
+          profile_id: "ap",
+          provider: "anthropic",
+          model: "claude-sonnet-4-5",
+          label: "Claude Sonnet",
+        }}
+        onChange={onChange}
+      />
     </QueryClientProvider>,
   );
   // Waited for, not assumed: `can()` answers false until the permission set
@@ -126,7 +135,7 @@ describe("who may move this conversation onto another model", () => {
     expect(screen.queryByText(/permission you do not hold/)).toBeNull();
   });
 
-  it("offers none of it without, and says so rather than going blank", async () => {
+  it("offers none of the fields without, but still says what it runs on", async () => {
     // An operator: they may run this agent, which is what opens the popover, and
     // may not define a model for the organization, which is what the form does.
     await mount([Perm.agentsView, Perm.agentsRun]);
@@ -134,10 +143,10 @@ describe("who may move this conversation onto another model", () => {
     expect(screen.queryByRole("combobox", { name: "Provider" })).toBeNull();
     expect(screen.queryByLabelText("Model")).toBeNull();
     expect(submit()).toBeNull();
-    // Paired with the absences deliberately: a panel rendering nothing at all
-    // would satisfy the three above, and the popover opens on this tab - so what
-    // the reader would get is a blank box with no account of itself.
     expect(screen.getByText(/permission you do not hold/)).toBeInTheDocument();
+    // Reading which model the conversation runs on is agents:view, not the
+    // permission being refused - so the model is shown even here.
+    expect(screen.getByText("Claude Sonnet")).toBeInTheDocument();
     expect(apiClient.post).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/components/chat/chat-model-picker.test.tsx
+++ b/frontend/src/components/chat/chat-model-picker.test.tsx
@@ -82,7 +82,7 @@ beforeEach(() => {
 
 describe("the chat's two-step model picker", () => {
   it("offers only model providers in step one, not every vault purpose", async () => {
-    render(<ChatModelPicker value={null} onChange={vi.fn()} />);
+    render(<ChatModelPicker value={null} agentModel={null} onChange={vi.fn()} />);
 
     await userEvent.click(screen.getByRole("combobox", { name: "Provider" }));
 
@@ -95,7 +95,7 @@ describe("the chat's two-step model picker", () => {
     // The same row the Builder draws. Radix mirrors the selected item's text
     // into the trigger, which is what makes the second half free.
     listedSecrets.mockReturnValue([{ id: "s1", purpose: "openai" }]);
-    render(<ChatModelPicker value={null} onChange={vi.fn()} />);
+    render(<ChatModelPicker value={null} agentModel={null} onChange={vi.fn()} />);
 
     await pickProvider("OpenRouter");
 
@@ -109,7 +109,7 @@ describe("the chat's two-step model picker", () => {
   it("keeps the model field closed until a provider is chosen", () => {
     // Step two depends on step one: a model id means nothing without knowing
     // whose catalog it names.
-    render(<ChatModelPicker value={null} onChange={vi.fn()} />);
+    render(<ChatModelPicker value={null} agentModel={null} onChange={vi.fn()} />);
 
     expect(screen.getByLabelText("Model")).toBeDisabled();
   });
@@ -119,7 +119,7 @@ describe("the chat's two-step model picker", () => {
     // conversation would fill the vault with copies of one fact.
     listedProfiles.mockReturnValue([profile("p1", "openai", "gpt-5")]);
     const onChange = vi.fn();
-    render(<ChatModelPicker value={null} onChange={onChange} />);
+    render(<ChatModelPicker value={null} agentModel={null} onChange={onChange} />);
 
     await pickProvider("OpenAI");
     await userEvent.type(screen.getByLabelText("Model"), "gpt-5");
@@ -133,7 +133,7 @@ describe("the chat's two-step model picker", () => {
     listedSecrets.mockReturnValue([{ id: "s-openai", purpose: "openai" }]);
     mutateAsync.mockResolvedValue(profile("p-new", "openai", "gpt-6"));
     const onChange = vi.fn();
-    render(<ChatModelPicker value={null} onChange={onChange} />);
+    render(<ChatModelPicker value={null} agentModel={null} onChange={onChange} />);
 
     await pickProvider("OpenAI");
     await userEvent.type(screen.getByLabelText("Model"), "gpt-6");
@@ -152,7 +152,7 @@ describe("the chat's two-step model picker", () => {
     // A model with no key is a model that cannot answer; the refusal belongs
     // here, not after the first message fails.
     const onChange = vi.fn();
-    render(<ChatModelPicker value={null} onChange={onChange} />);
+    render(<ChatModelPicker value={null} agentModel={null} onChange={onChange} />);
 
     await pickProvider("OpenAI");
     await userEvent.type(screen.getByLabelText("Model"), "gpt-6");
@@ -168,7 +168,7 @@ describe("the chat's two-step model picker", () => {
     // the Vault" when nothing is, is a dead end - and the provider is chosen, so the
     // purpose the key needs is known.
     listedSecrets.mockReturnValue([]);
-    render(<ChatModelPicker value={null} onChange={vi.fn()} />);
+    render(<ChatModelPicker value={null} agentModel={null} onChange={vi.fn()} />);
 
     await pickProvider("OpenAI");
 
@@ -178,7 +178,7 @@ describe("the chat's two-step model picker", () => {
 
   it("offers nothing once the provider has a key", async () => {
     listedSecrets.mockReturnValue([{ id: "s-1", purpose: "openai" }]);
-    render(<ChatModelPicker value={null} onChange={vi.fn()} />);
+    render(<ChatModelPicker value={null} agentModel={null} onChange={vi.fn()} />);
 
     await pickProvider("OpenAI");
 
@@ -188,7 +188,7 @@ describe("the chat's two-step model picker", () => {
   it("will not apply a bare OpenRouter id, same rule as the Builder", async () => {
     // OpenRouter ids carry the origin - openai/gpt-5 - and the backend refuses
     // a bare one; the button says no before the server does.
-    render(<ChatModelPicker value={null} onChange={vi.fn()} />);
+    render(<ChatModelPicker value={null} agentModel={null} onChange={vi.fn()} />);
 
     await pickProvider("OpenRouter");
     await userEvent.type(screen.getByLabelText("Model"), "gpt-5");
@@ -198,7 +198,7 @@ describe("the chat's two-step model picker", () => {
 
   it("suggests the provider's published models without constraining the field", async () => {
     listedModels.mockReturnValue([{ id: "gpt-5", name: "GPT-5" }]);
-    render(<ChatModelPicker value={null} onChange={vi.fn()} />);
+    render(<ChatModelPicker value={null} agentModel={null} onChange={vi.fn()} />);
 
     await pickProvider("OpenAI");
 
@@ -211,10 +211,59 @@ describe("the chat's two-step model picker", () => {
 
   it("names the profile the conversation currently runs on", () => {
     listedProfiles.mockReturnValue([profile("p1", "openai", "gpt-5")]);
-    render(<ChatModelPicker value="p1" onChange={vi.fn()} />);
+    render(
+      <ChatModelPicker
+        value="p1"
+        agentModel={{ profile_id: "ap", provider: "anthropic", model: "claude", label: "Agent" }}
+        onChange={vi.fn()}
+      />,
+    );
 
     expect(screen.getByText("Team gpt-5")).toBeInTheDocument();
     expect(screen.getByText("openai · gpt-5")).toBeInTheDocument();
+    expect(screen.getByText("Just this chat")).toBeInTheDocument();
+    expect(screen.queryByText("Agent")).not.toBeInTheDocument();
+  });
+
+  it("shows the agent's own model when there is no override", () => {
+    render(
+      <ChatModelPicker
+        value={null}
+        agentModel={{
+          profile_id: "ap",
+          provider: "anthropic",
+          model: "claude-sonnet-4-5",
+          label: "Claude Sonnet",
+        }}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Claude Sonnet")).toBeInTheDocument();
+    expect(screen.getByText("anthropic · claude-sonnet-4-5")).toBeInTheDocument();
+    expect(screen.getByText("Agent's model")).toBeInTheDocument();
+  });
+
+  it("shows the model to a caller who may not change it, and withholds only the fields", () => {
+    // Reading which model the conversation runs on is agents:view, not
+    // connections:manage - the person who may not change it most wants to know.
+    held.permissions = [];
+    render(
+      <ChatModelPicker
+        value={null}
+        agentModel={{
+          profile_id: "ap",
+          provider: "anthropic",
+          model: "claude-sonnet-4-5",
+          label: "Claude Sonnet",
+        }}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Claude Sonnet")).toBeInTheDocument();
+    expect(screen.getByText(/permission you do not hold/)).toBeInTheDocument();
+    expect(screen.queryByRole("combobox", { name: "Provider" })).toBeNull();
   });
 });
 
@@ -226,7 +275,7 @@ describe("storing the key the chosen model runs on", () => {
    */
 
   it("offers the key form to a caller who may write to the vault", async () => {
-    render(<ChatModelPicker value={null} onChange={vi.fn()} />);
+    render(<ChatModelPicker value={null} agentModel={null} onChange={vi.fn()} />);
     await pickProvider("OpenAI");
 
     expect(screen.getByRole("button", { name: "Add a key: OpenAI" })).toBeInTheDocument();
@@ -237,7 +286,7 @@ describe("storing the key the chosen model runs on", () => {
     // profile on a key somebody else stored, and taking the whole picker away
     // for want of `secrets:edit` would refuse something they hold.
     held.permissions = [Perm.connectionsManage];
-    render(<ChatModelPicker value={null} onChange={vi.fn()} />);
+    render(<ChatModelPicker value={null} agentModel={null} onChange={vi.fn()} />);
     await pickProvider("OpenAI");
 
     expect(screen.getByRole("button", { name: "Run on this model" })).toBeInTheDocument();

--- a/frontend/src/components/chat/chat-model-picker.tsx
+++ b/frontend/src/components/chat/chat-model-picker.tsx
@@ -30,12 +30,15 @@ import {
   useSecrets,
 } from "@/hooks";
 import { modelDetail } from "@/lib/model-profiles";
+import type { PublishedModel } from "@/types/agents";
 import { Perm } from "@/types/permissions";
 import { useTranslations } from "next-intl";
 
 interface ChatModelPickerProps {
-  /** The model profile this conversation runs on, or null for the agent's own. */
+  /** The model profile this conversation overrides to, or null for the agent's own. */
   value: string | null;
+  /** The agent's published model, shown as the current one when there is no override. */
+  agentModel: PublishedModel | null;
   onChange: (profileId: string | null) => void;
 }
 
@@ -50,25 +53,20 @@ interface ChatModelPickerProps {
  * one on the provider's vault key. A provider with no key in the vault cannot
  * answer, and the refusal says so here rather than after the first message.
  *
- * **It checks `connections:manage` itself, over the whole form.** Creating that
- * profile is `POST /providers/model-profiles`, which is gated on
- * `Perm.CONNECTIONS_MANAGE` and on nothing else, while opening a conversation is
+ * **It checks `connections:manage` over the fields, not over the whole panel.**
+ * Creating a profile is `POST /providers/model-profiles`, gated on
+ * `Perm.CONNECTIONS_MANAGE` and nothing else, while opening a conversation is
  * `agents:run` - so anybody who could type a message was offered these fields and
- * refused by the API after filling them in (#419). The gate is here rather than in
- * `ChatControls` because the permission belongs to the write and this component is
- * the only thing that makes it; the Model tab is also the one that opens by
- * default, so gating the tab button would leave the panel rendering anyway.
+ * refused by the API after filling them in (#419). The gate covers the fields and
+ * not only the submit, which is what #329 decided for the Builder's copy: three
+ * fields that lead nowhere are worse than none.
  *
- * It covers the fields and not only the submit, which is what #329 decided for the
- * Builder's copy of this control: three fields that lead nowhere are worse than
- * none. That does take the reuse path with it - matching an existing profile is a
- * read, and `GET /providers/model-profiles` is `agents:view` - but nothing here
- * lists those profiles, so reaching one means typing a provider and a model id
- * that happen to match, and every other combination is the 403 this exists to
- * stop. A sentence replaces the form, because a panel that goes blank explains
- * itself to nobody.
+ * But reading which model the conversation runs on is `agents:view`, not that
+ * permission's business, and the person who may not change it is the one most
+ * likely to want to know (#926) - so the current-model summary renders above the
+ * gate, and only the fields that write are withheld.
  */
-export function ChatModelPicker({ value, onChange }: ChatModelPickerProps) {
+export function ChatModelPicker({ value, agentModel, onChange }: ChatModelPickerProps) {
   const tErrors = useTranslations("errors");
   const t = useTranslations("chat.modelPicker");
   // Root, for the absolute keys `modelPlaceholder` answers with. Resolving them
@@ -87,16 +85,10 @@ export function ChatModelPicker({ value, onChange }: ChatModelPickerProps) {
   const providers = purposes.filter((entry) => entry.category === "model_provider");
   const provider = providers.find((entry) => entry.id === providerId);
   const { models: suggestions } = useProviderModels(providerId);
-  const active = profiles.find((profile) => profile.id === value) ?? null;
-  const activeDetail = active ? modelDetail(active) : null;
-
-  // Before the fields, not on the button: a disabled submit under three filled-in
-  // fields still says "you could do this", and the answer here is that somebody
-  // else has to. `can` answers false while the permission set is still loading,
-  // so the form arrives once rather than appearing and being taken back.
-  if (!can(Perm.connectionsManage)) {
-    return <p className="text-muted-foreground text-xs">{t("needsConnectionsManage")}</p>;
-  }
+  // An override profile and the agent's published model both carry
+  // provider/model/label, so one summary renders whichever is current.
+  const current = value === null ? agentModel : (profiles.find((p) => p.id === value) ?? null);
+  const currentDetail = current ? modelDetail(current) : null;
 
   const canApply =
     provider !== undefined &&
@@ -144,103 +136,113 @@ export function ChatModelPicker({ value, onChange }: ChatModelPickerProps) {
 
   return (
     <div className="space-y-4">
-      {active && (
+      {current && (
         <p className="border-border bg-accent/40 flex items-center gap-2 rounded-lg border px-3 py-2 text-xs">
-          <ProviderIcon provider={active.provider} />
+          <ProviderIcon provider={current.provider} />
           <span className="min-w-0 flex-1 truncate">
-            <span className="font-medium">{active.label}</span>
-            {activeDetail !== null && (
-              <span className="text-muted-foreground block truncate font-mono">{activeDetail}</span>
+            <span className="font-medium">{current.label}</span>
+            {currentDetail !== null && (
+              <span className="text-muted-foreground block truncate font-mono">
+                {currentDetail}
+              </span>
             )}
           </span>
-          <Check className="text-foreground h-3.5 w-3.5 shrink-0" aria-hidden />
+          <span className="text-muted-foreground shrink-0 font-mono text-[10px] tracking-wider uppercase">
+            {value === null ? t("agentModel") : t("thisChat")}
+          </span>
         </p>
       )}
 
-      <div className="space-y-1.5">
-        <Label htmlFor="chat-model-provider">{t("provider")}</Label>
-        <Select
-          value={providerId}
-          onValueChange={(next) => {
-            setProviderId(next);
-            setModel("");
-            setFailure(null);
-          }}
-        >
-          <SelectTrigger id="chat-model-provider">
-            <SelectValue placeholder={t("chooseProvider")} />
-          </SelectTrigger>
-          <SelectContent className="max-h-80">
-            {providers.map((entry) => {
-              const keyed = secrets.some((secret) => secret.purpose === entry.id);
-              return (
-                <SelectItem
-                  key={entry.id}
-                  value={entry.id}
-                  // Type-to-search keys off this rather than off the mark's own
-                  // title, which is otherwise part of the item's text.
-                  textValue={entry.label}
-                  // Outside the row: the trigger mirrors an item's text, and a
-                  // tick there reads as "selected" rather than "has a key".
-                  trailing={
-                    keyed && (
-                      <Check className="text-muted-foreground ml-auto h-3.5 w-3.5 shrink-0" />
-                    )
-                  }
-                >
-                  <ProviderRow provider={entry.id} name={entry.label} />
-                </SelectItem>
-              );
-            })}
-          </SelectContent>
-        </Select>
-      </div>
+      {!can(Perm.connectionsManage) ? (
+        <p className="text-muted-foreground text-xs">{t("needsConnectionsManage")}</p>
+      ) : (
+        <>
+          <div className="space-y-1.5">
+            <Label htmlFor="chat-model-provider">{t("provider")}</Label>
+            <Select
+              value={providerId}
+              onValueChange={(next) => {
+                setProviderId(next);
+                setModel("");
+                setFailure(null);
+              }}
+            >
+              <SelectTrigger id="chat-model-provider">
+                <SelectValue placeholder={t("chooseProvider")} />
+              </SelectTrigger>
+              <SelectContent className="max-h-80">
+                {providers.map((entry) => {
+                  const keyed = secrets.some((secret) => secret.purpose === entry.id);
+                  return (
+                    <SelectItem
+                      key={entry.id}
+                      value={entry.id}
+                      // Type-to-search keys off this rather than off the mark's own
+                      // title, which is otherwise part of the item's text.
+                      textValue={entry.label}
+                      // Outside the row: the trigger mirrors an item's text, and a
+                      // tick there reads as "selected" rather than "has a key".
+                      trailing={
+                        keyed && (
+                          <Check className="text-muted-foreground ml-auto h-3.5 w-3.5 shrink-0" />
+                        )
+                      }
+                    >
+                      <ProviderRow provider={entry.id} name={entry.label} />
+                    </SelectItem>
+                  );
+                })}
+              </SelectContent>
+            </Select>
+          </div>
 
-      <div className="space-y-1.5">
-        <Label htmlFor="chat-model-id">{t("model")}</Label>
-        {/* A list where the provider publishes one, and a plain field where it
-            does not - the same control either way, because the list is never
-            authoritative. */}
-        <Input
-          id="chat-model-id"
-          list={suggestions.length > 0 ? "chat-model-suggestions" : undefined}
-          value={model}
-          onChange={(event) => {
-            setModel(event.target.value);
-            setFailure(null);
-          }}
-          disabled={provider === undefined}
-          placeholder={placeholderWords(modelPlaceholder(provider?.id), tRoot)}
-          className="font-mono"
-        />
-        {suggestions.length > 0 && (
-          <datalist id="chat-model-suggestions">
-            {suggestions.map((entry) => (
-              <option key={entry.id} value={entry.id}>
-                {entry.name}
-              </option>
-            ))}
-          </datalist>
-        )}
-        {failure !== null && <p className="text-destructive text-xs">{failure}</p>}
-      </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="chat-model-id">{t("model")}</Label>
+            {/* A list where the provider publishes one, and a plain field where it
+                does not - the same control either way, because the list is never
+                authoritative. */}
+            <Input
+              id="chat-model-id"
+              list={suggestions.length > 0 ? "chat-model-suggestions" : undefined}
+              value={model}
+              onChange={(event) => {
+                setModel(event.target.value);
+                setFailure(null);
+              }}
+              disabled={provider === undefined}
+              placeholder={placeholderWords(modelPlaceholder(provider?.id), tRoot)}
+              className="font-mono"
+            />
+            {suggestions.length > 0 && (
+              <datalist id="chat-model-suggestions">
+                {suggestions.map((entry) => (
+                  <option key={entry.id} value={entry.id}>
+                    {entry.name}
+                  </option>
+                ))}
+              </datalist>
+            )}
+            {failure !== null && <p className="text-destructive text-xs">{failure}</p>}
+          </div>
 
-      {/* A key can be added here rather than on another page. A picker that can only
-          offer what is already stored, and answers "add one in the Vault" when
-          nothing is, is a dead end - and the provider is already chosen, so the
-          purpose this key needs is known. */}
-      {provider !== undefined && !secrets.some((secret) => secret.purpose === provider.id) && (
-        <InlineSecret
-          kind="api_key"
-          purpose={provider.id}
-          suggestedName={provider.label}
-          onCreated={() => setFailure(null)}
-        />
+          {/* A key can be added here rather than on another page. A picker that can
+              only offer what is already stored, and answers "add one in the Vault"
+              when nothing is, is a dead end - and the provider is already chosen, so
+              the purpose this key needs is known. */}
+          {provider !== undefined && !secrets.some((secret) => secret.purpose === provider.id) && (
+            <InlineSecret
+              kind="api_key"
+              purpose={provider.id}
+              suggestedName={provider.label}
+              onCreated={() => setFailure(null)}
+            />
+          )}
+
+          <Button type="button" size="sm" disabled={!canApply} onClick={apply}>
+            {t("runModel")}
+          </Button>
+        </>
       )}
-
-      <Button type="button" size="sm" disabled={!canApply} onClick={apply}>
-        {t("runModel")}
-      </Button>
     </div>
   );
 }

--- a/frontend/src/types/agents.ts
+++ b/frontend/src/types/agents.ts
@@ -267,6 +267,14 @@ export interface AgentSpec {
   observability?: ObservabilitySpec | null;
 }
 
+/** The model an agent's published version runs on. Enough to prefill a picker. */
+export interface PublishedModel {
+  profile_id: string;
+  provider: string;
+  model: string;
+  label: string;
+}
+
 export interface Agent {
   id: string;
   slug: string;
@@ -303,6 +311,13 @@ export interface Agent {
    * only.
    */
   context_window_tokens?: number | null;
+  /**
+   * The model the published version runs on, so the chat's model picker can open
+   * showing what the conversation is on and offer a way back after an override.
+   * Read off the frozen spec, not the draft; null for a draft agent and when the
+   * profile has been deleted. Listing only.
+   */
+  published_model?: PublishedModel | null;
   created_at?: string;
   /**
    * `null` until the row is first updated - `TimestampSchema.updated_at` is


### PR DESCRIPTION
## What changed

The chat's **Model** tab (Controls popover) opened empty and never said which model the conversation runs on — the one thing the panel is named after. The picker keyed its "currently running" line on the *override*, which is `null` until somebody sets one, so the normal case (every conversation before its first override) rendered blank and asked the reader to choose against a baseline it never showed. A caller without `connections:manage` got a bare refusal in place of the whole panel, though reading which model an agent runs on is `agents:view`.

## Backend

- New `published_model` on `AgentRead` — profile id, provider, model id, label — filled by the listing on the same "listing only" bargain as `budget_monthly_usd` / `context_window_tokens`. Read off the **frozen spec's** profile, not the draft's (which may name a different model than the agent runs); `null` for a draft agent and when the profile has been deleted.
- `_context_windows` already loaded the version→profile and profile→row maps; those now load once in the list flow and feed both it and the new `_published_models`, so the summary costs no extra query.

## Frontend

- The picker prefills its current-model summary from the agent's published model when there is no override, from the override profile when there is; the agent's model is threaded from the listing through `ChatControls`.
- Labels which is which (**"Agent's model"** / **"Just this chat"**). The one-click way back to the agent's model already lives in `ChatControls`.
- The summary is lifted **above** the `connections:manage` gate, so a viewer still sees what the conversation runs on; only the fields that write are withheld.

## Verification

- Backend: a published agent's model rides the listing and a draft's does not (proves the frozen-spec bargain); a deleted profile leaves the field `None`. Full backend suite 5652 passed, 100% platform gate held.
- Frontend: the agent's model shows with no override; the override shows, labelled as this chat's; a caller without `connections:manage` sees the model while the fields stay withheld. `make lint-frontend` clean; coverage gate green.

Closes #926