### PR TITLE
chore: cut 0.0.236

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,30 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.236] - 2026-08-21
+
+PII is redacted where records are actually emitted.
+
+### Fixed
+
+- **`PiiRedactionFilter` was attached to the root logger, where it scrubbed nothing
+  the application logs.** A filter on a logger runs only in `Logger.handle`, for a
+  record logged on that logger; a record from `logging.getLogger(__name__)` - which
+  is every log line in this codebase - propagates to its ancestors' **handlers**
+  through `Logger.callHandlers` and never touches their filters. Email addresses,
+  JWTs, `sk-` keys and bearer tokens reached Datadog, CloudWatch and Logfire
+  verbatim: the redaction a deployment believed stood between its logs and its
+  aggregator had never been there. The filter is attached to the root logger's
+  handlers now. (#440)
+- **`logging.lastResort` carries the filter too**, because that is what emits
+  `WARNING` and above in a process that configured no handler - the CLI, a flow
+  subprocess before logging is set up - and a credential in a `logger.exception` is
+  exactly such a record. (#440)
+- **The worker never called `setup_logging` at all.** The process that runs
+  ingestion, syncs and reports - a wrong embedding key, an SMTP failure, a connector
+  401 - redacted nothing even in theory. `setup_logging` is idempotent now and is
+  called by the worker (`prefect_app.main`) and the CLI (`cli.commands.main`) as well
+  as the API. (#440)
 ## [0.0.235] - 2026-08-21
 
 The auth surface is rate-limited, and bcrypt is off the event loop.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.235"
+version = "0.0.236"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.235"
+version = "0.0.236"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.235",
+  "version": "0.0.236",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.236. Bumps `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json` to 0.0.236 and adds the CHANGELOG entry.

Releases #1029: the PII redaction filter sat on the root logger, which is the one
place it could not run. Filters fire in `Logger.handle` for a record logged on that
logger; every line in this codebase is logged on a module logger and reaches the root
through `callHandlers`, which consults handlers and not their owner's filters. So
addresses, JWTs and API keys went to the aggregator in the clear while the deployment
believed otherwise - and the worker, the process with the most credential-shaped
exceptions in it, never configured logging at all.

## Verified

CI green end to end on #1029: a record logged through a module logger comes out
redacted at the handler, which is the case the old placement missed and which fails
against the old code; `lastResort` carries the filter, so an unconfigured process
still redacts; the filter is not doubled on a second call. Full backend suite 5681
passed, `make lint` clean.

Refs #440
