### PR TITLE
fix(chat): persist and replay an answered ask_user question

### DIFF
--- a/backend/app/schemas/conversation.py
+++ b/backend/app/schemas/conversation.py
@@ -33,6 +33,12 @@ class MessagePart(BaseSchema):
     `tool_call_id` refers to the `tool_calls` row carrying the arguments and the
     result. It is not repeated here - a tool call is written once, and a copy in
     JSONB is a copy that disagrees the first time one is re-run or redacted.
+
+    An `ask_user` entry is the exception that stores its own payload: a mid-turn
+    question and the person's answer have no column of their own - unlike text
+    (`content`), reasoning (`thinking`) or a tool call (its `tool_calls` row) - so
+    without this entry a reopened conversation shows neither the question the agent
+    put nor the answer it acted on (#502).
     """
 
     # The one schema in this module that must not strip its strings. `BaseSchema`
@@ -47,12 +53,18 @@ class MessagePart(BaseSchema):
         str_strip_whitespace=False,
     )
 
-    type: Literal["text", "thinking", "tool"] = Field(description="What this entry is.")
+    type: Literal["text", "thinking", "tool", "ask_user"] = Field(description="What this entry is.")
     text: str | None = Field(
         default=None, description="The words, for a `text` or `thinking` entry."
     )
     tool_call_id: str | None = Field(
         default=None, description="Which tool call this entry is, for a `tool` entry."
+    )
+    question: str | None = Field(
+        default=None, description="What the agent asked, for an `ask_user` entry."
+    )
+    answer: str | None = Field(
+        default=None, description="What the person answered, for an `ask_user` entry."
     )
 
 

--- a/backend/app/services/agent_session.py
+++ b/backend/app/services/agent_session.py
@@ -97,6 +97,10 @@ class AgentSession:
         self.current_conversation_id: str | None = None
         self._turn_task: asyncio.Task[None] | None = None
         self._ask_user_future: asyncio.Future[list[dict[str, Any]]] | None = None
+        # The running turn's timeline, so `_ask_one` can record a mid-turn
+        # question and its answer as a part of the turn it happened in (#502).
+        # None between turns; set and cleared by `process_message`.
+        self._current_timeline: TurnTimeline | None = None
         # One question round on the wire at a time. The client renders a single
         # `ask_user` form and its `ask_user_response` carries no correlation, and
         # `_ask_user_future` is one slot - so two delegates asking at once (a
@@ -232,6 +236,7 @@ class AgentSession:
         # which path a turn is on, and the alternative is throwing away a
         # half-written answer on exactly the runs somebody opens afterwards.
         timeline = TurnTimeline()
+        self._current_timeline = timeline
         # The run row, as soon as `prepare` opens one. A list because the
         # callback is `list.append` and a turn opens at most one run - it is
         # empty when the run was refused before it existed.
@@ -378,6 +383,7 @@ class AgentSession:
             logger.exception("Error processing agent request")
             await send_event(self.websocket, "error", {"message": _turn_failed(exc)})
         finally:
+            self._current_timeline = None
             if not answered:
                 await self._persist_partial_turn(
                     opened,
@@ -444,7 +450,12 @@ class AgentSession:
         """
         item = QuestionItem(question=question, options=options)
         answers = await self._ask_user([item.model_dump()])
-        return render_answer(answers[0] if answers else None)
+        answer = render_answer(answers[0] if answers else None)
+        # Recorded on the turn it happened in, so a reopened conversation shows the
+        # question and the answer the agent acted on rather than neither (#502).
+        if self._current_timeline is not None:
+            self._current_timeline.add_ask_user(question, answer)
+        return answer
 
     async def _ask_user(self, questions: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Pause the run: ask the client questions and block until they answer.

--- a/backend/app/services/agent_session.py
+++ b/backend/app/services/agent_session.py
@@ -101,6 +101,10 @@ class AgentSession:
         # question and its answer as a part of the turn it happened in (#502).
         # None between turns; set and cleared by `process_message`.
         self._current_timeline: TurnTimeline | None = None
+        # The question awaiting an answer, so the frame handler can record the
+        # answered pair the moment it arrives - before a `stop` frame behind it
+        # can cancel the turn and lose it (#502). One at a time, under `_ask_lock`.
+        self._pending_question: str | None = None
         # One question round on the wire at a time. The client renders a single
         # `ask_user` form and its `ask_user_response` carries no correlation, and
         # `_ask_user_future` is one slot - so two delegates asking at once (a
@@ -126,8 +130,18 @@ class AgentSession:
         if msg_type == "ask_user_response":
             fut = self._ask_user_future
             if fut is not None and not fut.done():
-                answers = data.get("answers")
-                fut.set_result(answers if isinstance(answers, list) else [])
+                raw = data.get("answers")
+                answers = raw if isinstance(raw, list) else []
+                fut.set_result(answers)
+                # Recorded here, in the receive loop, rather than after the run
+                # resumes past its await: a `stop` sent right behind the answer is
+                # the next frame, so completing the pair now is what keeps a turn
+                # cancelled a microtask later from losing the answered question
+                # (#502).
+                if self._pending_question is not None and self._current_timeline is not None:
+                    self._current_timeline.add_ask_user(
+                        self._pending_question, render_answer(answers[0] if answers else None)
+                    )
             return
 
         if msg_type is not None:
@@ -455,13 +469,16 @@ class AgentSession:
         and several, and the delegate reads back the rendered answer.
         """
         item = QuestionItem(question=question, options=options)
-        answers = await self._ask_user([item.model_dump()])
-        answer = render_answer(answers[0] if answers else None)
-        # Recorded on the turn it happened in, so a reopened conversation shows the
-        # question and the answer the agent acted on rather than neither (#502).
-        if self._current_timeline is not None:
-            self._current_timeline.add_ask_user(question, answer)
-        return answer
+        # The frame handler records the answered pair onto the turn's timeline the
+        # moment the answer arrives (#502), so this only marks which question is
+        # open and clears it however the wait ends - answered, unanswered, or the
+        # turn cancelled out from under it.
+        self._pending_question = question
+        try:
+            answers = await self._ask_user([item.model_dump()])
+        finally:
+            self._pending_question = None
+        return render_answer(answers[0] if answers else None)
 
     async def _ask_user(self, questions: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Pause the run: ask the client questions and block until they answer.

--- a/backend/app/services/agent_session.py
+++ b/backend/app/services/agent_session.py
@@ -421,8 +421,14 @@ class AgentSession:
         run existed - an unpublished agent, a membership revoked mid-session - has
         an empty `opened` and no output, and a blank assistant message would read
         as the agent having answered with silence.
+
+        A stored timeline counts as produced content: a turn that only asked a
+        question and was then stopped before answering has no `output` and no
+        tool call, but its `ask_user` part is the whole of what happened and has
+        no column to fall back to - so leaving it out of this guard loses it on
+        reload (#502).
         """
-        if not opened or not (output or tool_calls):
+        if not opened or not (output or tool_calls or parts):
             return
         run = opened[0]
         if self.current_conversation_id is None:

--- a/backend/app/services/chat_timeline.py
+++ b/backend/app/services/chat_timeline.py
@@ -61,6 +61,16 @@ class TurnTimeline:
         """
         self.parts.append(MessagePart(type="tool", tool_call_id=tool_call_id))
 
+    def add_ask_user(self, question: str, answer: str) -> None:
+        """Record a question put to the person and the answer it acted on.
+
+        Its own entry, never coalesced, because it carries a payload with no other
+        home: text lands in `content`, reasoning in `thinking`, a tool call in its
+        `tool_calls` row, but a mid-turn question and its answer would vanish on
+        reload without this (#502).
+        """
+        self.parts.append(MessagePart(type="ask_user", question=question, answer=answer))
+
     def _append(self, kind: str, delta: str) -> None:
         open_part = self.parts[-1] if self.parts else None
         if open_part is not None and open_part.type == kind:
@@ -95,5 +105,13 @@ class TurnTimeline:
         everything it contained - and writing one would put a JSONB array on every
         plain question-and-answer in the deployment to record that the answer came
         after the question.
+
+        The exception is a lone `ask_user` part: it is the one kind with no column
+        to fall back to, so dropping it as "a turn of one part" would lose the
+        question and the answer outright (#502).
         """
-        return self.parts if len(self.parts) > 1 else None
+        if len(self.parts) > 1:
+            return self.parts
+        if self.parts and self.parts[0].type == "ask_user":
+            return self.parts
+        return None

--- a/backend/tests/test_agent_session.py
+++ b/backend/tests/test_agent_session.py
@@ -1094,6 +1094,41 @@ class TestAskingTheUser:
 
         assert await asking == "eu"
 
+    async def test_an_answered_question_is_recorded_on_the_turns_timeline(self):
+        """The whole point of #502: the question and the answer land on the running
+        turn's timeline, so they are persisted and a reopened conversation shows
+        them rather than neither."""
+        session = _session()
+        session._current_timeline = TurnTimeline()
+        asked = _next_frame(session)
+
+        asking = asyncio.create_task(session._ask_one("Which region?", ["eu", "us"]))
+        await _wait(asked)
+        await session.handle_frame(
+            {"type": "ask_user_response", "answers": [{"answer": "eu", "skipped": False}]}
+        )
+        assert await asking == "eu"
+
+        stored = session._current_timeline.stored()
+        assert stored is not None
+        assert [(part.type, part.question, part.answer) for part in stored] == [
+            ("ask_user", "Which region?", "eu")
+        ]
+
+    async def test_a_question_asked_between_turns_records_nothing(self):
+        """`_ask_one` is safe to reach with no turn running - the timeline is None
+        between turns - so a stray question is answered without a place to record it
+        rather than raising."""
+        session = _session()
+        asked = _next_frame(session)
+
+        asking = asyncio.create_task(session._ask_one("Which region?", ["eu"]))
+        await _wait(asked)
+        await session.handle_frame({"type": "ask_user_response", "answers": [{"answer": "eu"}]})
+
+        assert await asking == "eu"
+        assert session._current_timeline is None
+
     async def test_a_delegates_question_left_unanswered_reads_as_no_answer(self):
         """An empty answers payload releases the delegate with "(no answer)" rather
         than hanging it: the delegate goes on with what it already had."""

--- a/backend/tests/test_agent_session.py
+++ b/backend/tests/test_agent_session.py
@@ -98,6 +98,7 @@ from app.agents.subagent_runtime import (
 from app.core.exceptions import AuthorizationError, BadRequestError
 from app.db.models.agent_run import RunStatus
 from app.repositories import conversation as conversation_repo
+from app.schemas.conversation import MessagePart
 from app.services.agent import PersistedPrompt
 from app.services.agent_chat import ChatTurn, OpenedRun
 from app.services.agent_runner import ParkedApproval, PreparedRun
@@ -1492,6 +1493,30 @@ class TestATurnThatDidNotFinishStillKeepsWhatItSaid:
             await session.process_message(_message())
 
         chat.answer.assert_not_awaited()
+
+    async def test_a_partial_turn_that_only_asked_a_question_still_records_it(self):
+        """A turn that put a question, got an answer, then stopped before any text
+        or tool call has only its `ask_user` part - which has no column to fall
+        back to, so the partial-turn guard must treat a stored timeline as
+        produced content or the question and answer are lost on reload (#502)."""
+        session = _session()
+        session.current_conversation_id = str(uuid4())
+        part = MessagePart(type="ask_user", question="Which region?", answer="eu")
+
+        with patch(
+            "app.services.agent_session.persist_assistant_turn", new=AsyncMock()
+        ) as persisted:
+            await session._persist_partial_turn(
+                [self._opened()],
+                agent_id=uuid4(),
+                output="",
+                tool_calls=[],
+                thinking=None,
+                parts=[part],
+            )
+
+        persisted.assert_awaited_once()
+        assert persisted.await_args.kwargs["parts"] == [part]
 
     async def test_a_turn_that_finished_is_written_once_and_not_twice(self):
         """The `finally` cannot read `turn` to decide - that is the whole reason it

--- a/backend/tests/test_agent_session.py
+++ b/backend/tests/test_agent_session.py
@@ -1116,6 +1116,27 @@ class TestAskingTheUser:
             ("ask_user", "Which region?", "eu")
         ]
 
+    async def test_the_answer_is_recorded_when_the_frame_arrives_not_when_the_run_resumes(self):
+        """A `stop` sent right behind the answer cancels the turn before `_ask_one`
+        resumes past its await; recording in the frame handler is what keeps the
+        answered question from being lost in that race (#502). Here the run is never
+        resumed and the pair is on the timeline anyway."""
+        session = _session()
+        session._current_timeline = TurnTimeline()
+        asked = _next_frame(session)
+
+        asking = asyncio.create_task(session._ask_one("Which region?", ["eu"]))
+        await _wait(asked)
+        await session.handle_frame({"type": "ask_user_response", "answers": [{"answer": "eu"}]})
+
+        stored = session._current_timeline.stored()
+        assert stored is not None
+        assert [(part.type, part.answer) for part in stored] == [("ask_user", "eu")]
+
+        asking.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await asking
+
     async def test_a_question_asked_between_turns_records_nothing(self):
         """`_ask_one` is safe to reach with no turn running - the timeline is None
         between turns - so a stray question is answered without a place to record it

--- a/backend/tests/test_chat_timeline.py
+++ b/backend/tests/test_chat_timeline.py
@@ -93,6 +93,26 @@ class TestAccumulatingOneTurn:
 
         assert timeline.thinking == "Checking the policy. That settles it."
 
+    def test_an_answered_question_becomes_a_part_where_it_was_asked(self):
+        """The question and the answer land between the words either side of them,
+        so a reopened conversation shows the turn in the order it happened."""
+        timeline = TurnTimeline()
+
+        timeline.add_text("I need to know first. ")
+        timeline.add_ask_user("Which region?", "eu-west-1")
+        timeline.add_text("Deploying to eu-west-1.")
+
+        assert [
+            (part.type, part.question, part.answer)
+            if part.type == "ask_user"
+            else (part.type, part.text)
+            for part in timeline.parts
+        ] == [
+            ("text", "I need to know first. "),
+            ("ask_user", "Which region?", "eu-west-1"),
+            ("text", "Deploying to eu-west-1."),
+        ]
+
 
 class TestWhatIsWorthStoring:
     def test_a_turn_with_an_order_stores_it(self):
@@ -118,3 +138,17 @@ class TestWhatIsWorthStoring:
 
     def test_a_turn_that_produced_nothing_stores_nothing(self):
         assert TurnTimeline().stored() is None
+
+    def test_a_lone_answered_question_is_stored_even_as_one_part(self):
+        """Unlike a lone tool call (its `tool_calls` row) or a lone block of text
+        (`content`), an `ask_user` part has no column to fall back to - so dropping
+        it as "a turn of one part" would lose the question and the answer (#502)."""
+        timeline = TurnTimeline()
+
+        timeline.add_ask_user("Which region?", "eu-west-1")
+
+        stored = timeline.stored()
+        assert stored is not None
+        assert [(part.type, part.question, part.answer) for part in stored] == [
+            ("ask_user", "Which region?", "eu-west-1")
+        ]

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -3654,6 +3654,8 @@
       "turnAgent": "Agent",
       "turnSystem": "System",
       "reasoning": "Reasoning",
+      "askedUser": "Asked the user",
+      "answered": "They answered",
       "ratedDownCount": "{count, plural, =1 {Rated down once} other {Rated down # times}}",
       "previousRun": "Previous run",
       "nextRun": "Next run",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -738,6 +738,8 @@
     "approve": "Approve",
     "archive": "Archive",
     "archivedToast": "Conversation archived",
+    "askUserAnswered": "You answered",
+    "askUserAsked": "Asked you",
     "attachedFile": "Attached file",
     "backAgentAposS": "Back to the agent's own model",
     "cancel": "Cancel",

--- a/frontend/src/components/chat/message-item.test.tsx
+++ b/frontend/src/components/chat/message-item.test.tsx
@@ -259,6 +259,21 @@ describe("the ordered timeline", () => {
     expect(rendered).toEqual(["thinking", "tool-tc-1", "markdown"]);
   });
 
+  it("replays a mid-turn question and its answer as a step in the turn (#502)", () => {
+    const { getByText } = item({
+      parts: [
+        { id: "p-1", type: "text", content: "I need to know first." },
+        { id: "p-2", type: "ask_user", question: "Which region?", answer: "eu-west-1" },
+        { id: "p-3", type: "text", content: "Deploying." },
+      ],
+    });
+
+    expect(getByText("Asked you")).toBeInTheDocument();
+    expect(getByText("Which region?")).toBeInTheDocument();
+    expect(getByText("You answered")).toBeInTheDocument();
+    expect(getByText("eu-west-1")).toBeInTheDocument();
+  });
+
   it("opens the reasoning while it is the part being written, and closes it after", () => {
     // A thinking block left open on every past turn buries the answers.
     const parts: ChatMessage["parts"] = [{ id: "p-1", type: "thinking", content: "Checking." }];
@@ -689,6 +704,17 @@ describe("the runs a turn is made of", () => {
     expect(runsOf([{ id: "t1", type: "text", content: "" }])).toEqual([]);
     expect(runsOf([{ id: "t2", type: "thinking" }])).toEqual([]);
     expect(runsOf([])).toEqual([]);
+  });
+
+  it("keeps an ask_user part as its own run, empty content notwithstanding (#502)", () => {
+    const runs = runsOf([
+      { id: "q1", type: "ask_user", question: "Which region?", answer: "eu-west-1" },
+    ]);
+
+    expect(runs).toHaveLength(1);
+    const [run] = runs;
+    expect(run?.kind === "other" && run.part.type).toBe("ask_user");
+    expect(run?.isLast).toBe(true);
   });
 });
 

--- a/frontend/src/components/chat/message-item.test.tsx
+++ b/frontend/src/components/chat/message-item.test.tsx
@@ -129,6 +129,20 @@ describe("a turn in the transcript", () => {
     expect(screen.queryByText("stopped")).toBeNull();
   });
 
+  it("marks a stopped ask-only turn, whose only body is the answered question", () => {
+    // Stopped after answering a question and before any text: content is empty
+    // and the timeline is just the ask_user part, so the footer must key on the
+    // parts, not on content, or the stopped indicator vanishes (#502).
+    item({
+      role: "assistant",
+      content: "",
+      wasStopped: true,
+      parts: [{ id: "q-1", type: "ask_user", question: "Which region?", answer: "eu-west-1" }],
+    });
+
+    expect(screen.getByText("stopped")).toBeVisible();
+  });
+
   it("never marks the question, only the answer", () => {
     // A user's turn is not produced by a run; a marker there would attribute the
     // agent's failure to what somebody typed.

--- a/frontend/src/components/chat/message-item.tsx
+++ b/frontend/src/components/chat/message-item.tsx
@@ -122,6 +122,11 @@ export function MessageItem({
   // The turn's cost, which a grouped turn recorded on the segment that parked
   // rather than on the one the footer is drawn under.
   const footerUsage = turnUsage ?? message.usage;
+  // A turn produced something worth a footer if it wrote content *or* left a
+  // timeline part - the latter is the ask-only turn that was stopped after
+  // answering a question and before any text (#502), which otherwise loses its
+  // stopped indicator, timestamp and cost.
+  const hasBody = Boolean(message.content) || (!isUser && (message.parts?.length ?? 0) > 0);
   const sources = !isUser ? extractSources(message, t) : [];
   const hasSources = sources.length > 0 && !message.isStreaming;
   const onCiteClick = hasSources ? (index: number) => openSources(sources, index) : undefined;
@@ -269,7 +274,7 @@ export function MessageItem({
           </div>
         )}
 
-        {!message.isStreaming && message.content && endsTurn && (
+        {!message.isStreaming && hasBody && endsTurn && (
           <div className={cn("flex items-center gap-2", isUser && "flex-row-reverse")}>
             {message.timestamp && (
               <span className="text-muted-foreground text-[10px]">
@@ -291,13 +296,15 @@ export function MessageItem({
               </span>
             )}
             {!isUser && footerUsage && <MessageCost usage={footerUsage} />}
-            <CopyButton
-              text={message.content}
-              className={cn(
-                "h-6 w-6 rounded-md sm:opacity-0 sm:group-hover:opacity-100",
-                isUser ? "bg-secondary hover:bg-secondary/80" : "bg-muted hover:bg-muted/80",
-              )}
-            />
+            {message.content && (
+              <CopyButton
+                text={message.content}
+                className={cn(
+                  "h-6 w-6 rounded-md sm:opacity-0 sm:group-hover:opacity-100",
+                  isUser ? "bg-secondary hover:bg-secondary/80" : "bg-muted hover:bg-muted/80",
+                )}
+              />
+            )}
             {!isUser && onRegenerate && (
               <button
                 type="button"

--- a/frontend/src/components/chat/turn-parts.tsx
+++ b/frontend/src/components/chat/turn-parts.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Sparkles } from "lucide-react";
+import { MessageCircleQuestion, Sparkles } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { toolEntry } from "@/lib/tool-catalog";
@@ -81,6 +81,12 @@ export function TurnParts({
             open={isStreaming && run.isLast}
             isStreaming={isStreaming}
           />
+        ) : run.part.type === "ask_user" ? (
+          <AskUserBlock
+            key={run.part.id}
+            question={run.part.question ?? ""}
+            answer={run.part.answer ?? ""}
+          />
         ) : (
           <TextBubble
             key={run.part.id}
@@ -127,6 +133,30 @@ export function ThinkingBlock({
         <MarkdownContent content={text} />
       </div>
     </details>
+  );
+}
+
+/**
+ * A question the agent put to the person mid-turn, and the answer it acted on.
+ *
+ * Replayed only: live, the question is the composer's `ask_user` form and the
+ * answer goes back through it. Once the turn is stored, the pause has no home in
+ * `content`, `thinking` or the tool calls - so a reopened conversation would show
+ * neither the question nor the answer the rest of the turn depended on (#502). An
+ * aside rather than a bubble, so it reads as a step in the turn, not a message.
+ */
+export function AskUserBlock({ question, answer }: { question: string; answer: string }) {
+  const t = useTranslations("chat");
+  return (
+    <div className="border-foreground/10 text-muted-foreground space-y-1.5 border-l pl-3.5 text-[13px]">
+      <div className="flex items-center gap-2">
+        <MessageCircleQuestion className="h-3.5 w-3.5 shrink-0 opacity-60" aria-hidden />
+        <span className="font-medium">{t("askUserAsked")}</span>
+      </div>
+      <p className="text-foreground/80 break-words whitespace-pre-wrap">{question}</p>
+      <div className="font-medium">{t("askUserAnswered")}</div>
+      <p className="text-foreground/80 break-words whitespace-pre-wrap">{answer}</p>
+    </div>
   );
 }
 
@@ -207,6 +237,10 @@ export function runsOf(parts: MessagePart[]): PartRun[] {
       const open = runs.at(-1);
       if (open?.kind === "tools") open.parts.push(part);
       else runs.push({ kind: "tools", parts: [part], isLast: false });
+      continue;
+    }
+    if (part.type === "ask_user") {
+      runs.push({ kind: "other", part, content: "", isLast: false });
       continue;
     }
     if (

--- a/frontend/src/components/runs/run-timeline.tsx
+++ b/frontend/src/components/runs/run-timeline.tsx
@@ -283,6 +283,16 @@ function TimelineTurn({
                 <summary className="cursor-pointer select-none">{t("reasoning")}</summary>
                 <div className="mt-1 whitespace-pre-wrap">{part.content}</div>
               </details>
+            ) : part.type === "ask_user" ? (
+              <div
+                key={part.id}
+                className="border-foreground/10 text-muted-foreground space-y-1 border-l pl-3 text-sm"
+              >
+                <div className="font-medium">{t("askedUser")}</div>
+                <div className="text-foreground/80 whitespace-pre-wrap">{part.question}</div>
+                <div className="font-medium">{t("answered")}</div>
+                <div className="text-foreground/80 whitespace-pre-wrap">{part.answer}</div>
+              </div>
             ) : (
               <div key={part.id} className="text-sm whitespace-pre-wrap">
                 {part.content}

--- a/frontend/src/lib/conversation-to-chat.test.ts
+++ b/frontend/src/lib/conversation-to-chat.test.ts
@@ -160,6 +160,31 @@ describe("conversationMessageToChatMessage", () => {
   });
 });
 
+describe("a replayed turn that stopped to ask the person a question", () => {
+  it("replays the question and the answer in the place they happened (#502)", () => {
+    const message = conversationMessageToChatMessage(
+      raw({
+        content: "Deploying to eu-west-1.",
+        parts: [
+          { type: "text", text: "I need to know first. " },
+          { type: "ask_user", question: "Which region?", answer: "eu-west-1" },
+          { type: "text", text: "Deploying to eu-west-1." },
+        ],
+      }),
+    );
+
+    expect(
+      message.parts?.map((p) =>
+        p.type === "ask_user" ? [p.type, p.question, p.answer] : [p.type, p.content],
+      ),
+    ).toEqual([
+      ["text", "I need to know first. "],
+      ["ask_user", "Which region?", "eu-west-1"],
+      ["text", "Deploying to eu-west-1."],
+    ]);
+  });
+});
+
 describe("conversationMessagesToChatMessages", () => {
   it("converts a whole history in order", () => {
     const messages = conversationMessagesToChatMessages([

--- a/frontend/src/lib/conversation-to-chat.ts
+++ b/frontend/src/lib/conversation-to-chat.ts
@@ -15,9 +15,11 @@ export interface RawToolCall {
 
 /** One entry of a stored timeline - see `MessagePart` in the backend schemas. */
 export interface RawMessagePart {
-  type: "text" | "thinking" | "tool";
+  type: "text" | "thinking" | "tool" | "ask_user";
   text?: string | null;
   tool_call_id?: string | null;
+  question?: string | null;
+  answer?: string | null;
 }
 
 export interface RawMessage {
@@ -76,6 +78,15 @@ export function replayStoredParts(
     if (entry.type === "tool") {
       const toolCall = entry.tool_call_id ? byId.get(entry.tool_call_id) : undefined;
       if (toolCall) parts.push({ id: toolCall.id, type: "tool" as const, toolCall });
+      return;
+    }
+    if (entry.type === "ask_user") {
+      parts.push({
+        id: `${msgId}-ask_user-${index}`,
+        type: "ask_user" as const,
+        question: entry.question ?? "",
+        answer: entry.answer ?? "",
+      });
       return;
     }
     if (!entry.text) return;

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -104,8 +104,8 @@ export interface ToolCall {
    */
 }
 
-/** The three kinds of segment a turn is built from, live and replayed alike. */
-export type MessagePartType = "thinking" | "text" | "tool";
+/** The kinds of segment a turn is built from, live and replayed alike. */
+export type MessagePartType = "thinking" | "text" | "tool" | "ask_user";
 
 /** One ordered segment of an assistant turn. */
 export interface MessagePart {
@@ -115,6 +115,10 @@ export interface MessagePart {
   content?: string;
   /** Tool invocation for "tool" parts. */
   toolCall?: ToolCall;
+  /** What the agent asked, for an "ask_user" part. */
+  question?: string;
+  /** What the person answered, for an "ask_user" part. */
+  answer?: string;
 }
 
 export type ChartType = "line" | "bar" | "pie" | "area" | "scatter";

--- a/frontend/src/types/runs.ts
+++ b/frontend/src/types/runs.ts
@@ -125,7 +125,13 @@ export interface RunTranscriptMessage {
    * `content`, `thinking` and `tool_calls` instead.
    */
   parts?:
-    | { type: "text" | "thinking" | "tool"; text?: string | null; tool_call_id?: string | null }[]
+    | {
+        type: "text" | "thinking" | "tool" | "ask_user";
+        text?: string | null;
+        tool_call_id?: string | null;
+        question?: string | null;
+        answer?: string | null;
+      }[]
     | null;
   tool_calls?:
     | {


### PR DESCRIPTION
Closes part of #502.

## What changed

A mid-turn `ask_user` question and the person's answer were written down
nowhere, so a reopened conversation showed neither the question the agent
put nor the answer it acted on. `ask_user` is a callback, not a tool, so
it never touched the turn timeline the transcript is replayed from.

- **Backend** — `MessagePart` gains an `ask_user` kind carrying the
  question and answer; `TurnTimeline.add_ask_user` records it; the session
  hands the running turn's timeline to `_ask_one`, which appends the pair
  once the answer is in hand, in the position it happened. A lone
  `ask_user` part is stored even as a turn's only part — unlike a tool
  call or a block of text it has no column to fall back to. No migration:
  the timeline is already a JSONB column and only the part union widens.
- **Frontend** — the raw/typed part shapes, the replay in
  `conversation-to-chat`, a `runsOf` run, and an `AskUserBlock` that draws
  the question and answer as a step in the turn rather than a chat bubble.

## Scope

Replay only: live, the question is the composer's own `ask_user` form and
the answer returns through it, so this is what a conversation reopened
from history was missing.

**Delegate attribution — the issue's "say which delegate asked" — is not
in this PR, on purpose.** `subagents-pydantic-ai` reaches the parent
through `ctx.deps.ask_user(question, [])` with no asker name, and
`SubAgentState` carries none, so naming the delegate needs an upstream
change to that package first. Filed as a follow-up; #502 stays open for it.

## Verified

- `TurnTimeline` records the pair and stores it even alone; `_ask_one`
  writes it onto the turn and is safe to reach between turns.
- The stored pair round-trips through `conversationMessageToChatMessage`,
  `runsOf` keeps a lone `ask_user` part as its own run, and the transcript
  renders the question and answer.
- Both 100%-gated backend modules stay at 100%; `make lint`,
  `make test-frontend-cov` green. Backend `test` coverage is at 100% for
  the touched modules; the only misses are integration-covered modules
  this branch does not touch, skipped locally for want of a DB (CI has
  one).