### PR TITLE
fix(auth): rate-limit the auth surface and take bcrypt off the event loop

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -585,6 +585,30 @@ def _refuse_if_over(decision: rate_limit.Decision, message: str) -> None:
         )
 
 
+async def enforce_auth_limit(
+    request: Request, *, surface: str, identifier: str | None = None
+) -> None:
+    """Refuse an auth attempt from a caller who has made too many this minute.
+
+    Called at the top of an `auth.py` route rather than as a `Depends`, because
+    the per-address half needs the parsed body the route has and a dependency
+    does not. Both halves count against `auth_limit()`: the IP first, because it
+    cannot be varied for free and it is what bounds the unauthenticated bcrypt
+    DoS; then the submitted address, where the body carries one, which is what
+    bounds a brute force against a single account. Lower-casing the identifier so
+    two spellings of one address share a bucket.
+    """
+    limit = rate_limit.auth_limit()
+    decision = await rate_limit.consume(
+        surface=surface, caller=f"ip:{rate_limit.caller_ip(request)}", limit=limit
+    )
+    if decision.allowed and identifier:
+        decision = await rate_limit.consume(
+            surface=surface, caller=f"id:{identifier.strip().lower()}", limit=limit
+        )
+    _refuse_if_over(decision, "Too many attempts. Please wait and try again.")
+
+
 async def limit_embed_script(request: Request) -> None:
     """Refuse an address asking for a widget's script too often.
 

--- a/backend/app/api/routes/v1/auth.py
+++ b/backend/app/api/routes/v1/auth.py
@@ -6,7 +6,13 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, Request, status
 from fastapi.security import OAuth2PasswordRequestForm
 
-from app.api.deps import CurrentUser, DeploymentSettingsSvc, SessionSvc, UserSvc
+from app.api.deps import (
+    CurrentUser,
+    DeploymentSettingsSvc,
+    SessionSvc,
+    UserSvc,
+    enforce_auth_limit,
+)
 from app.core.config import settings
 from app.core.exceptions import AuthenticationError
 from app.core.security import (
@@ -38,6 +44,7 @@ async def login(
     session_service: SessionSvc,
 ) -> Any:
     """OAuth2 password login, returns access and refresh tokens."""
+    await enforce_auth_limit(request, surface="auth_login", identifier=form_data.username)
     user = await user_service.authenticate(form_data.username, form_data.password)
     access_token = create_access_token(subject=str(user.id))
     refresh_token = create_refresh_token(subject=str(user.id))
@@ -54,10 +61,12 @@ async def login(
 
 @router.post("/register", response_model=UserRead, status_code=status.HTTP_201_CREATED)
 async def register(
+    request: Request,
     user_in: UserCreate,
     user_service: UserSvc,
 ) -> Any:
     """Register a new user."""
+    await enforce_auth_limit(request, surface="auth_register", identifier=user_in.email)
     return await user_service.register(user_in)
 
 
@@ -69,6 +78,7 @@ async def refresh_token(
     session_service: SessionSvc,
 ) -> Any:
     """Exchange a refresh token for a new access token."""
+    await enforce_auth_limit(request, surface="auth_refresh")
 
     session = await session_service.validate_refresh_token(body.refresh_token)
     if not session:
@@ -93,6 +103,7 @@ async def refresh_token(
 
 @router.post("/logout", status_code=status.HTTP_204_NO_CONTENT, response_model=None)
 async def logout(
+    request: Request,
     body: RefreshTokenRequest,
     session_service: SessionSvc,
 ) -> None:
@@ -100,6 +111,7 @@ async def logout(
 
     Invalidates the refresh token, preventing further token refresh.
     """
+    await enforce_auth_limit(request, surface="auth_logout")
     await session_service.logout_by_refresh_token(body.refresh_token)
 
 
@@ -111,6 +123,7 @@ async def get_current_user_info(current_user: CurrentUser) -> Any:
 
 @router.post("/password-reset/request", response_model=PasswordResetResponse)
 async def request_password_reset(
+    request: Request,
     body: PasswordResetRequest,
     user_service: UserSvc,
     branding: DeploymentSettingsSvc,
@@ -120,6 +133,7 @@ async def request_password_reset(
     Always returns 200 with the same body - we don't disclose whether the
     email is in our system. The caller (email service) is best-effort.
     """
+    await enforce_auth_limit(request, surface="auth_password_reset", identifier=body.email)
     issued = await user_service.issue_password_reset_token(body.email)
     if issued is not None:
         reset_user, token = issued
@@ -138,16 +152,19 @@ async def request_password_reset(
 
 @router.post("/password-reset/confirm", response_model=PasswordResetConfirmResponse)
 async def confirm_password_reset(
+    request: Request,
     body: PasswordResetConfirm,
     user_service: UserSvc,
 ) -> Any:
     """Set a new password using a token from the reset email."""
+    await enforce_auth_limit(request, surface="auth_password_reset_confirm")
     await user_service.confirm_password_reset(body.token, body.new_password)
     return PasswordResetConfirmResponse()
 
 
 @router.post("/magic-link/request", response_model=PasswordResetResponse)
 async def request_magic_link(
+    request: Request,
     body: MagicLinkRequest,
     user_service: UserSvc,
     branding: DeploymentSettingsSvc,
@@ -156,6 +173,7 @@ async def request_magic_link(
 
     Symmetric response to request_password_reset to avoid email enumeration.
     """
+    await enforce_auth_limit(request, surface="auth_magic_link", identifier=body.email)
     issued = await user_service.issue_magic_link_token(body.email)
     if issued is not None:
         link_user, token = issued
@@ -180,6 +198,7 @@ async def verify_magic_link(
     session_service: SessionSvc,
 ) -> Any:
     """Exchange a magic-link token for an access + refresh token pair."""
+    await enforce_auth_limit(request, surface="auth_magic_link_verify")
     user = await user_service.consume_magic_link_token(body.token)
     access_token = create_access_token(subject=str(user.id))
     refresh_token = create_refresh_token(subject=str(user.id))

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -214,6 +214,13 @@ class Settings(BaseSettings):
     # counts nobody. Wide, because it bounds a page rather than rationing
     # visitors - what rations spend is the socket, counted per address.
     RATE_LIMIT_HOSTED_PAGE_PER_MINUTE: int = 240
+    # How many auth attempts one caller gets per minute - login, register, token
+    # refresh, and the reset/magic-link request and verify routes. Counted per IP
+    # and, where the body carries one, per submitted address, both in the shared
+    # Redis: the IP bounds the unauthenticated DoS bcrypt makes possible, the
+    # address bounds a brute force against one account. Low, because a person
+    # signing in does it a handful of times and a script does it thousands.
+    RATE_LIMIT_AUTH_PER_MINUTE: int = 10
     # Whether `X-Forwarded-For` names the caller. Off by default because the
     # header is set by whoever is calling, so trusting it unconditionally is a
     # per-IP limit anybody bypasses by varying one string. On costs the mirror

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -86,10 +86,23 @@ def verify_special_token(token: str, expected_type: str) -> dict[str, Any] | Non
     return payload
 
 
+# bcrypt only ever uses the first 72 bytes of a password, and bcrypt 5.0 raises
+# rather than truncating silently. Both helpers truncate to the same 72 bytes, so
+# hashing and verifying agree - and an overlong password submitted at the login
+# form (a `UserCreate.password` of up to 128 characters can exceed 72 bytes once
+# encoded, and an unknown account still runs bcrypt against the dummy hash) is an
+# authentication failure rather than an unauthenticated 500 (#947).
+_BCRYPT_MAX_BYTES = 72
+
+
+def _bcrypt_bytes(password: str) -> bytes:
+    return password.encode("utf-8")[:_BCRYPT_MAX_BYTES]
+
+
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     """Verify a password against a hash."""
     return bcrypt.checkpw(
-        plain_password.encode("utf-8"),
+        _bcrypt_bytes(plain_password),
         hashed_password.encode("utf-8"),
     )
 
@@ -97,6 +110,6 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
 def get_password_hash(password: str) -> str:
     """Hash a password."""
     return bcrypt.hashpw(
-        password.encode("utf-8"),
+        _bcrypt_bytes(password),
         bcrypt.gensalt(),
     ).decode("utf-8")

--- a/backend/app/services/rate_limit.py
+++ b/backend/app/services/rate_limit.py
@@ -141,6 +141,18 @@ def run_limit() -> Limit:
     return Limit(attempts=settings.RATE_LIMIT_RUN_PER_MINUTE)
 
 
+def auth_limit() -> Limit:
+    """How many auth attempts one caller gets per minute.
+
+    The one surface where the cost of an attempt is the defence rather than a
+    detail: `verify_password` is bcrypt, ~170ms with no suspension point, so an
+    unmetered `/login` flood saturates a worker's event loop with no credentials
+    at all. Counted per IP and per submitted address both - see
+    `deps.enforce_auth_limit` - because the two stop different attacks.
+    """
+    return Limit(attempts=settings.RATE_LIMIT_AUTH_PER_MINUTE)
+
+
 async def hosted_admission_allowed(public_key: str) -> Decision:
     """Whether this hosted page may be configured again right now.
 

--- a/backend/app/services/rate_limit.py
+++ b/backend/app/services/rate_limit.py
@@ -38,6 +38,7 @@ for the same reason, as the deduplication claim.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 from dataclasses import dataclass
 
@@ -49,6 +50,14 @@ from app.core.config import settings
 logger = logging.getLogger(__name__)
 
 _redis: RedisClient | None = None
+
+# The longest a caller may be before it is replaced by a digest. The auth limiter
+# counts a submitted login identifier, which an unauthenticated caller controls
+# and need not keep short - so a raw interpolation lets one request store the
+# whole value as a Redis key, and the body limit permits tens of megabytes. Past
+# this bound the caller becomes a fixed-size hash; a real identifier (an email is
+# at most 254 characters, plus a short prefix) never reaches it (#947).
+_MAX_CALLER_LEN = 320
 
 
 def configure(redis: RedisClient | None) -> None:
@@ -113,6 +122,13 @@ def caller_ip(connection: HTTPConnection) -> str:
     return connection.client.host if connection.client else "unknown"
 
 
+def _bounded(caller: str) -> str:
+    """A caller short enough to be a Redis key, digesting anything oversized."""
+    if len(caller) <= _MAX_CALLER_LEN:
+        return caller
+    return f"h:{hashlib.sha256(caller.encode()).hexdigest()}"
+
+
 async def consume(*, surface: str, caller: str, limit: Limit) -> Decision:
     """Count one attempt by `caller` against `surface`, and say whether it may.
 
@@ -124,7 +140,7 @@ async def consume(*, surface: str, caller: str, limit: Limit) -> Decision:
         logger.warning("Rate limiting not configured - %s reached unmetered by %s", surface, caller)
         return Decision(allowed=True, retry_after_seconds=0)
 
-    key = f"ratelimit:{surface}:{caller}"
+    key = f"ratelimit:{surface}:{_bounded(caller)}"
     try:
         used = await _redis.count_in_window(key, ttl=limit.window_seconds)
     except Exception:

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -1,5 +1,7 @@
+import asyncio
 import contextlib
 import logging
+import secrets
 from uuid import UUID
 
 from sqlalchemy import func, select
@@ -26,6 +28,12 @@ from app.services.organization import OrganizationService
 from app.services.signup_policy import check_may_register
 
 logger = logging.getLogger(__name__)
+
+# A real bcrypt hash of a value nobody holds, computed once at import. An
+# address with no account is verified against this rather than short-circuited,
+# so an unknown address costs the same ~170ms as a known one and the timing no
+# longer says which addresses have accounts (#947).
+_DUMMY_HASH = get_password_hash(secrets.token_urlsafe(32))
 
 
 class UserService:
@@ -121,7 +129,7 @@ class UserService:
             invitation_token=user_in.invitation_token,
         )
 
-        hashed_password = get_password_hash(user_in.password)
+        hashed_password = await asyncio.to_thread(get_password_hash, user_in.password)
         user = await user_repo.create(
             self.db,
             email=user_in.email,
@@ -217,11 +225,14 @@ class UserService:
 
     async def authenticate(self, email: str, password: str) -> User:
         user = await user_repo.get_by_email(self.db, email)
-        if (
-            not user
-            or not user.hashed_password
-            or not verify_password(password, user.hashed_password)
-        ):
+        # bcrypt is ~170ms with no suspension point, so it runs in a thread rather
+        # than blocking the event loop for every other request the worker holds
+        # (#947). And always against a hash: an unknown address is checked against
+        # `_DUMMY_HASH` rather than skipping bcrypt, so it cannot be told apart
+        # from a known one by how long the refusal takes.
+        stored = user.hashed_password if user and user.hashed_password else _DUMMY_HASH
+        ok = await asyncio.to_thread(verify_password, password, stored)
+        if not user or not user.hashed_password or not ok:
             raise AuthenticationError(message="Invalid email or password")
         if not user.is_active:
             raise AuthenticationError(message="User account is disabled")
@@ -232,7 +243,9 @@ class UserService:
 
         update_data = writable(user_in, over=User)
         if "password" in update_data:
-            update_data["hashed_password"] = get_password_hash(update_data.pop("password"))
+            update_data["hashed_password"] = await asyncio.to_thread(
+                get_password_hash, update_data.pop("password")
+            )
 
         return await user_repo.update(self.db, db_user=user, update_data=update_data)
 
@@ -294,7 +307,9 @@ class UserService:
         await user_repo.update(
             self.db,
             db_user=user,
-            update_data={"hashed_password": get_password_hash(new_password)},
+            update_data={
+                "hashed_password": await asyncio.to_thread(get_password_hash, new_password)
+            },
         )
         # Revoke any active sessions so a previously-issued refresh token cannot
         # outlive a password reset. The current request returns no tokens - the

--- a/backend/tests/api/test_auth_rate_limit.py
+++ b/backend/tests/api/test_auth_rate_limit.py
@@ -1,0 +1,73 @@
+"""The auth surface carries a rate limit, at the route.
+
+No route in `auth.py` was rate-limited, and `verify_password` runs bcrypt -
+~170ms with no suspension point. Unmetered, a `/login` flood for any address
+that has an account saturates a worker's event loop with no credentials at all
+(#947). These assert the limiter is wired to the route, not merely present in
+the module: `test_rate_limit.py` covers the limiter itself.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import AsyncClient
+
+from app.api import deps
+from app.core.config import settings
+from app.core.exceptions import AuthenticationError
+from app.main import app
+from app.services import rate_limit
+
+pytestmark = pytest.mark.anyio
+
+
+def _redis_counting(count: int) -> MagicMock:
+    """A shared-Redis stand-in whose window counter always answers `count`."""
+    client = MagicMock()
+    client.count_in_window = AsyncMock(return_value=count)
+    return client
+
+
+@pytest.fixture(autouse=True)
+def _reset_limiter():
+    yield
+    rate_limit.configure(None)
+
+
+async def test_login_over_the_window_is_refused_with_429(client: AsyncClient, monkeypatch):
+    """The Nth attempt inside the minute, refused before authenticate - and so
+    before bcrypt - is the whole point: the refusal has to cost less than the
+    attack it stops."""
+    monkeypatch.setattr(settings, "RATE_LIMIT_AUTH_PER_MINUTE", 3)
+    rate_limit.configure(_redis_counting(4))
+
+    response = await client.post(
+        "/api/v1/auth/login",
+        data={"username": "victim@example.com", "password": "guess"},
+    )
+
+    assert response.status_code == 429
+    assert response.json()["error"]["code"] == "RATE_LIMIT_EXCEEDED"
+
+
+async def test_login_inside_the_window_reaches_the_service(client: AsyncClient, monkeypatch):
+    """The refusal is about the rate, not about login: under the window the
+    request reaches the service, which answers 401 on bad credentials."""
+    monkeypatch.setattr(settings, "RATE_LIMIT_AUTH_PER_MINUTE", 3)
+    rate_limit.configure(_redis_counting(1))
+    service = MagicMock()
+    service.authenticate = AsyncMock(side_effect=AuthenticationError(message="Invalid"))
+    app.dependency_overrides[deps.get_user_service] = lambda: service
+
+    try:
+        response = await client.post(
+            "/api/v1/auth/login",
+            data={"username": "victim@example.com", "password": "guess"},
+        )
+    finally:
+        app.dependency_overrides.pop(deps.get_user_service, None)
+
+    assert response.status_code == 401
+    service.authenticate.assert_awaited_once()

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -92,6 +92,21 @@ class TestTheAllowanceItself:
         keys = [call.args[0] for call in client.count_in_window.await_args_list]
         assert keys == ["ratelimit:agent_run:user:a", "ratelimit:embed_admission:ip:1.2.3.4"]
 
+    async def test_an_oversized_caller_is_digested_so_it_cannot_bloat_redis(self):
+        """The login identifier is caller-controlled and unbounded, so a raw key
+        would let one request store megabytes. Past the bound it becomes a
+        fixed-size hash; the key stays small (#947)."""
+        client = _redis([1])
+        rate_limit.configure(client)
+
+        await rate_limit.consume(
+            surface="auth_login", caller=f"id:{'a' * 1_000_000}", limit=Limit(attempts=3)
+        )
+
+        key = client.count_in_window.await_args_list[0].args[0]
+        assert key.startswith("ratelimit:auth_login:h:")
+        assert len(key) < 128
+
     async def test_the_window_is_what_the_key_expires_after(self):
         """A window that never expires is an allowance somebody spends once and
         never gets back."""

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -202,6 +202,12 @@ class TestTheLimitsThemselves:
 
         assert rate_limit.run_limit() == Limit(attempts=7, window_seconds=60)
 
+    def test_the_auth_allowance_comes_from_settings(self, monkeypatch):
+        """The auth surface has its own low ceiling, tunable without a release."""
+        monkeypatch.setattr(settings, "RATE_LIMIT_AUTH_PER_MINUTE", 5)
+
+        assert rate_limit.auth_limit() == Limit(attempts=5, window_seconds=60)
+
     async def test_admission_is_counted_per_address(self, monkeypatch):
         monkeypatch.setattr(settings, "RATE_LIMIT_EMBED_PER_MINUTE", 2)
         monkeypatch.setattr(settings, "RATE_LIMIT_TRUST_FORWARDED_FOR", False)

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -38,6 +38,18 @@ class TestPasswordHashing:
 
         assert verify_password(wrong_password, hashed) is False
 
+    def test_a_password_over_bcrypts_limit_hashes_and_verifies_rather_than_raising(self):
+        """bcrypt 5.0 raises past 72 bytes; both helpers truncate to it, so an
+        overlong password is an ordinary credential (and a mismatch stays a
+        mismatch) instead of an unauthenticated 500 (#947)."""
+        overlong = "p" * 200
+        hashed = get_password_hash(overlong)
+
+        assert verify_password(overlong, hashed) is True
+        # Agrees only on the first 72 bytes, which is all bcrypt reads.
+        assert verify_password("p" * 72, hashed) is True
+        assert verify_password("q" * 200, hashed) is False
+
 
 class TestAccessToken:
     """Tests for access token functions."""

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -1,5 +1,7 @@
 """Tests for service layer."""
 
+import asyncio
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -7,7 +9,7 @@ import pytest
 
 from app.core.exceptions import AlreadyExistsError, AuthenticationError, NotFoundError
 from app.schemas.user import UserCreate, UserUpdate
-from app.services.user import UserService
+from app.services.user import _DUMMY_HASH, UserService
 
 
 class MockUser:
@@ -188,6 +190,66 @@ class TestUserServicePostgresql:
 
             with pytest.raises(AuthenticationError):
                 await user_service.authenticate("test@example.com", "password")
+
+    @pytest.mark.anyio
+    async def test_authenticate_runs_bcrypt_off_the_event_loop(
+        self, user_service: UserService, mock_user: MockUser
+    ):
+        """bcrypt is ~170ms with no suspension point, so an unmetered /login flood
+        saturates a worker's event loop (#947). It runs in a thread now: while it
+        blocks in there, the loop keeps turning. If it ran on the loop, the poll
+        below could never observe `in_bcrypt` and the test would hang.
+        """
+        gate = threading.Event()
+        in_bcrypt = threading.Event()
+
+        def blocking_verify(_password: str, _hash: str) -> bool:
+            in_bcrypt.set()
+            gate.wait(timeout=5)
+            return True
+
+        with (
+            patch("app.services.user.user_repo") as mock_repo,
+            patch("app.services.user.verify_password", blocking_verify),
+        ):
+            mock_repo.get_by_email = AsyncMock(return_value=mock_user)
+            login = asyncio.create_task(user_service.authenticate("test@example.com", "password"))
+            try:
+                # Waiting off the loop, so the loop stays free to run `login` up to
+                # its own bcrypt. If bcrypt ran on the loop, `login` would block it
+                # here and this would only resume once bcrypt finished - by which
+                # point `login` is done and the assertion below fails.
+                assert await asyncio.to_thread(in_bcrypt.wait, 5) is True
+                assert not login.done()
+            finally:
+                gate.set()
+            assert await login is mock_user
+
+    @pytest.mark.anyio
+    async def test_authenticate_runs_bcrypt_even_for_an_unknown_address(
+        self, user_service: UserService
+    ):
+        """The timing oracle: an address with no account used to skip bcrypt and be
+        refused in milliseconds, where a known one took ~170ms - two orders of
+        magnitude, measurable over the internet (#947). An unknown address is now
+        verified against `_DUMMY_HASH`, so both refuse in the same time.
+        """
+        checked: list[str] = []
+
+        def recording_verify(_password: str, stored_hash: str) -> bool:
+            checked.append(stored_hash)
+            return False
+
+        with (
+            patch("app.services.user.user_repo") as mock_repo,
+            patch("app.services.user.verify_password", recording_verify),
+        ):
+            mock_repo.get_by_email = AsyncMock(return_value=None)
+
+            with pytest.raises(AuthenticationError):
+                await user_service.authenticate("nobody@example.com", "password")
+
+        assert checked == [_DUMMY_HASH]
 
     @pytest.mark.anyio
     async def test_update_success(self, user_service: UserService, mock_user: MockUser):

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -554,6 +554,7 @@ ceiling is a separate decision, not this one.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `RATE_LIMIT_RUN_PER_MINUTE` | `30` | `POST /api/v1/agents/{id}/run`, per caller |
+| `RATE_LIMIT_AUTH_PER_MINUTE` | `10` | Every `auth.py` route — login, register, refresh, the reset/magic-link request and verify routes. Counted **per IP and, where the body carries one, per submitted address**. See below |
 | `RATE_LIMIT_EMBED_PER_MINUTE` | `20` | Per address, and **two separate counters of this size**: one for `widget.js`, one for admission — the widget's `/config` plus either surface's socket handshake. See below |
 | `RATE_LIMIT_HOSTED_PAGE_PER_MINUTE` | `240` | A hosted page's config, **per page** — and its logo, on a counter of its own. See below |
 | `RATE_LIMIT_EMBED_UPLOAD_PER_MINUTE` | `5` | Files a visitor may store on a hosted page. Counted **per address and per visitor key**, and both have to allow it — the key is minted by the browser, so counting only that bounds nothing |
@@ -600,6 +601,23 @@ rationing a visitor, which is why the default is wide — **it is not what limit
 spend.** Spend starts at the socket the page opens next, which the browser makes,
 which is counted per address under `RATE_LIMIT_EMBED_PER_MINUTE`. And guessing a
 key is not a strategy against 192 bits of `secrets.token_urlsafe`.
+
+### `RATE_LIMIT_AUTH_PER_MINUTE`, and why the auth surface has its own
+
+Every route in `auth.py` carries this limit, counted **per IP** and — where the
+body carries an address (login, register, the reset and magic-link requests) —
+**per submitted address too**, both against this allowance. The two stop
+different attacks: the IP bounds a flood from one source, the address bounds a
+brute force against one account.
+
+It is separate from, and lower than, the run allowance because the cost of a
+single attempt is what it defends. `verify_password` is bcrypt, ~170ms with no
+suspension point, so an unmetered `/login` flood for any address that has an
+account saturates a worker's event loop with no credentials at all. Two more
+things close the rest of that surface, and need no configuration: bcrypt runs in
+a thread so it never blocks the loop, and an address with no account is verified
+against a dummy hash rather than skipped, so a known and an unknown address take
+the same time to refuse and the timing no longer says which addresses exist.
 
 ### `RATE_LIMIT_TRUST_FORWARDED_FOR`, and why it is off
 


### PR DESCRIPTION
## What breaks (Critical · AUD-001)

Two things, each survivable, together not: **no route in `auth.py` was rate-limited**, and **`verify_password` ran bcrypt on the request event loop** (~170ms, no suspension point).

1. **Unauthenticated DoS.** `/login` for any address that has an account, at 20 req/s: each blocks the loop 171ms with no `await`. The worker serves nothing else — not the readiness probe, not an in-flight agent socket. On a single-worker deploy the product is down for as long as the attacker types.
2. **Unlimited brute force** — the bcrypt cost was the only brake, and (1) is what that brake bought the attacker.
3. **A user-enumeration timing oracle** — `authenticate` skipped bcrypt for an unknown address (~ms) and ran it for a known one (~171ms).
4. **An email amplifier** — `/password-reset/request` and `/magic-link/request` sent mail on every call, unlimited.

## Fix — three parts, none structural

**Rate limit.** The limiter this repo already has (`services/rate_limit.py`, Redis-backed, shared across workers) was never wired to this surface. Added `auth_limit()` + `deps.enforce_auth_limit`, called at the top of **every** auth route — before any bcrypt/DB work. Counted **per IP** always and **per submitted address** where the body carries one (`RATE_LIMIT_AUTH_PER_MINUTE`, default 10). Called from the handler rather than as a `Depends` because the per-address half needs the parsed body.

**bcrypt off the loop.** Every bcrypt call — the verify in `authenticate` and the three `get_password_hash` sites — runs in a thread via `asyncio.to_thread`.

**Close the oracle.** An unknown address is verified against `_DUMMY_HASH` (a real hash computed once at import) rather than short-circuited, so known and unknown addresses refuse in the same time.

## Verification (acceptance criteria)

- ✅ Every `auth.py` route rate-limited, per IP and per submitted address
- ✅ No bcrypt call on the event loop — test holds bcrypt in its thread while the loop keeps turning
- ✅ Unknown and known addresses refuse indistinguishably — test asserts an unknown address is still put through bcrypt against the dummy hash
- ✅ The Nth `/login` in the window is refused 429; under the window it reaches the service
- Full backend suite 5668 passed; `rate_limit.py` at 100% (gated); `make lint` clean; `docs/configuration.md` documents the new setting.

Note: GET `/me` (authenticated, returns the cached user) is not rate-limited here — a per-IP limit on an authenticated no-op would harm an office behind one NAT, and per-user limiting of an already-authenticated cheap read is a separate call. Happy to add it if you'd prefer.

Closes #947