### PR TITLE
chore: cut 0.0.227

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.227] - 2026-08-20
+
+An attachment the router cannot read is named rather than dropped.
+
+### Fixed
+
+- **A file no parser could read contributed nothing to the prompt**, so the model
+  answered as though nothing had arrived - which reads as it denying a file the
+  transcript plainly shows. The reference now names the file and says its text
+  could not be extracted and that the agent has no workspace to open it from,
+  which is the same principle the too-large-image case already followed. (#746)
+- **A routing failure was silent too.** It still does not fail the turn - the
+  person asked a question, and answering without the file beats not answering -
+  but the model is told the file arrived and could not be processed. The error's
+  own text stays in the log line beside the raise, never in the prompt. (#746)
+
 ## [0.0.226] - 2026-08-20
 
 A malformed file id on the socket is a refusal, not a crash in the log.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.226"
+version = "0.0.227"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.226"
+version = "0.0.227"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.226",
+  "version": "0.0.227",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.227. Bumps `backend/pyproject.toml`,
`backend/uv.lock` and `frontend/package.json` to 0.0.227 and adds the
CHANGELOG entry.

One issue, #746, and it is the failure mode that reads as the model
lying: a file no parser could read contributed nothing to the prompt, so
the answer came back as though nothing had arrived - with the attachment
sitting in the transcript above it. Same for a routing failure, which was
caught, logged and dropped.

Both are named now. The turn still survives a routing failure - the
person asked a question, and answering without the file beats not
answering - but the model is told the file arrived and could not be
processed rather than being left to deny it. The upstream error's own
text stays in the log line beside the raise and never reaches the prompt,
which is the same rule `app/services/rag/failures.py` applies to a
stored error column.

## Verified

The two tests that asserted the silence now assert the naming, one per
path, and both check the filename reaches the prompt. CI green end to end
on #1012, which the automated review also passed.

Closes #746