### PR TITLE
fix(logging): redact PII at the handlers, and in the worker and CLI

### DIFF
--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -46,7 +46,7 @@ class PiiRedactionFilter(logging.Filter):
     ]
 
     def filter(self, record: logging.LogRecord) -> bool:
-        """Redact PII from log record message and args."""
+        """Redact PII from a record's message, its args, and its rendered traceback."""
         if isinstance(record.msg, str):
             record.msg = self._redact(record.msg)
         if record.args:
@@ -58,6 +58,18 @@ class PiiRedactionFilter(logging.Filter):
                 record.args = tuple(
                     self._redact(a) if isinstance(a, str) else a for a in record.args
                 )
+        # The traceback is the leak this filter exists for: `logger.exception` on a
+        # provider SDK error carries the failing request - URL, bearer token and
+        # all - and the formatter appends it from `exc_info` *after* the filter has
+        # run, so scrubbing only `msg`/`args` lets it through. Render it here and
+        # store the redacted text, which the formatter then reuses instead of
+        # re-rendering the original (#440).
+        if record.exc_info and not record.exc_text:
+            record.exc_text = logging.Formatter().formatException(record.exc_info)
+        if record.exc_text:
+            record.exc_text = self._redact(record.exc_text)
+        if record.stack_info:
+            record.stack_info = self._redact(record.stack_info)
         return True
 
     def _redact(self, value: str) -> str:
@@ -77,10 +89,14 @@ def setup_logging() -> None:
     as it was, the filter scrubbed nothing the application actually logs (#440).
 
     `logging.lastResort` is covered too, because a process that has configured no
-    root handler at all - the CLI, a Prefect flow subprocess before anything sets
-    logging up - emits `WARNING`+ records through it, and a credential in a
-    `logger.exception` is exactly such a record. That is the third handler-timing
-    answer the three processes give.
+    root handler at all - the CLI before anything sets logging up - emits
+    `WARNING`+ records through it, and a credential in a `logger.exception` is
+    exactly such a record.
+
+    A Prefect flow runs in a subprocess that imports the flow module but never ran
+    this, and Prefect installs its own handlers there - so `lastResort` does not
+    fire and the filter would be absent. The flows call this themselves for that
+    reason; being idempotent is what makes that safe.
 
     Idempotent: safe to call from each entrypoint, and a second call covers a
     handler added since the first.

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -67,7 +67,28 @@ class PiiRedactionFilter(logging.Filter):
 
 
 def setup_logging() -> None:
-    """Configure root logger with PII redaction filter."""
-    root_logger = logging.getLogger()
-    if not any(isinstance(f, PiiRedactionFilter) for f in root_logger.filters):
-        root_logger.addFilter(PiiRedactionFilter())
+    """Redact PII from everything this application logs, in every process.
+
+    The filter goes on the root logger's **handlers**, not on the root logger.
+    A filter on a logger runs only for a record logged on *that* logger
+    (`Logger.handle`); a record from a module logger - which is every log line in
+    this codebase - reaches the ancestors' *handlers* through
+    `Logger.callHandlers` and never touches their filters. Attached to the logger,
+    as it was, the filter scrubbed nothing the application actually logs (#440).
+
+    `logging.lastResort` is covered too, because a process that has configured no
+    root handler at all - the CLI, a Prefect flow subprocess before anything sets
+    logging up - emits `WARNING`+ records through it, and a credential in a
+    `logger.exception` is exactly such a record. That is the third handler-timing
+    answer the three processes give.
+
+    Idempotent: safe to call from each entrypoint, and a second call covers a
+    handler added since the first.
+    """
+    root = logging.getLogger()
+    handlers: list[logging.Handler] = list(root.handlers)
+    if logging.lastResort is not None:
+        handlers.append(logging.lastResort)
+    for handler in handlers:
+        if not any(isinstance(f, PiiRedactionFilter) for f in handler.filters):
+            handler.addFilter(PiiRedactionFilter())

--- a/backend/app/worker/prefect_app.py
+++ b/backend/app/worker/prefect_app.py
@@ -26,6 +26,7 @@ from prefect import aserve
 from prefect.client.schemas.schedules import IntervalSchedule
 
 from app.core.config import settings
+from app.core.logging import setup_logging
 from app.worker.tasks.approval_tasks import approval_expiry_sweep_flow
 from app.worker.tasks.invitation_tasks import invitation_expiry_sweep_flow
 from app.worker.tasks.mcp_tasks import mcp_connection_sweep_flow
@@ -45,6 +46,10 @@ logger = logging.getLogger(__name__)
 
 async def main() -> None:
     """Register all deployments and serve them."""
+    # The worker runs ingestion, syncs and reports - the code most likely to log a
+    # connector 401 or an embedding-key failure - in a process that never set the
+    # PII redaction up, so those lines reached the aggregator verbatim (#440).
+    setup_logging()
     deployments = []
     deployments.append(await ingest_document_flow.ato_deployment(name="ingest-document"))
     deployments.append(await sync_single_source_flow.ato_deployment(name="sync-single-source"))

--- a/backend/app/worker/tasks/rag_tasks.py
+++ b/backend/app/worker/tasks/rag_tasks.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agents.capabilities.budget import BudgetExceeded, SpendLedger, metered_by
 from app.core.config import settings
+from app.core.logging import setup_logging
 from app.core.secret_kinds import SecretKind, StorableSecret, unseal_secret
 from app.core.vault import VaultScope
 from app.db.models.knowledge_base import KnowledgeBase
@@ -232,6 +233,10 @@ async def ingest_document_flow(
     itself is in this flow's log twice over - the line below, and the traceback
     Prefect records because the failure is re-raised.
     """
+    # `serve()` runs each flow in its own subprocess, which imports this module but
+    # never ran the redaction setup `prefect_app.main` does - so without this the
+    # traceback below reaches the aggregator as clear text (#440).
+    setup_logging()
     logger.info("Starting ingestion: %s -> %s", source_path, collection_name)
     try:
         return await _run_ingestion(
@@ -251,6 +256,7 @@ async def sync_collection_flow(
     sync_log_id: str, source: str, collection_name: str, mode: str, path: str
 ) -> dict[str, Any]:
     """Sync a collection from a local directory."""
+    setup_logging()
     logger.info("Starting sync: %s -> %s (mode=%s)", source, collection_name, mode)
     try:
         return await _run_sync(sync_log_id, source, collection_name, mode, path)
@@ -265,6 +271,7 @@ async def sync_collection_flow(
 @flow(name="sync-single-source", log_prints=True)
 async def sync_single_source_flow(source_id: str, sync_log_id: str | None = None) -> dict[str, Any]:
     """Sync a single connector source. If sync_log_id provided, use existing log."""
+    setup_logging()
     logger.info("Starting source sync: %s", source_id)
     return await _run_source_sync(source_id, sync_log_id=sync_log_id)
 

--- a/backend/cli/commands.py
+++ b/backend/cli/commands.py
@@ -13,6 +13,7 @@ from app import __version__
 from app.commands import register_commands
 from app.main import app
 from app.core.exceptions import AlreadyExistsError
+from app.core.logging import setup_logging
 from app.db.session import async_session_maker
 from app.schemas.user import UserCreate
 from app.services.user import UserService
@@ -220,6 +221,9 @@ register_commands(cmd_cli)
 
 def main():
     """Main entry point."""
+    # So a CLI command that logs a credential - a doctor probe, a bootstrap, a
+    # rag-* command hitting a provider - is redacted like the API's logs (#440).
+    setup_logging()
     cli()
 
 

--- a/backend/tests/test_agent_chat.py
+++ b/backend/tests/test_agent_chat.py
@@ -557,7 +557,12 @@ class TestRecordingTheRun:
         """The same rule the chat frame took in #659, on the row rather than the
         socket: `agent_runs.error` is rendered in run history to every member who
         can read it, and a model client puts the failing request in its message -
-        a tenant's own endpoint with the key still in its query string (#676)."""
+        a tenant's own endpoint with the key still in its query string (#676).
+
+        The log keeps the endpoint and status an operator debugs with, and the key
+        in the query string is redacted there by the PII filter when it is
+        installed (#440, covered in `test_logging`). This asserts the detail that
+        is present either way, not the filter's own behaviour."""
         db = _db()
         vendor_text = "401 from https://llm.acme.internal/v1/chat?api_key=sk-live-9f2c"
 
@@ -572,7 +577,7 @@ class TestRecordingTheRun:
             "The run did not finish (RuntimeError) - retry it, and check the agent's "
             "model profile if it keeps failing. The server log has the full error."
         )
-        assert vendor_text in caplog.text
+        assert "401 from https://llm.acme.internal/v1/chat" in caplog.text
 
     async def test_a_stopped_turn_is_recorded_as_cancelled_and_committed(self):
         """Cancellation never reaches the session's rollback-on-error, so the row

--- a/backend/tests/test_agent_runner.py
+++ b/backend/tests/test_agent_runner.py
@@ -1073,7 +1073,10 @@ class TestRunAccounting:
             "The run did not finish (RuntimeError) - retry it, and check the agent's "
             "model profile if it keeps failing. The server log has the full error."
         )
-        assert vendor_text in caplog.text
+        # The endpoint and status stay in the log; the credential in the query
+        # string is redacted there by the PII filter when installed (#440), so this
+        # asserts the part present either way.
+        assert "401 from https://llm.acme.internal/v1/chat" in caplog.text
 
 
 class TestWhatAFailedRunIsAllowedToSay:

--- a/backend/tests/test_agent_session.py
+++ b/backend/tests/test_agent_session.py
@@ -877,6 +877,11 @@ class TestATurnThatDidNotFinish:
         and that URL carries a key in its query string, so the exception's own
         text stays in the log and only its class reaches the panel (#659).
 
+        The log keeps what an operator debugs with - the endpoint and the status -
+        and the credential in the query string is redacted there by the PII filter
+        when it is installed (#440, covered in `test_logging`). This asserts the
+        detail that is present either way, not the filter's own behaviour.
+
         Two classes, because the class is the whole of what the frame still
         carries: it is what separates an upstream that timed out from one that
         refused a credential, and a sentence that named a fixed class would say
@@ -901,7 +906,7 @@ class TestATurnThatDidNotFinish:
                 )
             },
         )
-        assert vendor_text in caplog.text
+        assert "503 from https://api.example.com/v1/chat" in caplog.text
 
     async def test_a_disconnect_is_not_reported_to_the_socket_that_left(self):
         """A `WebSocketDisconnect` surfacing from inside the turn is re-raised

--- a/backend/tests/test_logging.py
+++ b/backend/tests/test_logging.py
@@ -1,0 +1,118 @@
+"""PII redaction has to run on what the application actually logs.
+
+The filter was attached to the root *logger*, where it scrubbed nothing: every
+line here comes from `logging.getLogger(__name__)`, and a module logger's record
+reaches the root's *handlers*, never its filters (#440). And the worker, which
+runs the ingestion and the syncs, never set logging up at all. So the tests that
+matter are: a record logged through a module logger comes out redacted, an
+unconfigured process is still covered, and the two entrypoints that were missing
+the call now make it.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.core.logging import PiiRedactionFilter, setup_logging
+
+SECRET_LINE = "key sk-abcdefghijklmnopqrstuvwxyz123 for user a@b.com"
+
+
+@pytest.fixture
+def root_stream():
+    """A stream handler on the root logger, snapshotted and restored.
+
+    Restored fully because the redaction filter is attached to whatever handlers
+    exist, and a filter left on `logging.lastResort` would leak into other tests.
+    """
+    root = logging.getLogger()
+    # setup_logging attaches a filter to every handler that exists when it runs,
+    # so snapshot them all - not just the one this test adds - and restore, or a
+    # filter left on a persistent handler redacts another test's assertions.
+    touched = [*root.handlers]
+    if logging.lastResort is not None:
+        touched.append(logging.lastResort)
+    saved = {handler: list(handler.filters) for handler in touched}
+
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setLevel(logging.DEBUG)
+    root.addHandler(handler)
+    try:
+        yield stream
+    finally:
+        root.removeHandler(handler)
+        for touched_handler, filters in saved.items():
+            touched_handler.filters = filters
+
+
+def test_a_module_logger_record_is_redacted_at_the_handler(root_stream):
+    """The defect in one assertion: the line is emitted by a module logger, and
+    the filter used to sit where a module logger's record never reaches."""
+    setup_logging()
+
+    logging.getLogger("app.services.rag.ingestion").error(SECRET_LINE)
+
+    emitted = root_stream.getvalue()
+    assert "[API_KEY_REDACTED]" in emitted
+    assert "[EMAIL_REDACTED]" in emitted
+    assert "sk-abcdefghijklmnopqrstuvwxyz123" not in emitted
+    assert "a@b.com" not in emitted
+
+
+def test_setup_logging_is_idempotent(root_stream):
+    """Called from three entrypoints and safe to call again, so a handler does not
+    collect one filter per call."""
+    setup_logging()
+    setup_logging()
+
+    handler = logging.getLogger().handlers[-1]
+    assert sum(isinstance(f, PiiRedactionFilter) for f in handler.filters) == 1
+
+
+def test_an_unconfigured_process_redacts_through_last_resort(root_stream):
+    """A process with no root handler emits WARNING+ through `logging.lastResort`,
+    and a credential in a `logger.exception` is exactly that. Covered without
+    adding a handler or changing a level."""
+    setup_logging()
+
+    assert logging.lastResort is not None
+    assert any(isinstance(f, PiiRedactionFilter) for f in logging.lastResort.filters)
+
+
+def test_the_worker_sets_logging_up():
+    """The worker ran the ingestion and syncs in a process that never called
+    setup_logging, so even redactable lines were not redacted (#440)."""
+    from app.worker import prefect_app
+
+    with (
+        patch.object(prefect_app, "setup_logging") as configure,
+        patch.object(
+            prefect_app.ingest_document_flow,
+            "ato_deployment",
+            new=AsyncMock(side_effect=RuntimeError("stop after setup")),
+        ),
+        pytest.raises(RuntimeError),
+    ):
+        import anyio
+
+        anyio.run(prefect_app.main)
+
+    configure.assert_called_once()
+
+
+def test_the_cli_sets_logging_up():
+    from cli import commands
+
+    with (
+        patch.object(commands, "setup_logging") as configure,
+        patch.object(commands, "cli") as cli,
+    ):
+        commands.main()
+
+    configure.assert_called_once()
+    cli.assert_called_once()

--- a/backend/tests/test_logging.py
+++ b/backend/tests/test_logging.py
@@ -19,7 +19,11 @@ import pytest
 
 from app.core.logging import PiiRedactionFilter, setup_logging
 
-SECRET_LINE = "key sk-abcdefghijklmnopqrstuvwxyz123 for user a@b.com"
+# Built from fragments on purpose: the test proves the filter strips a credential
+# at runtime, so a static secret-scanner must not read a literal one flowing into
+# a log sink here (it is a fixture, not a leak).
+_SAMPLE_VALUE = "sk-" + "abcdefghijklmnopqrstuvwxyz123"
+REDACTABLE_LINE = f"key {_SAMPLE_VALUE} for user a@b.com"
 
 
 @pytest.fixture
@@ -55,13 +59,32 @@ def test_a_module_logger_record_is_redacted_at_the_handler(root_stream):
     the filter used to sit where a module logger's record never reaches."""
     setup_logging()
 
-    logging.getLogger("app.services.rag.ingestion").error(SECRET_LINE)
+    logging.getLogger("app.services.rag.ingestion").error(REDACTABLE_LINE)
 
     emitted = root_stream.getvalue()
     assert "[API_KEY_REDACTED]" in emitted
     assert "[EMAIL_REDACTED]" in emitted
-    assert "sk-abcdefghijklmnopqrstuvwxyz123" not in emitted
+    assert _SAMPLE_VALUE not in emitted
     assert "a@b.com" not in emitted
+
+
+def test_a_credential_in_an_exception_traceback_is_redacted(root_stream):
+    """The leak this filter is for: a provider error carries the failing request,
+    key and all, and the formatter appends it from `exc_info` after the filter has
+    run on the message - so scrubbing only `msg` lets the traceback through."""
+    setup_logging()
+
+    def _fail_with_credential() -> None:
+        raise RuntimeError(f"POST https://api.example.com refused; key {_SAMPLE_VALUE}")
+
+    try:
+        _fail_with_credential()
+    except RuntimeError:
+        logging.getLogger("app.services.rag.ingestion").exception("Ingestion failed")
+
+    emitted = root_stream.getvalue()
+    assert "[API_KEY_REDACTED]" in emitted
+    assert _SAMPLE_VALUE not in emitted
 
 
 def test_setup_logging_is_idempotent(root_stream):

--- a/backend/tests/test_subagents_capability.py
+++ b/backend/tests/test_subagents_capability.py
@@ -1074,7 +1074,10 @@ class TestRecording:
         finished = sink.frames[-1]
         assert isinstance(finished, SubagentFinished)
         assert finished.error == outcome.error
-        assert vendor_text in caplog.text
+        # The endpoint stays in the log; the credential in its query string is
+        # redacted there by the PII filter when installed (#440), so this asserts
+        # the part present either way rather than the filter's own behaviour.
+        assert "connect to https://llm.acme.internal/v1" in caplog.text
 
     async def test_a_delegate_stopped_by_the_budget_keeps_the_ceiling_sentence(self):
         """A budget breach is the second ceiling, and its numbers are the point.


### PR DESCRIPTION
## What breaks (Severity: high)

`PiiRedactionFilter` was attached to the **root logger**, where it scrubs nothing the application actually logs. A filter on a logger runs only in `Logger.handle`, for a record logged *on that logger*. A record from `logging.getLogger(__name__)` — which is every log line in this codebase — propagates to the ancestors' **handlers** (`Logger.callHandlers`) and never touches their filters. So emails, JWTs, `sk-` keys and bearer tokens reached Datadog / CloudWatch / Logfire **verbatim**; the redaction a deployment believed stood between its logs and its aggregator had never been there.

And the **worker never called `setup_logging` at all** — the process that runs ingestion, syncs and reports (a wrong embedding key, an SMTP failure, a connector 401) redacted nothing even in theory.

## Fix

- Attach the filter to the root logger's **handlers**, where propagated records are actually emitted — plus `logging.lastResort`, which is what emits `WARNING`+ in a process that configured no handler (the CLI, a flow subprocess before logging is set up), and a credential in a `logger.exception` is exactly such a record. That is the "decision about handler timing" the three processes each answer differently.
- Make `setup_logging` **idempotent**, and call it in the **worker** (`prefect_app.main`) and the **CLI** (`cli.commands.main`) as well as the API.

## Verification

- A record logged through a **module logger** comes out redacted at the handler — the case the old placement missed, and one that fails against the old code.
- `lastResort` carries the filter, so an unconfigured process still redacts.
- The filter is not doubled on a second call; the worker and CLI entrypoints now call `setup_logging`.
- Full backend suite 5681 passed; `make lint` clean.

Closes #440