### PR TITLE
fix(admin): stop an app admin from suspending or deleting their own account

### DIFF
--- a/backend/app/api/routes/v1/admin_users.py
+++ b/backend/app/api/routes/v1/admin_users.py
@@ -47,7 +47,7 @@ async def update_user(
     db: DBSession,
     service: UserSvc,
 ) -> Any:
-    user = await service.update(user_id, user_in)
+    user = await service.admin_update(user_id, user_in, acting_admin_id=admin.id)
     # Which fields were set, never what they were set to. `UserUpdate` carries
     # `password`, so dumping the submitted body wrote the plaintext an
     # administrator typed into `app_admin_audit_logs.details`, where it sat in a
@@ -76,7 +76,7 @@ async def delete_user(
     service: UserSvc,
 ) -> None:
     target = await service.get_by_id(user_id)
-    await service.delete(user_id)
+    await service.admin_delete(user_id, acting_admin_id=admin.id)
     await record_audit(
         db,
         actor_user_id=admin.id,

--- a/backend/app/api/routes/v1/users.py
+++ b/backend/app/api/routes/v1/users.py
@@ -38,8 +38,13 @@ async def update_current_user(
     non-admin had put in the body - has nothing left to strip. Granting the one
     global privilege is a CLI act (`agenticos cmd create-app-admin`), which
     keeps it off the surface a user can PATCH.
+
+    It can still take one away from its owner, though: `is_active` is on this
+    schema and this route reaches the same column the admin route does, so
+    `update_current` refuses an app admin suspending themselves here - otherwise
+    it is the way around #941's guard.
     """
-    return await user_service.update(current_user.id, user_in)
+    return await user_service.update_current(current_user, user_in)
 
 
 @router.post("/me/avatar", response_model=UserRead)

--- a/backend/app/api/routes/v1/users.py
+++ b/backend/app/api/routes/v1/users.py
@@ -86,17 +86,17 @@ async def update_user_by_id(
     user_id: UUID,
     user_in: UserUpdate,
     user_service: UserSvc,
-    _: CurrentAppAdmin,
+    admin: CurrentAppAdmin,
 ) -> Any:
     """Update user by ID (admin only)."""
-    return await user_service.update(user_id, user_in)
+    return await user_service.admin_update(user_id, user_in, acting_admin_id=admin.id)
 
 
 @router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None)
 async def delete_user_by_id(
     user_id: UUID,
     user_service: UserSvc,
-    _: CurrentAppAdmin,
+    admin: CurrentAppAdmin,
 ) -> None:
     """Delete user by ID (admin only)."""
-    await user_service.delete(user_id)
+    await user_service.admin_delete(user_id, acting_admin_id=admin.id)

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -6,7 +6,12 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
-from app.core.exceptions import AlreadyExistsError, AuthenticationError, NotFoundError
+from app.core.exceptions import (
+    AlreadyExistsError,
+    AuthenticationError,
+    AuthorizationError,
+    NotFoundError,
+)
 from app.core.security import (
     create_magic_link_token,
     create_password_reset_token,
@@ -269,6 +274,44 @@ class UserService:
                 details={"user_id": user_id},
             )
         return user
+
+    async def admin_update(
+        self, user_id: UUID, user_in: UserUpdate, *, acting_admin_id: UUID
+    ) -> User:
+        """An app admin updating another user's row, refusing self-suspension.
+
+        `is_active` is enforced on the very next request, so an admin flipping
+        their own to false is signed out of a deployment they administer - and on
+        a single-admin install that ends administration until somebody reaches a
+        terminal (#941). An admin genuinely leaving does it through another admin,
+        which is also what keeps the audit trail readable.
+
+        Only `is_active` is guarded because it is the only privilege this schema
+        carries: `is_app_admin` is not a `UserUpdate` field - the one global
+        privilege is granted by CLI, never over a surface a request can reach - so
+        there is no self-demotion here to refuse.
+        """
+        if user_id == acting_admin_id and user_in.is_active is False:
+            raise AuthorizationError(
+                message="You cannot suspend your own account; ask another app admin to."
+            )
+        return await self.update(user_id, user_in)
+
+    async def admin_delete(self, user_id: UUID, *, acting_admin_id: UUID) -> User:
+        """An app admin deleting a user, refusing self-deletion.
+
+        Deleting your own row takes the account and its conversations with it, and
+        on a single-admin install leaves the deployment with no administrator (#941).
+        Because `is_app_admin` cannot be cleared over the API, the set of app admins
+        only ever shrinks by deletion - so refusing self-deletion is what keeps the
+        last admin from being the one removed: any other admin deleting the *last*
+        one would have to be deleting themselves.
+        """
+        if user_id == acting_admin_id:
+            raise AuthorizationError(
+                message="You cannot delete your own account; ask another app admin to."
+            )
+        return await self.delete(user_id)
 
     async def issue_password_reset_token(self, email: str) -> tuple[User, str] | None:
         """Returns None (not raises) to avoid leaking whether the email is registered."""

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -241,6 +241,23 @@ class UserService:
 
         return await user_repo.update(self.db, db_user=user, update_data=update_data)
 
+    async def update_current(self, user: User, user_in: UserUpdate) -> User:
+        """A user updating their own row through `/users/me`.
+
+        `UserUpdate` carries `is_active`, and this route reaches the same column
+        the admin route does - so without the same refusal an app admin could
+        suspend themselves here, the exact lock-out #941 guards against one route
+        over (a single-admin install then stays locked until somebody reaches a
+        terminal). A non-admin deactivating their own account only affects
+        themselves and an admin can restore it, so the guard is the app admin's
+        alone.
+        """
+        if user.is_app_admin and user_in.is_active is False:
+            raise AuthorizationError(
+                message="You cannot suspend your own account; ask another app admin to."
+            )
+        return await self.update(user.id, user_in)
+
     async def update_avatar(
         self, user_id: UUID, file_data: bytes, filename: str, content_type: str
     ) -> User:

--- a/backend/tests/api/test_privilege_escalation.py
+++ b/backend/tests/api/test_privilege_escalation.py
@@ -73,6 +73,11 @@ class _RecordingUserService:
         self.received = user_in
         return self.stored
 
+    async def update_current(self, user: MagicMock, user_in: UserUpdate) -> MagicMock:
+        # The self-update route goes through the self-suspend guard; this test is
+        # about which fields reach the update, so it delegates like the real one.
+        return await self.update(user.id, user_in)
+
     async def admin_update(
         self, user_id: UUID, user_in: UserUpdate, *, acting_admin_id: UUID
     ) -> MagicMock:

--- a/backend/tests/api/test_privilege_escalation.py
+++ b/backend/tests/api/test_privilege_escalation.py
@@ -73,6 +73,13 @@ class _RecordingUserService:
         self.received = user_in
         return self.stored
 
+    async def admin_update(
+        self, user_id: UUID, user_in: UserUpdate, *, acting_admin_id: UUID
+    ) -> MagicMock:
+        # The admin-by-id route goes through the self-action guard; this test is
+        # about which fields reach the update, so it delegates like the real one.
+        return await self.update(user_id, user_in)
+
     async def get_by_id(self, user_id: UUID) -> MagicMock:
         return self.stored
 

--- a/backend/tests/api/test_users.py
+++ b/backend/tests/api/test_users.py
@@ -62,6 +62,7 @@ def mock_user_service(mock_user: MockUser) -> MagicMock:
     service.get_by_id = ServiceMock(return_value=mock_user)
     service.get_multi = ServiceMock(return_value=[mock_user])
     service.update = ServiceMock(return_value=mock_user)
+    service.update_current = ServiceMock(return_value=mock_user)
     service.delete = ServiceMock(return_value=mock_user)
     service.admin_update = ServiceMock(return_value=mock_user)
     service.admin_delete = ServiceMock(return_value=mock_user)
@@ -135,7 +136,7 @@ async def test_update_current_user(auth_client: AsyncClient, mock_user_service: 
         json={"full_name": "Updated Name"},
     )
     assert response.status_code == 200
-    mock_user_service.update.assert_called_once()
+    mock_user_service.update_current.assert_called_once()
 
 
 @pytest.mark.anyio
@@ -149,7 +150,7 @@ async def test_update_current_user_notification_preferences_reach_the_service(
         json={"notify_usage_reports": False, "notify_budget_alerts": False},
     )
     assert response.status_code == 200
-    user_in = mock_user_service.update.call_args.args[1]
+    user_in = mock_user_service.update_current.call_args.args[1]
     assert user_in.notify_usage_reports is False
     assert user_in.notify_budget_alerts is False
     assert user_in.notify_approval_requests is None  # untouched, not defaulted
@@ -166,14 +167,14 @@ async def test_choosing_an_avatar_colour_reaches_the_service(
         json={"avatar_color": 4},
     )
     assert response.status_code == 200
-    assert mock_user_service.update.call_args.args[1].avatar_color == 4
+    assert mock_user_service.update_current.call_args.args[1].avatar_color == 4
 
     reset = await auth_client.patch(
         f"{settings.API_V1_STR}/users/me",
         json={"avatar_color": None},
     )
     assert reset.status_code == 200
-    user_in = mock_user_service.update.call_args.args[1]
+    user_in = mock_user_service.update_current.call_args.args[1]
     assert user_in.avatar_color is None
     assert "avatar_color" in user_in.model_fields_set
 

--- a/backend/tests/api/test_users.py
+++ b/backend/tests/api/test_users.py
@@ -63,6 +63,8 @@ def mock_user_service(mock_user: MockUser) -> MagicMock:
     service.get_multi = ServiceMock(return_value=[mock_user])
     service.update = ServiceMock(return_value=mock_user)
     service.delete = ServiceMock(return_value=mock_user)
+    service.admin_update = ServiceMock(return_value=mock_user)
+    service.admin_delete = ServiceMock(return_value=mock_user)
     return service
 
 
@@ -239,7 +241,8 @@ async def test_update_user_by_id(
         json={"full_name": "Admin Updated"},
     )
     assert response.status_code == 200
-    mock_user_service.update.assert_called_once()
+    # The admin-by-id route goes through the self-action guard, not the bare update.
+    mock_user_service.admin_update.assert_called_once()
 
 
 @pytest.mark.anyio
@@ -251,7 +254,7 @@ async def test_delete_user_by_id(
     """Test deleting user by ID as superuser."""
     response = await superuser_client.delete(f"{settings.API_V1_STR}/users/{mock_user.id}")
     assert response.status_code == 204
-    mock_user_service.delete.assert_called_once()
+    mock_user_service.admin_delete.assert_called_once()
 
 
 @pytest.mark.anyio
@@ -261,7 +264,9 @@ async def test_delete_user_by_id_not_found(
 ):
     """Test deleting non-existent user."""
 
-    mock_user_service.delete = ServiceMock(side_effect=NotFoundError(message="User not found"))
+    mock_user_service.admin_delete = ServiceMock(
+        side_effect=NotFoundError(message="User not found")
+    )
 
     response = await superuser_client.delete(f"{settings.API_V1_STR}/users/{uuid4()}")
     assert response.status_code == 404

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -5,7 +5,12 @@ from uuid import uuid4
 
 import pytest
 
-from app.core.exceptions import AlreadyExistsError, AuthenticationError, NotFoundError
+from app.core.exceptions import (
+    AlreadyExistsError,
+    AuthenticationError,
+    AuthorizationError,
+    NotFoundError,
+)
 from app.schemas.user import UserCreate, UserUpdate
 from app.services.user import UserService
 
@@ -234,3 +239,56 @@ class TestUserServicePostgresql:
 
             with pytest.raises(NotFoundError):
                 await user_service.delete(uuid4())
+
+    @pytest.mark.anyio
+    async def test_an_admin_cannot_suspend_their_own_account(self, user_service: UserService):
+        """is_active is enforced on the next request, so this signs the admin out
+        of a deployment they administer - refused before the repo is touched (#941)."""
+        me = uuid4()
+        with patch("app.services.user.user_repo") as mock_repo:
+            mock_repo.update = AsyncMock()
+
+            with pytest.raises(AuthorizationError):
+                await user_service.admin_update(me, UserUpdate(is_active=False), acting_admin_id=me)
+
+            mock_repo.update.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_an_admin_may_suspend_another_user(
+        self, user_service: UserService, mock_user: MockUser
+    ):
+        """The refusal is about your own row, not about suspension."""
+        with patch("app.services.user.user_repo") as mock_repo:
+            mock_repo.get_by_id = AsyncMock(return_value=mock_user)
+            mock_repo.update = AsyncMock(return_value=mock_user)
+
+            await user_service.admin_update(
+                mock_user.id, UserUpdate(is_active=False), acting_admin_id=uuid4()
+            )
+
+            mock_repo.update.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_an_admin_cannot_delete_their_own_account(self, user_service: UserService):
+        """Deleting your own row takes administration with it on a single-admin
+        install; because is_app_admin cannot be cleared over the API, refusing this
+        is what keeps the last admin from being removed (#941)."""
+        me = uuid4()
+        with patch("app.services.user.user_repo") as mock_repo:
+            mock_repo.delete = AsyncMock()
+
+            with pytest.raises(AuthorizationError):
+                await user_service.admin_delete(me, acting_admin_id=me)
+
+            mock_repo.delete.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_an_admin_may_delete_another_user(
+        self, user_service: UserService, mock_user: MockUser
+    ):
+        with patch("app.services.user.user_repo") as mock_repo:
+            mock_repo.delete = AsyncMock(return_value=mock_user)
+
+            await user_service.admin_delete(mock_user.id, acting_admin_id=uuid4())
+
+            mock_repo.delete.assert_awaited_once()

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -254,6 +254,37 @@ class TestUserServicePostgresql:
             mock_repo.update.assert_not_awaited()
 
     @pytest.mark.anyio
+    async def test_an_app_admin_cannot_suspend_themselves_through_the_self_route(
+        self, user_service: UserService
+    ):
+        """`/users/me` reaches the same `is_active` column as the admin route, so
+        without the same guard it is the way around #941 - an app admin suspends
+        themselves and the next request signs them out."""
+        me = MagicMock(id=uuid4(), is_app_admin=True)
+        with patch("app.services.user.user_repo") as mock_repo:
+            mock_repo.update = AsyncMock()
+
+            with pytest.raises(AuthorizationError):
+                await user_service.update_current(me, UserUpdate(is_active=False))
+
+            mock_repo.update.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_a_non_admin_may_deactivate_their_own_account_through_the_self_route(
+        self, user_service: UserService, mock_user: MockUser
+    ):
+        """The guard is the app admin's alone - a member deactivating their own
+        row only affects themselves, and an admin can restore it."""
+        mock_user.is_app_admin = False
+        with patch("app.services.user.user_repo") as mock_repo:
+            mock_repo.get_by_id = AsyncMock(return_value=mock_user)
+            mock_repo.update = AsyncMock(return_value=mock_user)
+
+            await user_service.update_current(mock_user, UserUpdate(is_active=False))
+
+            mock_repo.update.assert_awaited_once()
+
+    @pytest.mark.anyio
     async def test_an_admin_may_suspend_another_user(
         self, user_service: UserService, mock_user: MockUser
     ):

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -162,6 +162,25 @@ know the rule exists and reads the refusal as the product being broken. That is
 also why the allowed domains are published: they are not a secret, and the
 deployment is on the company's own host.
 
+## An app admin cannot lock the deployment out through the console
+
+`is_active` is enforced on the next request and `is_app_admin` is what the admin
+pages read, so an app admin acting on **their own** row from `/admin/users` could
+sign themselves out, drop `/admin`, or delete the account — and on the
+single-admin install `make platform-bootstrap` produces, a stray click ended
+administration until somebody reached a terminal. `UserService.admin_update` and
+`admin_delete` refuse the self-suspend and the self-delete, and the drawer does
+not offer Suspend, Demote or Impersonate on your own row (Delete stays, visible
+and refused, because "why can I not delete myself" has an answer worth showing).
+
+The deployment cannot be left with no app admin through the API at all: the one
+global privilege is granted only by CLI (`agenticos cmd create-app-admin`) and
+there is no request that clears it, so the set of app admins shrinks only by
+deletion — and deleting the *last* one is deleting yourself, which is refused.
+Removing an admin genuinely leaving is another admin's action, which is also what
+keeps the audit trail readable. Recovery, if it is ever needed, is still
+`create-app-admin` from a shell on the deployment.
+
 ## Notices, and closing the deployment
 
 **The announcement** is one sentence with one of three styles, shown above every

--- a/frontend/src/components/admin/user-detail-drawer.tsx
+++ b/frontend/src/components/admin/user-detail-drawer.tsx
@@ -31,6 +31,7 @@ import type { AdminUser } from "@/types";
 import { apiClient } from "@/lib/api-client";
 import { formatDateTime } from "@/lib/utils";
 import { qk } from "@/lib/query-keys";
+import { useAuthStore } from "@/stores/auth-store";
 import { useLocale, useTranslations } from "next-intl";
 
 interface UserDetailDrawerProps {
@@ -60,6 +61,7 @@ export function UserDetailDrawer({
   const tErrors = useTranslations("errors");
   const t = useTranslations("admin");
   const locale = useLocale();
+  const currentUserId = useAuthStore((state) => state.user?.id);
   // Server data through the query layer, which is where `.claude/rules/frontend.md`
   // says it lives. It was three pieces of state and an effect: a list, a loading
   // flag, and a reset when the drawer closed - all of which `useQuery` already
@@ -90,6 +92,12 @@ export function UserDetailDrawer({
   const subject = user ?? shown;
 
   if (!subject) return null;
+
+  // Your own row does not offer Suspend, Demote or Impersonate: suspending or
+  // demoting yourself ends your administration of the deployment (#941), and
+  // impersonating yourself is meaningless. Delete stays visible and is refused
+  // by the API, because "why can I not delete myself" has an answer worth showing.
+  const isSelf = subject.id === currentUserId;
 
   const handleImpersonate = async () => {
     const token = await onImpersonate(subject.id);
@@ -201,44 +209,48 @@ export function UserDetailDrawer({
         </div>
 
         <footer className="border-border flex flex-wrap items-center gap-2 border-t px-5 py-4">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => onUpdate(subject.id, { is_active: !subject.is_active })}
-          >
-            {subject.is_active ? (
-              <>
-                <UserX className="mr-1.5 h-3.5 w-3.5" />
-                {t("suspend")}
-              </>
-            ) : (
-              <>
-                <Mail className="mr-1.5 h-3.5 w-3.5" />
-                {t("reactivate")}
-              </>
-            )}
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => onUpdate(subject.id, { is_app_admin: !subject.is_app_admin })}
-          >
-            {subject.is_app_admin ? (
-              <>
-                <ShieldOff className="mr-1.5 h-3.5 w-3.5" />
-                {t("demote")}
-              </>
-            ) : (
-              <>
-                <Shield className="mr-1.5 h-3.5 w-3.5" />
-                {t("promoteAdmin")}
-              </>
-            )}
-          </Button>
-          <Button variant="outline" size="sm" onClick={handleImpersonate}>
-            <KeyRound className="mr-1.5 h-3.5 w-3.5" />
-            {t("impersonate")}
-          </Button>
+          {!isSelf && (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onUpdate(subject.id, { is_active: !subject.is_active })}
+              >
+                {subject.is_active ? (
+                  <>
+                    <UserX className="mr-1.5 h-3.5 w-3.5" />
+                    {t("suspend")}
+                  </>
+                ) : (
+                  <>
+                    <Mail className="mr-1.5 h-3.5 w-3.5" />
+                    {t("reactivate")}
+                  </>
+                )}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onUpdate(subject.id, { is_app_admin: !subject.is_app_admin })}
+              >
+                {subject.is_app_admin ? (
+                  <>
+                    <ShieldOff className="mr-1.5 h-3.5 w-3.5" />
+                    {t("demote")}
+                  </>
+                ) : (
+                  <>
+                    <Shield className="mr-1.5 h-3.5 w-3.5" />
+                    {t("promoteAdmin")}
+                  </>
+                )}
+              </Button>
+              <Button variant="outline" size="sm" onClick={handleImpersonate}>
+                <KeyRound className="mr-1.5 h-3.5 w-3.5" />
+                {t("impersonate")}
+              </Button>
+            </>
+          )}
 
           <AlertDialog>
             <AlertDialogTrigger asChild>

--- a/frontend/src/components/derived-state.integration.test.tsx
+++ b/frontend/src/components/derived-state.integration.test.tsx
@@ -6,7 +6,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { UserDetailDrawer } from "./admin/user-detail-drawer";
 import { SyncSourceWizard } from "./rag/sync-source-wizard";
-import type { AdminUser } from "@/types";
+import type { AdminUser, User } from "@/types";
+import { useAuthStore } from "@/stores/auth-store";
 
 /**
  * Two components that read a row somebody else derives for them.
@@ -86,17 +87,23 @@ describe("the admin user drawer", () => {
     created_at: "2026-07-01T00:00:00Z",
   };
 
+  const props = {
+    open: true,
+    onOpenChange: vi.fn(),
+    onUpdate: vi.fn(),
+    onDelete: vi.fn(),
+    onImpersonate: vi.fn(),
+  };
+
+  function signedInAs(id: string) {
+    useAuthStore.setState({ user: { id, email: "who@example.com" } as unknown as User });
+  }
+
   it("keeps showing the row it was given while the sheet closes", () => {
     // The page holds the id and derives the row, so deleting the user takes it
     // away mid-animation. Returning null then rips the sheet off the screen
     // instead of letting it slide.
-    const props = {
-      open: true,
-      onOpenChange: vi.fn(),
-      onUpdate: vi.fn(),
-      onDelete: vi.fn(),
-      onImpersonate: vi.fn(),
-    };
+    signedInAs("someone-else");
     const { rerender } = mount(<UserDetailDrawer {...props} user={user} />);
     expect(screen.getAllByText("kacper@example.com").length).toBeGreaterThan(0);
 
@@ -111,5 +118,26 @@ describe("the admin user drawer", () => {
     );
 
     expect(screen.getAllByText("kacper@example.com").length).toBeGreaterThan(0);
+  });
+
+  it("does not offer suspend, demote or impersonate on your own row", () => {
+    // Suspending or demoting yourself ends your own administration of the
+    // deployment (#941); impersonating yourself is meaningless. Delete stays,
+    // visible and refused by the API.
+    signedInAs(user.id);
+    mount(<UserDetailDrawer {...props} user={user} />);
+
+    expect(screen.queryByRole("button", { name: "Suspend" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Promote to admin" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Impersonate" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+  });
+
+  it("offers them on somebody else's row", () => {
+    signedInAs("another-admin");
+    mount(<UserDetailDrawer {...props} user={user} />);
+
+    expect(screen.getByRole("button", { name: "Suspend" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Impersonate" })).toBeInTheDocument();
   });
 });

--- a/frontend/src/hooks/use-admin-users.ts
+++ b/frontend/src/hooks/use-admin-users.ts
@@ -4,6 +4,7 @@ import { useCallback, useState } from "react";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { apiClient } from "@/lib/api-client";
+import { ApiError, getErrorMessage } from "@/lib/api-error";
 import type { AdminUser, AdminUserListResponse } from "@/types";
 
 interface ImpersonateResponse {
@@ -16,6 +17,7 @@ interface ImpersonateResponse {
 
 export function useAdminUsers() {
   const t = useTranslations("admin");
+  const tError = useTranslations("errors");
   const [users, setUsers] = useState<AdminUser[]>([]);
   const [total, setTotal] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
@@ -77,11 +79,17 @@ export function useAdminUsers() {
         setUsers((prev) => prev.filter((u) => u.id !== userId));
         setTotal((count) => count - 1);
         toast.success(t("userDeleted"));
-      } catch {
-        toast.error(t("failedDeleteUser"));
+      } catch (error) {
+        // A refusal carries the backend's own words - deleting your own row is
+        // refused with an explanation the admin should see, not the generic
+        // "failed" that reads as a transient error (#941). Anything else keeps
+        // the generic toast.
+        toast.error(
+          error instanceof ApiError ? getErrorMessage(error, tError) : t("failedDeleteUser"),
+        );
       }
     },
-    [t],
+    [t, tError],
   );
 
   const impersonateUser = useCallback(

--- a/frontend/src/hooks/use-admin.test.tsx
+++ b/frontend/src/hooks/use-admin.test.tsx
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 
 import { useAdminUsers } from "./use-admin-users";
 import { apiClient } from "@/lib/api-client";
+import { ApiError } from "@/lib/api-error";
 
 vi.mock("@/lib/api-client", () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
@@ -145,6 +146,23 @@ describe("useAdminUsers", () => {
     await act(() => result.current.deleteUser("u-1"));
 
     expect(toast.error).toHaveBeenCalledWith("Failed to delete user");
+  });
+
+  it("surfaces the backend's reason when a deletion is refused (#941)", async () => {
+    // Deleting your own row is refused with an explanation; the admin should see
+    // it, not a generic "failed" that reads as a transient error.
+    vi.mocked(apiClient.delete).mockRejectedValue(
+      new ApiError(403, "You cannot delete your own account; ask another app admin to.", {
+        error: { code: "AUTHORIZATION_ERROR" },
+      }),
+    );
+    const { result } = renderHook(() => useAdminUsers());
+
+    await act(() => result.current.deleteUser("u-1"));
+
+    expect(toast.error).toHaveBeenCalledWith(
+      "You cannot delete your own account; ask another app admin to.",
+    );
   });
 
   it("marks who is being impersonated while the request is in flight", async () => {


### PR DESCRIPTION
## What breaks

`/admin/users` let an app admin open their **own** row and suspend, demote or delete themselves — unguarded at both layers, two of them one click with no confirmation. `is_active` is enforced on the next request, so self-suspend signs you out of a deployment you administer; self-delete takes the account and its conversations. On the single-admin install `make platform-bootstrap` produces, a stray click ends administration until somebody reaches a terminal. `security` / `severity:medium`.

## Backend

The guard lives in `UserService`, where both admin surfaces meet:

- `admin_update` refuses a **self-suspend**, `admin_delete` a **self-delete** — before the repository is touched.
- `PATCH`/`DELETE` on **both** `/admin/users/{id}` and `/users/{id}` (the twin route with the same hole) now route through them, carrying the acting admin's id.
- Only `is_active` is guarded on update because `is_app_admin` is **not a `UserUpdate` field** — the one global privilege is granted by CLI and cleared by nothing over the API.

**The last-admin question, answered in code:** because the app-admin set shrinks only by deletion and deleting the last one is deleting yourself (refused), the API cannot leave the deployment with no administrator. There is no API self-demote to worry about. Written up in `docs/deployment.md`.

## Frontend

The drawer no longer renders **Suspend, Demote or Impersonate** on your own row (`frontend.md`: a control you may not use is not rendered, never rendered-then-403). **Delete stays visible and is refused by the API** — "why can I not delete myself" has an answer worth showing.

## Verification

- Service tests: self-suspend and self-delete refused before the repo is touched; acting on another user still works.
- Drawer tests: the three controls are absent on your own row, present on somebody else's, and Delete stays either way.
- Full backend suite 5667 passed; frontend coverage gate green; `make lint` clean.

Closes #941