### PR TITLE
fix(organizations): reconcile deletes with the check constraints

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -957,6 +957,20 @@ async def get_vectorstore(
 VectorStoreSvc = Annotated[BaseVectorStore, Depends(get_vectorstore)]
 
 
+def get_organization_teardown_service(
+    db: DBSession, vector_store: VectorStoreSvc
+) -> OrganizationService:
+    """OrganizationService that can also drop a deleted tenant's vector tables.
+
+    Only the delete route wires the vector store in; every other org route uses
+    the plain factory so it does not build a store it never touches (#9).
+    """
+    return OrganizationService(db, vector_store=vector_store)
+
+
+OrganizationTeardownSvc = Annotated[OrganizationService, Depends(get_organization_teardown_service)]
+
+
 def get_retrieval_service(vector_store: VectorStoreSvc) -> RetrievalService:
     """Create RetrievalService instance."""
     return RetrievalService(vector_store=vector_store, settings=settings.rag)

--- a/backend/app/api/routes/v1/organizations.py
+++ b/backend/app/api/routes/v1/organizations.py
@@ -7,7 +7,7 @@ from uuid import UUID
 from fastapi import APIRouter, File, HTTPException, UploadFile, status
 from fastapi.responses import FileResponse
 
-from app.api.deps import CurrentUser, OrganizationSvc
+from app.api.deps import CurrentUser, OrganizationSvc, OrganizationTeardownSvc
 from app.schemas.organization import (
     OrganizationCreate,
     OrganizationList,
@@ -64,7 +64,7 @@ async def update_organization(
 @router.delete("/{org_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None)
 async def delete_organization(
     org_id: UUID,
-    service: OrganizationSvc,
+    service: OrganizationTeardownSvc,
     user: CurrentUser,
 ) -> None:
     """Delete an organization. Requires Owner role. Personal orgs cannot be deleted."""

--- a/backend/app/repositories/knowledge_base.py
+++ b/backend/app/repositories/knowledge_base.py
@@ -158,6 +158,24 @@ async def get_by_collection_name(db: AsyncSession, collection_name: str) -> Know
     return result.scalars().first()
 
 
+async def list_org_scoped(db: AsyncSession, organization_id: UUID) -> list[KnowledgeBase]:
+    """The org-scoped collections a tenant owns - the ones a deletion must remove.
+
+    `knowledge_bases.organization_id` is `ON DELETE SET NULL`, but
+    `ck_knowledge_bases_org_scope_has_org` forbids an org-scoped row with no org,
+    so nulling one on organization delete violates the check (#9). These rows are
+    deleted explicitly before the org row goes. Personal collections that merely
+    carry this org's id are left to the `SET NULL`, which their scope permits.
+    """
+    result = await db.execute(
+        select(KnowledgeBase).where(
+            KnowledgeBase.organization_id == organization_id,
+            KnowledgeBase.scope == KBScope.ORG.value,
+        )
+    )
+    return list(result.scalars().all())
+
+
 async def list_by_collection_name(db: AsyncSession, collection_name: str) -> list[KnowledgeBase]:
     """Every knowledge base claiming this collection name, oldest first.
 

--- a/backend/app/repositories/member.py
+++ b/backend/app/repositories/member.py
@@ -266,6 +266,23 @@ async def first_owner_id(db: AsyncSession, *, organization_id: UUID) -> UUID | N
     )
 
 
+async def other_owner_id(
+    db: AsyncSession, *, organization_id: UUID, exclude_user_id: UUID
+) -> UUID | None:
+    """The earliest-joined owner who is not this user - who a shared org is handed
+    to when its creator's account is deleted (#9)."""
+    return await db.scalar(
+        select(OrganizationMember.user_id)
+        .where(
+            OrganizationMember.organization_id == organization_id,
+            OrganizationMember.role == OrgRole.OWNER.value,
+            OrganizationMember.user_id != exclude_user_id,
+        )
+        .order_by(OrganizationMember.joined_at.asc())
+        .limit(1)
+    )
+
+
 async def create(
     db: AsyncSession,
     *,

--- a/backend/app/repositories/organization.py
+++ b/backend/app/repositories/organization.py
@@ -60,6 +60,29 @@ async def get_personal_for_user(db: AsyncSession, user_id: UUID) -> Organization
     return result.scalar_one_or_none()
 
 
+async def list_created_by(db: AsyncSession, user_id: UUID) -> list[Organization]:
+    """Every organization this user created - the rows that block their deletion.
+
+    `organizations.created_by_user_id` is `ON DELETE RESTRICT`, so each of these
+    has to be handed on or removed before the user row can go (#9).
+    """
+    result = await db.execute(
+        select(Organization)
+        .where(Organization.created_by_user_id == user_id)
+        .order_by(Organization.is_personal.desc(), Organization.created_at.asc())
+    )
+    return list(result.scalars().all())
+
+
+async def reassign_creator(
+    db: AsyncSession, *, org: Organization, new_creator_id: UUID
+) -> Organization:
+    org.created_by_user_id = new_creator_id
+    await db.flush()
+    await db.refresh(org)
+    return org
+
+
 async def list_for_user(db: AsyncSession, user_id: UUID) -> list[Organization]:
     result = await db.execute(
         select(Organization)

--- a/backend/app/repositories/organization_secret.py
+++ b/backend/app/repositories/organization_secret.py
@@ -8,6 +8,7 @@ look like an ordinary call (see tests/test_org_scope_regression.py).
 from uuid import UUID
 
 from sqlalchemy import bindparam, false, or_, select, text
+from sqlalchemy import update as sql_update
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -171,6 +172,31 @@ async def delete(db: AsyncSession, secret_id: UUID, *, organization_id: UUID) ->
     await db.delete(secret)
     await db.flush()
     return True
+
+
+async def promote_owned_private_to_org(db: AsyncSession, *, owner_user_id: UUID) -> int:
+    """Make every private secret this user owns org-visible, across all their orgs.
+
+    Deliberately not org-scoped, unlike the rest of this module: it runs when the
+    owner's account is deleted, and `owner_user_id` is about to be nulled by the
+    `SET NULL` cascade. `ck_secret_private_needs_owner` forbids a private secret
+    with no owner, so without this the delete violates the check and 500s (#9).
+    Promoting to org visibility is the outcome the column comment names - a
+    personal key whose owner leaves "becomes the organization's problem to clean
+    up" - and it leaves the row reachable rather than stranded.
+
+    Returns the number of rows promoted.
+    """
+    result = await db.execute(
+        sql_update(OrganizationSecret)
+        .where(
+            OrganizationSecret.owner_user_id == owner_user_id,
+            OrganizationSecret.visibility == Visibility.PRIVATE.value,
+        )
+        .values(visibility=Visibility.ORG.value)
+    )
+    await db.flush()
+    return result.rowcount  # ty: ignore[unresolved-attribute]
 
 
 async def agents_using(

--- a/backend/app/services/organization.py
+++ b/backend/app/services/organization.py
@@ -1,7 +1,9 @@
 import contextlib
 import logging
+from typing import TYPE_CHECKING
 from uuid import UUID
 
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -14,7 +16,7 @@ from app.core.exceptions import (
 from app.core.permissions import AuthContext, OrgRoleName, Perm, role_has
 from app.db.locks import LockScope, hold_subject
 from app.db.models.organization import Organization, OrganizationMember, OrgRole
-from app.repositories import member_repo, organization_repo
+from app.repositories import knowledge_base_repo, member_repo, organization_repo
 from app.schemas.organization import (
     OrganizationCreate,
     OrganizationList,
@@ -25,6 +27,9 @@ from app.services import skill_library
 from app.services.deployment_settings import DeploymentSettingsService
 from app.services.file_storage import avatar_filename, get_file_storage
 from app.services.skills import SkillService
+
+if TYPE_CHECKING:
+    from app.services.rag.vectorstore import BaseVectorStore
 
 logger = logging.getLogger(__name__)
 
@@ -54,8 +59,12 @@ def _org_read(org: Organization, member_count: int, role: str) -> OrganizationRe
 class OrganizationService:
     _ALLOWED_AVATAR_TYPES = {"image/jpeg", "image/png", "image/webp", "image/gif"}
 
-    def __init__(self, db: AsyncSession):
+    def __init__(self, db: AsyncSession, vector_store: "BaseVectorStore | None" = None):
         self.db = db
+        # Present only on the teardown path, where the request built a store to
+        # drop the tenant's vector tables with; None everywhere else, so ordinary
+        # org operations do not pay for one they never use (#9).
+        self._vector_store = vector_store
 
     async def get_by_id(self, org_id: UUID) -> Organization:
         org = await organization_repo.get_by_id(self.db, org_id)
@@ -297,6 +306,28 @@ class OrganizationService:
         if not role_has(membership.role, Perm.ORG_DELETE):
             raise AuthorizationError(message="Only the Owner can delete the organization")
 
+        await self.purge(org)
+
+    async def purge(self, org: Organization) -> None:
+        """Remove an organization and its org-scoped collections, no guards.
+
+        The guards live in :meth:`delete`; this is the shared teardown, also
+        reached when a user's account is deleted and their personal org goes with
+        them (`app.services.user.UserService.delete`). Org-scoped collections are
+        removed explicitly first: `knowledge_bases.organization_id` is
+        `ON DELETE SET NULL`, and nulling an org-scoped row violates
+        `ck_knowledge_bases_org_scope_has_org` (#9). Personal collections that
+        merely carry this org's id are left to the `SET NULL`.
+        """
+        for kb in await knowledge_base_repo.list_org_scoped(self.db, org.id):
+            if self._vector_store is not None:
+                # Best-effort, and only against the database: a zero-document
+                # collection has no table yet, which is a `SQLAlchemyError`, not a
+                # reason to abandon the deletion. Mirrors the `drop_collection`
+                # route.
+                with contextlib.suppress(SQLAlchemyError):
+                    await self._vector_store.delete_collection(kb.collection_name)
+            await knowledge_base_repo.delete(self.db, kb.id)
         await organization_repo.delete(self.db, org)
 
     async def upload_avatar(

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -12,6 +12,7 @@ from app.core.exceptions import (
     AlreadyExistsError,
     AuthenticationError,
     AuthorizationError,
+    BadRequestError,
     NotFoundError,
 )
 from app.core.security import (
@@ -23,7 +24,13 @@ from app.core.security import (
 )
 from app.db.models.user import User
 from app.db.updates import writable
-from app.repositories import session_repo, user_repo
+from app.repositories import (
+    member_repo,
+    organization_repo,
+    organization_secret_repo,
+    session_repo,
+    user_repo,
+)
 from app.schemas.conversation_share import AdminUserList, AdminUserRead
 from app.schemas.user import UserCreate, UserUpdate
 from app.services.deployment_settings import DeploymentSettingsService
@@ -301,13 +308,42 @@ class UserService:
         return str(full_path) if full_path is not None else None
 
     async def delete(self, user_id: UUID) -> User:
-        user = await user_repo.delete(self.db, user_id)
+        user = await user_repo.get_by_id(self.db, user_id)
         if not user:
             raise NotFoundError(
                 message="User not found",
                 details={"user_id": user_id},
             )
+        await self._release_owned_rows(user_id)
+        await user_repo.delete(self.db, user_id)
         return user
+
+    async def _release_owned_rows(self, user_id: UUID) -> None:
+        """Hand on or remove what would otherwise block the user's deletion (#9).
+
+        Three FK/CHECK pairs make a bare `DELETE users` 500: a private secret's
+        owner is `SET NULL` under a check that forbids an ownerless private
+        secret; every signup creates a personal org, and `created_by_user_id` is
+        `RESTRICT`. Each is resolved here in the request's own transaction, before
+        the row goes.
+        """
+        await organization_secret_repo.promote_owned_private_to_org(self.db, owner_user_id=user_id)
+
+        org_service = OrganizationService(self.db)
+        for org in await organization_repo.list_created_by(self.db, user_id):
+            if org.is_personal:
+                await org_service.purge(org)
+                continue
+            heir = await member_repo.other_owner_id(
+                self.db, organization_id=org.id, exclude_user_id=user_id
+            )
+            if heir is None:
+                raise BadRequestError(
+                    message="Cannot delete the sole owner of a shared organization; "
+                    "transfer ownership or delete the organization first",
+                    details={"user_id": user_id, "organization_id": org.id},
+                )
+            await organization_repo.reassign_creator(self.db, org=org, new_creator_id=heir)
 
     async def admin_update(
         self, user_id: UUID, user_in: UserUpdate, *, acting_admin_id: UUID

--- a/backend/tests/integration/test_deletion_reconciliation.py
+++ b/backend/tests/integration/test_deletion_reconciliation.py
@@ -1,0 +1,261 @@
+"""Deleting a user or an org no longer 500s on a cascade the schema forbids.
+
+Three `ON DELETE SET NULL`/RESTRICT cascades each drove precisely the write a
+CHECK constraint rejects, so the delete raised inside the database and surfaced
+as a 500 (#9). Each is reconciled in the service before the row goes: a private
+secret is promoted to the org, a personal org is removed with its owner, and an
+org-scoped collection is deleted - table and all - rather than orphaned.
+
+Integration rather than unit because the whole point is what the database does
+to neighbouring rows when one is deleted, which a mock cannot show.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
+
+from app.core.config import settings as app_settings
+from app.db.models.knowledge_base import KBScope, KnowledgeBase
+from app.db.models.organization import Organization, OrganizationMember
+from app.db.models.organization_secret import OrganizationSecret
+from app.db.models.user import User
+from app.services.organization import OrganizationService
+from app.services.rag.vectorstore import PgVectorStore
+from app.services.user import UserService
+
+pytestmark = pytest.mark.anyio
+
+
+def _user(email: str | None = None) -> User:
+    return User(
+        id=uuid.uuid4(),
+        email=email or f"{uuid.uuid4().hex}@example.com",
+        hashed_password="x",
+        is_active=True,
+    )
+
+
+async def _member(db, org_id: uuid.UUID, user_id: uuid.UUID, role: str) -> None:
+    db.add(OrganizationMember(id=uuid.uuid4(), organization_id=org_id, user_id=user_id, role=role))
+    await db.flush()
+
+
+async def _org(db, creator: User, *, is_personal: bool = False) -> Organization:
+    org = Organization(
+        id=uuid.uuid4(),
+        name="Acme",
+        slug=f"acme-{uuid.uuid4().hex[:8]}",
+        is_personal=is_personal,
+        created_by_user_id=creator.id,
+    )
+    db.add(org)
+    await db.flush()
+    await _member(db, org.id, creator.id, "owner")
+    return org
+
+
+def _org_collection(org_id: uuid.UUID, collection_name: str) -> KnowledgeBase:
+    return KnowledgeBase(
+        id=uuid.uuid4(),
+        name="Shared docs",
+        scope=KBScope.ORG.value,
+        collection_name=collection_name,
+        embedding_model="text-embedding-3-small",
+        embedding_dim=1536,
+        organization_id=org_id,
+        visibility="org",
+    )
+
+
+def _private_secret(org_id: uuid.UUID, owner_id: uuid.UUID) -> OrganizationSecret:
+    return OrganizationSecret(
+        id=uuid.uuid4(),
+        organization_id=org_id,
+        name="mine",
+        purpose="openai",
+        visibility="private",
+        owner_user_id=owner_id,
+        kind="api_key",
+        sealed_secret="{}",
+        hint="1234",
+    )
+
+
+class TestDeletingAUser:
+    async def test_a_normally_registered_user_can_be_deleted(self, db):
+        """Every signup creates a personal org whose creator FK is RESTRICT, so a
+        bare `DELETE users` never worked for a real account (#9)."""
+        user = _user()
+        db.add(user)
+        await db.flush()
+        org = await _org(db, user, is_personal=True)
+
+        await UserService(db).delete(user.id)
+
+        assert await db.get(User, user.id) is None
+        assert await db.get(Organization, org.id) is None
+
+    async def test_deleting_a_member_promotes_their_private_secret_to_the_org(self, db):
+        """`ck_secret_private_needs_owner` forbids the ownerless-private row the
+        `SET NULL` would otherwise leave; the key stays reachable by the org."""
+        creator = _user()
+        db.add(creator)
+        await db.flush()
+        org = await _org(db, creator)
+
+        leaver = _user()
+        db.add(leaver)
+        await db.flush()
+        await _member(db, org.id, leaver.id, "member")
+        secret = _private_secret(org.id, leaver.id)
+        db.add(secret)
+        await db.flush()
+
+        await UserService(db).delete(leaver.id)
+
+        await db.refresh(secret)
+        assert secret.owner_user_id is None
+        assert secret.visibility == "org"
+
+    async def test_deleting_a_user_removes_an_org_scoped_collection_they_owned(self, db):
+        """The personal-org teardown runs the same collection cleanup as an org
+        delete, with no vector store wired in - the row still has to go."""
+        user = _user()
+        db.add(user)
+        await db.flush()
+        org = await _org(db, user, is_personal=True)
+        kb = _org_collection(org.id, f"kbnine{uuid.uuid4().hex[:12]}")
+        db.add(kb)
+        await db.flush()
+
+        await UserService(db).delete(user.id)
+
+        assert await db.get(KnowledgeBase, kb.id) is None
+        assert await db.get(Organization, org.id) is None
+
+    async def test_the_sole_owner_of_a_shared_org_is_refused_not_500ed(self, db):
+        """A shared org with no other owner has nobody to hand the creator FK to,
+        so the delete is a clean refusal rather than a foreign-key 500."""
+        from app.core.exceptions import BadRequestError
+
+        owner = _user()
+        db.add(owner)
+        await db.flush()
+        await _org(db, owner)  # shared: is_personal defaults to False
+
+        with pytest.raises(BadRequestError):
+            await UserService(db).delete(owner.id)
+
+        assert await db.get(User, owner.id) is not None
+
+    async def test_a_shared_org_is_handed_to_another_owner(self, db):
+        """When a co-owner exists the org survives, reattributed to them."""
+        creator = _user()
+        heir = _user()
+        db.add_all([creator, heir])
+        await db.flush()
+        org = await _org(db, creator)
+        await _member(db, org.id, heir.id, "owner")
+
+        await UserService(db).delete(creator.id)
+
+        await db.refresh(org)
+        assert org.created_by_user_id == heir.id
+        assert await db.get(User, creator.id) is None
+
+
+class TestDeletingAnOrg:
+    async def test_it_drops_org_scoped_collections_and_their_vector_tables(
+        self, engine: AsyncEngine
+    ) -> None:
+        """The org-scope check turns a `SET NULL` on delete into a 500; the row is
+        removed explicitly, and the real vector table goes with it (#9)."""
+        store = PgVectorStore(
+            settings=app_settings.rag,
+            embedding_service=MagicMock(),
+            resolver=MagicMock(),
+        )
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        collection = f"kbnine{uuid.uuid4().hex[:12]}"
+        table = store._table(collection)
+        try:
+            async with factory() as s:
+                user = _user()
+                s.add(user)
+                await s.flush()
+                org = await _org(s, user)
+                s.add(_org_collection(org.id, collection))
+                await s.execute(text(f"CREATE TABLE {table} (id int)"))
+                await s.commit()
+                org_id = org.id
+
+            async with factory() as s:
+                assert (
+                    await s.execute(text("SELECT to_regclass(:t)"), {"t": table})
+                ).scalar() is not None
+
+            async with factory() as s:
+                org = await s.get(Organization, org_id)
+                await OrganizationService(s, vector_store=store).purge(org)
+                await s.commit()
+
+            async with factory() as s:
+                remaining = await s.execute(
+                    select(KnowledgeBase).where(KnowledgeBase.organization_id == org_id)
+                )
+                assert remaining.scalars().all() == []
+                assert (
+                    await s.execute(text("SELECT to_regclass(:t)"), {"t": table})
+                ).scalar() is None
+                assert await s.get(Organization, org_id) is None
+        finally:
+            await store.aclose()
+
+    async def test_a_personal_collection_survives_its_orgs_deletion(
+        self, engine: AsyncEngine
+    ) -> None:
+        """A personal collection merely carrying the org's id is detached by the
+        `SET NULL`, not deleted - its scope permits an absent org."""
+        store = PgVectorStore(
+            settings=app_settings.rag,
+            embedding_service=MagicMock(),
+            resolver=MagicMock(),
+        )
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        try:
+            async with factory() as s:
+                user = _user()
+                s.add(user)
+                await s.flush()
+                org = await _org(s, user)
+                personal = KnowledgeBase(
+                    id=uuid.uuid4(),
+                    name="My notes",
+                    scope=KBScope.PERSONAL.value,
+                    collection_name=f"kbnine{uuid.uuid4().hex[:12]}",
+                    embedding_model="text-embedding-3-small",
+                    embedding_dim=1536,
+                    organization_id=org.id,
+                    owner_user_id=user.id,
+                    visibility="private",
+                )
+                s.add(personal)
+                await s.commit()
+                org_id, kb_id = org.id, personal.id
+
+            async with factory() as s:
+                org = await s.get(Organization, org_id)
+                await OrganizationService(s, vector_store=store).purge(org)
+                await s.commit()
+
+            async with factory() as s:
+                surviving = await s.get(KnowledgeBase, kb_id)
+                assert surviving is not None
+                assert surviving.organization_id is None
+        finally:
+            await store.aclose()

--- a/backend/tests/test_repositories.py
+++ b/backend/tests/test_repositories.py
@@ -152,3 +152,33 @@ class TestAgentRepositoryLock:
         sql = str(statement.compile(dialect=postgresql.dialect()))
         assert "FOR KEY SHARE" in sql
         assert "FOR NO KEY UPDATE" not in sql
+
+
+class TestOrganizationSecretRepository:
+    """Promoting a departing owner's private keys before their row is deleted."""
+
+    @pytest.mark.anyio
+    async def test_promote_owned_private_to_org_only_touches_the_owners_private_rows(self):
+        """`ck_secret_private_needs_owner` is why this runs before the `SET NULL`:
+        an org key is left alone, and only the private ones this owner holds are
+        flipped to org visibility (#9)."""
+        from uuid import uuid4
+
+        from sqlalchemy.dialects import postgresql
+
+        from app.repositories import organization_secret as organization_secret_repo
+
+        session = MagicMock()
+        session.execute = AsyncMock(return_value=MagicMock(rowcount=2))
+        session.flush = AsyncMock()
+
+        owner_id = uuid4()
+        count = await organization_secret_repo.promote_owned_private_to_org(
+            session, owner_user_id=owner_id
+        )
+
+        assert count == 2
+        sql = str(session.execute.call_args.args[0].compile(dialect=postgresql.dialect()))
+        assert "UPDATE organization_secrets SET visibility" in sql
+        assert "owner_user_id" in sql
+        assert "visibility =" in sql  # the WHERE narrows to private rows only

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -286,7 +286,11 @@ class TestUserServicePostgresql:
     @pytest.mark.anyio
     async def test_delete_success(self, user_service: UserService, mock_user: MockUser):
         """Test deleting user."""
-        with patch("app.services.user.user_repo") as mock_repo:
+        with (
+            patch("app.services.user.user_repo") as mock_repo,
+            patch.object(user_service, "_release_owned_rows", new=AsyncMock()),
+        ):
+            mock_repo.get_by_id = AsyncMock(return_value=mock_user)
             mock_repo.delete = AsyncMock(return_value=mock_user)
 
             result = await user_service.delete(mock_user.id)
@@ -295,9 +299,9 @@ class TestUserServicePostgresql:
 
     @pytest.mark.anyio
     async def test_delete_not_found(self, user_service: UserService):
-        """Test deleting non-existent user."""
+        """A missing user is refused up front, before any teardown is attempted."""
         with patch("app.services.user.user_repo") as mock_repo:
-            mock_repo.delete = AsyncMock(return_value=None)
+            mock_repo.get_by_id = AsyncMock(return_value=None)
 
             with pytest.raises(NotFoundError):
                 await user_service.delete(uuid4())
@@ -379,7 +383,11 @@ class TestUserServicePostgresql:
     async def test_an_admin_may_delete_another_user(
         self, user_service: UserService, mock_user: MockUser
     ):
-        with patch("app.services.user.user_repo") as mock_repo:
+        with (
+            patch("app.services.user.user_repo") as mock_repo,
+            patch.object(user_service, "_release_owned_rows", new=AsyncMock()),
+        ):
+            mock_repo.get_by_id = AsyncMock(return_value=mock_user)
             mock_repo.delete = AsyncMock(return_value=mock_user)
 
             await user_service.admin_delete(mock_user.id, acting_admin_id=uuid4())

--- a/backend/tests/test_services_organizations.py
+++ b/backend/tests/test_services_organizations.py
@@ -337,6 +337,10 @@ class TestOrganizationService:
             patch.object(
                 service, "get_for_user", new=AsyncMock(return_value=(mock_org, mock_membership))
             ),
+            patch(
+                "app.services.organization.knowledge_base_repo.list_org_scoped",
+                new=AsyncMock(return_value=[]),
+            ),
             patch("app.services.organization.organization_repo.delete", new=AsyncMock()),
         ):
             await service.delete(uuid.uuid4(), uuid.uuid4())
@@ -669,3 +673,26 @@ class TestUserServiceRegistrationWithOrg:
             await svc.register(UserCreate(email="new@example.com", password="password123"))
 
         mock_create_org.assert_called_once()
+
+
+class TestTeardownWiring:
+    """The delete route is the only place a vector store reaches org deletion."""
+
+    @pytest.mark.anyio
+    async def test_the_delete_route_wires_the_store_so_vector_tables_are_dropped(self):
+        """A revert to the plain service would delete the org rows and orphan every
+        `rag_<collection>` table with no test noticing - this is that test (#9)."""
+        from app.api.deps import get_organization_teardown_service
+        from app.api.routes.v1 import organizations as org_routes
+
+        store = MagicMock()
+        service = get_organization_teardown_service(db=MagicMock(), vector_store=store)
+        assert service._vector_store is store
+
+        annotation = org_routes.delete_organization.__annotations__["service"]
+        wired = [
+            meta.dependency
+            for meta in getattr(annotation, "__metadata__", ())
+            if hasattr(meta, "dependency")
+        ]
+        assert get_organization_teardown_service in wired

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -276,6 +276,33 @@ table in the schema. The index on `parent_run_id` serves
 [Governance](governance.md#what-run-history-shows) for why run history never lists
 the two kinds of row together.
 
+## Deleting a member or a tenant
+
+A few foreign keys would, on delete, drive precisely the write a `CHECK`
+constraint forbids — so the cascade the schema declares and the invariant it also
+declares disagree, and the delete raises inside the database as a 500 rather than
+doing anything. Three pairs are reconciled in the service before the row goes,
+inside the request's own transaction:
+
+- **A leaver's private secret.** `organization_secrets.owner_user_id` is
+  `SET NULL`, but `ck_secret_private_needs_owner` forbids an ownerless private
+  secret. `UserService.delete` promotes the leaver's private secrets to org
+  visibility first, so the null the cascade writes is legal and the key stays
+  reachable by the organization rather than stranded.
+- **A creator's organizations.** `organizations.created_by_user_id` is
+  `RESTRICT`, and every signup creates a personal org, so a bare `DELETE users`
+  never worked for a real account. The personal org is removed with its owner; a
+  shared one is handed to another owner, or the delete is refused when there is
+  none to hand it to.
+- **An org-scoped collection.** `knowledge_bases.organization_id` is `SET NULL`,
+  but `ck_knowledge_bases_org_scope_has_org` forbids an org-scoped row with no
+  org. `OrganizationService.delete` removes org-scoped collections explicitly —
+  vector table and all — before the org row goes; a personal collection that
+  merely carries the org's id is left to the `SET NULL`, which its scope permits.
+  Because dropping the vector table needs the request-scoped store, the delete
+  route wires it in through a dedicated dependency; every other org route uses the
+  plain service and builds no store it would never touch.
+
 ## What a run handed its model, and why it is a table
 
 `run_manifests` holds one row per run: the instructions as composed and sent,


### PR DESCRIPTION
## What

Three delete paths 500d: an `ON DELETE SET NULL`/RESTRICT cascade drove exactly
the write a CHECK constraint forbids, so the delete raised inside Postgres
instead of doing anything. Each pair is now reconciled in the service, in the
request's own transaction, before the row goes.

- **A leaver's private secret** — `organization_secrets.owner_user_id` is
  SET NULL under `ck_secret_private_needs_owner`. `UserService.delete` promotes
  the leaver's private secrets to org visibility first, so the null is legal and
  the key stays reachable by the org.
- **A creator's organizations** — `organizations.created_by_user_id` is RESTRICT
  and every signup creates a personal org, so a bare `DELETE users` never worked
  for a real account. The personal org is removed with its owner; a shared one is
  handed to another owner, or the delete is refused when there is none.
- **An org-scoped collection** — `knowledge_bases.organization_id` is SET NULL
  under `ck_knowledge_bases_org_scope_has_org`. `OrganizationService.delete`
  removes org-scoped collections explicitly — vector table and all — before the
  org row goes; a personal collection merely carrying the org's id is left to the
  SET NULL. Dropping the vector table needs the request-scoped store, so the
  delete route wires it in through a dedicated dependency and every other org
  route builds none.

## How verified

Integration tests against a real pgvector Postgres (all four ACs):
- a normally-registered user deletes;
- a member holding a private secret leaves it org-reachable;
- deleting an org removes its org-scoped collections **and** drops their vector
  tables, while a personal collection survives detached;
- the sole-owner case is a clean `BadRequestError`, not a 500.

Plus unit tests for the gated repo helper (so the 100% platform-layer gate is met
without a local DB) and for the delete-route→teardown-service wiring. `make lint`,
`ty`, `vulture`, the guard scripts, and the changed unit + integration suites are
green locally; `docs/architecture.md` updated in the same commit.

Self-reviewed adversarially (the `ai-review` bot is off, #311): no P1/P2; the P3
items are the deliberate `_vector_store=None` teardown decision and the
schema-documented secret-promotion policy, all in-scope-correct.

## Deliberately out of scope → #1110

Three `ondelete`-less FKs to `users.id` (`OrganizationMember.invited_by_user_id`,
`Invitation.invited_by_user_id`, `Invitation.accepted_by_user_id`) are NO ACTION,
so deleting a user who invited someone still 500s — a separate wall needing a
migration. `delete_non_admins` (seed --clear) hits the same wall. Filed as #1110.

Closes #9
