### PR TITLE
fix(channels): require a freshness claim on an embed token

### DIFF
--- a/backend/app/services/agent_embed.py
+++ b/backend/app/services/agent_embed.py
@@ -612,10 +612,18 @@ class AgentEmbedService:
             raise EmbedDenied("token rejected") from exc
 
         issued_at = claims.get("iat")
-        if isinstance(issued_at, int | float):
-            age = datetime.now(UTC).timestamp() - float(issued_at)
-            if age > _MAX_TOKEN_AGE_SECONDS:
-                raise EmbedDenied("token too old")
+        if not isinstance(issued_at, int | float) or (
+            datetime.now(UTC).timestamp() - float(issued_at) > _MAX_TOKEN_AGE_SECONDS
+        ):
+            # A within-window `iat` is required, not checked opportunistically:
+            # PyJWT enforces neither `iat` nor a 12h ceiling, so a token with no
+            # `iat` - or a stale one hidden behind a far-future `exp` - would be
+            # fresh until it expired, if ever, and one scraped from a browser tab
+            # would answer on the organization's bill that whole time. `exp` is
+            # not an alternative: it lets a customer *shorten* the window (PyJWT
+            # rejects an expired token at decode), never extend it past the 12h
+            # platform ceiling (#23).
+            raise EmbedDenied("token too old")
 
         subject = claims.get("sub")
         if not subject:

--- a/backend/tests/test_agent_embed.py
+++ b/backend/tests/test_agent_embed.py
@@ -295,6 +295,68 @@ class TestTokenMode:
             await _service().admit("key-123", origin="https://acme.test", token=token)
 
     @pytest.mark.anyio
+    async def test_a_token_with_no_issued_at_is_refused_rather_than_treated_as_fresh(self):
+        """`{"sub": ...}` alone is correctly signed and carries no freshness claim,
+        which the old opportunistic `if isinstance(iat, ...)` check skipped - so
+        PyJWT accepted it forever and one scraped token answered on the bill
+        indefinitely (#23)."""
+        secret = "s" * 32
+        token = jwt.encode({"sub": "user-42"}, secret, algorithm="HS256")
+        with (
+            patch(
+                f"{MODULE}.agent_embed_repo.get_by_key",
+                new=AsyncMock(return_value=self._jwt_embed()),
+            ),
+            patch(f"{MODULE}.unseal", return_value=secret),
+            pytest.raises(EmbedDenied),
+        ):
+            await _service().admit("key-123", origin="https://acme.test", token=token)
+
+    @pytest.mark.anyio
+    async def test_a_stale_iat_is_refused_even_behind_a_future_exp(self):
+        """`exp` must not let a stale `iat` through: a far-future `exp` is common in
+        a customer's own tokens, and treating it as freshness would let a copied
+        token replay past the 12h ceiling until it expired. `exp` may only shorten
+        the window, never extend it (#23)."""
+        secret = "s" * 32
+        old = int(time.time()) - 60 * 60 * 24 * 30
+        token = jwt.encode(
+            {"sub": "user-42", "iat": old, "exp": int(time.time()) + 60 * 60 * 24 * 365},
+            secret,
+            algorithm="HS256",
+        )
+        with (
+            patch(
+                f"{MODULE}.agent_embed_repo.get_by_key",
+                new=AsyncMock(return_value=self._jwt_embed()),
+            ),
+            patch(f"{MODULE}.unseal", return_value=secret),
+            pytest.raises(EmbedDenied),
+        ):
+            await _service().admit("key-123", origin="https://acme.test", token=token)
+
+    @pytest.mark.anyio
+    async def test_a_recent_iat_alongside_a_future_exp_is_admitted(self):
+        """The ordinary case a customer mints: a fresh `iat` and an `exp` for the
+        session. It passes on the `iat`; PyJWT validates the `exp` too."""
+        secret = "s" * 32
+        token = jwt.encode(
+            {"sub": "user-42", "iat": int(time.time()), "exp": int(time.time()) + 3600},
+            secret,
+            algorithm="HS256",
+        )
+        with (
+            patch(
+                f"{MODULE}.agent_embed_repo.get_by_key",
+                new=AsyncMock(return_value=self._jwt_embed()),
+            ),
+            patch(f"{MODULE}.unseal", return_value=secret),
+        ):
+            admission = await _service().admit("key-123", origin="https://acme.test", token=token)
+
+        assert admission.visitor == "user-42"
+
+    @pytest.mark.anyio
     async def test_the_origin_is_checked_before_the_token(self):
         """A probe from an unlisted site must learn nothing about tokens - the
         unseal is what would tell it, so it must never happen."""

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -151,8 +151,11 @@ token = jwt.encode(
 - `sub` is required. It identifies the visitor for rate limiting, and a token
   without one is refused — otherwise a single leaked token becomes the whole
   widget's budget.
-- `iat` is checked: a token older than 12 hours is refused, so one that leaks
-  out of a browser does not work forever.
+- **`iat` is required and must be within the last 12 hours** — it is not checked
+  only when present. A token with no `iat`, or a stale one, is refused, so one
+  that leaks out of a browser cannot work forever. An `exp` you set is honoured
+  too, but only to **shorten** that window (an expired token is rejected); it
+  cannot extend a token past the 12-hour ceiling.
 - Mint it per page load, server-side. Never ship the signing secret to a browser.
 
 ---


### PR DESCRIPTION
## What & why

`AgentEmbedService._verify_token` checked max-age only `if isinstance(iat, int | float)` — opportunistically. PyJWT requires neither `iat` nor `exp`, so a correctly-signed `{"sub": "user-42"}` carried **no freshness claim and was accepted forever**. One token scraped from a browser's network tab kept the widget answering on the organization's bill indefinitely — the exact failure the surrounding code twice names as the dangerous one.

Require a within-window `iat` **unconditionally**: a token with no `iat`, or one older than the 12h ceiling, is refused. `exp` is **not** an alternative freshness claim — treating it as one would let a customer's ordinary far-future `exp` override the ceiling, so a copied token could replay until it expired (a milder version of the same leak, raised in review). `exp`, when present, is still validated by PyJWT, so it can only **shorten** the window, never extend it past 12h.

## Behaviour

Unchanged for every token that carries an `iat` — recent passes, stale refuses. Only the previously-accepted no-`iat` shape now refuses.

## Verification

- `test_a_token_with_no_issued_at_is_refused_rather_than_treated_as_fresh` (the leak), `test_a_stale_iat_is_refused_even_behind_a_future_exp` (a far-future `exp` does not rescue a stale `iat`), and `test_a_recent_iat_alongside_a_future_exp_is_admitted` (the ordinary customer case). Existing stale/no-subject tests untouched.
- `docs/channels.md` states the requirement. `make lint` clean; `test_agent_embed.py` green (100 passed). Adversarial review confirmed PyJWT validates `exp`/future-`iat` at decode.

One pre-existing, out-of-scope robustness gap (a malformed `null`/`[]` `exp`/`iat` raises a raw `TypeError` in `jwt.decode`, a 500 — not exploitable, fails closed) is filed as #1107.

Closes #23