### PR TITLE
chore: cut 0.0.238

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,33 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.238] - 2026-08-21
+
+A stored file is served as what it is, or not served inline at all.
+
+### Fixed
+
+- **Stored XSS through an avatar or a chat attachment.** The bytes behind both were
+  served with a type the backend took from the *name on disk*, while the upload paths
+  validated the `Content-Type` the client *declared* and never the bytes, keeping
+  whatever extension the uploader chose. So `x.html` whose bytes are `<script>…`,
+  declared as `image/png`, was accepted, stored as `<hex>_x.html`, guessed back as
+  `text/html`, and passed through the frontend proxy from the app's own origin -
+  where the CSP allows `'unsafe-inline'`. `X-Content-Type-Options: nosniff` does not
+  help, because the type is declared rather than sniffed. The same shape #634 fixed
+  for the hosted-page logo; these three require a session, so the audience is the
+  organization. (#702)
+- **Pinned at both ends.** The frontend proxies share their allowlists in
+  `src/lib/proxy-content-type.ts`: both avatar proxies refuse anything outside the
+  four image types with a 502 and drop the `image/jpeg` default over unknown bytes,
+  and the file proxy - which serves PDFs and spreadsheets on purpose - forces a
+  download for anything outside the render-safe set, so `text/html` and SVG are saved
+  rather than shown. `nosniff` on all three. (#702)
+- **And at the backend routes.** `image_media_type_for` lives beside `IMAGE_MIME_TYPES`
+  in `file_storage`: the user and organization avatar routes guess the type, 404 a
+  non-image and pass it explicitly with `nosniff`, and the chat-file route serves a
+  render-safe type inline and forces everything else to download - the declared
+  `mime_type` is not trusted to decide rendering. (#702)
 ## [0.0.237] - 2026-08-21
 
 Two chat controls that did nothing are gone.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.237"
+version = "0.0.238"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.237"
+version = "0.0.238"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.237",
+  "version": "0.0.238",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.238. Bumps `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json` to 0.0.238 and adds the CHANGELOG entry.

Releases #1034: an avatar or a chat attachment was served with a type guessed from
the name on disk, and the name on disk is whatever the uploader chose - the upload
paths validate the declared `Content-Type` and never the bytes. An `.html` file
declared as `image/png` came back as `text/html` from the app's own origin, where the
CSP allows inline script. `nosniff` is no defence against a type that is declared
rather than sniffed, so the type is pinned at both ends: the proxies refuse or force
a download, and the serving routes 404 a non-image avatar and send everything
non-render-safe as an attachment.

`docs/channels.md` already stated this principle, and named "an avatar uploaded years
ago through another route" while doing so; this makes the claim true, so no page
change is owed.

## Verified

CI green end to end on #1034: the frontend table drives `text/html`,
`image/svg+xml`, `application/xhtml+xml` and unnamed bytes to a 502 on each avatar
route and to a download on the file route, with images pinned and nosniffed and PDF
still inline; the backend refuses `.html`, `.svg`, `.xhtml` and a suffixless file,
404s a stored `.html` on each avatar route, downloads a `text/html` attachment and
leaves a PDF inline. Full backend suite 5693 passed with `_chat_file_bytes` gated at
100%, frontend coverage gate green, `make lint` clean.

The agent-avatar GET has the same defect and is out of scope here; it is filed as
#1035 and released next.

Refs #702
