### PR TITLE
fix(logging): stop logging domain refusals as application errors

### DIFF
--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -9,6 +9,7 @@ from sqlalchemy.pool import NullPool
 
 from app.core.background import discard_deferred, start_deferred
 from app.core.config import settings
+from app.core.exceptions import AppException
 
 logger = logging.getLogger(__name__)
 
@@ -49,8 +50,12 @@ async def _managed_session(
         try:
             yield session
             await session.commit()
-        except Exception:
-            logger.exception("DB session error, rolling back")
+        except Exception as exc:
+            # A domain refusal (a 4xx AppException) is an ordinary outcome, not an
+            # application error, so it rolls back without a traceback - the ERROR
+            # line, and its stack, is kept for the unexpected and for 5xx faults (#19).
+            if not isinstance(exc, AppException) or exc.status_code >= 500:
+                logger.exception("DB session error, rolling back")
             try:
                 await session.rollback()
             except Exception:

--- a/backend/tests/test_db_session_logging.py
+++ b/backend/tests/test_db_session_logging.py
@@ -1,0 +1,85 @@
+"""A domain refusal is not an application error in the log (#19).
+
+Every exception through the session dependency used to be logged at ERROR with a
+full traceback - including every `NotFoundError`, `AuthorizationError` and
+`AlreadyExistsError`, which are ordinary 4xx outcomes. On a platform whose value
+is mostly in what it refuses, the refusals were the loudest lines in the log and
+a real 500 was buried among them. `_managed_session` now rolls a domain refusal
+back and re-raises it without a traceback, and keeps ERROR for the unexpected.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.core.exceptions import ExternalServiceError, NotFoundError
+from app.db.session import _managed_session
+
+pytestmark = pytest.mark.anyio
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.commit = AsyncMock()
+        self.rollback = AsyncMock()
+        self.info: dict[str, object] = {}
+
+    async def __aenter__(self) -> _FakeSession:
+        return self
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False
+
+
+def _factory(session: _FakeSession):
+    return lambda: session
+
+
+async def test_a_domain_refusal_rolls_back_without_an_error_log(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    session = _FakeSession()
+    with caplog.at_level(logging.ERROR, logger="app.db.session"), pytest.raises(NotFoundError):
+        async with _managed_session(_factory(session)) as db:
+            assert db is session
+            raise NotFoundError(message="no such row")
+
+    session.rollback.assert_awaited_once()
+    session.commit.assert_not_awaited()
+    assert caplog.records == []
+
+
+async def test_an_unexpected_error_still_logs_at_error_with_a_traceback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    session = _FakeSession()
+    with caplog.at_level(logging.ERROR, logger="app.db.session"), pytest.raises(RuntimeError):
+        async with _managed_session(_factory(session)) as _db:
+            raise RuntimeError("something genuinely broke")
+
+    session.rollback.assert_awaited_once()
+    errors = [record for record in caplog.records if record.levelno == logging.ERROR]
+    assert len(errors) == 1
+    assert errors[0].exc_info is not None
+
+
+async def test_a_5xx_domain_error_still_logs_at_error_with_a_traceback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # A server-fault AppException (status >= 500) is not a refusal, so its
+    # traceback must survive - the suppression is for 4xx outcomes only.
+    session = _FakeSession()
+    with (
+        caplog.at_level(logging.ERROR, logger="app.db.session"),
+        pytest.raises(ExternalServiceError),
+    ):
+        async with _managed_session(_factory(session)) as _db:
+            raise ExternalServiceError(message="upstream is down")
+
+    session.rollback.assert_awaited_once()
+    errors = [record for record in caplog.records if record.levelno == logging.ERROR]
+    assert len(errors) == 1
+    assert errors[0].exc_info is not None


### PR DESCRIPTION
## What changed

`_managed_session` caught every exception with `logger.exception(...)`, so every
domain refusal — `NotFoundError` (404), `AuthorizationError` (403),
`AlreadyExistsError` (409) — wrote a full stack trace at ERROR. On a platform
whose value is mostly in what it refuses, the refusals were the loudest lines in
the log and a real 500 was buried among them.

A domain refusal now rolls back and re-raises without a traceback. The ERROR
line is kept for the unexpected — and, deliberately, for a **5xx** `AppException`
(`DatabaseError`, `ExternalServiceError`, …), a server-fault whose traceback the
exception handler does not log, so suppressing it here would lose it end to end.
The gate is `not isinstance(exc, AppException) or exc.status_code >= 500`, in a
single branch so the rollback stays wrapped for every path.

## Verification

- `tests/test_db_session_logging.py` drives the real `_managed_session`: a 404
  produces no ERROR record and still rolls back; an unexpected `RuntimeError` and
  a 5xx `ExternalServiceError` each log exactly one ERROR with `exc_info`.
- The conftest mocks `get_db_session`, so this lifecycle was off the tested path —
  which is why the noise went unseen. `app/db/session.py` is not on the coverage
  gate; the test is regression cover, not a gate requirement.

## Reviewed
Went through the Review session; the 5xx-traceback gap it raised is fixed above.

Closes #19