### PR TITLE
feat(rag): say who will be able to read what a source ingests

### DIFF
--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -901,12 +901,23 @@ naming the row it came from: it points a credential somebody already scoped at a
 different collection, so its audience changes while nothing about the credential
 does (#983).
 
-What this rule still owes, and does not yet have, is the other half - saying the
-consequence *before* the fact rather than after it:
-[#982](https://github.com/vstorm-co/agenticos/issues/982) states it in the
-wizard where the collection is chosen, and re-asks when a source is repointed at
-a different one. Today that step is silent, which is exactly the implicitness
-this section exists to name.
+**And it is said before the fact, not only after it.** The wizard's last step -
+the one that decides the collection - names the credential and the audience
+together, because the pair is the decision: *"<credential> can read whatever it
+has been granted, and everything it ingests becomes searchable in <collection>
+by ..."*. Each scope ends that sentence differently - `personal` is its owner,
+`org` is everyone who can view the collection, `app` is anybody in the
+deployment - and an integration filed under no knowledge base says that nothing
+can search it yet. The sentence does not wait for the collection *picker*, which
+only appears where there is more than one collection to choose from: the case
+this was filed from is a knowledge base offering exactly one, where there is
+nothing to pick and the consequence is the same (#982).
+
+Cloning says it too, and for the reason above: it is the only way to change a
+source's audience from this product's own UI. Repointing an existing one is a
+`PATCH` on `collection_name`, which no screen sends today - there is no source
+editor - so it is reachable through the API and the CLI, where the audit entry
+above is what records it.
 
 ### What a new connector owes
 

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -905,7 +905,9 @@ does (#983).
 the one that decides the collection - names the credential and the audience
 together, because the pair is the decision: *"<credential> can read whatever it
 has been granted, and everything it ingests becomes searchable in <collection>
-by ..."*. Each scope ends that sentence differently - `personal` is its owner,
+by ..."*. A connector that authenticates with nothing has no credential to name
+and the sentence does not invent one; nor does it name one whose reader holds no
+`secrets:view`. Each scope ends that sentence differently - `personal` is its owner,
 `org` is everyone who can view the collection, `app` is anybody in the
 deployment - and an integration filed under no knowledge base says that nothing
 can search it yet. The sentence does not wait for the collection *picker*, which

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -3913,6 +3913,11 @@
   },
   "rag": {
     "addSyncSource": "Add sync source",
+    "audienceApp": "{named, select, no {The credential this source uses} other {{credential}}} can read whatever it has been granted, and everything it ingests becomes searchable in {collection} by anybody in this deployment.",
+    "audienceOrg": "{named, select, no {The credential this source uses} other {{credential}}} can read whatever it has been granted, and everything it ingests becomes searchable in {collection} by everyone in this organization who can view that collection.",
+    "audiencePersonal": "{named, select, no {The credential this source uses} other {{credential}}} can read whatever it has been granted, and everything it ingests becomes searchable in {collection} — by you alone.",
+    "audienceTitle": "Who will be able to read this",
+    "audienceUnassigned": "This integration is filed under no knowledge base yet, so nothing can search what it ingests. Who can read it is decided when it is cloned into one.",
     "back": "Back",
     "cadenceDaily": "Daily",
     "cadenceManual": "Manual",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -3913,9 +3913,9 @@
   },
   "rag": {
     "addSyncSource": "Add sync source",
-    "audienceApp": "{named, select, no {The credential this source uses} other {{credential}}} can read whatever it has been granted, and everything it ingests becomes searchable in {collection} by anybody in this deployment.",
-    "audienceOrg": "{named, select, no {The credential this source uses} other {{credential}}} can read whatever it has been granted, and everything it ingests becomes searchable in {collection} by everyone in this organization who can view that collection.",
-    "audiencePersonal": "{named, select, no {The credential this source uses} other {{credential}}} can read whatever it has been granted, and everything it ingests becomes searchable in {collection} — by you alone.",
+    "audienceApp": "{credentialing, select, none {Everything this source ingests} unknown {The credential this source uses can read whatever it has been granted, and everything it ingests} other {{credential} can read whatever it has been granted, and everything it ingests}} becomes searchable in {collection} by anybody in this deployment.",
+    "audienceOrg": "{credentialing, select, none {Everything this source ingests} unknown {The credential this source uses can read whatever it has been granted, and everything it ingests} other {{credential} can read whatever it has been granted, and everything it ingests}} becomes searchable in {collection} by everyone in this organization who can view that collection.",
+    "audiencePersonal": "{credentialing, select, none {Everything this source ingests} unknown {The credential this source uses can read whatever it has been granted, and everything it ingests} other {{credential} can read whatever it has been granted, and everything it ingests}} becomes searchable in {collection} — by you alone.",
     "audienceTitle": "Who will be able to read this",
     "audienceUnassigned": "This integration is filed under no knowledge base yet, so nothing can search what it ingests. Who can read it is decided when it is cloned into one.",
     "back": "Back",

--- a/frontend/src/app/[locale]/(dashboard)/rag/[id]/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/rag/[id]/page.tsx
@@ -412,7 +412,7 @@ export default function KBDetailPage({ params }: KBDetailPageProps) {
         open={wizardOpen}
         onOpenChange={setWizardOpen}
         connectors={connectors}
-        collections={[{ name: kb.collection_name }]}
+        collections={[{ name: kb.collection_name, scope: kb.scope }]}
         defaultCollection={kb.collection_name}
         orgIntegrations={orgIntegrations}
         connectorsFailed={sectionFailures.connectors}

--- a/frontend/src/components/derived-state.integration.test.tsx
+++ b/frontend/src/components/derived-state.integration.test.tsx
@@ -54,7 +54,10 @@ describe("the sync source wizard", () => {
       open: true,
       onOpenChange: vi.fn(),
       connectors: CONNECTORS,
-      collections: [{ name: "alpha" }, { name: "beta" }],
+      collections: [
+        { name: "alpha", scope: "org" as const },
+        { name: "beta", scope: "org" as const },
+      ],
       orgIntegrations: [],
       onSubmit: vi.fn(),
       onClone: vi.fn(),

--- a/frontend/src/components/rag/sync-source-audience-notice.test.tsx
+++ b/frontend/src/components/rag/sync-source-audience-notice.test.tsx
@@ -1,7 +1,41 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import type { ReactElement } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SourceAudienceNotice } from "./sync-source-audience-notice";
+import { apiClient } from "@/lib/api-client";
+
+vi.mock("@/lib/api-client", () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+
+const CREDENTIAL = {
+  id: "secret-1",
+  name: "Drive service account",
+  kind: "gcp_service_account",
+  purpose: "custom",
+  hint: "a1b2",
+  visibility: "org",
+  created_at: "2026-08-20T00:00:00Z",
+};
+
+/** The notice reads the vault itself, so the vault has to answer. */
+function serve({ secrets = [CREDENTIAL] } = {}) {
+  vi.mocked(apiClient.get).mockImplementation(async (path: string) => {
+    if (path === "/secrets") return { items: secrets, total: secrets.length };
+    return {};
+  });
+}
+
+function withQuery(ui: ReactElement) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+beforeEach(() => {
+  serve();
+});
 
 /**
  * Each scope names a different set of people, so each has its own sentence.
@@ -11,62 +45,96 @@ import { SourceAudienceNotice } from "./sync-source-audience-notice";
  * always the same is one nobody reads twice (#982).
  */
 describe("SourceAudienceNotice", () => {
-  it("names everyone who can view an org collection", () => {
-    render(
+  it("names everyone who can view an org collection", async () => {
+    withQuery(
       <SourceAudienceNotice
         scope="org"
         collectionName="org_handbook"
-        credentialName="Drive service account"
+        secretId="secret-1"
+        needsCredential
       />,
     );
 
-    const sentence = screen.getByText(/Drive service account/);
+    const sentence = await screen.findByText(/Drive service account/);
     expect(sentence).toHaveTextContent("org_handbook");
     expect(sentence).toHaveTextContent(
       "everyone in this organization who can view that collection",
     );
   });
 
-  it("says only the owner for a personal collection", () => {
-    render(
-      <SourceAudienceNotice scope="personal" collectionName="my_notes" credentialName="My token" />,
+  it("says only the owner for a personal collection", async () => {
+    withQuery(
+      <SourceAudienceNotice
+        scope="personal"
+        collectionName="my_notes"
+        secretId="secret-1"
+        needsCredential
+      />,
     );
 
-    expect(screen.getByText(/my_notes/)).toHaveTextContent("by you alone");
+    expect(await screen.findByText(/my_notes/)).toHaveTextContent("by you alone");
   });
 
-  it("says the whole deployment for an app collection", () => {
-    render(
-      <SourceAudienceNotice scope="app" collectionName="shared_docs" credentialName="Ops key" />,
+  it("says the whole deployment for an app collection", async () => {
+    withQuery(
+      <SourceAudienceNotice
+        scope="app"
+        collectionName="shared_docs"
+        secretId="secret-1"
+        needsCredential
+      />,
     );
 
-    expect(screen.getByText(/shared_docs/)).toHaveTextContent("anybody in this deployment");
+    expect(await screen.findByText(/shared_docs/)).toHaveTextContent("anybody in this deployment");
   });
 
-  it("says an integration under no knowledge base can be searched by nobody yet", () => {
-    render(<SourceAudienceNotice credentialName="Drive service account" />);
+  it("describes a connector that authenticates with nothing without inventing a credential", async () => {
+    // `secret_kind: "none"` is a supported case - a public crawler - and the
+    // credential step says so in as many words. A sentence about "the credential
+    // this source uses" would contradict the step before it.
+    withQuery(
+      <SourceAudienceNotice scope="org" collectionName="org_handbook" needsCredential={false} />,
+    );
 
-    expect(screen.getByText(/filed under no knowledge base yet/)).toHaveTextContent(
+    const sentence = await screen.findByText(/Everything this source ingests/);
+    expect(sentence).toHaveTextContent("org_handbook");
+    expect(screen.queryByText(/The credential this source uses/)).toBeNull();
+  });
+
+  it("names no credential when the vault cannot be read", async () => {
+    // A member without `secrets:view` still chooses a collection, and the
+    // consequence is the same one - so the sentence drops the name rather than
+    // interpolating an empty one.
+    serve({ secrets: [] });
+    withQuery(
+      <SourceAudienceNotice
+        scope="org"
+        collectionName="org_handbook"
+        secretId="secret-1"
+        needsCredential
+      />,
+    );
+
+    expect(await screen.findByText(/The credential this source uses/)).toHaveTextContent(
+      "org_handbook",
+    );
+  });
+
+  it("says an integration under no knowledge base can be searched by nobody yet", async () => {
+    withQuery(<SourceAudienceNotice secretId="secret-1" needsCredential />);
+
+    expect(await screen.findByText(/filed under no knowledge base yet/)).toHaveTextContent(
       "decided when it is cloned into one",
     );
   });
 
-  it("names no credential when the vault cannot be read", () => {
-    // A member without `secrets:view` still chooses a collection, and the
-    // consequence is the same one - so the sentence drops the name rather than
-    // interpolating an empty one.
-    render(<SourceAudienceNotice scope="org" collectionName="org_handbook" />);
-
-    expect(screen.getByText(/The credential this source uses/)).toHaveTextContent("org_handbook");
-  });
-
-  it("says nothing about a collection it was given no scope for", () => {
+  it("says nothing about a collection it was given no scope for", async () => {
     // A name with no scope beside it cannot be described: the picker offers only
     // collections this caller may file under, and one missing from that list is
     // one whose audience this component does not know.
-    render(<SourceAudienceNotice collectionName="mystery" />);
+    withQuery(<SourceAudienceNotice collectionName="mystery" needsCredential />);
 
-    expect(screen.getByText(/filed under no knowledge base yet/)).toBeInTheDocument();
-    expect(screen.queryByText(/mystery/)).not.toBeInTheDocument();
+    expect(await screen.findByText(/filed under no knowledge base yet/)).toBeInTheDocument();
+    expect(screen.queryByText(/mystery/)).toBeNull();
   });
 });

--- a/frontend/src/components/rag/sync-source-audience-notice.test.tsx
+++ b/frontend/src/components/rag/sync-source-audience-notice.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SourceAudienceNotice } from "./sync-source-audience-notice";
+
+/**
+ * Each scope names a different set of people, so each has its own sentence.
+ *
+ * A `personal` collection saying what an `org` one says is the defect this
+ * component exists to prevent read the other way round: a sentence that is
+ * always the same is one nobody reads twice (#982).
+ */
+describe("SourceAudienceNotice", () => {
+  it("names everyone who can view an org collection", () => {
+    render(
+      <SourceAudienceNotice
+        scope="org"
+        collectionName="org_handbook"
+        credentialName="Drive service account"
+      />,
+    );
+
+    const sentence = screen.getByText(/Drive service account/);
+    expect(sentence).toHaveTextContent("org_handbook");
+    expect(sentence).toHaveTextContent(
+      "everyone in this organization who can view that collection",
+    );
+  });
+
+  it("says only the owner for a personal collection", () => {
+    render(
+      <SourceAudienceNotice scope="personal" collectionName="my_notes" credentialName="My token" />,
+    );
+
+    expect(screen.getByText(/my_notes/)).toHaveTextContent("by you alone");
+  });
+
+  it("says the whole deployment for an app collection", () => {
+    render(
+      <SourceAudienceNotice scope="app" collectionName="shared_docs" credentialName="Ops key" />,
+    );
+
+    expect(screen.getByText(/shared_docs/)).toHaveTextContent("anybody in this deployment");
+  });
+
+  it("says an integration under no knowledge base can be searched by nobody yet", () => {
+    render(<SourceAudienceNotice credentialName="Drive service account" />);
+
+    expect(screen.getByText(/filed under no knowledge base yet/)).toHaveTextContent(
+      "decided when it is cloned into one",
+    );
+  });
+
+  it("names no credential when the vault cannot be read", () => {
+    // A member without `secrets:view` still chooses a collection, and the
+    // consequence is the same one - so the sentence drops the name rather than
+    // interpolating an empty one.
+    render(<SourceAudienceNotice scope="org" collectionName="org_handbook" />);
+
+    expect(screen.getByText(/The credential this source uses/)).toHaveTextContent("org_handbook");
+  });
+
+  it("says nothing about a collection it was given no scope for", () => {
+    // A name with no scope beside it cannot be described: the picker offers only
+    // collections this caller may file under, and one missing from that list is
+    // one whose audience this component does not know.
+    render(<SourceAudienceNotice collectionName="mystery" />);
+
+    expect(screen.getByText(/filed under no knowledge base yet/)).toBeInTheDocument();
+    expect(screen.queryByText(/mystery/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/rag/sync-source-audience-notice.tsx
+++ b/frontend/src/components/rag/sync-source-audience-notice.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Eye } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import type { KBScope } from "@/types/knowledge-base";
+
+/** One message per scope, because each names a different set of people. */
+const AUDIENCE = {
+  personal: "audiencePersonal",
+  org: "audienceOrg",
+  app: "audienceApp",
+} as const satisfies Record<KBScope, string>;
+
+/**
+ * Who will be able to search what this source ingests.
+ *
+ * Access is decided at the **collection** and there is no per-document isolation
+ * inside one, so everything the credential can reach becomes readable by
+ * everyone who can read the collection it is filed under
+ * (`docs/file-processing.md#who-may-reach-a-collection`). The platform
+ * deliberately does not mirror a source's own ACLs - a Drive file's sharing, a
+ * Confluence space's restrictions - because a mirrored ACL goes stale between
+ * syncs and stale authorization is worse than none.
+ *
+ * That makes the decision the operator's, which was already true; what was wrong
+ * is that the wizard made it **silently**. A Confluence token issued for a whole
+ * instance, pointed at an `org` collection, published the instance to every
+ * member holding `collections:view` and nothing on any step said so (#982).
+ *
+ * The credential is named as well as the audience, because the pair is the
+ * decision: the credential's own permissions are a ceiling nothing in this
+ * product can raise, while `config` narrows the reach and cannot be relied on to
+ * keep it narrow - it is a field anyone with `collections:edit` can widen later.
+ */
+export function SourceAudienceNotice({
+  scope,
+  collectionName,
+  credentialName,
+}: {
+  /** The collection's scope, or `undefined` for a source filed under none. */
+  scope?: KBScope;
+  collectionName?: string;
+  /**
+   * The chosen vault credential. Absent when this caller cannot read the vault,
+   * or before one has been picked - the sentence then says "the credential this
+   * source uses" rather than naming it, because a message with an empty
+   * parameter in it is worse than one that never promised a name.
+   */
+  credentialName?: string;
+}) {
+  const t = useTranslations("rag");
+
+  return (
+    <div className="border-foreground/10 bg-foreground/[0.03] mt-5 rounded-xl border p-4">
+      <p className="text-foreground/80 flex items-center gap-2 text-xs font-medium tracking-wider uppercase">
+        <Eye className="h-3.5 w-3.5" aria-hidden />
+        {t("audienceTitle")}
+      </p>
+      <p className="text-foreground/70 mt-2 text-sm">
+        {scope === undefined || collectionName === undefined
+          ? t("audienceUnassigned")
+          : t(AUDIENCE[scope], {
+              named: credentialName === undefined ? "no" : "yes",
+              credential: credentialName ?? "",
+              collection: collectionName,
+            })}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/rag/sync-source-audience-notice.tsx
+++ b/frontend/src/components/rag/sync-source-audience-notice.tsx
@@ -3,6 +3,7 @@
 import { Eye } from "lucide-react";
 import { useTranslations } from "next-intl";
 
+import { useSecrets } from "@/hooks";
 import type { KBScope } from "@/types/knowledge-base";
 
 /** One message per scope, because each names a different set of people. */
@@ -32,24 +33,34 @@ const AUDIENCE = {
  * decision: the credential's own permissions are a ceiling nothing in this
  * product can raise, while `config` narrows the reach and cannot be relied on to
  * keep it narrow - it is a field anyone with `collections:edit` can widen later.
+ *
+ * **The vault is read here rather than by the wizard.** This renders inside the
+ * dialog, so the query starts when a reader is actually looking at the sentence;
+ * the same call in the wizard's own body ran on every load of the knowledge-base
+ * page, dialog shut, including for members who hold no `secrets:view` and get a
+ * refusal for it.
  */
 export function SourceAudienceNotice({
   scope,
   collectionName,
-  credentialName,
+  secretId,
+  needsCredential,
 }: {
   /** The collection's scope, or `undefined` for a source filed under none. */
   scope?: KBScope;
   collectionName?: string;
+  /** Which vault credential the source will authenticate with, if it has one. */
+  secretId?: string | null;
   /**
-   * The chosen vault credential. Absent when this caller cannot read the vault,
-   * or before one has been picked - the sentence then says "the credential this
-   * source uses" rather than naming it, because a message with an empty
-   * parameter in it is worse than one that never promised a name.
+   * Whether this connector authenticates at all. A connector declaring
+   * `secret_kind: "none"` - a public crawler - has none to name, and a sentence
+   * about "the credential this source uses" would contradict the step before it.
    */
-  credentialName?: string;
+  needsCredential: boolean;
 }) {
   const t = useTranslations("rag");
+  const { secrets } = useSecrets();
+  const credential = secrets.find((secret) => secret.id === secretId)?.name;
 
   return (
     <div className="border-foreground/10 bg-foreground/[0.03] mt-5 rounded-xl border p-4">
@@ -61,8 +72,14 @@ export function SourceAudienceNotice({
         {scope === undefined || collectionName === undefined
           ? t("audienceUnassigned")
           : t(AUDIENCE[scope], {
-              named: credentialName === undefined ? "no" : "yes",
-              credential: credentialName ?? "",
+              // Three states, not two: no credential to name, one this caller
+              // cannot read the name of, and one it can.
+              credentialing: !needsCredential
+                ? "none"
+                : credential === undefined
+                  ? "unknown"
+                  : "named",
+              credential: credential ?? "",
               collection: collectionName,
             })}
       </p>

--- a/frontend/src/components/rag/sync-source-wizard.integration.test.tsx
+++ b/frontend/src/components/rag/sync-source-wizard.integration.test.tsx
@@ -9,6 +9,7 @@ import { SyncSourceWizard } from "./sync-source-wizard";
 import { apiClient } from "@/lib/api-client";
 import { ApiError } from "@/lib/api-error";
 import type { ConnectorInfo, SyncSourceCreate } from "@/lib/rag-api";
+import type { KBScope } from "@/types/knowledge-base";
 
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 vi.mock("@/lib/api-client", () => ({
@@ -89,7 +90,7 @@ const CONNECTOR: ConnectorInfo = {
 
 /** Walk the wizard from its first step to the last, where the collection is chosen. */
 async function openScheduleStep(props: {
-  collections: { name: string }[];
+  collections: { name: string; scope: KBScope }[];
   defaultCollection?: string;
   onSubmit: (data: SyncSourceCreate) => void;
 }) {
@@ -116,7 +117,10 @@ async function openScheduleStep(props: {
 describe("the sync wizard's target collection", () => {
   it("is on screen, and starts on the one the caller suggested", async () => {
     await openScheduleStep({
-      collections: [{ name: "handbook" }, { name: "contracts" }],
+      collections: [
+        { name: "handbook", scope: "org" },
+        { name: "contracts", scope: "personal" },
+      ],
       defaultCollection: "contracts",
       onSubmit: vi.fn(),
     });
@@ -130,7 +134,10 @@ describe("the sync wizard's target collection", () => {
   it("files the source under the collection that was chosen, not the suggestion", async () => {
     const onSubmit = vi.fn();
     await openScheduleStep({
-      collections: [{ name: "handbook" }, { name: "contracts" }],
+      collections: [
+        { name: "handbook", scope: "org" },
+        { name: "contracts", scope: "personal" },
+      ],
       defaultCollection: "contracts",
       onSubmit,
     });
@@ -146,7 +153,7 @@ describe("the sync wizard's target collection", () => {
     // `kb/[id]`, whose sources belong to that base and nowhere else.
     const onSubmit = vi.fn();
     await openScheduleStep({
-      collections: [{ name: "org_handbook" }],
+      collections: [{ name: "org_handbook", scope: "org" }],
       defaultCollection: "org_handbook",
       onSubmit,
     });
@@ -169,6 +176,115 @@ describe("the sync wizard's target collection", () => {
 
     await userEvent.click(screen.getByRole("button", { name: /Create source/ }));
     expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ collection_name: null }));
+  });
+});
+
+/**
+ * The wizard says who will be able to read what the source ingests.
+ *
+ * Access is decided at the collection and there is no per-document isolation
+ * inside one, so the pair - this credential, that collection - *is* the decision.
+ * The wizard used to make it in silence, which is #982: a token issued for a
+ * whole Confluence instance, pointed at an `org` collection, published the
+ * instance to every member holding `collections:view` and no step said a word.
+ */
+describe("the audience of what a source ingests", () => {
+  it("is stated on the step that decides it, even where the collection is pinned", async () => {
+    // The issue's own repro: `kb/[id]` offers one collection, so there is no
+    // picker - which is exactly why the sentence cannot be conditional on one.
+    await openScheduleStep({
+      collections: [{ name: "org_handbook", scope: "org" }],
+      defaultCollection: "org_handbook",
+      onSubmit: vi.fn(),
+    });
+
+    expect(screen.getByText("Who will be able to read this")).toBeVisible();
+    expect(
+      screen.getByText(/everyone in this organization who can view that collection/),
+    ).toHaveTextContent("org_handbook");
+  });
+
+  it("follows the picker, so a personal collection reads differently", async () => {
+    await openScheduleStep({
+      collections: [
+        { name: "handbook", scope: "org" },
+        { name: "contracts", scope: "personal" },
+      ],
+      defaultCollection: "handbook",
+      onSubmit: vi.fn(),
+    });
+
+    expect(screen.getByText(/who can view that collection/)).toBeVisible();
+
+    await userEvent.click(screen.getByRole("combobox"));
+    await userEvent.click(await screen.findByRole("option", { name: "contracts" }));
+
+    expect(screen.getByText(/by you alone/)).toHaveTextContent("contracts");
+    expect(screen.queryByText(/who can view that collection/)).toBeNull();
+  });
+
+  it("names the credential that was chosen", async () => {
+    const view = withQuery(wizard(vi.fn()));
+    await userEvent.type(screen.getByLabelText("Source name"), "Engineering docs");
+    await userEvent.click(screen.getByRole("button", { name: /Google Drive/ }));
+    await userEvent.click(screen.getByRole("button", { name: /Continue/ }));
+    await userEvent.type(screen.getByLabelText(/Google Drive Folder ID/), "1AbC_-def");
+    await userEvent.click(screen.getByRole("button", { name: /Continue/ }));
+    await pickTheCredential();
+    await userEvent.click(screen.getByRole("button", { name: /Continue/ }));
+
+    expect(await screen.findByText(/Drive service account/)).toHaveTextContent("handbook");
+    view.unmount();
+  });
+
+  it("says an unassigned org integration can be searched by nobody yet", async () => {
+    await openScheduleStep({ collections: [], onSubmit: vi.fn() });
+
+    expect(screen.getByText(/filed under no knowledge base yet/)).toBeVisible();
+  });
+
+  it("is stated for a clone too, which repoints somebody else's credential", async () => {
+    // A clone references the same vault secret and names a different collection,
+    // so the audience changes while nothing about the credential does - and it
+    // is the only way to change one from this product's own UI.
+    withQuery(
+      <SyncSourceWizard
+        open
+        onOpenChange={vi.fn()}
+        connectors={[CONNECTOR]}
+        collections={[{ name: "org_handbook", scope: "org" }]}
+        defaultCollection="org_handbook"
+        orgIntegrations={[
+          {
+            id: "src-1",
+            organization_id: "org-1",
+            name: "Company Drive",
+            connector_type: "gdrive",
+            collection_name: null,
+            config: {},
+            secret_id: DRIVE_CREDENTIAL.id,
+            secret_hint: DRIVE_CREDENTIAL.hint,
+            sync_mode: "full",
+            schedule_minutes: null,
+            is_active: true,
+            last_sync_at: null,
+            last_sync_status: null,
+            last_error: null,
+            created_at: null,
+          },
+        ]}
+        onSubmit={vi.fn()}
+        onClone={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /Use existing/ }));
+    // Nothing is said before a source is picked: there is no credential to name.
+    expect(screen.queryByText("Who will be able to read this")).toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: /Company Drive/ }));
+
+    expect(await screen.findByText(/Drive service account/)).toHaveTextContent("org_handbook");
   });
 });
 
@@ -207,7 +323,7 @@ function wizard(onSubmit: (data: SyncSourceCreate) => Promise<void>, open = true
       open={open}
       onOpenChange={vi.fn()}
       connectors={[GDRIVE]}
-      collections={[{ name: "handbook" }]}
+      collections={[{ name: "handbook", scope: "org" }]}
       defaultCollection="handbook"
       onSubmit={onSubmit}
     />

--- a/frontend/src/components/rag/sync-source-wizard.integration.test.tsx
+++ b/frontend/src/components/rag/sync-source-wizard.integration.test.tsx
@@ -199,9 +199,11 @@ describe("the audience of what a source ingests", () => {
     });
 
     expect(screen.getByText("Who will be able to read this")).toBeVisible();
+    // This connector authenticates with nothing, so the sentence describes what
+    // the source ingests rather than a credential it does not have.
     expect(
       screen.getByText(/everyone in this organization who can view that collection/),
-    ).toHaveTextContent("org_handbook");
+    ).toHaveTextContent("Everything this source ingests becomes searchable in org_handbook");
   });
 
   it("follows the picker, so a personal collection reads differently", async () => {
@@ -243,6 +245,25 @@ describe("the audience of what a source ingests", () => {
     expect(screen.getByText(/filed under no knowledge base yet/)).toBeVisible();
   });
 
+  it("reads the vault only once somebody is looking at the sentence", async () => {
+    // The knowledge-base page mounts this wizard whether or not it is open, so a
+    // vault read in the wizard's own body ran on every page load - including for
+    // members holding no `secrets:view`, who get a refusal for it, retried.
+    vi.mocked(apiClient.get).mockClear();
+    withQuery(
+      <SyncSourceWizard
+        open={false}
+        onOpenChange={vi.fn()}
+        connectors={[GDRIVE]}
+        collections={[{ name: "org_handbook", scope: "org" }]}
+        defaultCollection="org_handbook"
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(vi.mocked(apiClient.get).mock.calls.map(([path]) => path)).not.toContain("/secrets");
+  });
+
   it("is stated for a clone too, which repoints somebody else's credential", async () => {
     // A clone references the same vault secret and names a different collection,
     // so the audience changes while nothing about the credential does - and it
@@ -251,7 +272,7 @@ describe("the audience of what a source ingests", () => {
       <SyncSourceWizard
         open
         onOpenChange={vi.fn()}
-        connectors={[CONNECTOR]}
+        connectors={[GDRIVE]}
         collections={[{ name: "org_handbook", scope: "org" }]}
         defaultCollection="org_handbook"
         orgIntegrations={[

--- a/frontend/src/components/rag/sync-source-wizard.tsx
+++ b/frontend/src/components/rag/sync-source-wizard.tsx
@@ -16,15 +16,18 @@ import { toast } from "sonner";
 
 import { Dialog, DialogContent, DialogHeader, DialogTitle, Spinner } from "@/components/ui";
 import { getErrorMessage, submitFailure } from "@/lib/api-error";
+import { SourceAudienceNotice } from "@/components/rag/sync-source-audience-notice";
 import { CloneStep } from "@/components/rag/sync-source-clone-step";
 import { ConfigureStep } from "@/components/rag/sync-source-configure-step";
 import { CredentialStep } from "@/components/rag/sync-source-credential-step";
 import { ConnectorStep } from "@/components/rag/sync-source-connector-step";
 import { ScheduleStep } from "@/components/rag/sync-source-schedule-step";
 import type { ConnectorInfo, SyncSourceCreate, SyncSourceRead } from "@/lib/rag-api";
+import type { KBScope } from "@/types/knowledge-base";
 import { cn } from "@/lib/utils";
 import { DIALOG_FORM } from "@/lib/dialog-widths";
 import { useChanged } from "@/hooks/use-changed";
+import { useSecrets } from "@/hooks";
 import { useTranslations } from "next-intl";
 
 interface SyncSourceWizardProps {
@@ -36,8 +39,13 @@ interface SyncSourceWizardProps {
    *
    * One entry pins it; more than one draws a picker on the schedule step. An
    * empty list is an integration no collection owns yet.
+   *
+   * The scope travels with the name because it is what decides the audience:
+   * `personal` is its owner, `org` is everyone who can view the collection, and
+   * `app` is anybody in the deployment - which the last step now says out loud
+   * (#982).
    */
-  collections: { name: string }[];
+  collections: { name: string; scope: KBScope }[];
   /** Which of {@link collections} the picker starts on, and what clone mode fills. */
   defaultCollection?: string;
   /** Existing org integrations (without this KB's collection_name) for "pick existing" flow. */
@@ -156,6 +164,28 @@ export function SyncSourceWizard({
   const hasOrgIntegrations = orgIntegrations.length > 0;
 
   const selectedIntegration = orgIntegrations.find((i) => i.id === cloneSourceId);
+
+  /**
+   * The collection this source will be filed under, and who that lets read it.
+   *
+   * Read from the picker's value where there is a picker and from
+   * `defaultCollection` where the collection is pinned - which is the case the
+   * issue's repro walks, so the sentence cannot be conditional on a control that
+   * only appears when there is more than one collection to choose from (#982).
+   */
+  const target = collections.find(
+    (c) =>
+      c.name ===
+      (mode === "clone" ? defaultCollection : (form.collection_name ?? defaultCollection)),
+  );
+  // The same list the credential step offers, so the name shown is the name that
+  // was chosen there. `undefined` covers both a caller who may not read the
+  // vault and a credential the org no longer holds; the sentence then does not
+  // name one rather than naming an empty string.
+  const { secrets } = useSecrets();
+  const credentialName = secrets.find(
+    (secret) => secret.id === (mode === "clone" ? selectedIntegration?.secret_id : form.secret_id),
+  )?.name;
 
   const handleCloneSubmit = async () => {
     if (!cloneSourceId || !defaultCollection) return;
@@ -386,6 +416,18 @@ export function SyncSourceWizard({
                 <ScheduleStep collections={collections} form={form} setForm={setForm} />
               )}
             </>
+          )}
+
+          {/* On the step that decides the collection, and on the clone step,
+              which decides the same thing for a credential somebody else
+              scoped. Not on the earlier steps: the sentence names a collection
+              and a credential, and neither is chosen yet. */}
+          {(mode === "clone" ? Boolean(cloneSourceId) : step === "schedule") && (
+            <SourceAudienceNotice
+              scope={target?.scope}
+              collectionName={target?.name}
+              credentialName={credentialName}
+            />
           )}
         </div>
 

--- a/frontend/src/components/rag/sync-source-wizard.tsx
+++ b/frontend/src/components/rag/sync-source-wizard.tsx
@@ -27,7 +27,6 @@ import type { KBScope } from "@/types/knowledge-base";
 import { cn } from "@/lib/utils";
 import { DIALOG_FORM } from "@/lib/dialog-widths";
 import { useChanged } from "@/hooks/use-changed";
-import { useSecrets } from "@/hooks";
 import { useTranslations } from "next-intl";
 
 interface SyncSourceWizardProps {
@@ -178,14 +177,14 @@ export function SyncSourceWizard({
       c.name ===
       (mode === "clone" ? defaultCollection : (form.collection_name ?? defaultCollection)),
   );
-  // The same list the credential step offers, so the name shown is the name that
-  // was chosen there. `undefined` covers both a caller who may not read the
-  // vault and a credential the org no longer holds; the sentence then does not
-  // name one rather than naming an empty string.
-  const { secrets } = useSecrets();
-  const credentialName = secrets.find(
-    (secret) => secret.id === (mode === "clone" ? selectedIntegration?.secret_id : form.secret_id),
-  )?.name;
+  // Which connector's credential the sentence is about - the one being
+  // configured, or the one the chosen integration already uses. A connector
+  // declaring `secret_kind: "none"` has none, and the notice says so rather than
+  // describing one that does not exist.
+  const audienceConnector =
+    mode === "clone"
+      ? connectors.find((c) => c.type === selectedIntegration?.connector_type)
+      : selectedConnector;
 
   const handleCloneSubmit = async () => {
     if (!cloneSourceId || !defaultCollection) return;
@@ -426,7 +425,8 @@ export function SyncSourceWizard({
             <SourceAudienceNotice
               scope={target?.scope}
               collectionName={target?.name}
-              credentialName={credentialName}
+              secretId={mode === "clone" ? selectedIntegration?.secret_id : form.secret_id}
+              needsCredential={audienceConnector?.secret_kind !== "none"}
             />
           )}
         </div>


### PR DESCRIPTION
The wizard asked for a connector, a credential, a config and a schedule, and the
collection was chosen without a word about the consequence. Access is decided at
the **collection** and there is no per-document isolation inside one, so
everything that credential can reach becomes readable by everyone who can read
that collection — a Confluence token issued for a whole instance, pointed at an
`org` collection, publishes the instance to every member holding
`collections:view`.

The decision is the operator's to make; the platform deliberately does not mirror
a source's own ACLs, because a mirrored ACL goes stale between syncs and stale
authorization is worse than none. What was wrong is that it was made silently.

## What it says

The last step — the one that decides the collection — names the credential and
the audience together, because the pair is the decision. The credential's own
permissions are a ceiling nothing in this product can raise; `config` narrows the
reach and cannot be relied on to keep it narrow, being a field anyone with
`collections:edit` can widen later.

One sentence per scope, because each names different people:

| Scope | Ends with |
|---|---|
| `personal` | by you alone |
| `org` | by everyone in this organization who can view that collection |
| `app` | by anybody in this deployment |
| no collection | nothing can search it yet; decided when it is cloned into a base |

## Where it appears — three things worth a reviewer's eye

- **Not conditional on the collection picker.** That control renders only where
  there is more than one collection to choose from, and the case the issue's repro
  walks is a knowledge base offering exactly one. The notice reads
  `defaultCollection` when there is nothing to pick — there is a test for exactly
  that.
- **The clone step carries it too**, which is the half of "repointing re-asks"
  this branch can honour: a clone references the same vault secret and names a
  different collection, so the audience changes while nothing about the credential
  does.
- **Repointing an existing source has no UI to ask in.** The issue says it "is one
  dropdown with no prompt at all" — there is no such dropdown.
  `PATCH /rag/sync/sources/{id}` has no frontend client, and there is no source
  editor anywhere in `src/components/rag`, so a repoint is reachable only through
  the API and the CLI. #983 (merged) is what records one. Say the word if you want
  the editor built and the prompt put on it; that is a feature, not this fix.

## Details

The credential's name comes from the same `/secrets` list the credential step
offers, so what is shown is what was chosen. A caller who cannot read the vault
gets the sentence *without* a name rather than one with an empty parameter in it —
an ICU `select`, not a ternary, per `.claude/rules/frontend.md`.

`collections` now carries `scope` alongside `name`; both call sites already had it
(`kb.scope` on the KB page, an empty list on the org-integration list, which is
what produces the "filed under no knowledge base" sentence).

No new page, tab or create control, so the onboarding walkthrough owes no stop —
the integrations stops in `tour.ts` already cover the surface this sits inside.

## How it was verified

- `sync-source-audience-notice.test.tsx` — 6 tests: one per scope, the unassigned
  case, the unnamed credential, and a name with no scope beside it.
- `sync-source-wizard.integration.test.tsx` — 5 more, including the issue's repro
  (a pinned `org` collection, no picker), the picker changing the sentence, and the
  clone path.
- `make lint-frontend`, `bun run check:i18n`, `make test-frontend-cov` — 5264
  passed, 100% lines/statements/functions — `make docs-build`, and `make check`
  green end to end.

Closes #982
