### PR TITLE
chore: cut 0.0.229

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,28 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.229] - 2026-08-20
+
+The invitation ceiling is what the requester holds, not whether they are Admin.
+
+### Fixed
+
+- **A custom role composed with `members:manage` could invite a new Admin.**
+  `InvitationService` capped who may be invited by comparing the requester's role
+  against the literal string `admin`, so the ceiling applied to a built-in Admin
+  and to nobody else - and the catalog is explicitly built to let a Phase 2 role
+  hold that permission. Both call sites, the email invite and the invite link, now
+  read `assignable_roles(requester.role)`: the same catalog-derived relation
+  `change_role` uses, where a role may be offered only when the requester's own
+  *strictly* outranks it. This is the invitation half of what #672 removed from
+  `change_role`. (#696)
+- Behaviour for the built-in roles is unchanged - `assignable_roles("admin")` is
+  exactly the set the literal check allowed, and an Owner still invites Admins.
+  An Owner may no longer invite an Owner, which the invite schemas already
+  refused and which is what "nobody at all assigns `owner`" means: ownership moves
+  through `transfer_ownership`, which demotes the outgoing owner in the same
+  breath. (#696)
+
 ## [0.0.228] - 2026-08-20
 
 The MCP connection dialog owns its own form.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.228"
+version = "0.0.229"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.228"
+version = "0.0.229"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.228",
+  "version": "0.0.229",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.229. Bumps `backend/pyproject.toml`,
`backend/uv.lock` and `frontend/package.json` to 0.0.229 and adds the
CHANGELOG entry.

One issue, #696, and it is the invitation half of the defect #672 removed
from `change_role`: the ceiling on who may be invited compared the
requester's role against the literal string `admin`, so it applied to a
built-in Admin and to nobody else. A custom role (Phase 2) composed with
`members:manage` - which the catalog is explicitly built to allow -
passed it untouched and could invite a new Admin, by email or by link.

Both call sites read `assignable_roles(requester.role)` now, the same
catalog-derived relation `change_role` uses.

## Verified

Checked rather than assumed, because the claim is "no behaviour change
for the built-in roles": `assignable_roles("admin")` is exactly the set
the literal check allowed - builder, operator, member, viewer - an Owner
still invites Admins, and only Owner and Admin hold `members:manage`
among the built-ins, so no other role's path changes. An Owner may no
longer invite an Owner; the invite schemas already refused that, and it
is what "nobody at all assigns `owner`" means.

Two new tests, one per call site, each with a synthetic role holding only
`members:manage`. The member and invitation suite passes (35), and CI was
green end to end on #1019, which the automated review also passed.

Closes #696