### PR TITLE
fix(alembic): put the audit migration after the embed one, not beside it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ An impersonated action names who was really acting.
   alike, reads `act` onto a context variable - the actor behind a request is a
   property of the request rather than something to thread through every service that
   records an action. `record_audit` writes it as `impersonator_user_id` beside the
-  actor, `0044_audit_impersonator` adds the nullable column and its index, and the
+  actor, `0045_audit_impersonator` adds the nullable column and its index, and the
   audit read schema and service expose it. Null on an ordinary request, and nothing
   is backfilled: whether a past action was impersonated is unknowable after the fact.
   `docs/governance.md` says what an impersonated action records. (#943)

--- a/backend/alembic/versions/0045_audit_impersonator.py
+++ b/backend/alembic/versions/0045_audit_impersonator.py
@@ -12,8 +12,8 @@ acting as anybody else, and nothing is backfilled - there is no way to know afte
 the fact whether a past action was impersonated, and guessing one would be a
 false accusation rather than a missing one.
 
-Revision ID: 0044_audit_impersonator
-Revises: 0043_rag_document_source_path
+Revision ID: 0045_audit_impersonator
+Revises: 0044_agent_embed_key_version
 Create Date: 2026-08-20
 
 """
@@ -24,8 +24,8 @@ import sqlalchemy as sa
 
 from alembic import op
 
-revision: str = "0044_audit_impersonator"
-down_revision: str | None = "0043_rag_document_source_path"
+revision: str = "0045_audit_impersonator"
+down_revision: str | None = "0044_agent_embed_key_version"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/tests/test_migration_chain.py
+++ b/backend/tests/test_migration_chain.py
@@ -1,0 +1,62 @@
+"""The migration chain has one head, and this test needs no database to say so.
+
+Two branches each wrote a migration against a `main` that ended at `0043`, each
+was green, and neither could see the other: `0044_agent_embed_key_version` (#552)
+and `0044_audit_impersonator` (#943) both pointed at `0043_rag_document_source_path`.
+Merged one after the other they made two heads, and `alembic upgrade head` answers
+`Multiple head revisions are present` and exits 255 - so no deployment could
+upgrade, and four cases in `tests/test_migrations.py` failed at once (#1059).
+
+Nothing on either pull request could have caught it. The required checks ran
+against a `main` holding only one of the two, and `make db-check` is
+`alembic check`, which compares the models to the chain's head and says nothing
+about how many heads there are.
+
+So the guard lives here rather than in `tests/test_migrations.py`: that module
+skips on a laptop with no Postgres, and a divergence is created by a merge on
+somebody's machine long before CI's database ever sees it. `ScriptDirectory`
+reads the files, and the files are the whole of the question.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+
+def _chain() -> ScriptDirectory:
+    root = Path(__file__).resolve().parent.parent
+    config = Config(str(root / "alembic.ini"))
+    config.set_main_option("script_location", str(root / "alembic"))
+    return ScriptDirectory.from_config(config)
+
+
+def test_the_chain_has_exactly_one_head() -> None:
+    heads = _chain().get_heads()
+    assert len(heads) == 1, (
+        f"{len(heads)} alembic heads: {', '.join(sorted(heads))}. Two migrations "
+        "written against the same parent were merged one after the other; point "
+        "the later one's down_revision at the earlier one."
+    )
+
+
+def test_no_two_migrations_claim_the_same_parent() -> None:
+    """The same defect one step earlier, and it names both files.
+
+    One head is what breaks the upgrade, so the test above is the one that
+    matters. This one fails on the fork itself rather than on its consequence,
+    which is the difference between a message naming the two revisions that
+    collided and one naming the two heads they produced.
+    """
+    parents: dict[str, list[str]] = {}
+    for revision in _chain().walk_revisions():
+        down = revision.down_revision
+        if down is None:
+            continue
+        for parent in (down,) if isinstance(down, str) else down:
+            parents.setdefault(parent, []).append(revision.revision)
+
+    forked = {parent: sorted(children) for parent, children in parents.items() if len(children) > 1}
+    assert not forked, f"revisions sharing a parent: {forked}"


### PR DESCRIPTION
`main` has two alembic heads, so `alembic upgrade head` exits 255, four cases in
`tests/test_migrations.py` fail, and no deployment can move off 0.0.238.

## What happened

`0044_agent_embed_key_version` (#1037, released in 0.0.239) and
`0044_audit_impersonator` (#1043, released in 0.0.241) both carry
`down_revision = "0043_rag_document_source_path"`. Each was written against a `main`
that ended at `0043`, each was green on its own branch, and neither branch could see
the other - the fork exists only in the merged history, and it was the merge order
that made it.

Nothing on either pull request could have caught it: the required checks ran against a
`main` holding one of the two, and `make db-check` is `alembic check`, which compares
the models to the chain's head and says nothing about how many heads there are.

## Fix

The audit migration becomes `0045_audit_impersonator` and points at
`0044_agent_embed_key_version`. Renaming the revision id is safe here because no
deployment has run either one.

## The guard

`backend/tests/test_migration_chain.py` asserts the chain has exactly one head, and
that no two revisions claim the same parent - the same defect one step earlier, where
the message can name the two files that collided rather than the two heads they
produced.

It is a new module rather than a case in `tests/test_migrations.py`, and both halves
of that placement are deliberate: that module skips where no Postgres answers, and a
divergence is created by a merge on somebody's laptop long before CI's database sees
it. `ScriptDirectory` reads the files, and the files are the whole of the question.

## Verified

`uv run alembic heads` names one revision. Both new tests fail with the
`down_revision` put back to `0043` and pass with it - checked rather than assumed.
`make lint-backend` clean.

Closes #1059

## One review finding, not taken

The automated reviewer asked for a merge revision instead of the rename, to preserve
`0044_audit_impersonator` for a deployment that already recorded it. The reasoning is
right and the premise is not: 0.0.241 was tagged forty minutes before this branch and
shipped with two heads, so `alembic upgrade head` - what every documented upgrade path
here runs - exits 255 against it. Recording that revision takes an operator who hit
that error and chose `upgrade heads` inside a forty-minute window, on a project with
no production installs. A merge revision is permanent and records a fork that existed
for one afternoon; every later reader of the chain pays for it. If such a database
turns up it is one command, `alembic stamp 0045_audit_impersonator`, because the two
scripts do the same thing to the same table.
