### PR TITLE
chore: cut 0.0.231

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,40 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.231] - 2026-08-20
+
+The organization in the URL is the tenant.
+
+### Fixed
+
+- **`/orgs/{id}/members` acted on the organization in its path and judged
+  permissions from the active one.** `X-Organization-Id` travels on every request
+  and names the active organization, while the organizations list opens any org's
+  members page through a link and *switching* is a separate button that navigates
+  to the dashboard - so the ordinary route to another organization's members page
+  was the one that left the active organization behind, and the page then judged
+  Acme's members by the caller's role in Globex. `ActiveOrgGuard` adopts the
+  organization a path names, before the page asks anything. (#1032)
+- Not only the role picker: `canManage` decides whether any role control, invite
+  button or spending field renders at all, and it read the same wrong answer long
+  before the picker did. (#1032)
+- **Switching organization from a page that names one now takes the route with
+  it** - Globex picked on Acme's members page lands on Globex's members page.
+  Adoption happens once per path, so a deliberate switch is not written back; the
+  two together are what keep the primary switcher working on those pages while
+  the URL still decides the tenant. (#1032)
+- An organization id in a URL is adopted lower-cased. The server serialises them
+  canonically and the active organization is found by identity, so an upper-case
+  spelling would be held as the selection, match nothing in the list - the
+  switcher showing the first organization while requests carried another - and be
+  unrecoverable, since the refusal check compares the same two strings. (#1032)
+
+### Changed
+
+- `OrgSwitcher` navigates through `@/lib/locale-navigation` rather than
+  `next/navigation`, so its pushes keep the locale prefix instead of sending a
+  Polish reader to the English `/orgs`. (#1032)
+
 ## [0.0.230] - 2026-08-20
 
 A role picker offers what the caller may actually assign.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.230"
+version = "0.0.231"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.230"
+version = "0.0.231"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.230",
+  "version": "0.0.231",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.231. Bumps `backend/pyproject.toml`,
`backend/uv.lock` and `frontend/package.json` to 0.0.231 and adds the
CHANGELOG entry.

One issue, #1032, found reviewing #1031: a page acting on the
organization in its path while judging permissions from the active one.
The alternative shape - `/me/permissions` taking an organization id -
cannot fix that page, and checking that is what decided it: the spending
section reads `/spend`, which has no organization in its path at all, so
one org's cap would go on sitting beside another's month-to-date figure.
One tenant per page is the only answer that covers the page.

The automated review found two things on the branch and both were real.
One was a defect the branch introduced: keyed on the selection, the
adoption wrote back whatever else moved it, so the organization switcher
- which sets the id without navigating - was inoperative on
`/orgs/{id}/members` and `/orgs/{id}/roles`. Adoption is once per path
now, and a switch on a scoped route takes the route with it; each half is
wrong alone. The other was casing: an id from a URL is stored, so it is
adopted lower-cased or it matches no organization in the list while every
request carries it.

## Verified

Eight tests on the parser and the adoption, three on the switcher (which
had none), and the one that matters most on the page itself: with the
permissions mock answering per organization, an Owner of the org in the
URL is offered an Owner's five roles while an Admin is active. All four
behavioural ones fail with the adoption removed, which I checked rather
than assumed. `make check`, `make test-frontend-cov` at 5306 passed and
100% lines/statements/functions, and CI green end to end on #1036.

Closes #1032