### PR TITLE
chore: cut 0.0.224

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.224] - 2026-08-20
+
+Only the thumb whose request is in flight spins.
+
+### Fixed
+
+- **Rating an answer spun both thumbs.** The spinner was keyed on
+  `isLoading && currentRating !== <the other value>`, and an unrated message has
+  `currentRating === null` - true for both thumbs at once, which is the normal
+  case rather than an edge one. It is keyed on *which* button's request is in
+  flight now, so the other thumb stays a thumb. (#928)
+
 ## [0.0.223] - 2026-08-20
 
 An object store's connector is a client, not a copy of the listing loop.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.223"
+version = "0.0.224"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.223"
+version = "0.0.224"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.223",
+  "version": "0.0.224",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.224. Bumps `backend/pyproject.toml`,
`backend/uv.lock` and `frontend/package.json` to 0.0.224 and adds the
CHANGELOG entry.

One issue, #928, and a small one with a wide reach: rating an answer spun
both thumbs. The spinner was keyed on `isLoading && currentRating !=
<the other value>`, and an unrated message has `currentRating === null` -
true for both thumbs at once, which is every message before it is rated
rather than an edge case. It is keyed on which button's request is in
flight now.

## Verified

Two tests on the two cases the old condition could not tell apart - an
unrated message, and a rating being removed - and CI green end to end on
#1005, which the automated review also passed.

Closes #928