### PR TITLE
chore: cut 0.0.230

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,34 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.230] - 2026-08-20
+
+A role picker offers what the caller may actually assign.
+
+### Fixed
+
+- **Every role picker offered every role in the catalog bar `owner`, whoever was
+  asking.** Both invite dialogs and the members table, with the service refusing
+  what the caller could not assign - so an Admin was offered Admin and got a 403
+  after typing the email address. `assignableRoles` is the client's copy of
+  `app.core.permissions.assignable_roles`, over the permissions
+  `GET /roles/catalog` already returns: a role is offered only when the caller's
+  own strictly outranks it. Pre-existing, and 0.0.229 widened who it happened to
+  - with the server's ceiling derived from what a role holds, every custom role
+  composed with `members:manage` met the same offer-then-refuse. (#1028)
+- **A picker seeded with a role it did not offer.** Both dialogs held Member as
+  their initial value and never reconciled it with the list; Member is kept where
+  it is on offer - which for every built-in role that may invite at all, it is -
+  and otherwise the least privileged role that is. (#1028)
+- **A peer Admin's row keeps its picker**, with that role in the list and
+  disabled. `change_role` judges the role being handed out rather than the one
+  being replaced, so an Admin may demote a peer Admin - and the row needs the
+  current role present or the trigger renders blank, because the chosen item's
+  text is what a trigger shows. (#1028)
+- **A role catalog that cannot be read says so**, in both dialogs and above the
+  members table. Offering nothing and being unable to answer are the same pixels
+  and a different fact, and the second one is permanent. (#1028)
+
 ## [0.0.229] - 2026-08-20
 
 The invitation ceiling is what the requester holds, not whether they are Admin.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.229"
+version = "0.0.230"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.229"
+version = "0.0.230"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.229",
+  "version": "0.0.230",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.230. Bumps `backend/pyproject.toml`,
`backend/uv.lock` and `frontend/package.json` to 0.0.230 and adds the
CHANGELOG entry.

One issue, #1028, found reviewing #1019: every role picker offered every
role in the catalog bar `owner`, whoever was asking, and the service
refused the rest - a control the caller may not use, rendered and then
403'd. The fix is the client computing the same relation the server
enforces, over the permissions `/roles/catalog` already returns, rather
than holding a list.

The automated review found three things on the branch and two are fixed
in it. A peer Admin's row had lost a supported action - `change_role`
judges the role being handed out rather than the one being replaced, so
an Admin may demote a peer Admin, and the row keeps its picker with that
role present and disabled. And a catalog that cannot be read now says so
on all three surfaces, where before it was indistinguishable from a
caller who may assign nothing - permanently, with a submit disabled for
good.

The third is filed as #1032 rather than half-fixed: `/me/permissions`
answers for the *active* organization, because the client puts
`X-Organization-Id` on every request, while the members page acts on the
organization in its URL - and the organizations list opens any org's
members page without switching. `canManage` one line above reads the same
wrong answer and has since long before, so scoping the picker alone would
leave the page deciding which controls exist from one organization and
what they offer from another.

## Verified

11 tests on the relation - the pairs the backend's own tests assert, a
custom role holding only `members:manage`, an unknown role, an unanswered
catalog, and a scope compared by rank rather than as a string; six across
the two dialogs; and a first integration test for the members page, four
cases including the peer-Admin row and the failed catalog.
`make test-frontend-cov` at 5292 passed and 100% lines/statements/
functions, `make check`, and CI green end to end on #1031 including
`e2e`.

Closes #1028