### PR TITLE
refactor(rag): S3Connector is an object store's subclass

### DIFF
--- a/backend/app/services/rag/connectors/object_store.py
+++ b/backend/app/services/rag/connectors/object_store.py
@@ -1,0 +1,138 @@
+"""What every object store's connector does identically.
+
+S3, Azure Blob Storage and Google Cloud Storage are one connector with three
+clients: a container, a prefix, a credential, and a flat listing of objects with
+a size and a modified time. #938 put the other two fifth on the list with a
+condition attached - *"if `S3Connector` is refactored to an object-store shape,
+these are configuration rather than code"* - and this is that shape, written
+before either of them rather than after, because the alternative is three
+connectors sharing a form by resemblance (#988).
+
+What a subclass supplies is a client and its SDK's vocabulary: how a listing
+paginates, and how one object is written to a path. What it inherits is
+everything a reader of three connectors would otherwise have to check three
+times - that a key ending in `/` is a directory marker and not a document, that
+`source_path` is `<scheme>://<container>/<key>` and is the dedup key the whole
+sync path matches on, and that the destination is the base class's answer rather
+than the connector's (`BaseSyncConnector.download_file`, which is inherited for
+the reason its own docstring gives).
+"""
+
+import asyncio
+import logging
+from abc import abstractmethod
+from datetime import datetime
+from pathlib import Path
+from typing import ClassVar
+
+from pydantic import BaseModel
+
+from app.core.secret_kinds import StorableSecret
+from app.services.rag.connectors import BaseSyncConnector, ConnectorConfig, RemoteFile
+
+logger = logging.getLogger(__name__)
+
+
+class StoredObject(BaseModel):
+    """One object in a listing, in the terms all three stores describe one in.
+
+    Deliberately not an `etag`. Every object store offers one and the sync path
+    reads none: it compares a `content_hash` of the bytes it downloaded (#990),
+    so an `etag` carried here would be a field nothing reads. A connector that
+    can answer "changed?" *without* the bytes is worth having - it saves the
+    transfer, not just the embedding - and `docs/file-processing.md` says so under
+    what a new connector owes; the place to add it is there and then, with the
+    caller that reads it.
+
+    `modified_at` is carried because `RemoteFile` already has somewhere to put
+    it.
+    """
+
+    key: str
+    size: int | None = None
+    modified_at: datetime | None = None
+
+
+class ObjectStoreConnector(BaseSyncConnector):
+    """A connector for a store addressed by container and key.
+
+    Two hooks, and both are **blocking**, run on a worker thread by the methods
+    below: boto3, `azure-storage-blob` and `google-cloud-storage` all ship
+    synchronous clients, and a hook declared `async` over one of those would
+    either block the event loop or be wrapped twice.
+    """
+
+    SCHEME: ClassVar[str] = ""
+    """What a `source_path` from this store starts with - `s3`, `gs`, `azblob`."""
+
+    CONTAINER_FIELD: ClassVar[str] = "bucket"
+    """Which `CONFIG_SCHEMA` field names the container. S3 and GCS call it a
+    bucket; Azure calls it a container, and the form should say what the store's
+    own console says."""
+
+    async def list_files(
+        self, config: ConnectorConfig, credential: StorableSecret | None
+    ) -> list[RemoteFile]:
+        """Every document under the configured prefix, newest state as listed.
+
+        A key ending in `/` is skipped here rather than in each client: a
+        console that creates a "folder" writes a zero-byte object with that name,
+        and ingesting one is a document with no bytes and a name of `''`.
+        """
+        container = config[self.CONTAINER_FIELD]
+        objects = await asyncio.to_thread(
+            self._objects, container, config.get("prefix", ""), config, credential
+        )
+        return [
+            RemoteFile(
+                id=obj.key,
+                name=Path(obj.key).name,
+                size=obj.size,
+                modified_at=obj.modified_at,
+                source_path=f"{self.SCHEME}://{container}/{obj.key}",
+            )
+            for obj in objects
+            if not obj.key.endswith("/")
+        ]
+
+    async def _fetch(
+        self,
+        file: RemoteFile,
+        dest_path: Path,
+        config: ConnectorConfig,
+        credential: StorableSecret | None,
+    ) -> None:
+        """Write one object to the path the base class chose."""
+        container = file.source_path.removeprefix(f"{self.SCHEME}://").split("/", 1)[0]
+        await asyncio.to_thread(self._download, container, file.id, dest_path, config, credential)
+        logger.info(
+            "Downloaded %s://%s/%s (%d bytes)",
+            self.SCHEME,
+            container,
+            file.id,
+            dest_path.stat().st_size,
+        )
+
+    @abstractmethod
+    def _objects(
+        self,
+        container: str,
+        prefix: str,
+        config: ConnectorConfig,
+        credential: StorableSecret | None,
+    ) -> list[StoredObject]:
+        """This store's listing, paginated the way its SDK paginates.
+
+        Blocking, and called on a worker thread by `list_files`.
+        """
+
+    @abstractmethod
+    def _download(
+        self,
+        container: str,
+        key: str,
+        dest_path: Path,
+        config: ConnectorConfig,
+        credential: StorableSecret | None,
+    ) -> None:
+        """Write one object's bytes to `dest_path`. Blocking, on a worker thread."""

--- a/backend/app/services/rag/connectors/object_store.py
+++ b/backend/app/services/rag/connectors/object_store.py
@@ -21,6 +21,7 @@ the reason its own docstring gives).
 import asyncio
 import logging
 from abc import abstractmethod
+from collections.abc import Iterable
 from datetime import datetime
 from pathlib import Path
 from typing import ClassVar
@@ -73,16 +74,36 @@ class ObjectStoreConnector(BaseSyncConnector):
     async def list_files(
         self, config: ConnectorConfig, credential: StorableSecret | None
     ) -> list[RemoteFile]:
-        """Every document under the configured prefix, newest state as listed.
-
-        A key ending in `/` is skipped here rather than in each client: a
-        console that creates a "folder" writes a zero-byte object with that name,
-        and ingesting one is a document with no bytes and a name of `''`.
-        """
-        container = config[self.CONTAINER_FIELD]
-        objects = await asyncio.to_thread(
-            self._objects, container, config.get("prefix", ""), config, credential
+        """Every document under the configured prefix, newest state as listed."""
+        return await asyncio.to_thread(
+            self._listing,
+            config[self.CONTAINER_FIELD],
+            config.get("prefix", ""),
+            config,
+            credential,
         )
+
+    def _listing(
+        self,
+        container: str,
+        prefix: str,
+        config: ConnectorConfig,
+        credential: StorableSecret | None,
+    ) -> list[RemoteFile]:
+        """The listing converted as it arrives, on the thread that fetched it.
+
+        One list in memory rather than two: `_objects` yields, so a bucket of a
+        million keys holds the `RemoteFile` list this returns and one
+        `StoredObject` at a time - which is what the connector held before it had
+        a shared class, and a peak worth not doubling on the largest sync anyone
+        runs. Converting here rather than in `list_files` is what keeps the
+        pagination *inside* the thread; a generator handed back to the event loop
+        would do the next page's network round trip on it.
+
+        A key ending in `/` is skipped here rather than in each client: a console
+        that creates a "folder" writes a zero-byte object with that name, and
+        ingesting one is a document with no bytes and a name of `''`.
+        """
         return [
             RemoteFile(
                 id=obj.key,
@@ -91,7 +112,7 @@ class ObjectStoreConnector(BaseSyncConnector):
                 modified_at=obj.modified_at,
                 source_path=f"{self.SCHEME}://{container}/{obj.key}",
             )
-            for obj in objects
+            for obj in self._objects(container, prefix, config, credential)
             if not obj.key.endswith("/")
         ]
 
@@ -120,10 +141,13 @@ class ObjectStoreConnector(BaseSyncConnector):
         prefix: str,
         config: ConnectorConfig,
         credential: StorableSecret | None,
-    ) -> list[StoredObject]:
+    ) -> Iterable[StoredObject]:
         """This store's listing, paginated the way its SDK paginates.
 
-        Blocking, and called on a worker thread by `list_files`.
+        Blocking, consumed on a worker thread by `_listing`, and a **generator**
+        rather than a list wherever the SDK pages: nothing needs every object at
+        once, and materializing them is a second copy of the largest thing a sync
+        holds.
         """
 
     @abstractmethod

--- a/backend/app/services/rag/connectors/s3.py
+++ b/backend/app/services/rag/connectors/s3.py
@@ -7,9 +7,12 @@ encrypted with one deployment-wide Fernet key (#937).
 
 `endpoint_url` and `region` stay in the config and still fall back to the
 `S3_RAG_*` settings: neither names a principal.
+
+What is left here is boto3's vocabulary and nothing else - the listing loop, the
+`source_path` shape and the destination are `ObjectStoreConnector`'s, so an Azure
+or GCS connector is a client rather than a second copy of them (#988).
 """
 
-import asyncio
 import logging
 from datetime import datetime
 from pathlib import Path
@@ -23,17 +26,13 @@ from app.core.config import settings
 from app.core.exceptions import BadRequestError
 from app.core.secret_kinds import AwsCredentialsSecret, SecretKind, StorableSecret
 from app.schemas.sync_source import ConnectorConfigField
-from app.services.rag.connectors import (
-    BaseSyncConnector,
-    ConfigRefusal,
-    ConnectorConfig,
-    RemoteFile,
-)
+from app.services.rag.connectors import ConnectorConfig
+from app.services.rag.connectors.object_store import ObjectStoreConnector, StoredObject
 
 logger = logging.getLogger(__name__)
 
 
-class S3Connector(BaseSyncConnector):
+class S3Connector(ObjectStoreConnector):
     """S3-compatible sync connector.
 
     Works with AWS S3, MinIO, and any S3-compatible storage.
@@ -48,6 +47,8 @@ class S3Connector(BaseSyncConnector):
     CONNECTOR_TYPE: ClassVar[str] = "s3"
     DISPLAY_NAME: ClassVar[str] = "S3 / MinIO"
     SECRET_KIND: ClassVar[SecretKind] = SecretKind.AWS_CREDENTIALS
+    SCHEME: ClassVar[str] = "s3"
+    CONTAINER_FIELD: ClassVar[str] = "bucket"
     CONFIG_SCHEMA: ClassVar[dict[str, ConnectorConfigField]] = {
         "bucket": ConnectorConfigField(type="string", label="Bucket Name", required=True),
         "prefix": ConnectorConfigField(
@@ -110,69 +111,46 @@ class S3Connector(BaseSyncConnector):
             client_kwargs["endpoint_url"] = endpoint
         return boto3.client("s3", **client_kwargs, config=Config(signature_version="s3v4"))
 
-    async def validate_config(self, config: ConnectorConfig) -> ConfigRefusal | None:
-        """Validate required fields only - connectivity is checked at sync time."""
-        return await super().validate_config(config)
-
-    async def list_files(
-        self, config: ConnectorConfig, credential: StorableSecret | None
-    ) -> list[RemoteFile]:
-        """List files in an S3 bucket/prefix."""
-        bucket = config["bucket"]
-        prefix = config.get("prefix", "")
-
-        def _list() -> list[RemoteFile]:
-            client = self._get_s3_client(config, credential)
-            paginator = client.get_paginator("list_objects_v2")
-            params: dict[str, Any] = {"Bucket": bucket}
-            if prefix:
-                params["Prefix"] = prefix
-
-            files: list[RemoteFile] = []
-            for page in paginator.paginate(**params):
-                for obj in page.get("Contents", []):
-                    key = obj["Key"]
-                    if key.endswith("/"):
-                        continue
-
-                    name = Path(key).name
-                    modified_at = None
-                    if obj.get("LastModified"):
-                        modified_at = obj["LastModified"]
-                        if isinstance(modified_at, str):
-                            modified_at = datetime.fromisoformat(modified_at)
-
-                    files.append(
-                        RemoteFile(
-                            id=key,
-                            name=name,
-                            mime_type=None,
-                            size=obj.get("Size"),
-                            modified_at=modified_at,
-                            source_path=f"s3://{bucket}/{key}",
-                        )
-                    )
-
-            return files
-
-        return await asyncio.to_thread(_list)
-
-    async def _fetch(
+    def _objects(
         self,
-        file: RemoteFile,
+        container: str,
+        prefix: str,
+        config: ConnectorConfig,
+        credential: StorableSecret | None,
+    ) -> list[StoredObject]:
+        """One page at a time, as `list_objects_v2` hands them over.
+
+        `Prefix` is omitted rather than sent empty, which is what the connector
+        did before this became a subclass: boto3 accepts `Prefix=""` and means
+        the same thing by it, and the two are kept the same call so a stored
+        source lists exactly what it listed yesterday.
+
+        boto3 hands `LastModified` over as a `datetime`; the string branch came
+        with this loop and stays with it, in the client's own method, because
+        which of the two arrives is the client's own vocabulary.
+        """
+        client = self._get_s3_client(config, credential)
+        params: dict[str, Any] = {"Bucket": container}
+        if prefix:
+            params["Prefix"] = prefix
+
+        objects: list[StoredObject] = []
+        for page in client.get_paginator("list_objects_v2").paginate(**params):
+            for obj in page.get("Contents", []):
+                modified_at = obj.get("LastModified")
+                if isinstance(modified_at, str):
+                    modified_at = datetime.fromisoformat(modified_at)
+                objects.append(
+                    StoredObject(key=obj["Key"], size=obj.get("Size"), modified_at=modified_at)
+                )
+        return objects
+
+    def _download(
+        self,
+        container: str,
+        key: str,
         dest_path: Path,
         config: ConnectorConfig,
         credential: StorableSecret | None,
     ) -> None:
-        """Download a file from S3 to the path the base class chose."""
-        parts = file.source_path.replace("s3://", "").split("/", 1)
-        bucket = parts[0]
-
-        def _download() -> None:
-            client = self._get_s3_client(config, credential)
-            client.download_file(bucket, file.id, str(dest_path))
-            logger.info(
-                "Downloaded s3://%s/%s (%d bytes)", bucket, file.id, dest_path.stat().st_size
-            )
-
-        await asyncio.to_thread(_download)
+        self._get_s3_client(config, credential).download_file(container, key, str(dest_path))

--- a/backend/app/services/rag/connectors/s3.py
+++ b/backend/app/services/rag/connectors/s3.py
@@ -14,6 +14,7 @@ or GCS connector is a client rather than a second copy of them (#988).
 """
 
 import logging
+from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
 from typing import Any, ClassVar
@@ -117,8 +118,11 @@ class S3Connector(ObjectStoreConnector):
         prefix: str,
         config: ConnectorConfig,
         credential: StorableSecret | None,
-    ) -> list[StoredObject]:
+    ) -> Iterator[StoredObject]:
         """One page at a time, as `list_objects_v2` hands them over.
+
+        A generator, so a bucket of a million keys is one page in memory rather
+        than a list of all of them beside the one the caller is building.
 
         `Prefix` is omitted rather than sent empty, which is what the connector
         did before this became a subclass: boto3 accepts `Prefix=""` and means
@@ -134,16 +138,12 @@ class S3Connector(ObjectStoreConnector):
         if prefix:
             params["Prefix"] = prefix
 
-        objects: list[StoredObject] = []
         for page in client.get_paginator("list_objects_v2").paginate(**params):
             for obj in page.get("Contents", []):
                 modified_at = obj.get("LastModified")
                 if isinstance(modified_at, str):
                     modified_at = datetime.fromisoformat(modified_at)
-                objects.append(
-                    StoredObject(key=obj["Key"], size=obj.get("Size"), modified_at=modified_at)
-                )
-        return objects
+                yield StoredObject(key=obj["Key"], size=obj.get("Size"), modified_at=modified_at)
 
     def _download(
         self,

--- a/backend/tests/test_object_store_connector.py
+++ b/backend/tests/test_object_store_connector.py
@@ -1,0 +1,231 @@
+"""What an object store's connector inherits rather than repeats (#988).
+
+S3, Azure Blob and GCS are one connector with three clients, and #938 made the
+other two conditional on this shape existing first - the alternative being three
+connectors sharing a form by resemblance, where a fix to the listing loop lands
+in one of them.
+
+So these tests are written against a **subclass that is not S3**: what they hold
+shut is the shared half - the `/`-terminated key that is a console's folder and
+not a document, the `source_path` the whole sync path matches on, and the
+container coming from whichever field the store's own console calls it. A test
+that used `S3Connector` for this would prove the same code twice and say nothing
+about the next store.
+
+`TestTheS3ConnectorStillListsWhatItListed` is the other half: the refactor is
+only correct if a stored source syncs exactly the way it did before it.
+"""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+from typing import Any, ClassVar
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from app.core.exceptions import BadRequestError
+from app.core.secret_kinds import AwsCredentialsSecret, StorableSecret
+from app.schemas.sync_source import ConnectorConfigField
+from app.services.rag.connectors import ConnectorConfig, RemoteFile
+from app.services.rag.connectors.object_store import ObjectStoreConnector, StoredObject
+from app.services.rag.connectors.s3 import S3Connector
+
+pytestmark = pytest.mark.anyio
+
+
+class BlobConnector(ObjectStoreConnector):
+    """A store that calls its container a container, as Azure's console does."""
+
+    CONNECTOR_TYPE: ClassVar[str] = "blob"
+    SCHEME: ClassVar[str] = "azblob"
+    CONTAINER_FIELD: ClassVar[str] = "container"
+    CONFIG_SCHEMA: ClassVar[dict[str, ConnectorConfigField]] = {
+        "container": ConnectorConfigField(type="string", label="Container", required=True),
+    }
+
+    def __init__(self, objects: list[StoredObject] | None = None) -> None:
+        self.objects = objects or []
+        self.listed: list[tuple[str, str]] = []
+        self.downloaded: list[tuple[str, str, Path]] = []
+
+    def _objects(
+        self,
+        container: str,
+        prefix: str,
+        config: ConnectorConfig,
+        credential: StorableSecret | None,
+    ) -> list[StoredObject]:
+        self.listed.append((container, prefix))
+        return self.objects
+
+    def _download(
+        self,
+        container: str,
+        key: str,
+        dest_path: Path,
+        config: ConnectorConfig,
+        credential: StorableSecret | None,
+    ) -> None:
+        self.downloaded.append((container, key, dest_path))
+        dest_path.write_bytes(b"contents")
+
+
+class TestWhatEveryObjectStoreGetsForFree:
+    async def test_the_container_comes_from_the_field_the_store_names(self):
+        """`bucket` is S3's and GCS's word; Azure's is `container`. A shared
+        listing that read `config["bucket"]` would make the next store's form
+        lie about itself."""
+        connector = BlobConnector([StoredObject(key="a.md")])
+
+        await connector.list_files({"container": "docs", "prefix": "legal/"}, None)
+
+        assert connector.listed == [("docs", "legal/")]
+
+    async def test_a_key_ending_in_a_slash_is_not_a_document(self):
+        """A console that creates a "folder" writes a zero-byte object with that
+        name. Ingested, it is a document with no bytes and no filename."""
+        connector = BlobConnector(
+            [StoredObject(key="legal/"), StoredObject(key="legal/nda.pdf", size=12)]
+        )
+
+        files = await connector.list_files({"container": "docs"}, None)
+
+        assert [f.name for f in files] == ["nda.pdf"]
+
+    async def test_the_dedup_key_is_scheme_container_and_key(self):
+        """`source_path` is what the sync path matches a stored row on (#996), so
+        it is built once here rather than per client."""
+        connector = BlobConnector([StoredObject(key="legal/nda.pdf")])
+
+        files = await connector.list_files({"container": "docs"}, None)
+
+        assert files[0].source_path == "azblob://docs/legal/nda.pdf"
+        assert files[0].id == "legal/nda.pdf"
+
+    async def test_two_containers_holding_one_basename_stay_two_documents(self):
+        """The collision #990 removed on the vector side, reached from here: the
+        name is a display name and the key is the identity."""
+        connector = BlobConnector(
+            [StoredObject(key="a/readme.md"), StoredObject(key="b/readme.md")]
+        )
+
+        files = await connector.list_files({"container": "docs"}, None)
+
+        assert {f.source_path for f in files} == {
+            "azblob://docs/a/readme.md",
+            "azblob://docs/b/readme.md",
+        }
+
+    async def test_a_listing_carries_the_size_and_the_modified_time(self):
+        when = datetime.datetime(2026, 8, 20, 9, 30, tzinfo=datetime.UTC)
+        connector = BlobConnector([StoredObject(key="a.md", size=41, modified_at=when)])
+
+        files = await connector.list_files({"container": "docs"}, None)
+
+        assert (files[0].size, files[0].modified_at) == (41, when)
+
+    async def test_the_download_reads_the_container_back_out_of_the_source_path(
+        self, tmp_path: Path
+    ):
+        """A `RemoteFile` reaches `_fetch` from a listing made earlier, and the
+        config it is handed need not be the one that listed it - the address is."""
+        connector = BlobConnector()
+
+        landed = await connector.download_file(
+            RemoteFile(
+                id="legal/nda.pdf", name="nda.pdf", source_path="azblob://docs/legal/nda.pdf"
+            ),
+            tmp_path,
+            config={"container": "ignored-here"},
+        )
+
+        assert connector.downloaded == [("docs", "legal/nda.pdf", tmp_path / "nda.pdf")]
+        assert landed.read_bytes() == b"contents"
+
+    async def test_a_name_climbing_out_of_the_sync_directory_is_refused(self, tmp_path: Path):
+        """Inherited from `BaseSyncConnector.download_file`, and asserted here
+        because it is the property a new store most easily loses: the destination
+        is not the connector's to choose."""
+        connector = BlobConnector()
+
+        with pytest.raises(BadRequestError):
+            await connector.download_file(
+                RemoteFile(id="docs/..", name="..", source_path="azblob://docs/docs/.."),
+                tmp_path,
+                config={"container": "docs"},
+            )
+
+        assert connector.downloaded == []
+
+
+class TestTheS3ConnectorStillListsWhatItListed:
+    """The refactor is only correct if a stored source syncs unchanged."""
+
+    @staticmethod
+    def _client(pages: list[dict[str, Any]]) -> MagicMock:
+        client = MagicMock()
+        client.get_paginator.return_value.paginate.return_value = pages
+        return client
+
+    @staticmethod
+    def _credential() -> AwsCredentialsSecret:
+        return AwsCredentialsSecret(
+            aws_access_key_id="AKIATENANT",
+            aws_secret_access_key=SecretStr("tenant-secret"),
+            region_name="eu-west-1",
+        )
+
+    async def test_a_bucket_listing_is_s3_addressed_and_skips_folder_markers(self):
+        client = self._client(
+            [
+                {
+                    "Contents": [
+                        {"Key": "legal/", "Size": 0},
+                        {
+                            "Key": "legal/nda.pdf",
+                            "Size": 12,
+                            "LastModified": "2026-08-20T09:30:00+00:00",
+                        },
+                    ]
+                }
+            ]
+        )
+        with patch.object(S3Connector, "_get_s3_client", return_value=client):
+            files = await S3Connector().list_files(
+                {"bucket": "acme", "prefix": "legal/"}, self._credential()
+            )
+
+        assert [f.source_path for f in files] == ["s3://acme/legal/nda.pdf"]
+        assert files[0].modified_at == datetime.datetime(2026, 8, 20, 9, 30, tzinfo=datetime.UTC)
+        client.get_paginator.assert_called_once_with("list_objects_v2")
+        client.get_paginator.return_value.paginate.assert_called_once_with(
+            Bucket="acme", Prefix="legal/"
+        )
+
+    async def test_an_empty_prefix_is_omitted_rather_than_sent_empty(self):
+        """What the connector did before it was a subclass, kept deliberately: a
+        stored source with no prefix must make the same call it made yesterday."""
+        client = self._client([{"Contents": []}])
+        with patch.object(S3Connector, "_get_s3_client", return_value=client):
+            await S3Connector().list_files({"bucket": "acme", "prefix": ""}, self._credential())
+
+        client.get_paginator.return_value.paginate.assert_called_once_with(Bucket="acme")
+
+    async def test_a_download_asks_the_client_for_the_key_it_listed(self, tmp_path: Path):
+        client = MagicMock()
+        client.download_file.side_effect = lambda bucket, key, path: Path(path).write_bytes(b"pdf")
+        with patch.object(S3Connector, "_get_s3_client", return_value=client):
+            landed = await S3Connector().download_file(
+                RemoteFile(
+                    id="legal/nda.pdf", name="nda.pdf", source_path="s3://acme/legal/nda.pdf"
+                ),
+                tmp_path,
+                config={"bucket": "acme"},
+                credential=self._credential(),
+            )
+
+        client.download_file.assert_called_once_with("acme", "legal/nda.pdf", str(landed))
+        assert landed.read_bytes() == b"pdf"

--- a/backend/tests/test_object_store_connector.py
+++ b/backend/tests/test_object_store_connector.py
@@ -19,6 +19,7 @@ only correct if a stored source syncs exactly the way it did before it.
 from __future__ import annotations
 
 import datetime
+import inspect
 from pathlib import Path
 from typing import Any, ClassVar
 from unittest.mock import MagicMock, patch
@@ -213,6 +214,19 @@ class TestTheS3ConnectorStillListsWhatItListed:
             await S3Connector().list_files({"bucket": "acme", "prefix": ""}, self._credential())
 
         client.get_paginator.return_value.paginate.assert_called_once_with(Bucket="acme")
+
+    def test_the_listing_is_never_materialized_beside_the_one_it_builds(self):
+        """`_objects` yields, and this is the guard on that.
+
+        The shared `_listing` builds the `RemoteFile` list the sync path reads;
+        a `_objects` that returned a list of `StoredObject` would hold a second
+        copy of the largest thing a sync ever holds, live at the same time - a
+        bucket of a million keys is the case where that stops being academic and
+        starts being the reason a previously-working sync runs out of memory.
+        Asserted on the function rather than on a measurement, because the shape
+        is what is easy to revert by accident.
+        """
+        assert inspect.isgeneratorfunction(S3Connector._objects)
 
     async def test_a_download_asks_the_client_for_the_key_it_listed(self, tmp_path: Path):
         client = MagicMock()

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -911,8 +911,17 @@ this section exists to name.
 ### What a new connector owes
 
 A connector is `list_files` + `_fetch` + a `CONFIG_SCHEMA`, and the API calls are
-the cheap part. Three things are not, and a connector without them is a bill or a
-surprise rather than a feature:
+the cheap part. **An object store is less than that**: S3, Azure Blob and GCS are
+one connector with three clients, so `ObjectStoreConnector` holds the listing
+loop, the `<scheme>://<container>/<key>` address and the directory-marker skip,
+and a subclass supplies a client, a `SCHEME`, and which `CONFIG_SCHEMA` field
+names the container - `bucket` for S3 and GCS, `container` for Azure. `S3Connector`
+is that subclass ([#988](https://github.com/vstorm-co/agenticos/issues/988)); its
+two hooks are deliberately blocking, because all three SDKs are, and the shared
+class runs them on a worker thread.
+
+Three things are not cheap, and a connector without them is a bill or a surprise
+rather than a feature:
 
 - **A change signal.** The sync path compares one since
   [#990](https://github.com/vstorm-co/agenticos/issues/990), and what it compares
@@ -946,8 +955,10 @@ Which connectors are being built, and in what order, is decided in
 OneDrive ([#985](https://github.com/vstorm-co/agenticos/issues/985)), Confluence
 ([#986](https://github.com/vstorm-co/agenticos/issues/986)), a git repository's
 documentation ([#987](https://github.com/vstorm-co/agenticos/issues/987)), and
-then Azure Blob and GCS once `S3Connector` is an object store rather than an S3
-one ([#988](https://github.com/vstorm-co/agenticos/issues/988)). Notion, Slack
+then Azure Blob and GCS, whose condition is met: `S3Connector` is an
+`ObjectStoreConnector` subclass, so each of those is a client and a
+`CONNECTOR_TYPE` rather than a second copy of the listing loop
+([#988](https://github.com/vstorm-co/agenticos/issues/988)). Notion, Slack
 and email archives are decided **against** for now, each for a reason recorded
 there — the last two because a conversation retrieves badly and the channel
 integrations already put an agent *in* Slack.


### PR DESCRIPTION
`S3Connector` was an S3 connector. Azure Blob Storage and Google Cloud Storage are
the same connector with a different client — a container, a prefix, a credential,
and a flat listing of objects with a size and a modified time. #938 put them fifth
on the list with a condition attached: *"if `S3Connector` is refactored to an
object-store shape, these are configuration rather than code."*

This is that refactor, before either of them rather than after, because the
alternative is three connectors sharing a shape by resemblance — where a fix to
the listing loop lands in one of the three.

## What moved

`ObjectStoreConnector` holds what all three do identically:

- the listing, and the skip for a key ending in `/` — a console's "folder" is a
  zero-byte object, which ingests as a document with no bytes and no filename;
- `source_path` as `<scheme>://<container>/<key>`, which is the address the whole
  sync path matches a stored row on (#996);
- the container read back out of that address on download;
- the destination, which is `BaseSyncConnector`'s answer and not a connector's —
  the property a new store most easily loses.

A subclass supplies a client, a `SCHEME`, and which `CONFIG_SCHEMA` field names
the container: `bucket` for S3 and GCS, `container` for Azure, because the form
should say what the store's own console says.

Both hooks are deliberately **blocking**, run on a worker thread by the shared
class. boto3, `azure-storage-blob` and `google-cloud-storage` all ship synchronous
clients, so a hook declared `async` over one of those would either block the event
loop or be wrapped twice.

## What was deliberately not carried

- **No `etag` on `StoredObject`.** Every object store offers one and the sync path
  reads none — it compares a `content_hash` of the bytes it downloaded (#990) — so
  it would be a field nothing reads. The right place for a bytes-free change signal
  is with the caller that reads it, which `docs/file-processing.md` already asks a
  new connector for.
- **`S3Connector.validate_config` is gone**: an override that called `super()` and
  added nothing.

## No behaviour change

A stored source lists and downloads exactly what it did before. `Prefix` is still
omitted rather than sent empty (boto3 means the same by `Prefix=""`, but the call
stays the call it was), and the string-or-`datetime` `LastModified` is still parsed
in the client's own method, because which of the two arrives is the client's own
vocabulary.

## How it was verified

- `tests/test_object_store_connector.py` — 10 tests. Seven are written against a
  subclass that is **not** S3: a test using `S3Connector` for the shared half would
  prove the same code twice and say nothing about the next store. Three pin S3's own
  calls unchanged — the paginator it asks for, the arguments it passes with and
  without a prefix, and the bucket/key a download names.
- The existing connector tests are untouched and pass: 102 across
  `test_object_store_connector`, `test_untrusted_remote_names`,
  `test_sync_source_credentials` and `test_commands`.
- `make check` green — every CI job except e2e — and `make docs-build`.

## Docs

`docs/file-processing.md` said what a new connector owes, and now says that an
object store owes less than that, plus what its subclass supplies. The connector
roadmap paragraph no longer states the #988 condition as pending.

Adding GCS from here is a client and a `CONNECTOR_TYPE`; Azure is that plus a new
`SecretKind` for a storage account key or a SAS token. Neither is in this PR.

Closes #988
