### PR TITLE
fix(rag): scope embedding and rerank resolution to the acting tenant

### DIFF
--- a/backend/app/agents/capabilities/knowledge/_search.py
+++ b/backend/app/agents/capabilities/knowledge/_search.py
@@ -3,6 +3,7 @@
 import contextvars
 import logging
 from typing import TYPE_CHECKING, Any
+from uuid import UUID
 
 from app.core.config import settings
 from app.core.exceptions import AppException, ExternalServiceError
@@ -100,6 +101,8 @@ async def search_knowledge_base(
     query: str,
     kb_collection_names: list[str] | None = None,
     top_k: int = 5,
+    *,
+    organization_id: UUID | None,
 ) -> str:
     """Search the knowledge base and return formatted results.
 
@@ -109,6 +112,9 @@ async def search_knowledge_base(
             agent's spec. Never supplied by the LLM directly - injected via
             PydanticAI Deps or the _active_kb_collections ContextVar.
         top_k: Number of top results to retrieve (default: 5).
+        organization_id: The organization the run acts for, so a collection name
+            shared across tenants resolves this one's embedding and rerank config
+            rather than another's (#913).
     """
     resolved = kb_collection_names if kb_collection_names else (_active_kb_collections.get() or [])
     if not resolved:
@@ -118,10 +124,18 @@ async def search_knowledge_base(
     one_collection = len(resolved) == 1
     try:
         if one_collection:
-            results = await service.retrieve(query=query, collection_name=resolved[0], limit=top_k)
+            results = await service.retrieve(
+                query=query,
+                collection_name=resolved[0],
+                limit=top_k,
+                organization_id=organization_id,
+            )
         else:
             results = await service.retrieve_multi(
-                query=query, collection_names=resolved, limit=top_k
+                query=query,
+                collection_names=resolved,
+                limit=top_k,
+                organization_id=organization_id,
             )
     except AppException:
         # Already an account of what is wrong and what to do about it - an

--- a/backend/app/agents/capabilities/knowledge/_toolset.py
+++ b/backend/app/agents/capabilities/knowledge/_toolset.py
@@ -40,6 +40,9 @@ def build_knowledge_toolset(*, default_top_k: int) -> FunctionToolset[AgentDeps]
                 # model chooses *what* to search, never *where*.
                 kb_collection_names=ctx.deps.kb_collection_names,
                 top_k=top_k or default_top_k,
+                # The run's own organization, so a collection name shared with
+                # another tenant resolves this agent's config, not theirs (#913).
+                organization_id=ctx.deps.organization_id,
             )
         except Exception as exc:
             raise ModelRetry("Knowledge base temporarily unavailable, please try again.") from exc

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -940,9 +940,14 @@ DocumentProcessorSvc = Annotated[DocumentProcessor, Depends(get_document_process
 def get_ingestion_service(
     processor: DocumentProcessorSvc,
     vector_store: VectorStoreSvc,
+    org: ActiveOrg,
 ) -> IngestionService:
-    """Create IngestionService instance."""
-    return IngestionService(processor=processor, vector_store=vector_store)
+    """Create IngestionService instance, scoped to the active organization.
+
+    The organization is what lets the store resolve this tenant's embedding key
+    on a collection name another tenant may share, rather than another's (#913).
+    """
+    return IngestionService(processor=processor, vector_store=vector_store, organization_id=org.id)
 
 
 IngestionSvc = Annotated[IngestionService, Depends(get_ingestion_service)]

--- a/backend/app/api/routes/v1/rag.py
+++ b/backend/app/api/routes/v1/rag.py
@@ -216,7 +216,9 @@ async def get_collection_info(
 ) -> Any:
     """Retrieve stats for a specific collection."""
     collection = await access.readable(ctx, name)
-    return await vector_store.get_collection_info(collection.collection_name)
+    return await vector_store.get_collection_info(
+        collection.collection_name, organization_id=collection.organization_id
+    )
 
 
 @router.get(

--- a/backend/app/api/routes/v1/rag.py
+++ b/backend/app/api/routes/v1/rag.py
@@ -159,7 +159,7 @@ async def create_collection(
     is refused rather than quietly aliased onto their vector table.
     """
     await access.claim(ctx, name)
-    await vector_store.create_collection(name)
+    await vector_store.create_collection(name, organization_id=ctx.organization_id)
     await kb_svc.create_for_rag_collection(
         name, user_id=ctx.subject_id, organization_id=ctx.organization_id
     )

--- a/backend/app/commands/rag.py
+++ b/backend/app/commands/rag.py
@@ -73,7 +73,11 @@ def get_rag_services() -> tuple[
     )
     processor = DocumentProcessor(settings=settings)
     retrieval = RetrievalService(vector_store=vector_store, settings=settings)
-    ingestion = IngestionService(processor=processor, vector_store=vector_store)
+    # CLI admin context: no single tenant, so resolution falls back to the name.
+    # Uploads through the API are org-scoped.
+    ingestion = IngestionService(
+        processor=processor, vector_store=vector_store, organization_id=None
+    )
     return settings, vector_store, processor, retrieval, ingestion
 
 
@@ -93,7 +97,7 @@ async def list_collections_async(vector_store: BaseVectorStore) -> None:
 
     for name in collection_names:
         try:
-            info_obj = await vector_store.get_collection_info(name)
+            info_obj = await vector_store.get_collection_info(name, organization_id=None)
             click.echo(f"  {name}")
             click.echo(f"    Vectors: {info_obj.total_vectors:,}")
             click.echo(f"    Dimension: {info_obj.dim}")
@@ -474,7 +478,7 @@ async def stats_async(settings: RAGSettings, vector_store: BaseVectorStore) -> N
         total_vectors = 0
         for name in collection_names:
             try:
-                info_obj = await vector_store.get_collection_info(name)
+                info_obj = await vector_store.get_collection_info(name, organization_id=None)
                 click.echo(f"  {name}:")
                 click.echo(f"    Vectors: {info_obj.total_vectors:,}")
                 total_vectors += info_obj.total_vectors

--- a/backend/app/repositories/knowledge_base.py
+++ b/backend/app/repositories/knowledge_base.py
@@ -186,3 +186,23 @@ async def list_by_collection_name(db: AsyncSession, collection_name: str) -> lis
         .order_by(KnowledgeBase.created_at)
     )
     return list(result.scalars().all())
+
+
+async def get_for_collection(
+    db: AsyncSession, collection_name: str, organization_id: UUID | None
+) -> KnowledgeBase | None:
+    """The knowledge base an organization resolves a collection name to.
+
+    `collection_name` is not unique across tenants, so resolving one by name
+    alone can return another organization's row - and then unseal and bill that
+    organization's key (#913). The organization narrows the candidates in two
+    passes: its own row wins, and an `app`-scoped collection (owned by no
+    organization) is the shared fallback. `organization_id` is `None` only where
+    there is genuinely no tenant to scope to - a CLI ingest - and then the first
+    candidate stands, which is the old name-only behaviour for that path alone.
+    """
+    candidates = await list_by_collection_name(db, collection_name)
+    for kb in candidates:
+        if organization_id is None or kb.organization_id == organization_id:
+            return kb
+    return next((kb for kb in candidates if kb.organization_id is None), None)

--- a/backend/app/services/embedding_resolution.py
+++ b/backend/app/services/embedding_resolution.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from enum import StrEnum
+from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -132,16 +133,24 @@ class ResolvedEmbeddings:
         return f"collection {collection_name!r}, which embeds on {self.key_source.explanation}"
 
 
-async def embeddings_for_collection(collection_name: str) -> ResolvedEmbeddings | None:
-    """Resolve one collection's embedding model and credential.
+async def embeddings_for_collection(
+    collection_name: str, organization_id: UUID | None
+) -> ResolvedEmbeddings | None:
+    """Resolve one collection's embedding model and credential, for one organization.
 
     Returns None for a collection no knowledge base claims - the store then
     uses its deployment defaults, which is what such collections have always
     gotten. Opens its own session because the store embeds from places with no
     request in sight: a worker mid-ingestion, a capability mid-run.
+
+    `organization_id` is required and scopes the resolution: `collection_name`
+    is not unique across tenants, so resolving by name alone could return - and
+    unseal and bill - another organization's key (#913). The caller passes the
+    organization the search or ingest is acting for; `None` only where there is
+    no tenant (a CLI ingest).
     """
     async with get_db_context() as db:
-        kb = await knowledge_base_repo.get_by_collection_name(db, collection_name)
+        kb = await knowledge_base_repo.get_for_collection(db, collection_name, organization_id)
         if kb is None:
             return None
         api_key, key_source = await _api_key_for(db, kb)

--- a/backend/app/services/knowledge_search.py
+++ b/backend/app/services/knowledge_search.py
@@ -80,6 +80,7 @@ class KnowledgeSearchService:
                         collection_names=collections,
                         limit=request.limit,
                         min_score=request.min_score,
+                        organization_id=ctx.organization_id,
                     )
                 else:
                     results = await self.retrieval.retrieve(
@@ -88,6 +89,7 @@ class KnowledgeSearchService:
                         limit=request.limit,
                         min_score=request.min_score,
                         filter=request.filter or "",
+                        organization_id=ctx.organization_id,
                     )
         except Exception:
             # The query embedding is booked before the vector query it pays for,

--- a/backend/app/services/rag/ingestion.py
+++ b/backend/app/services/rag/ingestion.py
@@ -4,6 +4,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
+from uuid import UUID
 
 from app.services.rag.documents import DocumentProcessor
 from app.services.rag.failures import IngestionStage, failure_summary
@@ -65,10 +66,15 @@ class IngestionService:
         processor: DocumentProcessor,
         vector_store: BaseVectorStore,
         on_event: Callable[..., Awaitable[None]] | None = None,
+        *,
+        organization_id: UUID | None,
     ):
         self.processor = processor
         self.store = vector_store
         self._on_event = on_event
+        # The organization this ingest embeds for, so the store resolves this
+        # tenant's key and not another's on a shared collection name (#913).
+        self._organization_id = organization_id
 
     async def _emit(self, event: str, data: dict[str, object]) -> None:
         if self._on_event:
@@ -174,6 +180,7 @@ class IngestionService:
             await self.store.insert_document(
                 collection_name=collection_name,
                 document=document,
+                organization_id=self._organization_id,
             )
 
             if existing_id:

--- a/backend/app/services/rag/reranker.py
+++ b/backend/app/services/rag/reranker.py
@@ -26,6 +26,7 @@ from abc import ABC, abstractmethod
 from decimal import Decimal
 from math import ceil
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 import cohere
 
@@ -159,7 +160,7 @@ class CohereReranker(BaseReranker):
         )
 
 
-async def build_reranker(collection_name: str) -> BaseReranker | None:
+async def build_reranker(collection_name: str, organization_id: UUID | None) -> BaseReranker | None:
     """Bind a collection's resolved rerank credential to a concrete reranker.
 
     The one composition point for reranking: resolution answers whether a
@@ -169,7 +170,7 @@ async def build_reranker(collection_name: str) -> BaseReranker | None:
     wired the same way in both, and a second provider is a branch here rather
     than a change at each call site.
     """
-    resolved = await reranker_for_collection(collection_name)
+    resolved = await reranker_for_collection(collection_name, organization_id)
     if resolved is None:
         return None
     return CohereReranker(model=resolved.model, api_key=resolved.api_key)

--- a/backend/app/services/rag/retrieval.py
+++ b/backend/app/services/rag/retrieval.py
@@ -5,6 +5,7 @@ import logging
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
+from uuid import UUID
 
 from rank_bm25 import BM25Okapi
 
@@ -18,7 +19,7 @@ logger = logging.getLogger(__name__)
 # How a retrieval service learns whether a collection reranks, and with what.
 # Async because the answer lives in the database, injected so the store never
 # imports platform policy - the same shape as the embedding resolver.
-RerankerResolver = Callable[[str], Awaitable[BaseReranker | None]]
+RerankerResolver = Callable[[str, UUID | None], Awaitable[BaseReranker | None]]
 
 # Recall overfetches so min-score filtering and dedup still leave `limit`
 # results. A reranker wants a wider net than that - the point of it is to
@@ -43,6 +44,8 @@ class BaseRetrievalService(ABC):
         limit: int = 5,
         min_score: float = 0.0,
         filter: str = "",
+        *,
+        organization_id: UUID | None,
     ) -> list[SearchResult]:
         pass
 
@@ -94,14 +97,17 @@ class RetrievalService(BaseRetrievalService):
         ]
 
     async def _bm25_search(
-        self, query: str, collection_name: str, limit: int
+        self, query: str, collection_name: str, limit: int, organization_id: UUID | None
     ) -> list[SearchResult]:
         docs = await self.store.get_documents(collection_name)
         if not docs:
             return []
 
         all_results = await self.store.search(
-            collection_name=collection_name, query=query, limit=min(limit * 10, 100)
+            collection_name=collection_name,
+            query=query,
+            limit=min(limit * 10, 100),
+            organization_id=organization_id,
         )
         if not all_results:
             return []
@@ -123,15 +129,20 @@ class RetrievalService(BaseRetrievalService):
             if s > 0
         ]
 
-    async def _reranker_for(self, collection_name: str) -> BaseReranker | None:
+    async def _reranker_for(
+        self, collection_name: str, organization_id: UUID | None
+    ) -> BaseReranker | None:
         """The reranker one collection uses, or None when none is configured.
 
         None whenever no resolver was injected, so a service built without one
         never reranks and never touches the database looking for a key.
+
+        `organization_id` scopes the resolution: a shared collection name must
+        resolve the caller's own rerank config, never another tenant's (#913).
         """
         if self._reranker_resolver is None:
             return None
-        return await self._reranker_resolver(collection_name)
+        return await self._reranker_resolver(collection_name, organization_id)
 
     @staticmethod
     def _shared_reranker(rerankers: list[BaseReranker | None]) -> BaseReranker | None:
@@ -179,11 +190,19 @@ class RetrievalService(BaseRetrievalService):
         limit: int = 5,
         min_score: float = 0.0,
         filter: str = "",
+        *,
+        organization_id: UUID | None,
     ) -> list[SearchResult]:
-        reranker = await self._reranker_for(collection_name)
+        reranker = await self._reranker_for(collection_name, organization_id)
         multiplier = _RERANK_FETCH_MULTIPLIER if reranker else _DEFAULT_FETCH_MULTIPLIER
         candidates = await self._recall(
-            query, collection_name, limit, min_score, filter, fetch_multiplier=multiplier
+            query,
+            collection_name,
+            limit,
+            min_score,
+            filter,
+            fetch_multiplier=multiplier,
+            organization_id=organization_id,
         )
         return await self._rank_and_truncate(reranker, query, candidates, limit)
 
@@ -196,6 +215,7 @@ class RetrievalService(BaseRetrievalService):
         filter: str,
         *,
         fetch_multiplier: int,
+        organization_id: UUID | None,
     ) -> list[SearchResult]:
         """Vector (and optionally BM25) recall, filtered and deduplicated.
 
@@ -225,6 +245,7 @@ class RetrievalService(BaseRetrievalService):
             query=query,
             filter_expr=filter,
             limit=limit * fetch_multiplier,
+            organization_id=organization_id,
         )
 
         search_time = time.time() - start_time
@@ -235,7 +256,9 @@ class RetrievalService(BaseRetrievalService):
         )
 
         if self._hybrid_enabled:
-            bm25_results = await self._bm25_search(query, collection_name, limit * fetch_multiplier)
+            bm25_results = await self._bm25_search(
+                query, collection_name, limit * fetch_multiplier, organization_id
+            )
             if bm25_results:
                 pipeline_results = self._rrf_fuse(pipeline_results, bm25_results)
                 logger.info("[RETRIEVAL] Hybrid search: fused %d results", len(pipeline_results))
@@ -297,6 +320,8 @@ class RetrievalService(BaseRetrievalService):
         collection_names: list[str],
         limit: int = 5,
         min_score: float = 0.0,
+        *,
+        organization_id: UUID | None,
     ) -> list[SearchResult]:
         """Search several collections and merge what they return.
 
@@ -326,14 +351,20 @@ class RetrievalService(BaseRetrievalService):
         merge - each collection's top `limit`, fused, sorted, deduplicated,
         truncated.
         """
-        rerankers = [await self._reranker_for(name) for name in collection_names]
+        rerankers = [await self._reranker_for(name, organization_id) for name in collection_names]
         reranker = self._shared_reranker(rerankers)
         multiplier = _RERANK_FETCH_MULTIPLIER if reranker else _DEFAULT_FETCH_MULTIPLIER
 
         all_results: list[SearchResult] = []
         for name in collection_names:
             recalled = await self._recall(
-                query, name, limit, min_score, "", fetch_multiplier=multiplier
+                query,
+                name,
+                limit,
+                min_score,
+                "",
+                fetch_multiplier=multiplier,
+                organization_id=organization_id,
             )
             all_results.extend(recalled if reranker else recalled[:limit])
 

--- a/backend/app/services/rag/vectorstore.py
+++ b/backend/app/services/rag/vectorstore.py
@@ -2,6 +2,7 @@ import logging
 import re
 from abc import ABC, abstractmethod
 from typing import Any
+from uuid import UUID
 
 # Registers every model table on `Base.metadata`, which `list_collections` judges a
 # `rag_` table against and `_table` refuses a collection name against. Another import
@@ -42,12 +43,20 @@ class BaseVectorStore(ABC):
         """
 
     @abstractmethod
-    async def insert_document(self, collection_name: str, document: Document) -> None:
+    async def insert_document(
+        self, collection_name: str, document: Document, *, organization_id: UUID | None
+    ) -> None:
         pass
 
     @abstractmethod
     async def search(
-        self, collection_name: str, query: str, limit: int = 4, filter_expr: str = ""
+        self,
+        collection_name: str,
+        query: str,
+        limit: int = 4,
+        filter_expr: str = "",
+        *,
+        organization_id: UUID | None,
     ) -> list[SearchResult]:
         pass
 
@@ -60,7 +69,9 @@ class BaseVectorStore(ABC):
         pass
 
     @abstractmethod
-    async def get_collection_info(self, collection_name: str) -> CollectionInfo:
+    async def get_collection_info(
+        self, collection_name: str, *, organization_id: UUID | None
+    ) -> CollectionInfo:
         pass
 
     @abstractmethod
@@ -178,7 +189,7 @@ from app.services.rag.embeddings import EmbeddingService
 # How a store learns which model a collection embeds with. Async because the
 # answer lives in the database, injected so the template's store never imports
 # platform policy.
-EmbeddingResolver = Callable[[str], Awaitable[ResolvedEmbeddings | None]]
+EmbeddingResolver = Callable[[str, UUID | None], Awaitable[ResolvedEmbeddings | None]]
 
 # pgvector's HNSW builds over a `vector` column only up to this width; past it,
 # `CREATE INDEX` fails with "column cannot have more than 2000 dimensions for
@@ -274,7 +285,9 @@ class PgVectorStore(BaseVectorStore):
         validate_collection_name(name, metadata=Base.metadata)
         return f"{VECTOR_TABLE_PREFIX}{name}"
 
-    async def _for_collection(self, name: str) -> tuple[EmbeddingService, int]:
+    async def _for_collection(
+        self, name: str, organization_id: UUID | None
+    ) -> tuple[EmbeddingService, int]:
         """The embedder and vector width this one collection uses.
 
         Cached per (collection, model, key): an `EmbeddingService` holds an
@@ -290,7 +303,7 @@ class PgVectorStore(BaseVectorStore):
         The recorded width wins over the catalog's: the table was created at
         that number.
         """
-        resolved = await self._resolver(name)
+        resolved = await self._resolver(name, organization_id)
         if resolved is None:
             return self.embedder, self.dim
         cache_key = (name, resolved.model, resolved.api_key)
@@ -324,10 +337,10 @@ class PgVectorStore(BaseVectorStore):
             return f"(embedding::halfvec({dim}))"
         return "embedding"
 
-    async def _ensure_collection(self, name: str) -> None:
+    async def _ensure_collection(self, name: str, organization_id: UUID | None) -> None:
         """Create table for collection if not exists."""
         table = self._table(name)
-        _, dim = await self._for_collection(name)
+        _, dim = await self._for_collection(name, organization_id)
         operator_class = "halfvec_cosine_ops" if dim > _HNSW_MAX_VECTOR_DIM else "vector_cosine_ops"
         async with self.async_session() as session:
             await session.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
@@ -363,7 +376,9 @@ class PgVectorStore(BaseVectorStore):
             )
             return result.scalar() is not None
 
-    async def insert_document(self, collection_name: str, document: Document) -> None:
+    async def insert_document(
+        self, collection_name: str, document: Document, *, organization_id: UUID | None
+    ) -> None:
         """Write a document's chunks, a batch of rows per statement.
 
         One statement per `_CHUNK_INSERT_BATCH` chunks rather than one per chunk:
@@ -383,10 +398,10 @@ class PgVectorStore(BaseVectorStore):
         while leaving the worker's memory exactly where it was.
         """
         table = self._table(collection_name)
-        await self._ensure_collection(collection_name)
+        await self._ensure_collection(collection_name, organization_id)
         if not document.chunked_pages:
             raise ValueError("Document has no chunked pages.")
-        embedder, _ = await self._for_collection(collection_name)
+        embedder, _ = await self._for_collection(collection_name, organization_id)
         vectors = embedder.embed_document(document)
         statement = text(f"""
             INSERT INTO {table} (id, parent_doc_id, content, embedding, metadata)
@@ -411,7 +426,13 @@ class PgVectorStore(BaseVectorStore):
             await session.commit()
 
     async def search(
-        self, collection_name: str, query: str, limit: int = 4, filter_expr: str = ""
+        self,
+        collection_name: str,
+        query: str,
+        limit: int = 4,
+        filter_expr: str = "",
+        *,
+        organization_id: UUID | None,
     ) -> list[SearchResult]:
         """Nearest chunks in a collection, reporting an absent one as empty.
 
@@ -425,7 +446,7 @@ class PgVectorStore(BaseVectorStore):
         table = self._table(collection_name)
         if not await self._collection_exists(collection_name):
             return []
-        embedder, dim = await self._for_collection(collection_name)
+        embedder, dim = await self._for_collection(collection_name, organization_id)
         query_vector = embedder.embed_query(query)
 
         # Parse the shared `parent_doc_id == "<value>"` filter format and apply
@@ -469,7 +490,9 @@ class PgVectorStore(BaseVectorStore):
             for row in rows
         ]
 
-    async def get_collection_info(self, collection_name: str) -> CollectionInfo:
+    async def get_collection_info(
+        self, collection_name: str, *, organization_id: UUID | None
+    ) -> CollectionInfo:
         """Vector count for a collection, reporting an absent one as empty.
 
         A collection's table is created lazily by the first ingest, so "no table"
@@ -481,7 +504,7 @@ class PgVectorStore(BaseVectorStore):
         question with an empty list; its comment claimed this method already did
         the same, and now it does.
         """
-        _, dim = await self._for_collection(collection_name)
+        _, dim = await self._for_collection(collection_name, organization_id)
         if not await self._collection_exists(collection_name):
             return CollectionInfo(name=collection_name, total_vectors=0, dim=dim)
         table = self._table(collection_name)

--- a/backend/app/services/rag/vectorstore.py
+++ b/backend/app/services/rag/vectorstore.py
@@ -110,7 +110,7 @@ class BaseVectorStore(ABC):
             total=len(docs),
         )
 
-    async def create_collection(self, name: str) -> None:
+    async def create_collection(self, name: str, *, organization_id: UUID | None) -> None:
         """Make the collection's backing objects, refusing a name that cannot have any.
 
         The check is here as well as in `_table` because a subclass is free to
@@ -123,7 +123,7 @@ class BaseVectorStore(ABC):
                 :func:`app.db.vector_tables.validate_collection_name`.
         """
         validate_collection_name(name, metadata=Base.metadata)
-        await self._ensure_collection(name)
+        await self._ensure_collection(name, organization_id)
 
     def _build_chunk_metadata(
         self, chunk: "DocumentPageChunk", document: Document

--- a/backend/app/services/rag_document.py
+++ b/backend/app/services/rag_document.py
@@ -251,7 +251,7 @@ class RAGDocumentService:
         )
         doc_id = rag_doc.id
 
-        await vector_store.create_collection(collection_name)
+        await vector_store.create_collection(collection_name, organization_id=organization_id)
 
         await self._queue_parse(
             doc_id,

--- a/backend/app/services/rerank_resolution.py
+++ b/backend/app/services/rerank_resolution.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from enum import StrEnum
+from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -100,7 +101,9 @@ class ResolvedReranker:
         return f"ResolvedReranker(model={self.model!r}, api_key='***')"
 
 
-async def reranker_for_collection(collection_name: str) -> ResolvedReranker | None:
+async def reranker_for_collection(
+    collection_name: str, organization_id: UUID | None
+) -> ResolvedReranker | None:
     """Resolve one collection's reranker, or `None` if it has none.
 
     `None` for a collection no knowledge base claims, for one that named no
@@ -108,9 +111,14 @@ async def reranker_for_collection(collection_name: str) -> ResolvedReranker | No
     kind - the last three with a warning, because they are a misconfiguration
     rather than the off state. Opens its own session because retrieval reaches
     here from places with no request in sight: an agent mid-run, a direct search.
+
+    `organization_id` scopes the resolution: `collection_name` is not unique
+    across tenants, so resolving by name alone could read another organization's
+    rerank config and unseal its key (#913). The caller passes the organization
+    the search is acting for.
     """
     async with get_db_context() as db:
-        kb = await knowledge_base_repo.get_by_collection_name(db, collection_name)
+        kb = await knowledge_base_repo.get_for_collection(db, collection_name, organization_id)
         if kb is None:
             return None
         resolved, source = await _resolve_reranker(db, kb)

--- a/backend/app/worker/tasks/rag_tasks.py
+++ b/backend/app/worker/tasks/rag_tasks.py
@@ -82,8 +82,10 @@ def _announcing_resolver() -> EmbeddingResolver:
     """
     announced: set[str] = set()
 
-    async def resolve(collection_name: str) -> ResolvedEmbeddings | None:
-        resolved = await embeddings_for_collection(collection_name)
+    async def resolve(
+        collection_name: str, organization_id: UUID | None
+    ) -> ResolvedEmbeddings | None:
+        resolved = await embeddings_for_collection(collection_name, organization_id)
         if (
             resolved is not None
             and resolved.key_source.is_degraded
@@ -135,7 +137,9 @@ async def _ingestion_service_for(
         embedding_service=EmbeddingService(settings=rag_settings),
         resolver=_announcing_resolver(),
     )
-    return IngestionService(processor=processor, vector_store=vector_store)
+    return IngestionService(
+        processor=processor, vector_store=vector_store, organization_id=organization_id
+    )
 
 
 async def _record_embedding_spend(
@@ -191,11 +195,7 @@ async def _knowledge_base_for(
     """
     if collection_name is None:
         return None
-    candidates = await knowledge_base_repo.list_by_collection_name(db, collection_name)
-    for kb in candidates:
-        if organization_id is None or kb.organization_id == organization_id:
-            return kb
-    return next((kb for kb in candidates if kb.organization_id is None), None)
+    return await knowledge_base_repo.get_for_collection(db, collection_name, organization_id)
 
 
 async def _config_for_collection(

--- a/backend/tests/api/test_error_envelope.py
+++ b/backend/tests/api/test_error_envelope.py
@@ -495,7 +495,9 @@ class TestDetailsDescribeTheRefusalNotTheServer:
             ),
             pytest.raises(ExternalServiceError) as refusal,
         ):
-            await search_knowledge_base(query="our refund policy", kb_collection_names=["kb_ops"])
+            await search_knowledge_base(
+                query="our refund policy", kb_collection_names=["kb_ops"], organization_id=None
+            )
 
         response = await self._refusal_on_the_wire(client, refusal.value)
 
@@ -521,7 +523,9 @@ class TestDetailsDescribeTheRefusalNotTheServer:
             ),
             pytest.raises(ExternalServiceError) as refusal,
         ):
-            await search_knowledge_base(query="x", kb_collection_names=["kb_ops", "kb_hr"])
+            await search_knowledge_base(
+                query="x", kb_collection_names=["kb_ops", "kb_hr"], organization_id=None
+            )
 
         response = await self._refusal_on_the_wire(client, refusal.value)
 

--- a/backend/tests/integration/test_chunk_insert_batching.py
+++ b/backend/tests/integration/test_chunk_insert_batching.py
@@ -80,7 +80,7 @@ async def test_a_document_spanning_several_batches_writes_every_row(
     collection = f"batched_{uuid.uuid4().hex[:8]}"
     store = _store(engine)
 
-    await store.insert_document(collection, _document(chunks=250))
+    await store.insert_document(collection, _document(chunks=250), organization_id=None)
 
     assert await _count(engine, f"rag_{collection}") == 250
 
@@ -95,10 +95,10 @@ async def test_re_inserting_the_same_chunks_updates_rather_than_duplicates(
     store = _store(engine)
     document = _document(chunks=10)
 
-    await store.insert_document(collection, document)
+    await store.insert_document(collection, document, organization_id=None)
     for chunk in document.chunked_pages:
         chunk.chunk_content = f"revised {chunk.chunk_num}"
-    await store.insert_document(collection, document)
+    await store.insert_document(collection, document, organization_id=None)
 
     table = f"rag_{collection}"
     assert await _count(engine, table) == 10
@@ -120,7 +120,7 @@ async def test_the_chunks_are_readable_back_in_document_order(
     document = _document(chunks=8)
     parent = document.chunked_pages[0].parent_doc_id
 
-    await store.insert_document(collection, document)
+    await store.insert_document(collection, document, organization_id=None)
 
     chunks = await store.get_document_chunks(collection, parent)
     assert [chunk.content for chunk in chunks] == [f"chunk {index}" for index in range(8)]

--- a/backend/tests/integration/test_collection_name_tenant_isolation.py
+++ b/backend/tests/integration/test_collection_name_tenant_isolation.py
@@ -1,0 +1,119 @@
+"""Two organizations sharing a collection name each resolve their own config.
+
+`collection_name` is indexed but not unique, so two tenants can name a
+collection the same thing. Resolving one by name alone returned whichever row
+the database yielded first, which could unseal and bill another organization's
+key (#913). The resolvers now take the organization the search or ingest acts
+for; these run them against a real database with two tenants on one name and
+assert each gets its own embedding and rerank configuration - never the other's.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from pydantic import SecretStr
+
+from app.core.secret_kinds import ApiKeySecret, seal_secret
+from app.core.vault import VaultScope
+from app.db.models.knowledge_base import KBScope, KnowledgeBase
+from app.db.models.organization import Organization
+from app.db.models.organization_secret import OrganizationSecret
+from app.db.models.user import User
+from app.services.embedding_resolution import embeddings_for_collection
+from app.services.rerank_resolution import reranker_for_collection
+
+pytestmark = pytest.mark.anyio
+
+_SHARED = "shared_collection"
+
+
+async def _org(db, name: str) -> Organization:
+    founder = User(
+        id=uuid.uuid4(),
+        email=f"{uuid.uuid4().hex}@example.com",
+        hashed_password="x",
+        is_active=True,
+    )
+    db.add(founder)
+    await db.flush()
+    org = Organization(
+        id=uuid.uuid4(),
+        name=name,
+        slug=f"{name}-{uuid.uuid4().hex[:8]}",
+        created_by_user_id=founder.id,
+    )
+    db.add(org)
+    await db.flush()
+    return org
+
+
+async def _cohere_secret(db, org: Organization, key: str) -> OrganizationSecret:
+    sealed = seal_secret(
+        ApiKeySecret(api_key=SecretStr(key)), scope=VaultScope.organization(org.id)
+    )
+    secret = OrganizationSecret(
+        id=uuid.uuid4(),
+        organization_id=org.id,
+        name="cohere",
+        kind="api_key",
+        purpose="cohere",
+        sealed_secret=sealed.ciphertext,
+        hint=sealed.hint,
+        key_version=sealed.key_version,
+    )
+    db.add(secret)
+    await db.flush()
+    return secret
+
+
+async def _kb(db, org: Organization, *, embedding_model: str, rerank_key: str) -> None:
+    secret = await _cohere_secret(db, org, rerank_key)
+    db.add(
+        KnowledgeBase(
+            id=uuid.uuid4(),
+            name=f"{org.name} handbook",
+            scope=KBScope.ORG.value,
+            collection_name=_SHARED,
+            embedding_model=embedding_model,
+            embedding_dim=1536,
+            rerank_model="rerank-v3.5",
+            rerank_secret_id=secret.id,
+            organization_id=org.id,
+            ingestion_config={},
+        )
+    )
+    await db.flush()
+
+
+async def test_each_organization_resolves_its_own_embedding_and_rerank_config(db) -> None:
+    org_a = await _org(db, "acme")
+    org_b = await _org(db, "globex")
+    await _kb(db, org_a, embedding_model="model-a", rerank_key="cohere-key-a")
+    await _kb(db, org_b, embedding_model="model-b", rerank_key="cohere-key-b")
+    # The resolvers open their own session, so the rows must be committed to be
+    # visible to it.
+    await db.commit()
+
+    emb_a = await embeddings_for_collection(_SHARED, organization_id=org_a.id)
+    emb_b = await embeddings_for_collection(_SHARED, organization_id=org_b.id)
+    assert emb_a is not None and emb_a.model == "model-a"
+    assert emb_b is not None and emb_b.model == "model-b"
+
+    rer_a = await reranker_for_collection(_SHARED, organization_id=org_a.id)
+    rer_b = await reranker_for_collection(_SHARED, organization_id=org_b.id)
+    assert rer_a is not None and rer_a.api_key == "cohere-key-a"
+    assert rer_b is not None and rer_b.api_key == "cohere-key-b"
+
+
+async def test_an_organization_without_a_row_for_the_name_resolves_nothing(db) -> None:
+    """A third organization sharing neither row gets no config - not another
+    tenant's - so it can never unseal a key that is not its own (#913)."""
+    org_a = await _org(db, "acme")
+    await _kb(db, org_a, embedding_model="model-a", rerank_key="cohere-key-a")
+    stranger = await _org(db, "initech")
+    await db.commit()
+
+    assert await embeddings_for_collection(_SHARED, organization_id=stranger.id) is None
+    assert await reranker_for_collection(_SHARED, organization_id=stranger.id) is None

--- a/backend/tests/integration/test_platform_flows.py
+++ b/backend/tests/integration/test_platform_flows.py
@@ -1293,7 +1293,7 @@ class _AcceptingStore:
     def __init__(self) -> None:
         self.created: list[str] = []
 
-    async def create_collection(self, name: str) -> None:
+    async def create_collection(self, name: str, *, organization_id: object = None) -> None:
         self.created.append(name)
 
 

--- a/backend/tests/integration/test_vector_store_reserved_names.py
+++ b/backend/tests/integration/test_vector_store_reserved_names.py
@@ -30,7 +30,7 @@ _A_TRACKED_DOCUMENT = text(
 )
 
 
-async def _no_collection_of_its_own(name: str) -> None:
+async def _no_collection_of_its_own(name: str, organization_id: object = None) -> None:
     """A resolver that answers "nothing recorded for this one".
 
     Not `None` in place of the resolver: `resolver` is a required argument since
@@ -90,7 +90,7 @@ async def test_a_collection_beside_it_is_created_and_dropped_for_real(
     """
     store = _store_on(engine)
 
-    await store.create_collection("documents_archive")
+    await store.create_collection("documents_archive", organization_id=None)
 
     async with engine.connect() as connection:
         created = await connection.execute(

--- a/backend/tests/test_capability_edges.py
+++ b/backend/tests/test_capability_edges.py
@@ -71,7 +71,7 @@ class TestSearchingSeveralCollections:
 
         with pytest.raises(RuntimeError):
             await _retrieval_over(store).retrieve_multi(
-                query="anything", collection_names=["healthy", "broken"]
+                query="anything", collection_names=["healthy", "broken"], organization_id=None
             )
 
     @pytest.mark.anyio
@@ -83,7 +83,7 @@ class TestSearchingSeveralCollections:
         )
 
         results = await _retrieval_over(store).retrieve_multi(
-            query="anything", collection_names=["populated", "never_ingested"]
+            query="anything", collection_names=["populated", "never_ingested"], organization_id=None
         )
 
         assert [r.content for r in results] == ["found"]
@@ -100,7 +100,7 @@ class TestSearchingSeveralCollections:
         store.search = AsyncMock(return_value=[SearchResult(content="chunk", score=0.5)])
 
         results = await _retrieval_over(store).retrieve(
-            query="anything", collection_name="handbook"
+            query="anything", collection_name="handbook", organization_id=None
         )
 
         assert [r.metadata["collection"] for r in results] == ["handbook"]
@@ -110,7 +110,9 @@ class TestKnowledgeSearchGuards:
     @pytest.mark.anyio
     async def test_no_collections_says_so_rather_than_searching_everything(self):
         """The dangerous failure mode would be an unscoped search."""
-        result = await search_knowledge_base(query="x", kb_collection_names=[])
+        result = await search_knowledge_base(
+            query="x", kb_collection_names=[], organization_id=None
+        )
         assert "No active knowledge bases" in result
 
     @pytest.mark.anyio
@@ -121,7 +123,9 @@ class TestKnowledgeSearchGuards:
             "app.agents.capabilities.knowledge._search.get_retrieval_service",
             return_value=service,
         ):
-            await search_knowledge_base(query="x", kb_collection_names=["kb_a"])
+            await search_knowledge_base(
+                query="x", kb_collection_names=["kb_a"], organization_id=None
+            )
         service.retrieve.assert_awaited_once()
 
     @pytest.mark.anyio
@@ -132,7 +136,9 @@ class TestKnowledgeSearchGuards:
             "app.agents.capabilities.knowledge._search.get_retrieval_service",
             return_value=service,
         ):
-            await search_knowledge_base(query="x", kb_collection_names=["kb_a", "kb_b"])
+            await search_knowledge_base(
+                query="x", kb_collection_names=["kb_a", "kb_b"], organization_id=None
+            )
         service.retrieve_multi.assert_awaited_once()
 
     @pytest.mark.anyio
@@ -147,7 +153,9 @@ class TestKnowledgeSearchGuards:
             ),
             pytest.raises(ExternalServiceError),
         ):
-            await search_knowledge_base(query="x", kb_collection_names=["kb_a"])
+            await search_knowledge_base(
+                query="x", kb_collection_names=["kb_a"], organization_id=None
+            )
 
     @pytest.mark.anyio
     async def test_an_unconfigured_deployment_keeps_saying_what_to_configure(self):
@@ -171,7 +179,9 @@ class TestKnowledgeSearchGuards:
             ),
             pytest.raises(ConfigurationError) as refusal,
         ):
-            await search_knowledge_base(query="x", kb_collection_names=["kb_a"])
+            await search_knowledge_base(
+                query="x", kb_collection_names=["kb_a"], organization_id=None
+            )
 
         assert refusal.value.details == {"setting": "OPENROUTER_API_KEY"}
 
@@ -227,7 +237,7 @@ class TestEmbeddingCredential:
         # empty collection must not depend on the query succeeding.
         store.async_session = MagicMock(side_effect=AssertionError("should not query"))
 
-        info = asyncio.run(store.get_collection_info("never_ingested"))
+        info = asyncio.run(store.get_collection_info("never_ingested", organization_id=None))
 
         assert (info.name, info.total_vectors, info.dim) == ("never_ingested", 0, 1536)
 
@@ -248,7 +258,7 @@ class TestEmbeddingCredential:
         store._for_collection = AsyncMock(side_effect=AssertionError("should not embed"))
         store.async_session = MagicMock(side_effect=AssertionError("should not query"))
 
-        assert asyncio.run(store.search("never_ingested", "anything")) == []
+        assert asyncio.run(store.search("never_ingested", "anything", organization_id=None)) == []
 
     def test_the_service_builds_on_a_deployment_with_no_key(self, monkeypatch):
         """`get_embedding_service` is a FastAPI dependency of every RAG route.

--- a/backend/tests/test_chunk_insert_batching.py
+++ b/backend/tests/test_chunk_insert_batching.py
@@ -98,7 +98,7 @@ class TestHowManyStatementsOneDocumentCosts:
         monkeypatch.setattr(vectorstore_module, "_CHUNK_INSERT_BATCH", 100)
         session = RecordingSession()
 
-        await _store(session).insert_document("docs", _document(chunks=250))
+        await _store(session).insert_document("docs", _document(chunks=250), organization_id=None)
 
         assert len(session.calls) == 3
         assert [len(batch) for batch in session.calls] == [100, 100, 50]  # ty: ignore[invalid-argument-type]
@@ -109,7 +109,7 @@ class TestHowManyStatementsOneDocumentCosts:
         monkeypatch.setattr(vectorstore_module, "_CHUNK_INSERT_BATCH", 200)
         session = RecordingSession()
 
-        await _store(session).insert_document("docs", _document(chunks=7))
+        await _store(session).insert_document("docs", _document(chunks=7), organization_id=None)
 
         assert len(session.calls) == 1
         assert len(session.calls[0]) == 7  # ty: ignore[invalid-argument-type]
@@ -120,8 +120,8 @@ class TestHowManyStatementsOneDocumentCosts:
         monkeypatch.setattr(vectorstore_module, "_CHUNK_INSERT_BATCH", 500)
         small, large = RecordingSession(), RecordingSession()
 
-        await _store(small).insert_document("docs", _document(chunks=40))
-        await _store(large).insert_document("docs", _document(chunks=400))
+        await _store(small).insert_document("docs", _document(chunks=40), organization_id=None)
+        await _store(large).insert_document("docs", _document(chunks=400), organization_id=None)
 
         assert len(small.calls) == len(large.calls) == 1
 
@@ -131,7 +131,7 @@ class TestHowManyStatementsOneDocumentCosts:
         session = RecordingSession()
         document = _document(chunks=10)
 
-        await _store(session).insert_document("docs", document)
+        await _store(session).insert_document("docs", document, organization_id=None)
 
         written = [row["id"] for batch in session.calls for row in batch]  # ty: ignore[invalid-argument-type]
         assert written == [chunk.chunk_id for chunk in document.chunked_pages]
@@ -145,7 +145,7 @@ class TestHowManyStatementsOneDocumentCosts:
         for index, chunk in enumerate(document.chunked_pages):
             chunk.page_num = index + 1
 
-        await _store(session).insert_document("docs", document)
+        await _store(session).insert_document("docs", document, organization_id=None)
 
         rows = session.calls[0]
         assert [json.loads(row["metadata"])["page_num"] for row in rows] == [1, 2, 3, 4]  # ty: ignore[invalid-argument-type]
@@ -178,7 +178,7 @@ class TestHowManyStatementsOneDocumentCosts:
         seen: list[int] = []
         session.on_execute = lambda: seen.append(built)
 
-        await store.insert_document("docs", _document(chunks=30))
+        await store.insert_document("docs", _document(chunks=30), organization_id=None)
 
         assert seen == [10, 20, 30]
 
@@ -188,6 +188,6 @@ class TestHowManyStatementsOneDocumentCosts:
         session = RecordingSession()
 
         with pytest.raises(ValueError, match="no chunked pages"):
-            await _store(session).insert_document("docs", _document(chunks=0))
+            await _store(session).insert_document("docs", _document(chunks=0), organization_id=None)
 
         assert session.calls == []

--- a/backend/tests/test_collection_name_rules.py
+++ b/backend/tests/test_collection_name_rules.py
@@ -212,6 +212,6 @@ class TestTheStorePathsAgree:
         store = PgVectorStore.__new__(PgVectorStore)
 
         with pytest.raises(BadRequestError):
-            await store.create_collection(name)
+            await store.create_collection(name, organization_id=None)
         with pytest.raises(BadRequestError):
             await store.delete_collection(name)

--- a/backend/tests/test_embedding_resolution.py
+++ b/backend/tests/test_embedding_resolution.py
@@ -65,9 +65,9 @@ async def _resolve(kb, secret_row=None):
     ):
         db_ctx.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
         db_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
-        kbs.get_by_collection_name = AsyncMock(return_value=kb)
+        kbs.get_for_collection = AsyncMock(return_value=kb)
         secrets.get = AsyncMock(return_value=secret_row)
-        return await embeddings_for_collection("handbook"), secrets
+        return await embeddings_for_collection("handbook", organization_id=uuid.uuid4()), secrets
 
 
 class TestResolution:

--- a/backend/tests/test_ingestion_embedding_key.py
+++ b/backend/tests/test_ingestion_embedding_key.py
@@ -144,12 +144,12 @@ async def _the_flows_embedder(
 
         db_ctx.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
         db_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
-        bases.get_by_collection_name = AsyncMock(return_value=_knowledge_base(secret_id=secret_id))
+        bases.get_for_collection = AsyncMock(return_value=_knowledge_base(secret_id=secret_id))
         secrets.get = AsyncMock(return_value=vault_row)
         resolution_env.OPENROUTER_API_KEY = deployment_key
         embedding_env.OPENROUTER_API_KEY = deployment_key
 
-        embedder, dim = await (await _store())._for_collection("handbook")
+        embedder, dim = await (await _store())._for_collection("handbook", None)
         yield embedder, dim, openai
 
 
@@ -224,11 +224,13 @@ class TestTheCollectionsKeyPays:
                 model=_MODEL, dim=_DIM, api_key="", key_source=EmbeddingKeySource.DEPLOYMENT
             ),
         }
-        store._resolver = AsyncMock(side_effect=lambda name: resolutions[name])
+        store._resolver = AsyncMock(
+            side_effect=lambda name, organization_id=None: resolutions[name]
+        )
 
         origins = []
         for collection in resolutions:
-            embedder, _ = await store._for_collection(collection)
+            embedder, _ = await store._for_collection(collection, None)
             with pytest.raises(ConfigurationError) as refusal:
                 embedder.embed_query("anything")
             origins.append(refusal.value.details["key_origin"])
@@ -319,7 +321,7 @@ class TestWhatTheFlowLogSays:
             ),
             patch("app.worker.tasks.rag_tasks._say_in_flow_log") as said,
         ):
-            answer = await _announcing_resolver()("handbook")
+            answer = await _announcing_resolver()("handbook", None)
         return answer, said
 
     async def test_a_degraded_credential_is_announced_with_the_reason(self):
@@ -348,7 +350,7 @@ class TestWhatTheFlowLogSays:
             ),
             patch("app.worker.tasks.rag_tasks._say_in_flow_log") as said,
         ):
-            assert await _announcing_resolver()("unclaimed") is None
+            assert await _announcing_resolver()("unclaimed", None) is None
 
         said.assert_not_called()
 
@@ -366,13 +368,13 @@ class TestWhatTheFlowLogSays:
         with (
             patch(
                 "app.worker.tasks.rag_tasks.embeddings_for_collection",
-                new=AsyncMock(side_effect=lambda name: resolutions[name]),
+                new=AsyncMock(side_effect=lambda name, organization_id=None: resolutions[name]),
             ),
             patch("app.worker.tasks.rag_tasks._say_in_flow_log") as said,
         ):
             resolve = _announcing_resolver()
             for name in ("handbook", "handbook", "policies", "handbook"):
-                await resolve(name)
+                await resolve(name, None)
 
         assert [call.args[0].split("'")[1] for call in said.call_args_list] == [
             "handbook",
@@ -393,8 +395,8 @@ class TestWhatTheFlowLogSays:
             ),
             patch("app.worker.tasks.rag_tasks._say_in_flow_log") as said,
         ):
-            await _announcing_resolver()("handbook")
-            await _announcing_resolver()("handbook")
+            await _announcing_resolver()("handbook", None)
+            await _announcing_resolver()("handbook", None)
 
         assert said.call_count == 2
 

--- a/backend/tests/test_knowledge_base_repo.py
+++ b/backend/tests/test_knowledge_base_repo.py
@@ -1,0 +1,67 @@
+"""Resolving a collection name to the right organization's knowledge base.
+
+`collection_name` is not unique across tenants, so resolving one by name alone
+can return another organization's row - and then unseal and bill that
+organization's key (#913). `get_for_collection` narrows by organization in two
+passes: the caller's own row wins, and an `app`-scoped row (owned by no
+organization) is the shared fallback.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.repositories import knowledge_base as kb_repo
+
+pytestmark = pytest.mark.anyio
+
+
+def _kb(organization_id: uuid.UUID | None) -> MagicMock:
+    kb = MagicMock()
+    kb.organization_id = organization_id
+    return kb
+
+
+async def _resolve(candidates: list[MagicMock], organization_id: uuid.UUID | None) -> MagicMock:
+    with patch.object(kb_repo, "list_by_collection_name", new=AsyncMock(return_value=candidates)):
+        return await kb_repo.get_for_collection(MagicMock(), "shared", organization_id)
+
+
+async def test_a_shared_name_resolves_to_the_callers_own_organization() -> None:
+    org_a, org_b = uuid.uuid4(), uuid.uuid4()
+    a, b = _kb(org_a), _kb(org_b)
+
+    assert await _resolve([a, b], org_a) is a
+    assert await _resolve([a, b], org_b) is b
+
+
+async def test_an_organization_without_its_own_row_never_gets_anothers() -> None:
+    """The security property: org B resolving a name only org A holds gets
+    nothing, not org A's key."""
+    only_a = _kb(uuid.uuid4())
+
+    assert await _resolve([only_a], uuid.uuid4()) is None
+
+
+async def test_an_app_scoped_row_is_the_shared_fallback() -> None:
+    """A collection owned by no organization is matched on the second pass, so an
+    organization with no row of its own still resolves the deployment-wide one."""
+    app_kb = _kb(None)
+
+    assert await _resolve([app_kb], uuid.uuid4()) is app_kb
+
+
+async def test_an_organizations_own_row_wins_over_an_app_scoped_one() -> None:
+    org = uuid.uuid4()
+    app_kb, own = _kb(None), _kb(org)
+
+    assert await _resolve([app_kb, own], org) is own
+
+
+async def test_no_tenant_takes_the_first_candidate() -> None:
+    """`organization_id=None` is a CLI ingest with no tenant to scope to, where
+    the old name-only behaviour stands."""
+    first, second = _kb(uuid.uuid4()), _kb(uuid.uuid4())
+
+    assert await _resolve([first, second], None) is first

--- a/backend/tests/test_rag_chunk_count.py
+++ b/backend/tests/test_rag_chunk_count.py
@@ -57,6 +57,7 @@ def _service(processor: MagicMock) -> IngestionService:
     return IngestionService(
         processor=processor,
         vector_store=MagicMock(insert_document=AsyncMock(), delete_document=AsyncMock()),
+        organization_id=None,
     )
 
 

--- a/backend/tests/test_rag_document_lookup.py
+++ b/backend/tests/test_rag_document_lookup.py
@@ -42,7 +42,7 @@ pytestmark = pytest.mark.anyio
 
 def _service(docs: list[DocumentInfo]) -> IngestionService:
     store = MagicMock(get_documents=AsyncMock(return_value=docs))
-    return IngestionService(processor=MagicMock(), vector_store=store)
+    return IngestionService(processor=MagicMock(), vector_store=store, organization_id=None)
 
 
 def _doc(
@@ -131,7 +131,7 @@ class TestOnePrecedenceForBothAnswers:
         """A listing that cannot be read is not evidence the document is absent -
         but treating it as a match would delete one on a failed query."""
         store = MagicMock(get_documents=AsyncMock(side_effect=RuntimeError("connection refused")))
-        service = IngestionService(processor=MagicMock(), vector_store=store)
+        service = IngestionService(processor=MagicMock(), vector_store=store, organization_id=None)
 
         assert await service.existing_document("kb", "/srv/sync/handbook.pdf") == StoredDocument()
 
@@ -219,7 +219,7 @@ class TestHowManyTimesTheCollectionIsRead:
                 ]
             )
         )
-        service = IngestionService(processor=MagicMock(), vector_store=store)
+        service = IngestionService(processor=MagicMock(), vector_store=store, organization_id=None)
 
         existing = await service.existing_document("kb", "/srv/sync/handbook.pdf")
 
@@ -246,7 +246,7 @@ class TestHowManyTimesTheCollectionIsRead:
         ]
         document.metadata.content_hash = "hash-a"
         processor = MagicMock(process_file=AsyncMock(return_value=document))
-        service = IngestionService(processor=processor, vector_store=store)
+        service = IngestionService(processor=processor, vector_store=store, organization_id=None)
 
         result = await service.ingest_file(
             filepath=Path("handbook.pdf"),
@@ -294,7 +294,9 @@ class TestReplacingADocument:
         ]
         document.metadata.content_hash = "hash-new"
         processor = MagicMock(process_file=AsyncMock(return_value=document))
-        return store, IngestionService(processor=processor, vector_store=store)
+        return store, IngestionService(
+            processor=processor, vector_store=store, organization_id=None
+        )
 
     async def test_a_failed_embedding_leaves_the_old_document_in_place(self):
         store, service = self._replacing(AsyncMock(side_effect=RuntimeError("provider refused")))

--- a/backend/tests/test_rag_failure_messages.py
+++ b/backend/tests/test_rag_failure_messages.py
@@ -148,7 +148,7 @@ class TestTheIngestionServiceMovesItToTheLog:
     def _service(*, parse: AsyncMock, insert: AsyncMock) -> IngestionService:
         processor = MagicMock(process_file=parse)
         store = MagicMock(insert_document=insert)
-        return IngestionService(processor=processor, vector_store=store)
+        return IngestionService(processor=processor, vector_store=store, organization_id=None)
 
     @staticmethod
     def _document() -> MagicMock:

--- a/backend/tests/test_rerank_resolution.py
+++ b/backend/tests/test_rerank_resolution.py
@@ -70,9 +70,9 @@ async def _resolve(kb, secret_row=None):
     ):
         db_ctx.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
         db_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
-        kbs.get_by_collection_name = AsyncMock(return_value=kb)
+        kbs.get_for_collection = AsyncMock(return_value=kb)
         secrets.get = AsyncMock(return_value=secret_row)
-        return await reranker_for_collection("handbook"), secrets
+        return await reranker_for_collection("handbook", organization_id=uuid.uuid4()), secrets
 
 
 class TestResolution:

--- a/backend/tests/test_reranker.py
+++ b/backend/tests/test_reranker.py
@@ -191,14 +191,14 @@ class TestBuildReranker:
             "app.services.rag.reranker.reranker_for_collection",
             new=AsyncMock(return_value=None),
         ):
-            assert await build_reranker("handbook") is None
+            assert await build_reranker("handbook", None) is None
 
     async def test_a_configured_collection_gets_a_cohere_reranker(self):
         with patch(
             "app.services.rag.reranker.reranker_for_collection",
             new=AsyncMock(return_value=ResolvedReranker(model="rerank-v3.5", api_key="co-key")),
         ):
-            reranker = await build_reranker("handbook")
+            reranker = await build_reranker("handbook", None)
         assert isinstance(reranker, CohereReranker)
         assert reranker.model == "rerank-v3.5"
 

--- a/backend/tests/test_reserved_collection_names.py
+++ b/backend/tests/test_reserved_collection_names.py
@@ -126,7 +126,7 @@ async def test_creating_a_collection_named_after_a_model_table_is_refused() -> N
     store, executed = _store()
 
     with pytest.raises(BadRequestError) as refused:
-        await store.create_collection("documents")
+        await store.create_collection("documents", organization_id=None)
 
     assert refused.value.details == {"collection": "documents", "table": "rag_documents"}
     assert executed == []

--- a/backend/tests/test_retrieval_reranking.py
+++ b/backend/tests/test_retrieval_reranking.py
@@ -62,7 +62,7 @@ def _service_by_name(store: MagicMock, mapping: dict[str, BaseReranker | None]) 
     settings = MagicMock()
     settings.enable_hybrid_search = False
 
-    async def resolver(name: str) -> BaseReranker | None:
+    async def resolver(name: str, organization_id: object = None) -> BaseReranker | None:
         return mapping.get(name)
 
     return RetrievalService(vector_store=store, settings=settings, reranker_resolver=resolver)
@@ -75,22 +75,28 @@ def _hits(*names: str) -> list[SearchResult]:
 class TestSingleCollection:
     async def test_a_configured_collection_returns_the_reranked_order(self):
         store = _store_returning(_hits("a", "b", "c"))
-        results = await _service(store, _ReverseReranker()).retrieve("q", "kb", limit=3)
+        results = await _service(store, _ReverseReranker()).retrieve(
+            "q", "kb", limit=3, organization_id=None
+        )
         assert [r.content for r in results] == ["c", "b", "a"]
 
     async def test_it_truncates_to_the_limit_after_reranking(self):
         store = _store_returning(_hits("a", "b", "c", "d"))
-        results = await _service(store, _ReverseReranker()).retrieve("q", "kb", limit=2)
+        results = await _service(store, _ReverseReranker()).retrieve(
+            "q", "kb", limit=2, organization_id=None
+        )
         assert [r.content for r in results] == ["d", "c"]
 
     async def test_without_a_reranker_the_order_is_left_as_the_store_gave_it(self):
         store = _store_returning(_hits("a", "b", "c"))
-        results = await _service(store, None).retrieve("q", "kb", limit=3)
+        results = await _service(store, None).retrieve("q", "kb", limit=3, organization_id=None)
         assert [r.content for r in results] == ["a", "b", "c"]
 
     async def test_a_reranker_failure_falls_back_to_the_distance_order(self):
         store = _store_returning(_hits("a", "b", "c"))
-        results = await _service(store, _FailingReranker()).retrieve("q", "kb", limit=2)
+        results = await _service(store, _FailingReranker()).retrieve(
+            "q", "kb", limit=2, organization_id=None
+        )
         assert [r.content for r in results] == ["a", "b"]
 
 
@@ -99,13 +105,15 @@ class TestMultiCollection:
         store = _store_returning(_hits("a", "b"))
         reranker = _ReverseReranker()
         await _service(store, reranker).retrieve_multi(
-            "q", collection_names=["kb_a", "kb_b"], limit=3
+            "q", collection_names=["kb_a", "kb_b"], limit=3, organization_id=None
         )
         assert reranker.calls == 1
 
     async def test_the_collection_stamp_survives_reranking(self):
         store = _store_returning(_hits("a"))
-        results = await _service(store, _ReverseReranker()).retrieve("q", "handbook", limit=1)
+        results = await _service(store, _ReverseReranker()).retrieve(
+            "q", "handbook", limit=1, organization_id=None
+        )
         assert results[0].metadata["collection"] == "handbook"
 
 
@@ -121,7 +129,9 @@ class TestMixedRerankConfig:
         store = _store_returning(_hits("a", "b"))
         r1, r2 = _ReverseReranker(), _ReverseReranker()
         svc = _service_by_name(store, {"kb_a": r1, "kb_b": r2})
-        await svc.retrieve_multi("q", collection_names=["kb_a", "kb_b"], limit=3)
+        await svc.retrieve_multi(
+            "q", collection_names=["kb_a", "kb_b"], limit=3, organization_id=None
+        )
         assert r1.calls == 0
         assert r2.calls == 0
 
@@ -129,7 +139,9 @@ class TestMixedRerankConfig:
         store = _store_returning(_hits("a", "b"))
         r = _ReverseReranker()
         svc = _service_by_name(store, {"kb_a": r, "kb_b": None})
-        await svc.retrieve_multi("q", collection_names=["kb_a", "kb_b"], limit=3)
+        await svc.retrieve_multi(
+            "q", collection_names=["kb_a", "kb_b"], limit=3, organization_id=None
+        )
         assert r.calls == 0
 
 

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -428,6 +428,15 @@ the one caller that never asked the resolver at all, so every uploaded document
 was embedded with the deployment's model and key whatever its collection had
 chosen.
 
+Both resolvers take the organization the ingest or search acts for, because the
+vector namespace is deployment-global and a collection name is not unique across
+tenants — two organizations may hold one name. Resolving by name alone returned
+whichever row the database yielded first, so a shared name could embed or rerank
+on another tenant's model and unseal its key. `get_for_collection` narrows the
+candidates to the caller's own row, falling back to a deployment-wide
+(`app`-scoped) collection and, only for a CLI ingest with no tenant, to the name
+alone.
+
 ### Reranking — a second pass, off unless configured
 
 Vector search orders results by embedding distance, which is a proxy for


### PR DESCRIPTION
## What

`knowledge_bases.collection_name` is indexed but **not unique** across tenants, so two
organizations can name a collection the same thing. The per-collection embedding and
rerank resolvers looked a knowledge base up by name alone
(`get_by_collection_name(...).first()`), so on a shared name a caller could resolve
another tenant's `embedding_model`/`rerank_model` and **unseal and bill its vault key** —
a cross-tenant credential leak (#913).

This is the store/retrieval/ingest counterpart to the route-level isolation
`CollectionAccessService` already enforces; the two resolution paths are separate, and
only the route one was tenant-aware.

## How (Option 1 — thread the acting tenant, no uniqueness migration)

- New `knowledge_base_repo.get_for_collection(db, name, organization_id)` — two passes:
  the caller's own row wins; an `app`-scoped collection (owned by no organization) is the
  shared fallback. `organization_id=None` (a CLI ingest, no tenant) keeps the old
  name-only behaviour for that path alone.
- `embeddings_for_collection` / `reranker_for_collection` take the acting organization and
  resolve through it. Identity threaded through every caller: `build_reranker`,
  `PgVectorStore` (`insert_document`/`search`/`get_collection_info`/`_for_collection`/
  `_ensure_collection`), `RetrievalService` (`retrieve`/`retrieve_multi`/`_recall`/
  `_bm25_search`), `IngestionService`, the knowledge capability + toolset,
  `KnowledgeSearchService`, the `/rag` routes, the ingestion DI factory and the worker
  ingest flow.
- `organization_id` is **positional** on the two resolvers so the injected
  `EmbeddingResolver`/`RerankerResolver` protocols still match without rewiring, and
  keyword-only on the store/retrieval methods that already had positional args.

## Verification

- Unit suite green (5726 passed, 0 failed).
- New integration test (`test_collection_name_tenant_isolation.py`) runs **two tenants
  sharing one collection name against a real database**: each resolves its own embedding
  model and rerank key, and a third organization resolves neither.
- Both gated resolver modules (`embedding_resolution`, `rerank_resolution`) stay at 100%.
- `make lint-backend` exit 0, ty 0 errors.
- `docs/file-processing.md` gains the tenant-scoping guarantee beside the per-collection
  resolution it already documents; docs-drift clean.

Based off `feat/rag-reranker` (#911), which carries both resolvers — retarget to `main`
on merge.

Closes #913
