### PR TITLE
fix(chat): name an attachment the router cannot read instead of going silent

### DIFF
--- a/backend/app/services/attachments.py
+++ b/backend/app/services/attachments.py
@@ -155,6 +155,37 @@ def _unstored(chat_file: ChatFile) -> str:
     return "".join(parts)
 
 
+def _unreadable(chat_file: ChatFile) -> str:
+    """A file no parser could read, with no workspace to open it from.
+
+    Said rather than skipped, the same principle as `_too_large_to_show`: the
+    person attached a file and asked about it, so an empty prompt reads as the
+    model denying the file the transcript says arrived. There is nothing to
+    sample and no path to give, so the model is told what came and why it cannot
+    be opened.
+    """
+    return (
+        f"\n---\nAttached file: {chat_file.filename} "
+        f"({_size(chat_file)}, {chat_file.file_type}) - its text could not be extracted, "
+        "and this agent has no workspace to open it from."
+    )
+
+
+def _unprocessable(chat_file: ChatFile) -> str:
+    """Named when routing the file raised, so the turn survives but the model is
+    not left denying it.
+
+    The error's own text stays in the `logger.warning` beside the raise; the
+    model is told only that the file arrived and could not be processed, which is
+    all it can honestly say about it.
+    """
+    return (
+        f"\n---\nAttached file: {chat_file.filename} "
+        f"({_size(chat_file)}, {chat_file.file_type}) - it arrived but could not be "
+        "processed, so its contents are unavailable."
+    )
+
+
 class AttachmentRouter:
     """Turns attached files into a prompt, and into files an agent can open.
 
@@ -206,7 +237,7 @@ class AttachmentRouter:
             logger.warning(
                 "attachment_routing_failed", extra={"file_id": str(chat_file.id)}, exc_info=True
             )
-            return AttachmentPlan(reference=None, inline=None)
+            return AttachmentPlan(reference=_unprocessable(chat_file), inline=None)
 
     async def _route(self, chat_file: ChatFile) -> AttachmentPlan:
         backend = self._backend
@@ -236,7 +267,7 @@ class AttachmentRouter:
             return AttachmentPlan(reference=None, inline=inline)
         if chat_file.parsed_content:
             return AttachmentPlan(reference=_pasted(chat_file), inline=None)
-        return AttachmentPlan(reference=None, inline=None)
+        return AttachmentPlan(reference=_unreadable(chat_file), inline=None)
 
     async def _into_workspace(
         self, backend: AsyncBackendProtocol, chat_file: ChatFile

--- a/backend/tests/test_attachments.py
+++ b/backend/tests/test_attachments.py
@@ -70,12 +70,16 @@ class TestWithoutAWorkspace:
         assert isinstance(prompt, list)
         assert isinstance(prompt[1], BinaryContent)
 
-    async def test_a_file_nothing_could_parse_contributes_nothing(self, storage):
+    async def test_a_file_nothing_could_parse_is_named_not_dropped(self, storage):
+        # Silence reads as the model denying a file the transcript says arrived,
+        # so the reference names it and why it cannot be read.
         prompt = await AttachmentRouter().build_prompt(
-            "look", [_file(file_type="binary", parsed_content=None)]
+            "look", [_file(filename="dump.zip", file_type="binary", parsed_content=None)]
         )
 
-        assert prompt == "look"
+        assert isinstance(prompt, str)
+        assert "dump.zip" in prompt
+        assert "could not be extracted" in prompt
 
     async def test_no_attachments_is_the_message_unchanged(self):
         assert await AttachmentRouter().build_prompt("hello", []) == "hello"
@@ -253,18 +257,24 @@ class TestWithAWorkspace:
         assert isinstance(prompt, list)
         assert any(isinstance(part, BinaryContent) for part in prompt)
 
-    async def test_a_file_the_store_cannot_load_is_skipped_rather_than_fatal(self, monkeypatch):
-        """The person asked a question; answering without the file beats not
-        answering at all."""
+    async def test_a_file_the_store_cannot_load_is_named_rather_than_fatal(self, monkeypatch):
+        """A routing failure must not fail the turn - the person asked a question
+        and answering without the file beats not answering. But the model is told
+        the file arrived and could not be processed, not left denying it."""
         monkeypatch.setattr(
             attachments_module,
             "get_file_storage",
             lambda: SimpleNamespace(load=AsyncMock(side_effect=OSError("gone"))),
         )
 
-        prompt = await AttachmentRouter(_workspace()).build_prompt("summarise", [_file()])
+        prompt = await AttachmentRouter(_workspace()).build_prompt(
+            "summarise", [_file(filename="raport.csv")]
+        )
 
-        assert prompt == "summarise"
+        assert isinstance(prompt, str)
+        assert prompt.startswith("summarise")
+        assert "raport.csv" in prompt
+        assert "could not be processed" in prompt
 
 
 class TestFilenamesAreNotTrusted:


### PR DESCRIPTION
## What changed

Two routings in `attachments.py` handed the model **no text at all** about a file that arrived, so the agent denied receiving what the person just sent. Since #704 the transcript names the file, which makes the mismatch stark: `Attached file: report.zip` as the user's turn, then the agent claiming no file exists.

- A **non-image file with no `parsed_content` on an agent with no workspace** (`_without_workspace`) returned `AttachmentPlan(reference=None, inline=None)`.
- A **routing failure** (`route`) swallowed the exception and returned an empty plan — right that it does not fail the turn, wrong that it tells the model nothing.

`_too_large_to_show` in the same file already states the principle these two violated: *"Said rather than skipped: the person attached a picture and asked about it, so silence reads as the model ignoring them."*

## Fix

Both routings now yield a reference naming the file and why it cannot be read — the shape `_too_large_to_show` / `_unstored` already use. Two helpers:

- `_unreadable` — no parser could extract the text and there is no workspace to open it from.
- `_unprocessable` — routing raised; the error's own text stays in the `logger.warning` beside it, and the model is told only that the file arrived and could not be processed.

## Verification

- An unparsed file with no workspace is named (`could not be extracted`); a store that cannot load a file is named rather than dropped (`could not be processed`) — both assert `build_prompt` output carries the filename, and the failure path still does not fail the turn.
- Full backend suite: 5663 passed, 100% platform coverage gate held.

Closes #746