### PR TITLE
chore: cut 0.0.243

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.243] - 2026-08-21
+
+The agent avatar is served as an image or not at all.
+
+### Fixed
+
+- **`GET /api/v1/agents/{agent_id}/avatar` guessed its content-type from the filename
+  on disk** - `mimetypes.guess_type(path)[0] or "application/octet-stream"`, straight
+  into a `FileResponse`. An avatar is stored under whatever suffix the uploader chose
+  and the app serves from an origin whose CSP allows inline script, so a file uploaded
+  as `x.html` was served as `text/html` from that origin and executed. Stored XSS,
+  exactly the class 0.0.238 fixed for the user and organization avatars, and the route
+  it deliberately left out of scope. (#1035)
+- The route reuses `image_media_type_for` rather than growing a second copy of the
+  helper: the type is pinned to the file's actual image type, anything that is not an
+  image is refused with a 404, and `X-Content-Type-Options: nosniff` goes out with it -
+  the same shape the user and organization avatar routes already use. `mimetypes` is
+  dropped from the module. (#1035)
 ## [0.0.242] - 2026-08-21
 
 The migration chain has one head again.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.242"
+version = "0.0.243"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.242"
+version = "0.0.243"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.242",
+  "version": "0.0.243",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.243. Bumps `backend/pyproject.toml`, `backend/uv.lock` and
`frontend/package.json` to 0.0.243 and adds the CHANGELOG entry.

Releases #1045, the route 0.0.238 named and left alone: the agent avatar was served
under a type guessed from the stored filename, so an avatar uploaded as `.html` came
back as `text/html` from an origin whose CSP allows inline script. It now goes through
the same `image_media_type_for` the user and organization routes use - pinned, 404 for
anything that is not an image, `nosniff` on the way out - rather than a second copy of
the helper.

The branch was written against #1034 and merged squashed, so bringing it onto main
took two conflict resolutions, both keeping the newer side: `update_current` from #941
in `services/user.py`, which this branch never touched, and the branch's own
`test_avatar_content_type.py`, which is main's file plus the two agent-avatar cases.
The net diff against main is the agent-avatar change alone.

## Verified

CI green end to end on #1045 after the rebase, the `test` and `e2e` jobs included: an
avatar stored as `.html` is refused, an image is pinned to its type and nosniffed, in
`tests/api/test_avatar_content_type.py` beside the user and organization cases.

Refs #1035
