### PR TITLE
chore: cut 0.0.223

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,39 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.223] - 2026-08-20
+
+An object store's connector is a client, not a copy of the listing loop.
+
+### Changed
+
+- **`S3Connector` is an `ObjectStoreConnector` subclass**, with no behaviour
+  change: a stored source lists and downloads exactly what it did before.
+  #938 made Azure Blob and GCS conditional on this shape existing first, and the
+  condition is now met - each of those is a client, a `SCHEME` and a
+  `CONNECTOR_TYPE` rather than a second copy of the listing. The shared class
+  holds the pagination, the `<scheme>://<container>/<key>` address the sync path
+  matches a row on, the skip for a key ending in `/` (a console's "folder", which
+  would ingest as a document with no bytes and no name), and the destination,
+  which is the base class's answer and the property a new store most easily
+  loses. (#988)
+- A subclass says which `CONFIG_SCHEMA` field names its container - `bucket` for
+  S3 and GCS, `container` for Azure - because a form should say what the store's
+  own console says. Both of its hooks are blocking, run on a worker thread,
+  because all three SDKs are synchronous. (#988)
+- `S3Connector.validate_config` is gone: an override that called `super()` and
+  added nothing. (#988)
+
+### Performance
+
+- **An object listing is converted as it arrives.** The refactor first built a
+  complete list of the shared listing type and then allocated the complete
+  `RemoteFile` list beside it, where the connector before it kept only the
+  second - on a bucket of a million keys, a previously working sync running out
+  of memory. The listing yields, and the conversion happens inside the same
+  worker thread, so one entry exists at a time beside the list being built.
+  Found by the automated review on the branch. (#988)
+
 ## [0.0.222] - 2026-08-20
 
 The sync wizard says who will be able to read what a source ingests.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.222"
+version = "0.0.223"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.222"
+version = "0.0.223"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.222",
+  "version": "0.0.223",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.223. Bumps `backend/pyproject.toml`,
`backend/uv.lock` and `frontend/package.json` to 0.0.223 and adds the
CHANGELOG entry.

One issue, #988, and no behaviour change: `S3Connector` was an S3
connector, and Azure Blob and GCS are the same connector with a different
client. #938 made both conditional on this refactor happening first, and
doing it before either of them is the point - the alternative is three
connectors sharing a shape by resemblance, where a fix to the listing loop
lands in one of the three.

The automated review found one thing on the branch and it was real: the
refactor held two copies of the largest thing a sync ever holds. The
listing yields now and the conversion happens inside the same worker
thread - converting it in `list_files` instead would have handed a
generator back to the event loop and done the next page's network round
trip on it, which is the reason those hooks are blocking to begin with.

## Verified

11 tests, seven of them written against a subclass that is *not* S3,
because a test using `S3Connector` for the shared half would prove the
same code twice and say nothing about the next store. Three pin S3's own
calls unchanged - the paginator, the arguments with and without a prefix,
and the bucket and key a download names. `make check` and CI green end to
end on #1018 including `e2e`.

Closes #988