### PR TITLE
test(frontend): complete the local next-intl mocks with t.rich

### DIFF
--- a/frontend/src/app/[locale]/(dashboard)/dashboard/dashboard.integration.test.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/dashboard/dashboard.integration.test.tsx
@@ -28,10 +28,11 @@ vi.mock("@/lib/api-client", async () => {
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
 // Full-key echo, so "dashboard.errors.title" is assertable and unambiguous.
-vi.mock("next-intl", () => ({
+vi.mock("next-intl", async () => ({
   useLocale: () => "en",
-  useTranslations: (namespace?: string) => (key: string) =>
+  useTranslations: (await import("@/test-utils/intl")).keyTranslations((namespace, key) =>
     namespace ? `${namespace}.${key}` : key,
+  ),
 }));
 
 const auth = {

--- a/frontend/src/app/[locale]/(dashboard)/rag/[id]/kb-detail-sections.integration.test.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/rag/[id]/kb-detail-sections.integration.test.tsx
@@ -23,22 +23,26 @@ vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 // runs `useEffect(() => refresh(), [refresh])`, so a translator rebuilt per call made
 // that effect re-fire forever and every test here timed out (#446).
 //
-// `rich` hangs off the same function, because a component under this tree reads a
-// message with a tag in it. A mock modelling only half of `t` fails as
-// `t.rich is not a function` inside a render, several files from the assertion.
-const translators = new Map<string, (key: string) => string>();
-vi.mock("next-intl", () => ({
-  useLocale: () => "en",
-  useTranslations: (ns: string) => {
-    const cached = translators.get(ns);
-    if (cached !== undefined) return cached;
-    const translate = Object.assign((key: string): string => `${ns}.${key}`, {
-      rich: (key: string): string => `${ns}.${key}`,
-    });
-    translators.set(ns, translate);
-    return translate;
-  },
-}));
+// `rich`/`markup`/`has` hang off the same function, because a component under this
+// tree reads a message with a tag in it; a mock modelling only part of `t` fails
+// as `t.rich is not a function` inside a render, several files from the assertion
+// (#612). The shared `keyTranslations` carries all three; the cache keeps the same
+// `t` reference per namespace, which is what stops the effect above re-firing.
+vi.mock("next-intl", async () => {
+  const build = (await import("@/test-utils/intl")).keyTranslations((ns, key) => `${ns}.${key}`);
+  const cache = new Map<string, ReturnType<typeof build>>();
+  return {
+    useLocale: () => "en",
+    useTranslations: (ns: string) => {
+      let translate = cache.get(ns);
+      if (translate === undefined) {
+        translate = build(ns);
+        cache.set(ns, translate);
+      }
+      return translate;
+    },
+  };
+});
 
 const perms = new Set<string>(["collections:view"]);
 vi.mock("@/hooks/use-permissions", () => ({

--- a/frontend/src/app/[locale]/(dashboard)/rag/rag-page.integration.test.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/rag/rag-page.integration.test.tsx
@@ -22,11 +22,8 @@ vi.mock("@/lib/rag-api", async (importOriginal) => ({
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 // Key-returning translator, the same convention as the sidebar tests: the
 // assertions below name message keys, not English copy.
-vi.mock("next-intl", () => ({
-  useTranslations:
-    (ns: string) =>
-    (key: string): string =>
-      `${ns}.${key}`,
+vi.mock("next-intl", async () => ({
+  useTranslations: (await import("@/test-utils/intl")).keyTranslations((ns, key) => `${ns}.${key}`),
 }));
 
 const perms = new Set<string>();

--- a/frontend/src/app/[locale]/auth/session-adoption.integration.test.tsx
+++ b/frontend/src/app/[locale]/auth/session-adoption.integration.test.tsx
@@ -27,7 +27,9 @@ vi.mock("@/lib/api-client", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api-client")>("@/lib/api-client");
   return { ...actual, apiClient: { get: vi.fn(), post: vi.fn() } };
 });
-vi.mock("next-intl", () => ({ useTranslations: () => (key: string) => key }));
+vi.mock("next-intl", async () => ({
+  useTranslations: (await import("@/test-utils/intl")).keyTranslations(),
+}));
 
 const replace = vi.hoisted(() => vi.fn());
 const searchParams = vi.hoisted(() => new URLSearchParams());

--- a/frontend/src/components/chat/rating-buttons.test.tsx
+++ b/frontend/src/components/chat/rating-buttons.test.tsx
@@ -6,7 +6,9 @@ import { toast } from "sonner";
 import { RatingButtons } from "./rating-buttons";
 import { RatingValue, type UserRating } from "@/types";
 
-vi.mock("next-intl", () => ({ useTranslations: () => (key: string) => key }));
+vi.mock("next-intl", async () => ({
+  useTranslations: (await import("@/test-utils/intl")).keyTranslations(),
+}));
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
 let fetchMock: ReturnType<typeof vi.fn>;

--- a/frontend/src/components/layout/active-org-guard.integration.test.tsx
+++ b/frontend/src/components/layout/active-org-guard.integration.test.tsx
@@ -15,7 +15,9 @@ vi.mock("next/navigation", () => ({
   redirect: vi.fn(),
   permanentRedirect: vi.fn(),
 }));
-vi.mock("next-intl", () => ({ useTranslations: () => (key: string) => key }));
+vi.mock("next-intl", async () => ({
+  useTranslations: (await import("@/test-utils/intl")).keyTranslations(),
+}));
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 vi.mock("@/lib/api-client", async () => {
   const { ApiError } = await import("@/lib/api-error");

--- a/frontend/src/components/layout/app-sidebar.test.tsx
+++ b/frontend/src/components/layout/app-sidebar.test.tsx
@@ -13,7 +13,9 @@ vi.mock("next/navigation", () => ({
   redirect: vi.fn(),
   permanentRedirect: vi.fn(),
 }));
-vi.mock("next-intl", () => ({ useTranslations: () => (key: string) => key }));
+vi.mock("next-intl", async () => ({
+  useTranslations: (await import("@/test-utils/intl")).keyTranslations(),
+}));
 vi.mock("@/hooks/use-permissions", () => ({ usePermissions: () => ({ can }) }));
 vi.mock("@/stores", () => ({ useAuthStore: () => ({ user: currentUser() }) }));
 

--- a/frontend/src/components/layout/command-palette.test.tsx
+++ b/frontend/src/components/layout/command-palette.test.tsx
@@ -16,7 +16,9 @@ const currentUser = vi.fn<() => { is_app_admin?: boolean } | null>(() => ({
 }));
 const push = vi.fn();
 
-vi.mock("next-intl", () => ({ useTranslations: () => (key: string) => key }));
+vi.mock("next-intl", async () => ({
+  useTranslations: (await import("@/test-utils/intl")).keyTranslations(),
+}));
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push }),
   // next-intl's createNavigation wraps these at module scope; see `vitest.setup.ts`.

--- a/frontend/src/components/layout/mobile-tab-bar.test.tsx
+++ b/frontend/src/components/layout/mobile-tab-bar.test.tsx
@@ -9,7 +9,9 @@ vi.mock("next/navigation", () => ({
   usePathname: () => currentPath(),
   useRouter: () => ({ push: vi.fn() }),
 }));
-vi.mock("next-intl", () => ({ useTranslations: () => (key: string) => key }));
+vi.mock("next-intl", async () => ({
+  useTranslations: (await import("@/test-utils/intl")).keyTranslations(),
+}));
 
 /**
  * The tab bar had the same bug the desktop sidebar had, in a worse form: it

--- a/frontend/src/components/layout/sidebar-search.test.tsx
+++ b/frontend/src/components/layout/sidebar-search.test.tsx
@@ -3,7 +3,9 @@ import { describe, expect, it, vi } from "vitest";
 
 import { SidebarSearch } from "./sidebar-search";
 
-vi.mock("next-intl", () => ({ useTranslations: () => (key: string) => key }));
+vi.mock("next-intl", async () => ({
+  useTranslations: (await import("@/test-utils/intl")).keyTranslations(),
+}));
 
 describe("SidebarSearch", () => {
   it("opens the command palette rather than searching anything itself", () => {

--- a/frontend/src/components/layout/sidebar-user.test.tsx
+++ b/frontend/src/components/layout/sidebar-user.test.tsx
@@ -14,7 +14,9 @@ const OWNER: User = {
   created_at: "2026-01-01T00:00:00Z",
 };
 
-vi.mock("next-intl", () => ({ useTranslations: () => (key: string) => key }));
+vi.mock("next-intl", async () => ({
+  useTranslations: (await import("@/test-utils/intl")).keyTranslations(),
+}));
 vi.mock("@/hooks", () => ({ useAuth: () => ({ user: currentUser(), logout: vi.fn() }) }));
 vi.mock("@/stores", () => ({
   useAuthStore: <T,>(selector: (state: { avatarVersion: number }) => T): T =>

--- a/frontend/src/components/runs/spend-by-person.integration.test.tsx
+++ b/frontend/src/components/runs/spend-by-person.integration.test.tsx
@@ -25,9 +25,10 @@ vi.mock("@/lib/api-client", async () => {
 });
 
 // Full-key echo, so a chrome string is assertable and unambiguous.
-vi.mock("next-intl", () => ({
-  useTranslations: (namespace?: string) => (key: string) =>
+vi.mock("next-intl", async () => ({
+  useTranslations: (await import("@/test-utils/intl")).keyTranslations((namespace, key) =>
     namespace ? `${namespace}.${key}` : key,
+  ),
 }));
 
 const auth = {

--- a/frontend/src/test-utils/intl.test.ts
+++ b/frontend/src/test-utils/intl.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { keyTranslations } from "./intl";
+
+describe("keyTranslations", () => {
+  it("returns keys, and carries the members the real t has", () => {
+    const t = keyTranslations()("ns");
+
+    expect(t("k")).toBe("k");
+    // The members a bare `(key) => key` mock lacks: a component reading a message
+    // with a tag calls `t.rich`, and the missing method throws inside an
+    // unrelated spec (#612).
+    expect(t.rich("k")).toBe("k");
+    expect(t.markup("k")).toBe("k");
+    expect(t.has("k")).toBe(true);
+  });
+
+  it("preserves a caller's namespaced key format", () => {
+    const t = keyTranslations((ns, key) => (ns ? `${ns}.${key}` : key))("pages");
+
+    expect(t("title")).toBe("pages.title");
+    expect(t.rich("title")).toBe("pages.title");
+  });
+});

--- a/frontend/src/test-utils/intl.ts
+++ b/frontend/src/test-utils/intl.ts
@@ -1,0 +1,26 @@
+/**
+ * A key-as-value `useTranslations` for tests, carrying the members the real `t`
+ * has.
+ *
+ * Local `next-intl` mocks return keys instead of copy so assertions can name a
+ * message rather than its English. A bare `(key) => key` is not `t`, though: `t`
+ * carries `t.rich`, `t.markup` and `t.has`, and a component reading a message
+ * with a tag calls `t.rich`. A bare mock throws `t.rich is not a function`
+ * inside a component several files from the assertion, in a spec about something
+ * else (#612). One definition here keeps every local mock complete.
+ *
+ * `format` preserves each caller's existing key shape - `(key) => key`, or
+ * `(ns, key) => ns.key` - so no assertion moves.
+ */
+export function keyTranslations(
+  format: (namespace: string | undefined, key: string) => string = (_namespace, key) => key,
+) {
+  return (namespace?: string) => {
+    const translate = (key: string) => format(namespace, key);
+    return Object.assign(translate, {
+      rich: (key: string) => format(namespace, key),
+      markup: (key: string) => format(namespace, key),
+      has: (_key: string) => true,
+    });
+  };
+}


### PR DESCRIPTION
## What changed

Twelve specs mocked `next-intl` as a translator missing part of `t`: eleven as a
bare `(key) => key`, and `kb-detail-sections` as a hand-rolled cache that had
grown `t.rich` (via #610) but still lacked `t.markup`/`t.has`. `t` carries all of
`rich`, `markup` and `has`, and a component reading a message with a tag calls
`t.rich`. All are green today only because none of their components reads a rich
message yet — the #395 guard now steers copy toward `t.rich`, so they will, and
then one throws `t.rich is not a function` inside a component several files from
the assertion, exactly as #610 hit once.

A shared `keyTranslations(format)` helper (`src/test-utils/intl.ts`) is now the
one definition of a key-returning translator, complete with `rich`/`markup`/`has`,
and each local mock uses it — preserving its own key shape (and, for kb-detail,
its per-namespace cache) so no assertion moves. The mock factory is `async` and
imports the helper inside it, because `vi.mock` is hoisted above the static
imports (a direct import reference throws "Cannot access … before
initialization"). `copy.integration` is untouched — it already builds a real
translator through `createTranslator`.

## Verification

- `intl.test.ts` asserts the helper carries `rich`/`markup`/`has`, so the next
  mock added by copy-paste cannot lose them silently.
- All twelve migrated specs + the helper test are green (116 tests).
- `make lint-frontend` clean.

Closes #612