### PR TITLE
chore: cut 0.0.241

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,39 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.241] - 2026-08-21
+
+An impersonated action names who was really acting.
+
+### Fixed
+
+- **`POST /admin/users/{id}/impersonate` minted an access token whose `sub` is the
+  target account**, so every request made with it - every row written, every audit
+  entry triggered - was attributed to the target and to nobody else. An admin who
+  read a customer's conversation and one who deleted their agent left the same trace:
+  the customer's own. "Who accessed my account" had no answer. (#943)
+
+### Added
+
+- **An `act` claim.** `create_access_token(..., act=...)` carries the administrator
+  behind the subject, and the impersonate route sets it. It is absent on every
+  ordinary token, so those are byte for byte unchanged. (#943)
+- **A request-scoped audit context.** The auth dependency, over HTTP and WebSocket
+  alike, reads `act` onto a context variable - the actor behind a request is a
+  property of the request rather than something to thread through every service that
+  records an action. `record_audit` writes it as `impersonator_user_id` beside the
+  actor, `0044_audit_impersonator` adds the nullable column and its index, and the
+  audit read schema and service expose it. Null on an ordinary request, and nothing
+  is backfilled: whether a past action was impersonated is unknowable after the fact.
+  `docs/governance.md` says what an impersonated action records. (#943)
+
+### Changed
+
+- Deliberately not the whole of #943. A raw token still reaches the clipboard, and an
+  impersonation session is still neither revocable nor endable in product - those two
+  are one larger full-stack flow, with a banner, an End button and revocation, filed
+  as a follow-up. #943 stays open for it, along with the policy question of whether
+  the target is notified. (#943)
 ## [0.0.240] - 2026-08-21
 
 An answered `ask_user` question survives the conversation.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.240"
+version = "0.0.241"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.240"
+version = "0.0.241"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.240",
+  "version": "0.0.241",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.241. Bumps `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json` to 0.0.241 and adds the CHANGELOG entry.

Releases #1043, the actor-attribution half of #943 and the issue's own cheapest and
most important piece: an impersonation token's `sub` is the target, so the audit trail
of an admin acting as a customer was indistinguishable from the customer acting
themselves. An `act` claim carries the administrator, the auth dependency puts it on a
request-scoped context rather than threading it through every service, and
`record_audit` writes it beside the actor.

The rest of #943 - no raw token on the clipboard, and a revocable session that can be
ended - is one full-stack flow and is filed separately; #943 stays open for it.

## Verified

CI green end to end on #1043: the claim survives from a minted token through the auth
context into the entry; an ordinary action and an admin acting as themselves record no
impersonator; the read service reports it. Migration up, down and up clean with
`alembic check` finding no drift. Full backend suite 5688 passed; `make lint-backend`
and `make docs-build` green.

Refs #943
