### PR TITLE
fix(api): register SecurityHeadersMiddleware

### DIFF
--- a/backend/app/api/exception_handlers.py
+++ b/backend/app/api/exception_handlers.py
@@ -36,6 +36,7 @@ from starlette.requests import HTTPConnection
 from app.agents.capabilities.budget import BudgetExceeded
 from app.core.exceptions import AppException, ValidationError
 from app.core.field_errors import request_field_problems
+from app.core.middleware import security_headers_for_error
 
 logger = logging.getLogger(__name__)
 
@@ -241,11 +242,15 @@ async def unhandled_exception_handler(
     if _is_websocket(request):
         return None
 
+    # ServerErrorMiddleware, which runs this handler, sits outside the whole
+    # middleware stack, so SecurityHeadersMiddleware never reaches a 500 - it has
+    # to carry the headers itself (#18).
     return _envelope(
         status_code=500,
         code="INTERNAL_ERROR",
         message="An unexpected error occurred",
         details=None,
+        headers=security_headers_for_error(),
     )
 
 

--- a/backend/app/core/middleware.py
+++ b/backend/app/core/middleware.py
@@ -74,19 +74,24 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         self.exclude_paths = exclude_paths or {"/docs", "/redoc", "/openapi.json"}
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
-        """Add security headers to the response."""
+        """Add security headers to the response.
+
+        `exclude_paths` drops only the Content-Security-Policy, never the rest of
+        the set: the CSP is what breaks Swagger and ReDoc, which pull assets a
+        strict policy forbids, but those pages still need their framing and MIME
+        protections - excluding them wholesale would leave /docs embeddable by any
+        origin while an operator uses its authenticated controls.
+        """
         response = await call_next(request)
 
-        if request.url.path in self.exclude_paths:
-            return response
+        if request.url.path not in self.exclude_paths:
+            csp_value = "; ".join(
+                f"{directive} {value}" for directive, value in self.csp_directives.items()
+            )
+            # Respect an already-set header so an endpoint can opt into a looser
+            # policy (e.g. user-content files in the chat preview panel).
+            response.headers.setdefault("Content-Security-Policy", csp_value)
 
-        csp_value = "; ".join(
-            f"{directive} {value}" for directive, value in self.csp_directives.items()
-        )
-
-        # Respect any already-set headers so an endpoint can opt into less
-        # restrictive framing (e.g. user-content files in the chat preview panel).
-        response.headers.setdefault("Content-Security-Policy", csp_value)
         response.headers.setdefault("X-Content-Type-Options", "nosniff")
         response.headers.setdefault("X-Frame-Options", "DENY")
         # 0, not "1; mode=block": the legacy auditor is deprecated and its

--- a/backend/app/core/middleware.py
+++ b/backend/app/core/middleware.py
@@ -27,6 +27,23 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
         return response
 
 
+PERMISSIONS_POLICY = (
+    "accelerometer=(), camera=(), geolocation=(), gyroscope=(), "
+    "magnetometer=(), microphone=(), payment=(), usb=()"
+)
+
+# The headers that go on every response regardless of path. X-XSS-Protection is
+# 0, not "1; mode=block": the legacy auditor is deprecated and its blocking mode
+# opens XS-Leak vectors in the browsers that still ship it, so OWASP is to
+# disable it and rely on the CSP.
+_STATIC_SECURITY_HEADERS: dict[str, str] = {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "X-XSS-Protection": "0",
+    "Referrer-Policy": "strict-origin-when-cross-origin",
+}
+
+
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
     """Middleware that adds security headers to all responses.
 
@@ -72,6 +89,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
         self.csp_directives = csp_directives or self.DEFAULT_CSP_DIRECTIVES
         self.exclude_paths = exclude_paths or {"/docs", "/redoc", "/openapi.json"}
+        self._csp_value = "; ".join(f"{d} {v}" for d, v in self.csp_directives.items())
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         """Add security headers to the response.
@@ -85,23 +103,32 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response = await call_next(request)
 
         if request.url.path not in self.exclude_paths:
-            csp_value = "; ".join(
-                f"{directive} {value}" for directive, value in self.csp_directives.items()
-            )
             # Respect an already-set header so an endpoint can opt into a looser
             # policy (e.g. user-content files in the chat preview panel).
-            response.headers.setdefault("Content-Security-Policy", csp_value)
+            response.headers.setdefault("Content-Security-Policy", self._csp_value)
 
-        response.headers.setdefault("X-Content-Type-Options", "nosniff")
-        response.headers.setdefault("X-Frame-Options", "DENY")
-        # 0, not "1; mode=block": the legacy auditor is deprecated and its
-        # blocking mode opens XS-Leak vectors in the browsers that still have it,
-        # so OWASP is to disable it and rely on the CSP above.
-        response.headers.setdefault("X-XSS-Protection", "0")
-        response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
-        response.headers["Permissions-Policy"] = (
-            "accelerometer=(), camera=(), geolocation=(), gyroscope=(), "
-            "magnetometer=(), microphone=(), payment=(), usb=()"
-        )
+        for name, value in _STATIC_SECURITY_HEADERS.items():
+            response.headers.setdefault(name, value)
+        response.headers["Permissions-Policy"] = PERMISSIONS_POLICY
 
         return response
+
+
+def security_headers_for_error() -> dict[str, str]:
+    """The security header set for a response the middleware never sees.
+
+    An unhandled exception is turned into a 500 by Starlette's
+    ServerErrorMiddleware, which is installed outside the whole middleware stack,
+    so `SecurityHeadersMiddleware` never runs over that response and the 500
+    handler stamps the headers itself (#18). A 500 is a JSON envelope rather than
+    a docs page, so it carries the CSP too.
+    """
+    csp = "; ".join(
+        f"{directive} {value}"
+        for directive, value in SecurityHeadersMiddleware.DEFAULT_CSP_DIRECTIVES.items()
+    )
+    return {
+        "Content-Security-Policy": csp,
+        **_STATIC_SECURITY_HEADERS,
+        "Permissions-Policy": PERMISSIONS_POLICY,
+    }

--- a/backend/app/core/middleware.py
+++ b/backend/app/core/middleware.py
@@ -89,7 +89,10 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers.setdefault("Content-Security-Policy", csp_value)
         response.headers.setdefault("X-Content-Type-Options", "nosniff")
         response.headers.setdefault("X-Frame-Options", "DENY")
-        response.headers.setdefault("X-XSS-Protection", "1; mode=block")
+        # 0, not "1; mode=block": the legacy auditor is deprecated and its
+        # blocking mode opens XS-Leak vectors in the browsers that still have it,
+        # so OWASP is to disable it and rely on the CSP above.
+        response.headers.setdefault("X-XSS-Protection", "0")
         response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
         response.headers["Permissions-Policy"] = (
             "accelerometer=(), camera=(), geolocation=(), gyroscope=(), "

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -26,7 +26,7 @@ from app.core.logging import setup_logging
 from app.core.body_limit import BodySizeLimitMiddleware
 from app.core import maintenance
 from app.core.maintenance import MaintenanceModeMiddleware
-from app.core.middleware import RequestIDMiddleware
+from app.core.middleware import RequestIDMiddleware, SecurityHeadersMiddleware
 from app.core.watchdog import EventLoopWatchdog
 from app.clients.redis import RedisClient
 from app.services.rag.embeddings import EmbeddingService
@@ -306,6 +306,18 @@ OS for your agents.
     app.add_middleware(MaintenanceModeMiddleware)
 
     app.add_middleware(RequestIDMiddleware)
+
+    # Security headers on every response - CSP, nosniff, X-Frame-Options: DENY,
+    # Referrer-Policy, Permissions-Policy. It was written and never registered, so
+    # `files.py` already opts its one framed endpoint down to SAMEORIGIN against a
+    # default that was not there (#18); the headers use `setdefault`, so that
+    # per-response override still wins. The doc pages are excluded by their real
+    # mounted paths (the schema lives under the API prefix, not at `/openapi.json`),
+    # so the CSP cannot break Swagger/ReDoc loading their CDN assets.
+    app.add_middleware(
+        SecurityHeadersMiddleware,
+        exclude_paths={path for path in (docs_url, redoc_url, openapi_url) if path},
+    )
 
     register_exception_handlers(app)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -307,18 +307,6 @@ OS for your agents.
 
     app.add_middleware(RequestIDMiddleware)
 
-    # Security headers on every response - CSP, nosniff, X-Frame-Options: DENY,
-    # Referrer-Policy, Permissions-Policy. It was written and never registered, so
-    # `files.py` already opts its one framed endpoint down to SAMEORIGIN against a
-    # default that was not there (#18); the headers use `setdefault`, so that
-    # per-response override still wins. The doc pages are excluded by their real
-    # mounted paths (the schema lives under the API prefix, not at `/openapi.json`),
-    # so the CSP cannot break Swagger/ReDoc loading their CDN assets.
-    app.add_middleware(
-        SecurityHeadersMiddleware,
-        exclude_paths={path for path in (docs_url, redoc_url, openapi_url) if path},
-    )
-
     register_exception_handlers(app)
 
     app.add_middleware(
@@ -330,6 +318,21 @@ OS for your agents.
     )
 
     app.add_middleware(SessionMiddleware, secret_key=settings.SECRET_KEY)
+
+    # Added last, so it is the outermost middleware and wraps CORS: a preflight
+    # OPTIONS is answered by CORSMiddleware without calling inward, so a security
+    # layer beneath it would never see that response and the preflight would go
+    # out bare. The set uses `setdefault`, so a per-response override still wins -
+    # `files.py` opts its one framed endpoint down to SAMEORIGIN this way. The doc
+    # pages are excluded by their real mounted paths (the schema lives under the
+    # API prefix, not at `/openapi.json`), so the CSP cannot break Swagger/ReDoc
+    # loading their CDN assets. A genuinely unhandled exception is the one 500
+    # this cannot reach - ServerErrorMiddleware sits outside every app middleware
+    # - so its handler stamps the headers itself (#18).
+    app.add_middleware(
+        SecurityHeadersMiddleware,
+        exclude_paths={path for path in (docs_url, redoc_url, openapi_url) if path},
+    )
 
     app.include_router(api_router, prefix=settings.API_V1_STR)
 

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -47,3 +47,23 @@ async def test_a_per_response_x_frame_options_override_survives_the_middleware()
     assert resp.headers["x-frame-options"] == "SAMEORIGIN"
     assert "content-security-policy" in resp.headers
     assert resp.headers["x-content-type-options"] == "nosniff"
+
+
+async def test_an_excluded_path_keeps_its_framing_but_drops_the_csp() -> None:
+    # /docs drops only the CSP - Swagger's assets need it relaxed - but must keep
+    # its framing and MIME protections, or excluding it would leave the page
+    # embeddable by any origin.
+    app = FastAPI()
+    app.add_middleware(SecurityHeadersMiddleware, exclude_paths={"/docs"})
+
+    @app.get("/docs")
+    async def docs() -> Response:
+        return Response(content=b"<html></html>")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        resp = await ac.get("/docs")
+
+    assert "content-security-policy" not in resp.headers
+    assert resp.headers["x-frame-options"] == "DENY"
+    assert resp.headers["x-content-type-options"] == "nosniff"
+    assert resp.headers["x-xss-protection"] == "0"

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -1,0 +1,49 @@
+"""Every response carries the security headers, and a per-response override wins (#18).
+
+`SecurityHeadersMiddleware` was fully written and never registered, so no API
+response carried a Content-Security-Policy, and `files.py` opted its one framed
+endpoint down to `SAMEORIGIN` against a default that was not there. It is
+registered now, and because it sets each header with `setdefault`, that
+per-response override still wins.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI, Response
+from httpx import ASGITransport, AsyncClient
+
+from app.core.config import settings
+from app.core.middleware import SecurityHeadersMiddleware
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_an_ordinary_response_carries_the_security_headers(client: AsyncClient) -> None:
+    resp = await client.get(f"{settings.API_V1_STR}/health")
+
+    assert resp.status_code == 200
+    assert "content-security-policy" in resp.headers
+    assert resp.headers["x-content-type-options"] == "nosniff"
+    assert resp.headers["x-frame-options"] == "DENY"
+    # 0 disables the deprecated legacy auditor; the CSP is the real defence.
+    assert resp.headers["x-xss-protection"] == "0"
+
+
+async def test_a_per_response_x_frame_options_override_survives_the_middleware() -> None:
+    # The files download sets SAMEORIGIN so its PDF preview can be framed; the
+    # middleware sets its headers with setdefault, so that choice is not
+    # overwritten back to DENY - which is what `files.py` already assumes.
+    app = FastAPI()
+    app.add_middleware(SecurityHeadersMiddleware)
+
+    @app.get("/framed")
+    async def framed() -> Response:
+        return Response(content=b"pdf", headers={"X-Frame-Options": "SAMEORIGIN"})
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        resp = await ac.get("/framed")
+
+    assert resp.headers["x-frame-options"] == "SAMEORIGIN"
+    assert "content-security-policy" in resp.headers
+    assert resp.headers["x-content-type-options"] == "nosniff"

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -13,6 +13,7 @@ import pytest
 from fastapi import FastAPI, Response
 from httpx import ASGITransport, AsyncClient
 
+from app.api.exception_handlers import register_exception_handlers
 from app.core.config import settings
 from app.core.middleware import SecurityHeadersMiddleware
 
@@ -66,4 +67,46 @@ async def test_an_excluded_path_keeps_its_framing_but_drops_the_csp() -> None:
     assert "content-security-policy" not in resp.headers
     assert resp.headers["x-frame-options"] == "DENY"
     assert resp.headers["x-content-type-options"] == "nosniff"
+    assert resp.headers["x-xss-protection"] == "0"
+
+
+async def test_an_unhandled_error_still_carries_the_security_headers() -> None:
+    # A genuinely unhandled exception is turned into a 500 by Starlette's
+    # ServerErrorMiddleware, which sits outside the whole middleware stack - so
+    # SecurityHeadersMiddleware never sees that response and the handler stamps
+    # the set itself. Without that, a 500 goes out bare.
+    app = FastAPI()
+    register_exception_handlers(app)
+    app.add_middleware(SecurityHeadersMiddleware)
+
+    @app.get("/boom")
+    async def boom() -> Response:
+        raise RuntimeError("kaboom")
+
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/boom")
+
+    assert resp.status_code == 500
+    assert "content-security-policy" in resp.headers
+    assert resp.headers["x-content-type-options"] == "nosniff"
+    assert resp.headers["x-frame-options"] == "DENY"
+    assert resp.headers["x-xss-protection"] == "0"
+    assert "permissions-policy" in resp.headers
+
+
+async def test_a_cors_preflight_carries_the_security_headers(client: AsyncClient) -> None:
+    # CORSMiddleware answers a preflight OPTIONS without calling inward, so the
+    # security layer has to sit outside it or the preflight response goes out
+    # without the headers.
+    resp = await client.options(
+        f"{settings.API_V1_STR}/health",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert resp.headers["x-content-type-options"] == "nosniff"
+    assert resp.headers["x-frame-options"] == "DENY"
     assert resp.headers["x-xss-protection"] == "0"

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -35,7 +35,7 @@ curl http://localhost:8000/api/v1/health
 ### Reverse proxy
 Nginx config in `nginx/` proxies `/` → frontend, `/api` → backend, `/ws` → backend WebSocket. Update `server_name` and TLS cert paths in `nginx/conf.d/app.conf`.
 
-The backend sets its own security headers on every response — a Content-Security-Policy, `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy` and `Permissions-Policy` — so a deployment behind any proxy, not only the bundled Nginx, is covered. The interactive API docs (`/docs`, `/redoc`, `/openapi.json`) are the one exception, and only for the CSP: Swagger and ReDoc load assets a strict policy forbids, so those pages drop the CSP while keeping their framing and MIME protections. HSTS is deliberately left to the proxy, which is where TLS terminates; a front proxy that sets its own CSP should make sure it is at least as strict.
+The backend sets its own security headers on every response — a Content-Security-Policy, `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy` and `Permissions-Policy` — so a deployment behind any proxy, not only the bundled Nginx, is covered. A response for an unhandled exception is turned into a 500 outside the middleware stack, so its handler stamps the same headers itself. The interactive API docs (`/docs`, `/redoc`, `/api/v1/openapi.json`) are the one exception, and only for the CSP: Swagger and ReDoc load assets a strict policy forbids, so those pages drop the CSP while keeping their framing and MIME protections. HSTS is deliberately left to the proxy, which is where TLS terminates; a front proxy that sets its own CSP should make sure it is at least as strict.
 
 
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -35,6 +35,8 @@ curl http://localhost:8000/api/v1/health
 ### Reverse proxy
 Nginx config in `nginx/` proxies `/` → frontend, `/api` → backend, `/ws` → backend WebSocket. Update `server_name` and TLS cert paths in `nginx/conf.d/app.conf`.
 
+The backend sets its own security headers on every response — a Content-Security-Policy, `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy` and `Permissions-Policy` — so a deployment behind any proxy, not only the bundled Nginx, is covered. HSTS is deliberately left to the proxy, which is where TLS terminates; a front proxy that sets its own CSP should make sure it is at least as strict.
+
 
 
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -35,7 +35,7 @@ curl http://localhost:8000/api/v1/health
 ### Reverse proxy
 Nginx config in `nginx/` proxies `/` → frontend, `/api` → backend, `/ws` → backend WebSocket. Update `server_name` and TLS cert paths in `nginx/conf.d/app.conf`.
 
-The backend sets its own security headers on every response — a Content-Security-Policy, `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy` and `Permissions-Policy` — so a deployment behind any proxy, not only the bundled Nginx, is covered. HSTS is deliberately left to the proxy, which is where TLS terminates; a front proxy that sets its own CSP should make sure it is at least as strict.
+The backend sets its own security headers on every response — a Content-Security-Policy, `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy` and `Permissions-Policy` — so a deployment behind any proxy, not only the bundled Nginx, is covered. The interactive API docs (`/docs`, `/redoc`, `/openapi.json`) are the one exception, and only for the CSP: Swagger and ReDoc load assets a strict policy forbids, so those pages drop the CSP while keeping their framing and MIME protections. HSTS is deliberately left to the proxy, which is where TLS terminates; a front proxy that sets its own CSP should make sure it is at least as strict.
 
 
 

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -23,8 +23,12 @@ const securityHeaders = [
     value: "DENY",
   },
   {
+    // 0, not "1; mode=block": the legacy auditor is deprecated and its blocking
+    // mode opens XS-Leak vectors, so OWASP is to disable it and rely on the CSP.
+    // This matches the backend and the bundled Nginx, so a proxied response does
+    // not carry two conflicting values.
     key: "X-XSS-Protection",
-    value: "1; mode=block",
+    value: "0",
   },
   {
     key: "Referrer-Policy",

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -76,7 +76,7 @@ server {
     # Security Headers
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
-    add_header X-XSS-Protection "1; mode=block" always;
+    add_header X-XSS-Protection "0" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
@@ -138,7 +138,7 @@ server {
     # Security Headers
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
-    add_header X-XSS-Protection "1; mode=block" always;
+    add_header X-XSS-Protection "0" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 


### PR DESCRIPTION
## What changed

`SecurityHeadersMiddleware` is fully written but was never registered, so no API
response carried a Content-Security-Policy, `X-Content-Type-Options`,
`X-Frame-Options`, `Referrer-Policy` or `Permissions-Policy`. The bundled nginx
sets a weaker subset and no CSP, and a self-hosted deployment not fronted by that
exact nginx got nothing. The sharpest sign it was an oversight: `files.py`
already opts its framed endpoint down to `SAMEORIGIN` against a default that was
not there.

Registered in `create_app`, with `setdefault`, so the files download's
per-response `X-Frame-Options: SAMEORIGIN` still wins.

Two things the registration makes live for the first time, fixed here (raised in
review):
- `X-XSS-Protection: 0` instead of the deprecated `1; mode=block`, per OWASP —
  the CSP is the real defence.
- The doc pages are excluded by their **real** mounted paths (schema is under the
  API prefix, not `/openapi.json`), so the exclusion is not a dead entry and the
  CSP can't break Swagger/ReDoc's CDN.

## Verification

- `tests/test_security_headers.py`: `/health` carries the CSP, `nosniff` and
  `X-XSS-Protection: 0`; a `SAMEORIGIN` response survives the middleware and still
  gains the CSP.
- `tests/api/` + `test_core` (722) green — no header regression.
- `docs/deploy.md` records the app-level headers for operators with their own proxy.

## Reviewed
Went through the Review session; its two minors (X-XSS-Protection, dead openapi
exclusion) and the docs note are applied.

Closes #18