### PR TITLE
fix(channels): refuse a malformed embed-token claim instead of 500ing

### DIFF
--- a/backend/app/services/agent_embed.py
+++ b/backend/app/services/agent_embed.py
@@ -608,7 +608,11 @@ class AgentEmbedService:
         )
         try:
             claims = jwt.decode(token, secret, algorithms=["HS256"])
-        except jwt.PyJWTError as exc:
+        except (jwt.PyJWTError, TypeError) as exc:
+            # `exp`/`iat` as null, [] or {} makes PyJWT's own validation run
+            # `int()` on it - a raw `TypeError`, not a `PyJWTError` - so without
+            # this a malformed-but-signed token escaped as a 500 rather than a
+            # clean refusal (#1107).
             raise EmbedDenied("token rejected") from exc
 
         issued_at = claims.get("iat")

--- a/backend/tests/test_agent_embed.py
+++ b/backend/tests/test_agent_embed.py
@@ -237,6 +237,21 @@ class TestTokenMode:
 
         assert _service()._verify_token(embed, token) == "user-42"
 
+    @pytest.mark.parametrize("claim", ["exp", "iat"])
+    @pytest.mark.parametrize("value", [None, [], {}])
+    def test_a_signed_token_with_a_malformed_time_claim_is_refused_not_500ed(self, claim, value):
+        """`exp`/`iat` as null, [] or {} makes PyJWT's own validation run `int()`
+        on it - a raw `TypeError`, not a `PyJWTError` - so a malformed-but-signed
+        token escaped the handler and became a 500 rather than a clean refusal
+        (#1107)."""
+        secret = "s" * 32
+        token = jwt.encode({"sub": "user-42", claim: value}, secret, algorithm="HS256")
+        with (
+            patch(f"{MODULE}.unseal", return_value=secret),
+            pytest.raises(EmbedDenied),
+        ):
+            _service()._verify_token(self._jwt_embed(), token)
+
     @pytest.mark.anyio
     async def test_a_token_signed_with_the_wrong_secret_is_refused(self):
         token = jwt.encode({"sub": "user-42"}, "attacker-secret", algorithm="HS256")


### PR DESCRIPTION
## What

`AgentEmbedService._verify_token` decoded a visitor token inside a
`try/except jwt.PyJWTError`. A signed token whose `exp` or `iat` is `null`, `[]`
or `{}` makes PyJWT's own validation run `int()` on it, which raises a raw
`TypeError` — not a `PyJWTError` — so it escaped the handler and became an
uncaught 500 with a logged traceback instead of a clean refusal.

Not attacker-exploitable: claim validation runs after signature verification, so
minting such a token needs the customer's own signing secret, and it fails
closed. A robustness gap — a customer's malformed-but-signed token should be a
4xx, not a 500.

The catch now also covers `TypeError`, raising `EmbedDenied`. `ValueError` was
left out deliberately: on the pinned PyJWT only these coercions raise a bare
`TypeError`; every malformed-segment/base64/JSON/non-numeric case is a
`PyJWTError` subclass, so a `ValueError` catch would be an unreachable branch.

## How verified

Regression test parametrized over `exp`/`iat` × `null`/`[]`/`{}` (6 cases) asserts
`EmbedDenied`; without the broadened catch each raises `TypeError` from PyJWT's
`int()` (confirmed: `jwt/api_jwt.py` `int(None)`). `make lint`, `ty`, `vulture`
and the full embed suite green.

Adversarially reviewed (a `@codex review` follows): no P1/P2; the reviewer's
points — drop the unreachable `ValueError`, parametrize `exp`/`iat` × the three
malformed shapes — are applied here.

Pre-existing, found reviewing #23 (which fixed the freshness-claim leak and left
this out of scope).

Closes #1107
