### PR TITLE
fix(dev): judge the reload beat on wall clock, not monotonic

### DIFF
--- a/backend/cli/reload_supervisor.py
+++ b/backend/cli/reload_supervisor.py
@@ -40,10 +40,12 @@ while every request times out (#336).
 
 So the worker also says, from its own event loop, that the loop is turning.
 uvicorn already has the hook: `Config.callback_notify` is awaited by
-`Server.on_tick` every `timeout_notify` seconds, which is the integration point
-systemd's watchdog uses. The callback stamps `time.monotonic()` into a shared
-cell; the supervisor reads the cell on the same quiet poll as everything else,
-and replaces a worker whose loop has not turned for `WEDGED_AFTER` seconds.
+`Server.on_tick` once `time.time()` has advanced past `timeout_notify` since the
+last beat, which is the integration point systemd's watchdog uses. The callback
+stamps `time.time()` into a shared cell - the same wall clock the cadence is
+gated on, so the verdict cannot diverge from it (#1080); the supervisor reads
+the cell on the same quiet poll as everything else, and replaces a worker whose
+loop has not turned for `WEDGED_AFTER` seconds.
 
 Four properties of that choice are the reason for it:
 
@@ -69,11 +71,14 @@ Four properties of that choice are the reason for it:
   hung. `shutdown` needs the same escalation for the same reason, or Ctrl+C on a
   wedged worker blocks until Docker's grace period runs out.
 - **A frozen host is not a wedged worker.** `docker pause`, a frozen cgroup and
-  a Docker Desktop VM resuming after the host slept all advance the monotonic
-  clock while *nothing* runs, worker and supervisor alike, so the first poll
-  after one reads a stale beat that says nothing about the worker. Two
-  consecutive silent polls are therefore needed rather than one: by the second,
-  a healthy worker has beaten again and the verdict clears.
+  a Docker Desktop VM resuming after the host slept all step the wall clock
+  forward while *nothing* runs, worker and supervisor alike, so the first poll
+  after one reads a beat stamped before the jump and finds a gap that says
+  nothing about the worker. Two consecutive silent polls are therefore needed
+  rather than one: by the second, a healthy worker has beaten again and the
+  verdict clears. The beat and the verdict read the same wall clock uvicorn
+  gates the cadence on, so a stalled clock never reads as a wedge on its own
+  (#1080).
 
 ## The other two stacks, which do not run this module
 
@@ -153,25 +158,27 @@ BEAT_INTERVAL: Final = 1
 # laptop, and replacing a healthy one early drops in-flight requests. Fifteen
 # seconds of an event loop not turning is not load - a loaded loop still runs a
 # timer callback in milliseconds - it is blocked, stopped or deadlocked. It also
-# leaves room for the beat's own jitter: `on_tick` schedules on `time.time()`
-# while the verdict is monotonic, so a backwards clock step delays a beat by the
-# size of the step. Fifteen seconds absorbs that; two would not. The
-# supervisor notices within `WEDGED_AFTER` plus the two polls
-# `POLLS_BEFORE_WEDGED` costs, so about twenty-five seconds, against the ninety a
-# container health check takes to reach a verdict nothing acts on.
+# leaves room for the beat's own jitter: the beat and the verdict both read
+# `time.time()`, the clock uvicorn gates the cadence on (#1080), so a wall-clock
+# step moves the beat and the reading together rather than only one of them - but
+# a forward step still stretches the gap by its size until the next beat lands,
+# and fifteen seconds absorbs that where two would not. The supervisor notices
+# within `WEDGED_AFTER` plus the two polls `POLLS_BEFORE_WEDGED` costs, so about
+# twenty-five seconds, against the ninety a container health check takes to reach
+# a verdict nothing acts on.
 WEDGED_AFTER: Final = 15.0
 
 # Consecutive silent polls before the worker is replaced. Two, not one, because
 # `docker pause`, a frozen cgroup and a Docker Desktop VM resuming after the host
-# slept all advance the monotonic clock while *nothing* runs - supervisor
-# included - and the first poll after one of those reads a stale beat that says
-# nothing about the worker. By the next poll a healthy worker has beaten again,
-# about a second having passed, and the verdict clears; a wedged one fails both.
-# The reprieve costs one poll of detection, and it is deliberately not measured
-# as a gap in the supervisor's own polling: watchfiles ticks every five seconds
-# or so, so any threshold below that would have compared a poll gap against a
-# smaller number, judged every poll a freeze, and switched the check off in
-# silence.
+# slept all step the wall clock forward while *nothing* runs - supervisor
+# included - so the first poll after one of those reads a beat stamped before the
+# jump and finds a gap that says nothing about the worker. By the next poll a
+# healthy worker has beaten again, about a second having passed, and the verdict
+# clears; a wedged one fails both. The reprieve costs one poll of detection, and
+# it is deliberately not measured as a gap in the supervisor's own polling:
+# watchfiles ticks every five seconds or so, so any threshold below that would
+# have compared a poll gap against a smaller number, judged every poll a freeze,
+# and switched the check off in silence.
 POLLS_BEFORE_WEDGED: Final = 2
 
 # Seconds without a beat before a worker is replaced, `0` or below to switch the
@@ -214,6 +221,17 @@ class EventLoopHeartbeat:
     because the pickling happens while the child is being spawned, which is the
     one time `multiprocessing` permits a shared value to cross.
 
+    **The stamp is `time.time()`, not `time.monotonic()`, and that is the whole
+    of #1080.** uvicorn does not call this on a fixed cadence: `Server.on_tick`
+    beats only when `time.time() - last_notified > timeout_notify`, so *when* a
+    beat happens is governed by the wall clock. The verdict has to read the same
+    clock the cadence runs on, or the two diverge: on Docker Desktop's VM the
+    wall clock can stall for tens of seconds relative to the monotonic clock
+    while the loop keeps serving, and a monotonic verdict then read that stalled
+    beat as a wedge and killed a healthy worker. Wall on both sides cannot
+    diverge from itself - a stalled wall clock stalls the cadence and the verdict
+    together, so the reading stays near zero.
+
     `RawValue` and not `Value`, on two counts. `Value`'s lock is a `SemLock` from
     the *default* context, which on Linux is `fork` - and uvicorn spawns, so
     handing the worker one raises `A SemLock created in a fork context is being
@@ -230,7 +248,7 @@ class EventLoopHeartbeat:
         self._beat = beat
 
     async def __call__(self) -> None:
-        self._beat.value = time.monotonic()
+        self._beat.value = time.time()
 
 
 class SupervisedReload(ChangeReload):
@@ -421,7 +439,10 @@ class SupervisedReload(ChangeReload):
         if beat == NOT_YET_BEATEN:
             return None
 
-        silent_for = time.monotonic() - beat
+        # `time.time()`, matching the clock the beat is stamped with and the one
+        # uvicorn gates the beat's cadence on (#1080). A monotonic verdict here
+        # read a wall-clock stall - the loop still serving - as a wedge.
+        silent_for = time.time() - beat
         return silent_for if silent_for >= self._wedged_after else None
 
     def _replace_a_wedged_worker(self) -> None:

--- a/backend/tests/test_reload_supervisor.py
+++ b/backend/tests/test_reload_supervisor.py
@@ -392,7 +392,7 @@ def test_a_worker_whose_event_loop_stopped_turning_is_replaced(
     supervisor: RecordingReload, beat: ctypes.c_double
 ) -> None:
     """The whole of #336: this worker is alive, so nothing else would ever act on it."""
-    beat.value = time.monotonic() - A_SHORT_WEDGE - 1
+    beat.value = time.time() - A_SHORT_WEDGE - 1
     wedged = FakeWorker(None)
     supervisor.process = wedged
 
@@ -408,19 +408,41 @@ def test_one_silent_poll_is_not_a_verdict(
 ) -> None:
     """`docker pause`, a frozen cgroup, a Docker Desktop VM after the host slept.
 
-    All of them advance the monotonic clock while the supervisor is not running
-    either, so the first poll afterwards reads a stale beat that says nothing
-    about the worker. A healthy one has beaten again by the next poll.
+    All of them step the wall clock forward while the supervisor is not running
+    either, so the first poll afterwards reads a beat stamped before the jump and
+    finds a gap that says nothing about the worker. A healthy one has beaten again
+    by the next poll.
     """
-    beat.value = time.monotonic() - A_SHORT_WEDGE - 1
+    beat.value = time.time() - A_SHORT_WEDGE - 1
     supervisor.process = FakeWorker(None)
 
     assert supervisor.should_restart() is None
     assert supervisor.replacements == 0
 
-    beat.value = time.monotonic()
+    beat.value = time.time()
 
     assert supervisor.should_restart() is None
+    assert supervisor.replacements == 0
+
+
+def test_a_wall_clock_stall_while_monotonic_runs_on_is_not_a_wedge(
+    supervisor: RecordingReload, beat: ctypes.c_double, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1080. The loop is serving, but the wall clock - which gates uvicorn's
+    beat cadence - has stalled while the monotonic clock has run on, as it does
+    on Docker Desktop's VM. A monotonic verdict read that stalled beat as a
+    wedge and killed a healthy worker; the verdict now reads the same wall clock
+    the beat is stamped with, so the reading stays near zero and the worker
+    lives. Both clocks are pinned so the divergence is the whole of the test
+    rather than a race.
+    """
+    monkeypatch.setattr(reload_supervisor.time, "monotonic", lambda: 10_000.0)
+    monkeypatch.setattr(reload_supervisor.time, "time", lambda: 1_000.0)
+    beat.value = 1_000.0  # stamped at the wall clock, which has since stalled here
+    supervisor.process = FakeWorker(None)
+
+    assert supervisor.should_restart() is None
+    assert supervisor.should_restart() is None  # and still, past POLLS_BEFORE_WEDGED
     assert supervisor.replacements == 0
 
 
@@ -431,9 +453,9 @@ def test_the_silent_polls_have_to_be_consecutive(
     supervisor.process = FakeWorker(None)
 
     for _ in range(POLLS_BEFORE_WEDGED * 3):
-        beat.value = time.monotonic() - A_SHORT_WEDGE - 1
+        beat.value = time.time() - A_SHORT_WEDGE - 1
         supervisor.should_restart()
-        beat.value = time.monotonic()
+        beat.value = time.time()
         supervisor.should_restart()
 
     assert supervisor.replacements == 0
@@ -443,7 +465,7 @@ def test_a_worker_still_beating_is_left_alone(
     supervisor: RecordingReload, beat: ctypes.c_double
 ) -> None:
     """A slow server is not a wedged one, and replacing it drops requests it was serving."""
-    beat.value = time.monotonic()
+    beat.value = time.time()
     supervisor.process = FakeWorker(None)
 
     assert supervisor.should_restart() is None
@@ -471,7 +493,7 @@ def test_a_worker_that_exited_on_its_own_is_not_killed_for_its_stale_beat(
     Without the guard, the wedge check would undo the one decision
     `_replace_a_dead_worker` makes deliberately.
     """
-    beat.value = time.monotonic() - A_SHORT_WEDGE - 1
+    beat.value = time.time() - A_SHORT_WEDGE - 1
     supervisor.process = FakeWorker(1)
 
     for _ in range(POLLS_BEFORE_WEDGED):
@@ -484,7 +506,7 @@ def test_a_replacement_is_not_judged_on_the_beat_of_the_worker_it_replaced(
     supervisor: RecordingReload, beat: ctypes.c_double
 ) -> None:
     """Otherwise the first replacement inherits a stale cell and is killed on the next poll."""
-    beat.value = time.monotonic() - A_SHORT_WEDGE - 1
+    beat.value = time.time() - A_SHORT_WEDGE - 1
     supervisor.process = FakeWorker(None)
 
     for _ in range(POLLS_BEFORE_WEDGED * 2):
@@ -499,7 +521,7 @@ def test_a_worker_wedging_during_shutdown_is_not_replaced(
 ) -> None:
     """A worker stops beating as it shuts down, and its replacement would be an orphan."""
     supervisor.should_exit.set()
-    beat.value = time.monotonic() - A_SHORT_WEDGE - 1
+    beat.value = time.time() - A_SHORT_WEDGE - 1
     supervisor.process = FakeWorker(None)
 
     for _ in range(POLLS_BEFORE_WEDGED):
@@ -520,7 +542,7 @@ def test_a_last_gasp_beat_from_a_dying_worker_does_not_reach_its_replacement(
     """
 
     def _beat_on_the_way_out(self: RecordingReload) -> None:
-        beat.value = time.monotonic()
+        beat.value = time.time()
         _record_the_replacement(self)
 
     monkeypatch.setattr(BaseReload, "restart", _beat_on_the_way_out)
@@ -543,7 +565,7 @@ def test_shutting_down_kills_a_wedged_worker_rather_than_waiting_for_it(
     """
     wedged = FakeWorker(None, ignores_sigterm=True)
     supervisor.process = wedged
-    beat.value = time.monotonic() - A_SHORT_WEDGE - 1
+    beat.value = time.time() - A_SHORT_WEDGE - 1
 
     supervisor.shutdown()
 
@@ -557,7 +579,7 @@ def test_shutting_down_leaves_a_healthy_worker_to_drain(
     """`SIGTERM` is how in-flight requests finish; escalating always would drop them."""
     healthy = FakeWorker(None)
     supervisor.process = healthy
-    beat.value = time.monotonic()
+    beat.value = time.time()
 
     supervisor.shutdown()
 
@@ -572,7 +594,7 @@ def test_shutting_down_stops_waiting_on_a_worker_that_never_drains(
     """The bound is not a timeout that hides a hang - it says what it killed."""
     stuck = FakeWorker(None, ignores_sigterm=True)
     supervisor.process = stuck
-    beat.value = time.monotonic()
+    beat.value = time.time()
 
     supervisor.shutdown()
 
@@ -616,7 +638,7 @@ def test_shutting_down_closes_the_socket_it_bound(
     listening = socket()
     supervisor.sockets = [listening]
     supervisor.process = FakeWorker(None)
-    beat.value = time.monotonic()
+    beat.value = time.time()
 
     supervisor.shutdown()
 
@@ -631,7 +653,7 @@ def test_the_wedge_check_can_be_switched_off(
     monkeypatch.setattr(BaseReload, "restart", _record_the_replacement)
     off = RecordingReload(Config(APP, reload=True, ws=WS_PROTOCOL), beat, wedged_after=0)
     off.process = FakeWorker(None)
-    beat.value = time.monotonic() - A_SHORT_WEDGE - 1
+    beat.value = time.time() - A_SHORT_WEDGE - 1
 
     for _ in range(POLLS_BEFORE_WEDGED):
         assert off.should_restart() is None
@@ -644,7 +666,7 @@ async def test_the_heartbeat_stamps_the_cell_the_supervisor_reads(
 ) -> None:
     await EventLoopHeartbeat(beat)()
 
-    assert beat.value == pytest.approx(time.monotonic(), abs=1)
+    assert beat.value == pytest.approx(time.time(), abs=1)
 
 
 async def test_uvicorn_awaits_the_heartbeat_on_its_own_tick(beat: ctypes.c_double) -> None:
@@ -664,7 +686,7 @@ async def test_uvicorn_awaits_the_heartbeat_on_its_own_tick(beat: ctypes.c_doubl
 
     await Server(config).on_tick(counter=0)
 
-    assert beat.value == pytest.approx(time.monotonic(), abs=1)
+    assert beat.value == pytest.approx(time.time(), abs=1)
 
 
 def test_the_worker_reports_its_event_loop_through_uvicorns_notify_hook(


### PR DESCRIPTION
## What

The local dev stack runs `python -m cli.reload_supervisor`, whose `SupervisedReload` replaces a worker whose event loop has stopped turning. The worker reports liveness through uvicorn's `Config.callback_notify`, which `Server.on_tick` calls only once **`time.time() - last_notified > timeout_notify`** — so the beat **cadence is gated on the wall clock**. The beat stamped `time.monotonic()` and the supervisor judged with `time.monotonic() - beat` — a *different* clock from the one the cadence runs on.

On Docker Desktop's VM the wall clock can stall for tens of seconds relative to monotonic while the loop keeps serving. The cadence froze while the monotonic verdict climbed, so a **healthy, serving worker was read as wedged and killed** — and the replacement, beating once then killed again on the next poll, is the "container Up, nothing serving" the issue also reports. The module's own docstrings already named the mismatch.

## Fix

The beat now stamps `time.time()` and the verdict reads `time.time() - beat` — both on the clock uvicorn gates the cadence on, so they cannot diverge: a stalled wall clock stalls the cadence and the reading together.

`app/core/watchdog.py` (the in-process watchdog on the other two stacks) is **left untouched** — it beats via `loop.call_later` and judges with `time.monotonic()`, both the event loop's own clock, so it is internally consistent and never used uvicorn's notify hook. The issue pointed here, but the killer's log line is `SupervisedReload`'s.

## Trade, stated

A real wedge coinciding with a *backward* NTP step reads `silent_for` negative for the length of the step and defers the verdict — bounded by `POLLS_BEFORE_WEDGED`, self-healing once the wall clock passes `beat + WEDGED_AFTER`, and local-dev only. Since uvicorn gates the cadence on wall time, a wall-clock verdict is the only self-consistent choice.

## Tests

A new test pins both clocks divergent (monotonic ahead, wall stalled at the beat) and asserts no replacement past `POLLS_BEFORE_WEDGED`; it and the heartbeat-stamp test both **fail against the monotonic code** (verified by reverting). The ~18 existing beat-value assertions move to `time.time()`; the harness deadline loops stay monotonic. `make lint` + `make test` green (6901 passed, coverage 100%). Root cause verified against uvicorn 0.52.3's `on_tick` source.

Closes #1080