### PR TITLE
chore: cut 0.0.228

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.228] - 2026-08-20
+
+The MCP connection dialog owns its own form.
+
+### Changed
+
+- **`McpConnectionDialog` was a controlled shell.** `McpServerList` held its five
+  form fields as state and drilled a value *and* a setter each into it - thirteen
+  props - seeding them by hand when a draft opened. The dialog owns those fields
+  now, in an inner form keyed on the draft, so switching servers remounts it with
+  freshly seeded state instead of carrying the previous server's name and token
+  across. The list keeps which server is being edited and reads the values back on
+  submit; `handleSubmit` stays with the list, because it drives the connection
+  mutations, the tool refresh and the OAuth redirect, none of which are the
+  dialog's. Prop surface: 13 to 5. Behaviour unchanged, and the integration suite
+  that drives the dialog through the DOM asserts the same API payloads untouched.
+  (#569)
+
 ## [0.0.227] - 2026-08-20
 
 An attachment the router cannot read is named rather than dropped.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.227"
+version = "0.0.228"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.227"
+version = "0.0.228"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.227",
+  "version": "0.0.228",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.228. Bumps `backend/pyproject.toml`,
`backend/uv.lock` and `frontend/package.json` to 0.0.228 and adds the
CHANGELOG entry.

One issue, #569, and it closes the umbrella: the MCP connection dialog
was a controlled shell whose five form fields lived in `McpServerList`,
drilled in as a value and a setter each - thirteen props - and seeded by
hand when a draft opened. The dialog owns them now, in an inner form keyed
on the draft, so switching servers remounts it with freshly seeded state
rather than carrying the previous server's name and token across.
`handleSubmit` deliberately stays with the list: it drives the connection
mutations, the tool refresh and the OAuth redirect, none of which are the
dialog's.

Seven of #569's eight items had already been resolved by later PRs since
the 2026-08-10 audit, and the PR body records which - worth reading
before anyone reopens the umbrella looking for the rest.

## Verified

Behaviour is unchanged, and the check on that is the integration suite
that drives the dialog through the DOM and asserts the same API payloads -
connect, edit, OAuth, personal versus organization - passing untouched.
CI green end to end on #1013, which the automated review also passed.

Closes #569