### PR TITLE
chore: cut 0.0.232

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,33 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.232] - 2026-08-21
+
+The active-sessions card holds while the next page loads.
+
+### Fixed
+
+- **Paging the Active sessions card on `/settings/profile` blanked it and threw the
+  scroll to the top.** The query keyed on the page number with no `placeholderData`,
+  so each page change was a new key: `data` went `undefined`, `isPending` flipped
+  true, and the `loading && sessions.length === 0` branch drew two skeletons in
+  place of five rows. The card collapsed from roughly 340px to 120px, everything
+  below it jumped, and a card below the fold took the scroll with it.
+  `placeholderData: keepPreviousData` holds the current rows while the next page
+  loads, so the skeleton branch means first load again - the treatment
+  `use-agents`, `use-runs`, `use-skills` and `use-context` already had, and this was
+  the one paged list without it. (#944)
+- The held list is dimmed and marked `aria-busy` while stale, as `UsageBody` does,
+  and the pager is disabled while the fetch is in flight - so the hold is visible,
+  and audible to a screen reader, rather than silently wrong. (#944)
+
+### Changed
+
+- The card's hand-rolled pager is now the shared `PaginationBar` that admin/users,
+  run history and version history already use; it was the fourth implementation of
+  one control. Single-page behaviour differs - the chevrons render disabled rather
+  than the pager disappearing - so the orphaned `dashboard.previousPage` and
+  `dashboard.nextPage` keys are removed from both catalogs. (#944)
 ## [0.0.231] - 2026-08-20
 
 The organization in the URL is the tenant.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.231"
+version = "0.0.232"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.231"
+version = "0.0.232"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.231",
+  "version": "0.0.232",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.232. Bumps `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json` to 0.0.232 and adds the CHANGELOG entry.

Releases #1004: the Active sessions card on `/settings/profile` was the one paged
list in the product with no `placeholderData`, so paging past five rows blanked the
card, collapsed it from roughly 340px to 120px and threw the scroll to the top. The
rows are held now, dimmed and `aria-busy` while the next page loads, and the pager
is disabled in flight. The hand-rolled pager - the fourth implementation of that
control - is the shared `PaginationBar`.

## Verified

CI green end to end on #1004: an integration spec holds the second page in flight
and asserts the previous rows stay on screen, the list is `aria-busy` and the pager
is disabled until the fetch lands. `make lint-frontend` clean and the frontend
coverage gate green at 100% statements, functions and lines.

Refs #944
