### PR TITLE
chore: cut 0.0.222

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,42 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.222] - 2026-08-20
+
+The sync wizard says who will be able to read what a source ingests.
+
+### Added
+
+- **The step that decides a source's collection now names the audience.** Access
+  is decided at the collection and there is no per-document isolation inside one,
+  so everything the credential can reach becomes readable by everyone who can read
+  that collection - a Confluence token issued for a whole instance, pointed at an
+  `org` collection, publishes the instance to every member holding
+  `collections:view`. The decision is the operator's, deliberately; what was wrong
+  is that it was made silently. One sentence per scope: `personal` is its owner,
+  `org` is everyone who can view the collection, `app` is anybody in the
+  deployment. (#982)
+- **The credential is named alongside the audience**, because the pair is the
+  decision: a credential's own permissions are a ceiling nothing here can raise,
+  while `config` narrows the reach and cannot be relied on to keep it narrow. A
+  connector that authenticates with nothing has none to name and the sentence does
+  not invent one, and neither does one whose reader holds no `secrets:view`.
+  (#982)
+- **Cloning says it too**, which is the reachable half of "repointing re-asks": a
+  clone references the same vault secret and names a different collection, so the
+  audience changes while nothing about the credential does. Repointing an existing
+  source has no screen to ask on - `PATCH` on `collection_name` is reachable
+  through the API and the CLI only, where the audit entry added in 0.0.221 is what
+  records it. (#982)
+
+### Fixed
+
+- **The knowledge-base page no longer reads the vault on every load.** The
+  wizard mounts whether or not it is open, so a credential lookup in its own body
+  fired `/secrets` and `/secrets/kinds` on each page load - including for members
+  holding no `secrets:view`, who get a refusal and a retry of it. The lookup lives
+  in the notice, which renders inside the dialog. (#982)
+
 ## [0.0.221] - 2026-08-20
 
 Who bound a credential to a collection is recorded.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.221"
+version = "0.0.222"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.221"
+version = "0.0.222"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.221",
+  "version": "0.0.222",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.222. Bumps `backend/pyproject.toml`,
`backend/uv.lock` and `frontend/package.json` to 0.0.222 and adds the
CHANGELOG entry.

One issue, #982, and it is frontend-only: the sync wizard asked for a
connector, a credential, a config and a schedule, and the collection was
chosen without a word about the consequence. Access is decided at the
collection, so everything that credential can reach becomes readable by
everyone who can read it - the decision the platform deliberately leaves
to the operator, made silently.

Two things Codex found on the branch, both real. A closed wizard was
reading the vault, on every load of the knowledge-base page and for
members who hold no `secrets:view`. And a connector declaring
`secret_kind: "none"` was described as having a credential, contradicting
the step before it; the sentence selects on three states now.

One claim in the issue turned out to be wrong and is recorded rather than
worked around: "repointing is one dropdown with no prompt at all" - there
is no such dropdown. `PATCH /rag/sync/sources/{id}` has no frontend
client and there is no source editor, so a repoint is reachable only
through the API and the CLI, where #983's audit entry records it. The
wizard's clone step is the audience change that *is* reachable, and it
carries the sentence.

## Verified

Eleven new tests - six on the notice, five on the wizard including the
issue's own repro (a pinned `org` collection, where there is no picker) -
`make test-frontend-cov` at 5266 passed and 100% lines/statements/
functions, `bun run check:i18n`, `make check`, and CI green end to end on
#1010.

Closes #982