### PR TITLE
fix(rag): paginate the tracked-documents listing

### DIFF
--- a/backend/app/api/routes/v1/rag.py
+++ b/backend/app/api/routes/v1/rag.py
@@ -349,14 +349,17 @@ async def list_rag_documents(
     access: CollectionAccessSvc,
     ctx: Auth,
     collection_name: str | None = Query(None),
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=100),
 ) -> Any:
-    """List tracked RAG documents.
+    """List a page of tracked RAG documents.
 
     Without `collection_name` this answers with the caller's collections -
-    not, as it once did, with every document in the deployment.
+    not, as it once did, with every document in the deployment - and it pages
+    rather than serializing every row across them (#27).
     """
     collections = await access.readable_names_for(ctx, collection_name)
-    return await rag_doc_svc.list_documents(collections=collections)
+    return await rag_doc_svc.list_documents(collections=collections, skip=skip, limit=limit)
 
 
 @router.get(

--- a/backend/app/repositories/rag_document.py
+++ b/backend/app/repositories/rag_document.py
@@ -38,8 +38,14 @@ async def get_all(
     db: AsyncSession,
     *,
     collections: list[str],
-) -> list[RAGDocument]:
-    """Documents tracked in the named collections, newest first.
+    skip: int = 0,
+    limit: int = 50,
+) -> tuple[list[RAGDocument], int]:
+    """A page of documents tracked in the named collections, newest first.
+
+    Returns `(rows, total)`, the same shape as `get_for_kb`: without a bound this
+    selected and serialized every row across the caller's collections, which grows
+    without limit with tenant data (#27).
 
     Filtering on `organization_id` would be the obvious alternative and is not
     equivalent: the column is nullable and a document ingested by a sync task
@@ -48,14 +54,15 @@ async def get_all(
     `knowledge_bases` row authorized, so the collection is what this asks for.
     """
     if not collections:
-        return []
-    query = (
-        select(RAGDocument)
-        .where(RAGDocument.collection_name.in_(collections))
-        .order_by(RAGDocument.created_at.desc())
+        return [], 0
+    base = select(RAGDocument).where(RAGDocument.collection_name.in_(collections))
+    total = (await db.execute(select(func.count()).select_from(base.subquery()))).scalar_one()
+    rows = (
+        (await db.execute(base.order_by(RAGDocument.created_at.desc()).offset(skip).limit(limit)))
+        .scalars()
+        .all()
     )
-    result = await db.execute(query)
-    return list(result.scalars().all())
+    return list(rows), int(total)
 
 
 async def get_for_kb(

--- a/backend/app/services/rag_document.py
+++ b/backend/app/services/rag_document.py
@@ -72,18 +72,22 @@ class RAGDocumentService:
     def __init__(self, db: AsyncSession):
         self.db = db
 
-    async def list_documents(self, *, collections: list[str]) -> RAGTrackedDocumentList:
-        """List tracked RAG documents belonging to the named collections.
+    async def list_documents(
+        self, *, collections: list[str], skip: int = 0, limit: int = 50
+    ) -> RAGTrackedDocumentList:
+        """List a page of tracked RAG documents belonging to the named collections.
 
-        The argument is required and takes no default on purpose: the caller
-        decides which collections it is entitled to see, and there is no way to
-        ask for "all of them" by forgetting to say. An empty list is an empty
-        answer.
+        The `collections` argument is required and takes no default on purpose:
+        the caller decides which collections it is entitled to see, and there is
+        no way to ask for "all of them" by forgetting to say. An empty list is an
+        empty answer.
         """
-        docs = await rag_document_repo.get_all(self.db, collections=collections)
+        rows, total = await rag_document_repo.get_all(
+            self.db, collections=collections, skip=skip, limit=limit
+        )
         return RAGTrackedDocumentList(
-            items=[_tracked_item(d) for d in docs],
-            total=len(docs),
+            items=[_tracked_item(d) for d in rows],
+            total=total,
         )
 
     async def list_for_kb(

--- a/backend/tests/test_rag_document_listing.py
+++ b/backend/tests/test_rag_document_listing.py
@@ -1,0 +1,113 @@
+"""GET /rag/documents pages rather than serializing every row (#27).
+
+Unbounded, this selected every `rag_documents` row across the caller's readable
+collections and held the whole set in memory to answer one request - multi-second
+and tens of MB for a tenant with 50k documents. The service now pages and reports
+the collection's own count, and the route takes the standard `skip`/`limit`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.api import deps
+from app.core.config import settings
+from app.core.permissions import AuthContext, OrgRoleName
+from app.db.models.rag_document import RAGDocument
+from app.main import app
+from app.repositories import rag_document as rag_document_repo
+from app.schemas.rag import RAGTrackedDocumentList
+from app.services.rag_document import RAGDocumentService, _tracked_item
+
+pytestmark = pytest.mark.anyio
+
+
+def _doc() -> RAGDocument:
+    return RAGDocument(
+        id=uuid.uuid4(),
+        collection_name="docs",
+        filename="report.pdf",
+        filesize=1024,
+        filetype="pdf",
+        status="done",
+        vector_document_id="vec-1",
+        chunk_count=0,
+        ingestion_config={},
+    )
+
+
+async def test_the_service_pages_and_reports_the_collection_total(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The total is the collection's count, not the length of the page returned,
+    so a client can page the rest (#27). Without the fix the repo took no
+    `skip`/`limit` and the service reported `len(docs)`."""
+    page = [_doc(), _doc()]
+    captured: dict[str, object] = {}
+
+    async def get_all(
+        _db: Any, *, collections: list[str], skip: int, limit: int
+    ) -> tuple[list[RAGDocument], int]:
+        captured.update(collections=collections, skip=skip, limit=limit)
+        return page, 137
+
+    monkeypatch.setattr(rag_document_repo, "get_all", get_all)
+
+    result = await RAGDocumentService(db=cast("Any", None)).list_documents(
+        collections=["c1"], skip=50, limit=25
+    )
+
+    assert captured == {"collections": ["c1"], "skip": 50, "limit": 25}
+    assert len(result.items) == 2
+    assert result.total == 137
+
+
+@pytest.fixture
+def client(mock_db_session: Any, mock_redis: MagicMock) -> Iterator[AsyncClient]:
+    context = AuthContext(
+        user_id=uuid.uuid4(), organization_id=uuid.uuid4(), role=OrgRoleName.OWNER
+    )
+    access = MagicMock(readable_names_for=AsyncMock(return_value=["c1"]))
+    listing = RAGTrackedDocumentList(
+        items=[_tracked_item(_doc()), _tracked_item(_doc())], total=137
+    )
+    rag_doc_svc = MagicMock(list_documents=AsyncMock(return_value=listing))
+
+    app.dependency_overrides[deps.get_db_session] = lambda: mock_db_session
+    app.dependency_overrides[deps.get_redis] = lambda: mock_redis
+    app.dependency_overrides[deps.get_auth_context] = lambda: context
+    app.dependency_overrides[deps.get_collection_access_service] = lambda: access
+    app.dependency_overrides[deps.get_rag_document_service] = lambda: rag_doc_svc
+
+    transport = ASGITransport(app=app)
+    opened = AsyncClient(transport=transport, base_url="http://test")
+    opened.rag_doc_svc = rag_doc_svc  # type: ignore[attr-defined]
+    yield opened
+    app.dependency_overrides.clear()
+
+
+async def test_the_route_respects_limit_and_reports_a_larger_total(client: AsyncClient) -> None:
+    async with client as opened:
+        response = await opened.get(f"{settings.API_V1_STR}/rag/documents", params={"limit": 2})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["items"]) == 2
+    assert body["total"] == 137
+    opened.rag_doc_svc.list_documents.assert_awaited_once_with(  # type: ignore[attr-defined]
+        collections=["c1"], skip=0, limit=2
+    )
+
+
+async def test_the_route_refuses_a_limit_over_the_ceiling(client: AsyncClient) -> None:
+    """`le=100` per api-conventions, so an unbounded response cannot be asked for."""
+    async with client as opened:
+        response = await opened.get(f"{settings.API_V1_STR}/rag/documents", params={"limit": 5000})
+
+    assert response.status_code == 422


### PR DESCRIPTION
## What & why

`GET /api/v1/rag/documents` selected **every** `rag_documents` row across the caller's readable collections and serialized the whole set in one response — unbounded, so a tenant with 50k documents got a multi-second query and tens of MB held entirely in memory. The sibling `get_for_kb` already paged; this path just did not use the pattern.

## Change

- `get_all` takes `skip`/`limit` and a `COUNT` for the total, returning `(rows, total)` like `get_for_kb`. Its only caller is this listing, so the `list`→`tuple` change is contained.
- The service threads `skip`/`limit` and reports the repo's `total` (was `len(docs)`).
- The route adds `skip: Query(0, ge=0)`, `limit: Query(50, ge=1, le=100)` per `.claude/rules/api-conventions.md`.

No frontend caller: the console pages `/kb/{id}/documents` (the already-paginated `get_for_kb`), not this endpoint.

## Scope

This is the pagination half (the issue's first acceptance criterion). The second — making ingestion's `existing_document` O(1) instead of a full `rag_<collection>` scan — rewrites a hot path with a documented precedence/consistency history (#548, #566) and needs a JSONB predicate query plus a supporting expression index on the **runtime-created** vector tables, verified against a real database. A `source_path` fast-path alone is not low-risk (still a sequential scan without the index; two passes on the common miss). Split to the follow-up #1102 rather than shipped blind.

## Verification

- Service test: `skip`/`limit` reach the repo and the reported `total` is the collection's count, not the page length.
- Route tests: the endpoint forwards `limit` and reports a total larger than the page, and refuses a `limit` past `le=100` with 422.
- `make lint` green; full non-integration suite green (6283 passed, 0 failed). Adversarial review confirmed COUNT correctness, contained blast radius, and test genuineness.

Closes #27
