### PR TITLE
fix(organizations): SET NULL the three invite FKs into users

### DIFF
--- a/backend/alembic/versions/0056_invite_fk_ondelete.py
+++ b/backend/alembic/versions/0056_invite_fk_ondelete.py
@@ -1,0 +1,98 @@
+"""Let a deleted user keep their invite audit trail instead of blocking deletion.
+
+Three foreign keys into `users.id` - who invited a member, who authored an
+invitation, who accepted one - carried no `ondelete`, so PostgreSQL's NO ACTION
+made any of them an absolute bar on deleting the referenced user. #9 reconciled
+the CHECK-versus-cascade collisions for a normally-registered user, but a user
+who had ever invited another member still failed `DELETE /users/{id}` with a
+foreign-key violation surfaced as a 500 (#1110).
+
+`SET NULL` on all three: who invited a member and who accepted an invitation are
+audit context that should outlive the user, the way the secret and
+knowledge-base attribution FKs already null. `invitations.invited_by_user_id`
+was NOT NULL, so it is made nullable in the same step - it is set on every create
+and null only once the inviter is gone.
+
+The downgrade re-tightens that column to NOT NULL, which fails if the SET NULL
+schema has run long enough for an inviter to be deleted and left a null behind -
+the standard nullable->NOT NULL rollback risk, no data loss, and it aborts
+cleanly.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0056_invite_fk_ondelete"
+down_revision: str | Sequence[str] | None = "0055_sandbox_operations"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "organization_members_invited_by_user_id_fkey", "organization_members", type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "organization_members_invited_by_user_id_fkey",
+        "organization_members",
+        "users",
+        ["invited_by_user_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    op.alter_column("invitations", "invited_by_user_id", existing_type=sa.UUID(), nullable=True)
+    op.drop_constraint("invitations_invited_by_user_id_fkey", "invitations", type_="foreignkey")
+    op.create_foreign_key(
+        "invitations_invited_by_user_id_fkey",
+        "invitations",
+        "users",
+        ["invited_by_user_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    op.drop_constraint("invitations_accepted_by_user_id_fkey", "invitations", type_="foreignkey")
+    op.create_foreign_key(
+        "invitations_accepted_by_user_id_fkey",
+        "invitations",
+        "users",
+        ["accepted_by_user_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("invitations_accepted_by_user_id_fkey", "invitations", type_="foreignkey")
+    op.create_foreign_key(
+        "invitations_accepted_by_user_id_fkey",
+        "invitations",
+        "users",
+        ["accepted_by_user_id"],
+        ["id"],
+    )
+
+    op.drop_constraint("invitations_invited_by_user_id_fkey", "invitations", type_="foreignkey")
+    op.create_foreign_key(
+        "invitations_invited_by_user_id_fkey",
+        "invitations",
+        "users",
+        ["invited_by_user_id"],
+        ["id"],
+    )
+    op.alter_column("invitations", "invited_by_user_id", existing_type=sa.UUID(), nullable=False)
+
+    op.drop_constraint(
+        "organization_members_invited_by_user_id_fkey", "organization_members", type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "organization_members_invited_by_user_id_fkey",
+        "organization_members",
+        "users",
+        ["invited_by_user_id"],
+        ["id"],
+    )

--- a/backend/app/db/models/organization.py
+++ b/backend/app/db/models/organization.py
@@ -110,9 +110,13 @@ class OrganizationMember(Base):
         index=True,
     )
     role: Mapped[str] = mapped_column(String(20), nullable=False, default=OrgRole.MEMBER.value)
+    # SET NULL, not the default NO ACTION: who invited a member is audit context
+    # that should outlive the inviter, and a NO-ACTION reference blocked deleting
+    # anyone who had ever invited another member (#1110). Matches how the
+    # secret/KB attribution FKs already null on the referenced user's deletion.
     invited_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
-        ForeignKey("users.id"),
+        ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
     )
     joined_at: Mapped[datetime] = mapped_column(
@@ -166,10 +170,14 @@ class Invitation(Base):
     # posted in a channel is a link that can be forwarded, and "anyone with the
     # URL" is a different risk from "anyone at our company".
     email_domain: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    invited_by_user_id: Mapped[uuid.UUID] = mapped_column(
+    # Nullable and SET NULL: the inviter is audit context that outlives them, and
+    # a NOT NULL / NO-ACTION reference made an invitation authored by a user an
+    # absolute bar on deleting that user (#1110). Set on every create, null only
+    # once the inviter is gone.
+    invited_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
-        ForeignKey("users.id"),
-        nullable=False,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
     )
     token: Mapped[str] = mapped_column(String(64), unique=True, nullable=False, index=True)
     status: Mapped[str] = mapped_column(
@@ -185,7 +193,7 @@ class Invitation(Base):
     accepted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     accepted_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
-        ForeignKey("users.id"),
+        ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
     )
 

--- a/backend/tests/integration/test_user_deletion_invites.py
+++ b/backend/tests/integration/test_user_deletion_invites.py
@@ -1,0 +1,169 @@
+"""Deleting a user who touched an invitation no longer 500s on a NO-ACTION FK.
+
+Three foreign keys into `users.id` - who invited a member, who authored an
+invitation, who accepted one - carried no `ondelete`, so PostgreSQL's NO ACTION
+made any of them an absolute bar on deleting the referenced user (#1110). #9
+reconciled the CHECK-versus-cascade collisions, but a user who had ever invited
+another member still failed `DELETE /users/{id}` with a foreign-key violation.
+
+Integration, not unit: the whole point is what the database does to the
+neighbouring invite rows when the referenced user is deleted, which a mock
+cannot show.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models.organization import (
+    Invitation,
+    InvitationStatus,
+    Organization,
+    OrganizationMember,
+)
+from app.db.models.user import User
+from app.services.user import UserService
+
+pytestmark = pytest.mark.anyio
+
+
+def _user(*, is_app_admin: bool = False) -> User:
+    return User(
+        id=uuid.uuid4(),
+        email=f"{uuid.uuid4().hex}@example.com",
+        hashed_password="x",
+        is_active=True,
+        is_app_admin=is_app_admin,
+    )
+
+
+async def _org(db: AsyncSession, creator: User) -> Organization:
+    org = Organization(
+        id=uuid.uuid4(),
+        name="Acme",
+        slug=f"acme-{uuid.uuid4().hex[:8]}",
+        is_personal=False,
+        created_by_user_id=creator.id,
+    )
+    db.add(org)
+    await db.flush()
+    db.add(
+        OrganizationMember(
+            id=uuid.uuid4(), organization_id=org.id, user_id=creator.id, role="owner"
+        )
+    )
+    await db.flush()
+    return org
+
+
+async def _member(
+    db: AsyncSession, org_id: uuid.UUID, user_id: uuid.UUID, *, invited_by: uuid.UUID | None
+) -> OrganizationMember:
+    member = OrganizationMember(
+        id=uuid.uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        role="member",
+        invited_by_user_id=invited_by,
+    )
+    db.add(member)
+    await db.flush()
+    return member
+
+
+def _invitation(org_id: uuid.UUID, inviter_id: uuid.UUID) -> Invitation:
+    return Invitation(
+        id=uuid.uuid4(),
+        organization_id=org_id,
+        email=f"{uuid.uuid4().hex}@example.com",
+        role="member",
+        invited_by_user_id=inviter_id,
+        token=uuid.uuid4().hex,
+        status=InvitationStatus.PENDING.value,
+        expires_at=datetime.now(UTC) + timedelta(days=1),
+    )
+
+
+async def test_deleting_a_user_who_invited_another_nulls_the_invite_refs(db: AsyncSession) -> None:
+    owner = _user()
+    inviter = _user()
+    invitee = _user()
+    db.add_all([owner, inviter, invitee])
+    await db.flush()
+    org = await _org(db, owner)
+    await _member(db, org.id, inviter.id, invited_by=None)
+    invitee_member = await _member(db, org.id, invitee.id, invited_by=inviter.id)
+    invitation = _invitation(org.id, inviter.id)
+    db.add(invitation)
+    await db.flush()
+    inviter_id = inviter.id
+
+    await UserService(db).delete(inviter_id)
+    await db.flush()
+
+    assert await db.get(User, inviter_id) is None
+    await db.refresh(invitee_member)
+    assert invitee_member.invited_by_user_id is None
+    await db.refresh(invitation)
+    assert invitation.invited_by_user_id is None
+
+
+async def test_deleting_the_accepter_of_an_invitation_nulls_that_reference(
+    db: AsyncSession,
+) -> None:
+    owner = _user()
+    accepter = _user()
+    db.add_all([owner, accepter])
+    await db.flush()
+    org = await _org(db, owner)
+    invitation = _invitation(org.id, owner.id)
+    invitation.status = InvitationStatus.ACCEPTED.value
+    invitation.accepted_by_user_id = accepter.id
+    invitation.accepted_at = datetime.now(UTC)
+    db.add(invitation)
+    await db.flush()
+    accepter_id = accepter.id
+
+    await UserService(db).delete(accepter_id)
+    await db.flush()
+
+    assert await db.get(User, accepter_id) is None
+    await db.refresh(invitation)
+    assert invitation.accepted_by_user_id is None
+
+
+async def test_the_bulk_delete_nulls_the_invite_ref_it_no_longer_blocks_on(
+    db: AsyncSession,
+) -> None:
+    """The SET NULL fires on the bulk path too, not only single-row `delete()`.
+
+    `delete_non_admins` is a bare `DELETE FROM users` and does not go through
+    `_release_owned_rows`, so it exercises the FK's own `ondelete` rather than a
+    service reconciliation. The author here owns no personal org, which isolates
+    the invite FK: `organizations.created_by_user_id` is still `RESTRICT`, so a
+    real `seed --clear` of users that each own a personal org is a separate bar
+    this change does not lift (filed follow-up).
+    """
+    admin = _user(is_app_admin=True)
+    inviter = _user()
+    db.add_all([admin, inviter])
+    await db.flush()
+    org = await _org(db, admin)
+    await _member(db, org.id, inviter.id, invited_by=None)
+    invitation = _invitation(org.id, inviter.id)
+    db.add(invitation)
+    await db.flush()
+    inviter_id, admin_id = inviter.id, admin.id
+
+    removed = await UserService(db).delete_non_admins()
+    await db.flush()
+
+    assert removed >= 1
+    assert await db.get(User, inviter_id) is None
+    assert await db.get(User, admin_id) is not None
+    await db.refresh(invitation)
+    assert invitation.invited_by_user_id is None


### PR DESCRIPTION
> **Stacked on #9** (`fix/9-delete-cascade-check-reconcile`). Based against that branch so the diff is only #1110's; the `DELETE /users/{id}` test relies on #9's `_release_owned_rows`. **Retarget to `main` once #9 (PR #1112) merges.**

## What

Three foreign keys into `users.id` — `OrganizationMember.invited_by_user_id`, `Invitation.invited_by_user_id`, `Invitation.accepted_by_user_id` — carried no `ondelete`, so PostgreSQL's NO ACTION made each an **absolute bar on deleting the referenced user**. #9 reconciled the CHECK-versus-cascade collisions, but a user who had ever invited another member still failed `DELETE /users/{id}` with a foreign-key violation surfaced as a 500 — common in any real deployment.

All three become `ON DELETE SET NULL`: who invited a member and who accepted an invitation are audit context that should outlive the user, the way the secret/KB attribution FKs already null. `Invitation.invited_by_user_id` was NOT NULL, so **migration 0056** makes it nullable in the same step (set on every create, null only once the inviter is gone).

## Tests

Three real-Postgres integration tests (`tests/integration/test_user_deletion_invites.py`):
- deleting an inviter leaves the invitee's membership and the invitation, both with the inviter nulled;
- deleting the accepter nulls `accepted_by_user_id`;
- the SET NULL fires on the bulk `delete_non_admins` path too.

Each **fails without the model change**. Migration applies forward+back+forward on a scratch DB; `alembic check` reports no drift. `make lint` + `make test` green (6912 passed, coverage 100%).

## Deliberately out of scope → #1124

`seed --clear`'s bulk `delete_non_admins` still 500s on `organizations.created_by_user_id` **RESTRICT** for a user who owns a personal org — that path bypasses `_release_owned_rows` and hits a different FK/mechanism than the invite bar. Filed as #1124 (found reviewing this).

Closes #1110
Refs #9, #1124