### PR TITLE
chore: cut 0.0.242

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,30 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.242] - 2026-08-21
+
+The migration chain has one head again.
+
+### Fixed
+
+- **`main` had two alembic heads, so `alembic upgrade head` exited 255 and no
+  deployment could move off 0.0.238.** `0044_agent_embed_key_version` (0.0.239) and
+  `0044_audit_impersonator` (0.0.241) both carried
+  `down_revision = "0043_rag_document_source_path"`: each was written against a `main`
+  that ended at `0043`, each was green on its own branch, and the fork existed only in
+  the merged history. The audit migration is `0045_audit_impersonator` now and points
+  at the embed one. (#1059)
+
+### Added
+
+- **A guard that needs no database.** `backend/tests/test_migration_chain.py` asserts
+  the chain has exactly one head, and that no two revisions claim the same parent -
+  the same defect one step earlier, where the message names the two files that
+  collided rather than the two heads they produced. It is a module of its own rather
+  than a case in `tests/test_migrations.py`, because that one skips where no Postgres
+  answers and a divergence is made by a merge on a laptop hours before CI's database
+  sees it. `make db-check` is `alembic check`, which compares the models to the head
+  and never counts them. (#1059)
 ## [0.0.241] - 2026-08-21
 
 An impersonated action names who was really acting.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.241"
+version = "0.0.242"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.241"
+version = "0.0.242"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.241",
+  "version": "0.0.242",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.242. Bumps `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json` to 0.0.242 and adds the CHANGELOG entry.

Releases #1060: two migrations written against the same parent were merged one after
the other, so `main` carried two alembic heads and no deployment could upgrade past
0.0.238. Neither branch was at fault and neither pull request could have caught it -
the required checks each ran against a `main` holding one of the two. The audit
migration moves onto the embed one, and a database-free test now counts the heads,
which is the question `alembic check` does not ask.

## Verified

CI green end to end on #1060, the `test` job included - the four `TestMigrations`
cases that were failing on `main` pass again. Both new tests fail with the
`down_revision` put back to `0043`, which was checked rather than assumed.

Refs #1059
