### PR TITLE
fix(audit): make an impersonated action name who was really acting

### DIFF
--- a/backend/alembic/versions/0044_audit_impersonator.py
+++ b/backend/alembic/versions/0044_audit_impersonator.py
@@ -1,0 +1,51 @@
+"""An audit entry records who was acting behind the actor.
+
+An impersonated request is attributed to the account it acts *as* - its token's
+`sub` is the target - so every row it writes and every action it records named
+the target and nobody else. An administrator who read a customer's conversation
+and one who deleted their agent left the same trace: the customer's own.
+
+So the actor behind the actor is stored. `impersonator_user_id` is the
+administrator an `act` claim on the token names, written by `record_audit` from
+the request's audit context (#943). Null on an ordinary request, where nobody is
+acting as anybody else, and nothing is backfilled - there is no way to know after
+the fact whether a past action was impersonated, and guessing one would be a
+false accusation rather than a missing one.
+
+Revision ID: 0044_audit_impersonator
+Revises: 0043_rag_document_source_path
+Create Date: 2026-08-20
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0044_audit_impersonator"
+down_revision: str | None = "0043_rag_document_source_path"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "app_admin_audit_logs",
+        sa.Column("impersonator_user_id", sa.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_index(
+        "app_admin_audit_logs_impersonator_user_id_idx",
+        "app_admin_audit_logs",
+        ["impersonator_user_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "app_admin_audit_logs_impersonator_user_id_idx",
+        table_name="app_admin_audit_logs",
+    )
+    op.drop_column("app_admin_audit_logs", "impersonator_user_id")

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -14,7 +14,7 @@ is why every write in this API used to be acknowledged before it was durable
 # ruff: noqa: I001 - Imports structured for Jinja2 template conditionals
 
 from collections.abc import AsyncGenerator, Awaitable, Callable
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import Depends
 from fastapi import Header
@@ -266,10 +266,28 @@ from app.core.exceptions import (
     RateLimitError,
 )
 from app.services import rate_limit
+from app.core.audit import set_impersonator
 from app.core.security import verify_token
 from app.db.models.user import User
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl=f"{settings.API_V1_STR}/auth/login")
+
+
+def _impersonator_from(payload: dict[str, Any]) -> UUID | None:
+    """The administrator behind an impersonated token, or None for an ordinary one.
+
+    An `act` claim that is not a valid uuid is dropped rather than trusted: a
+    malformed actor is no actor, and the request is still attributable to its
+    subject. Set on the audit context so every action the request records names
+    who was really acting (#943).
+    """
+    act = payload.get("act")
+    if not act:
+        return None
+    try:
+        return UUID(str(act))
+    except ValueError:
+        return None
 
 
 async def get_current_user(
@@ -294,6 +312,8 @@ async def get_current_user(
     user_id = payload.get("sub")
     if user_id is None:
         raise AuthenticationError(message="Invalid token payload")
+
+    set_impersonator(_impersonator_from(payload))
 
     user = await user_service.get_by_id(UUID(user_id))
     if not user.is_active:
@@ -754,6 +774,8 @@ async def get_current_user_ws(
     user_id = payload.get("sub")
     if user_id is None:
         raise WebSocketException(code=4001, reason="Invalid token payload")
+
+    set_impersonator(_impersonator_from(payload))
 
     async with get_db_context() as db:
         user_service = UserService(db)

--- a/backend/app/api/routes/v1/admin_users.py
+++ b/backend/app/api/routes/v1/admin_users.py
@@ -96,11 +96,17 @@ async def impersonate_user(
     db: DBSession,
     service: UserSvc,
 ) -> Any:
-    """Issue a short-lived (1h) access token to act as the target user."""
+    """Issue a short-lived (1h) access token to act as the target user.
+
+    The token carries the administrator as an `act` claim, so every action taken
+    with it is attributable to who was really acting and not only to the account
+    they were acting as (#943).
+    """
     target = await service.get_by_id(user_id)
     token = create_access_token(
         subject=str(target.id),
         expires_delta=timedelta(hours=1),
+        act=str(admin.id),
     )
     await record_audit(
         db,

--- a/backend/app/api/routes/v1/admin_users.py
+++ b/backend/app/api/routes/v1/admin_users.py
@@ -5,7 +5,7 @@ from uuid import UUID
 from fastapi import APIRouter, Query, Request, status
 
 from app.api.deps import CurrentAppAdmin, DBSession, UserSvc
-from app.core.audit import record_audit
+from app.core.audit import current_impersonator, record_audit
 from app.core.security import create_access_token
 from app.schemas.user import AdminUserList, ImpersonateResponse, UserRead, UserUpdate
 
@@ -100,13 +100,16 @@ async def impersonate_user(
 
     The token carries the administrator as an `act` claim, so every action taken
     with it is attributable to who was really acting and not only to the account
-    they were acting as (#943).
+    they were acting as (#943). If this request is itself impersonated - one app
+    admin acting as another, who impersonates a third - the claim keeps naming
+    the human who started the chain rather than the account one hop up it.
     """
     target = await service.get_by_id(user_id)
+    actor = current_impersonator() or admin.id
     token = create_access_token(
         subject=str(target.id),
         expires_delta=timedelta(hours=1),
-        act=str(admin.id),
+        act=str(actor),
     )
     await record_audit(
         db,

--- a/backend/app/core/audit.py
+++ b/backend/app/core/audit.py
@@ -1,12 +1,29 @@
 """Audit log helpers for recording privileged actions."""
 
 import logging
+from contextvars import ContextVar
 from typing import Any
 from uuid import UUID
 
 from app.db.models.audit_log import AppAdminAuditLog
 
 logger = logging.getLogger(__name__)
+
+_impersonator_id: ContextVar[UUID | None] = ContextVar("audit_impersonator_id", default=None)
+"""The administrator acting behind the current request's subject, or None.
+
+Set by the auth dependency when the access token carries an `act` claim, read by
+:func:`record_audit`. A context variable rather than an argument threaded through
+every call site because the actor behind an impersonated request is a property of
+the request, not of the mutation - and every service that records an action would
+otherwise have to learn to carry it. Each request runs in its own task, so the
+value is isolated to that request and its background children (#943).
+"""
+
+
+def set_impersonator(impersonator_id: UUID | None) -> None:
+    """Record who is acting behind this request's subject, for the audit trail."""
+    _impersonator_id.set(impersonator_id)
 
 
 async def record_audit(
@@ -28,8 +45,10 @@ async def record_audit(
     instead of the thing that happens when an argument is forgotten.
     """
     try:
+        impersonator_id = _impersonator_id.get()
         entry = AppAdminAuditLog(
             actor_user_id=actor_user_id,
+            impersonator_user_id=impersonator_id if impersonator_id != actor_user_id else None,
             action=action,
             organization_id=organization_id,
             target_type=target_type,

--- a/backend/app/core/audit.py
+++ b/backend/app/core/audit.py
@@ -26,6 +26,15 @@ def set_impersonator(impersonator_id: UUID | None) -> None:
     _impersonator_id.set(impersonator_id)
 
 
+def current_impersonator() -> UUID | None:
+    """The administrator acting behind this request's subject, or None.
+
+    Used when minting a token so a nested impersonation keeps naming the human
+    who started the chain rather than the account one hop up it (#943).
+    """
+    return _impersonator_id.get()
+
+
 async def record_audit(
     db,
     *,

--- a/backend/app/core/background.py
+++ b/backend/app/core/background.py
@@ -24,12 +24,15 @@ id, and under `READ COMMITTED` does not find it (#417).
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import logging
 from collections.abc import Coroutine
 from dataclasses import dataclass
 from typing import Any, cast
 
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.audit import set_impersonator
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +69,14 @@ def spawn(coro: Coroutine[Any, Any, Any], *, name: str) -> asyncio.Task[Any]:
         The task, for callers that want to await or cancel it. Ignoring the
         return value is safe, which is the point.
     """
-    task = asyncio.create_task(coro, name=name)
+    # Background work is not the request that spawned it. `create_task` copies the
+    # current context, so a task started inside an impersonated request would
+    # inherit that actor - and a long-lived one (a channel poller opened while an
+    # admin was impersonating) would then stamp every later audit entry with them.
+    # Reset the impersonation actor in the task's own context so it does not (#943).
+    context = contextvars.copy_context()
+    context.run(set_impersonator, None)
+    task = asyncio.create_task(coro, name=name, context=context)
     _running.add(task)
     task.add_done_callback(_on_done)
     return task

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -12,14 +12,25 @@ from app.core.config import settings
 def create_access_token(
     subject: str | Any,
     expires_delta: timedelta | None = None,
+    *,
+    act: str | None = None,
 ) -> str:
-    """Create a JWT access token."""
+    """Create a JWT access token.
+
+    `act` is the actor behind the subject when the two differ - an administrator
+    impersonating another account. It is carried as its own claim so a request
+    made with the token is attributable to the person who is really acting, not
+    only to the account they are acting as (#943). Omitted from the payload when
+    unset, so an ordinary token is byte-for-byte what it was.
+    """
     if expires_delta:
         expire = datetime.now(UTC) + expires_delta
     else:
         expire = datetime.now(UTC) + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
 
-    to_encode = {"exp": expire, "sub": str(subject), "type": "access"}
+    to_encode: dict[str, Any] = {"exp": expire, "sub": str(subject), "type": "access"}
+    if act is not None:
+        to_encode["act"] = str(act)
     return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
 
 

--- a/backend/app/db/models/audit_log.py
+++ b/backend/app/db/models/audit_log.py
@@ -24,6 +24,14 @@ class AppAdminAuditLog(Base, TimestampMixin):
     actor_user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), nullable=True, index=True
     )
+    # The administrator acting behind `actor_user_id`, when the two differ - an
+    # impersonated session. Null on an ordinary request, where nobody is acting
+    # as anybody else. This is what lets the trail answer "who was really acting"
+    # rather than attributing an impersonated action to the person it was done to
+    # (#943).
+    impersonator_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), nullable=True, index=True
+    )
     organization_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), nullable=True, index=True
     )

--- a/backend/app/schemas/audit.py
+++ b/backend/app/schemas/audit.py
@@ -13,6 +13,9 @@ class AuditEntryRead(BaseSchema):
     id: UUID
     actor_user_id: UUID | None = None
     """Who did it, or `None` where the platform did - see `record_audit`."""
+    impersonator_user_id: UUID | None = None
+    """The administrator acting behind `actor_user_id`, or `None` when the actor
+    was acting as themselves - an impersonated action names both (#943)."""
     action: str
     target_type: str | None = None
     target_id: str | None = None

--- a/backend/app/services/audit.py
+++ b/backend/app/services/audit.py
@@ -62,6 +62,7 @@ class AuditService:
                 AuditEntryRead(
                     id=entry.id,
                     actor_user_id=entry.actor_user_id,
+                    impersonator_user_id=entry.impersonator_user_id,
                     action=entry.action,
                     target_type=entry.target_type,
                     target_id=entry.target_id,

--- a/backend/tests/test_audit_impersonation.py
+++ b/backend/tests/test_audit_impersonation.py
@@ -95,3 +95,32 @@ class TestRecordingWhoWasActing:
         await record_audit(db, actor_user_id=target, action="conversation.read")
 
         assert db.added[0].impersonator_user_id == admin
+
+
+class TestNestedImpersonation:
+    def teardown_method(self) -> None:
+        set_impersonator(None)
+
+    async def test_a_nested_impersonation_names_the_human_who_started_the_chain(self) -> None:
+        """A impersonates app-admin B, whose token impersonates C. The minted
+        token must keep naming A, not B - or the chain launders A out of the audit
+        trail one hop at a time (#943)."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from app.api.routes.v1.admin_users import impersonate_user
+        from app.core.security import verify_token
+
+        a, b, c = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        set_impersonator(a)  # this request runs on B's token, itself impersonated by A
+
+        admin = MagicMock(id=b)
+        target = MagicMock(id=c, email="c@example.com")
+        service = MagicMock(get_by_id=AsyncMock(return_value=target))
+        request = MagicMock(client=MagicMock(host="1.2.3.4"))
+
+        response = await impersonate_user(request, c, admin, _CapturingDB(), service)
+
+        payload = verify_token(response.access_token)
+        assert payload is not None
+        assert payload["sub"] == str(c)
+        assert payload["act"] == str(a)

--- a/backend/tests/test_audit_impersonation.py
+++ b/backend/tests/test_audit_impersonation.py
@@ -1,0 +1,97 @@
+"""An impersonated action names who was really acting.
+
+Impersonation issues a token whose `sub` is the target account, so without this
+every row it writes and every action it records is attributed to the person it
+was done *to*. The `act` claim on the token carries the administrator, the auth
+dependency puts it on the request's audit context, and `record_audit` writes it
+beside the actor - so the trail answers "who read this customer's conversation"
+rather than pointing at the customer (#943).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.api.deps import _impersonator_from
+from app.core.audit import record_audit, set_impersonator
+from app.core.security import create_access_token
+from app.core.security import verify_token as _verify_token
+
+pytestmark = pytest.mark.anyio
+
+
+class _CapturingDB:
+    """A session that keeps what was added, so a test can read the entry back."""
+
+    def __init__(self) -> None:
+        self.added: list[object] = []
+
+    def add(self, entry: object) -> None:
+        self.added.append(entry)
+
+    async def flush(self) -> None:
+        pass
+
+
+class TestReadingTheActorFromAToken:
+    def test_an_ordinary_token_has_no_actor_behind_it(self) -> None:
+        assert _impersonator_from({"sub": "user"}) is None
+
+    def test_an_impersonation_token_names_its_actor(self) -> None:
+        admin = uuid.uuid4()
+        assert _impersonator_from({"sub": "target", "act": str(admin)}) == admin
+
+    def test_a_malformed_actor_claim_is_dropped_rather_than_trusted(self) -> None:
+        """A garbage `act` is no actor; the request is still attributable to its
+        subject rather than refused."""
+        assert _impersonator_from({"sub": "target", "act": "not-a-uuid"}) is None
+
+
+class TestRecordingWhoWasActing:
+    def teardown_method(self) -> None:
+        set_impersonator(None)
+
+    async def test_an_impersonated_action_records_the_administrator_behind_it(self) -> None:
+        admin, target = uuid.uuid4(), uuid.uuid4()
+        set_impersonator(admin)
+
+        db = _CapturingDB()
+        await record_audit(db, actor_user_id=target, action="agent.deleted")
+
+        entry = db.added[0]
+        assert entry.actor_user_id == target
+        assert entry.impersonator_user_id == admin
+
+    async def test_an_ordinary_action_records_no_impersonator(self) -> None:
+        set_impersonator(None)
+
+        db = _CapturingDB()
+        await record_audit(db, actor_user_id=uuid.uuid4(), action="agent.published")
+
+        assert db.added[0].impersonator_user_id is None
+
+    async def test_acting_as_oneself_is_not_recorded_as_impersonation(self) -> None:
+        """`act` equal to the actor is nobody impersonating anybody, so the
+        impersonator stays null rather than naming the actor twice."""
+        me = uuid.uuid4()
+        set_impersonator(me)
+
+        db = _CapturingDB()
+        await record_audit(db, actor_user_id=me, action="agent.published")
+
+        assert db.added[0].impersonator_user_id is None
+
+    async def test_the_claim_survives_from_the_token_into_the_entry(self) -> None:
+        """The whole chain #943 turns on: a minted impersonation token, decoded,
+        read onto the audit context, and recorded on the action it produces."""
+        admin, target = uuid.uuid4(), uuid.uuid4()
+        payload = _verify_token(create_access_token(str(target), act=str(admin)))
+        assert payload is not None
+        set_impersonator(_impersonator_from(payload))
+
+        db = _CapturingDB()
+        await record_audit(db, actor_user_id=target, action="conversation.read")
+
+        assert db.added[0].impersonator_user_id == admin

--- a/backend/tests/test_audit_service.py
+++ b/backend/tests/test_audit_service.py
@@ -32,16 +32,38 @@ def _ctx(org_id: uuid.UUID | None = None) -> AuthContext:
     )
 
 
-def _entry(*, action: str = "agent.published") -> MagicMock:
+def _entry(
+    *, action: str = "agent.published", impersonator_user_id: uuid.UUID | None = None
+) -> MagicMock:
     entry = MagicMock()
     entry.id = uuid.uuid4()
     entry.actor_user_id = uuid.uuid4()
+    entry.impersonator_user_id = impersonator_user_id
     entry.action = action
     entry.target_type = "agent"
     entry.target_id = str(uuid.uuid4())
     entry.details = {"version": 3}
     entry.created_at = datetime.now(UTC)
     return entry
+
+
+async def test_an_impersonated_entry_reports_who_was_acting() -> None:
+    """The read half of #943: the trail names the administrator behind the
+    account an impersonated action was recorded as."""
+    admin_id = uuid.uuid4()
+    entry = _entry(action="agent.deleted", impersonator_user_id=admin_id)
+
+    with (
+        patch(
+            "app.services.audit.audit_log_repo.list_for_org",
+            new=AsyncMock(return_value=[entry]),
+        ),
+        patch("app.services.audit.audit_log_repo.count_for_org", new=AsyncMock(return_value=1)),
+    ):
+        page = await AuditService(MagicMock()).list_for_organization(_ctx())
+
+    assert page.items[0].impersonator_user_id == admin_id
+    assert page.items[0].actor_user_id == entry.actor_user_id
 
 
 async def test_an_entry_is_reported_as_the_page_it_belongs_to() -> None:

--- a/backend/tests/test_background.py
+++ b/backend/tests/test_background.py
@@ -58,6 +58,29 @@ class TestKeepingWorkAlive:
 
         assert task.get_name() == "ingest-document-7"
 
+    async def test_a_spawned_task_does_not_inherit_the_impersonation_actor(self) -> None:
+        """A long-lived task started inside an impersonated request must not stamp
+        its own audit entries with that administrator - #943. The reset happens in
+        the task's copied context, so the caller's own actor is left intact."""
+        import uuid
+
+        from app.core.audit import current_impersonator, set_impersonator
+
+        admin = uuid.uuid4()
+        set_impersonator(admin)
+        try:
+            seen: list[uuid.UUID | None] = []
+
+            async def work() -> None:
+                seen.append(current_impersonator())
+
+            await background.spawn(work(), name="channel-poller")
+
+            assert seen == [None]
+            assert current_impersonator() == admin
+        finally:
+            set_impersonator(None)
+
 
 class TestWhatHappensWhenBackgroundWorkFails:
     async def test_a_failure_is_logged_because_there_is_no_caller_to_raise_into(

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -72,6 +72,22 @@ class TestAccessToken:
         assert payload["sub"] == subject
         assert payload["type"] == "access"
 
+    def test_an_ordinary_token_carries_no_actor_claim(self):
+        """The `act` claim is absent unless someone is impersonating, so an
+        ordinary token is exactly what it was before #943."""
+        payload = verify_token(create_access_token("user123"))
+
+        assert payload is not None
+        assert "act" not in payload
+
+    def test_an_impersonation_token_names_the_actor_behind_the_subject(self):
+        """The subject is the account being acted as; `act` is who is acting."""
+        payload = verify_token(create_access_token("target-user", act="admin-user"))
+
+        assert payload is not None
+        assert payload["sub"] == "target-user"
+        assert payload["act"] == "admin-user"
+
     def test_verify_invalid_token(self):
         """Test verifying invalid token."""
         payload = verify_token("invalid.token.here")

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -966,6 +966,16 @@ question that is cheap to answer now and impossible to reconstruct later.
 `audit:read` gates reading it. An app admin's bypass is exactly what the trail
 exists to hold to account.
 
+An **impersonated** action names both. When an app admin acts as another account,
+the access token carries the administrator as an `act` claim; every entry that
+request records keeps `actor_user_id` as the account being acted as and adds
+`impersonator_user_id` — the administrator behind it. So "who read this customer's
+conversation" resolves to a person even when the action was recorded as the
+customer's own. It is null on an ordinary request, where nobody is acting as
+anybody else, and nothing is backfilled: whether a past action was impersonated
+cannot be known after the fact, and inventing an answer would be a false
+accusation rather than a missing one.
+
 ## What none of this covers
 
 Worth stating, because a governance page implies otherwise:


### PR DESCRIPTION
Addresses the actor-attribution half of #943 — the issue's stated most
important and cheapest piece.

## The problem

`POST /admin/users/{id}/impersonate` mints an access token whose `sub` is
the **target** account. Every request made with it — every row written,
every audit entry triggered — was attributed to the target and nobody
else. An admin who read a customer's conversation and one who deleted
their agent left the same trace: the customer's own. "Who accessed my
account" had no answer.

## What changed

- **`act` claim.** `create_access_token(..., act=...)` carries the
  administrator behind the subject; the impersonate route sets it. Absent
  on every ordinary token, so those are byte-for-byte unchanged.
- **Audit context.** The auth dependency (HTTP and WebSocket) reads `act`
  onto a request-scoped context variable — the actor behind a request is a
  property of the request, not something to thread through every service
  that records an action.
- **`record_audit`** writes it as `impersonator_user_id` beside the actor;
  `0044_audit_impersonator` adds the nullable column and index; the audit
  read schema/service expose it. Null on an ordinary request; nothing
  backfilled (whether a past action was impersonated is unknowable after
  the fact).
- **`docs/governance.md`** says what an impersonated action records.

## Scope — deliberately not the whole issue

Done-when #2 (an impersonated request is identifiable; the audit says who
acted as whom) and #4 (a test asserts the claim survives into an audit
entry) are here. **#1 (no raw token on the clipboard) and #3 (revocable,
endable impersonation)** are one larger full-stack flow — an in-product
impersonation session with a banner and an End button, plus revocation —
filed as a follow-up. #943 stays open for it. The issue also flags a
policy question (whether the target is notified); that belongs with the
flow, not this change.

## Verified

- The claim survives from a minted token through the auth context into the
  entry; an ordinary action and an admin acting as themselves record no
  impersonator; the read service reports it.
- Migration up/down/up clean, `alembic check` finds no drift.
- Full backend suite green (5688 passed); `make lint-backend`,
  `make docs-build` green. Backend `test` coverage is 100% on the touched
  gated module (`services/audit.py`); the core auth/audit modules changed
  here are not in the gate.