### PR TITLE
fix(security): encode interpolated path segments in the hand-rolled proxies

### DIFF
--- a/frontend/src/app/api/admin/users/[userId]/impersonate/route.ts
+++ b/frontend/src/app/api/admin/users/[userId]/impersonate/route.ts
@@ -13,10 +13,13 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const { accessToken } = adminCheck;
 
     const { userId } = await params;
-    const data = await backendFetch(`/api/v1/admin/users/${userId}/impersonate`, {
-      method: "POST",
-      headers: { Authorization: `Bearer ${accessToken}` },
-    });
+    const data = await backendFetch(
+      `/api/v1/admin/users/${encodeURIComponent(userId)}/impersonate`,
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${accessToken}` },
+      },
+    );
     return bffJson(data);
   } catch (error) {
     if (error instanceof BackendApiError) {

--- a/frontend/src/app/api/admin/users/[userId]/route.ts
+++ b/frontend/src/app/api/admin/users/[userId]/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const { accessToken } = adminCheck;
 
     const { userId } = await params;
-    const data = await backendFetch(`/api/v1/admin/users/${userId}`, {
+    const data = await backendFetch(`/api/v1/admin/users/${encodeURIComponent(userId)}`, {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
     return bffJson(data);
@@ -34,7 +34,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     const { userId } = await params;
     const body = await request.json();
 
-    const data = await backendFetch(`/api/v1/admin/users/${userId}`, {
+    const data = await backendFetch(`/api/v1/admin/users/${encodeURIComponent(userId)}`, {
       method: "PATCH",
       headers: {
         Authorization: `Bearer ${accessToken}`,
@@ -58,7 +58,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     const { accessToken } = adminCheck;
 
     const { userId } = await params;
-    await backendFetch(`/api/v1/admin/users/${userId}`, {
+    await backendFetch(`/api/v1/admin/users/${encodeURIComponent(userId)}`, {
       method: "DELETE",
       headers: { Authorization: `Bearer ${accessToken}` },
     });

--- a/frontend/src/app/api/generated/[filename]/route.ts
+++ b/frontend/src/app/api/generated/[filename]/route.ts
@@ -17,7 +17,7 @@ export async function GET(
     // Forward ?download=true so an explicit Download control can force a save
     // dialog; the default renders the image inline in the chat.
     const qs = request.nextUrl.searchParams.toString();
-    const url = `${BACKEND_URL}/api/v1/generated/${filename}${qs ? `?${qs}` : ""}`;
+    const url = `${BACKEND_URL}/api/v1/generated/${encodeURIComponent(filename)}${qs ? `?${qs}` : ""}`;
     const response = await fetch(url, {
       headers: {
         Authorization: `Bearer ${accessToken}`,

--- a/frontend/src/app/api/invitations/[token]/route.ts
+++ b/frontend/src/app/api/invitations/[token]/route.ts
@@ -10,7 +10,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const accessToken = request.cookies.get("access_token")?.value;
     if (!accessToken) return bffRefusal("NOT_AUTHENTICATED", 401);
     const { token } = await params;
-    const data = await backendFetch(`/api/v1/invitations/${token}/accept`, {
+    const data = await backendFetch(`/api/v1/invitations/${encodeURIComponent(token)}/accept`, {
       method: "POST",
       headers: { Authorization: `Bearer ${accessToken}` },
     });
@@ -27,7 +27,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     const accessToken = request.cookies.get("access_token")?.value;
     if (!accessToken) return bffRefusal("NOT_AUTHENTICATED", 401);
     const { token } = await params;
-    await backendFetch(`/api/v1/invitations/${token}`, {
+    await backendFetch(`/api/v1/invitations/${encodeURIComponent(token)}`, {
       method: "DELETE",
       headers: { Authorization: `Bearer ${accessToken}` },
     });

--- a/frontend/src/app/api/me/mcp-connections/[id]/route.ts
+++ b/frontend/src/app/api/me/mcp-connections/[id]/route.ts
@@ -10,11 +10,14 @@ export async function PATCH(request: NextRequest, context: { params: Promise<{ i
   const { id } = await context.params;
   try {
     const body = (await request.json()) as Record<string, unknown>;
-    const data = await backendFetch<unknown>(`/api/v1/me/mcp-connections/${id}`, {
-      method: "PATCH",
-      body: JSON.stringify(body),
-      headers: { Authorization: `Bearer ${accessToken}` },
-    });
+    const data = await backendFetch<unknown>(
+      `/api/v1/me/mcp-connections/${encodeURIComponent(id)}`,
+      {
+        method: "PATCH",
+        body: JSON.stringify(body),
+        headers: { Authorization: `Bearer ${accessToken}` },
+      },
+    );
     return bffJson(data);
   } catch (error) {
     if (error instanceof BackendApiError) {
@@ -31,7 +34,7 @@ export async function DELETE(request: NextRequest, context: { params: Promise<{ 
   }
   const { id } = await context.params;
   try {
-    await backendFetch<null>(`/api/v1/me/mcp-connections/${id}`, {
+    await backendFetch<null>(`/api/v1/me/mcp-connections/${encodeURIComponent(id)}`, {
       method: "DELETE",
       headers: { Authorization: `Bearer ${accessToken}` },
     });

--- a/frontend/src/app/api/me/mcp-connections/[id]/test/route.ts
+++ b/frontend/src/app/api/me/mcp-connections/[id]/test/route.ts
@@ -9,10 +9,13 @@ export async function POST(request: NextRequest, context: { params: Promise<{ id
   }
   const { id } = await context.params;
   try {
-    const data = await backendFetch<unknown>(`/api/v1/me/mcp-connections/${id}/test`, {
-      method: "POST",
-      headers: { Authorization: `Bearer ${accessToken}` },
-    });
+    const data = await backendFetch<unknown>(
+      `/api/v1/me/mcp-connections/${encodeURIComponent(id)}/test`,
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${accessToken}` },
+      },
+    );
     return bffJson(data);
   } catch (error) {
     if (error instanceof BackendApiError) {

--- a/frontend/src/app/api/me/slash-commands/[id]/route.ts
+++ b/frontend/src/app/api/me/slash-commands/[id]/route.ts
@@ -10,11 +10,14 @@ export async function PATCH(request: NextRequest, context: { params: Promise<{ i
   const { id } = await context.params;
   try {
     const body = (await request.json()) as Record<string, unknown>;
-    const data = await backendFetch<unknown>(`/api/v1/me/slash-commands/${id}`, {
-      method: "PATCH",
-      body: JSON.stringify(body),
-      headers: { Authorization: `Bearer ${accessToken}` },
-    });
+    const data = await backendFetch<unknown>(
+      `/api/v1/me/slash-commands/${encodeURIComponent(id)}`,
+      {
+        method: "PATCH",
+        body: JSON.stringify(body),
+        headers: { Authorization: `Bearer ${accessToken}` },
+      },
+    );
     return bffJson(data);
   } catch (error) {
     if (error instanceof BackendApiError) {
@@ -31,7 +34,7 @@ export async function DELETE(request: NextRequest, context: { params: Promise<{ 
   }
   const { id } = await context.params;
   try {
-    await backendFetch<null>(`/api/v1/me/slash-commands/${id}`, {
+    await backendFetch<null>(`/api/v1/me/slash-commands/${encodeURIComponent(id)}`, {
       method: "DELETE",
       headers: { Authorization: `Bearer ${accessToken}` },
     });

--- a/frontend/src/app/api/orgs/[id]/integrations/[sourceId]/route.ts
+++ b/frontend/src/app/api/orgs/[id]/integrations/[sourceId]/route.ts
@@ -11,7 +11,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
   if (!accessToken) return bffRefusal("NOT_AUTHENTICATED", 401);
   const { id, sourceId } = await params;
   try {
-    await backendFetch<null>(`/api/v1/org/integrations/${sourceId}`, {
+    await backendFetch<null>(`/api/v1/org/integrations/${encodeURIComponent(sourceId)}`, {
       method: "DELETE",
       headers: {
         Authorization: `Bearer ${accessToken}`,

--- a/frontend/src/app/api/orgs/[id]/integrations/[sourceId]/trigger/route.ts
+++ b/frontend/src/app/api/orgs/[id]/integrations/[sourceId]/trigger/route.ts
@@ -11,13 +11,16 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   if (!accessToken) return bffRefusal("NOT_AUTHENTICATED", 401);
   const { id, sourceId } = await params;
   try {
-    const data = await backendFetch(`/api/v1/org/integrations/${sourceId}/trigger`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "X-Organization-Id": id,
+    const data = await backendFetch(
+      `/api/v1/org/integrations/${encodeURIComponent(sourceId)}/trigger`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "X-Organization-Id": id,
+        },
       },
-    });
+    );
     return bffJson(data);
   } catch (error) {
     if (error instanceof BackendApiError)

--- a/frontend/src/app/api/orgs/[id]/invitations/[invitationId]/route.ts
+++ b/frontend/src/app/api/orgs/[id]/invitations/[invitationId]/route.ts
@@ -18,10 +18,13 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     const accessToken = request.cookies.get("access_token")?.value;
     if (!accessToken) return bffRefusal("NOT_AUTHENTICATED", 401);
     const { id, invitationId } = await params;
-    await backendFetch(`/api/v1/orgs/${id}/invitations/${invitationId}`, {
-      method: "DELETE",
-      headers: { Authorization: `Bearer ${accessToken}` },
-    });
+    await backendFetch(
+      `/api/v1/orgs/${encodeURIComponent(id)}/invitations/${encodeURIComponent(invitationId)}`,
+      {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${accessToken}` },
+      },
+    );
     return new NextResponse(null, { status: 204 });
   } catch (error) {
     if (error instanceof BackendApiError)

--- a/frontend/src/app/api/orgs/[id]/invitations/route.ts
+++ b/frontend/src/app/api/orgs/[id]/invitations/route.ts
@@ -10,7 +10,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const accessToken = request.cookies.get("access_token")?.value;
     if (!accessToken) return bffRefusal("NOT_AUTHENTICATED", 401);
     const { id } = await params;
-    const data = await backendFetch(`/api/v1/orgs/${id}/invitations`, {
+    const data = await backendFetch(`/api/v1/orgs/${encodeURIComponent(id)}/invitations`, {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
     return bffJson(data);
@@ -27,7 +27,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     if (!accessToken) return bffRefusal("NOT_AUTHENTICATED", 401);
     const { id } = await params;
     const body = await request.json();
-    const data = await backendFetch(`/api/v1/orgs/${id}/invitations`, {
+    const data = await backendFetch(`/api/v1/orgs/${encodeURIComponent(id)}/invitations`, {
       method: "POST",
       headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
       body: JSON.stringify(body),

--- a/frontend/src/app/api/orgs/[id]/members/[userId]/route.ts
+++ b/frontend/src/app/api/orgs/[id]/members/[userId]/route.ts
@@ -11,11 +11,14 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     if (!accessToken) return bffRefusal("NOT_AUTHENTICATED", 401);
     const { id, userId } = await params;
     const body = await request.json();
-    const data = await backendFetch(`/api/v1/orgs/${id}/members/${userId}`, {
-      method: "PATCH",
-      headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    });
+    const data = await backendFetch(
+      `/api/v1/orgs/${encodeURIComponent(id)}/members/${encodeURIComponent(userId)}`,
+      {
+        method: "PATCH",
+        headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
+    );
     return bffJson(data);
   } catch (error) {
     if (error instanceof BackendApiError)
@@ -29,10 +32,13 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     const accessToken = request.cookies.get("access_token")?.value;
     if (!accessToken) return bffRefusal("NOT_AUTHENTICATED", 401);
     const { id, userId } = await params;
-    await backendFetch(`/api/v1/orgs/${id}/members/${userId}`, {
-      method: "DELETE",
-      headers: { Authorization: `Bearer ${accessToken}` },
-    });
+    await backendFetch(
+      `/api/v1/orgs/${encodeURIComponent(id)}/members/${encodeURIComponent(userId)}`,
+      {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${accessToken}` },
+      },
+    );
     return new NextResponse(null, { status: 204 });
   } catch (error) {
     if (error instanceof BackendApiError)

--- a/frontend/src/app/api/orgs/[id]/members/route.ts
+++ b/frontend/src/app/api/orgs/[id]/members/route.ts
@@ -10,7 +10,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const accessToken = request.cookies.get("access_token")?.value;
     if (!accessToken) return bffRefusal("NOT_AUTHENTICATED", 401);
     const { id } = await params;
-    const data = await backendFetch(`/api/v1/orgs/${id}/members`, {
+    const data = await backendFetch(`/api/v1/orgs/${encodeURIComponent(id)}/members`, {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
     return bffJson(data);

--- a/frontend/src/app/api/orgs/[id]/route.ts
+++ b/frontend/src/app/api/orgs/[id]/route.ts
@@ -10,7 +10,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const accessToken = request.cookies.get("access_token")?.value;
     if (!accessToken) return bffRefusal("NOT_AUTHENTICATED", 401);
     const { id } = await params;
-    const data = await backendFetch(`/api/v1/orgs/${id}`, {
+    const data = await backendFetch(`/api/v1/orgs/${encodeURIComponent(id)}`, {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
     return bffJson(data);
@@ -27,7 +27,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     if (!accessToken) return bffRefusal("NOT_AUTHENTICATED", 401);
     const { id } = await params;
     const body = await request.json();
-    const data = await backendFetch(`/api/v1/orgs/${id}`, {
+    const data = await backendFetch(`/api/v1/orgs/${encodeURIComponent(id)}`, {
       method: "PATCH",
       headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
       body: JSON.stringify(body),
@@ -45,7 +45,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     const accessToken = request.cookies.get("access_token")?.value;
     if (!accessToken) return bffRefusal("NOT_AUTHENTICATED", 401);
     const { id } = await params;
-    await backendFetch(`/api/v1/orgs/${id}`, {
+    await backendFetch(`/api/v1/orgs/${encodeURIComponent(id)}`, {
       method: "DELETE",
       headers: { Authorization: `Bearer ${accessToken}` },
     });

--- a/frontend/src/lib/platform-proxy.test.ts
+++ b/frontend/src/lib/platform-proxy.test.ts
@@ -278,6 +278,52 @@ describe("every org-scoped request carries the organization", () => {
   });
 });
 
+// -- is every interpolated path segment encoded? ------------------------------
+
+/**
+ * Path segments a hand-rolled proxy interpolates into a `/api/v1` template
+ * without encoding.
+ *
+ * `${x}` immediately after a `/` inside a versioned-API template literal is a
+ * path segment, and `%2f`/`%2e%2e` in the raw value decode and normalise there:
+ * `x%2F..%2F..%2Fopenapi.json` reaches the backend as a different path (#13,
+ * #30). The host prefix (`${BACKEND_URL}`, before `/api/v1`) and the query
+ * (`${...search}`, `${qs}` - never after a `/`) are not segments and not
+ * matched. A route built on the shared platformProxy forwards `nextUrl.pathname`
+ * verbatim, so it interpolates nothing here and is left alone.
+ */
+function unencodedSegments(source: string): string[] {
+  const offenders: string[] = [];
+  for (const template of source.match(/`[^`]*\/api\/v1\/[^`]*`/g) ?? []) {
+    for (const match of template.matchAll(/\/\$\{([^{}]+)\}/g)) {
+      const expr = (match[1] ?? "").trim();
+      if (!expr.startsWith("encodeURIComponent")) offenders.push(expr);
+    }
+  }
+  return offenders;
+}
+
+describe("every hand-rolled proxy encodes its path segments", () => {
+  const routeFiles = sourceFiles(APP_ROOT, (name) => name.endsWith("route.ts"));
+
+  it("recognises a bare segment, an encoded one, and a query", () => {
+    expect(unencodedSegments("fetch(`/api/v1/orgs/${id}`)")).toEqual(["id"]);
+    expect(unencodedSegments("fetch(`/api/v1/orgs/${encodeURIComponent(id)}`)")).toEqual([]);
+    expect(unencodedSegments("fetch(`${BACKEND_URL}/api/v1/x${request.nextUrl.search}`)")).toEqual(
+      [],
+    );
+  });
+
+  it("has no hand-rolled proxy interpolating a bare segment", () => {
+    const offenders = routeFiles
+      .filter((path) => unencodedSegments(readFileSync(path, "utf8")).length > 0)
+      .map((path) => path.slice(APP_ROOT.length + 1))
+      .sort();
+
+    expect(offenders).toEqual([]);
+  });
+});
+
 // -- is there a route behind every path the client calls? ---------------------
 
 /**


### PR DESCRIPTION
## What changed

About a dozen route handlers under `src/app/api` interpolated a client-supplied
path segment straight into the backend URL with no `encodeURIComponent`. Next
decodes `%2F` into the param and `fetch` normalises `..`, so a segment escapes
its intended route — e.g. an org id of `x%2F..%2F..%2Fadmin%2Fusers` reached the
backend as `/api/v1/admin/users`. This is **defence-in-depth, not live
escalation**: the backend re-gates admin on `CurrentAppAdmin`, so nothing
currently reachable would not be anyway. But the BFF's own fence was decorative,
and any future backend route that assumes "only reachable via a handler that
checks X" would be exposed the day it lands.

Every interpolated segment is now `encodeURIComponent`-wrapped, matching the
sibling routes that already did it. A new sweep in `platform-proxy.test.ts`
fails any route interpolating a bare `${param}` into a `/api/v1` template — the
next hand-rolled route can't repeat the omission, which is the same reasoning the
file already gives for its org-header sweep. The host prefix (`${BACKEND_URL}`)
and query interpolations are not path segments and are left alone; a
`platformProxy` route forwards its path verbatim and has nothing to encode.

## On #13

The avatar proxy already encodes and UUID-validates its segment on `main`; the
only outstanding item in #13 was the repo-wide sweep, which this PR adds and
which now guards the avatar route too. So this closes both.

## Verification

- `platform-proxy.test.ts` — new sweep reports zero offenders across all route
  files, and self-checks that it recognises a bare segment, an encoded one, and
  a query.
- Full `src/app/api` suite (400 tests) green — the edits change only the URL
  string, no control flow, so route coverage is unaffected.

Closes #30
Closes #13