### PR TITLE
fix(chat): refuse a malformed socket file id instead of logging a crash

### DIFF
--- a/backend/app/services/conversation.py
+++ b/backend/app/services/conversation.py
@@ -776,7 +776,15 @@ class ConversationService:
             )
 
     async def list_attached_files(self, file_ids: list[str], *, user_id: UUID) -> list[Any]:
-        """The caller's rows behind the ids a client sent; anybody else's resolve to nothing (#706)."""
-        return await chat_file_repo.get_many(
-            self.db, [UUID(fid) for fid in file_ids], user_id=user_id
-        )
+        """The caller's rows behind the ids a client sent; anybody else's resolve to nothing (#706).
+
+        The ids come off an untyped socket payload, so one that is not a UUID is
+        refused as validation naming `file_ids` - the same loud refusal
+        `link_files_to_message` gives. A bare `UUID()` here raised a `ValueError`
+        that the turn handler caught in its infrastructure net and resurfaced a
+        step later as a generic failed turn, logged as a server error.
+        """
+        ids, malformed = _file_uuids(file_ids)
+        if malformed:
+            raise BadRequestError(message="Invalid file id", details={"file_ids": malformed})
+        return await chat_file_repo.get_many(self.db, ids, user_id=user_id)

--- a/backend/tests/test_services_conversation.py
+++ b/backend/tests/test_services_conversation.py
@@ -1423,6 +1423,25 @@ class TestConversationServiceLinkFiles:
         assert refusal.value.details == {"file_ids": [spent]}
         repo.link_to_message.assert_not_awaited()
 
+    @pytest.mark.anyio
+    async def test_listing_attached_files_refuses_a_malformed_id(
+        self, service: ConversationService
+    ):
+        """The read path for a message with no text of its own. A `UUID(fid)` here
+        raised a `ValueError` that the socket handler logged as its own error and
+        answered with a generic failed turn; the id is client input, so it is
+        refused as validation naming `file_ids` instead."""
+        good = uuid4()
+
+        with patch("app.services.conversation.chat_file_repo") as repo:
+            repo.get_many = AsyncMock()
+
+            with pytest.raises(BadRequestError) as refusal:
+                await service.list_attached_files([str(good), "not-a-uuid"], user_id=uuid4())
+
+        assert refusal.value.details == {"file_ids": ["not-a-uuid"]}
+        repo.get_many.assert_not_awaited()
+
 
 class TestSayingATurnWasStopped:
     """`run_status` on a listed message.


### PR DESCRIPTION
## What changed

A web-chat socket frame carrying a non-UUID `file_ids` entry (`["not-a-uuid"]`) was answered with a **generic turn failure** and the server logged it as **its own error** — an `ERROR`-level traceback for what is client input.

`ConversationService.list_attached_files` coerced every id with `UUID(fid)`, so a malformed value raised `ValueError` before any query ran. On the socket that landed in `AgentSession`'s broad `except Exception`, which sends the sanitized `_turn_failed` sentence and writes `logger.exception("Error processing agent request")`.

Nothing leaked and nothing crashed — the frame is sanitized (#659) and the turn aborts before any run row or model cost exists. The defect was **shape**: a refusal dressed as a server error.

## Fix

Parse the ids with the existing `_file_uuids` helper and raise `BadRequestError` naming `file_ids` on a malformed one — the same loud refusal `link_files_to_message` already gives. `AgentSession` catches `AppException` one handler *earlier* than the broad one (logging at INFO, sending `str(exc)`), so the client gets a frame it can act on and the log carries no exception-level entry. A well-formed id that is not the caller's keeps today's behaviour (resolves to nothing, #706).

## Verification

- New service test: a malformed id is refused with `details == {"file_ids": ["not-a-uuid"]}` and the repository read is never reached.
- Full backend suite: 5664 passed, 100% platform coverage gate held.

Closes #749