### PR TITLE
chore: cut 0.0.226

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.226] - 2026-08-20
+
+A malformed file id on the socket is a refusal, not a crash in the log.
+
+### Fixed
+
+- **A file id that is not a UUID crashed the turn handler.** `list_attached_files`
+  called `UUID(fid)` on ids that arrive in an untyped socket payload, so a
+  malformed one raised `ValueError` into the handler's infrastructure net and
+  resurfaced a step later as a generic failed turn, logged as a server error. It
+  is client input, so it is refused as validation naming `file_ids` - the same
+  loud refusal `link_files_to_message` already gave. (#749)
+
 ## [0.0.225] - 2026-08-20
 
 The chat says which model the conversation runs on.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.225"
+version = "0.0.226"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.225"
+version = "0.0.226"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.225",
+  "version": "0.0.226",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.226. Bumps `backend/pyproject.toml`,
`backend/uv.lock` and `frontend/package.json` to 0.0.226 and adds the
CHANGELOG entry.

One issue, #749. `list_attached_files` called `UUID(fid)` on ids that
arrive in an untyped socket payload, so a malformed one raised
`ValueError` into the turn handler's infrastructure net and resurfaced a
step later as a generic failed turn, logged as a server error - a client
mistake reported as ours, on the read path a message with no text of its
own takes.

It is client input, so it is refused as validation naming `file_ids`,
which is the refusal `link_files_to_message` next to it already gave.

## Verified

One test: a good id beside a bad one refuses without reaching the
repository, and the refusal names the malformed value rather than the
whole payload. CI green end to end on #1011, which the automated review
also passed.

Closes #749