### PR TITLE
chore: cut 0.0.233

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,28 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.233] - 2026-08-21
+
+A conversation is shared inside its organization or not at all.
+
+### Fixed
+
+- **`POST /conversations/{id}/share` resolved the target user deployment-wide and
+  never checked they belong to the conversation's organization.** The row was
+  created and the dialog listed the outsider under "Shared with" - while the read
+  path refuses on the tenant before it ever consults the share, so the target got a
+  404 and the owner a lie. Not a leak, since the tenant gate holds, but a contract
+  that lies. `share_conversation` now checks the target is a member of the
+  conversation's organization, by id and by email alike. (#930)
+- A non-member is refused **as though they did not exist**, with the same
+  `NotFoundError` the not-found case raises: naming them "a member of another
+  organization" would turn the share form into a cross-tenant probe for which
+  addresses hold an account elsewhere on the deployment. Membership is read with
+  `member_repo.get` rather than `get_active` - the question is tenancy, and whether
+  a member can currently sign in is the read path's call. (#930)
+- The owner's "Shared with" listing drops rows already in that state, in one query:
+  a target who is a current member is kept, and so is a public-link share, which has
+  no target. Cheaper than a migration, and self-correcting. (#930)
 ## [0.0.232] - 2026-08-21
 
 The active-sessions card holds while the next page loads.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.232"
+version = "0.0.233"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.232"
+version = "0.0.233"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.232",
+  "version": "0.0.233",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.233. Bumps `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json` to 0.0.233 and adds the CHANGELOG entry.

Releases #1014: sharing a conversation resolved the target deployment-wide, so a
share with somebody in another organization was created, listed under "Shared with",
and then refused by the read path's tenant gate - the owner told the share worked and
the target given a 404. The refusal moves to share time, and reads as not-found so
the form cannot be used to probe which addresses hold an account elsewhere.

## Verified

CI green end to end on #1014: unit tests refuse the outsider by id and by email with
`create` never reached, and an integration test against a real database lists a
colleague and a public link while dropping a member of another organization. Full
backend suite 5665 passed, `make lint` clean.

Refs #930
