### PR TITLE
chore: cut 0.0.239

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,34 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.239] - 2026-08-21
+
+A multi-column row is sealed under one key version.
+
+### Fixed
+
+- **"A row has several ciphertext columns sharing one `key_version`" was hand-rolled
+  at several models, each differently, and the vault offered no primitive for it.**
+  The failures are latent - `rewrap`, master-key rotation, has no production caller
+  yet - but the day it runs, a rotated `jwt` widget can never be opened again and a
+  channel bot's row disagrees with its own envelopes. `vault.seal_fields(values, *,
+  scope, key_version)` seals every field at one version and hands that version back
+  to store, so "seal at v2 but record v1" and "no version column at all" cannot be
+  written by hand. (#552)
+- **`agent_embed` had no `key_version` column**, and `_verify_token` unsealed at an
+  implicit v1 - so a rotated widget would answer `EmbedDenied` to every visitor. It
+  gains `secret_key_version` (the migration backfills existing rows to 1), seals
+  through `seal_fields` and unseals at the row's own version. `docs/secrets.md` now
+  lists the embed among the sealed rows. (#552)
+- **`channel_bot`'s `update` re-sealed a changed token at the default v1 and reset the
+  column** while its siblings kept the rotated version, leaving the row's version
+  disagreeing with its envelopes (AUD-008). It seals at the row's existing version,
+  beside its siblings, and never resets the column. (#552)
+- Left alone deliberately: `mcp_connection` already seals one field per write at the
+  row's `secret_key_version`, and `organization_secret` stores its ciphertext, hint
+  and version through the typed `secret_kinds` wrappers. Both already record one
+  version per row, so routing them through the multi-field helper would be churn
+  rather than a fix. (#552)
 ## [0.0.238] - 2026-08-21
 
 A stored file is served as what it is, or not served inline at all.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.238"
+version = "0.0.239"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.238"
+version = "0.0.239"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.238",
+  "version": "0.0.239",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.239. Bumps `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json` to 0.0.239 and adds the CHANGELOG entry.

Releases #1037: sealing several columns of one row under one key version was
hand-rolled at each model that needed it, and the vault had no primitive to hand them.
`seal_fields` is that primitive, and it makes the two shapes that were wrong
unwritable: `agent_embed`, which had no version column and unsealed at an implicit v1,
and `channel_bot`'s update, which re-sealed at the default and reset the column its
siblings still used. Both are latent until `rewrap` gets a production caller, which is
the reason to fix them before it does.

## Verified

CI green end to end on #1037: `seal_fields` round-trips, skips empty fields and
rewraps a whole row together; an embed secret sealed at v1 and rewrapped to v2 still
verifies a visitor token, which is the round trip that fails against the old implicit
read; a channel-bot token update on a v2 bot keeps v2. The migration cycles up, down
and up cleanly with `alembic check` reporting no drift. Full backend suite 5683
passed, `vault.py` gated at 100%, `make lint` clean.

Refs #552
