### PR TITLE
fix(permissions): cap the invitable role by what the requester holds

### DIFF
--- a/backend/app/services/invitation.py
+++ b/backend/app/services/invitation.py
@@ -13,22 +13,13 @@ from app.core.exceptions import (
     NotFoundError,
     PaymentRequiredError,
 )
-from app.core.permissions import OrgRoleName, Perm, role_has
-from app.db.models.organization import Invitation, InvitationStatus, OrgRole
+from app.core.permissions import Perm, assignable_roles, role_has
+from app.db.models.organization import Invitation, InvitationStatus
 from app.repositories import invitation_repo, member_repo, organization_repo, user_repo
 from app.services.deployment_settings import DeploymentSettingsService
 from app.services.email.service import get_email_service
 
 logger = logging.getLogger(__name__)
-
-# Roles an admin may invite into. Owner and admin are excluded: inviting a peer
-# to your own level is an ownership decision.
-_ADMIN_INVITABLE_ROLES = {
-    OrgRoleName.BUILDER.value,
-    OrgRoleName.OPERATOR.value,
-    OrgRoleName.MEMBER.value,
-    OrgRoleName.VIEWER.value,
-}
 
 
 class InvitationService:
@@ -48,8 +39,14 @@ class InvitationService:
         if not requester or not role_has(requester.role, Perm.MEMBERS_MANAGE):
             raise AuthorizationError(message="Only Owner or Admin can invite members")
 
-        if requester.role == OrgRole.ADMIN.value and role not in _ADMIN_INVITABLE_ROLES:
-            raise AuthorizationError(message="Admin can only invite as Member or Viewer")
+        # A role may be offered only when the requester's own strictly outranks
+        # it, off the catalog rather than the literal "admin": a custom role
+        # (Phase 2) holding `members:manage` would otherwise invite a new Admin (#696).
+        if role not in assignable_roles(requester.role):
+            raise AuthorizationError(
+                message="You cannot invite as a role your own does not outrank",
+                details={"role": role},
+            )
 
         normalized_email = email.lower()
 
@@ -131,8 +128,14 @@ class InvitationService:
         )
         if not requester or not role_has(requester.role, Perm.MEMBERS_MANAGE):
             raise AuthorizationError(message="Only Owner or Admin can invite members")
-        if requester.role == OrgRole.ADMIN.value and role not in _ADMIN_INVITABLE_ROLES:
-            raise AuthorizationError(message="Admin can only invite as Member or Viewer")
+        # A role may be offered only when the requester's own strictly outranks
+        # it, off the catalog rather than the literal "admin": a custom role
+        # (Phase 2) holding `members:manage` would otherwise invite a new Admin (#696).
+        if role not in assignable_roles(requester.role):
+            raise AuthorizationError(
+                message="You cannot invite as a role your own does not outrank",
+                details={"role": role},
+            )
 
         invite = await invitation_repo.create(
             self.db,

--- a/backend/tests/test_services_members.py
+++ b/backend/tests/test_services_members.py
@@ -354,6 +354,47 @@ class TestInvitationService:
             )
 
     @pytest.mark.anyio
+    async def test_a_custom_role_holding_members_manage_cannot_invite_an_admin(
+        self, service, monkeypatch
+    ):
+        """The ceiling is what the requester holds, not whether they are `admin`.
+
+        Keyed on the literal role name, this let a custom role (Phase 2) composed
+        with `members:manage` invite a new Admin unchecked - the invitation half of
+        the defect #672 removed from `change_role` (#696). The membership half is
+        `test_a_custom_role_holding_roles_manage_cannot_mint_an_owner`.
+        """
+        from app.core.permissions import ROLE_PERMS, Perm, Scope
+
+        monkeypatch.setitem(ROLE_PERMS, "test:inviter", {Perm.MEMBERS_MANAGE: Scope.ALL})
+        requester = MagicMock(role="test:inviter")
+
+        with (
+            patch("app.services.invitation.member_repo.get", new=AsyncMock(return_value=requester)),
+            pytest.raises(AuthorizationError),
+        ):
+            await service.invite(
+                uuid.uuid4(), "user@example.com", "admin", requester_id=uuid.uuid4()
+            )
+
+    @pytest.mark.anyio
+    async def test_a_custom_role_holding_members_manage_cannot_link_an_admin(
+        self, service, monkeypatch
+    ):
+        """The same ceiling on the invite-link path, the second call site keyed on
+        the literal `admin` (#696)."""
+        from app.core.permissions import ROLE_PERMS, Perm, Scope
+
+        monkeypatch.setitem(ROLE_PERMS, "test:inviter", {Perm.MEMBERS_MANAGE: Scope.ALL})
+        requester = MagicMock(role="test:inviter")
+
+        with (
+            patch("app.services.invitation.member_repo.get", new=AsyncMock(return_value=requester)),
+            pytest.raises(AuthorizationError),
+        ):
+            await service.create_link(uuid.uuid4(), "admin", requester_id=uuid.uuid4())
+
+    @pytest.mark.anyio
     async def test_invite_raises_on_duplicate_pending(self, service):
         mock_requester = MagicMock()
         mock_requester.role = "owner"


### PR DESCRIPTION
## What breaks

`InvitationService` capped who may be invited by comparing the requester's role against the literal string `admin`, so `_ADMIN_INVITABLE_ROLES` only applied to a built-in Admin. A **custom role (Phase 2)** composed with `members:manage` — which the catalog is explicitly built to allow — passed the ceiling untouched and could invite a **new Admin**, by email (`invite`) or by invite link (`create_link`). It is the invitation half of the defect #672 removed from `change_role`; #672's fix supplies the function this should call.

`owner` is already refused by the schema (`InvitationCreate` subtracts it), so the reachable breach is Admin, not Owner — `severity:medium`.

## Fix

Both call sites now read `assignable_roles(requester.role)` — the same catalog-derived relation `change_role` uses — so a role may be offered only when the requester's own **strictly outranks** it. `_ADMIN_INVITABLE_ROLES` and both `== "admin"` comparisons are gone. Behaviour is unchanged for the built-in roles (Owner still invites Admins; Admin still invites down to Viewer) and closed for a custom one.

## Verification

- New tests: a synthetic role holding only `members:manage` is refused inviting as `admin` on **both** the email and the invite-link path — the pair of `test_a_custom_role_holding_roles_manage_cannot_mint_an_owner`.
- Full member/invitation suite passes; full backend suite 5665 passed; `make lint` clean.

Closes #696