### PR TITLE
fix(rag): index the ingestion existence check instead of scanning

### DIFF
--- a/backend/alembic/versions/0056_backfill_rag_lookup_indexes.py
+++ b/backend/alembic/versions/0056_backfill_rag_lookup_indexes.py
@@ -1,0 +1,72 @@
+"""Backfill the metadata lookup indexes onto collections that predate them (#1102).
+
+`_ensure_collection` now builds a hash index on each metadata key the existence
+check looks a document up by - but only when a collection's runtime table is
+(re)created. The `new_only` and `update_only` sync modes skip an unchanged file
+*before* any insert, so a stable collection created before this change would keep
+scanning its whole `rag_<collection>` table on every nightly sync forever - the
+exact case the O(1) lookup was meant to fix.
+
+This creates the same indexes on every existing runtime vector table, once, so
+the indexed lookup applies to collections nobody has re-ingested into. Idempotent
+with `_ensure_collection` via `IF NOT EXISTS` and the same names.
+
+The index names are written out here rather than imported from
+`app.db.vector_tables`: a migration is a snapshot of the names that existed when
+it ran, and a later rename must not retroactively change what this backfilled.
+"""
+
+from collections.abc import Sequence
+
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+
+from alembic import op
+
+revision: str = "0056_backfill_rag_lookup_indexes"
+down_revision: str | Sequence[str] | None = "0055_sandbox_operations"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Mirror `app.db.vector_tables` and `PgVectorStore._ensure_collection` as of this
+# revision: hash indexes (equality-only, and `source_path` is unbounded) on the
+# three metadata keys.
+_KEYS: tuple[tuple[str, str], ...] = (
+    ("_srcpath_idx", "source_path"),
+    ("_fname_idx", "filename"),
+    ("_chash_idx", "content_hash"),
+)
+
+
+def _runtime_vector_tables(conn: Connection) -> list[str]:
+    """The `rag_` tables the store created, told apart from the model table.
+
+    A runtime vector table carries the `metadata` jsonb column the store writes;
+    `rag_documents` (the model table alembic owns) has no such column, so this
+    excludes it without needing the model metadata here.
+    """
+    rows = conn.execute(
+        text(
+            "SELECT table_name FROM information_schema.columns "
+            "WHERE table_schema = 'public' AND column_name = 'metadata' "
+            "AND data_type = 'jsonb' AND table_name LIKE 'rag\\_%' ESCAPE '\\'"
+        )
+    )
+    return [row[0] for row in rows]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    for table in _runtime_vector_tables(conn):
+        for suffix, key in _KEYS:
+            op.execute(
+                f"CREATE INDEX IF NOT EXISTS {table}{suffix} "
+                f"ON {table} USING hash ((metadata->>'{key}'))"
+            )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    for table in _runtime_vector_tables(conn):
+        for suffix, _key in _KEYS:
+            op.execute(f"DROP INDEX IF EXISTS {table}{suffix}")

--- a/backend/app/db/vector_tables.py
+++ b/backend/app/db/vector_tables.py
@@ -57,6 +57,26 @@ length, so a rename in one place without the other silently re-opens the
 truncation below.
 """
 
+VECTOR_SOURCE_PATH_INDEX_SUFFIX = "_srcpath_idx"
+VECTOR_FILENAME_INDEX_SUFFIX = "_fname_idx"
+VECTOR_CONTENT_HASH_INDEX_SUFFIX = "_chash_idx"
+"""The expression indexes the store builds on the metadata keys the existence
+check looks a document up by (`source_path`, `filename`, `content_hash`).
+
+Kept no longer than :data:`VECTOR_INDEX_SUFFIX`, so the HNSW index stays the
+binding constraint on :data:`MAX_COLLECTION_NAME_LENGTH` and every one of these
+survives the same names the embedding index does - the derivation below takes
+the longest of them all, so a suffix that outgrew it would tighten the bound
+rather than silently truncate into the collision below.
+"""
+
+_INDEX_SUFFIXES = (
+    VECTOR_INDEX_SUFFIX,
+    VECTOR_SOURCE_PATH_INDEX_SUFFIX,
+    VECTOR_FILENAME_INDEX_SUFFIX,
+    VECTOR_CONTENT_HASH_INDEX_SUFFIX,
+)
+
 _MAX_IDENTIFIER_LENGTH = 63
 """What Postgres keeps of an identifier - `NAMEDATALEN - 1`, in bytes.
 
@@ -65,7 +85,7 @@ a name that got this far the two are the same number.
 """
 
 MAX_COLLECTION_NAME_LENGTH = (
-    _MAX_IDENTIFIER_LENGTH - len(VECTOR_TABLE_PREFIX) - len(VECTOR_INDEX_SUFFIX)
+    _MAX_IDENTIFIER_LENGTH - len(VECTOR_TABLE_PREFIX) - max(len(s) for s in _INDEX_SUFFIXES)
 )
 """The longest collection name every identifier built from it survives.
 

--- a/backend/app/services/rag/ingestion.py
+++ b/backend/app/services/rag/ingestion.py
@@ -36,27 +36,6 @@ def _stored(doc: DocumentInfo) -> StoredDocument:
     )
 
 
-def _unaddressed(doc: DocumentInfo) -> bool:
-    """Whether this document may be matched by its *name* alone.
-
-    Only one that does not already claim an address of its own. A file uploaded
-    through the browser stores its filename as its `source_path`, so the two
-    agree and it stays reachable by name - which is what the fallback is for: a
-    document uploaded once and later synced from the folder it came from should
-    be replaced rather than duplicated.
-
-    A document that names a *different* address is a different document, and
-    matching it by basename loses one of them. An S3 bucket holding
-    `a/readme.md` and `b/readme.md` is the case: the second key found the
-    first's document by name, so equal contents skipped it and unequal contents
-    replaced the first - either way a first sync could not keep both, silently
-    (#990). The same collision existed for two local files of the same name in
-    different directories.
-    """
-    stored_path = str((doc.additional_info or {}).get("source_path") or "")
-    return not stored_path or stored_path == doc.filename
-
-
 class IngestionService:
     """File → Parse/Chunk → Deduplicate → Embed/Store → Query-Ready."""
 
@@ -80,52 +59,27 @@ class IngestionService:
     async def existing_document(
         self, collection_name: str, source_path: str, *, content_hash: str = ""
     ) -> StoredDocument:
-        """The stored document this file refers to, found in one pass.
+        """The stored document this file refers to, id and hash together.
 
-        **One scan, one precedence, both answers.** A `source_path` match
-        anywhere in the collection beats a `filename` match anywhere in it, and
-        a `content_hash` match is the last resort - the order the ingest already
-        applied by calling two helpers in sequence, each walking the whole
-        collection with a predicate of its own.
+        The precedence and the single-document invariant belong to the store's
+        `find_existing_document`: a `source_path` match beats a `filename` one
+        beats a `content_hash` one (#548, #990), and the id and hash it returns
+        are one document's because they come from one. `PgVectorStore` answers
+        it with an indexed lookup per key rather than a full-collection read
+        (#1102).
 
-        There were three lookups over one listing before this, and they cost two
-        things. The obvious one is the scans: the sync modes asked for an id and
-        then for a hash, and `ingest_file` then asked twice more, so ingesting
-        one changed file read the entire collection four times (#566, and #27
-        for why reading it once is still not cheap).
-
-        The other is the reason those two answers are returned together rather
-        than by two methods. They are answers about *one document*, and when
-        they were computed separately they disagreed: the id lookup checked every
-        document for a `source_path` match before falling back to `filename`
-        while the hash lookup interleaved the two, so a caller compared a live
-        file's hash against a different document's `content_hash` than the one it
-        was about to replace - an unchanged file re-embedded on every sync, or a
-        changed one skipped as current (#548). A caller that cannot ask for one
-        without the other cannot reintroduce that.
-
-        A store that refuses answers "no match", as it did before: a listing this
-        cannot read is not evidence that the document is absent, but treating it
-        as a match would delete a document on the strength of a failed query.
+        A store that refuses the lookup answers "no match": a listing this cannot
+        read is not evidence the document is absent, but treating it as a match
+        would delete a document on the strength of a failed query.
         """
         try:
-            docs = await self.store.get_documents(collection_name)
+            doc = await self.store.find_existing_document(
+                collection_name, source_path=source_path, content_hash=content_hash
+            )
         except Exception as exc:
             logger.warning("Could not check for existing document: %s", exc, exc_info=True)
             return StoredDocument()
-        filename = Path(source_path).name if source_path else ""
-        by_filename: DocumentInfo | None = None
-        by_hash: DocumentInfo | None = None
-        for doc in docs:
-            meta = doc.additional_info or {}
-            if source_path and meta.get("source_path") == source_path:
-                return _stored(doc)
-            if by_filename is None and filename and doc.filename == filename and _unaddressed(doc):
-                by_filename = doc
-            if by_hash is None and content_hash and meta.get("content_hash") == content_hash:
-                by_hash = doc
-        matched = by_filename or by_hash
-        return _stored(matched) if matched is not None else StoredDocument()
+        return _stored(doc) if doc is not None else StoredDocument()
 
     async def ingest_file(
         self,

--- a/backend/app/services/rag/vectorstore.py
+++ b/backend/app/services/rag/vectorstore.py
@@ -417,7 +417,15 @@ class PgVectorStore(BaseVectorStore):
             )
             # The keys `find_existing_document` looks a document up by; without
             # them that check is a full read of the runtime table (#1102).
-            # `IF NOT EXISTS` backfills an established collection's next ingest.
+            #
+            # `hash`, not btree: the lookups are equality only, and a btree entry
+            # is capped near 2700 bytes - so a btree on `source_path` fails the
+            # index-row-size limit the moment a document carries a path longer
+            # than that (they are unbounded - `s3://`, `gdrive://`, a deep key -
+            # and `RAGDocument.source_path` is a hash index for the same reason),
+            # which would fail every ingest into the collection. Hashing the
+            # value has no such ceiling. `IF NOT EXISTS` so this is idempotent;
+            # `migrations/0056` backfills the collections that predate it.
             for suffix, key in (
                 (VECTOR_SOURCE_PATH_INDEX_SUFFIX, "source_path"),
                 (VECTOR_FILENAME_INDEX_SUFFIX, "filename"),
@@ -426,7 +434,7 @@ class PgVectorStore(BaseVectorStore):
                 await session.execute(
                     text(
                         f"CREATE INDEX IF NOT EXISTS {table}{suffix} "
-                        f"ON {table} ((metadata->>'{key}'))"
+                        f"ON {table} USING hash ((metadata->>'{key}'))"
                     )
                 )
             await session.commit()

--- a/backend/app/services/rag/vectorstore.py
+++ b/backend/app/services/rag/vectorstore.py
@@ -1,6 +1,7 @@
 import logging
 import re
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any
 
 # Registers every model table on `Base.metadata`, which `list_collections` judges a
@@ -12,7 +13,10 @@ from typing import Any
 import app.db.models  # noqa: F401
 from app.db.base import Base
 from app.db.vector_tables import (
+    VECTOR_CONTENT_HASH_INDEX_SUFFIX,
+    VECTOR_FILENAME_INDEX_SUFFIX,
     VECTOR_INDEX_SUFFIX,
+    VECTOR_SOURCE_PATH_INDEX_SUFFIX,
     VECTOR_TABLE_PREFIX,
     is_runtime_vector_table,
     validate_collection_name,
@@ -28,6 +32,27 @@ from app.services.rag.models import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _document_is_unaddressed(doc: DocumentInfo) -> bool:
+    """Whether this document may be matched by its *name* alone.
+
+    Only one that does not already claim an address of its own. A file uploaded
+    through the browser stores its filename as its `source_path`, so the two
+    agree and it stays reachable by name - which is what the filename fallback is
+    for: a document uploaded once and later synced from the folder it came from
+    should be replaced rather than duplicated.
+
+    A document that names a *different* address is a different document, and
+    matching it by basename loses one of them. An S3 bucket holding
+    `a/readme.md` and `b/readme.md` is the case: the second key found the first's
+    document by name, so equal contents skipped it and unequal contents replaced
+    the first - either way a first sync could not keep both, silently (#990). The
+    same collision existed for two local files of the same name in different
+    directories.
+    """
+    stored_path = str((doc.additional_info or {}).get("source_path") or "")
+    return not stored_path or stored_path == doc.filename
 
 
 class BaseVectorStore(ABC):
@@ -98,6 +123,48 @@ class BaseVectorStore(ABC):
             ],
             total=len(docs),
         )
+
+    async def find_existing_document(
+        self, collection_name: str, *, source_path: str, content_hash: str
+    ) -> DocumentInfo | None:
+        """The stored document this file refers to, found by one precedence.
+
+        **One precedence, both answers about one document.** A `source_path`
+        match anywhere in the collection beats a `filename` match anywhere in it,
+        and a `content_hash` match is the last resort - the order the ingest
+        applies to decide whether a file is already held.
+
+        The id and the hash returned are the *same* document's, which is the
+        invariant this exists to keep. Computed by two lookups with different
+        rules they disagreed: one checked every document for a `source_path`
+        match before falling back to `filename` while the other interleaved the
+        two, so a caller compared a live file's hash against a different
+        document's `content_hash` than the one it was about to replace - an
+        unchanged file re-embedded on every sync, or a changed one skipped as
+        current (#548). Returning one document forecloses that.
+
+        This reference implementation reads the whole collection; `PgVectorStore`
+        overrides it with an indexed lookup per key (#1102). Both answer `None`
+        for no match - never an empty document, a stored hash of `""` included.
+        """
+        docs = await self.get_documents(collection_name)
+        filename = Path(source_path).name if source_path else ""
+        by_filename: DocumentInfo | None = None
+        by_hash: DocumentInfo | None = None
+        for doc in docs:
+            meta = doc.additional_info or {}
+            if source_path and meta.get("source_path") == source_path:
+                return doc
+            if (
+                by_filename is None
+                and filename
+                and doc.filename == filename
+                and _document_is_unaddressed(doc)
+            ):
+                by_filename = doc
+            if by_hash is None and content_hash and meta.get("content_hash") == content_hash:
+                by_hash = doc
+        return by_filename or by_hash
 
     async def create_collection(self, name: str) -> None:
         """Make the collection's backing objects, refusing a name that cannot have any.
@@ -348,6 +415,20 @@ class PgVectorStore(BaseVectorStore):
                 ON {table} USING hnsw ({self._distance_expr(dim)} {operator_class})
             """)
             )
+            # The keys `find_existing_document` looks a document up by; without
+            # them that check is a full read of the runtime table (#1102).
+            # `IF NOT EXISTS` backfills an established collection's next ingest.
+            for suffix, key in (
+                (VECTOR_SOURCE_PATH_INDEX_SUFFIX, "source_path"),
+                (VECTOR_FILENAME_INDEX_SUFFIX, "filename"),
+                (VECTOR_CONTENT_HASH_INDEX_SUFFIX, "content_hash"),
+            ):
+                await session.execute(
+                    text(
+                        f"CREATE INDEX IF NOT EXISTS {table}{suffix} "
+                        f"ON {table} ((metadata->>'{key}'))"
+                    )
+                )
             await session.commit()
 
     async def _collection_exists(self, name: str) -> bool:
@@ -528,6 +609,81 @@ class PgVectorStore(BaseVectorStore):
             for row in rows
         ]
         return self._group_documents(results)
+
+    async def find_existing_document(
+        self, collection_name: str, *, source_path: str, content_hash: str
+    ) -> DocumentInfo | None:
+        """Look the document up by its indexed metadata keys, not a full scan (#1102).
+
+        One indexed statement per key, in the precedence the base class
+        documents - `source_path`, then a `filename` the stored document has not
+        addressed under another path, then `content_hash` - stopping at the
+        first hit. Each statement returns one document, so the id and hash a
+        caller reads name one document, which is the #548 invariant.
+
+        The expression indexes these lean on are built by `_ensure_collection`;
+        a collection predating them still answers correctly, at a scan, until
+        its next ingest rebuilds them through that same path.
+        """
+        if not await self._collection_exists(collection_name):
+            return None
+        table = self._table(collection_name)
+        filename = Path(source_path).name if source_path else ""
+        async with self.async_session() as session:
+            if source_path:
+                hit = await self._first_document(
+                    session, table, "metadata->>'source_path' = :v", {"v": source_path}
+                )
+                if hit is not None:
+                    return hit
+            if filename:
+                hit = await self._first_document(
+                    session,
+                    table,
+                    "metadata->>'filename' = :v AND ("
+                    "coalesce(metadata->>'source_path', '') = '' "
+                    "OR metadata->>'source_path' = :v)",
+                    {"v": filename},
+                )
+                if hit is not None:
+                    return hit
+            if content_hash:
+                hit = await self._first_document(
+                    session, table, "metadata->>'content_hash' = :v", {"v": content_hash}
+                )
+                if hit is not None:
+                    return hit
+        return None
+
+    async def _first_document(
+        self, session: AsyncSession, table: str, where: str, params: dict[str, Any]
+    ) -> DocumentInfo | None:
+        """The first document by `(parent_doc_id, id)` matching `where`, or None.
+
+        The order makes a fallback that matches several rows pick the one the
+        reference scan would, rather than whichever the heap returns (#548).
+        `where` is built from literals here and every value it reads is bound,
+        so the only interpolation is the already-validated `table`.
+        """
+        result = await session.execute(
+            text(
+                f"SELECT parent_doc_id, metadata FROM {table} "
+                f"WHERE {where} ORDER BY parent_doc_id, id LIMIT 1"
+            ),
+            params,
+        )
+        row = result.fetchone()
+        if row is None:
+            return None
+        grouped = self._group_documents(
+            [
+                {
+                    "parent_doc_id": row[0],
+                    "metadata": row[1] if isinstance(row[1], dict) else json.loads(row[1]),
+                }
+            ]
+        )
+        return grouped[0] if grouped else None
 
     async def get_document_chunks(
         self, collection_name: str, document_id: str

--- a/backend/tests/integration/test_rag_existence_index.py
+++ b/backend/tests/integration/test_rag_existence_index.py
@@ -93,13 +93,20 @@ async def test_ensure_collection_builds_an_index_per_lookup_key(engine: AsyncEng
 
     async with store.async_session() as session:
         result = await session.execute(
-            text("SELECT indexname FROM pg_indexes WHERE tablename = :t"), {"t": TABLE}
+            text("SELECT indexname, indexdef FROM pg_indexes WHERE tablename = :t"), {"t": TABLE}
         )
-        names = {row[0] for row in result.all()}
+        defs = {row[0]: row[1] for row in result.all()}
 
-    assert f"{TABLE}{VECTOR_SOURCE_PATH_INDEX_SUFFIX}" in names
-    assert f"{TABLE}{VECTOR_FILENAME_INDEX_SUFFIX}" in names
-    assert f"{TABLE}{VECTOR_CONTENT_HASH_INDEX_SUFFIX}" in names
+    # Hash, not btree: a btree on an unbounded `source_path` fails the index-row
+    # -size limit and takes ingestion down with it (#1102 review).
+    for suffix in (
+        VECTOR_SOURCE_PATH_INDEX_SUFFIX,
+        VECTOR_FILENAME_INDEX_SUFFIX,
+        VECTOR_CONTENT_HASH_INDEX_SUFFIX,
+    ):
+        name = f"{TABLE}{suffix}"
+        assert name in defs
+        assert "USING hash" in defs[name]
 
 
 async def test_source_path_wins_and_returns_that_documents_own_hash(engine: AsyncEngine) -> None:
@@ -198,6 +205,21 @@ async def test_the_fallback_tiebreak_is_deterministic(engine: AsyncEngine) -> No
 
     assert hit is not None
     assert hit.document_id == "aaa"
+
+
+async def test_a_source_path_too_long_for_a_btree_index_still_ingests(engine: AsyncEngine) -> None:
+    """#1102 review: a btree metadata index caps entries near 2700 bytes, so a
+    long path would fail every ingest into the collection. The hash index has no
+    such ceiling - this row inserts and is found."""
+    store = _store(engine)
+    await store._ensure_collection(COLLECTION)
+    long_path = "s3://bucket/" + "a" * 3000
+    await _insert(store, doc_id="big", source_path=long_path, filename="big.pdf", content_hash="h")
+
+    hit = await store.find_existing_document(COLLECTION, source_path=long_path, content_hash="")
+
+    assert hit is not None
+    assert hit.document_id == "big"
 
 
 async def test_no_key_matches_answers_none(engine: AsyncEngine) -> None:

--- a/backend/tests/integration/test_rag_existence_index.py
+++ b/backend/tests/integration/test_rag_existence_index.py
@@ -1,0 +1,214 @@
+"""The existence check, asked of a real Postgres and its indexes (#1102).
+
+`IngestionService.existing_document` used to read every row of the runtime
+`rag_<collection>` table to answer "does this collection already hold this
+file". `PgVectorStore.find_existing_document` now looks the document up by an
+indexed `metadata->>` key instead - which only a real database, carrying the
+expression indexes `_ensure_collection` builds, actually exercises.
+
+The precedence and the #548 single-document invariant are pinned by name in the
+unit suite (`tests/test_rag_document_lookup.py`); what is here is that the
+indexes exist and that the indexed SQL agrees with that precedence on real rows,
+including the two orderings a heap would decide wrong.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncGenerator
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
+
+from app.db.vector_tables import (
+    VECTOR_CONTENT_HASH_INDEX_SUFFIX,
+    VECTOR_FILENAME_INDEX_SUFFIX,
+    VECTOR_SOURCE_PATH_INDEX_SUFFIX,
+)
+from app.services.rag.vectorstore import PgVectorStore
+
+pytestmark = pytest.mark.anyio
+
+COLLECTION = "handbook"
+TABLE = f"rag_{COLLECTION}"
+
+
+async def _no_resolution(_name: str) -> None:
+    """A resolver that defers to the store's default embedder and width.
+
+    `_ensure_collection` reads only the width to build the table; the embedder
+    it returns is never touched on the DDL path.
+    """
+    return
+
+
+def _store(engine: AsyncEngine) -> PgVectorStore:
+    store = PgVectorStore.__new__(PgVectorStore)
+    store.async_session = async_sessionmaker(engine, expire_on_commit=False)
+    store.dim = 3
+    store.embedder = None  # type: ignore[assignment]  # unread for DDL, see _no_resolution
+    store._resolver = _no_resolution  # type: ignore[assignment]
+    return store
+
+
+async def _insert(
+    store: PgVectorStore,
+    *,
+    doc_id: str,
+    source_path: str,
+    filename: str,
+    content_hash: str,
+) -> None:
+    meta = json.dumps(
+        {"source_path": source_path, "filename": filename, "content_hash": content_hash}
+    )
+    # TABLE is a module constant and every value is bound - the interpolation S608
+    # flags is the table name, which no test controls.
+    insert = (
+        f"INSERT INTO {TABLE} (id, parent_doc_id, content, metadata) "  # noqa: S608
+        "VALUES (:id, :pid, :content, CAST(:meta AS jsonb))"
+    )
+    async with store.async_session() as session:
+        await session.execute(
+            text(insert),
+            {"id": f"{doc_id}-0", "pid": doc_id, "content": "body", "meta": meta},
+        )
+        await session.commit()
+
+
+@pytest.fixture(autouse=True)
+async def _clean_runtime_table(engine: AsyncEngine) -> AsyncGenerator[None, None]:
+    """The runtime table is not a model, so nothing else drops it between tests."""
+    async with engine.begin() as conn:
+        await conn.execute(text(f"DROP TABLE IF EXISTS {TABLE}"))
+    yield
+    async with engine.begin() as conn:
+        await conn.execute(text(f"DROP TABLE IF EXISTS {TABLE}"))
+
+
+async def test_ensure_collection_builds_an_index_per_lookup_key(engine: AsyncEngine) -> None:
+    store = _store(engine)
+    await store._ensure_collection(COLLECTION)
+
+    async with store.async_session() as session:
+        result = await session.execute(
+            text("SELECT indexname FROM pg_indexes WHERE tablename = :t"), {"t": TABLE}
+        )
+        names = {row[0] for row in result.all()}
+
+    assert f"{TABLE}{VECTOR_SOURCE_PATH_INDEX_SUFFIX}" in names
+    assert f"{TABLE}{VECTOR_FILENAME_INDEX_SUFFIX}" in names
+    assert f"{TABLE}{VECTOR_CONTENT_HASH_INDEX_SUFFIX}" in names
+
+
+async def test_source_path_wins_and_returns_that_documents_own_hash(engine: AsyncEngine) -> None:
+    """#548: the id and the hash name one document.
+
+    `decoy` shares the filename and is *unaddressed* (its source_path is its own
+    name), so a by-filename read would take it - and it sorts before `live` by
+    `parent_doc_id`, so a heap-ordered scan would too. The source_path match must
+    still win and hand back `live`'s own hash, not `decoy`'s.
+    """
+    store = _store(engine)
+    await store._ensure_collection(COLLECTION)
+    await _insert(
+        store,
+        doc_id="decoy",
+        source_path="handbook.pdf",
+        filename="handbook.pdf",
+        content_hash="v2",
+    )
+    await _insert(
+        store,
+        doc_id="live",
+        source_path="/srv/sync/handbook.pdf",
+        filename="handbook.pdf",
+        content_hash="v1",
+    )
+
+    hit = await store.find_existing_document(
+        COLLECTION, source_path="/srv/sync/handbook.pdf", content_hash="unrelated"
+    )
+
+    assert hit is not None
+    assert hit.document_id == "live"
+    assert (hit.additional_info or {}).get("content_hash") == "v1"
+
+
+async def test_the_filename_fallback_keeps_the_unaddressed_rule(engine: AsyncEngine) -> None:
+    """#990: a source_path miss matches a same-name document only where that
+    document has not addressed itself under a different path."""
+    store = _store(engine)
+    await store._ensure_collection(COLLECTION)
+    await _insert(
+        store,
+        doc_id="addressed",
+        source_path="/srv/a/handbook.pdf",
+        filename="handbook.pdf",
+        content_hash="v1",
+    )
+    await _insert(
+        store,
+        doc_id="unaddressed",
+        source_path="handbook.pdf",
+        filename="handbook.pdf",
+        content_hash="v2",
+    )
+
+    hit = await store.find_existing_document(
+        COLLECTION, source_path="/elsewhere/handbook.pdf", content_hash=""
+    )
+
+    assert hit is not None
+    assert hit.document_id == "unaddressed"
+
+
+async def test_content_hash_is_the_last_resort(engine: AsyncEngine) -> None:
+    store = _store(engine)
+    await store._ensure_collection(COLLECTION)
+    await _insert(
+        store, doc_id="moved", source_path="/old/name.pdf", filename="name.pdf", content_hash="same"
+    )
+
+    hit = await store.find_existing_document(
+        COLLECTION, source_path="/new/renamed.pdf", content_hash="same"
+    )
+
+    assert hit is not None
+    assert hit.document_id == "moved"
+
+
+async def test_the_fallback_tiebreak_is_deterministic(engine: AsyncEngine) -> None:
+    """#548's other half: when several rows match one fallback branch, the row
+    chosen is fixed by `ORDER BY parent_doc_id, id`, not by heap order. Two
+    unaddressed documents share a filename; the lower `parent_doc_id` wins."""
+    store = _store(engine)
+    await store._ensure_collection(COLLECTION)
+    await _insert(
+        store, doc_id="bbb", source_path="dup.pdf", filename="dup.pdf", content_hash="v-b"
+    )
+    await _insert(
+        store, doc_id="aaa", source_path="dup.pdf", filename="dup.pdf", content_hash="v-a"
+    )
+
+    hit = await store.find_existing_document(
+        COLLECTION, source_path="/nowhere/dup.pdf", content_hash=""
+    )
+
+    assert hit is not None
+    assert hit.document_id == "aaa"
+
+
+async def test_no_key_matches_answers_none(engine: AsyncEngine) -> None:
+    store = _store(engine)
+    await store._ensure_collection(COLLECTION)
+    await _insert(
+        store, doc_id="only", source_path="/srv/other.pdf", filename="other.pdf", content_hash="h"
+    )
+
+    hit = await store.find_existing_document(
+        COLLECTION, source_path="/srv/absent.pdf", content_hash="nope"
+    )
+
+    assert hit is None

--- a/backend/tests/test_connector_sync_modes.py
+++ b/backend/tests/test_connector_sync_modes.py
@@ -32,6 +32,7 @@ import pytest
 
 from app.services.rag.connectors import RemoteFile
 from app.services.rag.models import IngestionStatus
+from app.services.rag.vectorstore import BaseVectorStore
 from app.worker.tasks import rag_tasks
 
 pytestmark = pytest.mark.anyio
@@ -108,6 +109,7 @@ async def _syncing(
     store = MagicMock()
     store.aclose = AsyncMock()
     store.get_documents = AsyncMock(return_value=listing)
+    store.find_existing_document = BaseVectorStore.find_existing_document.__get__(store)
 
     source = MagicMock(
         connector_type="gdrive",
@@ -483,6 +485,9 @@ class TestAListingTheStoreCannotAnswer:
         store_error = MagicMock()
         store_error.aclose = AsyncMock()
         store_error.get_documents = AsyncMock(side_effect=RuntimeError("no such table"))
+        store_error.find_existing_document = BaseVectorStore.find_existing_document.__get__(
+            store_error
+        )
 
         connector = _connector()
         source = MagicMock(

--- a/backend/tests/test_rag_chunk_count.py
+++ b/backend/tests/test_rag_chunk_count.py
@@ -30,6 +30,7 @@ from app.services.rag.models import (
     DocumentPageChunk,
     IngestionStatus,
 )
+from app.services.rag.vectorstore import BaseVectorStore
 from app.services.rag_document import RAGDocumentService
 from app.worker.tasks.rag_tasks import _run_ingestion
 
@@ -54,10 +55,9 @@ def _document(*, chunks: int) -> Document:
 
 
 def _service(processor: MagicMock) -> IngestionService:
-    return IngestionService(
-        processor=processor,
-        vector_store=MagicMock(insert_document=AsyncMock(), delete_document=AsyncMock()),
-    )
+    store = MagicMock(insert_document=AsyncMock(), delete_document=AsyncMock())
+    store.find_existing_document = BaseVectorStore.find_existing_document.__get__(store)
+    return IngestionService(processor=processor, vector_store=store)
 
 
 class TestWhatThePipelineReports:

--- a/backend/tests/test_rag_document_lookup.py
+++ b/backend/tests/test_rag_document_lookup.py
@@ -35,14 +35,29 @@ from app.services.rag.models import (
     DocumentPageChunk,
     IngestionStatus,
 )
-from app.services.rag.vectorstore import PgVectorStore
+from app.services.rag.vectorstore import BaseVectorStore, PgVectorStore
 
 pytestmark = pytest.mark.anyio
 
 
+def _store(docs: list[DocumentInfo], **overrides: object) -> MagicMock:
+    """A mock store whose precedence is the real one.
+
+    `find_existing_document` is bound from `BaseVectorStore`, so it runs the
+    reference precedence over `get_documents` rather than a mock returning a
+    truthy stand-in - the same code `PgVectorStore` overrides for the indexed
+    path, and the thing every assertion below is actually about.
+    """
+    store = MagicMock()
+    store.get_documents = AsyncMock(return_value=docs)
+    store.find_existing_document = BaseVectorStore.find_existing_document.__get__(store)
+    for name, value in overrides.items():
+        setattr(store, name, value)
+    return store
+
+
 def _service(docs: list[DocumentInfo]) -> IngestionService:
-    store = MagicMock(get_documents=AsyncMock(return_value=docs))
-    return IngestionService(processor=MagicMock(), vector_store=store)
+    return IngestionService(processor=MagicMock(), vector_store=_store(docs))
 
 
 def _doc(
@@ -130,7 +145,7 @@ class TestOnePrecedenceForBothAnswers:
     async def test_a_store_failure_answers_no_match(self):
         """A listing that cannot be read is not evidence the document is absent -
         but treating it as a match would delete one on a failed query."""
-        store = MagicMock(get_documents=AsyncMock(side_effect=RuntimeError("connection refused")))
+        store = _store([], get_documents=AsyncMock(side_effect=RuntimeError("connection refused")))
         service = IngestionService(processor=MagicMock(), vector_store=store)
 
         assert await service.existing_document("kb", "/srv/sync/handbook.pdf") == StoredDocument()
@@ -207,17 +222,15 @@ class TestHowManyTimesTheCollectionIsRead:
     """#566. Three lookups over one listing, and a sync asked for two of them."""
 
     async def test_both_answers_cost_one_read(self):
-        store = MagicMock(
-            get_documents=AsyncMock(
-                return_value=[
-                    _doc(
-                        "doc-a",
-                        filename="handbook.pdf",
-                        source_path="/srv/sync/handbook.pdf",
-                        content_hash="hash-a",
-                    )
-                ]
-            )
+        store = _store(
+            [
+                _doc(
+                    "doc-a",
+                    filename="handbook.pdf",
+                    source_path="/srv/sync/handbook.pdf",
+                    content_hash="hash-a",
+                )
+            ]
         )
         service = IngestionService(processor=MagicMock(), vector_store=store)
 
@@ -232,11 +245,7 @@ class TestHowManyTimesTheCollectionIsRead:
         Both are decided in one pass now, so the count is one whether the path
         matched or the hash did.
         """
-        store = MagicMock(
-            get_documents=AsyncMock(return_value=[]),
-            insert_document=AsyncMock(),
-            delete_document=AsyncMock(),
-        )
+        store = _store([], insert_document=AsyncMock(), delete_document=AsyncMock())
         document = Document(
             pages=[DocumentPage(page_num=1, content="body")],
             metadata=DocumentMetadata(filename="handbook.pdf", filesize=4, filetype="pdf"),
@@ -271,17 +280,15 @@ class TestReplacingADocument:
 
     @staticmethod
     def _replacing(insert: AsyncMock) -> tuple[MagicMock, IngestionService]:
-        store = MagicMock(
-            get_documents=AsyncMock(
-                return_value=[
-                    _doc(
-                        "doc-old",
-                        filename="handbook.pdf",
-                        source_path="/srv/sync/handbook.pdf",
-                        content_hash="hash-old",
-                    )
-                ]
-            ),
+        store = _store(
+            [
+                _doc(
+                    "doc-old",
+                    filename="handbook.pdf",
+                    source_path="/srv/sync/handbook.pdf",
+                    content_hash="hash-old",
+                )
+            ],
             insert_document=insert,
             delete_document=AsyncMock(),
         )
@@ -322,6 +329,87 @@ class TestReplacingADocument:
         assert result.status is IngestionStatus.DONE
         assert result.replaced_document_id == "doc-old"
         store.delete_document.assert_awaited_once_with("kb", "doc-old")
+
+
+class TestTheIndexedLookupIssuesOneStatementPerKey:
+    """`PgVectorStore` answers the existence check by index, not by a scan (#1102).
+
+    The real SQL and the indexes it leans on are exercised against a populated
+    Postgres in `tests/integration/test_rag_existence_index.py`; here the
+    statements are asserted on a mock session, which is where the *precedence*
+    and the "one statement, then stop" shape are cheap to pin - a heap that
+    happened to be ordered would pass a behavioural check falsely.
+    """
+
+    @staticmethod
+    def _store_over(execute: AsyncMock) -> PgVectorStore:
+        session = MagicMock(execute=execute)
+        session_ctx = MagicMock()
+        session_ctx.__aenter__ = AsyncMock(return_value=session)
+        session_ctx.__aexit__ = AsyncMock(return_value=False)
+        store = PgVectorStore.__new__(PgVectorStore)
+        store.async_session = MagicMock(return_value=session_ctx)
+        store._collection_exists = AsyncMock(return_value=True)  # type: ignore[method-assign]
+        store._table = MagicMock(return_value="rag_kb")  # type: ignore[method-assign]
+        return store
+
+    @staticmethod
+    def _result(row: tuple[str, dict[str, str]] | None) -> MagicMock:
+        return MagicMock(fetchone=MagicMock(return_value=row))
+
+    async def test_a_source_path_hit_is_one_indexed_statement(self):
+        """The common case: the file's `source_path` is already stored. One
+        `WHERE metadata->>'source_path'` statement answers it, and the filename
+        and content_hash statements never run."""
+        execute = AsyncMock(
+            return_value=self._result(
+                ("doc-a", {"source_path": "/p/handbook.pdf", "content_hash": "h"})
+            )
+        )
+        store = self._store_over(execute)
+
+        hit = await store.find_existing_document(
+            "kb", source_path="/p/handbook.pdf", content_hash="h"
+        )
+
+        assert hit is not None and hit.document_id == "doc-a"
+        assert execute.await_count == 1
+        statement = str(execute.await_args.args[0])
+        assert "metadata->>'source_path' = :v" in statement
+        assert "ORDER BY parent_doc_id, id" in statement
+        assert "LIMIT 1" in statement
+
+    async def test_the_keys_are_tried_in_precedence_and_stop_at_the_first_hit(self):
+        """source_path misses, filename misses, content_hash answers - three
+        statements in that order, and the hash one's row is returned."""
+        execute = AsyncMock(
+            side_effect=[
+                self._result(None),
+                self._result(None),
+                self._result(("doc-c", {"content_hash": "h"})),
+            ]
+        )
+        store = self._store_over(execute)
+
+        hit = await store.find_existing_document(
+            "kb", source_path="/p/handbook.pdf", content_hash="h"
+        )
+
+        assert hit is not None and hit.document_id == "doc-c"
+        keys = [str(call.args[0]) for call in execute.await_args_list]
+        assert "metadata->>'source_path'" in keys[0]
+        assert "metadata->>'filename'" in keys[1]
+        assert "metadata->>'content_hash'" in keys[2]
+
+    async def test_an_absent_collection_issues_no_statement(self):
+        execute = AsyncMock()
+        store = self._store_over(execute)
+        store._collection_exists = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+        assert (
+            await store.find_existing_document("kb", source_path="/p/x.pdf", content_hash="h")
+        ) is None
+        execute.assert_not_awaited()
 
 
 class TestGetDocumentsIsDeterministic:

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -731,21 +731,26 @@ Sync operations are tracked via the `SyncLog` model, recording source, mode,
 total files, ingested/updated/skipped/failed counts, and timing. View sync
 history via `GET /rag/sync/logs`.
 
-**Which stored document a file corresponds to is one question, asked once.**
-`IngestionService.existing_document` reads the collection's document listing a
-single time and answers with both the document's id and its stored
-`content_hash`, in one precedence: a `source_path` match beats a `filename`
-match, and a `content_hash` match is the last resort. The two answers come back
-together on purpose — they are facts about *one* document, and while they were
-computed by separate lookups they could disagree, so a sync compared a live
-file's hash against a different document's and either re-embedded an unchanged
-file every night or skipped a changed one as current
-([#548](https://github.com/vstorm-co/agenticos/issues/548)). That also made
-ingesting one changed file read the whole collection up to four times; it is now
-once for the decision and once inside the ingest
-([#566](https://github.com/vstorm-co/agenticos/issues/566)). Reading it at all is
-still a full scan — [#27](https://github.com/vstorm-co/agenticos/issues/27) is the
-pagination that would fix that.
+**Which stored document a file corresponds to is one question, and an indexed
+one.** `IngestionService.existing_document` hands it to the store's
+`find_existing_document`, which looks the document up one metadata key at a
+time — `source_path`, then a `filename` the document has not addressed under a
+different path, then `content_hash` — in that precedence, stopping at the first
+hit. It answers with both the document's id and its stored `content_hash`, and
+the two come back together on purpose: they are facts about *one* document, and
+while they were computed by separate lookups with different rules they could
+disagree, so a sync compared a live file's hash against a different document's
+and either re-embedded an unchanged file every night or skipped a changed one as
+current ([#548](https://github.com/vstorm-co/agenticos/issues/548)). `PgVectorStore`
+serves each lookup from an expression index on that metadata key — built with the
+runtime table, so an established collection gains the indexes on its next ingest —
+which makes the check a handful of indexed statements rather than the read of the
+whole `rag_<collection>` table into worker memory it used to be, once per ingested
+document on a collection that could hold hundreds of thousands of chunks
+([#1102](https://github.com/vstorm-co/agenticos/issues/1102), the ingest half of
+[#27](https://github.com/vstorm-co/agenticos/issues/27); its other half paginated
+the tracked-documents listing). A base-class fallback still answers by reading the
+listing, for a store that has no index to lean on.
 
 `new_only` skips a file whose stored hash matches, `update_only` skips one that
 is unchanged and ignores one that is new, and `full` replaces whatever it

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -742,11 +742,14 @@ while they were computed by separate lookups with different rules they could
 disagree, so a sync compared a live file's hash against a different document's
 and either re-embedded an unchanged file every night or skipped a changed one as
 current ([#548](https://github.com/vstorm-co/agenticos/issues/548)). `PgVectorStore`
-serves each lookup from an expression index on that metadata key — built with the
-runtime table, so an established collection gains the indexes on its next ingest —
-which makes the check a handful of indexed statements rather than the read of the
-whole `rag_<collection>` table into worker memory it used to be, once per ingested
-document on a collection that could hold hundreds of thousands of chunks
+serves each lookup from a **hash** index on that metadata key — hash, not btree,
+because the lookups are equality-only and a `source_path` is unbounded, so a
+btree would fail its row-size limit and take ingestion down with it. The indexes
+are built with the runtime table and backfilled onto older collections by
+migration `0056`, which makes the check a handful of indexed statements rather
+than the read of the whole `rag_<collection>` table into worker memory it used to
+be, once per ingested document on a collection that could hold hundreds of
+thousands of chunks
 ([#1102](https://github.com/vstorm-co/agenticos/issues/1102), the ingest half of
 [#27](https://github.com/vstorm-co/agenticos/issues/27); its other half paginated
 the tracked-documents listing). A base-class fallback still answers by reading the


### PR DESCRIPTION
## What

`IngestionService.existing_document` answered "does this collection already hold this file" by reading **every** row of the runtime `rag_<collection>` table through `get_documents` and grouping in Python — a full read into worker memory once per ingested document. On a 200k-chunk collection that dominates a nightly sync.

The lookup now belongs to the store as `find_existing_document`, which `PgVectorStore` answers with **one indexed statement per key** in the same precedence — `source_path`, then an unaddressed `filename`, then `content_hash`, stopping at the first hit. `_ensure_collection` builds an expression index on each of the three metadata keys alongside the table, so an established collection gains them on its next ingest through the write path's existing `_ensure_collection` call.

## Invariants preserved

- The **#548** single-document invariant (the id and the hash name *one* document) and the **#990** unaddressed-filename rule are unchanged. They move into a reference implementation on `BaseVectorStore` that scans, so a store with no index still answers correctly; `PgVectorStore` overrides it with the indexed path.
- Index suffixes are kept no longer than the HNSW `_embedding_idx`, so `MAX_COLLECTION_NAME_LENGTH` stays 45 and no identifier truncates.
- `existing_document`'s signature is unchanged — `rag_tasks` and the `rag-*` commands are untouched.

## Tests

- Unit suite pins the precedence by name against the reference implementation.
- New real-Postgres integration test (`tests/integration/test_rag_existence_index.py`) pins the three indexes' existence (`pg_indexes`) and the SQL precedence on populated rows — including the `ORDER BY parent_doc_id, id` tiebreak and the unaddressed rule.
- `make lint` and `make test` green (6909 passed, coverage 100%).

## Out of scope

The vector store's document *listing* (`get_documents`) is still a full scan — that is the display path, not the ingest existence check. Split from #27, whose pagination half shipped in #1101; this is the ingest-scan half.

Closes #1102
Refs #27