### PR TITLE
test(sanitize): cover the DNS-failure paths and gate the SSRF module

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -468,6 +468,10 @@ include = [
     "app/core/secret_kinds.py",
     "app/core/vault.py",
     "app/core/background.py",
+    # The SSRF allow/deny every outbound URL a tenant chooses is checked against -
+    # a webhook, an MCP server address. A hole here is a request to an internal
+    # address the operator cannot see, which is the pair to pinned_http below (#28).
+    "app/core/sanitize.py",
     # The client that dials the address it validated, for a URL the party being
     # validated chose. A miss here is an SSRF the operator cannot see.
     "app/core/pinned_http.py",
@@ -688,6 +692,10 @@ include = [
     "app/core/secret_kinds.py",
     "app/core/vault.py",
     "app/core/background.py",
+    # The SSRF allow/deny every outbound URL a tenant chooses is checked against -
+    # a webhook, an MCP server address. A hole here is a request to an internal
+    # address the operator cannot see, which is the pair to pinned_http below (#28).
+    "app/core/sanitize.py",
     # The client that dials the address it validated, for a URL the party being
     # validated chose. A miss here is an SSRF the operator cannot see.
     "app/core/pinned_http.py",

--- a/backend/tests/test_ssrf.py
+++ b/backend/tests/test_ssrf.py
@@ -3,6 +3,7 @@
 Covers validate_webhook_url() and _is_ip_blocked() from app.core.sanitize.
 """
 
+import socket
 from unittest.mock import patch
 
 import pytest
@@ -139,6 +140,27 @@ class TestDnsResolution:
         with patch("app.core.sanitize.socket.getaddrinfo", self._mock_getaddrinfo_public):
             result = validate_webhook_url("https://example.com/webhook")
             assert result == "https://example.com/webhook"
+
+    def test_a_hostname_that_fails_to_resolve_is_blocked(self):
+        """A lookup that raises is refused here, not left to fail later against an
+        address the pinning never vetted."""
+
+        def _raise(*_args: object, **_kwargs: object) -> list[object]:
+            raise socket.gaierror("Name or service not known")
+
+        with (
+            patch("app.core.sanitize.socket.getaddrinfo", _raise),
+            pytest.raises(SSRFBlockedError, match="unable to resolve"),
+        ):
+            validate_webhook_url("https://nonexistent.invalid/hook")
+
+    def test_a_hostname_resolving_to_no_address_is_blocked(self):
+        """`getaddrinfo` returning nothing is treated as a block, not an allow."""
+        with (
+            patch("app.core.sanitize.socket.getaddrinfo", lambda *_a, **_k: []),
+            pytest.raises(SSRFBlockedError, match="did not resolve"),
+        ):
+            validate_webhook_url("https://empty.example.com/hook")
 
 
 # validate_webhook_url - edge cases


### PR DESCRIPTION
## What & why

`app/core/sanitize.py` — the SSRF allow/deny every outbound URL a tenant chooses is checked against (a webhook target, an MCP server address) — was in neither `[tool.coverage.run] include` nor `[[tool.ty.overrides]] include`, the 100% gate #28 asks to extend to the modules implementing the refusals CLAUDE.md names as must-cover. It sat at 95%: the two DNS-failure exits in `resolve_pinned_url` (a lookup that raises `gaierror`; one that resolves to no address) had no test.

Cover both with a mocked `getaddrinfo`, then add the module to both lists (verbatim, same position), beside `pinned_http.py` — the validator paired with the client that dials what it validated. It types clean under the stricter checker and reaches 100% line+branch.

## Scope — the coverage-gate tail (this issue's remaining work)

Per Kacper's decision, this PR does the coverage-gate tail only; it does **not** implement the `_listing_key` visibility narrowing (AC 2/3), which the maintainer declined. The five-routes layering (AC 1) already landed via #232.

sanitize.py is the one tail module ready to gate right now:

| Module | Status |
|---|---|
| `app/core/audit.py` | gated by its own branch (#20) |
| `app/services/embed_session.py` | already in both lists |
| `app/services/agent_embed.py` | 85% — needs substantial tests first |
| `channels/slack.py`, `telegram.py`, `mattermost.py`, `router.py` | hold open bugs (supervisor loop, concurrency races); need to reach 100% and a real DB to measure |

#28 stays open for those.

## Verification

`test_coverage_gate.py` green (the two lists stay in sync), `sanitize.py` at 100% line+branch via the SSRF suite, `make lint` (ruff + ty + guards) clean. The two new tests fail without the DNS-failure handling they cover.

Closes #28