### PR TITLE
fix(audit): fail closed when an audit write cannot be recorded

### DIFF
--- a/backend/app/core/audit.py
+++ b/backend/app/core/audit.py
@@ -5,6 +5,8 @@ from contextvars import ContextVar
 from typing import Any
 from uuid import UUID
 
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from app.db.models.audit_log import AppAdminAuditLog
 
 logger = logging.getLogger(__name__)
@@ -36,7 +38,7 @@ def current_impersonator() -> UUID | None:
 
 
 async def record_audit(
-    db,
+    db: AsyncSession,
     *,
     actor_user_id: UUID | None,
     action: str,
@@ -46,26 +48,31 @@ async def record_audit(
     details: dict[str, Any] | None = None,
     ip_address: str | None = None,
 ) -> None:
-    """Persist an audit log entry. Failures are logged but do not raise.
+    """Persist an audit log entry within the caller's transaction.
+
+    The write shares the request's session, so it commits or rolls back with the
+    action it records: a failure to record propagates and rolls the mutation back
+    rather than letting a privileged action land unaudited. The trail is
+    load-bearing for the app-admin bypass story in `docs/governance.md`, so
+    fail-open here would be a hole, not resilience. Swallowing the error also
+    never achieved silence - `flush` leaves the session needing a rollback, so
+    the request's commit raised `PendingRollbackError` and 500'd anyway.
 
     `actor_user_id` is `None` for the one caller that has no actor: the approval
     expiry sweep, which records that *nobody* decided. It is required rather than
     defaulted, so passing no actor stays a deliberate act at each call site
     instead of the thing that happens when an argument is forgotten.
     """
-    try:
-        impersonator_id = _impersonator_id.get()
-        entry = AppAdminAuditLog(
-            actor_user_id=actor_user_id,
-            impersonator_user_id=impersonator_id if impersonator_id != actor_user_id else None,
-            action=action,
-            organization_id=organization_id,
-            target_type=target_type,
-            target_id=str(target_id) if target_id is not None else None,
-            details=details,
-            ip_address=ip_address,
-        )
-        db.add(entry)
-        await db.flush()
-    except Exception:
-        logger.exception("Failed to write audit log for action=%s actor=%s", action, actor_user_id)
+    impersonator_id = _impersonator_id.get()
+    entry = AppAdminAuditLog(
+        actor_user_id=actor_user_id,
+        impersonator_user_id=impersonator_id if impersonator_id != actor_user_id else None,
+        action=action,
+        organization_id=organization_id,
+        target_type=target_type,
+        target_id=str(target_id) if target_id is not None else None,
+        details=details,
+        ip_address=ip_address,
+    )
+    db.add(entry)
+    await db.flush()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -467,6 +467,10 @@ include = [
     "app/core/catalog/**",
     "app/core/secret_kinds.py",
     "app/core/vault.py",
+    # The audit trail, fail-closed and part of the caller's transaction. Every
+    # service that records a privileged action is already in this list; the trail
+    # they write to was not (#20).
+    "app/core/audit.py",
     "app/core/background.py",
     # The client that dials the address it validated, for a URL the party being
     # validated chose. A miss here is an SSRF the operator cannot see.
@@ -687,6 +691,10 @@ include = [
     "app/core/catalog/**",
     "app/core/secret_kinds.py",
     "app/core/vault.py",
+    # The audit trail, fail-closed and part of the caller's transaction. Every
+    # service that records a privileged action is already in this list; the trail
+    # they write to was not (#20).
+    "app/core/audit.py",
     "app/core/background.py",
     # The client that dials the address it validated, for a URL the party being
     # validated chose. A miss here is an SSRF the operator cannot see.

--- a/backend/tests/test_audit_record.py
+++ b/backend/tests/test_audit_record.py
@@ -1,0 +1,76 @@
+"""The audit write is part of the action it records, not a best-effort aside.
+
+`record_audit` used to swallow every failure, which was fail-open on a trail that
+`docs/governance.md` makes load-bearing for the app-admin bypass story - and it
+did not even buy silence, since a flushed-then-abandoned session made the
+request's commit raise anyway (#20).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.core.audit import current_impersonator, record_audit, set_impersonator
+
+pytestmark = pytest.mark.anyio
+
+
+class _CapturingDB:
+    def __init__(self) -> None:
+        self.added: list[object] = []
+
+    def add(self, entry: object) -> None:
+        self.added.append(entry)
+
+    async def flush(self) -> None:
+        pass
+
+
+class _FlushRaisesDB(_CapturingDB):
+    async def flush(self) -> None:
+        raise RuntimeError("connection reset")
+
+
+class TestFailsClosed:
+    def teardown_method(self) -> None:
+        set_impersonator(None)
+
+    async def test_a_failed_audit_write_propagates_rather_than_being_swallowed(self) -> None:
+        with pytest.raises(RuntimeError):
+            await record_audit(_FlushRaisesDB(), actor_user_id=uuid.uuid4(), action="agent.deleted")
+
+
+class TestTheEntry:
+    def teardown_method(self) -> None:
+        set_impersonator(None)
+
+    async def test_a_non_string_target_id_is_stringified_onto_the_entry(self) -> None:
+        target = uuid.uuid4()
+        db = _CapturingDB()
+        await record_audit(
+            db,
+            actor_user_id=uuid.uuid4(),
+            action="skill.deleted",
+            target_id=target,  # type: ignore[arg-type]  # exercise the defensive str()
+        )
+        assert db.added[0].target_id == str(target)
+
+    async def test_no_target_leaves_the_column_null(self) -> None:
+        db = _CapturingDB()
+        await record_audit(db, actor_user_id=uuid.uuid4(), action="settings.updated")
+        assert db.added[0].target_id is None
+
+
+class TestImpersonatorContext:
+    def teardown_method(self) -> None:
+        set_impersonator(None)
+
+    def test_the_impersonator_round_trips_through_the_context(self) -> None:
+        admin = uuid.uuid4()
+        set_impersonator(admin)
+        assert current_impersonator() == admin
+
+    def test_no_impersonator_by_default(self) -> None:
+        assert current_impersonator() is None

--- a/backend/tests/test_sandbox_connections.py
+++ b/backend/tests/test_sandbox_connections.py
@@ -101,7 +101,9 @@ def _service(monkeypatch, *, secret: Any = None) -> SandboxConnectionService:
     The vault itself is proven in `tests/test_secrets.py`; here the question is
     what this service does with what it gets back.
     """
-    service = SandboxConnectionService(MagicMock())
+    db = MagicMock()
+    db.flush = AsyncMock()
+    service = SandboxConnectionService(db)
     resolved = {} if secret is None else {secret[0]: secret[1]}
     service.secrets = MagicMock()
     service.secrets.resolve_for_bindings = AsyncMock(return_value=resolved)

--- a/backend/tests/test_skill_proposals.py
+++ b/backend/tests/test_skill_proposals.py
@@ -65,7 +65,9 @@ def _change(**overrides: object) -> SkillChange:
 
 def _service(monkeypatch) -> SkillProposalService:
     """A service whose skill writes succeed, so the tests are about the decision."""
-    service = SkillProposalService(MagicMock())
+    db = MagicMock()
+    db.flush = AsyncMock()
+    service = SkillProposalService(db)
     skill = MagicMock(id=uuid.uuid4())
     skill.name = "refunds"
     service.skills = MagicMock()

--- a/backend/tests/test_sync_source_credentials.py
+++ b/backend/tests/test_sync_source_credentials.py
@@ -98,7 +98,9 @@ def _service(
             )
         ),
     )
-    return SyncSourceService(MagicMock())
+    db = MagicMock()
+    db.flush = AsyncMock()
+    return SyncSourceService(db)
 
 
 def _vault_row(*, kind: str, hint: str = "a1b2") -> SimpleNamespace:

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -984,6 +984,10 @@ export writes a `runs.export`, `approvals.export` or `spend.export` entry naming
 the window and the row count, because who took the whole table off the screen is a
 question that is cheap to answer now and impossible to reconstruct later.
 
+The write shares the acting request's transaction, so it fails closed: an entry
+that cannot be recorded rolls back the action it describes rather than letting a
+privileged mutation land unaudited.
+
 `audit:read` gates reading it. An app admin's bypass is exactly what the trail
 exists to hold to account.
 


### PR DESCRIPTION
## What & why

`record_audit` swallowed every exception, which was **fail-open on the audit trail** — the trail `docs/governance.md` makes load-bearing for the app-admin bypass story. Worse, the swallow never even bought silence: `flush()` inside the `try` left the session needing a rollback, so the request's `scope="function"` commit then raised `PendingRollbackError` and 500'd anyway, with an opaque error naming the session rather than the audit.

The write now shares the caller's transaction: a failure propagates and rolls the recorded action back rather than letting a privileged mutation land unaudited. `db` is typed `AsyncSession` (it never was), and `app/core/audit.py` is added to both the coverage `include` and the ty overrides — every service that records an action was already gated; the trail they write to was not.

## Test fixtures the swallow was hiding

The fix surfaced three unit-test fixtures (`sync_source`, `sandbox_connection`, `skill_proposal`) built with a bare `MagicMock()` db, where `await db.flush()` raised `TypeError` inside `record_audit`. The old swallow hid it, so the audit write was a **silent no-op the green suite never noticed**. They now build the db the way every other audit-calling test already does (`db.flush = AsyncMock()`).

## Accepted trade-off (not a defect)

A failure specific to the audit row (a bad `details`, an FK on `organization_id`) now rolls the *action* back rather than being dropped — the intended atomicity per governance.md. The recorded `details` were reviewed and are all serialisable.

## Verification

- New `tests/test_audit_record.py`: fail-closed propagation (a regression that passed silently before — confirmed failing against `main`'s `audit.py`), the defensive `target_id` stringify, and the impersonator context. The impersonator-onto-entry behaviour stays covered by the existing `test_audit_impersonation.py`.
- `make lint` and `make test` green; **100% coverage** including the newly-gated module.
- Reviewed by a peer session (blast radius across 60+ callers, #353 transaction ordering, two-lists rule, docs) — APPROVE.

## Noted, out of scope

The `CLAUDE.md` doc trigger-map has no explicit `app/core/audit.py → governance.md` row (the concept already maps there). Left for a follow-up so a future `audit.py` editor finds the page.

Closes #20