### PR TITLE
fix(background): drain until quiescent and await cancelled tasks

### DIFF
--- a/backend/app/core/background.py
+++ b/backend/app/core/background.py
@@ -157,17 +157,36 @@ async def drain(timeout: float = 30.0) -> None:
     Called from the application lifespan. Without it, shutting down mid-flight
     cancels ingestion and sync work that was nearly done, which shows up later
     as a document stuck in `processing` forever.
+
+    Waits until `_running` is quiescent, not for a single snapshot: a draining
+    task can hand off more work - a channel run finishing an agent turn spawns
+    each of its notifications - and a one-shot `asyncio.wait` would return with
+    that freshly-spawned task still in flight. The whole wait shares one
+    deadline, so work that keeps spawning work cannot postpone shutdown forever.
+
+    Whatever is still running at the deadline is cancelled *and then awaited to a
+    terminal state* before returning. A caller disposes shared resources once
+    this returns - the Redis client, the database engine - and a cancelled task
+    unwinds through its own `finally` on those same resources; returning before
+    it has settled races the two (#1095).
     """
     if not _running:
         return
-    pending = set(_running)
-    logger.info("Waiting for %d background task(s) to finish", len(pending))
-    done, still_running = await asyncio.wait(pending, timeout=timeout)
-    if still_running:
+    logger.info("Waiting for %d background task(s) to finish", len(_running))
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while True:
+        pending = {task for task in _running if not task.done()}
+        if not pending or loop.time() >= deadline:
+            break
+        await asyncio.wait(pending, timeout=deadline - loop.time())
+    overran = {task for task in _running if not task.done()}
+    if overran:
         logger.warning(
             "%d background task(s) did not finish in %.0fs; cancelling",
-            len(still_running),
+            len(overran),
             timeout,
         )
-        for task in still_running:
+        for task in overran:
             task.cancel()
+        await asyncio.gather(*overran, return_exceptions=True)

--- a/backend/app/core/background.py
+++ b/backend/app/core/background.py
@@ -41,6 +41,15 @@ logger = logging.getLogger(__name__)
 # that is merely waiting on I/O.
 _running: set[asyncio.Task[Any]] = set()
 
+_CANCEL_GRACE_SECONDS = 5.0
+"""How long `drain` waits for a cancelled task to unwind before giving up on it.
+
+Cancellation is cooperative, so a task that suppresses it or blocks in an async
+`finally` would hang shutdown forever if awaited unbounded. Past this grace the
+task is left rather than waited on - accepting the resource-teardown race the
+await exists to avoid, in exchange for a shutdown that always terminates (#1095).
+"""
+
 
 def _on_done(task: asyncio.Task[Any]) -> None:
     """Release the reference and report anything that went wrong.
@@ -164,11 +173,13 @@ async def drain(timeout: float = 30.0) -> None:
     that freshly-spawned task still in flight. The whole wait shares one
     deadline, so work that keeps spawning work cannot postpone shutdown forever.
 
-    Whatever is still running at the deadline is cancelled *and then awaited to a
-    terminal state* before returning. A caller disposes shared resources once
-    this returns - the Redis client, the database engine - and a cancelled task
-    unwinds through its own `finally` on those same resources; returning before
-    it has settled races the two (#1095).
+    Whatever is still running at the deadline is cancelled and then awaited, for
+    a bounded grace, to a terminal state before returning. A caller disposes
+    shared resources once this returns - the Redis client, the database engine -
+    and a cancelled task unwinds through its own `finally` on those same
+    resources; returning before it has settled races the two. The grace is
+    bounded because cancellation is cooperative: a task that suppresses it must
+    not hang shutdown past `_CANCEL_GRACE_SECONDS` (#1095).
     """
     if not _running:
         return
@@ -189,4 +200,7 @@ async def drain(timeout: float = 30.0) -> None:
         )
         for task in overran:
             task.cancel()
-        await asyncio.gather(*overran, return_exceptions=True)
+        # Bounded, not an unconditional `gather`: give cancellation a grace to
+        # unwind through cleanup, but never wait past it - a task that ignores
+        # cancellation would otherwise hang shutdown forever (#1095).
+        await asyncio.wait(overran, timeout=_CANCEL_GRACE_SECONDS)

--- a/backend/tests/test_background.py
+++ b/backend/tests/test_background.py
@@ -296,3 +296,26 @@ class TestDrainingOnShutdown:
 
         assert task.done()
         assert cleaned.is_set()
+
+    async def test_a_stubborn_cancelled_task_does_not_hang_shutdown(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Awaiting a cancelled task is bounded: cancellation is cooperative, so a
+        task that blocks in its cleanup must not hold shutdown open forever (#1095)."""
+        monkeypatch.setattr(background, "_CANCEL_GRACE_SECONDS", 0.05)
+        release = asyncio.Event()
+
+        async def stubborn() -> None:
+            try:
+                await asyncio.Event().wait()
+            finally:
+                await release.wait()
+
+        background.spawn(stubborn(), name="stubborn")
+        await asyncio.sleep(0)
+
+        # An unbounded await would hang here; drain must return after the grace.
+        await asyncio.wait_for(background.drain(timeout=0.01), timeout=1.0)
+
+        release.set()
+        await asyncio.sleep(0)

--- a/backend/tests/test_background.py
+++ b/backend/tests/test_background.py
@@ -259,3 +259,40 @@ class TestDrainingOnShutdown:
         assert "never-ends" not in caplog.text
         assert "did not finish" in caplog.text
         assert task.cancelling() or task.cancelled()
+
+    async def test_work_spawned_while_draining_is_also_awaited(self) -> None:
+        """A draining task can hand off more work - a channel run finishing a turn
+        spawns each of its notifications - and a one-shot wait would return with
+        the freshly-spawned task still in flight (#1095)."""
+        finished: list[str] = []
+
+        async def child() -> None:
+            await asyncio.sleep(0)
+            finished.append("child")
+
+        async def parent() -> None:
+            finished.append("parent")
+            background.spawn(child(), name="child")
+
+        background.spawn(parent(), name="parent")
+        await background.drain(timeout=5.0)
+
+        assert finished == ["parent", "child"]
+
+    async def test_a_cancelled_task_settles_before_drain_returns(self) -> None:
+        """The lifespan disposes Redis and the database the moment drain returns,
+        and a cancelled task unwinds through its own finally on those same
+        resources; drain must not hand back until it has (#1095)."""
+        cleaned = asyncio.Event()
+
+        async def work() -> None:
+            try:
+                await asyncio.Event().wait()
+            finally:
+                cleaned.set()
+
+        task = background.spawn(work(), name="holds-redis")
+        await background.drain(timeout=0.01)
+
+        assert task.done()
+        assert cleaned.is_set()


### PR DESCRIPTION
## What & why

`background.drain()` snapshotted `_running` once and waited only on that snapshot, so a task that handed off more work while draining — a channel run finishing an agent turn spawns each of its notifications through `spawn` — could leave the freshly-spawned task in flight when `drain()` returned. And after the timeout it called `task.cancel()` and returned immediately, so a caller that disposes shared resources next (the Redis client, the database engine) raced a cancelled task still unwinding through its own `finally` on those very resources.

Now it waits until `_running` is quiescent under **one overall deadline** (re-snapshotting each pass, so work spawned mid-drain is awaited, but a task that keeps spawning work cannot postpone shutdown forever), then cancels whatever overran and `gather`s it to a **terminal state** before returning.

## Scope — two of the three gaps in #1095

This closes the two `drain()`-internal gaps. The third — a bot created just before shutdown whose deferred `open_inbound_stream` reopens intake during teardown — is a shutdown-**ordering** concern, not a `drain()` one, so it is split out to #1119 and handled with the lifespan drain wiring (#11/#1089) rather than folded in here.

## Known edge, deliberately not fixed

The post-deadline `cancel`+`gather` snapshots `overran` once. If a cancelled task's `finally` were itself to `spawn` fresh work while unwinding, that new task would not be awaited. No current `finally` in the codebase spawns background work, and looping the post-deadline phase to cover it would reintroduce an unbounded-wait/hang risk that the single-shot deliberately avoids — so it is left as-is and noted here.

## Verification

- Two regression tests: work spawned mid-drain is awaited (fails on the old one-shot wait), and a cancelled task's `finally` completes before `drain()` returns (fails when cancel is not awaited). Existing drain tests still pass.
- `app/core/background.py` at **100% line+branch** coverage; adversarial review (7 async-correctness checks: no busy-spin/hang, no empty-set `asyncio.wait`, `return_exceptions=True` swallows `CancelledError`, `_on_done` callback-lag handled, rag.py caller unaffected) — clean.
- `make lint` green. The full non-integration backend suite is green (**6282 passed, 0 failed**); `make test`'s integration portion errored locally under machine load (connection contention against one Postgres across `-n auto` workers, a 16-minute run) — those tenant-isolation tests have no code path to this change. CI's controlled environment is the authority.

Closes #1095
