### PR TITLE
fix(auth): deliver the OAuth sign-in via a single-use code

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -83,6 +83,7 @@ Redis = Annotated[RedisClient, Depends(get_redis)]
 
 from app.services.user import UserService
 from app.services.session import SessionService
+from app.services.oauth_exchange import OAuthExchangeService
 from app.services.conversation import ConversationService
 from app.services.sandbox_connection import SandboxConnectionService
 from app.services.sandbox_workspace import SandboxWorkspaceService
@@ -99,8 +100,14 @@ def get_session_service(db: DBSession) -> SessionService:
     return SessionService(db)
 
 
+def get_oauth_exchange_service(redis: Redis) -> OAuthExchangeService:
+    """Create OAuthExchangeService instance with the Redis client."""
+    return OAuthExchangeService(redis)
+
+
 UserSvc = Annotated[UserService, Depends(get_user_service)]
 SessionSvc = Annotated[SessionService, Depends(get_session_service)]
+OAuthExchangeSvc = Annotated[OAuthExchangeService, Depends(get_oauth_exchange_service)]
 
 
 def get_conversation_service(db: DBSession) -> ConversationService:

--- a/backend/app/api/routes/v1/oauth.py
+++ b/backend/app/api/routes/v1/oauth.py
@@ -1,15 +1,18 @@
 """OAuth2 authentication routes."""
 
 import logging
+from typing import Any
 from urllib.parse import urlencode
 
 from fastapi import APIRouter, Request
 from fastapi.responses import RedirectResponse
 
-from app.api.deps import UserSvc
+from app.api.deps import OAuthExchangeSvc, UserSvc
 from app.core.config import settings
+from app.core.exceptions import AuthenticationError
 from app.core.oauth import oauth
 from app.core.security import create_access_token, create_refresh_token
+from app.schemas.token import OAuthExchangeRequest, Token
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +47,9 @@ async def google_login(request: Request, invitation: str | None = None):
 
 
 @router.get("/google/callback", response_model=None)
-async def google_callback(request: Request, user_service: UserSvc):
+async def google_callback(
+    request: Request, user_service: UserSvc, exchange_service: OAuthExchangeSvc
+):
     """Handle Google OAuth2 callback."""
     frontend = settings.FRONTEND_URL.rstrip("/")
     try:
@@ -69,15 +74,24 @@ async def google_callback(request: Request, user_service: UserSvc):
         access_token = create_access_token(subject=str(user.id))
         refresh_token = create_refresh_token(subject=str(user.id))
 
-        params = urlencode(
-            {
-                "access_token": access_token,
-                "refresh_token": refresh_token,
-            }
-        )
+        # A single-use code, not the tokens: a token in the redirect URL reaches
+        # the address bar, the server access log, and the `Referer` of the next
+        # same-origin request, and the refresh token is good for a week (#14).
+        code = await exchange_service.issue(access_token=access_token, refresh_token=refresh_token)
+        params = urlencode({"code": code})
         return RedirectResponse(url=f"{frontend}/auth/callback?{params}")
 
     except Exception:
         logger.exception("google_oauth_callback_failed")
         params = urlencode({"error": "Sign-in failed. Please try again."})
         return RedirectResponse(url=f"{frontend}/login?{params}")
+
+
+@router.post("/exchange", response_model=Token)
+async def exchange_code(body: OAuthExchangeRequest, exchange_service: OAuthExchangeSvc) -> Any:
+    """Swap a single-use OAuth code for its token pair, server to server."""
+    tokens = await exchange_service.redeem(body.code)
+    if tokens is None:
+        raise AuthenticationError(message="Invalid or expired exchange code")
+    access_token, refresh_token = tokens
+    return Token(access_token=access_token, refresh_token=refresh_token)

--- a/backend/app/clients/redis.py
+++ b/backend/app/clients/redis.py
@@ -89,6 +89,16 @@ class RedisClient:
             raise RuntimeError("Redis client not connected")
         return await self.client.delete(key)  # type: ignore[no-any-return]
 
+    async def getdel(self, key: str) -> str | None:
+        """Read a key and delete it in one atomic step (Redis GETDEL).
+
+        A single-use value cannot be read twice: the second reader finds the key
+        already gone, so a replayed OAuth exchange code redeems nothing.
+        """
+        if not self.client:
+            raise RuntimeError("Redis client not connected")
+        return await self.client.getdel(key)  # ty: ignore[invalid-return-type]
+
     async def exists(self, key: str) -> bool:
         """Check if key exists."""
         if not self.client:

--- a/backend/app/schemas/token.py
+++ b/backend/app/schemas/token.py
@@ -25,3 +25,9 @@ class RefreshTokenRequest(BaseSchema):
     """Request body for token refresh."""
 
     refresh_token: str
+
+
+class OAuthExchangeRequest(BaseSchema):
+    """Request body swapping a single-use OAuth code for its token pair."""
+
+    code: str

--- a/backend/app/services/oauth_exchange.py
+++ b/backend/app/services/oauth_exchange.py
@@ -1,0 +1,50 @@
+"""Single-use exchange codes for the OAuth redirect.
+
+The provider round trip hands the browser a short-lived, single-use code instead
+of the token pair itself, so neither an access token nor a refresh token ever
+appears in a redirect URL, an access log, or a `Referer` header. The frontend
+swaps the code for the pair server-to-server.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.clients.redis import RedisClient
+
+_KEY = "oauth:exchange:{code}"
+_TTL_SECONDS = 60
+
+
+class OAuthExchangeService:
+    """Mint and redeem the one-time code that stands in for the token pair.
+
+    Example:
+        code = await service.issue(access_token=a, refresh_token=r)
+        tokens = await service.redeem(code)  # (a, r), then None on any replay
+    """
+
+    def __init__(self, redis: RedisClient) -> None:
+        self.redis = redis
+
+    async def issue(self, *, access_token: str, refresh_token: str) -> str:
+        """Store the token pair under a fresh code and return the code."""
+        code = secrets.token_urlsafe(32)
+        payload = json.dumps({"access_token": access_token, "refresh_token": refresh_token})
+        await self.redis.set(_KEY.format(code=code), payload, ttl=_TTL_SECONDS)
+        return code
+
+    async def redeem(self, code: str) -> tuple[str, str] | None:
+        """Consume a code and return its token pair, or None if it is unknown.
+
+        The read deletes the key, so a code redeems exactly once; a replay, an
+        expired code, and a forged one are indistinguishable and all answer None.
+        """
+        raw = await self.redis.getdel(_KEY.format(code=code))
+        if raw is None:
+            return None
+        data = json.loads(raw)
+        return data["access_token"], data["refresh_token"]

--- a/backend/tests/api/test_platform_routes.py
+++ b/backend/tests/api/test_platform_routes.py
@@ -1348,6 +1348,11 @@ UNAUTHENTICATED_ROUTES: frozenset[tuple[str, str]] = frozenset(
         ("POST", f"{V1}/auth/magic-link/verify"),
         ("GET", f"{V1}/oauth/google/login"),
         ("GET", f"{V1}/oauth/google/callback"),
+        # The sign-in code exchange (#14). The callback redirects the browser
+        # with a single-use, one-minute code instead of the tokens; the frontend
+        # swaps it here server to server. There is no session yet - the code is
+        # the credential, and it redeems exactly once.
+        ("POST", f"{V1}/oauth/exchange"),
         # Redirect targets. The provider drives the browser back here with a
         # code, and it cannot be asked to carry our session while doing so; the
         # code itself is the credential.

--- a/backend/tests/test_oauth_signin_exchange.py
+++ b/backend/tests/test_oauth_signin_exchange.py
@@ -57,7 +57,7 @@ async def test_an_unknown_code_redeems_to_none() -> None:
 async def test_the_callback_redirect_carries_a_code_not_the_tokens(
     client: AsyncClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    app.dependency_overrides[get_redis] = lambda: _FakeRedis()
+    app.dependency_overrides[get_redis] = _FakeRedis
     monkeypatch.setattr(
         oauth.google,
         "authorize_access_token",
@@ -92,7 +92,7 @@ async def test_exchange_returns_the_pair_for_a_valid_code(client: AsyncClient) -
 
 
 async def test_exchange_refuses_an_unknown_code(client: AsyncClient) -> None:
-    app.dependency_overrides[get_redis] = lambda: _FakeRedis()
+    app.dependency_overrides[get_redis] = _FakeRedis
 
     resp = await client.post(_EXCHANGE, json={"code": "never-issued"})
 

--- a/backend/tests/test_oauth_signin_exchange.py
+++ b/backend/tests/test_oauth_signin_exchange.py
@@ -1,0 +1,99 @@
+"""The OAuth sign-in redirect delivers a code, never the token pair (#14).
+
+A token in the redirect URL reaches the browser address bar, the frontend
+server's access log, and the `Referer` of the next same-origin request - and the
+refresh token is good for a week. The callback therefore hands out a single-use
+code that the frontend swaps for the pair server to server.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+
+from app.api.deps import get_redis
+from app.core.config import settings
+from app.core.oauth import oauth
+from app.main import app
+from app.services.oauth_exchange import OAuthExchangeService
+from app.services.user import UserService
+
+pytestmark = pytest.mark.anyio
+
+_CALLBACK = f"{settings.API_V1_STR}/oauth/google/callback"
+_EXCHANGE = f"{settings.API_V1_STR}/oauth/exchange"
+
+
+class _FakeRedis:
+    """An in-memory stand-in with the two methods the exchange touches."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, str] = {}
+
+    async def set(self, key: str, value: str, ttl: int | None = None, nx: bool = False) -> bool:
+        self._store[key] = value
+        return True
+
+    async def getdel(self, key: str) -> str | None:
+        return self._store.pop(key, None)
+
+
+async def test_a_code_redeems_its_pair_exactly_once() -> None:
+    service = OAuthExchangeService(_FakeRedis())
+    code = await service.issue(access_token="acc", refresh_token="ref")
+    assert await service.redeem(code) == ("acc", "ref")
+    assert await service.redeem(code) is None
+
+
+async def test_an_unknown_code_redeems_to_none() -> None:
+    service = OAuthExchangeService(_FakeRedis())
+    assert await service.redeem("never-issued") is None
+
+
+async def test_the_callback_redirect_carries_a_code_not_the_tokens(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app.dependency_overrides[get_redis] = lambda: _FakeRedis()
+    monkeypatch.setattr(
+        oauth.google,
+        "authorize_access_token",
+        AsyncMock(return_value={"userinfo": {"sub": "s", "email": "u@e.com", "name": "U"}}),
+    )
+    monkeypatch.setattr(
+        UserService,
+        "get_or_create_oauth_user",
+        AsyncMock(return_value=SimpleNamespace(id=uuid4())),
+    )
+
+    resp = await client.get(_CALLBACK)
+
+    assert resp.status_code == 307
+    location = resp.headers["location"]
+    assert "code=" in location
+    assert "access_token" not in location
+    assert "refresh_token" not in location
+
+
+async def test_exchange_returns_the_pair_for_a_valid_code(client: AsyncClient) -> None:
+    fake = _FakeRedis()
+    app.dependency_overrides[get_redis] = lambda: fake
+    code = await OAuthExchangeService(fake).issue(access_token="acc", refresh_token="ref")
+
+    resp = await client.post(_EXCHANGE, json={"code": code})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["access_token"] == "acc"
+    assert body["refresh_token"] == "ref"
+
+
+async def test_exchange_refuses_an_unknown_code(client: AsyncClient) -> None:
+    app.dependency_overrides[get_redis] = lambda: _FakeRedis()
+
+    resp = await client.post(_EXCHANGE, json={"code": "never-issued"})
+
+    assert resp.status_code == 401

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,6 +124,13 @@ API, which then sends the browser on to `FRONTEND_URL`. Registering the
 frontend URL instead is the mistake worth naming: the consent screen works, and
 the callback 404s.
 
+The browser is sent on with a single-use, one-minute code, never the session
+tokens themselves: a token in a redirect URL reaches the address bar, the
+frontend server's access log, and the `Referer` of the next same-origin request,
+and the refresh token is good for a week. The frontend swaps the code for the
+token pair server to server at `POST /api/v1/oauth/exchange`, which redeems it
+exactly once.
+
 
 ## Database (PostgreSQL)
 

--- a/frontend/src/app/[locale]/auth/callback/page.tsx
+++ b/frontend/src/app/[locale]/auth/callback/page.tsx
@@ -10,6 +10,27 @@ import { postSignInDestination } from "@/lib/auth-landing";
 import type { User } from "@/types";
 import { useTranslations } from "next-intl";
 
+type Adopted = { user: User; access_token: string };
+
+// A single-use code must be POSTed exactly once. React Strict Mode mounts this
+// effect, cleans it up, and mounts it again in development, and a plain remount
+// does the same: without sharing the request the second POST sends the code the
+// first already spent and gets a 401, failing a sign-in that worked. Keyed by
+// code and held outside the component so it survives the remount; cleared when
+// the request settles.
+const exchanges = new Map<string, Promise<Adopted>>();
+
+function exchangeCode(code: string): Promise<Adopted> {
+  let pending = exchanges.get(code);
+  if (pending === undefined) {
+    pending = apiClient
+      .post<Adopted>("/auth/oauth-callback", { code })
+      .finally(() => exchanges.delete(code));
+    exchanges.set(code, pending);
+  }
+  return pending;
+}
+
 export default function AuthCallbackPage() {
   const t = useTranslations("pages.root");
   const router = useRouter();
@@ -44,10 +65,7 @@ export default function AuthCallbackPage() {
     let cancelled = false;
     (async () => {
       try {
-        const data = await apiClient.post<{ user: User; access_token: string }>(
-          "/auth/oauth-callback",
-          { code },
-        );
+        const data = await exchangeCode(code);
         if (cancelled) return;
         adoptSession(data.user, data.access_token);
         // No deep link here yet - nothing carries a returnTo through the

--- a/frontend/src/app/[locale]/auth/callback/page.tsx
+++ b/frontend/src/app/[locale]/auth/callback/page.tsx
@@ -26,8 +26,7 @@ export default function AuthCallbackPage() {
   const adoptSession = useAdoptSession();
 
   useEffect(() => {
-    const accessToken = searchParams.get("access_token");
-    const refreshToken = searchParams.get("refresh_token");
+    const code = searchParams.get("code");
     const errParam = searchParams.get("error");
 
     if (errParam) {
@@ -37,8 +36,8 @@ export default function AuthCallbackPage() {
       );
       return () => clearTimeout(t);
     }
-    if (!accessToken || !refreshToken) {
-      router.replace("/login?error=missing_tokens");
+    if (!code) {
+      router.replace("/login?error=missing_code");
       return;
     }
 
@@ -47,7 +46,7 @@ export default function AuthCallbackPage() {
       try {
         const data = await apiClient.post<{ user: User; access_token: string }>(
           "/auth/oauth-callback",
-          { access_token: accessToken, refresh_token: refreshToken },
+          { code },
         );
         if (cancelled) return;
         adoptSession(data.user, data.access_token);

--- a/frontend/src/app/[locale]/auth/session-adoption.integration.test.tsx
+++ b/frontend/src/app/[locale]/auth/session-adoption.integration.test.tsx
@@ -75,6 +75,35 @@ describe("the OAuth callback", () => {
     expect(useConversationStore.getState().currentConversationId).toBeNull();
     expect(useAuthStore.getState().accessToken).toBe("t-new");
   });
+
+  it("spends a single-use code once across a remount", async () => {
+    // Strict Mode mounts this effect, cleans it up and mounts it again in dev;
+    // both must share the one request, or the second POSTs a code the first
+    // already redeemed and the sign-in 401s (#14, codex).
+    searchParams.set("code", "dupe");
+    let resolve!: (value: { user: typeof arriving; access_token: string }) => void;
+    vi.mocked(apiClient.post).mockReturnValue(
+      new Promise<{ user: typeof arriving; access_token: string }>((r) => {
+        resolve = r;
+      }),
+    );
+
+    render(
+      <QueryClientProvider client={client}>
+        <CallbackPage />
+      </QueryClientProvider>,
+    );
+    render(
+      <QueryClientProvider client={client}>
+        <CallbackPage />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(apiClient.post).toHaveBeenCalledTimes(1));
+    resolve({ user: arriving, access_token: "t-new" });
+    await waitFor(() => expect(useAuthStore.getState().user?.id).toBe("u-new"));
+    expect(apiClient.post).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("the magic link", () => {

--- a/frontend/src/app/[locale]/auth/session-adoption.integration.test.tsx
+++ b/frontend/src/app/[locale]/auth/session-adoption.integration.test.tsx
@@ -64,13 +64,13 @@ beforeEach(() => {
 
 describe("the OAuth callback", () => {
   it("empties the previous account before adopting the one it exchanged", async () => {
-    searchParams.set("access_token", "a-1");
-    searchParams.set("refresh_token", "r-1");
+    searchParams.set("code", "one-time");
     vi.mocked(apiClient.post).mockResolvedValue({ user: arriving, access_token: "t-new" });
     mountOver(<CallbackPage />);
 
     await waitFor(() => expect(useAuthStore.getState().user?.id).toBe("u-new"));
 
+    expect(apiClient.post).toHaveBeenCalledWith("/auth/oauth-callback", { code: "one-time" });
     expect(client.getQueryData(["sessions", "list", 0])).toBeUndefined();
     expect(useConversationStore.getState().currentConversationId).toBeNull();
     expect(useAuthStore.getState().accessToken).toBe("t-new");

--- a/frontend/src/app/api/auth/oauth-callback/route.ts
+++ b/frontend/src/app/api/auth/oauth-callback/route.ts
@@ -3,6 +3,10 @@ import { NextRequest } from "next/server";
 import { BackendApiError, backendFetch, bffJson, bffRefusal } from "@/lib/server-api";
 
 interface OAuthCallbackBody {
+  code: string;
+}
+
+interface TokenPair {
   access_token: string;
   refresh_token: string;
 }
@@ -10,28 +14,33 @@ interface OAuthCallbackBody {
 export async function POST(request: NextRequest) {
   try {
     const body = (await request.json()) as Partial<OAuthCallbackBody>;
-    if (!body.access_token || !body.refresh_token) {
-      return bffRefusal("MISSING_TOKENS", 400);
+    if (!body.code) {
+      return bffRefusal("MISSING_AUTHORIZATION_CODE", 400);
     }
 
+    const tokens = await backendFetch<TokenPair>("/api/v1/oauth/exchange", {
+      method: "POST",
+      body: JSON.stringify({ code: body.code }),
+    });
+
     const user = await backendFetch("/api/v1/auth/me", {
-      headers: { Authorization: `Bearer ${body.access_token}` },
+      headers: { Authorization: `Bearer ${tokens.access_token}` },
     });
 
     const response = bffJson({
       user,
-      access_token: body.access_token,
+      access_token: tokens.access_token,
     });
 
     const isProd = process.env.NODE_ENV === "production";
-    response.cookies.set("access_token", body.access_token, {
+    response.cookies.set("access_token", tokens.access_token, {
       httpOnly: true,
       secure: isProd,
       sameSite: "lax",
       maxAge: 60 * 15,
       path: "/",
     });
-    response.cookies.set("refresh_token", body.refresh_token, {
+    response.cookies.set("refresh_token", tokens.refresh_token, {
       httpOnly: true,
       secure: isProd,
       sameSite: "lax",

--- a/frontend/src/app/api/auth/session-routes.test.ts
+++ b/frontend/src/app/api/auth/session-routes.test.ts
@@ -423,55 +423,58 @@ describe("signing in without a password", () => {
 });
 
 describe("finishing an OAuth sign-in", () => {
-  it("stores the tokens the provider flow handed back", async () => {
-    // The tokens arrive in the body from the callback page; this route is what
-    // moves them into HttpOnly cookies, which is the whole point of it.
-    vi.mocked(backendFetch).mockResolvedValue({ id: "u-1" });
+  it("swaps the single-use code for the token pair, and stores it", async () => {
+    // The redirect carries a code, not the tokens (#14): a token in a redirect
+    // URL reaches the address bar, the access log and the next Referer.
+    vi.mocked(backendFetch)
+      .mockResolvedValueOnce({ access_token: "at", refresh_token: "rt" })
+      .mockResolvedValueOnce({ id: "u-1" });
 
-    const response = await oauthCallback(request({}, { access_token: "at", refresh_token: "rt" }));
+    const response = await oauthCallback(request({}, { code: "one-time" }));
 
-    expect(backendFetch).toHaveBeenCalledWith("/api/v1/auth/me", {
+    expect(backendFetch).toHaveBeenNthCalledWith(1, "/api/v1/oauth/exchange", {
+      method: "POST",
+      body: JSON.stringify({ code: "one-time" }),
+    });
+    expect(backendFetch).toHaveBeenNthCalledWith(2, "/api/v1/auth/me", {
       headers: { Authorization: "Bearer at" },
     });
     expect(cookie(response, "access_token")).toMatchObject({ value: "at" });
     expect(cookie(response, "refresh_token")).toMatchObject({ value: "rt" });
   });
 
-  it("refuses a callback that is missing either token", async () => {
-    // Which is what a truncated or tampered redirect looks like; setting one
-    // cookie and not the other produces a session that half-works.
-    for (const body of [{ access_token: "at" }, { refresh_token: "rt" }, {}]) {
-      const response = await oauthCallback(request({}, body));
+  it("refuses a callback carrying no code", async () => {
+    const response = await oauthCallback(request({}, {}));
 
-      expect(response.status).toBe(400);
-      expect(cookie(response, "access_token")).toBeUndefined();
-    }
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ code: "MISSING_AUTHORIZATION_CODE" });
+    expect(cookie(response, "access_token")).toBeUndefined();
     expect(backendFetch).not.toHaveBeenCalled();
   });
 
-  it("passes the backend's refusal of the token through", async () => {
+  it("passes the backend's refusal of the code through", async () => {
     vi.mocked(backendFetch).mockRejectedValue(
-      new BackendApiError(401, "Unauthorized", { detail: "Token is not valid" }),
+      new BackendApiError(401, "Unauthorized", { detail: "Invalid or expired exchange code" }),
     );
 
-    const response = await oauthCallback(request({}, { access_token: "x", refresh_token: "y" }));
+    const response = await oauthCallback(request({}, { code: "stale" }));
 
     expect(response.status).toBe(401);
-    await expect(response.json()).resolves.toEqual({ detail: "Token is not valid" });
+    await expect(response.json()).resolves.toEqual({ detail: "Invalid or expired exchange code" });
   });
 
   it("says sign-in failed when the refusal named no reason", async () => {
     vi.mocked(backendFetch).mockRejectedValue(new BackendApiError(401, "Unauthorized", null));
 
-    const response = await oauthCallback(request({}, { access_token: "x", refresh_token: "y" }));
+    const response = await oauthCallback(request({}, { code: "stale" }));
 
     await expect(response.json()).resolves.toEqual({ code: "LOGIN_FAILED" });
   });
 
-  it("answers 500 when the check could not be made", async () => {
+  it("answers 500 when the exchange could not be made", async () => {
     vi.mocked(backendFetch).mockRejectedValue(new Error("ECONNREFUSED"));
 
-    const response = await oauthCallback(request({}, { access_token: "x", refresh_token: "y" }));
+    const response = await oauthCallback(request({}, { code: "x" }));
 
     expect(response.status).toBe(500);
   });


### PR DESCRIPTION
## What changed

The Google OAuth callback redirected the browser to the frontend with the
access and refresh tokens in the query string. That URL reaches the address
bar and session history, the frontend server's access log and any reverse
proxy in front of it, and the `Referer` of the next same-origin request the
callback page makes (`Referrer-Policy: strict-origin-when-cross-origin` sends
the full URL same-origin). The refresh token is valid for a week, so a reader
of any access log had a week of full account access.

The callback now hands out a **single-use, one-minute code** and keeps the
token pair in Redis. A new server-to-server endpoint, `POST /api/v1/oauth/exchange`,
redeems it with `GETDEL`, so a replayed, expired, or forged code all redeem to
nothing and answer 401. The frontend BFF swaps the code for the pair, verifies
the access token against `/auth/me`, and moves both into HttpOnly cookies — the
tokens never touch a URL. This also closes the session-fixation shape the issue
flagged, since the BFF no longer accepts a client-supplied token pair.

## Verification

- Backend: `tests/test_oauth_signin_exchange.py` — the redirect Location carries
  a `code` and neither token; a code redeems its pair exactly once; an unknown
  code is refused with 401.
- Frontend: `session-routes.test.ts` and `session-adoption.integration.test.tsx`
  updated to the code contract, including that the callback page posts `{ code }`
  rather than the token pair.
- `docs/configuration.md` now records the token-delivery decision under the
  OAuth section.

Closes #14