### PR TITLE
fix(files): move blocking upload parse and storage IO off the loop

### DIFF
--- a/backend/app/services/file_storage.py
+++ b/backend/app/services/file_storage.py
@@ -4,6 +4,7 @@ Supports local filesystem storage.
 Files are organized per-user: {storage_root}/{user_id}/{uuid}_{filename}
 """
 
+import asyncio
 import logging
 import os
 import re
@@ -210,14 +211,17 @@ class LocalFileStorage(BaseFileStorage):
         user_dir.mkdir(parents=True, exist_ok=True)
         storage_name = make_storage_filename(filename)
         file_path = user_dir / storage_name
-        file_path.write_bytes(data)
+        # Up to MAX_UPLOAD_SIZE bytes; on the request loop it stalls every other
+        # request on this worker until the write lands (the sibling in
+        # rag_document.py switched to anyio for the same reason).
+        await asyncio.to_thread(file_path.write_bytes, data)
         return f"{safe_user}/{storage_name}"
 
     async def load(self, storage_path: str) -> bytes:
         file_path = self._resolve_safe_path(storage_path)
         if not file_path.exists():
             raise FileNotFoundError(f"File not found: {storage_path}")
-        return file_path.read_bytes()
+        return await asyncio.to_thread(file_path.read_bytes)
 
     async def delete(self, storage_path: str) -> None:
         file_path = self._resolve_safe_path(storage_path)

--- a/backend/app/services/file_upload.py
+++ b/backend/app/services/file_upload.py
@@ -1,5 +1,6 @@
 """File upload service."""
 
+import asyncio
 import io
 import logging
 from typing import Any
@@ -96,15 +97,21 @@ class FileUploadService:
         """Parse file content based on file type.
 
         Returns extracted text content or None if parsing fails.
+
+        Every branch is blocking CPU work - pymupdf over every page, openpyxl over
+        every cell, a decode of up to `MAX_UPLOAD_SIZE` bytes - with no suspension
+        point, so it is run in a thread rather than on the request loop, where one
+        large upload would otherwise freeze every other request and agent stream on
+        this worker.
         """
         if file_type == "text":
-            return self._parse_text_content(data, mime_type)
+            return await asyncio.to_thread(self._parse_text_content, data, mime_type)
         if file_type == "pdf":
-            return self._parse_pdf_content(data)
+            return await asyncio.to_thread(self._parse_pdf_content, data)
         if file_type == "docx":
-            return self._parse_docx_content(data)
+            return await asyncio.to_thread(self._parse_docx_content, data)
         if file_type == "spreadsheet":
-            return self._parse_spreadsheet_content(data)
+            return await asyncio.to_thread(self._parse_spreadsheet_content, data)
         return None
 
     @staticmethod

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -368,7 +368,7 @@ ignore = [
 # third-party SDK calls are its debt, tracked rather than silently accepted:
 # they move out of this list when that subsystem is rewritten.
 "app/services/rag/retrieval.py" = ["A002", "S324"]
-"app/services/file_upload.py" = ["ASYNC230", "TRY300", "PTH123", "PTH108"]
+"app/services/file_upload.py" = ["TRY300", "PTH123", "PTH108"]
 # Template-inherited subsystems. These are readability rules whose value is
 # real but whose cost right now is churn in code we did not design and are not
 # yet responsible for. They lift file by file as each subsystem is rewritten —

--- a/backend/tests/test_blocking_io_offload.py
+++ b/backend/tests/test_blocking_io_offload.py
@@ -1,0 +1,72 @@
+"""Blocking file work runs off the request loop, not on it (#25).
+
+Two request-path functions were `async def` over pure blocking work - parsing an
+upload, and reading or writing it to local storage - so one large file froze
+every other request and every agent stream on the worker until it finished. Both
+offload to a thread now; each test asserts the blocking call lands on a thread
+other than the event loop's, which fails if the `asyncio.to_thread` is removed.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from app.services.file_storage import LocalFileStorage
+from app.services.file_upload import FileUploadService
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_parsing_an_upload_runs_off_the_request_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = FileUploadService(db=None)  # ty: ignore[invalid-argument-type]
+    loop_thread = threading.get_ident()
+    ran_on: list[int] = []
+
+    def record(_self: FileUploadService, _data: bytes) -> str:
+        ran_on.append(threading.get_ident())
+        return "parsed"
+
+    monkeypatch.setattr(FileUploadService, "_parse_pdf_content", record)
+
+    assert await service.parse_content(b"%PDF-1.7 fixture", "pdf") == "parsed"
+    assert ran_on and ran_on[0] != loop_thread
+
+
+async def test_saving_to_local_storage_runs_off_the_request_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    storage = LocalFileStorage(base_dir=tmp_path / "media")
+    loop_thread = threading.get_ident()
+    ran_on: list[int] = []
+    real_write = Path.write_bytes
+
+    def recording(self: Path, data: bytes) -> int:
+        ran_on.append(threading.get_ident())
+        return real_write(self, data)
+
+    monkeypatch.setattr(Path, "write_bytes", recording)
+
+    await storage.save("u1", "report.bin", b"payload")
+    assert ran_on and ran_on[0] != loop_thread
+
+
+async def test_loading_from_local_storage_runs_off_the_request_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    storage = LocalFileStorage(base_dir=tmp_path / "media")
+    stored = await storage.save("u1", "report.bin", b"payload")
+    loop_thread = threading.get_ident()
+    ran_on: list[int] = []
+    real_read = Path.read_bytes
+
+    def recording(self: Path) -> bytes:
+        ran_on.append(threading.get_ident())
+        return real_read(self)
+
+    monkeypatch.setattr(Path, "read_bytes", recording)
+
+    assert await storage.load(stored) == b"payload"
+    assert ran_on and ran_on[0] != loop_thread


### PR DESCRIPTION
## What & why

`FileUploadService.parse_content` and `LocalFileStorage.save`/`load` were `async def` over pure blocking work — pymupdf over every page, openpyxl over every cell, a decode and `Path.write_bytes`/`read_bytes` of up to `MAX_UPLOAD_SIZE`/10 MB — **with no suspension point**. One user uploading a large PDF, or an agent turn loading three attached images, froze every other request and every in-flight agent WebSocket stream on that uvicorn worker until the work landed.

The codebase already knew the pattern: `agents/mcp.py` routes DNS through `asyncio.to_thread`, and `rag_document.py` switched a write to anyio saying *"writing it synchronously stalls every other request on this worker"* — and that same file writes the identical bytes twice, only one of which had been fixed.

## Change

- Offload every branch of `parse_content` and both storage byte operations with `asyncio.to_thread`.
- Drop the now-dead `ASYNC230` per-file ruff ignore on `file_upload.py` — the only blocking-open left is `pymupdf.open` inside a sync helper, so the rule no longer fires (verified with `--select ASYNC230`).

## Scope

Fixes the two request-path functions (23a, 23b). The worker-side blocking IO the issue also lists (`worker/tasks/rag_tasks.py`) is the worker, not the request path — lower severity, tracked as a follow-up.

## Verification

- Three thread-identity regression tests assert the parse and the save/load byte ops each run on a thread other than the event loop's — each fails if its `to_thread` is reverted to a direct call.
- Existing storage round-trip and spreadsheet-parse tests pass; `make lint` green; the full non-integration suite is green (6283 passed, 0 failed). Adversarial review confirmed correctness, caller safety, exception propagation, and that `to_thread` genuinely un-freezes the loop for every branch (the old code had no await point at all).

Closes #25