### PR TITLE
refactor(mcp): let the connection dialog own its own form

### DIFF
--- a/frontend/src/components/mcp/mcp-connection-dialog.tsx
+++ b/frontend/src/components/mcp/mcp-connection-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { Dispatch, SetStateAction } from "react";
+import { useState } from "react";
 import { Building2, User } from "lucide-react";
 import { useTranslations } from "next-intl";
 
@@ -18,8 +18,10 @@ import {
 import { cn } from "@/lib/utils";
 import {
   SCOPE_LABEL,
+  type ConnectionFormValues,
   type DraftAuth,
   type DraftState,
+  type Scope,
 } from "@/components/mcp/mcp-server-list-types";
 
 const AUTH_CHOICES: { value: DraftAuth; labelKey: string; hintKey: string }[] = [
@@ -28,220 +30,251 @@ const AUTH_CHOICES: { value: DraftAuth; labelKey: string; hintKey: string }[] = 
   { value: "oauth", labelKey: "authOauth", hintKey: "authOauthHint" },
 ];
 
-interface McpConnectionDialogProps {
-  draft: DraftState | null;
-  setDraft: Dispatch<SetStateAction<DraftState | null>>;
-  draftName: string;
-  setDraftName: Dispatch<SetStateAction<string>>;
-  draftUrl: string;
-  setDraftUrl: Dispatch<SetStateAction<string>>;
-  draftToken: string;
-  setDraftToken: Dispatch<SetStateAction<string>>;
-  draftAuth: DraftAuth;
-  setDraftAuth: Dispatch<SetStateAction<DraftAuth>>;
-  clearToken: boolean;
-  setClearToken: Dispatch<SetStateAction<boolean>>;
-  submitting: boolean;
-  canManageOrganization: boolean;
-  onSubmit: () => void;
+/** How the dialog's fields start, read off the row and any connection being edited. */
+function initialAuth(draft: DraftState): DraftAuth {
+  if (draft.existing?.auth_type === "oauth") return "oauth";
+  if (draft.row.entry?.auth === "oauth") return "oauth";
+  if (draft.row.entry?.auth === "none") return "none";
+  return "token";
 }
 
+interface McpConnectionDialogProps {
+  draft: DraftState | null;
+  onClose: () => void;
+  submitting: boolean;
+  canManageOrganization: boolean;
+  onSubmit: (values: ConnectionFormValues) => void;
+}
+
+/**
+ * Connect or edit one MCP server.
+ *
+ * The form fields live here rather than in the list: the list opens the dialog
+ * with a `DraftState` (the row, and the connection if editing) and reads back a
+ * `ConnectionFormValues` on submit. The inner form is keyed on the draft, so
+ * switching from one server to another remounts it with fresh seeded state
+ * rather than carrying the last one's name and token across.
+ */
 export function McpConnectionDialog({
   draft,
-  setDraft,
-  draftName,
-  setDraftName,
-  draftUrl,
-  setDraftUrl,
-  draftToken,
-  setDraftToken,
-  draftAuth,
-  setDraftAuth,
-  clearToken,
-  setClearToken,
+  onClose,
   submitting,
   canManageOrganization,
   onSubmit,
 }: McpConnectionDialogProps) {
-  const t = useTranslations("mcp");
-  // The hint under the radio group. It used to be rendered as the *key* -
-  // `authTokenHint` on screen, in every locale (#446).
-  const hint = AUTH_CHOICES.find((choice) => choice.value === draftAuth)?.hintKey;
-
   return (
-    <Dialog open={draft !== null} onOpenChange={(open) => !open && !submitting && setDraft(null)}>
+    <Dialog open={draft !== null} onOpenChange={(open) => !open && !submitting && onClose()}>
       <DialogContent>
-        <DialogHeader>
-          <DialogTitle>
-            {draft === null
-              ? ""
-              : draft.existing
-                ? t("editNamed", { name: draft.existing.name })
-                : t("connectForScope", { name: draft.row.name, scope: draft.scope })}
-          </DialogTitle>
-        </DialogHeader>
-        <div className="space-y-4" data-tour="mcp-dialog-form">
-          <div>
-            <Label htmlFor="mcp-name">{t("name")}</Label>
-            <Input
-              id="mcp-name"
-              value={draftName}
-              onChange={(event) => setDraftName(event.target.value.toLowerCase())}
-              placeholder={t("github")}
-              maxLength={32}
-              className="mt-1.5"
-            />
-            <p className="text-foreground/45 mt-1 text-[11px]">
-              {t("namePrefixesToolNames", { scope: draft?.scope ?? "personal" })}
-            </p>
-          </div>
-          <div>
-            <Label htmlFor="mcp-url">{t("serverUrl")}</Label>
-            <Input
-              id="mcp-url"
-              value={draftUrl}
-              onChange={(event) => setDraftUrl(event.target.value)}
-              placeholder="https://example.com/mcp"
-              maxLength={2048}
-              className="mt-1.5 font-mono text-sm"
-            />
-          </div>
-          <div>
-            <Label>{t("connectAction")}</Label>
-            <div
-              className="mt-1.5 flex flex-wrap gap-1.5"
-              role="radiogroup"
-              aria-label={t("connect2")}
-            >
-              {(["organization", "personal"] as const)
-                .filter((scope) => scope !== "organization" || canManageOrganization)
-                .map((scope) => {
-                  const Icon = scope === "organization" ? Building2 : User;
-                  return (
-                    <button
-                      key={scope}
-                      type="button"
-                      role="radio"
-                      aria-checked={draft?.scope === scope}
-                      disabled={draft?.existing !== null}
-                      onClick={() =>
-                        setDraft((previous) => (previous ? { ...previous, scope } : previous))
-                      }
-                      className={cn(
-                        "inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm transition-colors",
-                        draft?.scope === scope
-                          ? "border-foreground/30 bg-accent text-foreground"
-                          : "border-input text-muted-foreground hover:text-foreground",
-                        draft?.existing !== null && "cursor-not-allowed opacity-60",
-                      )}
-                    >
-                      <Icon className="h-3.5 w-3.5" />
-                      {t(SCOPE_LABEL[scope])}
-                    </button>
-                  );
-                })}
-            </div>
-            <p className="text-muted-foreground mt-1.5 text-xs">
-              {draft?.scope === "organization" ? t("everyAgentCanReach") : t("yoursAloneYourOwn")}
-            </p>
-            {draft?.existing !== null && (
-              // Moving a live connection between owners would mean re-sealing
-              // its credential under another envelope and changing who may
-              // revoke it. Disconnect and connect again is the honest path.
-              <p className="text-muted-foreground mt-1 text-xs">
-                {t("existingConnectionCannotChange")}
-              </p>
-            )}
-          </div>
-
-          <div>
-            <Label>{t("authentication")}</Label>
-            <div
-              className="mt-1.5 flex flex-wrap gap-1.5"
-              role="radiogroup"
-              aria-label={t("authentication2")}
-            >
-              {AUTH_CHOICES.map((choice) => (
-                <button
-                  key={choice.value}
-                  type="button"
-                  role="radio"
-                  aria-checked={draftAuth === choice.value}
-                  onClick={() => setDraftAuth(choice.value)}
-                  className={cn(
-                    "rounded-md border px-3 py-1.5 text-sm transition-colors",
-                    draftAuth === choice.value
-                      ? "border-foreground/30 bg-accent text-foreground"
-                      : "border-input text-muted-foreground hover:text-foreground",
-                  )}
-                >
-                  {t(choice.labelKey)}
-                </button>
-              ))}
-            </div>
-            <p className="text-muted-foreground mt-1.5 text-xs">
-              {hint === undefined ? null : t(hint)}
-            </p>
-            {draftAuth === "oauth" && draft?.scope === "organization" && (
-              // Said once, where the choice is made. The grant is the
-              // consenting person's at the provider, so revoking their access
-              // there stops the organization's server working until somebody
-              // authorizes it again - which is why a shared service account is
-              // the right thing to consent with.
-              <p className="text-muted-foreground mt-1.5 text-xs">{t("whoeverSignsGrantsIf")}</p>
-            )}
-          </div>
-
-          <div className={cn(draftAuth !== "token" && "hidden")}>
-            <Label htmlFor="mcp-token">{t("accessToken")}</Label>
-            {/* The catalog's own advice for *this* server, which used to sit on
-                the card. It is instructions for filling in the field below it,
-                so it belongs next to the field and not in a list somebody is
-                still browsing. Generic guidance is the main reason token setup
-                fails, which is why the backend carries a per-entry hint. */}
-            {draft?.row.tokenHint && (
-              <p className="text-muted-foreground mt-1.5 text-xs">{draft.row.tokenHint}</p>
-            )}
-            <Input
-              id="mcp-token"
-              type="password"
-              value={draftToken}
-              onChange={(event) => {
-                setDraftToken(event.target.value);
-                if (event.target.value) setClearToken(false);
-              }}
-              placeholder={
-                draft?.existing?.has_auth_token
-                  ? "•••••• (stored - type to replace)"
-                  : t("pasteHere")
-              }
-              maxLength={4096}
-              className="mt-1.5 font-mono text-sm"
-            />
-            <p className="text-foreground/45 mt-1 text-[11px]">
-              {draft?.scope === "organization"
-                ? t("useServiceCredentialNot")
-                : t("storedEncryptedNeverShown")}
-            </p>
-            {draft?.existing?.has_auth_token && !draftToken && (
-              <div className="mt-2 flex items-center gap-2">
-                <Switch id="mcp-clear-token" checked={clearToken} onCheckedChange={setClearToken} />
-                <Label htmlFor="mcp-clear-token" className="text-xs font-normal">
-                  {t("removeStoredCredential")}
-                </Label>
-              </div>
-            )}
-          </div>
-        </div>
-        <DialogFooter>
-          <Button variant="ghost" onClick={() => setDraft(null)} disabled={submitting}>
-            {t("cancel")}
-          </Button>
-          <Button onClick={onSubmit} disabled={submitting} data-tour="mcp-dialog-connect">
-            {submitting ? t("saving") : draft?.existing ? t("save") : t("connectCheck")}
-          </Button>
-        </DialogFooter>
+        {draft !== null && (
+          <ConnectionForm
+            key={draft.existing?.id ?? draft.row.key}
+            draft={draft}
+            submitting={submitting}
+            canManageOrganization={canManageOrganization}
+            onCancel={onClose}
+            onSubmit={onSubmit}
+          />
+        )}
       </DialogContent>
     </Dialog>
+  );
+}
+
+function ConnectionForm({
+  draft,
+  submitting,
+  canManageOrganization,
+  onCancel,
+  onSubmit,
+}: {
+  draft: DraftState;
+  submitting: boolean;
+  canManageOrganization: boolean;
+  onCancel: () => void;
+  onSubmit: (values: ConnectionFormValues) => void;
+}) {
+  const t = useTranslations("mcp");
+  const [name, setName] = useState(draft.existing?.name ?? draft.row.entry?.key ?? "");
+  const [url, setUrl] = useState(draft.existing?.url ?? draft.row.entry?.url ?? "");
+  const [token, setToken] = useState("");
+  const [auth, setAuth] = useState<DraftAuth>(() => initialAuth(draft));
+  const [clearToken, setClearToken] = useState(false);
+  const [scope, setScope] = useState<Scope>(draft.scope);
+
+  // The hint under the radio group. It used to be rendered as the *key* -
+  // `authTokenHint` on screen, in every locale (#446).
+  const hint = AUTH_CHOICES.find((choice) => choice.value === auth)?.hintKey;
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>
+          {draft.existing
+            ? t("editNamed", { name: draft.existing.name })
+            : t("connectForScope", { name: draft.row.name, scope })}
+        </DialogTitle>
+      </DialogHeader>
+      <div className="space-y-4" data-tour="mcp-dialog-form">
+        <div>
+          <Label htmlFor="mcp-name">{t("name")}</Label>
+          <Input
+            id="mcp-name"
+            value={name}
+            onChange={(event) => setName(event.target.value.toLowerCase())}
+            placeholder={t("github")}
+            maxLength={32}
+            className="mt-1.5"
+          />
+          <p className="text-foreground/45 mt-1 text-[11px]">
+            {t("namePrefixesToolNames", { scope })}
+          </p>
+        </div>
+        <div>
+          <Label htmlFor="mcp-url">{t("serverUrl")}</Label>
+          <Input
+            id="mcp-url"
+            value={url}
+            onChange={(event) => setUrl(event.target.value)}
+            placeholder="https://example.com/mcp"
+            maxLength={2048}
+            className="mt-1.5 font-mono text-sm"
+          />
+        </div>
+        <div>
+          <Label>{t("connectAction")}</Label>
+          <div
+            className="mt-1.5 flex flex-wrap gap-1.5"
+            role="radiogroup"
+            aria-label={t("connect2")}
+          >
+            {(["organization", "personal"] as const)
+              .filter((option) => option !== "organization" || canManageOrganization)
+              .map((option) => {
+                const Icon = option === "organization" ? Building2 : User;
+                return (
+                  <button
+                    key={option}
+                    type="button"
+                    role="radio"
+                    aria-checked={scope === option}
+                    disabled={draft.existing !== null}
+                    onClick={() => setScope(option)}
+                    className={cn(
+                      "inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm transition-colors",
+                      scope === option
+                        ? "border-foreground/30 bg-accent text-foreground"
+                        : "border-input text-muted-foreground hover:text-foreground",
+                      draft.existing !== null && "cursor-not-allowed opacity-60",
+                    )}
+                  >
+                    <Icon className="h-3.5 w-3.5" />
+                    {t(SCOPE_LABEL[option])}
+                  </button>
+                );
+              })}
+          </div>
+          <p className="text-muted-foreground mt-1.5 text-xs">
+            {scope === "organization" ? t("everyAgentCanReach") : t("yoursAloneYourOwn")}
+          </p>
+          {draft.existing !== null && (
+            // Moving a live connection between owners would mean re-sealing
+            // its credential under another envelope and changing who may
+            // revoke it. Disconnect and connect again is the honest path.
+            <p className="text-muted-foreground mt-1 text-xs">
+              {t("existingConnectionCannotChange")}
+            </p>
+          )}
+        </div>
+
+        <div>
+          <Label>{t("authentication")}</Label>
+          <div
+            className="mt-1.5 flex flex-wrap gap-1.5"
+            role="radiogroup"
+            aria-label={t("authentication2")}
+          >
+            {AUTH_CHOICES.map((choice) => (
+              <button
+                key={choice.value}
+                type="button"
+                role="radio"
+                aria-checked={auth === choice.value}
+                onClick={() => setAuth(choice.value)}
+                className={cn(
+                  "rounded-md border px-3 py-1.5 text-sm transition-colors",
+                  auth === choice.value
+                    ? "border-foreground/30 bg-accent text-foreground"
+                    : "border-input text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {t(choice.labelKey)}
+              </button>
+            ))}
+          </div>
+          <p className="text-muted-foreground mt-1.5 text-xs">
+            {hint === undefined ? null : t(hint)}
+          </p>
+          {auth === "oauth" && scope === "organization" && (
+            // Said once, where the choice is made. The grant is the
+            // consenting person's at the provider, so revoking their access
+            // there stops the organization's server working until somebody
+            // authorizes it again - which is why a shared service account is
+            // the right thing to consent with.
+            <p className="text-muted-foreground mt-1.5 text-xs">{t("whoeverSignsGrantsIf")}</p>
+          )}
+        </div>
+
+        <div className={cn(auth !== "token" && "hidden")}>
+          <Label htmlFor="mcp-token">{t("accessToken")}</Label>
+          {/* The catalog's own advice for *this* server, which used to sit on
+              the card. It is instructions for filling in the field below it,
+              so it belongs next to the field and not in a list somebody is
+              still browsing. Generic guidance is the main reason token setup
+              fails, which is why the backend carries a per-entry hint. */}
+          {draft.row.tokenHint && (
+            <p className="text-muted-foreground mt-1.5 text-xs">{draft.row.tokenHint}</p>
+          )}
+          <Input
+            id="mcp-token"
+            type="password"
+            value={token}
+            onChange={(event) => {
+              setToken(event.target.value);
+              if (event.target.value) setClearToken(false);
+            }}
+            placeholder={
+              draft.existing?.has_auth_token ? "•••••• (stored - type to replace)" : t("pasteHere")
+            }
+            maxLength={4096}
+            className="mt-1.5 font-mono text-sm"
+          />
+          <p className="text-foreground/45 mt-1 text-[11px]">
+            {scope === "organization"
+              ? t("useServiceCredentialNot")
+              : t("storedEncryptedNeverShown")}
+          </p>
+          {draft.existing?.has_auth_token && !token && (
+            <div className="mt-2 flex items-center gap-2">
+              <Switch id="mcp-clear-token" checked={clearToken} onCheckedChange={setClearToken} />
+              <Label htmlFor="mcp-clear-token" className="text-xs font-normal">
+                {t("removeStoredCredential")}
+              </Label>
+            </div>
+          )}
+        </div>
+      </div>
+      <DialogFooter>
+        <Button variant="ghost" onClick={onCancel} disabled={submitting}>
+          {t("cancel")}
+        </Button>
+        <Button
+          onClick={() => onSubmit({ name, url, token, auth, clearToken, scope })}
+          disabled={submitting}
+          data-tour="mcp-dialog-connect"
+        >
+          {submitting ? t("saving") : draft.existing ? t("save") : t("connectCheck")}
+        </Button>
+      </DialogFooter>
+    </>
   );
 }

--- a/frontend/src/components/mcp/mcp-server-list-types.ts
+++ b/frontend/src/components/mcp/mcp-server-list-types.ts
@@ -36,6 +36,22 @@ export interface DraftState {
   existing: McpConnectionRecord | null;
 }
 
+/**
+ * The fields the connection dialog collects, handed to the list on submit.
+ *
+ * The dialog owns this while it is open and seeds it from the `DraftState`; the
+ * list reads it back in one object rather than holding a `useState` per field
+ * and drilling a setter each into the dialog.
+ */
+export interface ConnectionFormValues {
+  name: string;
+  url: string;
+  token: string;
+  auth: DraftAuth;
+  clearToken: boolean;
+  scope: Scope;
+}
+
 /** A probed connection and which of its tools are currently checked. */
 export interface ToolPickerState {
   scope: Scope;

--- a/frontend/src/components/mcp/mcp-server-list.tsx
+++ b/frontend/src/components/mcp/mcp-server-list.tsx
@@ -30,7 +30,7 @@ import { McpConnectionDialog } from "@/components/mcp/mcp-connection-dialog";
 import { McpToolPickerDialog } from "@/components/mcp/mcp-tool-picker-dialog";
 import {
   SCOPE_LABEL,
-  type DraftAuth,
+  type ConnectionFormValues,
   type DraftState,
   type Scope,
   type ToolPickerState,
@@ -139,14 +139,6 @@ export function McpServerList({ canManageOrganization }: McpServerListProps) {
   });
 
   const [draft, setDraft] = useState<DraftState | null>(null);
-  const [draftName, setDraftName] = useState("");
-  const [draftUrl, setDraftUrl] = useState("");
-  const [draftToken, setDraftToken] = useState("");
-  // How the server is authenticated. A catalog entry states this; a custom one
-  // has to be asked, and asking was the gap - the dialog offered a token field
-  // and nothing else, so a server behind OAuth could not be added at all.
-  const [draftAuth, setDraftAuth] = useState<DraftAuth>("token");
-  const [clearToken, setClearToken] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [toolPicker, setToolPicker] = useState<ToolPickerState | null>(null);
@@ -163,22 +155,9 @@ export function McpServerList({ canManageOrganization }: McpServerListProps) {
   const api = (scope: Scope) => (scope === "organization" ? organization : personal);
 
   const openDraft = (scope: Scope, row: McpServerRow, existing: McpConnectionRecord | null) => {
+    // The dialog seeds its own fields from this - name, url and auth type off
+    // the row and any connection being edited.
     setDraft({ scope, row, existing });
-    // The catalog knows; a custom server defaults to a token, which is what most
-    // self-hosted ones use and what this dialog could always do.
-    setDraftAuth(
-      existing?.auth_type === "oauth"
-        ? "oauth"
-        : row.entry?.auth === "oauth"
-          ? "oauth"
-          : row.entry?.auth === "none"
-            ? "none"
-            : "token",
-    );
-    setDraftName(existing?.name ?? row.entry?.key ?? "");
-    setDraftUrl(existing?.url ?? row.entry?.url ?? "");
-    setDraftToken("");
-    setClearToken(false);
   };
 
   /** Probe a server, returning its tools or null after saying why not. */
@@ -227,13 +206,13 @@ export function McpServerList({ canManageOrganization }: McpServerListProps) {
     // On success the browser navigates away - leave the row busy.
   };
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (values: ConnectionFormValues) => {
     if (!draft) return;
-    const name = draftName.trim().toLowerCase();
-    const url = draftUrl.trim();
+    const name = values.name.trim().toLowerCase();
+    const url = values.url.trim();
     // Only a token connection carries one. Switching to OAuth or None and
     // submitting must not quietly store whatever was typed before.
-    const token = draftAuth === "token" ? draftToken.trim() : "";
+    const token = values.auth === "token" ? values.token.trim() : "";
     if (!NAME_PATTERN.test(name)) {
       toast.error(t("nameMustBeLowercase"));
       return;
@@ -242,13 +221,14 @@ export function McpServerList({ canManageOrganization }: McpServerListProps) {
       toast.error(t("urlMustStartWithHttp"));
       return;
     }
-    const { scope, row, existing } = draft;
+    const { row, existing } = draft;
+    const scope = values.scope;
 
     // OAuth is not a row this dialog writes: the grant is obtained at the
     // provider's consent screen and the connection is created by the callback.
     // Sending the form would make an unauthorized bearer connection that then
     // has to be repaired.
-    if (draftAuth === "oauth" && existing === null) {
+    if (values.auth === "oauth" && existing === null) {
       setDraft(null);
       await handleOAuth({ ...row, url }, name, scope);
       return;
@@ -279,7 +259,7 @@ export function McpServerList({ canManageOrganization }: McpServerListProps) {
         await api(scope).update(existing.id, {
           ...(name !== existing.name ? { name } : {}),
           ...(url !== existing.url ? { url } : {}),
-          ...(token ? { auth_token: token } : clearToken ? { auth_token: "" } : {}),
+          ...(token ? { auth_token: token } : values.clearToken ? { auth_token: "" } : {}),
         });
         toast.success(t("serverUpdated", { name }));
         setDraft(null);
@@ -561,17 +541,7 @@ export function McpServerList({ canManageOrganization }: McpServerListProps) {
 
       <McpConnectionDialog
         draft={draft}
-        setDraft={setDraft}
-        draftName={draftName}
-        setDraftName={setDraftName}
-        draftUrl={draftUrl}
-        setDraftUrl={setDraftUrl}
-        draftToken={draftToken}
-        setDraftToken={setDraftToken}
-        draftAuth={draftAuth}
-        setDraftAuth={setDraftAuth}
-        clearToken={clearToken}
-        setClearToken={setClearToken}
+        onClose={() => setDraft(null)}
         submitting={submitting}
         canManageOrganization={canManageOrganization}
         onSubmit={handleSubmit}


### PR DESCRIPTION
## What changed

Closes the last actionable item of the #569 cleanup umbrella: the MCP connection dialog's form.

`McpConnectionDialog` was a controlled shell — `McpServerList` held its five form fields as `useState` and drilled a value **and** a setter each into it (**13 props**), seeding them by hand in `openDraft`. The dialog now owns those fields in an inner `ConnectionForm`, keyed on the draft so switching servers remounts it with fresh seeded state rather than carrying the last one's name and token across.

The list keeps only `draft` (which server, and the connection if editing) and reads a `ConnectionFormValues` back on submit. `handleSubmit` **stays** in the list — it drives the connection mutations, `handleTools` and the OAuth redirect, which belong to the list, not the dialog. Net: the dialog's prop surface drops 13 → 5, and five `useState` plus the field-seeding leave `McpServerList`.

## The rest of the umbrella was already done

Of #569's eight items, seven were resolved by later PRs since the 2026-08-10 audit:

- `conversations.count` is gone; `kb.detail`/`kb.documents` are now **live** (#557 wired them in) — nothing to delete
- `patchKB` already rethrows like its siblings
- the sandbox `usage` discriminator is already a param on the `sessions(id, usage)` key factory
- `files/[id]/route.ts` already `encodeURIComponent`s the id
- the members page already gates on `permissionsLoading`
- `MessageBody` is already extracted from `message-item.tsx`
- the i18n guard passes — the untranslated clusters are already translated

The MCP dialogs were also already extracted as components; this PR completes that by moving the connection dialog's form ownership into it — the "MCP churn" the audit named.

## Verification

Behaviour is unchanged: `mcp-server-list.integration.test.tsx` drives the dialog through the DOM and asserts the same API payloads (connect, edit, OAuth, personal vs organization), and passes untouched. `make lint-frontend` clean; frontend coverage gate green.

Closes #569