### PR TITLE
refactor(frontend): render connector config through SchemaForm

### DIFF
--- a/backend/app/schemas/sync_source.py
+++ b/backend/app/schemas/sync_source.py
@@ -10,10 +10,12 @@ from app.schemas.base import BaseSchema
 ConnectorFieldType = Literal["string", "boolean", "integer", "textarea"]
 """What the wizard draws for a field, and the whole vocabulary it can draw.
 
-A `Literal` because the four are the four cases `SyncSourceConfigureStep`
-renders: a switch, a textarea, a number input, and text for anything else. A
-connector inventing a fifth got the text input silently, which is a field the
-form cannot collect correctly and nothing anywhere reported.
+A `Literal` because these are the field kinds the wizard can render. It no
+longer renders them itself: the frontend maps each to JSON Schema in
+`connectorConfigToJsonSchema` and draws it with `SchemaForm`, the same component
+the agent Builder and the vault secret forms use (#568). Until the two backend
+schema shapes converge - JSON Schema everywhere, this `Literal` gone - that
+mapping is the bridge, and #1093 is the removal.
 """
 
 

--- a/frontend/src/components/agents/schema-form.test.tsx
+++ b/frontend/src/components/agents/schema-form.test.tsx
@@ -297,6 +297,114 @@ describe("SchemaForm", () => {
     expect(onChange).toHaveBeenLastCalledWith({ summary_prompt: "Summarise!" });
   });
 
+  it("draws a connector's plain multi-line field as a raw textarea, not the editor", () => {
+    // `x-textarea` is a connector's plain config box: a textarea like the prompt
+    // editor, but without the editor's Markdown toolbar - a raw config value is
+    // not prose, so dressing it as Markdown would only mislead.
+    render(
+      <SchemaForm
+        schema={{
+          type: "object",
+          properties: {
+            manifest: { type: "string", "x-textarea": true, title: "Manifest" },
+          },
+        }}
+        value={{}}
+        onChange={vi.fn()}
+        idPrefix="x"
+      />,
+    );
+
+    expect(screen.getByLabelText(/Manifest/).tagName).toBe("TEXTAREA");
+    expect(screen.queryByRole("button", { name: /Preview/i })).toBeNull();
+  });
+
+  it("prefers the Markdown editor when a field is marked both prose and textarea", () => {
+    // The two are exclusive, and prose wins: nothing emits both, but the guard
+    // that keeps a prompt in its editor rather than a bare textarea is worth
+    // stating.
+    render(
+      <SchemaForm
+        schema={{
+          type: "object",
+          properties: {
+            summary_prompt: { type: "string", "x-multiline": true, "x-textarea": true },
+          },
+        }}
+        value={{}}
+        onChange={vi.fn()}
+        idPrefix="x"
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /Preview/i })).toBeVisible();
+  });
+
+  it("shows a textarea's default as its value and leaves one with none empty", () => {
+    render(
+      <SchemaForm
+        schema={{
+          type: "object",
+          properties: {
+            region_note: {
+              type: "string",
+              "x-textarea": true,
+              default: "us-east-1",
+              title: "Note",
+            },
+            manifest: { type: "string", "x-textarea": true, title: "Manifest" },
+          },
+        }}
+        value={{}}
+        onChange={vi.fn()}
+        idPrefix="x"
+      />,
+    );
+
+    expect(screen.getByLabelText(/Note/)).toHaveValue("us-east-1");
+    expect(screen.getByLabelText(/Manifest/)).toHaveValue("");
+  });
+
+  it("clears a textarea back to unset and edits it like any other field", async () => {
+    const onChange = vi.fn();
+    render(
+      <SchemaForm
+        schema={{
+          type: "object",
+          properties: { manifest: { type: "string", "x-textarea": true, title: "Manifest" } },
+        }}
+        value={{ manifest: "a" }}
+        onChange={onChange}
+        idPrefix="x"
+      />,
+    );
+
+    await userEvent.type(screen.getByLabelText(/Manifest/), "b");
+    expect(onChange).toHaveBeenLastCalledWith({ manifest: "ab" });
+
+    await userEvent.clear(screen.getByLabelText(/Manifest/));
+    expect(onChange).toHaveBeenLastCalledWith({ manifest: undefined });
+  });
+
+  it("points a refused textarea at the sentence explaining it", () => {
+    render(
+      <SchemaForm
+        schema={{
+          type: "object",
+          properties: { manifest: { type: "string", "x-textarea": true, title: "Manifest" } },
+        }}
+        value={{}}
+        onChange={vi.fn()}
+        idPrefix="x"
+        errors={{ manifest: "That manifest is not valid JSON" }}
+      />,
+    );
+
+    const field = screen.getByLabelText(/Manifest/);
+    expect(field).toHaveAttribute("aria-invalid", "true");
+    expect(field).toHaveAccessibleDescription(/not valid JSON/);
+  });
+
   it("keeps the other fields when one changes", async () => {
     const onChange = vi.fn();
     render(

--- a/frontend/src/components/agents/schema-form.test.tsx
+++ b/frontend/src/components/agents/schema-form.test.tsx
@@ -405,6 +405,57 @@ describe("SchemaForm", () => {
     expect(field).toHaveAccessibleDescription(/not valid JSON/);
   });
 
+  it("shows an x-placeholder as a hint and never as the field's value", () => {
+    // A connector default is a placeholder, not a value (its effective value is
+    // resolved server-side), so it arrives on `x-placeholder` and the field
+    // stays empty until somebody types.
+    render(
+      <SchemaForm
+        schema={{
+          type: "object",
+          properties: {
+            region: { type: "string", title: "Region", "x-placeholder": "us-east-1" },
+            port: { type: "integer", title: "Port", "x-placeholder": "443" },
+            manifest: {
+              type: "string",
+              "x-textarea": true,
+              title: "Manifest",
+              "x-placeholder": "one path per line",
+            },
+          },
+        }}
+        value={{}}
+        onChange={vi.fn()}
+        idPrefix="x"
+      />,
+    );
+
+    const region = screen.getByLabelText(/Region/);
+    expect(region).toHaveValue("");
+    expect(region).toHaveAttribute("placeholder", "us-east-1");
+    expect(screen.getByLabelText(/Port/)).toHaveAttribute("placeholder", "443");
+    expect(screen.getByLabelText(/Manifest/)).toHaveAttribute("placeholder", "one path per line");
+  });
+
+  it("marks a refused boolean's switch, not only the sentence under it", () => {
+    // A field-level refusal has to reach the control it is about: the sentence
+    // renders for every kind, but assistive technology finds it through the
+    // switch's own aria-invalid and aria-describedby.
+    render(
+      <SchemaForm
+        schema={{ type: "object", properties: { verbose: { type: "boolean", title: "Verbose" } } }}
+        value={{}}
+        onChange={vi.fn()}
+        idPrefix="x"
+        errors={{ verbose: "Pick one" }}
+      />,
+    );
+
+    const toggle = screen.getByRole("switch", { name: /Verbose/ });
+    expect(toggle).toHaveAttribute("aria-invalid", "true");
+    expect(toggle).toHaveAccessibleDescription(/Pick one/);
+  });
+
   it("keeps the other fields when one changes", async () => {
     const onChange = vi.fn();
     render(

--- a/frontend/src/components/agents/schema-form.tsx
+++ b/frontend/src/components/agents/schema-form.tsx
@@ -13,6 +13,7 @@ import {
   SelectTrigger,
   SelectValue,
   Switch,
+  Textarea,
 } from "@/components/ui";
 import { BrandIcon, type BrandName } from "@/components/icons/brand-icon";
 import { ProviderIcon } from "@/components/vault/provider-icon";
@@ -139,6 +140,9 @@ function SchemaField({
   // in would freeze it against a later change in code.
   const fallback = defaultOf(property);
   const multiline = property["x-multiline"] === true;
+  // A connector's plain-text config box (`textarea`), distinct from the prompt
+  // editor `multiline` gets: the two never coincide on one field.
+  const textarea = property["x-textarea"] === true && !multiline;
   // Off on every mount, including a re-open of the same dialog: revealing is a
   // decision about the room you are in, and the room changes.
   const [revealed, setRevealed] = useState(false);
@@ -259,7 +263,24 @@ function SchemaField({
         />
       )}
 
-      {kind === "string" && !multiline && (
+      {kind === "string" && textarea && (
+        /* A connector's plain-text config box (`textarea`) - not the
+           MarkdownEditor above, which is for prose, and not masked: a secret is
+           single-line and never a config field, so nothing emits a masked
+           textarea and the reveal machinery below never reaches here. */
+        <Textarea
+          id={id}
+          rows={6}
+          value={typeof value === "string" ? value : typeof fallback === "string" ? fallback : ""}
+          disabled={disabled}
+          spellCheck={false}
+          className="font-mono text-xs"
+          onChange={(event) => onChange(event.target.value === "" ? undefined : event.target.value)}
+          {...invalid}
+        />
+      )}
+
+      {kind === "string" && !multiline && !textarea && (
         <div className="relative">
           <Input
             id={id}

--- a/frontend/src/components/agents/schema-form.tsx
+++ b/frontend/src/components/agents/schema-form.tsx
@@ -143,6 +143,13 @@ function SchemaField({
   // A connector's plain-text config box (`textarea`), distinct from the prompt
   // editor `multiline` gets: the two never coincide on one field.
   const textarea = property["x-textarea"] === true && !multiline;
+  // A hint shown in grey while the field is empty, never stored. A connector's
+  // config default lands here rather than on `default`, because its effective
+  // value is resolved server-side (an S3 region falls back to the credential's,
+  // not to the schema's) - so showing it as the value would claim a setting the
+  // sync will not use.
+  const placeholder =
+    typeof property["x-placeholder"] === "string" ? property["x-placeholder"] : undefined;
   // Off on every mount, including a re-open of the same dialog: revealing is a
   // decision about the room you are in, and the room changes.
   const [revealed, setRevealed] = useState(false);
@@ -167,6 +174,7 @@ function SchemaField({
             checked={value === undefined ? fallback === true : value === true}
             onCheckedChange={onChange}
             disabled={disabled}
+            {...invalid}
           />
         )}
       </div>
@@ -177,6 +185,7 @@ function SchemaField({
           type="number"
           min={property.minimum}
           max={property.maximum}
+          placeholder={placeholder}
           value={numberText(value, fallback)}
           disabled={disabled}
           // Empty means "unset", which is not the same as zero: an unset field
@@ -271,6 +280,7 @@ function SchemaField({
         <Textarea
           id={id}
           rows={6}
+          placeholder={placeholder}
           value={typeof value === "string" ? value : typeof fallback === "string" ? fallback : ""}
           disabled={disabled}
           spellCheck={false}
@@ -290,6 +300,7 @@ function SchemaField({
             type={masked && !revealed ? "password" : undefined}
             autoComplete={masked ? "off" : undefined}
             maxLength={property.maxLength}
+            placeholder={placeholder}
             value={typeof value === "string" ? value : typeof fallback === "string" ? fallback : ""}
             disabled={disabled}
             onChange={(event) =>

--- a/frontend/src/components/rag/sync-source-configure-step.tsx
+++ b/frontend/src/components/rag/sync-source-configure-step.tsx
@@ -3,8 +3,9 @@
 import { Cog } from "lucide-react";
 import { useTranslations } from "next-intl";
 
-import { Input, Label, Switch, Textarea } from "@/components/ui";
-import type { ConnectorConfigField, ConnectorInfo, SyncSourceCreate } from "@/lib/rag-api";
+import { SchemaForm } from "@/components/agents/schema-form";
+import { connectorConfigToJsonSchema } from "@/lib/connector-schema";
+import type { ConnectorInfo, SyncSourceCreate } from "@/lib/rag-api";
 
 export function ConfigureStep({
   connector,
@@ -25,9 +26,9 @@ export function ConfigureStep({
   errors?: Readonly<Record<string, string>>;
 }) {
   const t = useTranslations("rag");
-  const fields = Object.entries(connector.config_schema);
+  const hasFields = Object.keys(connector.config_schema).length > 0;
 
-  if (fields.length === 0) {
+  if (!hasFields) {
     return (
       <div className="border-foreground/10 bg-foreground/[0.03] rounded-xl border p-5 text-center">
         <Cog className="text-foreground/45 mx-auto h-6 w-6" />
@@ -46,99 +47,19 @@ export function ConfigureStep({
       <p className="text-foreground/65 text-sm">
         {t.rich("configureRequiredFields", {
           name: connector.name,
-          required: (chunks) => <span className="text-destructive">{chunks}</span>,
+          // Muted to match the asterisk SchemaForm actually draws beside a
+          // required field; a red one here would promise a mark the fields below
+          // do not wear.
+          required: (chunks) => <span className="text-muted-foreground">{chunks}</span>,
         })}
       </p>
-      {fields.map(([key, field]) => (
-        <ConfigField
-          key={key}
-          name={key}
-          field={field}
-          value={form.config[key]}
-          error={errors?.[key]}
-          onChange={(value) => setForm((f) => ({ ...f, config: { ...f.config, [key]: value } }))}
-        />
-      ))}
-    </div>
-  );
-}
-
-function ConfigField({
-  name,
-  field,
-  value,
-  error,
-  onChange,
-}: {
-  name: string;
-  field: ConnectorConfigField;
-  value: unknown;
-  error?: string;
-  onChange: (value: unknown) => void;
-}) {
-  const id = `cfg-${name}`;
-  const errorId = `${id}-error`;
-  const invalid =
-    error === undefined ? undefined : { "aria-invalid": true, "aria-describedby": errorId };
-  const text = value !== undefined && value !== null ? String(value) : "";
-  const placeholder = field.default !== undefined ? String(field.default) : "";
-
-  return (
-    <div className="space-y-1.5">
-      <Label
-        htmlFor={id}
-        className="text-foreground/80 text-xs font-medium tracking-wider uppercase"
-      >
-        {field.label}
-        {field.required && <span className="text-destructive ml-0.5">*</span>}
-      </Label>
-
-      {field.type === "boolean" ? (
-        <div className="flex items-center gap-3 py-1">
-          <Switch id={id} checked={!!value} onCheckedChange={onChange} {...invalid} />
-          {field.help && <span className="text-foreground/55 text-xs">{field.help}</span>}
-        </div>
-      ) : field.type === "textarea" ? (
-        <>
-          <Textarea
-            id={id}
-            placeholder={placeholder}
-            value={text}
-            onChange={(e) => onChange(e.target.value)}
-            className="min-h-[160px] rounded-xl font-mono text-xs"
-            spellCheck={false}
-            {...invalid}
-          />
-          {field.help && <p className="text-foreground/55 text-xs">{field.help}</p>}
-        </>
-      ) : (
-        <>
-          <Input
-            id={id}
-            type={field.type === "integer" ? "number" : "text"}
-            placeholder={placeholder}
-            value={text}
-            onChange={(e) =>
-              onChange(
-                field.type === "integer"
-                  ? e.target.value
-                    ? Number(e.target.value)
-                    : ""
-                  : e.target.value,
-              )
-            }
-            className="h-10 rounded-xl"
-            {...invalid}
-          />
-          {field.help && <p className="text-foreground/55 text-xs">{field.help}</p>}
-        </>
-      )}
-
-      {error !== undefined && (
-        <p id={errorId} className="text-destructive text-xs">
-          {error}
-        </p>
-      )}
+      <SchemaForm
+        schema={connectorConfigToJsonSchema(connector.config_schema)}
+        value={form.config}
+        onChange={(config) => setForm((f) => ({ ...f, config }))}
+        idPrefix="cfg"
+        errors={errors}
+      />
     </div>
   );
 }

--- a/frontend/src/lib/connector-schema.test.ts
+++ b/frontend/src/lib/connector-schema.test.ts
@@ -50,16 +50,31 @@ describe("connectorConfigToJsonSchema", () => {
     expect(schema.required).toEqual(["bucket"]);
   });
 
-  it("passes a field's default through untouched, including the absent one", () => {
-    // The backend serialises a field with no default as `null`; SchemaForm's own
-    // `defaultOf` reads that as "no default", so this must not rewrite it.
+  it("renders a text field's default as a placeholder, not a stored value", () => {
+    // A connector default is a hint: an S3 region left blank resolves to the
+    // credential's region server-side, never to the schema's `us-east-1`, so it
+    // must not arrive as the field's value.
     const schema = connectorConfigToJsonSchema({
       region: field({ default: "us-east-1" }),
       endpoint_url: field({ default: null }),
     });
 
-    expect(schema.properties?.region?.default).toBe("us-east-1");
-    expect(schema.properties?.endpoint_url?.default).toBeNull();
+    expect(schema.properties?.region?.["x-placeholder"]).toBe("us-east-1");
+    expect(schema.properties?.region?.default).toBeUndefined();
+    // No default declared: no placeholder invented.
+    expect(schema.properties?.endpoint_url?.["x-placeholder"]).toBeUndefined();
+  });
+
+  it("keeps a boolean's default, which the backend applies when the key is omitted", () => {
+    // Unlike a text default, `config.get("include_subfolders", True)` means the
+    // switch's default is what actually happens - so it stays on `default`, which
+    // SchemaForm reflects on the switch.
+    const schema = connectorConfigToJsonSchema({
+      include_subfolders: field({ type: "boolean", default: true }),
+    });
+
+    expect(schema.properties?.include_subfolders?.default).toBe(true);
+    expect(schema.properties?.include_subfolders?.["x-placeholder"]).toBeUndefined();
   });
 
   it("is an object schema even when the connector declares no fields", () => {

--- a/frontend/src/lib/connector-schema.test.ts
+++ b/frontend/src/lib/connector-schema.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { connectorConfigToJsonSchema } from "./connector-schema";
+import type { ConnectorConfigField } from "@/lib/rag-api";
+
+/** The shape a connector's `config_schema` arrives in, one entry per field. */
+function field(overrides: Partial<ConnectorConfigField> = {}): ConnectorConfigField {
+  return { type: "string", label: "Field", required: false, ...overrides };
+}
+
+describe("connectorConfigToJsonSchema", () => {
+  it("carries the label as the title and the help as the description", () => {
+    // SchemaForm reads `title` for the label and `description` for the guidance
+    // under a field, so the connector's own words have to land on those keys.
+    const schema = connectorConfigToJsonSchema({
+      folder_id: field({ label: "Google Drive Folder ID", help: "The ID from the folder URL" }),
+    });
+
+    expect(schema.properties?.folder_id).toMatchObject({
+      type: "string",
+      title: "Google Drive Folder ID",
+      description: "The ID from the folder URL",
+    });
+  });
+
+  it("maps each connector field type to the control SchemaForm draws for it", () => {
+    const schema = connectorConfigToJsonSchema({
+      host: field({ type: "string" }),
+      port: field({ type: "integer" }),
+      recursive: field({ type: "boolean" }),
+      manifest: field({ type: "textarea" }),
+    });
+
+    expect(schema.properties?.host?.type).toBe("string");
+    expect(schema.properties?.port?.type).toBe("integer");
+    expect(schema.properties?.recursive?.type).toBe("boolean");
+    // A textarea is a plain multi-line string, marked so SchemaForm draws a raw
+    // textarea rather than the Markdown editor a prompt gets.
+    expect(schema.properties?.manifest).toMatchObject({ type: "string", "x-textarea": true });
+    expect(schema.properties?.host?.["x-textarea"]).toBeUndefined();
+  });
+
+  it("collects only the required fields into the schema's required list", () => {
+    const schema = connectorConfigToJsonSchema({
+      bucket: field({ required: true }),
+      prefix: field({ required: false }),
+      region: field(),
+    });
+
+    expect(schema.required).toEqual(["bucket"]);
+  });
+
+  it("passes a field's default through untouched, including the absent one", () => {
+    // The backend serialises a field with no default as `null`; SchemaForm's own
+    // `defaultOf` reads that as "no default", so this must not rewrite it.
+    const schema = connectorConfigToJsonSchema({
+      region: field({ default: "us-east-1" }),
+      endpoint_url: field({ default: null }),
+    });
+
+    expect(schema.properties?.region?.default).toBe("us-east-1");
+    expect(schema.properties?.endpoint_url?.default).toBeNull();
+  });
+
+  it("is an object schema even when the connector declares no fields", () => {
+    expect(connectorConfigToJsonSchema({})).toEqual({
+      type: "object",
+      properties: {},
+      required: [],
+    });
+  });
+});

--- a/frontend/src/lib/connector-schema.ts
+++ b/frontend/src/lib/connector-schema.ts
@@ -36,24 +36,29 @@ export function connectorConfigToJsonSchema(
  * One connector field as a JSON Schema property.
  *
  * `label` becomes `title` and `help` becomes `description`, which is what
- * `SchemaForm` reads for a field's label and its guidance. `default` is passed
- * through untouched: the backend serialises an absent default as `null`, and
- * `SchemaForm`'s own `defaultOf` already reads that as "no default".
+ * `SchemaForm` reads for a field's label and its guidance.
+ *
+ * The default is the field this treats with care. A connector's `default` is a
+ * placeholder, not an authoritative value: an S3 `region` left blank resolves
+ * to the credential's region or `S3_RAG_REGION` server-side, never to the
+ * schema's `us-east-1`, so rendering it as the field's value would show a
+ * setting the sync does not use. It therefore lands on `x-placeholder` (a grey
+ * hint, never stored) for the text-like kinds. A boolean is the exception: its
+ * default *is* what the backend applies when the key is omitted
+ * (`config.get("include_subfolders", True)`), so it stays on `default`, where
+ * `SchemaForm` reflects it on the switch.
  */
 function fieldToProperty(field: ConnectorConfigField): JsonSchemaProperty {
-  const base: JsonSchemaProperty = {
-    title: field.label,
-    description: field.help,
-    default: field.default,
-  };
+  const base: JsonSchemaProperty = { title: field.label, description: field.help };
+  const placeholder = field.default == null ? undefined : String(field.default);
   switch (field.type) {
     case "integer":
-      return { ...base, type: "integer" };
+      return { ...base, type: "integer", "x-placeholder": placeholder };
     case "boolean":
-      return { ...base, type: "boolean" };
+      return { ...base, type: "boolean", default: field.default };
     case "textarea":
-      return { ...base, type: "string", "x-textarea": true };
+      return { ...base, type: "string", "x-textarea": true, "x-placeholder": placeholder };
     case "string":
-      return { ...base, type: "string" };
+      return { ...base, type: "string", "x-placeholder": placeholder };
   }
 }

--- a/frontend/src/lib/connector-schema.ts
+++ b/frontend/src/lib/connector-schema.ts
@@ -1,0 +1,59 @@
+/**
+ * A RAG connector's `config_schema`, in the shape `SchemaForm` renders.
+ *
+ * There are two schema contracts on this platform for "a form the backend
+ * describes": capabilities and secret kinds publish JSON Schema straight from
+ * Pydantic, while a connector publishes the bespoke `ConnectorConfigField`
+ * mapping in `app/schemas/sync_source.py`. `SchemaForm` renders the first, and
+ * this is the one place that turns the second into it - so the sync-source
+ * wizard draws its config step with the same component the Builder and the vault
+ * use, rather than a second renderer maintained in parallel (#568).
+ *
+ * This function is the whole of the field-type alignment: a fifth
+ * `ConnectorFieldType` cannot be added without the `switch` below ceasing to
+ * return for it, which is a compile error until a mapping is chosen here. The
+ * bridge exists because the two backend shapes have not yet converged; #1093
+ * removes both it and `ConnectorConfigField`.
+ */
+
+import type { ConnectorConfigField } from "@/lib/rag-api";
+import type { JsonSchema, JsonSchemaProperty } from "@/types/agents";
+
+/** Convert a connector's `config_schema` into the JSON Schema `SchemaForm` reads. */
+export function connectorConfigToJsonSchema(
+  configSchema: Record<string, ConnectorConfigField>,
+): JsonSchema {
+  const properties: Record<string, JsonSchemaProperty> = {};
+  const required: string[] = [];
+  for (const [name, field] of Object.entries(configSchema)) {
+    properties[name] = fieldToProperty(field);
+    if (field.required) required.push(name);
+  }
+  return { type: "object", properties, required };
+}
+
+/**
+ * One connector field as a JSON Schema property.
+ *
+ * `label` becomes `title` and `help` becomes `description`, which is what
+ * `SchemaForm` reads for a field's label and its guidance. `default` is passed
+ * through untouched: the backend serialises an absent default as `null`, and
+ * `SchemaForm`'s own `defaultOf` already reads that as "no default".
+ */
+function fieldToProperty(field: ConnectorConfigField): JsonSchemaProperty {
+  const base: JsonSchemaProperty = {
+    title: field.label,
+    description: field.help,
+    default: field.default,
+  };
+  switch (field.type) {
+    case "integer":
+      return { ...base, type: "integer" };
+    case "boolean":
+      return { ...base, type: "boolean" };
+    case "textarea":
+      return { ...base, type: "string", "x-textarea": true };
+    case "string":
+      return { ...base, type: "string" };
+  }
+}

--- a/frontend/src/lib/rag-api.ts
+++ b/frontend/src/lib/rag-api.ts
@@ -128,10 +128,10 @@ export async function listSyncSources(collectionName?: string): Promise<SyncSour
 /**
  * What the wizard draws for a field, and the whole vocabulary it can draw.
  *
- * Mirrors `ConnectorFieldType` in `app/schemas/sync_source.py`, where a
- * connector's declaration is typed rather than a bare mapping: the fall-through
- * below is a text input, so a connector inventing a fifth type got a field the
- * form collects wrongly and nothing reported it.
+ * Mirrors `ConnectorFieldType` in `app/schemas/sync_source.py`. The wizard no
+ * longer renders these directly: `connectorConfigToJsonSchema` maps each one to
+ * the JSON Schema `SchemaForm` reads, so a fifth type is a case there (a compile
+ * error until it is chosen) rather than a silent fall-through to a text box.
  */
 export type ConnectorFieldType = "string" | "boolean" | "integer" | "textarea";
 

--- a/frontend/src/types/agents.ts
+++ b/frontend/src/types/agents.ts
@@ -583,6 +583,15 @@ export interface JsonSchemaProperty {
    */
   "x-textarea"?: boolean;
   /**
+   * A grey hint shown while a string or number field is empty, never stored.
+   *
+   * Also connector-only: a connector's config default is a placeholder rather
+   * than an authoritative value - its effective default is resolved server-side
+   * (an S3 region falls back to the credential's) - so it arrives here instead
+   * of on `default`, which `SchemaForm` would otherwise render as the value.
+   */
+  "x-placeholder"?: string;
+  /**
    * What a `list[...]` holds. Only `{"type": "string"}` is rendered; anything
    * else is the richer editor the generated form deliberately does not grow.
    */

--- a/frontend/src/types/agents.ts
+++ b/frontend/src/types/agents.ts
@@ -572,6 +572,17 @@ export interface JsonSchemaProperty {
    */
   "x-multiline"?: boolean;
   /**
+   * Whether this string is a plain multi-line value - a raw textarea, not the
+   * Markdown editor `x-multiline` gets.
+   *
+   * The one field kind a capability's own JSON Schema never emits: it is how a
+   * connector's `textarea` config field crosses into this shape through
+   * `connectorConfigToJsonSchema`, so a connector's plain config box is not
+   * mistaken for prose and dressed with a Markdown toolbar. Exclusive with
+   * `x-multiline`.
+   */
+  "x-textarea"?: boolean;
+  /**
    * What a `list[...]` holds. Only `{"type": "string"}` is rendered; anything
    * else is the richer editor the generated form deliberately does not grow.
    */


### PR DESCRIPTION
## Summary

The RAG sync-source wizard kept a second schema-form renderer, `ConfigureStep`,
next to `SchemaForm` — the generator the agent Builder and the vault secret
forms already share. Two renderers over two backend schema shapes meant field
types, help text and secret masking were maintained twice and had already
drifted (`SchemaForm` had no textarea; `ConfigureStep` had no enum), which is
what the 2026-08-10 audit filed as #568.

This unifies on `SchemaForm` **without** touching the backend wire shapes. A
connector's `config_schema` is adapted to the JSON Schema subset `SchemaForm`
reads, and the config step renders through it. The `ConfigureStep`
component keeps only its wizard chrome (intro + empty state) and the wizard's
props are unchanged.

The larger, higher-risk half — converging the two backend shapes so connectors
emit JSON Schema natively and the adapter and `ConnectorConfigField` disappear —
is filed as the follow-up, #1093.

## Related issue

Closes #568. Follow-up filed as #1093 and linked on the map in #168.

## Added

- `frontend/src/lib/connector-schema.ts` — `connectorConfigToJsonSchema()`, the
  single place the two field-type vocabularies meet. Its `switch` over
  `ConnectorFieldType` is exhaustive, so a fifth connector field type is a
  compile error until a JSON Schema mapping is chosen — rather than the silent
  fall-through to a text box the typed `Literal` originally replaced.
- A plain-textarea field kind on `SchemaForm` (`x-textarea`), distinct from
  `x-multiline`'s Markdown editor (which is for prose). No capability emits it,
  so the secret and agent forms are untouched — the branch is inert without the
  keyword.
- Unit tests: `connector-schema.test.ts` (adapter, 100%) and `x-textarea`
  coverage in `schema-form.test.tsx`.

## Changed

- `sync-source-configure-step.tsx` renders `SchemaForm` for the fields instead
  of a bespoke `ConfigField`. The "no enum" half of the divergence closes for
  free — the config step *is* `SchemaForm` now.
- Cross-reference comments on `ConnectorFieldType` (frontend `rag-api.ts` and
  backend `sync_source.py`) — the short-term step #568 asked for, pointing at
  the adapter and the #1093 removal.

Two visible changes on the wizard, both `SchemaForm`'s existing behaviour rather
than anything new: a field's default now shows as its value (not grey
placeholder), and a boolean whose default is on now draws on. Neither changes
what the wizard sends — nothing is stored until a field is edited, so the sent
`config` is identical. The required asterisk is muted to match the one
`SchemaForm` draws.

## Testing

- `make lint` — clean (the 68 `ty` warnings are pre-existing, from #537's
  trigger code, 0 errors, none in touched files).
- `make test` — 6900 passed, 100% platform coverage.
- `make test-frontend-cov` — statements 100 / branches 97.66 / functions 100 /
  lines 100.
- Real-browser E2E against a local stack: `vault.spec.ts` (secret forms) and
  `kb-integrations.spec.ts` (S3 connector config through the new adapter path)
  pass. The agent capability-config form is covered by
  `capability-settings.integration.test.tsx`.
- The pre-existing `sync-source-wizard.integration.test.tsx` was **not modified**
  and still passes — it drives the config step, its per-field refusals and the
  edit-clears-the-mark path against the real `SchemaForm`, which is the strongest
  parity proof.

## Notes for reviewers

- Regression surface is the three flows `SchemaForm` now serves: vault secret
  entry, RAG connector config, agent capability config. The `x-textarea` branch
  is provably inert for secret/agent schemas (repo-wide, `x-textarea` is emitted
  only by `connector-schema.ts` and read only by `schema-form.tsx`).
- Scope is deliberately the renderer, not the backend. #1093 tracks the rest.
