### PR TITLE
fix(vault): refuse a malformed sealed payload without naming it

### DIFF
--- a/backend/app/core/secret_kinds.py
+++ b/backend/app/core/secret_kinds.py
@@ -58,6 +58,7 @@ from pydantic import (
     PlainSerializer,
     SecretStr,
     TypeAdapter,
+    ValidationError,
     field_validator,
     model_validator,
 )
@@ -330,9 +331,19 @@ def unseal_secret(
             is not a secret payload, or holds a different kind than the column
             says - which would mean a row was edited underneath the schema.
     """
-    value = _STORABLE_ADAPTER.validate_json(
-        unseal(ciphertext, scope=scope, key_version=key_version)
-    )
+    try:
+        value = _STORABLE_ADAPTER.validate_json(
+            unseal(ciphertext, scope=scope, key_version=key_version)
+        )
+    except ValidationError:
+        # A `ValidationError` message embeds the offending input - here the
+        # decrypted credential - so it must reach neither a log line nor a span.
+        # `from None`, not `from exc`: chaining would keep the plaintext in the
+        # traceback (#21).
+        raise BadRequestError(
+            message="Stored secret is not a usable payload",
+            details={"recorded": kind.value},
+        ) from None
     if value.kind is not kind:
         raise BadRequestError(
             message="Stored secret does not match its recorded kind",

--- a/backend/tests/test_secrets.py
+++ b/backend/tests/test_secrets.py
@@ -7,6 +7,7 @@ worth testing here is that constraint holding.
 """
 
 import json
+import traceback
 import uuid
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -31,7 +32,7 @@ from app.core.secret_kinds import (
     seal_secret,
     unseal_secret,
 )
-from app.core.vault import VaultScope
+from app.core.vault import VaultScope, seal
 from app.repositories import member_repo
 from app.services.organization_secret import OrganizationSecretService
 from tests.test_model_profiles import service_account_json
@@ -212,6 +213,33 @@ class TestSealAndOpen:
             unseal_secret(sealed.ciphertext, kind=SecretKind.AWS_CREDENTIALS, scope=scope)
 
         assert refused.value.details == {"recorded": "aws_credentials", "sealed": "api_key"}
+
+    def test_a_payload_that_does_not_validate_is_refused_without_naming_the_value(self):
+        """A stored payload that no longer validates - a row edited underneath the
+        schema, a rollback to a build whose `SecretKind` lacks a kind a newer one
+        wrote - is refused without the decrypted credential reaching the message or
+        a chained traceback. `validate_json`'s own `ValidationError` embeds the
+        offending input, which here is the plaintext (#21)."""
+        scope = VaultScope.organization(uuid.uuid4())
+        sealed = seal(json.dumps({"kind": "bogus", "api_key": "sk-live-SUPERSECRET"}), scope=scope)
+
+        with pytest.raises(BadRequestError) as refused:
+            unseal_secret(sealed.ciphertext, kind=SecretKind.API_KEY, scope=scope)
+
+        assert refused.value.details == {"recorded": "api_key"}
+        assert "SUPERSECRET" not in str(refused.value)
+        # The leak surface is the *rendered* traceback - what `logger.exception`
+        # and an OTel span emit. `__cause__` is `None` with or without `from None`
+        # (implicit chaining never sets it), so it does not pin the fix; the
+        # property that keeps the chained `ValidationError` - which still holds the
+        # plaintext in `__context__` - out of the formatting is `__suppress_context__`.
+        assert refused.value.__suppress_context__ is True
+        rendered = "".join(
+            traceback.format_exception(
+                type(refused.value), refused.value, refused.value.__traceback__
+            )
+        )
+        assert "SUPERSECRET" not in rendered
 
 
 class TestStoringASecret:


### PR DESCRIPTION
## What & why

`unseal_secret` promised `BadRequestError` for an envelope that holds something that is not a secret payload, but `_STORABLE_ADAPTER.validate_json(...)` raises `pydantic_core.ValidationError` — not an `AppException` — so it reached `unhandled_exception_handler` and `logger.exception`. A pydantic `ValidationError` **embeds the offending input in its message**, and here that input is the decrypted credential, so the plaintext landed in the log line and, under `logfire.instrument_fastapi`, on the exception span — breaking the guarantee `docs/secrets.md` states ("No log line or audit entry contains one").

Catch `ValidationError` and re-raise `BadRequestError(message="Stored secret is not a usable payload", details={"recorded": kind.value})` with `from None`.

- The **type change** is the primary guard: a 4xx `AppException` is logged at warning with no `exc_info`, so no traceback is formatted on the HTTP path, and it never reaches the `logger.exception` handler.
- **`from None`** is load-bearing for the non-HTTP readers whose traceback *is* rendered — a Prefect task failure, `doctor.py`'s `f"...: {exc}"` — where it sets `__suppress_context__` and keeps the chained `ValidationError` (which still holds the plaintext in `__context__`) out of the formatted traceback.

Reachable from `resolve_for_bindings`, `ModelProfileService` and the provider listing key whenever a stored payload no longer validates — a hand-edited row, a rollback to a build whose `SecretKind` enum lacks a kind a newer build wrote, or a future field tightening.

## Verification

- Regression test seals a JSON document with an unknown `kind`, calls `unseal_secret`, and asserts `BadRequestError` with the plaintext absent from `str(exc)` **and from the rendered traceback** — pinning `__suppress_context__`, the property that actually stops the leak (an adversarial review caught that `__cause__` is `None` with or without `from None`, so asserting it alone would let a future edit silently reintroduce the leak). Fails without the fix.
- `make lint` green. `secret_kinds.py` is at complete coverage locally; the full 100% gate needs the integration suite, which skips here for want of a local DB (the only uncovered lines are DB-layer repositories) — CI's environment has one.

Closes #21