### PR TITLE
feat(triggers): finish stitching routines into one product

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -257,6 +257,36 @@ flow, which needs the list reachable.
 The full picture, including what CLAUDE.md requires, is in `CLAUDE.md` under
 "A new surface owes the walkthrough a stop".
 
+## A feature with glanceable state owes the dashboard a widget
+
+The arrangeable dashboard is a registry with the same failure mode as the tour: a
+feature added anywhere else is simply absent from the catalog, nothing fails, and
+the product reads as parallel features rather than one — #594 stitched exactly
+these seams after W3 shipped four features on branches that could not see each
+other. If a feature produces activity or state a person would want at a glance
+(runs, schedules, sync health, spend), it ships its card in the same change. Five
+edits, each demonstrated by every existing widget:
+
+- the id in `WidgetId` and its def in `WIDGETS` (`src/lib/dashboard/registry.ts`) —
+  gate on the permission the card's **primary** read demands, and fetch a more
+  privileged half conditionally rather than raising the gate to it (the routines
+  card gates `agents:view`, which `GET /triggers` asks, and reads the run outcomes
+  only for a caller holding `runs:view` — a card that 403s on a permission its
+  primary data never needed is a card its audience cannot add);
+- the component under `components/dashboard/widgets/`, registered in
+  `WIDGET_COMPONENTS` (`widgets/index.ts`) — built on `WidgetFrame` and the
+  `widget-states` trio, reusing an existing hook rather than adding a card-only
+  endpoint;
+- a placement in `DEFAULT_SECTIONS` (`src/lib/dashboard/layouts.ts`) when the card
+  belongs on the default arrangement, not merely in the add-a-widget catalog;
+- the id mirrored in `WIDGET_IDS` in `backend/app/schemas/dashboard_layout.py` —
+  `backend/tests/test_dashboard_registry.py` fails the build when the two drift,
+  and `registry.test.ts`'s gate table plus its widget count both name the new id;
+- `dashboard.widgets.<id>.*` copy (title, description, states) in en **and** pl,
+  and the file itself in `vitest.config.ts`'s coverage include — the widget
+  directory is gated file-by-file, so a new card is otherwise invisible to the
+  100% gate however green its tests run.
+
 ## Permissions
 
 `use-permissions.ts` gives the effective permission set for the active organization. A

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -129,6 +129,15 @@ accepted it. And every schedule and event in an organization is
 listed together across its agents, each filtered to the ones the caller may run -
 the same per-resource `agents:run` that gates creating one.
 
+Together the two families are the product's **Routines** - the one umbrella name
+the nav, the chat sidebar, the onboarding and the Polish copy (*Rutyny*) all use,
+so a person meets one word wherever the feature surfaces. The org-wide list is
+the `/routines` page, and the dashboard carries a **Routines widget**: an addable
+card showing each routine's cadence, next fire, and the last run's outcome, cost
+and rating, so the unattended half of an organization is visible at the same
+glance as the attended one. [Triggers & schedules](triggers.md) is the whole
+story.
+
 ## Run
 
 **One execution.** It has a subject, a version, a surface, a status, token counts

--- a/docs/first-agent.md
+++ b/docs/first-agent.md
@@ -57,13 +57,22 @@ is a tour that stopped one step short of the point.
 
 Declining guides nobody; the offer returns at the end of the Agents **?** walk.
 Every other section's **?** ends the same way, offering to create that section's
-resource - a skill, a knowledge base, an MCP connection, an organization - and the
-Chat **?** offers a guided run through the chat surface itself: starting a
-conversation, switching which agent answers, and changing the model or thinking
-effort for a single chat. Chat can only talk to a *published* agent, so if there
-is none it opens by offering to build one first - a yes hands straight over to the
-agent flow. Past that it creates nothing, so it advances on Next rather than on
-anything appearing.
+resource - a skill, a knowledge base, an MCP connection, an organization, a
+routine. The Routines flow is the one that ends past its own create: a schedule
+that sits waiting for the clock teaches nothing, so the walk's last stop is the
+fresh row's own **Run now**, and the first fire lands in the run log while the
+reader watches. The Chat **?** offers a guided run through the chat surface
+itself: starting a conversation, switching which agent answers, and changing the
+model or thinking effort for a single chat. Chat can only talk to a *published*
+agent, so if there is none it opens by offering to build one first - a yes hands
+straight over to the agent flow. Past that it creates nothing, so it advances on
+Next rather than on anything appearing.
+
+The dashboard's own **?** is worth replaying once: its customize stop explains
+the whole editor - adding cards from the catalog (the same card more than once,
+if you want it per agent), dragging them between sections, resizing, hiding,
+renaming and colouring the sections themselves, named layouts and the reset -
+and every arrangement is per-person, so experimenting moves nobody else's page.
 
 ## 1. Store a provider key
 

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2545,6 +2545,10 @@
         "title": "Create an organization?",
         "body": "An organization is a separate space with its own agents, members and settings. Want to create one now? We'll walk you through it."
       },
+      "create-routine": {
+        "title": "Set up your first routine?",
+        "body": "A routine runs an agent with nobody at the keyboard - on a schedule, or when an event arrives. Want to set one up now? We'll walk you through it and fire the first run together."
+      },
       "explore-chat": {
         "title": "Take a quick tour of chat?",
         "body": "See how to start a conversation, switch which agent answers, and change the model or thinking effort for a single chat. Want a quick guided run through it?"

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1626,7 +1626,7 @@
         "description": "What runs with nobody at the keyboard, soonest first, and how the last one went.",
         "unnamed": "Untitled routine",
         "cost": "${cost}",
-        "nextFire": "next {at}",
+        "nextFire": "next {at} UTC",
         "paused": "paused",
         "neverRun": "not run yet",
         "fired": "fired",
@@ -1635,8 +1635,8 @@
         "status": {
           "failed": "failed",
           "budget_exceeded": "over budget",
+          "guardrail_blocked": "guardrail blocked",
           "running": "running",
-          "pending": "starting",
           "cancelled": "cancelled",
           "awaiting_approval": "awaiting approval"
         },

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1626,6 +1626,7 @@
         "description": "What runs with nobody at the keyboard, soonest first, and how the last one went.",
         "unnamed": "Untitled routine",
         "cost": "${cost}",
+        "nextFire": "next {at}",
         "paused": "paused",
         "neverRun": "not run yet",
         "fired": "fired",

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -977,7 +977,7 @@
         "description": "Co działa, gdy nikogo nie ma przy klawiaturze - najbliższe najpierw - i jak poszło ostatnie uruchomienie.",
         "unnamed": "Rutyna bez nazwy",
         "cost": "${cost}",
-        "nextFire": "następne {at}",
+        "nextFire": "następne {at} UTC",
         "paused": "wstrzymana",
         "neverRun": "jeszcze nie uruchomiona",
         "fired": "odpalona",
@@ -986,8 +986,8 @@
         "status": {
           "failed": "niepowodzenie",
           "budget_exceeded": "przekroczony budżet",
+          "guardrail_blocked": "zablokowana przez guardrail",
           "running": "w toku",
-          "pending": "startuje",
           "cancelled": "anulowana",
           "awaiting_approval": "czeka na zatwierdzenie"
         },

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -1245,6 +1245,10 @@
         "title": "Utworzyć organizację?",
         "body": "Organizacja to osobna przestrzeń z własnymi agentami, członkami i ustawieniami. Utworzymy jedną teraz? Przeprowadzimy Cię przez to."
       },
+      "create-routine": {
+        "title": "Ustawić pierwszą rutynę?",
+        "body": "Rutyna uruchamia agenta, gdy nikogo nie ma przy klawiaturze - według harmonogramu albo gdy nadejdzie zdarzenie. Ustawimy jedną teraz? Przeprowadzimy Cię przez to i razem odpalimy pierwszy run."
+      },
       "explore-chat": {
         "title": "Krótki przewodnik po czacie?",
         "body": "Zobacz, jak zacząć rozmowę, przełączyć, który agent odpowiada, i zmienić model albo wysiłek myślenia dla pojedynczego czatu. Chcesz szybki, prowadzony przegląd?"

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -971,6 +971,30 @@
           "title": "Nic nie uruchomiono w tym okresie",
           "description": "Rytm pojawi się, gdy będą runy do rozłożenia."
         }
+      },
+      "routines": {
+        "title": "Rutyny",
+        "description": "Co działa, gdy nikogo nie ma przy klawiaturze - najbliższe najpierw - i jak poszło ostatnie uruchomienie.",
+        "unnamed": "Rutyna bez nazwy",
+        "cost": "${cost}",
+        "nextFire": "następne {at}",
+        "paused": "wstrzymana",
+        "neverRun": "jeszcze nie uruchomiona",
+        "fired": "odpalona",
+        "succeeded": "ok",
+        "ratedDown": "oceniona negatywnie",
+        "status": {
+          "failed": "niepowodzenie",
+          "budget_exceeded": "przekroczony budżet",
+          "running": "w toku",
+          "pending": "startuje",
+          "cancelled": "anulowana",
+          "awaiting_approval": "czeka na zatwierdzenie"
+        },
+        "empty": {
+          "title": "Nic jeszcze nie działa samo",
+          "description": "Harmonogram uruchamia agenta według zegara; wyzwalacz - gdy coś nadejdzie."
+        }
       }
     },
     "activeSessions": "Aktywne sesje",

--- a/frontend/src/components/dashboard/widgets/routines.test.tsx
+++ b/frontend/src/components/dashboard/widgets/routines.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { NextIntlClientProvider } from "next-intl";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -165,6 +166,31 @@ describe("the routines widget", () => {
     expect(screen.getByText(/\$0\.0042/)).toBeVisible();
   });
 
+  it("says when a live schedule fires next", () => {
+    // Matched on the caption word, not the formatted instant: the time renders in
+    // the machine's own timezone, which differs between a laptop and CI.
+    renderWidget([trigger({ next_fire_at: "2099-01-05T12:00:00Z" })]);
+
+    expect(screen.getByText(/next /)).toBeVisible();
+  });
+
+  it("does not call an overdue fire 'next' - a missed time is not a future", () => {
+    // The heartbeat claims a due schedule at tick time, so a next_fire_at in the
+    // past is a fire that has not happened yet; "next <past instant>" would
+    // assert a future that already failed, loudest exactly when the worker is
+    // down. The fixture's default next_fire_at is such an instant.
+    renderWidget([trigger()]);
+
+    expect(screen.queryByText(/next /)).toBeNull();
+  });
+
+  it("gives a paused routine no next fire, whatever its row still holds", () => {
+    renderWidget([trigger({ is_active: false, next_fire_at: "2099-01-05T12:00:00Z" })]);
+
+    expect(screen.queryByText(/next /)).toBeNull();
+    expect(screen.getByText("paused")).toBeVisible();
+  });
+
   it("reads an event trigger's own phrase rather than a cadence it has none of", () => {
     renderWidget([
       trigger({
@@ -255,7 +281,7 @@ describe("the routines widget", () => {
     expect(screen.queryByText("Nothing runs on its own yet")).toBeNull();
   });
 
-  it("says the list could not be read, rather than that there is nothing", () => {
+  it("says the list could not be read, rather than that there is nothing", async () => {
     // This page fans out to a query per card: an empty list and a 502 are the
     // same pixels unless the failure is its own state.
     const refetch = vi.fn();
@@ -275,5 +301,8 @@ describe("the routines widget", () => {
     );
 
     expect(screen.queryByText("Nothing runs on its own yet")).toBeNull();
+    // The failure state must offer the retry, and the retry must reach the query.
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(refetch).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/components/dashboard/widgets/routines.test.tsx
+++ b/frontend/src/components/dashboard/widgets/routines.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { NextIntlClientProvider } from "next-intl";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -159,6 +159,12 @@ describe("the routines widget", () => {
     expect(screen.getByText("running")).toBeVisible();
   });
 
+  it("marks a guardrail-blocked routine as a failure, not a curiosity", () => {
+    renderWidget([trigger()], [run({ status: "guardrail_blocked" })]);
+
+    expect(screen.getByText("guardrail blocked")).toBeVisible();
+  });
+
   it("shows the cadence and what the last run cost", () => {
     renderWidget([trigger()]);
 
@@ -166,12 +172,49 @@ describe("the routines widget", () => {
     expect(screen.getByText(/\$0\.0042/)).toBeVisible();
   });
 
-  it("says when a live schedule fires next", () => {
-    // Matched on the caption word, not the formatted instant: the time renders in
-    // the machine's own timezone, which differs between a laptop and CI.
+  it("says when a live schedule fires next, in UTC, with the year when it is far", () => {
+    // UTC because the cadence beside it is; the year because a 999-day interval
+    // can put the fire outside the current one, where "Jan 5" alone names the
+    // wrong January.
     renderWidget([trigger({ next_fire_at: "2099-01-05T12:00:00Z" })]);
 
-    expect(screen.getByText(/next /)).toBeVisible();
+    expect(screen.getByText(/next Jan 5, 2099.*UTC/)).toBeVisible();
+  });
+
+  it("keeps the year out of a fire within the current one", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2099-01-01T00:00:00Z"));
+      renderWidget([trigger({ next_fire_at: "2099-01-05T12:00:00Z" })]);
+
+      expect(screen.getByText(/next Jan 5, 12/)).toBeVisible();
+      expect(screen.queryByText(/2099/)).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("drops the 'next' caption at the instant the fire comes due", () => {
+    // The card can sit on screen past the fire; the data stays as fresh as the
+    // query, but the clock half of the caption re-renders itself honest.
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2099-01-05T11:59:00Z"));
+      // Two upcoming fires: the ticker re-arms on the sooner of them.
+      renderWidget([
+        trigger({ id: "t-due", next_fire_at: "2099-01-05T12:00:00Z" }),
+        trigger({ id: "t-later", name: "Later digest", next_fire_at: "2099-01-05T12:30:00Z" }),
+      ]);
+      expect(screen.getByText(/next Jan 5, 12:00/)).toBeVisible();
+
+      act(() => {
+        vi.advanceTimersByTime(62_000);
+      });
+      expect(screen.queryByText(/next Jan 5, 12:00/)).toBeNull();
+      expect(screen.getByText(/next Jan 5, 12:30/)).toBeVisible();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not call an overdue fire 'next' - a missed time is not a future", () => {
@@ -223,15 +266,18 @@ describe("the routines widget", () => {
       trigger({ id: "t-soon", name: "Soon", next_fire_at: "2026-08-21T08:00:00Z" }),
       trigger({ id: "t-later", name: "Later", next_fire_at: "2026-08-21T20:00:00Z" }),
       trigger({ id: "t-event", name: "On an issue", trigger_type: "event", next_fire_at: null }),
+      trigger({ id: "t-event-2", name: "On a push", trigger_type: "event", next_fire_at: null }),
     ]);
 
     const labels = screen.getAllByRole("listitem").map((row) => row.textContent);
 
     expect(labels[0]).toContain("Soon");
     expect(labels[1]).toContain("Later");
-    // Live but not on a clock: after the schedules, before the paused.
+    // Live but not on a clock: after the schedules, before the paused - and two
+    // of them keep their incoming order, having no fire to sort between.
     expect(labels[2]).toContain("On an issue");
-    expect(labels[3]).toContain("Paused one");
+    expect(labels[3]).toContain("On a push");
+    expect(labels[4]).toContain("Paused one");
   });
 
   it("lists a routine by its agent when it has no name of its own", () => {

--- a/frontend/src/components/dashboard/widgets/routines.tsx
+++ b/frontend/src/components/dashboard/widgets/routines.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useLocale, useTranslations } from "next-intl";
 
 import { StatusList, type StatusRow, type StatusTone } from "../primitives/status-list";
@@ -52,6 +53,7 @@ export function RoutinesWidget({ title, hint, seeAll, options }: DashboardWidget
   const mayReadRuns = can(Perm.runsView);
   const { triggers, isLoading, isError, refetch } = useOrgTriggers();
   const { runs } = useRuns(undefined, { surface: "schedule", enabled: mayReadRuns });
+  useNextFireTick(triggers);
 
   if (isLoading) {
     return (
@@ -125,26 +127,61 @@ function row(
   };
 }
 
+/** The upcoming fire of a live schedule, in ms - null when there is none, or
+ * when the instant has passed: a `next_fire_at` in the past is a fire the
+ * heartbeat has yet to claim, and "next" about it would assert a future that
+ * already failed to happen, loudest exactly when the worker is down. */
+function upcomingFireMs(trigger: Trigger): number | null {
+  if (!trigger.is_active || trigger.next_fire_at === null) return null;
+  const at = new Date(trigger.next_fire_at).getTime();
+  return at >= Date.now() ? at : null;
+}
+
 /**
- * "next Aug 22, 09:00" for a live schedule whose next fire is still ahead.
+ * "next Aug 22, 09:00 UTC" for a live schedule whose next fire is still ahead.
  *
- * A `next_fire_at` in the past is a fire the heartbeat has yet to claim, so
- * "next" about it would assert a future that already failed to happen - loudest
- * exactly when the worker is down - and the caption drops instead, leaving the
- * cadence. Compact, no year: a live schedule's next fire is near by
- * construction, and the row has two other facts to hold.
+ * In UTC, because the cadence beside it is ("Daily at 09:00 UTC") - a local
+ * instant next to a UTC cadence reads as a contradiction two hours wide. The
+ * year appears only when the fire is outside the current one: a 999-day
+ * interval can put it years out, where "Feb 29" alone names the wrong February.
  */
 function nextFireText(trigger: Trigger, t: Translate, locale: string): string | null {
-  if (!trigger.is_active || trigger.next_fire_at === null) return null;
-  const at = new Date(trigger.next_fire_at);
-  if (at.getTime() < Date.now()) return null;
+  const upcoming = upcomingFireMs(trigger);
+  if (upcoming === null) return null;
+  const at = new Date(upcoming);
   const shown = at.toLocaleString(locale, {
+    timeZone: "UTC",
     month: "short",
     day: "numeric",
     hour: "2-digit",
     minute: "2-digit",
+    ...(at.getUTCFullYear() === new Date().getUTCFullYear() ? {} : { year: "numeric" as const }),
   });
   return t("nextFire", { at: shown });
+}
+
+/** setTimeout's ceiling; a longer delay wraps and fires at once. */
+const MAX_DELAY_MS = 2 ** 31 - 1;
+
+/**
+ * Re-render when the soonest upcoming fire comes due, so a card left on screen
+ * drops its "next" caption the moment it stops being true. The data stays as
+ * fresh as the query; only the clock half of the caption is ours to keep
+ * honest. A fire further out than setTimeout's ceiling just re-arms early.
+ */
+function useNextFireTick(triggers: Trigger[]): void {
+  const [, setTick] = useState(0);
+  const soonest = triggers.reduce<number | null>((min, trigger) => {
+    const upcoming = upcomingFireMs(trigger);
+    if (upcoming === null) return min;
+    return min === null ? upcoming : Math.min(min, upcoming);
+  }, null);
+  useEffect(() => {
+    if (soonest === null) return;
+    const delay = Math.min(Math.max(soonest - Date.now(), 0) + 1_000, MAX_DELAY_MS);
+    const timer = setTimeout(() => setTick((tick) => tick + 1), delay);
+    return () => clearTimeout(timer);
+  }, [soonest]);
 }
 
 function outcome(trigger: Trigger, run: AgentRun | undefined, t: Translate): [string, StatusTone] {
@@ -154,7 +191,11 @@ function outcome(trigger: Trigger, run: AgentRun | undefined, t: Translate): [st
   // than the page reaches, or this reader may not read runs at all. Saying
   // "succeeded" would be a guess and saying "failed" a worse one.
   if (run === undefined) return [t("fired"), "neutral"];
-  if (run.status === "failed" || run.status === "budget_exceeded")
+  if (
+    run.status === "failed" ||
+    run.status === "budget_exceeded" ||
+    run.status === "guardrail_blocked"
+  )
     return [t(`status.${run.status}`), "err"];
   if (run.down_rated) return [t("ratedDown"), "warn"];
   if (run.status === "completed") return [t("succeeded"), "ok"];

--- a/frontend/src/components/dashboard/widgets/routines.tsx
+++ b/frontend/src/components/dashboard/widgets/routines.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 import { StatusList, type StatusRow, type StatusTone } from "../primitives/status-list";
 import { WidgetFrame } from "../widget-frame";
@@ -47,6 +47,7 @@ export function RoutinesWidget({ title, hint, seeAll, options }: DashboardWidget
   // row and the chat's own summary read it from - one wording for "every 15
   // minutes" across the product rather than a second copy under this card.
   const tt = useTranslations("triggers");
+  const locale = useLocale();
   const { can } = usePermissions();
   const mayReadRuns = can(Perm.runsView);
   const { triggers, isLoading, isError, refetch } = useOrgTriggers();
@@ -68,7 +69,7 @@ export function RoutinesWidget({ title, hint, seeAll, options }: DashboardWidget
   const rows = [...triggers]
     .sort((left, right) => rank(left) - rank(right) || due(left) - due(right))
     .slice(0, SHOWN)
-    .map((trigger) => row(trigger, lastRun.get(trigger.last_run_id ?? ""), t, tt));
+    .map((trigger) => row(trigger, lastRun.get(trigger.last_run_id ?? ""), t, tt, locale));
 
   return (
     <WidgetFrame title={title} hint={hint} seeAll={seeAll} options={options}>
@@ -98,19 +99,52 @@ function due(trigger: Trigger): number {
  *
  * The pill is the *outcome*, because that is the question a glance asks: a
  * routine that has been failing every hour for a day looks exactly like a
- * healthy one if the card only says when it next fires. What it cost goes in the
- * subtitle beside the cadence, where it is legible without competing.
+ * healthy one if the card only says when it next fires. When it next fires and
+ * what the last run cost go in the subtitle beside the cadence, where they are
+ * legible without competing.
  */
-function row(trigger: Trigger, run: AgentRun | undefined, t: Translate, tt: Translate): StatusRow {
+function row(
+  trigger: Trigger,
+  run: AgentRun | undefined,
+  t: Translate,
+  tt: Translate,
+  locale: string,
+): StatusRow {
   const [pill, tone] = outcome(trigger, run, t);
   return {
     label: trigger.name ?? trigger.agent_name ?? t("unnamed"),
-    sub: [cadenceText(trigger, tt), run ? t("cost", { cost: run.cost_usd }) : null]
+    sub: [
+      cadenceText(trigger, tt),
+      nextFireText(trigger, t, locale),
+      run ? t("cost", { cost: run.cost_usd }) : null,
+    ]
       .filter((part) => part !== null)
       .join(" · "),
     pill,
     tone,
   };
+}
+
+/**
+ * "next Aug 22, 09:00" for a live schedule whose next fire is still ahead.
+ *
+ * A `next_fire_at` in the past is a fire the heartbeat has yet to claim, so
+ * "next" about it would assert a future that already failed to happen - loudest
+ * exactly when the worker is down - and the caption drops instead, leaving the
+ * cadence. Compact, no year: a live schedule's next fire is near by
+ * construction, and the row has two other facts to hold.
+ */
+function nextFireText(trigger: Trigger, t: Translate, locale: string): string | null {
+  if (!trigger.is_active || trigger.next_fire_at === null) return null;
+  const at = new Date(trigger.next_fire_at);
+  if (at.getTime() < Date.now()) return null;
+  const shown = at.toLocaleString(locale, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  return t("nextFire", { at: shown });
 }
 
 function outcome(trigger: Trigger, run: AgentRun | undefined, t: Translate): [string, StatusTone] {

--- a/frontend/src/components/onboarding/creation-offer.integration.test.tsx
+++ b/frontend/src/components/onboarding/creation-offer.integration.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactElement } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -29,7 +29,7 @@ function renderOffer(
   if (seed.agents !== undefined) {
     client.setQueryData(qk.agents.list(), { items: [], total: seed.agents });
   }
-  return render(<QueryClientProvider client={client}>{node}</QueryClientProvider>);
+  return { client, ...render(<QueryClientProvider client={client}>{node}</QueryClientProvider>) };
 }
 
 beforeEach(() => {
@@ -124,5 +124,18 @@ describe("CreationOffer", () => {
     useOnboardingStore.setState({ offer: "create-routine" });
     renderOffer(<CreationOffer />, { anyRunnable: true });
     expect(screen.getByText("Set up your first routine?")).toBeInTheDocument();
+  });
+
+  it("holds the routine offer until the runnable-agent answer lands, then shows it", async () => {
+    // A walk can finish before the page's runnable-agent sweep resolves. The
+    // offer is subscribed to that query, not snapshotting it: unanswered means
+    // no dialog yet, and the store still holds the offer - so when the answer
+    // lands as yes, the dialog appears rather than having been lost.
+    useOnboardingStore.setState({ offer: "create-routine" });
+    const { client } = renderOffer(<CreationOffer />);
+    expect(screen.queryByText("Set up your first routine?")).toBeNull();
+
+    act(() => client.setQueryData(qk.agents.anyRunnable(), true));
+    expect(await screen.findByText("Set up your first routine?")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/onboarding/creation-offer.integration.test.tsx
+++ b/frontend/src/components/onboarding/creation-offer.integration.test.tsx
@@ -19,10 +19,13 @@ vi.mock("@/hooks/use-permissions", () => ({
 // render needs a client, and `seed` fills whichever of those a test is about.
 function renderOffer(
   node: ReactElement,
-  seed: { catalog?: { items: unknown[] }; agents?: number } = {},
+  seed: { catalog?: { items: unknown[] }; agents?: number; anyRunnable?: boolean } = {},
 ) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   if (seed.catalog) client.setQueryData(qk.mcpServers.catalog(), seed.catalog);
+  if (seed.anyRunnable !== undefined) {
+    client.setQueryData(qk.agents.anyRunnable(), seed.anyRunnable);
+  }
   if (seed.agents !== undefined) {
     client.setQueryData(qk.agents.list(), { items: [], total: seed.agents });
   }
@@ -104,5 +107,22 @@ describe("CreationOffer", () => {
   it("renders nothing when there is no offer", () => {
     const { container } = renderOffer(<CreationOffer />);
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it("suppresses the routine offer for a caller who can run no agent", () => {
+    // Role-level `agents:run` passes the flow's own gate, but the flow's first
+    // target is the Routines page's create buttons, which mount only on the
+    // per-agent answer - and the coach waits on a flow target without a timeout.
+    // The check reads the same cached answer the buttons read, so the two can
+    // never disagree.
+    useOnboardingStore.setState({ offer: "create-routine" });
+    renderOffer(<CreationOffer />, { anyRunnable: false });
+    expect(screen.queryByText("Set up your first routine?")).toBeNull();
+  });
+
+  it("offers the routine flow to a caller with a runnable agent", () => {
+    useOnboardingStore.setState({ offer: "create-routine" });
+    renderOffer(<CreationOffer />, { anyRunnable: true });
+    expect(screen.getByText("Set up your first routine?")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/onboarding/creation-offer.tsx
+++ b/frontend/src/components/onboarding/creation-offer.tsx
@@ -62,6 +62,18 @@ export function CreationOffer() {
   ) {
     return null;
   }
+  // The routine flow's first target is the Routines page's create buttons, which
+  // mount on the per-agent `can_run` answer, not on the scope-blind `can` above -
+  // and the coach waits on a flow target with no timeout. Read the same cache
+  // the page's own gate fills (`useCanCreateTrigger`): a caller it refused gets
+  // no offer, because accepting one would open a flow whose every step that
+  // answer excludes.
+  if (
+    offer === "create-routine" &&
+    queryClient.getQueryData<boolean>(qk.agents.anyRunnable()) === false
+  ) {
+    return null;
+  }
 
   return (
     <ConfirmDialog

--- a/frontend/src/components/onboarding/creation-offer.tsx
+++ b/frontend/src/components/onboarding/creation-offer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useQueryClient } from "@tanstack/react-query";
+import { skipToken, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 
 import { ConfirmDialog } from "@/components/ui";
@@ -36,6 +36,15 @@ export function CreationOffer() {
   const dismissOffer = useOnboardingStore((state) => state.dismissOffer);
   const { can } = usePermissions();
   const queryClient = useQueryClient();
+  // Subscribed, never fetching (`skipToken`): the answer is produced by the
+  // Routines page's own gate (`useCanCreateTrigger`), and a subscription - where
+  // a one-time `getQueryData` snapshot missed it - re-renders this component
+  // when it lands, so a walk that finishes before the query settles shows the
+  // offer the moment the answer says it may, and never on a refusal.
+  const { data: anyRunnable } = useQuery({
+    queryKey: qk.agents.anyRunnable(),
+    queryFn: skipToken,
+  });
 
   if (offer === null || !canOfferFlow(FLOWS[offer], can)) return null;
   // The MCP catalog is compiled into the deployment; empty, there is nothing to
@@ -64,14 +73,11 @@ export function CreationOffer() {
   }
   // The routine flow's first target is the Routines page's create buttons, which
   // mount on the per-agent `can_run` answer, not on the scope-blind `can` above -
-  // and the coach waits on a flow target with no timeout. Read the same cache
-  // the page's own gate fills (`useCanCreateTrigger`): a caller it refused gets
-  // no offer, because accepting one would open a flow whose every step that
-  // answer excludes.
-  if (
-    offer === "create-routine" &&
-    queryClient.getQueryData<boolean>(qk.agents.anyRunnable()) === false
-  ) {
+  // and the coach waits on a flow target with no timeout. So the offer needs the
+  // same answer to say yes: a caller it refused gets no offer, and one it has
+  // not answered yet gets it only once it does - the store holds the offer, so
+  // waiting loses nothing.
+  if (offer === "create-routine" && anyRunnable !== true) {
     return null;
   }
 

--- a/frontend/src/hooks/use-can-create-trigger.ts
+++ b/frontend/src/hooks/use-can-create-trigger.ts
@@ -24,8 +24,12 @@ const PAGE_SIZE = 100;
  * so the sweep pages through `/agents` until it finds one or runs out, stopping
  * at the first hit (for most callers, the first page).
  */
-export function useCanCreateTriggerQuery(): { canCreate: boolean; isLoading: boolean } {
-  const { data, isLoading } = useQuery({
+export function useCanCreateTriggerQuery(): {
+  canCreate: boolean;
+  isLoading: boolean;
+  isFetching: boolean;
+} {
+  const { data, isLoading, isFetching } = useQuery({
     queryKey: qk.agents.anyRunnable(),
     queryFn: async () => {
       for (let skip = 0; ; skip += PAGE_SIZE) {
@@ -39,7 +43,7 @@ export function useCanCreateTriggerQuery(): { canCreate: boolean; isLoading: boo
       }
     },
   });
-  return { canCreate: data ?? false, isLoading };
+  return { canCreate: data ?? false, isLoading, isFetching };
 }
 
 /**

--- a/frontend/src/hooks/use-can-create-trigger.ts
+++ b/frontend/src/hooks/use-can-create-trigger.ts
@@ -12,7 +12,10 @@ const PAGE_SIZE = 100;
 /**
  * Whether the caller may create a trigger on *any* agent - the floor for the
  * org-wide create controls that are not tied to one agent, the chat sidebar's
- * "New" menu and the Routines page's "New schedule".
+ * "New" menu and the Routines page's "New schedule" - with the answer's own
+ * loading state, for a caller that must wait for it rather than read the
+ * conservative false (the onboarding snapshot, which would otherwise freeze
+ * "no runnable agent" from the unanswered first frame).
  *
  * The floor is a per-agent signal, not the role-level `agents:run`: a Viewer
  * granted run on a single agent may create a trigger there, so the control has
@@ -20,13 +23,9 @@ const PAGE_SIZE = 100;
  * past the first page - that one runnable agent can sit anywhere in the list,
  * so the sweep pages through `/agents` until it finds one or runs out, stopping
  * at the first hit (for most callers, the first page).
- *
- * While the answer is loading this returns false - the same conservatism
- * `usePermissions` applies, so a control is revealed once the data says it may
- * be rather than flashed and withdrawn.
  */
-export function useCanCreateTrigger(): boolean {
-  const { data } = useQuery({
+export function useCanCreateTriggerQuery(): { canCreate: boolean; isLoading: boolean } {
+  const { data, isLoading } = useQuery({
     queryKey: qk.agents.anyRunnable(),
     queryFn: async () => {
       for (let skip = 0; ; skip += PAGE_SIZE) {
@@ -40,5 +39,14 @@ export function useCanCreateTrigger(): boolean {
       }
     },
   });
-  return data ?? false;
+  return { canCreate: data ?? false, isLoading };
+}
+
+/**
+ * The same answer as a bare boolean, false while it loads - the same
+ * conservatism `usePermissions` applies, so a control is revealed once the data
+ * says it may be rather than flashed and withdrawn.
+ */
+export function useCanCreateTrigger(): boolean {
+  return useCanCreateTriggerQuery().canCreate;
 }

--- a/frontend/src/hooks/use-onboarding-flow.test.ts
+++ b/frontend/src/hooks/use-onboarding-flow.test.ts
@@ -29,6 +29,8 @@ const rig = vi.hoisted(() => ({
   mcpLoading: false,
   orgs: [] as unknown[] | undefined,
   routines: 0,
+  anyRunnable: true,
+  anyRunnableLoading: false,
   can: (_permission: Permission): boolean => true,
 }));
 
@@ -79,6 +81,12 @@ vi.mock("@/hooks/use-organizations", () => ({
 vi.mock("@/hooks/use-org-triggers", () => ({
   useOrgTriggers: () => ({ total: rig.routines, isLoading: false }),
 }));
+vi.mock("@/hooks/use-can-create-trigger", () => ({
+  useCanCreateTriggerQuery: () => ({
+    canCreate: rig.anyRunnable,
+    isLoading: rig.anyRunnableLoading,
+  }),
+}));
 vi.mock("@/hooks/use-permissions", () => ({
   usePermissions: () => ({ can: rig.can, isLoading: false, error: null }),
 }));
@@ -120,6 +128,8 @@ beforeEach(() => {
   rig.mcpLoading = false;
   rig.orgs = [];
   rig.routines = 0;
+  rig.anyRunnable = true;
+  rig.anyRunnableLoading = false;
   rig.can = () => true;
   nav.pathname = "/dashboard";
   useAgentSelectionStore.setState({ selectedAgentId: null });
@@ -177,6 +187,37 @@ describe("useOnboardingFlow", () => {
     rig.agentsLoading = false;
     rerender();
     expect(result.current.isActive).toBe(true);
+  });
+
+  it("waits for the runnable-agent answer, then runs the routine flow inert-free", () => {
+    // The routine flow's steps branch on the per-agent `can_run` answer, so the
+    // snapshot must not freeze "no runnable agent" from the unanswered first
+    // frame - a flow frozen on that default would drop both steps for a caller
+    // whose answer was merely still in flight.
+    rig.anyRunnableLoading = true;
+    const { result, rerender } = renderHook(() => useOnboardingFlow());
+    act(() => useOnboardingStore.getState().openFlow("create-routine"));
+    expect(result.current.isActive).toBe(false);
+
+    rig.anyRunnableLoading = false;
+    rerender();
+    expect(result.current.isActive).toBe(true);
+    expect(result.current.steps.map((step) => step.id)).toEqual([
+      "flow-routine-create",
+      "flow-routine-run-now",
+    ]);
+  });
+
+  it("goes inert, not frozen, for a caller who can run no agent", () => {
+    // Scope-blind `can` passes here, but no reachable agent is runnable, so the
+    // page never mounts the create buttons the first step points at - and the
+    // coach waits on a flow target without a timeout. Zero steps keeps the coach
+    // unmounted instead.
+    rig.anyRunnable = false;
+    const { result } = renderHook(() => useOnboardingFlow());
+    act(() => useOnboardingStore.getState().openFlow("create-routine"));
+    expect(result.current.steps).toHaveLength(0);
+    expect(result.current.isActive).toBe(false);
   });
 
   it("meets the signal only once the resource list grows past where it began", () => {

--- a/frontend/src/hooks/use-onboarding-flow.test.ts
+++ b/frontend/src/hooks/use-onboarding-flow.test.ts
@@ -31,6 +31,7 @@ const rig = vi.hoisted(() => ({
   routines: 0,
   anyRunnable: true,
   anyRunnableLoading: false,
+  anyRunnableFetching: false,
   can: (_permission: Permission): boolean => true,
 }));
 
@@ -85,6 +86,7 @@ vi.mock("@/hooks/use-can-create-trigger", () => ({
   useCanCreateTriggerQuery: () => ({
     canCreate: rig.anyRunnable,
     isLoading: rig.anyRunnableLoading,
+    isFetching: rig.anyRunnableLoading || rig.anyRunnableFetching,
   }),
 }));
 vi.mock("@/hooks/use-permissions", () => ({
@@ -130,6 +132,7 @@ beforeEach(() => {
   rig.routines = 0;
   rig.anyRunnable = true;
   rig.anyRunnableLoading = false;
+  rig.anyRunnableFetching = false;
   rig.can = () => true;
   nav.pathname = "/dashboard";
   useAgentSelectionStore.setState({ selectedAgentId: null });
@@ -206,6 +209,21 @@ describe("useOnboardingFlow", () => {
       "flow-routine-create",
       "flow-routine-run-now",
     ]);
+  });
+
+  it("does not freeze a runnable-agent answer a refetch is about to replace", () => {
+    // Cached-but-stale: React Query reports isLoading false the moment it holds
+    // any answer, while the refetch that may overturn it is still in flight.
+    // Freezing that stale answer strands the flow either way - a revoked grant
+    // waits on buttons the refresh hides, a fresh one reads as inert.
+    rig.anyRunnableFetching = true;
+    const { result, rerender } = renderHook(() => useOnboardingFlow());
+    act(() => useOnboardingStore.getState().openFlow("create-routine"));
+    expect(result.current.isActive).toBe(false);
+
+    rig.anyRunnableFetching = false;
+    rerender();
+    expect(result.current.isActive).toBe(true);
   });
 
   it("goes inert, not frozen, for a caller who can run no agent", () => {

--- a/frontend/src/hooks/use-onboarding-flow.ts
+++ b/frontend/src/hooks/use-onboarding-flow.ts
@@ -118,6 +118,9 @@ function useOrgSnapshot(): {
   const routines = useOrgTriggers();
   // The same query the Routines page gates its create buttons on
   // (`qk.agents.anyRunnable()`), so the flow and the buttons can never disagree.
+  // `isFetching` too, not only `isLoading`: a cached answer being refetched is a
+  // stale one, and freezing it can strand the flow either way - a revoked grant
+  // waits on buttons the refresh hides, a fresh grant reads as inert.
   const anyRunnable = useCanCreateTriggerQuery();
   const stateSettled =
     !agents.isLoading &&
@@ -126,7 +129,8 @@ function useOrgSnapshot(): {
     !skills.isLoading &&
     !mcp.isLoading &&
     !personalMcp.isLoading &&
-    !anyRunnable.isLoading;
+    !anyRunnable.isLoading &&
+    !anyRunnable.isFetching;
   return {
     counts: {
       agent: settled(agents.isLoading, agents.isFetching, agents.total),

--- a/frontend/src/hooks/use-onboarding-flow.ts
+++ b/frontend/src/hooks/use-onboarding-flow.ts
@@ -4,6 +4,7 @@ import { useCallback, useMemo, useState } from "react";
 import { usePathname } from "next/navigation";
 
 import { useAgent, useAgents } from "@/hooks/use-agents";
+import { useCanCreateTriggerQuery } from "@/hooks/use-can-create-trigger";
 import { useKnowledgeBases } from "@/hooks/use-knowledge-bases";
 import { useMcpConnections } from "@/hooks/use-mcp-connections";
 import { useModelProviders } from "@/hooks/use-model-providers";
@@ -70,6 +71,7 @@ const DEFAULT_STATE: OrgState = {
   hasSkill: false,
   hasOrgMcp: false,
   hasPublishedAgent: false,
+  hasRunnableAgent: false,
 };
 
 /**
@@ -114,13 +116,17 @@ function useOrgSnapshot(): {
   // The org-wide list, which is what the Routines page shows and therefore what
   // grows by one when the reader creates a schedule or a trigger.
   const routines = useOrgTriggers();
+  // The same query the Routines page gates its create buttons on
+  // (`qk.agents.anyRunnable()`), so the flow and the buttons can never disagree.
+  const anyRunnable = useCanCreateTriggerQuery();
   const stateSettled =
     !agents.isLoading &&
     !models.isLoading &&
     !kb.isLoading &&
     !skills.isLoading &&
     !mcp.isLoading &&
-    !personalMcp.isLoading;
+    !personalMcp.isLoading &&
+    !anyRunnable.isLoading;
   return {
     counts: {
       agent: settled(agents.isLoading, agents.isFetching, agents.total),
@@ -154,6 +160,7 @@ function useOrgSnapshot(): {
           hasSkill: skills.total > 0,
           hasOrgMcp: mcp.connections.length > 0,
           hasPublishedAgent: agents.agents.some((agent) => agent.status === "published"),
+          hasRunnableAgent: anyRunnable.canCreate,
         }
       : null,
   };

--- a/frontend/src/lib/onboarding/flows.test.ts
+++ b/frontend/src/lib/onboarding/flows.test.ts
@@ -20,6 +20,7 @@ const EMPTY: OrgState = {
   hasSkill: false,
   hasOrgMcp: false,
   hasPublishedAgent: false,
+  hasRunnableAgent: false,
 };
 const HAS_MODEL: OrgState = {
   hasRunnableModel: true,
@@ -27,6 +28,7 @@ const HAS_MODEL: OrgState = {
   hasSkill: false,
   hasOrgMcp: false,
   hasPublishedAgent: false,
+  hasRunnableAgent: false,
 };
 const STOCKED: OrgState = {
   hasRunnableModel: true,
@@ -34,6 +36,7 @@ const STOCKED: OrgState = {
   hasSkill: true,
   hasOrgMcp: true,
   hasPublishedAgent: true,
+  hasRunnableAgent: true,
 };
 const NO_CHOICES: Record<string, "yes" | "skip"> = {};
 
@@ -208,6 +211,18 @@ describe("flowForPage", () => {
 
   it("offers nothing on a page with no create", () => {
     expect(flowForPage(ROUTES.DASHBOARD)).toBeNull();
+  });
+});
+
+describe("create-routine", () => {
+  it("drops the whole flow for a caller who can run no agent", () => {
+    // The flow's `can` gate is scope-blind, so it passes for a role that says run
+    // while no agent in reach is actually runnable - and the first target mounts
+    // only on that per-agent answer, which the coach would wait on with no
+    // timeout. Zero steps means an inert flow instead of a frozen page.
+    expect(stepsForFlow(FLOWS["create-routine"], STOCKED, allow, NO_CHOICES)).toHaveLength(2);
+    const noRunnable = { ...STOCKED, hasRunnableAgent: false };
+    expect(stepsForFlow(FLOWS["create-routine"], noRunnable, allow, NO_CHOICES)).toHaveLength(0);
   });
 });
 

--- a/frontend/src/lib/onboarding/flows.ts
+++ b/frontend/src/lib/onboarding/flows.ts
@@ -94,8 +94,10 @@ export type FlowSignal =
  * key was deleted is not either; a knowledge base, a skill or an MCP connection is
  * simply one the organization holds. `hasPublishedAgent` is the one the chat needs
  * — only a published agent has a version to run, so a draft does not count — which
- * is why the chat run asks to build one when there is none. A flow grows this as it
- * grows the branches that read it.
+ * is why the chat run asks to build one when there is none. `hasRunnableAgent` is
+ * the routine flow's floor: the per-agent `can_run` answer the Routines page gates
+ * its create buttons on, which the role-level permission cannot mirror in either
+ * direction. A flow grows this as it grows the branches that read it.
  */
 export interface OrgState {
   hasRunnableModel: boolean;
@@ -103,6 +105,7 @@ export interface OrgState {
   hasSkill: boolean;
   hasOrgMcp: boolean;
   hasPublishedAgent: boolean;
+  hasRunnableAgent: boolean;
 }
 
 /**
@@ -717,17 +720,22 @@ export const FLOWS: Record<FlowId, CreationFlow> = {
   // whichever door it came through.
   "create-routine": {
     id: "create-routine",
-    // The floor a trigger is actually created at, per resource: a Viewer holding
-    // one explicit run grant may create one, where a role-level `agents:run` reads
-    // false. The page hides the buttons on the same test, so a reader who cannot
-    // create one is offered no flow rather than a flow that waits for a control
-    // that never mounts.
+    // The floor a trigger is actually created at is per resource, and the
+    // role-level `agents:run` here misreads it in both directions: a Viewer
+    // holding one explicit run grant may create one where the role reads false,
+    // and the role reads true for a caller none of whose reachable agents is
+    // actually runnable. The page hides its create buttons on the per-agent
+    // answer, and the coach waits on a flow target with no timeout - so every
+    // step carries `hasRunnableAgent`, the same answer, and the mismatch yields
+    // an inert flow rather than a wait on a control that never mounts. The offer
+    // reads the same cache in `CreationOffer`, so it is not made at all.
     permission: Perm.agentsRun,
     steps: [
       {
         id: "flow-routine-create",
         page: ROUTES.ROUTINES,
         target: "routines-create",
+        include: (state) => state.hasRunnableAgent,
         signal: { kind: "created", resource: "routine" },
       },
       // A schedule created at 09:00 and next due at midnight taught nothing: the
@@ -736,7 +744,12 @@ export const FLOWS: Record<FlowId, CreationFlow> = {
       // the same run log - so the walk ends on a routine that has actually run.
       // No signal: the fire is a mutation on a row rather than something
       // appearing, and it is fine to end the walk having pointed at it.
-      { id: "flow-routine-run-now", page: ROUTES.ROUTINES, target: "routine-run-now" },
+      {
+        id: "flow-routine-run-now",
+        page: ROUTES.ROUTINES,
+        target: "routine-run-now",
+        include: (state) => state.hasRunnableAgent,
+      },
     ],
   },
   "create-org": {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -61,6 +61,8 @@ export default defineConfig({
         // cards #149 added are outside the gate, and pulling them in with a
         // directory glob would make this branch responsible for covering them.
         "src/components/dashboard/widgets/sandbox-*.tsx",
+        // The routines card, held to the gate by #594's own "done when".
+        "src/components/dashboard/widgets/routines.tsx",
         "src/components/orgs/**/*.tsx",
         "src/components/runs/**/*.tsx",
         "src/components/sandboxes/**/*.tsx",


### PR DESCRIPTION
## Summary

#537 landed most of #594's seams — the routines widget, the tour stops, the
`create-routine` flow, the umbrella name, the customize stop, the CLAUDE.md rule.
This PR closes what it left open, plus two defects found auditing those seams
against the issue's "done when".

**Two fixes on the routine onboarding path:**

- **A frozen page.** Completing a `?` walk on `/routines` offers `create-routine`
  gated on the scope-blind role-level `agents:run`, but the flow's first target is
  the page's create buttons, which mount only on the per-agent `can_run` answer —
  and the coach waits on a flow target with no timeout. An Owner in an organization
  with no agents accepted the offer into a permanently frozen page. Fixed in two
  layers reading one answer (`qk.agents.anyRunnable()`, the same query the buttons
  gate on): `CreationOffer` suppresses the offer from that cache, and every
  `create-routine` step carries an `OrgState.hasRunnableAgent` include fed by the
  same query, so any residual path yields an inert flow.
- **A raw i18n key.** That offer rendered `offer.create-routine.title` literally —
  the copy was never added, and the dynamic `t(`offer.${offer}.title`)` read is
  invisible to the static catalog checks. Added (en+pl).

**Finishing the widget to the issue's spec:**

- The card sorted by next fire and never said it; the sub-line now carries
  "next <instant>" for a live schedule — and deliberately not for an overdue
  `next_fire_at`, which is a fire the heartbeat has yet to claim, loudest exactly
  when the worker is down.
- Polish copy for the whole card (it fell back to English), and `routines.tsx`
  added to the coverage include — the widget directory is gated file-by-file, so
  the card was invisible to the 100% gate (which then found the error state's
  retry unexercised; covered).

**Docs and the standing rule:**

- CLAUDE.md's "ships its seams" rule points at `.claude/rules/frontend.md` for the
  widget mechanics; that section didn't exist. Added — the five edits a new card
  is, each with the failure it prevents.
- `docs/concepts.md` names Routines and the widget (delegating to
  `docs/triggers.md`); `docs/first-agent.md` walks the reader through the routine
  flow's Run now ending and the dashboard customize stop.

## Verification

- `make check` green end to end, with the backend suite against a real pgvector
  (6900 passed, platform layer at 100.00%).
- Frontend coverage gate green; `routines.tsx` now inside it at 100% lines /
  statements / functions.
- `make docs-build` (`--strict`) checks the new cross-page link.
- New tests: the offer suppressed/offered on the runnable-agent answer, the flow
  inert (not frozen) for a caller who can run no agent, the snapshot waiting for
  that answer before freezing, next-fire shown / dropped when overdue / absent on
  paused.

Closes #594
