### PR TITLE
fix(concurrency): row-lock four check-then-act races

### DIFF
--- a/backend/app/repositories/agent_run.py
+++ b/backend/app/repositories/agent_run.py
@@ -1378,14 +1378,24 @@ async def create_approval(
 
 
 async def get_approval(
-    db: AsyncSession, approval_id: UUID, *, organization_id: UUID
+    db: AsyncSession, approval_id: UUID, *, organization_id: UUID, for_update: bool = False
 ) -> ToolApproval | None:
-    result = await db.execute(
-        select(ToolApproval).where(
-            ToolApproval.id == approval_id,
-            ToolApproval.organization_id == organization_id,
-        )
+    """Read one approval; with `for_update`, hold its row for the transaction.
+
+    Deciding twice is a check-then-act race: two approvers open the queue, one
+    rejects and one approves within the same read-committed window, both read
+    `pending`, both pass the guard, and the audit trail ends with two
+    contradictory entries for one decision. `decide` takes the lock so the second
+    caller waits and then finds the row no longer pending - the same shape as
+    `claim_parked_run`.
+    """
+    query = select(ToolApproval).where(
+        ToolApproval.id == approval_id,
+        ToolApproval.organization_id == organization_id,
     )
+    if for_update:
+        query = query.with_for_update()
+    result = await db.execute(query)
     return result.scalar_one_or_none()
 
 

--- a/backend/app/repositories/channel_identity.py
+++ b/backend/app/repositories/channel_identity.py
@@ -3,6 +3,7 @@
 from uuid import UUID
 
 from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models.channel_identity import ChannelIdentity
@@ -64,6 +65,67 @@ async def create(
     await db.flush()
     await db.refresh(identity)
     return identity
+
+
+async def get_or_create(
+    db: AsyncSession,
+    *,
+    platform: str,
+    platform_user_id: str,
+    platform_username: str | None = None,
+    platform_display_name: str | None = None,
+    user_id: UUID | None = None,
+) -> ChannelIdentity:
+    """The identity for this platform user, inserted once under contention.
+
+    One person messaging two chats at once produces two webhooks whose sessions
+    race here: both miss the `SELECT`, both `INSERT`, and the second violates
+    `uq_channel_identity_platform_user` - the whole event fails and the user gets
+    no reply (#17). The router's in-process lock does not help, because it is
+    keyed on the chat, not on the identity, so the two webhooks hold different
+    locks.
+
+    The insert runs only on a miss, so an existing identity - every message after
+    the first - is a plain read that takes no lock and writes nothing. That
+    matters here because the whole inbound message runs in one transaction, right
+    through the agent's model call, and the identity is keyed per platform user
+    rather than per chat: an unconditional upsert would row-lock the identity on
+    every message and hold it across the LLM call, serialising a user active in
+    two chats at once. The old get-then-create read without locking on a hit; this
+    keeps that.
+
+    On the miss the insert closes the creation race with `ON CONFLICT DO UPDATE`,
+    not `DO NOTHING`: a `DO NOTHING` that loses to a concurrent *uncommitted*
+    insert writes nothing and returns nothing, and a re-`SELECT` in this
+    transaction would not see the other's uncommitted row. `DO UPDATE` waits on
+    that row's lock instead, so the following `SELECT` reads a committed row. The
+    update is a no-op - it sets the key to itself - so a linked `user_id`, a
+    username or a display name on the existing row is left as it was.
+    """
+    existing = await get_by_platform_user(db, platform, platform_user_id)
+    if existing is not None:
+        return existing
+
+    insert_stmt = pg_insert(ChannelIdentity).values(
+        platform=platform,
+        platform_user_id=platform_user_id,
+        platform_username=platform_username,
+        platform_display_name=platform_display_name,
+        user_id=user_id,
+    )
+    await db.execute(
+        insert_stmt.on_conflict_do_update(
+            index_elements=["platform", "platform_user_id"],
+            set_={"platform_user_id": insert_stmt.excluded.platform_user_id},
+        )
+    )
+    result = await db.execute(
+        select(ChannelIdentity).where(
+            ChannelIdentity.platform == platform,
+            ChannelIdentity.platform_user_id == platform_user_id,
+        )
+    )
+    return result.scalar_one()
 
 
 async def update(

--- a/backend/app/repositories/channel_identity.py
+++ b/backend/app/repositories/channel_identity.py
@@ -86,21 +86,22 @@ async def get_or_create(
     locks.
 
     The insert runs only on a miss, so an existing identity - every message after
-    the first - is a plain read that takes no lock and writes nothing. That
-    matters here because the whole inbound message runs in one transaction, right
-    through the agent's model call, and the identity is keyed per platform user
-    rather than per chat: an unconditional upsert would row-lock the identity on
-    every message and hold it across the LLM call, serialising a user active in
-    two chats at once. The old get-then-create read without locking on a hit; this
-    keeps that.
+    the first - is a plain read that writes nothing and holds no lock. That matters
+    because the whole inbound message runs in one transaction, right through the
+    agent's model call, and the identity is keyed per platform user rather than per
+    chat: anything that wrote or locked the row here would hold it across the LLM
+    call and serialise a user active in two chats at once.
 
-    On the miss the insert closes the creation race with `ON CONFLICT DO UPDATE`,
-    not `DO NOTHING`: a `DO NOTHING` that loses to a concurrent *uncommitted*
-    insert writes nothing and returns nothing, and a re-`SELECT` in this
-    transaction would not see the other's uncommitted row. `DO UPDATE` waits on
-    that row's lock instead, so the following `SELECT` reads a committed row. The
-    update is a no-op - it sets the key to itself - so a linked `user_id`, a
-    username or a display name on the existing row is left as it was.
+    On the miss the insert closes the creation race with `ON CONFLICT DO NOTHING`
+    and a re-`SELECT`. `DO NOTHING` waits on a concurrent *uncommitted* insert of
+    the same key - it cannot decide whether to insert until that transaction ends -
+    so by the time it returns the other row is committed, and the re-`SELECT`, a
+    fresh statement under `READ COMMITTED`, reads it. The loser writes nothing and
+    takes no row lock, so it does not hold one through its own run; `DO UPDATE`
+    would, which is the difference on a first-message burst. The row is always
+    present by the `SELECT` - inserted here, or committed by the winner this one
+    lost to - so `scalar_one` cannot come up empty, and an existing `user_id`,
+    username or display name is left untouched.
     """
     existing = await get_by_platform_user(db, platform, platform_user_id)
     if existing is not None:
@@ -114,10 +115,7 @@ async def get_or_create(
         user_id=user_id,
     )
     await db.execute(
-        insert_stmt.on_conflict_do_update(
-            index_elements=["platform", "platform_user_id"],
-            set_={"platform_user_id": insert_stmt.excluded.platform_user_id},
-        )
+        insert_stmt.on_conflict_do_nothing(index_elements=["platform", "platform_user_id"])
     )
     result = await db.execute(
         select(ChannelIdentity).where(

--- a/backend/app/repositories/invitation.py
+++ b/backend/app/repositories/invitation.py
@@ -13,8 +13,21 @@ from app.db.models.organization import Invitation, InvitationStatus, OrgRole
 _INVITE_TTL_DAYS = 7
 
 
-async def get_by_token(db: AsyncSession, token: str) -> Invitation | None:
-    result = await db.execute(select(Invitation).where(Invitation.token == token))
+async def get_by_token(
+    db: AsyncSession, token: str, *, for_update: bool = False
+) -> Invitation | None:
+    """Read an invitation by its token; with `for_update`, lock the row.
+
+    `accept` reads `used_count`, checks it against `max_uses` in Python, and then
+    increments it - a check-then-act that, unlocked, admits two people through a
+    one-use link posted in a channel and clicked at once. Locking the row in
+    `accept` serializes the second caller behind the first, which then re-reads
+    the bumped count and is refused.
+    """
+    query = select(Invitation).where(Invitation.token == token)
+    if for_update:
+        query = query.with_for_update()
+    result = await db.execute(query)
     return result.scalar_one_or_none()
 
 

--- a/backend/app/services/approvals.py
+++ b/backend/app/services/approvals.py
@@ -149,7 +149,7 @@ class ApprovalService:
                 make the audit trail ambiguous about who authorised the action.
         """
         approval = await agent_run_repo.get_approval(
-            self.db, approval_id, organization_id=ctx.organization_id
+            self.db, approval_id, organization_id=ctx.organization_id, for_update=True
         )
         if approval is None:
             raise NotFoundError(

--- a/backend/app/services/channels/router.py
+++ b/backend/app/services/channels/router.py
@@ -782,20 +782,14 @@ class ChannelMessageRouter:
         policy: dict[str, Any] = self._parse_policy(bot)
         mode: str = policy.get("mode", "open")
 
-        identity = await channel_identity_repo.get_by_platform_user(
+        identity = await channel_identity_repo.get_or_create(
             db,
             platform=incoming.platform,
             platform_user_id=incoming.platform_user_id,
+            platform_username=incoming.platform_username,
+            platform_display_name=incoming.platform_display_name,
+            user_id=None,
         )
-        if not identity:
-            identity = await channel_identity_repo.create(
-                db,
-                platform=incoming.platform,
-                platform_user_id=incoming.platform_user_id,
-                platform_username=incoming.platform_username,
-                platform_display_name=incoming.platform_display_name,
-                user_id=None,
-            )
 
         if mode == "jwt_linked" and policy.get("require_link", False) and not identity.user_id:
             raise AuthorizationError(

--- a/backend/app/services/invitation.py
+++ b/backend/app/services/invitation.py
@@ -176,7 +176,11 @@ class InvitationService:
         )
 
     async def accept(self, token: str, accepting_user_id: UUID):
-        invite = await invitation_repo.get_by_token(self.db, token)
+        # Locked for the rest of the request: the `used_count`/`max_uses` guard
+        # below and the increment in `record_use` are a check-then-act, and two
+        # accepts of a one-use link arriving together would otherwise both pass
+        # (#17).
+        invite = await invitation_repo.get_by_token(self.db, token, for_update=True)
         if not invite:
             raise NotFoundError(message="Invitation not found or already used")
 

--- a/backend/tests/integration/test_approvals_queue.py
+++ b/backend/tests/integration/test_approvals_queue.py
@@ -318,3 +318,95 @@ class TestTheOrderTheQueueDrainsIn:
         # the one the tiebreaker fixes.
         assert paged == expected
         assert len(set(paged)) == 5
+
+
+class TestDecidingTwiceIsRefused:
+    """Two approvers, one decision: the row is locked so the second is refused.
+
+    `decide` reads the approval, checks it is pending, and writes - a check-then-act
+    that, unlocked, lets a concurrent reject and approve both pass the guard and
+    both write, leaving the audit trail with two contradictory entries for one
+    decision (#17). The `with_for_update` in `get_approval` serializes them.
+
+    Deterministic on purpose: one approver's decision is held open (uncommitted,
+    lock still on the row) while the other's runs. With the lock the second
+    blocks on the *read* and, once the first commits, re-reads a decided row and
+    is refused - one audit entry. Without it the second blocks on the *write*
+    instead, having already passed the guard against a `pending` read, and writes
+    a second, contradictory decision. Racing the two through `gather` alone does
+    not reproduce this: the pair serialises, and the first commits before the
+    second reads.
+    """
+
+    async def test_a_held_decision_blocks_the_second_which_is_then_refused(
+        self, db, engine
+    ) -> None:
+        import asyncio
+        import contextlib
+
+        from sqlalchemy import func, select
+        from sqlalchemy.ext.asyncio import async_sessionmaker
+
+        from app.core.exceptions import BadRequestError
+        from app.db.models.audit_log import AppAdminAuditLog
+
+        org, owner = await _org(db)
+        approver_a = await _user(db)
+        approver_b = await _user(db)
+        db.add_all(
+            [
+                OrganizationMember(
+                    id=uuid.uuid4(), organization_id=org.id, user_id=approver_a.id, role="admin"
+                ),
+                OrganizationMember(
+                    id=uuid.uuid4(), organization_id=org.id, user_id=approver_b.id, role="admin"
+                ),
+            ]
+        )
+        await db.flush()
+        agent = await _agent(db, org)
+        run = await _run(db, org, agent, started_by=owner)
+        approval = await _approval(db, org, run)
+        await db.commit()
+
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        session_a = factory()
+        b_task: asyncio.Task[None] | None = None
+        try:
+            # A decides and holds it open: the row lock stays on the approval.
+            await ApprovalService(session_a).decide(
+                _ctx(org, approver_a), approval.id, approved=True
+            )
+
+            async def decide_b() -> None:
+                async with factory() as session_b:
+                    await ApprovalService(session_b).decide(
+                        _ctx(org, approver_b), approval.id, approved=False
+                    )
+                    await session_b.commit()
+
+            b_task = asyncio.create_task(decide_b())
+            await asyncio.sleep(0.4)
+            assert not b_task.done()  # blocked on A's lock
+
+            await session_a.commit()
+
+            with pytest.raises(BadRequestError):
+                await b_task
+            b_task = None
+        finally:
+            if b_task is not None:
+                b_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await b_task
+            await session_a.close()
+
+        async with factory() as session:
+            decided = await session.get(ToolApproval, approval.id)
+            assert decided.status == ApprovalStatus.APPROVED.value
+            audit_rows = await session.scalar(
+                select(func.count())
+                .select_from(AppAdminAuditLog)
+                .where(AppAdminAuditLog.target_id == str(approval.id))
+            )
+            assert audit_rows == 1

--- a/backend/tests/integration/test_channel_identity_race.py
+++ b/backend/tests/integration/test_channel_identity_race.py
@@ -1,0 +1,86 @@
+"""One person, two chats, two webhooks at once: still one identity row.
+
+A Slack user messaging two channels at the same moment produces two webhooks
+whose sessions both resolve the same identity. Unlocked get-then-create had them
+both miss the `SELECT` and both `INSERT`, and the second violated
+`uq_channel_identity_platform_user` - so the whole event failed and that user got
+no reply (#17). The in-process lock did not help: it is keyed on the chat, so the
+two webhooks held different locks. Only the database can show the fix, because
+what makes it work is `ON CONFLICT` against the unique index across two
+transactions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import uuid
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
+
+from app.db.models.channel_identity import ChannelIdentity
+from app.repositories import channel_identity_repo
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_a_held_insert_does_not_make_the_second_resolve_fail(
+    engine: AsyncEngine,
+) -> None:
+    """Deterministic on purpose: one webhook's insert is held open (uncommitted,
+    the unique-index lock on the new row) while the other resolves the same user.
+
+    With `ON CONFLICT DO UPDATE` the second blocks on that lock and, once the
+    first commits, resolves the existing row - one identity, no error. The naive
+    get-then-create it replaces would instead have the second's own `INSERT`
+    unblock into a `uq_channel_identity_platform_user` violation and fail the
+    event. Racing two resolves through `gather` alone does not reproduce this: the
+    pair serialises and the first commits before the second inserts.
+    """
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    platform = "slack"
+    platform_user_id = uuid.uuid4().hex
+
+    session_a = factory()
+    b_task: asyncio.Task[uuid.UUID] | None = None
+    try:
+        first = await channel_identity_repo.get_or_create(
+            session_a, platform=platform, platform_user_id=platform_user_id
+        )
+
+        async def resolve_b() -> uuid.UUID:
+            async with factory() as session_b:
+                identity = await channel_identity_repo.get_or_create(
+                    session_b, platform=platform, platform_user_id=platform_user_id
+                )
+                await session_b.commit()
+                return identity.id
+
+        b_task = asyncio.create_task(resolve_b())
+        await asyncio.sleep(0.4)
+        assert not b_task.done()  # blocked on A's uncommitted insert
+
+        await session_a.commit()
+
+        second = await b_task
+        b_task = None
+        assert second == first.id  # the same identity, no error
+    finally:
+        if b_task is not None:
+            b_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await b_task
+        await session_a.close()
+
+    async with factory() as session:
+        rows = await session.scalar(
+            select(func.count())
+            .select_from(ChannelIdentity)
+            .where(
+                ChannelIdentity.platform == platform,
+                ChannelIdentity.platform_user_id == platform_user_id,
+            )
+        )
+        assert rows == 1

--- a/backend/tests/integration/test_invitation_reservations.py
+++ b/backend/tests/integration/test_invitation_reservations.py
@@ -15,6 +15,7 @@ is the row lock and the `WHERE` being re-evaluated against the version it locked
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import secrets
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -171,3 +172,70 @@ async def test_two_registrations_racing_on_the_last_use_do_not_both_get_it(db, e
     assert [first, second].count(True) == 1
     await db.refresh(invite)
     assert len(invite.reserved_emails) == 1
+
+
+async def _acceptor(db) -> User:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"{uuid.uuid4().hex}@example.com",
+        hashed_password="x",
+        is_active=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def test_two_accepts_of_a_one_use_link_admit_exactly_one_member(db, engine) -> None:
+    """The acceptance-side race, which `reserve_use` does not cover.
+
+    `accept` reads `used_count`, checks it against `max_uses`, and increments -
+    unlocked, two accepts of a one-use link both read zero and both create a
+    member (#17). Locking the invitation row in `accept` serializes them.
+
+    Deterministic on purpose: one acceptance is held open (uncommitted, lock on
+    the invitation row) while the other runs. With the lock the second blocks on
+    the `get_by_token` read and, once the first commits, re-reads an exhausted
+    link and is refused; without it the second blocks later on the `record_use`
+    write, having already passed the guard against a `used_count` of zero, and a
+    second member is created. `gather` alone does not reproduce it - the pair
+    serialises and the first commits before the second reads.
+    """
+    from app.core.exceptions import BadRequestError
+    from app.repositories import member_repo
+    from app.services.invitation import InvitationService
+
+    invite = await _link(db, max_uses=1)
+    one = await _acceptor(db)
+    two = await _acceptor(db)
+    await db.commit()
+
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    session_a = factory()
+    b_task: asyncio.Task[None] | None = None
+    try:
+        await InvitationService(session_a).accept(invite.token, accepting_user_id=one.id)
+
+        async def accept_b() -> None:
+            async with factory() as session_b:
+                await InvitationService(session_b).accept(invite.token, accepting_user_id=two.id)
+                await session_b.commit()
+
+        b_task = asyncio.create_task(accept_b())
+        await asyncio.sleep(0.4)
+        assert not b_task.done()  # blocked on A's lock
+
+        await session_a.commit()
+
+        with pytest.raises(BadRequestError):
+            await b_task
+        b_task = None
+    finally:
+        if b_task is not None:
+            b_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await b_task
+        await session_a.close()
+
+    members = await member_repo.count_for_org(db, invite.organization_id)
+    assert members == 1

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -81,6 +81,18 @@ one expensive call every time.
     to the session context - which rolls back on any exception and is never
     reached at all on cancellation.
 
+The guard is a hard stop for a run that *sees* the spend, and a run's own cost
+only lands on its row when it finishes. So the baseline a run reads is the sum of
+runs that have already finished, and concurrent runs are invisible to one
+another: fifty runs starting together against an organization one call short of
+its cap each read the same under-cap baseline and each proceed, overshooting by
+up to their combined cost. This is a property of an aggregate with no single row
+to lock - unlike the per-run and per-loop overshoot above, which the
+before-the-request check does bound - and it is why the cap is a ceiling on
+committed spend rather than a gate that serialises simultaneous runs. A
+deployment that needs a strict cap runs its agents through one queue rather than
+in parallel.
+
 ### A run costs more than its model requests
 
 A knowledge search embeds the question before it can search it, and that embedding


### PR DESCRIPTION
## What

Four check-then-act races, each fixed with the row-lock/atomic-write pattern the
codebase already uses in `claim_parked_run`.

- **Approvals (`decide`)** — read pending, guard, write, with no lock: a
  concurrent reject and approve both passed the guard and both wrote, leaving two
  contradictory audit entries for one decision. `get_approval` grows a
  `for_update` variant; the second decide now blocks, re-reads a decided row, and
  is refused.
- **Channel identity (`_resolve_identity`)** — get-then-create on
  `uq_channel_identity_platform_user`: one person messaging two chats at once had
  the second webhook 500 on the unique violation and get no reply. New
  `get_or_create` reads first (no lock, no write on the common path — the whole
  message runs in one transaction through the LLM call, so an unconditional
  upsert would serialise a user active in two chats) and, only on a miss, inserts
  with `INSERT ... ON CONFLICT DO UPDATE` + read-back.
- **Invitation accept** — read `used_count`, guard against `max_uses`, increment,
  unlocked: two accepts of a one-use link both passed and both created a member.
  `get_by_token` grows a `for_update` variant; the second accept blocks, re-reads
  the exhausted link, and is refused.
- **Budget cap (docs)** — the cap bounds committed spend, not simultaneous runs:
  a run's cost lands on its row only when it finishes, so concurrent runs read the
  same baseline and can overshoot. This is an aggregate with no single row to
  lock; documented in `docs/governance.md` as the issue's sanctioned fix.

## How verified

Deterministic regression tests against a real Postgres for the three lock/upsert
fixes: one transaction is held open with the row locked (or the insert
uncommitted) while the second runs, which provably blocks and is then
refused / resolves to the one row. Each **fails without its fix** (verified:
approvals → no `BadRequestError`, 2 audit rows; invitations → second not blocked,
2 members; channels → `uq_channel_identity_platform_user` violation). Racing
through `asyncio.gather` alone does not reproduce any of them — the pair
serialises and the first commits before the second reads — which is why the tests
orchestrate the interleaving explicitly.

`make lint`, `ty`, `vulture`, the guard scripts and the touched suites are green
locally; `app/services/approvals.py` (the one gated file) stays at 100%.

Self-reviewed adversarially (the `ai-review` bot is off, #311); the reviewer's one
substantive find — 15c originally locking the identity on every message and
holding it across the agent run — is fixed here by the SELECT-first refinement.

## Out of scope → #1113

`ChannelLinkService.confirm` still get-then-creates on the same identity key — a
sibling of the race 15c closed. Filed as #1113 rather than folded in.

Closes #17
