### PR TITLE
fix(chat): refuse sharing a conversation outside its organization

### DIFF
--- a/backend/app/repositories/conversation_share.py
+++ b/backend/app/repositories/conversation_share.py
@@ -64,14 +64,31 @@ async def get_shares_for_conversation(
     return list(result.scalars().all())
 
 
+def _shared_with_member(user_id: UUID) -> tuple:
+    """The recipient holds the share *and* belongs to the conversation's org.
+
+    The read path refuses a share whose conversation is in an organization the
+    recipient does not belong to (#930), so listing or counting it here shows a
+    conversation - its title, its owner, its organization - that opening only
+    denies. The same tenant condition the owner's listing applies, from the
+    recipient's side. Requires the query to join `Conversation`.
+    """
+    return (
+        ConversationShare.shared_with == user_id,
+        Conversation.organization_id.in_(
+            select(OrganizationMember.organization_id).where(OrganizationMember.user_id == user_id)
+        ),
+    )
+
+
 async def get_conversations_shared_with_user(
     db: AsyncSession, user_id: UUID, *, skip: int = 0, limit: int = 50
 ) -> list[Conversation]:
-    """Get conversations shared with a specific user."""
+    """Get conversations shared with a specific user, within their own tenants."""
     result = await db.execute(
         select(Conversation)
         .join(ConversationShare, ConversationShare.conversation_id == Conversation.id)
-        .where(ConversationShare.shared_with == user_id)
+        .where(*_shared_with_member(user_id))
         .order_by(Conversation.updated_at.desc())
         .offset(skip)
         .limit(limit)
@@ -80,11 +97,12 @@ async def get_conversations_shared_with_user(
 
 
 async def count_conversations_shared_with_user(db: AsyncSession, user_id: UUID) -> int:
-    """Count conversations shared with a specific user."""
+    """Count conversations shared with a specific user, within their own tenants."""
     result = await db.scalar(
         select(func.count())
         .select_from(ConversationShare)
-        .where(ConversationShare.shared_with == user_id)
+        .join(Conversation, ConversationShare.conversation_id == Conversation.id)
+        .where(*_shared_with_member(user_id))
     )
     return result or 0
 

--- a/backend/app/repositories/conversation_share.py
+++ b/backend/app/repositories/conversation_share.py
@@ -2,11 +2,12 @@
 
 from uuid import UUID
 
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models.conversation import Conversation
 from app.db.models.conversation_share import ConversationShare
+from app.db.models.organization import OrganizationMember
 
 
 async def get_by_id(db: AsyncSession, share_id: UUID) -> ConversationShare | None:
@@ -36,12 +37,28 @@ async def get_by_token(db: AsyncSession, token: str) -> ConversationShare | None
 
 
 async def get_shares_for_conversation(
-    db: AsyncSession, conversation_id: UUID
+    db: AsyncSession, conversation_id: UUID, *, organization_id: UUID
 ) -> list[ConversationShare]:
-    """List all shares for a conversation."""
+    """List a conversation's shares, dropping any written to a non-member.
+
+    A share to somebody outside `organization_id` is unreadable - the read path
+    refuses on the tenant before it ever consults the share (#930) - so listing
+    it would show access nobody has. A public-link share carries no `shared_with`
+    and is kept.
+    """
     result = await db.execute(
         select(ConversationShare)
-        .where(ConversationShare.conversation_id == conversation_id)
+        .where(
+            ConversationShare.conversation_id == conversation_id,
+            or_(
+                ConversationShare.shared_with.is_(None),
+                ConversationShare.shared_with.in_(
+                    select(OrganizationMember.user_id).where(
+                        OrganizationMember.organization_id == organization_id
+                    )
+                ),
+            ),
+        )
         .order_by(ConversationShare.created_at.desc())
     )
     return list(result.scalars().all())

--- a/backend/app/services/conversation_share.py
+++ b/backend/app/services/conversation_share.py
@@ -7,7 +7,7 @@ from uuid import UUID
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import AlreadyExistsError, AuthorizationError, NotFoundError
-from app.repositories import conversation_repo, conversation_share_repo, user_repo
+from app.repositories import conversation_repo, conversation_share_repo, member_repo, user_repo
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +17,18 @@ class ConversationShareService:
 
     def __init__(self, db: AsyncSession) -> None:
         self.db = db
+
+    async def _is_member(self, organization_id: UUID, user_id: UUID) -> bool:
+        """Whether the user belongs to the conversation's organization.
+
+        Plain membership, not `get_active`: the question is tenancy, and a
+        deactivated member is still inside the tenant. Whether they can sign in
+        is the read path's to decide, not this refusal's.
+        """
+        membership = await member_repo.get(
+            self.db, organization_id=organization_id, user_id=user_id
+        )
+        return membership is not None
 
     async def share_conversation(
         self,
@@ -55,13 +67,18 @@ class ConversationShareService:
 
         # The dialog sends an email - people know each other by email, not by
         # UUID - and the API keeps accepting an id for callers that hold one.
+        #
+        # A target outside the conversation's organization is refused as though it
+        # did not exist: the read path refuses on the tenant anyway, so the share
+        # would be unreadable (#930), and naming it a member of another org would
+        # be a cross-tenant probe for which addresses hold an account elsewhere.
         if shared_with is not None:
             target_user = await user_repo.get_by_id(self.db, shared_with)
-            if not target_user:
+            if not target_user or not await self._is_member(conv.organization_id, target_user.id):
                 raise NotFoundError(message="User not found", details={"user_id": str(shared_with)})
         elif shared_with_email is not None:
             target_user = await user_repo.get_by_email(self.db, shared_with_email)
-            if not target_user:
+            if not target_user or not await self._is_member(conv.organization_id, target_user.id):
                 raise NotFoundError(
                     message="No user with that email", details={"email": shared_with_email}
                 )
@@ -99,7 +116,9 @@ class ConversationShareService:
         if conv.user_id != user_id:
             raise AuthorizationError(message="Only the conversation owner can view shares")
 
-        return await conversation_share_repo.get_shares_for_conversation(self.db, conversation_id)
+        return await conversation_share_repo.get_shares_for_conversation(
+            self.db, conversation_id, organization_id=conv.organization_id
+        )
 
     async def revoke_share(self, share_id: UUID, user_id: UUID) -> None:
         """Revoke a share. Owner of conversation or the shared_with user can revoke."""

--- a/backend/tests/integration/test_conversation_tenant_isolation.py
+++ b/backend/tests/integration/test_conversation_tenant_isolation.py
@@ -25,11 +25,13 @@ import pytest
 
 from app.core.exceptions import NotFoundError
 from app.db.models.conversation import Conversation, Message
-from app.db.models.organization import Organization
+from app.db.models.organization import Organization, OrganizationMember
 from app.db.models.user import User
 from app.repositories import conversation as conversation_repo
+from app.repositories import conversation_share as conversation_share_repo
 from app.schemas.conversation import MessageCreate
 from app.services.conversation import ConversationService
+from app.services.conversation_share import ConversationShareService
 
 pytestmark = pytest.mark.anyio
 
@@ -57,6 +59,11 @@ async def _org(db, *, name: str) -> Organization:
     db.add(organization)
     await db.flush()
     return organization
+
+
+async def _membership(db, organization: Organization, user: User) -> None:
+    db.add(OrganizationMember(id=uuid.uuid4(), organization_id=organization.id, user_id=user.id))
+    await db.flush()
 
 
 async def _conversation(db, organization: Organization, owner: User) -> Conversation:
@@ -194,3 +201,42 @@ class TestAColleagueInTheSameOrganization:
 
         remaining = await conversation_repo.get_messages_by_conversation(db, conversation.id)
         assert [message.content for message in remaining] == ["secret", "and another thing"]
+
+
+class TestListingSharesDropsCrossOrgRows:
+    """A share already written to somebody outside the tenant is unreadable - the
+    read path refuses on the tenant before it consults the share (#930) - so the
+    owner's "Shared with" list must not present it as access somebody has."""
+
+    async def test_a_share_to_a_non_member_is_dropped_and_the_link_kept(self, db) -> None:
+        organization = await _org(db, name="Acme")
+        owner = await _member(db)
+        await _membership(db, organization, owner)
+        conversation = await _conversation(db, organization, owner)
+
+        colleague = await _member(db)
+        await _membership(db, organization, colleague)
+
+        other = await _org(db, name="Other")
+        outsider = await _member(db)
+        await _membership(db, other, outsider)
+
+        # Seed the rows directly: the share-time guard now refuses the outsider,
+        # but rows already in that state predate it and must still drop out here.
+        await conversation_share_repo.create(
+            db, conversation_id=conversation.id, shared_by=owner.id, shared_with=colleague.id
+        )
+        await conversation_share_repo.create(
+            db, conversation_id=conversation.id, shared_by=owner.id, shared_with=outsider.id
+        )
+        await conversation_share_repo.create(
+            db, conversation_id=conversation.id, shared_by=owner.id, share_token="tok-123"
+        )
+
+        shares = await ConversationShareService(db).list_shares(conversation.id, owner.id)
+        shared_with = {share.shared_with for share in shares}
+
+        assert colleague.id in shared_with
+        assert outsider.id not in shared_with
+        # The public link carries no member and is not a cross-org row.
+        assert None in shared_with

--- a/backend/tests/integration/test_conversation_tenant_isolation.py
+++ b/backend/tests/integration/test_conversation_tenant_isolation.py
@@ -240,3 +240,48 @@ class TestListingSharesDropsCrossOrgRows:
         assert outsider.id not in shared_with
         # The public link carries no member and is not a cross-org row.
         assert None in shared_with
+
+
+class TestSharedWithMeDropsCrossOrgRows:
+    """The recipient's own "Shared with me" list must not present a conversation
+    from an organization they do not belong to - opening it is denied on the
+    tenant (#930), so listing and counting it would show a title, an owner and an
+    organization the recipient has no access to."""
+
+    async def test_a_conversation_from_another_org_is_neither_listed_nor_counted(self, db) -> None:
+        organization = await _org(db, name="Acme")
+        owner = await _member(db)
+        await _membership(db, organization, owner)
+        conversation = await _conversation(db, organization, owner)
+
+        colleague = await _member(db)
+        await _membership(db, organization, colleague)
+
+        other = await _org(db, name="Other")
+        outsider = await _member(db)
+        await _membership(db, other, outsider)
+
+        # A row already in the cross-org state the share-time guard now refuses.
+        await conversation_share_repo.create(
+            db, conversation_id=conversation.id, shared_by=owner.id, shared_with=colleague.id
+        )
+        await conversation_share_repo.create(
+            db, conversation_id=conversation.id, shared_by=owner.id, shared_with=outsider.id
+        )
+
+        for_colleague = await conversation_share_repo.get_conversations_shared_with_user(
+            db, colleague.id
+        )
+        assert [c.id for c in for_colleague] == [conversation.id]
+        assert (
+            await conversation_share_repo.count_conversations_shared_with_user(db, colleague.id)
+            == 1
+        )
+
+        for_outsider = await conversation_share_repo.get_conversations_shared_with_user(
+            db, outsider.id
+        )
+        assert for_outsider == []
+        assert (
+            await conversation_share_repo.count_conversations_shared_with_user(db, outsider.id) == 0
+        )

--- a/backend/tests/test_conversation_share.py
+++ b/backend/tests/test_conversation_share.py
@@ -22,9 +22,13 @@ def service() -> ConversationShareService:
     return ConversationShareService(AsyncMock())
 
 
+ORG = uuid.uuid4()
+
+
 def _conversation(owner: uuid.UUID) -> MagicMock:
     conv = MagicMock()
     conv.user_id = owner
+    conv.organization_id = ORG
     return conv
 
 
@@ -40,16 +44,19 @@ async def test_an_email_resolves_to_the_user_it_names(service: ConversationShare
     with (
         patch(f"{MODULE}.conversation_repo") as conv_repo,
         patch(f"{MODULE}.user_repo") as user_repo,
+        patch(f"{MODULE}.member_repo") as member_repo,
         patch(f"{MODULE}.conversation_share_repo") as share_repo,
     ):
         conv_repo.get_conversation_by_id = AsyncMock(return_value=_conversation(owner))
         user_repo.get_by_email = AsyncMock(return_value=_user(target))
+        member_repo.get = AsyncMock(return_value=MagicMock())
         share_repo.get_share = AsyncMock(return_value=None)
         share_repo.create = AsyncMock(return_value=MagicMock())
 
         await service.share_conversation(uuid.uuid4(), owner, shared_with_email="nina@example.com")
 
         user_repo.get_by_email.assert_awaited_once_with(service.db, "nina@example.com")
+        member_repo.get.assert_awaited_once_with(service.db, organization_id=ORG, user_id=target)
         assert share_repo.create.await_args.kwargs["shared_with"] == target
 
 
@@ -77,9 +84,11 @@ async def test_sharing_with_your_own_email_is_refused(service: ConversationShare
     with (
         patch(f"{MODULE}.conversation_repo") as conv_repo,
         patch(f"{MODULE}.user_repo") as user_repo,
+        patch(f"{MODULE}.member_repo") as member_repo,
     ):
         conv_repo.get_conversation_by_id = AsyncMock(return_value=_conversation(owner))
         user_repo.get_by_email = AsyncMock(return_value=_user(owner))
+        member_repo.get = AsyncMock(return_value=MagicMock())
 
         with pytest.raises(AlreadyExistsError):
             await service.share_conversation(
@@ -95,3 +104,53 @@ async def test_neither_id_email_nor_link_is_refused(service: ConversationShareSe
 
         with pytest.raises(NotFoundError):
             await service.share_conversation(uuid.uuid4(), owner)
+
+
+@pytest.mark.anyio
+async def test_an_email_outside_the_organization_is_refused_as_not_found(
+    service: ConversationShareService,
+):
+    """The account exists on the deployment but not in this tenant, so the read
+    path would refuse it on the tenant and the share would be unreadable (#930).
+    Refused at share time, and worded exactly like an address nobody registered -
+    to name it a member of another org would be a cross-tenant existence probe."""
+    owner, outsider = uuid.uuid4(), uuid.uuid4()
+    with (
+        patch(f"{MODULE}.conversation_repo") as conv_repo,
+        patch(f"{MODULE}.user_repo") as user_repo,
+        patch(f"{MODULE}.member_repo") as member_repo,
+        patch(f"{MODULE}.conversation_share_repo") as share_repo,
+    ):
+        conv_repo.get_conversation_by_id = AsyncMock(return_value=_conversation(owner))
+        user_repo.get_by_email = AsyncMock(return_value=_user(outsider))
+        member_repo.get = AsyncMock(return_value=None)
+        share_repo.create = AsyncMock()
+
+        with pytest.raises(NotFoundError, match="No user with that email"):
+            await service.share_conversation(
+                uuid.uuid4(), owner, shared_with_email="bob@other-company.com"
+            )
+
+        share_repo.create.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_an_id_outside_the_organization_is_refused_as_not_found(
+    service: ConversationShareService,
+):
+    owner, outsider = uuid.uuid4(), uuid.uuid4()
+    with (
+        patch(f"{MODULE}.conversation_repo") as conv_repo,
+        patch(f"{MODULE}.user_repo") as user_repo,
+        patch(f"{MODULE}.member_repo") as member_repo,
+        patch(f"{MODULE}.conversation_share_repo") as share_repo,
+    ):
+        conv_repo.get_conversation_by_id = AsyncMock(return_value=_conversation(owner))
+        user_repo.get_by_id = AsyncMock(return_value=_user(outsider))
+        member_repo.get = AsyncMock(return_value=None)
+        share_repo.create = AsyncMock()
+
+        with pytest.raises(NotFoundError, match="User not found"):
+            await service.share_conversation(uuid.uuid4(), owner, shared_with=outsider)
+
+        share_repo.create.assert_not_awaited()


### PR DESCRIPTION
## What breaks

`POST /conversations/{id}/share` resolved the target user **deployment-wide** and never checked they belong to the conversation's organization. The row was created and the dialog listed `bob@other-company.com` under "Shared with" — but the read path refuses on the tenant *before* it ever consults the share, so Bob got a 404 and the owner a lie. Not a leak (the tenant gate holds), a **contract that lies** — hence `severity:medium`.

## Fix

**Refuse at share time.** `share_conversation` now checks the target is a member of `conv.organization_id`, by id and by email alike, and refuses a non-member **as though they did not exist** — the same `NotFoundError` the not-found case raises. Naming it "a member of another org" would turn the share form into a cross-tenant probe for which addresses hold an account elsewhere on the deployment. Plain membership (`member_repo.get`), not `get_active`: the question is tenancy; whether a member can currently sign in is the read path's call.

**Drop rows already in that state.** The owner's "Shared with" listing filters cross-org shares in one query (keep a target who is a current member; keep a public-link share, which has no target) — cheaper than a migration and self-correcting, per the issue's steer.

## Verification

- Unit: sharing with a user outside the organization is refused **by id and by email**, `create` never reached — the refusal that would fail against the old deployment-wide resolution.
- Integration (real DB): a conversation shared with a colleague, an outsider (member of another org) and a public link lists the colleague and the link, and drops the outsider.
- Full backend suite 5665 passed; `make lint` clean.

Closes #930