### PR TITLE
chore: cut 0.0.234

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,31 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.234] - 2026-08-21
+
+An app admin cannot suspend or delete their own account.
+
+### Fixed
+
+- **`/admin/users` let an app admin open their own row and suspend, demote or delete
+  themselves**, unguarded at both layers and two of the three one click away with no
+  confirmation. `is_active` is enforced on the next request, so a self-suspend signs
+  you out of a deployment you administer, and a self-delete takes the account and its
+  conversations with it - on the single-admin install `make platform-bootstrap`
+  produces, a stray click ends administration until somebody reaches a terminal.
+  (#941)
+- The guard lives in `UserService`, where both admin surfaces meet: `admin_update`
+  refuses a self-suspend and `admin_delete` a self-delete, before the repository is
+  touched. `PATCH` and `DELETE` on both `/admin/users/{id}` and the twin `/users/{id}`
+  route - which had the same hole - carry the acting admin's id through them. (#941)
+- Only `is_active` is guarded on update, because `is_app_admin` is not a `UserUpdate`
+  field: the one global privilege is granted by CLI and cleared by nothing over the
+  API. That is also what answers the last-admin question in code rather than in a
+  policy - the app-admin set shrinks only by deletion, and deleting the last one is
+  deleting yourself, which is refused. Written up in `docs/deployment.md`. (#941)
+- The admin drawer no longer renders **Suspend**, **Demote** or **Impersonate** on
+  your own row. **Delete stays visible and is refused by the API** - "why can I not
+  delete myself" is a question worth answering on screen. (#941)
 ## [0.0.233] - 2026-08-21
 
 A conversation is shared inside its organization or not at all.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.233"
+version = "0.0.234"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.233"
+version = "0.0.234"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.233",
+  "version": "0.0.234",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.234. Bumps `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json` to 0.0.234 and adds the CHANGELOG entry.

Releases #1015: an app admin could suspend, demote or delete their own account from
`/admin/users`, with nothing guarding either layer. On a single-admin deployment that
is one click from having no administrator at all. The guard sits in `UserService`,
where both admin surfaces meet, and the two twin routes carry the acting admin's id
into it; the drawer stops rendering the three controls it may not use on your own row
and keeps Delete visible so the refusal has somewhere to be read.

## Verified

CI green end to end on #1015: service tests refuse a self-suspend and a self-delete
before the repository is touched and leave action on another user working; drawer
tests assert the three controls are absent on your own row, present on somebody
else's, and Delete either way. Full backend suite 5667 passed, frontend coverage gate
green, `make lint` clean.

Refs #941
