### PR TITLE
chore: cut 0.0.237

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,34 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.237] - 2026-08-21
+
+Two chat controls that did nothing are gone.
+
+### Removed
+
+- **The temperature slider and the thinking-effort picker in the chat Settings tab.**
+  Both were sent on every turn and read by nothing: `agent_session` reads
+  `model_profile_id` and the environment off the frame and no other key, and
+  `thinking_effort` appears nowhere in the backend at all. Whatever the person chose,
+  the run used the agent's spec. Worse than doing nothing, the controls said they did
+  something - `chat-controls`' own docstring claimed "both are recorded on the run, so
+  an override stays attributable", and neither was, because neither arrived. The same
+  class as #29 and #561: a stated contract the code does not keep, and a control that
+  lies is worse than one that is absent. (#924)
+- The Settings tab was those two controls, so it goes with them - leaving the model
+  picker, which works and no longer needs tabs - along with the `use-chat` refs,
+  setters and send-frame lines behind them, and the orphaned `chat.controls.*` keys
+  (and a stray `chat.settingsPersistCurrentChat` their removal orphaned). The
+  docstring now says what is true. (#924)
+
+### Changed
+
+- Thinking effort stays a **capability binding** rather than a model setting
+  (`spec.py`), so overriding it per turn is a larger design than a slider: it is not
+  being quietly dropped, it never worked, and wiring it is its own issue. Temperature
+  is genuinely a model setting and the easy half, but half-wiring one while deleting
+  the other leaves the same one-control-in-a-tab shape. (#924)
 ## [0.0.236] - 2026-08-21
 
 PII is redacted where records are actually emitted.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.236"
+version = "0.0.237"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.236"
+version = "0.0.237"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.236",
+  "version": "0.0.237",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.237. Bumps `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json` to 0.0.237 and adds the CHANGELOG entry.

Releases #1030: the chat Settings tab offered a temperature slider and a
thinking-effort picker that were sent every turn and read by nothing, under a
docstring claiming both were recorded on the run. Per the issue's and the reviewer's
recommendation they are deleted rather than half-wired - thinking effort is a
capability binding and wiring it is its own design, and fixing only temperature would
leave the same one-control-in-a-tab shape.

## Verified

CI green end to end on #1030: `use-chat` sends only `model_profile_id` and the model
override still works end to end; the chat-controls tests are trimmed to the override
that exists (name, back-to-agent, saved and unsaved, rotated-away profile) and the
model picker's own tests are untouched; the `/settings` slash command still opens the
popover. `make lint-frontend` clean, frontend coverage gate green.

Refs #924
