### PR TITLE
fix(permissions): the organization in the URL is the tenant

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -252,6 +252,20 @@ control the caller may not use is **not rendered** — not rendered and then 403
 Prove it with an integration test (`*.integration.test.tsx`, Testing Library against a
 mocked API), not with Playwright.
 
+**Which roles a picker offers is arithmetic, not a list.** `assignableRoles` in
+`lib/assignable-roles.ts` mirrors the server's `assignable_roles` over the catalog's
+permission sets: a role is offered only when the caller's own strictly outranks it.
+A list of "every role but owner" is what offered an Admin the Admin option and 403'd
+after the email address was typed (#1028).
+
+**And a page that names an organization in its URL *is* that organization.**
+`apiClient` stamps `X-Organization-Id: activeOrgId` on every request, so a page acting
+on the org in its path while reading permissions for the active one decides Acme's
+members by the caller's role in Globex — which is what `/orgs/{id}/members` did, because
+the organizations list opens it without switching (#1032). The adoption lives in
+`ActiveOrgGuard`, once, beside the tenant cache reset it has to happen before; a page
+does not do it for itself.
+
 ## An empty page is ambiguous
 
 Every dashboard page fans out to several queries and renders its empty state when one

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -147,6 +147,14 @@ Derived from the catalog rather than from a role name, so a custom role (Phase
 against the literal `"admin"` and could not see one at all - on the invitation
 paths as well as on `change_role`, which is what #696 closed.
 
+**A page's organization is the one in its URL.** `X-Organization-Id` travels on
+every request from the console and names the *active* organization, so a page
+that acts on an org from its path - `/orgs/{id}/members` - has two notions of
+"which tenant" and the organizations list opens that page without switching. They
+are one now: the dashboard's `ActiveOrgGuard` adopts the organization a path
+names, before the page asks anything, so what a caller may do there is what they
+may do *there* (#1032).
+
 **The console computes the same relation rather than being told it.** Every role
 picker - the two invite dialogs and the members table - offers what
 `assignableRoles` in `frontend/src/lib/assignable-roles.ts` answers, over the

--- a/frontend/src/app/[locale]/(dashboard)/orgs/[id]/members/members.integration.test.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/orgs/[id]/members/members.integration.test.tsx
@@ -5,8 +5,9 @@ import { Suspense, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import MembersPage from "./page";
+import { ActiveOrgGuard } from "@/components/layout/active-org-guard";
 import { apiClient } from "@/lib/api-client";
-import { useAuthStore } from "@/stores";
+import { useAuthStore, useOrgStore } from "@/stores";
 import { permissionsOf, ROLE_CATALOG } from "@/test-utils/role-catalog";
 
 /**
@@ -33,6 +34,17 @@ vi.mock("@/lib/api-client", async () => {
   };
 });
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+// The tenant is the organization in the path, so this file needs to move it.
+// The rest are what `vitest.setup.ts` provides, and for its reason.
+const path = vi.fn(() => "/");
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => path(),
+  useParams: () => ({}),
+  redirect: vi.fn(),
+  permanentRedirect: vi.fn(),
+}));
 
 const ME = "user-me";
 
@@ -83,17 +95,21 @@ function serve(role: string) {
  * suspends - and a suspension inside a synchronous `act` never resolves. Awaited
  * here, which is what React's own warning asks for.
  */
-async function mount() {
+async function mount(orgId = "org-1") {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
   const wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={client}>
+      {/* Before the page, as the dashboard layout has it: the guard adopts the
+          organization the path names, and it has to happen before the page's
+          own requests go out (#1032). */}
+      <ActiveOrgGuard />
       <Suspense>{children}</Suspense>
     </QueryClientProvider>
   );
   await act(async () => {
-    render(<MembersPage params={Promise.resolve({ id: "org-1" })} />, { wrapper });
+    render(<MembersPage params={Promise.resolve({ id: orgId })} />, { wrapper });
   });
 }
 
@@ -107,6 +123,8 @@ async function roleCell(email: string): Promise<HTMLElement> {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  path.mockReturnValue("/orgs/org-1/members");
+  useOrgStore.setState({ activeOrgId: "org-1", refusedOrgIds: [] });
   useAuthStore.setState({
     user: {
       id: ME,
@@ -154,6 +172,61 @@ describe("the members table's role control", () => {
       "viewer",
     ]);
     expect(options[0]).toHaveAttribute("data-disabled");
+  });
+
+  it("judges the organization in its URL, not whichever one is active", async () => {
+    // #1032: `X-Organization-Id` names the *active* organization on every
+    // request, and the organizations list opens any org's members page without
+    // switching - so this page judged Acme's members by the caller's role in
+    // Globex. The guard adopts the path's organization, so what the page offers
+    // is what the caller may do *there*.
+    //
+    // The mock answers per organization, which is what makes the difference
+    // visible: an Owner of the org in the URL, an Admin of the active one.
+    const URL_ORG = "22222222-2222-2222-2222-222222222222";
+    path.mockReturnValue(`/orgs/${URL_ORG}/members`);
+    useOrgStore.setState({ activeOrgId: "org-1", refusedOrgIds: [] });
+    vi.mocked(apiClient.get).mockImplementation((url: string) => {
+      if (url === "/roles/catalog") return Promise.resolve(ROLE_CATALOG);
+      if (url.startsWith("/me/permissions")) {
+        const asked = useOrgStore.getState().activeOrgId;
+        return Promise.resolve(permissionsOf(asked === URL_ORG ? "owner" : "admin"));
+      }
+      if (url === "/orgs")
+        return Promise.resolve({
+          items: [
+            { id: "org-1", name: "Globex", avatar_color: null },
+            { id: URL_ORG, name: "Acme", avatar_color: null },
+          ],
+          total: 2,
+        });
+      if (url.endsWith("/members"))
+        return Promise.resolve({
+          items: [
+            member(ME, "me@acme.test", "owner"),
+            member("user-peer", "peer@acme.test", "admin"),
+          ],
+          total: 2,
+        });
+      return Promise.resolve({ items: [], total: 0 });
+    });
+
+    await mount(URL_ORG);
+
+    const row = await roleCell("peer@acme.test");
+    await userEvent.click(within(row).getByRole("combobox"));
+
+    // An Owner's five, not an Admin's four - and `admin` selectable rather than
+    // the disabled placeholder an Admin would see on this row.
+    const options = screen.getAllByRole("option");
+    expect(options.map((option) => option.textContent?.trim())).toEqual([
+      "admin",
+      "builder",
+      "operator",
+      "member",
+      "viewer",
+    ]);
+    expect(options[0]).not.toHaveAttribute("data-disabled");
   });
 
   it("says so when the role catalog could not be read, rather than showing labels", async () => {

--- a/frontend/src/components/teams/org-switcher.test.tsx
+++ b/frontend/src/components/teams/org-switcher.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OrgSwitcher } from "./org-switcher";
+import { useOrgStore } from "@/stores";
+
+/**
+ * Switching organization from a page that names one in its URL.
+ *
+ * The URL decides the tenant (#1032), so a switch that only set the id left the
+ * page acting on the organization just left - and the guard, which adopts what
+ * the path names, wrote the id straight back. The switch takes the route with
+ * it, which is what makes it a switch rather than a flicker.
+ */
+
+const ACME = "11111111-1111-1111-1111-111111111111";
+const GLOBEX = "22222222-2222-2222-2222-222222222222";
+
+const push = vi.fn();
+let pathname = "/agents";
+
+vi.mock("@/lib/locale-navigation", () => ({
+  useRouter: () => ({ push }),
+  usePathname: () => pathname,
+}));
+
+vi.mock("@/hooks", () => ({
+  useOrganizations: () => ({
+    orgs: [
+      { id: ACME, name: "Acme", is_personal: false, avatar_url: null, avatar_color: null },
+      { id: GLOBEX, name: "Globex", is_personal: false, avatar_url: null, avatar_color: null },
+    ],
+    activeOrg: { id: ACME, name: "Acme", is_personal: false, avatar_url: null, avatar_color: null },
+    fetchOrgs: vi.fn(),
+    switchOrg: (id: string) => useOrgStore.getState().setActiveOrgId(id),
+  }),
+}));
+
+function mount() {
+  render(
+    <NextIntlClientProvider locale="en" messages={{}}>
+      <OrgSwitcher />
+    </NextIntlClientProvider>,
+  );
+}
+
+async function choose(name: string) {
+  await userEvent.click(screen.getByRole("button", { name: /Organization/ }));
+  await userEvent.click(await screen.findByText(name));
+}
+
+beforeEach(() => {
+  push.mockClear();
+  useOrgStore.setState({ activeOrgId: ACME, refusedOrgIds: [] });
+});
+
+describe("OrgSwitcher", () => {
+  it("takes an organization-scoped page to the same page for the one picked", async () => {
+    pathname = `/orgs/${ACME}/members`;
+    mount();
+
+    await choose("Globex");
+
+    expect(useOrgStore.getState().activeOrgId).toBe(GLOBEX);
+    expect(push).toHaveBeenCalledWith(`/orgs/${GLOBEX}/members`);
+  });
+
+  it("keeps the sub-page, so the roles page switches to the roles page", async () => {
+    pathname = `/orgs/${ACME}/roles`;
+    mount();
+
+    await choose("Globex");
+
+    expect(push).toHaveBeenCalledWith(`/orgs/${GLOBEX}/roles`);
+  });
+
+  it("stays put on a page that belongs to no organization in particular", async () => {
+    // Every other route is tenant-agnostic: the switch changes what they show,
+    // not which of them is open.
+    pathname = "/agents";
+    mount();
+
+    await choose("Globex");
+
+    expect(useOrgStore.getState().activeOrgId).toBe(GLOBEX);
+    expect(push).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/teams/org-switcher.tsx
+++ b/frontend/src/components/teams/org-switcher.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { EntityAvatar } from "@/components/ui/entity-avatar";
 import { useOrganizations } from "@/hooks";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "@/lib/locale-navigation";
 import { useTranslations } from "next-intl";
 
 /**
@@ -28,6 +28,28 @@ export function OrgSwitcher() {
   const t = useTranslations("teams");
   const { orgs, activeOrg, fetchOrgs, switchOrg } = useOrganizations();
   const router = useRouter();
+  const pathname = usePathname();
+
+  /**
+   * Switch, and take an organization-scoped route with it.
+   *
+   * `/orgs/{id}/members` and `/orgs/{id}/roles` name their organization in the
+   * URL, and the URL is what decides the tenant (#1032) - so setting the id and
+   * staying put would leave the page acting on the organization just left. The
+   * same page for the organization picked is what "switch" means here; every
+   * other route is tenant-agnostic and stays where it is.
+   *
+   * Both hooks come from `@/lib/locale-navigation` rather than
+   * `next/navigation`: its `usePathname` hands back the path without the locale
+   * prefix, so the pattern below does not have to know about one, and its
+   * `router` puts the prefix back - which the two pushes further down were
+   * losing, sending a Polish reader to the English `/orgs`.
+   */
+  const pick = (id: string) => {
+    switchOrg(id);
+    const scoped = pathname.match(/\/orgs\/[^/]+(\/.*)?$/);
+    if (scoped) router.push(`/orgs/${id}${scoped[1] ?? ""}`);
+  };
 
   useEffect(() => {
     fetchOrgs();
@@ -75,7 +97,7 @@ export function OrgSwitcher() {
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="w-56">
         {orgs.map((org) => (
-          <DropdownMenuItem key={org.id} onSelect={() => switchOrg(org.id)} className="gap-2">
+          <DropdownMenuItem key={org.id} onSelect={() => pick(org.id)} className="gap-2">
             <EntityAvatar
               seed={org.id}
               name={org.name}

--- a/frontend/src/hooks/use-active-organization.test.tsx
+++ b/frontend/src/hooks/use-active-organization.test.tsx
@@ -4,7 +4,11 @@ import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { toast } from "sonner";
 
-import { refusesOrganization, useActiveOrganizationRecovery } from "./use-active-organization";
+import {
+  organizationInPath,
+  refusesOrganization,
+  useActiveOrganizationRecovery,
+} from "./use-active-organization";
 import { apiClient } from "@/lib/api-client";
 import { ApiError } from "@/lib/api-error";
 import { useAgentSelectionStore, useConversationStore, useOrgStore } from "@/stores";
@@ -14,6 +18,18 @@ vi.mock("@/lib/api-client", async () => {
   return { apiClient: { get: vi.fn() }, ApiError };
 });
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+// The path decides the tenant now, so this file needs to move it. The other
+// exports are the ones `vitest.setup.ts` provides for the same reason it does:
+// next-intl's `createNavigation` reads them at module scope.
+const path = vi.fn(() => "/");
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => path(),
+  useParams: () => ({}),
+  redirect: vi.fn(),
+  permanentRedirect: vi.fn(),
+}));
 
 const STALE = "11111111-1111-1111-1111-111111111111";
 const PERSONAL = "22222222-2222-2222-2222-222222222222";
@@ -93,10 +109,41 @@ describe("refusesOrganization", () => {
   });
 });
 
+describe("organizationInPath", () => {
+  const ORG = "33333333-3333-3333-3333-333333333333";
+
+  it("reads the organization a members or roles page names", () => {
+    expect(organizationInPath(`/orgs/${ORG}/members`)).toBe(ORG);
+    expect(organizationInPath(`/orgs/${ORG}/roles`)).toBe(ORG);
+    expect(organizationInPath(`/orgs/${ORG}`)).toBe(ORG);
+  });
+
+  it("reads one through a locale prefix", () => {
+    // `next/navigation` keeps the prefix, and `/pl/orgs/{id}` names the same
+    // organization as `/orgs/{id}`.
+    expect(organizationInPath(`/pl/orgs/${ORG}/members`)).toBe(ORG);
+  });
+
+  it("names none where the path names none", () => {
+    expect(organizationInPath("/orgs")).toBeNull();
+    expect(organizationInPath("/agents")).toBeNull();
+    expect(organizationInPath("/")).toBeNull();
+    expect(organizationInPath(`/agents/${ORG}`)).toBeNull();
+  });
+
+  it("takes a UUID and nothing else", () => {
+    // A later `/orgs/new` would otherwise be adopted as a tenant id and
+    // refused on every request the page made.
+    expect(organizationInPath("/orgs/new")).toBeNull();
+    expect(organizationInPath("/orgs/new/members")).toBeNull();
+  });
+});
+
 describe("useActiveOrganizationRecovery", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     useOrgStore.setState({ activeOrgId: null, refusedOrgIds: [] });
+    path.mockReturnValue("/");
     client = new QueryClient({
       // Matching `app/providers.tsx`. At the library default of 0 a switch
       // refetches whether or not anything dropped the cache, which is the
@@ -250,6 +297,60 @@ describe("useActiveOrganizationRecovery", () => {
 
     await waitFor(() => expect(useOrgStore.getState().refusedOrgIds).toEqual([STALE]));
     expect(useOrgStore.getState().activeOrgId).toBeNull();
+  });
+
+  it("adopts the organization a page names, so the page judges its own tenant", async () => {
+    // The whole of #1032: `/orgs/{B}/members` acted on B and read permissions
+    // for whatever was active, and the organizations list opens that page
+    // without switching - so an Owner of B was judged by their role in A.
+    const OTHER = "33333333-3333-3333-3333-333333333333";
+    answerWith([{ id: PERSONAL, is_personal: true }], { permissions: [] });
+    useOrgStore.setState({ activeOrgId: PERSONAL });
+    path.mockReturnValue(`/orgs/${OTHER}/members`);
+
+    renderHook(() => useActiveOrganizationRecovery(), { wrapper });
+
+    await waitFor(() => expect(useOrgStore.getState().activeOrgId).toBe(OTHER));
+  });
+
+  it("leaves the selection alone on a page that names no organization", async () => {
+    answerWith([{ id: PERSONAL, is_personal: true }], { permissions: [] });
+    useOrgStore.setState({ activeOrgId: PERSONAL });
+    path.mockReturnValue("/agents");
+
+    renderHook(() => useActiveOrganizationRecovery(), { wrapper });
+
+    await waitFor(() => expect(useOrgStore.getState().activeOrgId).toBe(PERSONAL));
+  });
+
+  it("does not adopt an organization the server has already refused", async () => {
+    // Otherwise opening its page hands the selection straight back to the one
+    // the recovery has just moved off, which is how a switch loop starts.
+    answerWith([{ id: PERSONAL, is_personal: true }], { permissions: [] });
+    useOrgStore.setState({ activeOrgId: PERSONAL, refusedOrgIds: [STALE] });
+    path.mockReturnValue(`/orgs/${STALE}/members`);
+
+    renderHook(() => useActiveOrganizationRecovery(), { wrapper });
+
+    await waitFor(() => expect(useOrgStore.getState().activeOrgId).toBe(PERSONAL));
+  });
+
+  it("keeps what a page loaded directly cached, rather than dropping it a commit later", async () => {
+    // The cache's tenant is the URL's organization from the first commit, so
+    // the reset does not fire on top of the requests the page has just started
+    // - the failure mode the first-tenant skip exists for.
+    const OTHER = "33333333-3333-3333-3333-333333333333";
+    answerWith([{ id: PERSONAL, is_personal: true }], { permissions: [] });
+    useOrgStore.setState({ activeOrgId: PERSONAL });
+    path.mockReturnValue(`/orgs/${OTHER}/members`);
+
+    renderHook(() => useActiveOrganizationRecovery(), { wrapper });
+    client.setQueryData(["agents", "list", false], [{ id: "a-1", name: "The page's own read" }]);
+
+    await waitFor(() => expect(useOrgStore.getState().activeOrgId).toBe(OTHER));
+    expect(client.getQueryData(["agents", "list", false])).toEqual([
+      { id: "a-1", name: "The page's own read" },
+    ]);
   });
 
   it("leaves a working organization alone", async () => {

--- a/frontend/src/hooks/use-active-organization.test.tsx
+++ b/frontend/src/hooks/use-active-organization.test.tsx
@@ -131,6 +131,14 @@ describe("organizationInPath", () => {
     expect(organizationInPath(`/agents/${ORG}`)).toBeNull();
   });
 
+  it("answers in canonical lower case, because the answer is stored", () => {
+    // The server serialises UUIDs lower-cased and `activeOrg` is found by
+    // `===`, so holding an upper-case spelling would match no organization in
+    // the list - the switcher showing the first one while requests carried
+    // another tenant - and `refusesOrganization` could not recover it either.
+    expect(organizationInPath(`/orgs/${ORG.toUpperCase()}/members`)).toBe(ORG);
+  });
+
   it("takes a UUID and nothing else", () => {
     // A later `/orgs/new` would otherwise be adopted as a tenant id and
     // refused on every request the page made.
@@ -351,6 +359,25 @@ describe("useActiveOrganizationRecovery", () => {
     expect(client.getQueryData(["agents", "list", false])).toEqual([
       { id: "a-1", name: "The page's own read" },
     ]);
+  });
+
+  it("leaves a deliberate switch standing on a page that names an organization", async () => {
+    // Keyed on the selection rather than the path, the adoption wrote back
+    // whatever else moved it - so the organization switcher, which sets the id
+    // without navigating, was inoperative on `/orgs/{id}/members`: the store
+    // went to the chosen organization and was snapped back before the menu
+    // closed. `OrgSwitcher` takes the route with it; this is the other half.
+    const OTHER = "33333333-3333-3333-3333-333333333333";
+    answerWith([{ id: PERSONAL, is_personal: true }], { permissions: [] });
+    useOrgStore.setState({ activeOrgId: PERSONAL });
+    path.mockReturnValue(`/orgs/${OTHER}/members`);
+    const { rerender } = renderHook(() => useActiveOrganizationRecovery(), { wrapper });
+    await waitFor(() => expect(useOrgStore.getState().activeOrgId).toBe(OTHER));
+
+    useOrgStore.setState({ activeOrgId: PERSONAL });
+    rerender();
+
+    expect(useOrgStore.getState().activeOrgId).toBe(PERSONAL);
   });
 
   it("leaves a working organization alone", async () => {

--- a/frontend/src/hooks/use-active-organization.ts
+++ b/frontend/src/hooks/use-active-organization.ts
@@ -52,6 +52,13 @@ export function refusesOrganization(failure: unknown, activeOrgId: string | null
  * would otherwise be adopted as a tenant id and refused on every request the
  * page made.
  *
+ * Lower-cased, because the id is *stored*. The server serialises UUIDs in
+ * canonical lower case and `activeOrg` is found by `===`, so an upper-case
+ * spelling in the URL would be held as the selection, match no organization in
+ * the list - the switcher then showing `orgs[0]` while requests carried another
+ * tenant - and be unrecoverable, since `refusesOrganization` compares the same
+ * two strings.
+ *
  * The prefix is tolerated because this reads `next/navigation`'s pathname, which
  * keeps one: `/pl/orgs/{id}/members` names the same organization as
  * `/orgs/{id}/members`. Reading rather than navigating, so the rule against
@@ -65,7 +72,7 @@ export function organizationInPath(pathname: string): string | null {
   const start = localePrefixOf(pathname) === null ? 0 : 1;
   if (segments[start] !== "orgs") return null;
   const id = segments[start + 1];
-  return id !== undefined && UUID.test(id) ? id : null;
+  return id !== undefined && UUID.test(id) ? id.toLowerCase() : null;
 }
 
 /**
@@ -171,7 +178,8 @@ export function useActiveOrganizationRecovery(): void {
   const markOrgRefused = useOrgStore((state) => state.markOrgRefused);
   const { error } = usePermissions();
   const { data: orgs } = useOrganizationList();
-  const named = organizationInPath(usePathname());
+  const pathname = usePathname();
+  const named = organizationInPath(pathname);
   // A refused organization is not adopted from a URL either, or opening its
   // page would hand the selection straight back to the one the recovery below
   // has just moved off - the shape an infinite switch loop takes.
@@ -186,11 +194,20 @@ export function useActiveOrganizationRecovery(): void {
    * the selection is already the URL's by the time the page asks anything, and
    * this component is rendered before `{children}` in the dashboard layout,
    * which is what puts it before the page's own effects rather than beside them.
+   *
+   * **Once per path, not once per change of selection.** Keyed on the selection,
+   * this wrote back whatever else moved it: the organization switcher sets the
+   * id and does not navigate, so on `/orgs/{B}/members` the store went to A and
+   * was snapped to B before the menu had closed - the product's primary switcher,
+   * inoperative on two pages, silently. Adoption is what a *navigation* means;
+   * `OrgSwitcher` handles the other direction by taking the scoped route with it.
    */
+  const adoptedFor = useRef<string | null>(null);
   useLayoutEffect(() => {
-    if (adopted === null || adopted === activeOrgId) return;
-    setActiveOrgId(adopted);
-  }, [adopted, activeOrgId, setActiveOrgId]);
+    if (adopted === null || pathname === adoptedFor.current) return;
+    adoptedFor.current = pathname;
+    if (adopted !== activeOrgId) setActiveOrgId(adopted);
+  }, [adopted, activeOrgId, pathname, setActiveOrgId]);
 
   // Whatever moved the selection - the switcher, the URL above, or the recovery
   // below - the cache follows it. The URL's organization is passed rather than

--- a/frontend/src/hooks/use-active-organization.ts
+++ b/frontend/src/hooks/use-active-organization.ts
@@ -1,10 +1,12 @@
 "use client";
 
 import { useEffect, useLayoutEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 
+import { localePrefixOf } from "@/lib/locale-routing";
 import { usePermissions } from "@/hooks/use-permissions";
 import { preferredOrg, useOrganizationList } from "@/hooks/use-organizations";
 import { ApiError } from "@/lib/api-client";
@@ -32,6 +34,38 @@ export function refusesOrganization(failure: unknown, activeOrgId: string | null
   if (activeOrgId === null) return false;
   if (!(failure instanceof ApiError) || failure.status !== 404) return false;
   return failure.details?.org_id === activeOrgId;
+}
+
+/**
+ * The organization a path names, when it names one.
+ *
+ * `/orgs/{id}/members` and `/orgs/{id}/roles` act on the organization in their
+ * URL, while every request they make carries the *active* one in
+ * `X-Organization-Id` - and nothing kept the two the same: the organizations
+ * list opens either page through an overlay link, where *switching* is a
+ * separate button that navigates to the dashboard. So the ordinary way to reach
+ * another organization's members page was the way that left the active
+ * organization behind, and the page then judged Acme's members by the caller's
+ * role in Globex (#1032).
+ *
+ * A UUID, deliberately, rather than any second segment: a later `/orgs/new`
+ * would otherwise be adopted as a tenant id and refused on every request the
+ * page made.
+ *
+ * The prefix is tolerated because this reads `next/navigation`'s pathname, which
+ * keeps one: `/pl/orgs/{id}/members` names the same organization as
+ * `/orgs/{id}/members`. Reading rather than navigating, so the rule against
+ * reaching for that module holds - it is about switching locale, which loses the
+ * cookie.
+ */
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function organizationInPath(pathname: string): string | null {
+  const segments = pathname.split("/").filter(Boolean);
+  const start = localePrefixOf(pathname) === null ? 0 : 1;
+  if (segments[start] !== "orgs") return null;
+  const id = segments[start + 1];
+  return id !== undefined && UUID.test(id) ? id : null;
 }
 
 /**
@@ -137,10 +171,33 @@ export function useActiveOrganizationRecovery(): void {
   const markOrgRefused = useOrgStore((state) => state.markOrgRefused);
   const { error } = usePermissions();
   const { data: orgs } = useOrganizationList();
+  const named = organizationInPath(usePathname());
+  // A refused organization is not adopted from a URL either, or opening its
+  // page would hand the selection straight back to the one the recovery below
+  // has just moved off - the shape an infinite switch loop takes.
+  const adopted = named !== null && !refusedOrgIds.includes(named) ? named : null;
 
-  // Whatever moved the selection - the switcher, the recovery below, or a
-  // path that does not exist yet - the cache follows it.
-  useTenantCacheReset(activeOrgId);
+  /**
+   * A page that names an organization *is* that organization.
+   *
+   * A **layout effect**, and before the queries: the API client stamps
+   * `X-Organization-Id` when a request is made, and react-query starts one from
+   * a passive effect - which runs after every layout effect in the commit. So
+   * the selection is already the URL's by the time the page asks anything, and
+   * this component is rendered before `{children}` in the dashboard layout,
+   * which is what puts it before the page's own effects rather than beside them.
+   */
+  useLayoutEffect(() => {
+    if (adopted === null || adopted === activeOrgId) return;
+    setActiveOrgId(adopted);
+  }, [adopted, activeOrgId, setActiveOrgId]);
+
+  // Whatever moved the selection - the switcher, the URL above, or the recovery
+  // below - the cache follows it. The URL's organization is passed rather than
+  // the stored one so that a direct load of another organization's page records
+  // *it* as the tenant the cache belongs to: the reset would otherwise fire one
+  // commit later, cancelling the requests the page had already started.
+  useTenantCacheReset(adopted ?? activeOrgId);
 
   useEffect(() => {
     if (activeOrgId === null || orgs === undefined) return;


### PR DESCRIPTION
`/orgs/{id}/members` acts on the organization in its **path** and judged
permissions from the **active** one, and the two are routinely different.

`apiClient` stamps `X-Organization-Id: activeOrgId` on every request, so
`/me/permissions` answers for whatever is active. Meanwhile the organizations
list opens any org's members page through an overlay link, and *switching* is a
separate button that navigates to the dashboard — so the ordinary route to
another organization's members page is the one that leaves the active
organization behind. The page then judged Acme's members by the caller's role in
Globex.

Not only the role picker #1028 added: `canManage` decides whether any role
control, invite button or spending field renders at all, and it read the same
wrong answer long before that.

## Why the URL wins, rather than the permissions request taking an org id

The issue named two candidate shapes. The second one — ask `/me/permissions` for
the organization on screen — **cannot fix this page**, and that is what decided
it: not everything the page reads is path-scoped. The spending section renders
`/spend`, which has no organization in its path at all, so an org's cap would go
on sitting beside another org's month-to-date figure. One tenant per page is the
only answer that covers the page; two notions of "current" is the defect itself.

## Where it lives, and why there

`ActiveOrgGuard` — which the dashboard layout already renders **before**
`{children}`, and which already owns the tenant cache reset. Three things follow
from that placement, and each of them is the reason for it:

- **It is race-free.** A layout effect there runs before the page's own passive
  effects, which is where react-query starts a request and therefore when the
  header is read. So the selection is already the URL's by the time the page asks
  anything.
- **The cache reset is given the *effective* tenant** — the URL's organization,
  not the stored one — so a direct load records it as the tenant the cache
  belongs to, instead of dropping the page's first requests one commit later.
  That is the failure the hook's first-tenant skip exists for, and it would
  otherwise have been reintroduced from the other side.
- **A page does not do it for itself.** One place, as the recovery already is,
  for the reason its own docstring gives: `usePermissions` is rendered by a dozen
  components at once.

A refused organization is not adopted from a URL: opening its page would hand the
selection back to the one the recovery has just moved off, which is how a switch
loop starts.

`organizationInPath` takes a UUID and nothing else, so a later `/orgs/new` is not
adopted as a tenant id and refused on every request the page makes. It tolerates a
locale prefix because it reads `next/navigation`'s pathname, which keeps one —
reading, not navigating, so `.claude/rules/frontend.md`'s rule against that module
still holds.

## What this changes for a person

Opening another organization's members page **switches to that organization** —
the sidebar, the switcher and the dashboard follow. That is the intended
semantics rather than a side effect: "I am looking at Acme" and "Acme is my
organization" being two different things is the root cause here.

## How it was verified

- Four tests on the parser: a members page, a roles page, a locale prefix, `/orgs`,
  an unrelated path, and `/orgs/new`.
- Three on the adoption: the switch, a page that names no organization, and a
  refused one left alone. Plus one that the cache a directly loaded page filled
  survives.
- The one that matters most, on the page itself: with the permissions mock
  answering **per organization**, an Owner of the org in the URL is offered an
  Owner's five roles while an Admin is the active organization.
- All four of the behavioural ones fail with the adoption removed — I checked
  that rather than assuming it.
- `make check` green, `make test-frontend-cov` at 5301 passed and 100%
  lines/statements/functions, `make docs-build`.

## Docs

`docs/permissions.md` gains the rule under "Who may hand out which role", and
`.claude/rules/frontend.md` gains it beside the picker rule from #1028 — both say
where the adoption lives and that a page does not do it itself.

Closes #1032
