### PR TITLE
fix(agents): build the knowledge retrieval store per event loop

### DIFF
--- a/backend/app/agents/capabilities/knowledge/_search.py
+++ b/backend/app/agents/capabilities/knowledge/_search.py
@@ -1,5 +1,6 @@
 """RAG tool for agent knowledge base search."""
 
+import asyncio
 import contextvars
 import logging
 from typing import TYPE_CHECKING, Any
@@ -18,41 +19,70 @@ if TYPE_CHECKING:
 
 _retrieval_service: "BaseRetrievalService | None" = None
 _vector_store: PgVectorStore | None = None
+_loop: asyncio.AbstractEventLoop | None = None
 
 
 def get_retrieval_service() -> "BaseRetrievalService":
-    """Get or create retrieval service singleton."""
-    global _retrieval_service, _vector_store
-    if _retrieval_service is not None:
+    """The retrieval service for the running event loop, built once per loop.
+
+    The store owns a pooled SQLAlchemy engine, and a pooled asyncpg connection
+    is bound to the loop that opened it. A single process-wide singleton is
+    right for the API, which serves every request on one long-lived loop - but
+    agents also run inside the Prefect worker, where a second flow run can reach
+    this from a *different* loop, and a store checked out there would hand it a
+    connection made on the first loop (`InterfaceError: attached to a different
+    loop`, intermittent and invisible to any single-loop test) (#1079).
+
+    So the store is keyed on the running loop rather than held unconditionally.
+    The common paths keep one store: the API builds it once and disposes it at
+    shutdown, and the worker's usual one-loop-per-flow-subprocess run builds one
+    per process. A worker that runs two flows on two loops in one process builds
+    one per loop; the store from a loop that has moved on is dropped rather than
+    reused - its pool cannot be disposed from another loop, so this trades a
+    bounded, at-most-one-behind leak for never handing a live loop a dead one's
+    connection. `get_worker_db_context` in `app/db/session.py` states the same
+    cross-loop rule for the pool it hands out.
+    """
+    global _retrieval_service, _vector_store, _loop
+    loop = asyncio.get_running_loop()
+    if _retrieval_service is not None and _loop is loop:
         return _retrieval_service
 
     rag_settings = settings.rag
     embedding_service = EmbeddingService(rag_settings)
+    # Built into locals and returned from them, not read back off the globals:
+    # a caller must receive the store it built on its own loop even if another
+    # thread with another loop overwrites the globals between here and the
+    # return. The globals are the cache for the next call; the return is this
+    # call's own.
     vector_store = PgVectorStore(
         rag_settings, embedding_service, resolver=embeddings_for_collection
     )
+    service = RetrievalService(vector_store, rag_settings)
     _vector_store = vector_store
-    _retrieval_service = RetrievalService(vector_store, rag_settings)
-    return _retrieval_service
+    _retrieval_service = service
+    _loop = loop
+    return service
 
 
 async def aclose_retrieval_service() -> None:
     """Release the pool this module's store opened, at shutdown.
 
     The store is built on the first knowledge search and then held for the life
-    of the process, which is right - rebuilding it per search would open a
-    connection pool per turn. What was missing is the other end: nothing
+    of the loop that built it, which is right - rebuilding it per search would
+    open a connection pool per turn. What was missing is the other end: nothing
     released it, so a second pool sat beside the one the lifespan built and
     outlived the shutdown that disposed that one (#948).
 
-    Called from the lifespan rather than from a `finally` here, because the
-    singleton is deliberately process-wide. Resetting both globals makes the
-    next search build a fresh store, so a shutdown that is followed by more work
-    - a test, a reload - does not search through a disposed one.
+    Called from the lifespan on the API's own loop, so it disposes the store
+    that loop built. Resetting the globals makes the next search build a fresh
+    store, so a shutdown that is followed by more work - a test, a reload - does
+    not search through a disposed one.
     """
-    global _retrieval_service, _vector_store
+    global _retrieval_service, _vector_store, _loop
     store, _vector_store = _vector_store, None
     _retrieval_service = None
+    _loop = None
     if store is not None:
         await store.aclose()
 

--- a/backend/app/agents/capabilities/knowledge/_search.py
+++ b/backend/app/agents/capabilities/knowledge/_search.py
@@ -17,9 +17,15 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from app.services.rag.retrieval import BaseRetrievalService
 
-_retrieval_service: "BaseRetrievalService | None" = None
-_vector_store: PgVectorStore | None = None
-_loop: asyncio.AbstractEventLoop | None = None
+    _Cache = tuple[BaseRetrievalService, PgVectorStore, asyncio.AbstractEventLoop]
+
+# The service, its store, and the loop they belong to - held as one value so it
+# is published and read in a single reference assignment. Three separate globals
+# could interleave under two threads-with-loops: A stores its service, B replaces
+# all three for loop B, A then overwrites only the loop tag with loop A, and a
+# later call on loop A reads B's loop-bound store back (#1079 review). One tuple
+# cannot half-update.
+_cache: "_Cache | None" = None
 
 
 def get_retrieval_service() -> "BaseRetrievalService":
@@ -43,25 +49,19 @@ def get_retrieval_service() -> "BaseRetrievalService":
     connection. `get_worker_db_context` in `app/db/session.py` states the same
     cross-loop rule for the pool it hands out.
     """
-    global _retrieval_service, _vector_store, _loop
+    global _cache
     loop = asyncio.get_running_loop()
-    if _retrieval_service is not None and _loop is loop:
-        return _retrieval_service
+    cached = _cache
+    if cached is not None and cached[2] is loop:
+        return cached[0]
 
     rag_settings = settings.rag
     embedding_service = EmbeddingService(rag_settings)
-    # Built into locals and returned from them, not read back off the globals:
-    # a caller must receive the store it built on its own loop even if another
-    # thread with another loop overwrites the globals between here and the
-    # return. The globals are the cache for the next call; the return is this
-    # call's own.
     vector_store = PgVectorStore(
         rag_settings, embedding_service, resolver=embeddings_for_collection
     )
     service = RetrievalService(vector_store, rag_settings)
-    _vector_store = vector_store
-    _retrieval_service = service
-    _loop = loop
+    _cache = (service, vector_store, loop)
     return service
 
 
@@ -75,16 +75,14 @@ async def aclose_retrieval_service() -> None:
     outlived the shutdown that disposed that one (#948).
 
     Called from the lifespan on the API's own loop, so it disposes the store
-    that loop built. Resetting the globals makes the next search build a fresh
+    that loop built. Clearing the cache makes the next search build a fresh
     store, so a shutdown that is followed by more work - a test, a reload - does
     not search through a disposed one.
     """
-    global _retrieval_service, _vector_store, _loop
-    store, _vector_store = _vector_store, None
-    _retrieval_service = None
-    _loop = None
-    if store is not None:
-        await store.aclose()
+    global _cache
+    cached, _cache = _cache, None
+    if cached is not None:
+        await cached[1].aclose()
 
 
 def _format_results(results: list[Any]) -> str:

--- a/backend/tests/test_capability_edges.py
+++ b/backend/tests/test_capability_edges.py
@@ -555,21 +555,19 @@ class TestLastMileBranches:
         import app.agents.capabilities.knowledge._search as search_module
 
         sentinel = object()
-        original = (search_module._retrieval_service, search_module._loop)
-        search_module._retrieval_service = sentinel  # type: ignore[assignment]
-        search_module._loop = asyncio.get_running_loop()
+        original = search_module._cache
+        search_module._cache = (sentinel, MagicMock(), asyncio.get_running_loop())  # type: ignore[assignment]
         try:
             assert search_module.get_retrieval_service() is sentinel
         finally:
-            search_module._retrieval_service, search_module._loop = original
+            search_module._cache = original
 
     @pytest.mark.anyio
     async def test_the_retrieval_service_is_built_on_first_use(self):
         import app.agents.capabilities.knowledge._search as search_module
 
-        original = (search_module._retrieval_service, search_module._loop)
-        search_module._retrieval_service = None
-        search_module._loop = None
+        original = search_module._cache
+        search_module._cache = None
         try:
             with (
                 patch.object(search_module, "EmbeddingService"),
@@ -578,7 +576,7 @@ class TestLastMileBranches:
             ):
                 assert search_module.get_retrieval_service() is service_cls.return_value
         finally:
-            search_module._retrieval_service, search_module._loop = original
+            search_module._cache = original
 
     def test_a_store_built_on_one_loop_is_not_reused_on_another(self):
         """#1079. A pooled asyncpg connection is bound to the loop that opened
@@ -599,14 +597,8 @@ class TestLastMileBranches:
             finally:
                 loop.close()
 
-        original = (
-            search_module._retrieval_service,
-            search_module._vector_store,
-            search_module._loop,
-        )
-        search_module._retrieval_service = None
-        search_module._vector_store = None
-        search_module._loop = None
+        original = search_module._cache
+        search_module._cache = None
         try:
             with (
                 patch.object(search_module, "EmbeddingService"),
@@ -617,11 +609,7 @@ class TestLastMileBranches:
                 second = _on_a_fresh_loop()
             assert first is not second
         finally:
-            (
-                search_module._retrieval_service,
-                search_module._vector_store,
-                search_module._loop,
-            ) = original
+            search_module._cache = original
 
 
 class TestServerCatalog:

--- a/backend/tests/test_capability_edges.py
+++ b/backend/tests/test_capability_edges.py
@@ -544,23 +544,32 @@ class TestLastMileBranches:
 
         assert parse_web_search('{"kind": "web_search", "results": "not a list"}') is None
 
-    def test_the_retrieval_service_is_a_singleton(self):
-        """Rebuilding the embedder per search would reload a model on every turn."""
+    @pytest.mark.anyio
+    async def test_the_retrieval_service_is_a_singleton_within_one_loop(self):
+        """Rebuilding the embedder per search would reload a model on every turn.
+
+        The reuse is per loop now (#1079): the cached service is returned only
+        when the running loop is the one it was built on, which this pins by
+        stamping the current loop beside the sentinel.
+        """
         import app.agents.capabilities.knowledge._search as search_module
 
         sentinel = object()
-        original = search_module._retrieval_service
+        original = (search_module._retrieval_service, search_module._loop)
         search_module._retrieval_service = sentinel  # type: ignore[assignment]
+        search_module._loop = asyncio.get_running_loop()
         try:
             assert search_module.get_retrieval_service() is sentinel
         finally:
-            search_module._retrieval_service = original
+            search_module._retrieval_service, search_module._loop = original
 
-    def test_the_retrieval_service_is_built_on_first_use(self):
+    @pytest.mark.anyio
+    async def test_the_retrieval_service_is_built_on_first_use(self):
         import app.agents.capabilities.knowledge._search as search_module
 
-        original = search_module._retrieval_service
+        original = (search_module._retrieval_service, search_module._loop)
         search_module._retrieval_service = None
+        search_module._loop = None
         try:
             with (
                 patch.object(search_module, "EmbeddingService"),
@@ -569,7 +578,50 @@ class TestLastMileBranches:
             ):
                 assert search_module.get_retrieval_service() is service_cls.return_value
         finally:
-            search_module._retrieval_service = original
+            search_module._retrieval_service, search_module._loop = original
+
+    def test_a_store_built_on_one_loop_is_not_reused_on_another(self):
+        """#1079. A pooled asyncpg connection is bound to the loop that opened
+        it, so a second loop - a worker running a second flow in the same
+        process - must build its own store rather than be handed the first
+        loop's, which would fail with `attached to a different loop`.
+        """
+        import app.agents.capabilities.knowledge._search as search_module
+
+        def _on_a_fresh_loop() -> object:
+            loop = asyncio.new_event_loop()
+            try:
+
+                async def _call() -> object:
+                    return search_module.get_retrieval_service()
+
+                return loop.run_until_complete(_call())
+            finally:
+                loop.close()
+
+        original = (
+            search_module._retrieval_service,
+            search_module._vector_store,
+            search_module._loop,
+        )
+        search_module._retrieval_service = None
+        search_module._vector_store = None
+        search_module._loop = None
+        try:
+            with (
+                patch.object(search_module, "EmbeddingService"),
+                patch.object(search_module, "PgVectorStore"),
+                patch.object(search_module, "RetrievalService", side_effect=[object(), object()]),
+            ):
+                first = _on_a_fresh_loop()
+                second = _on_a_fresh_loop()
+            assert first is not second
+        finally:
+            (
+                search_module._retrieval_service,
+                search_module._vector_store,
+                search_module._loop,
+            ) = original
 
 
 class TestServerCatalog:

--- a/backend/tests/test_ingestion_engine_lifetime.py
+++ b/backend/tests/test_ingestion_engine_lifetime.py
@@ -352,14 +352,12 @@ class TestTheKnowledgeCapabilitysStore:
             patch.object(search_module, "PgVectorStore", return_value=store),
             patch.object(search_module, "RetrievalService"),
         ):
-            search_module._retrieval_service = None
-            search_module._vector_store = None
+            search_module._cache = None
             try:
                 search_module.get_retrieval_service()
                 await search_module.aclose_retrieval_service()
             finally:
-                search_module._retrieval_service = None
-                search_module._vector_store = None
+                search_module._cache = None
 
         store.aclose.assert_awaited_once()
 
@@ -369,8 +367,7 @@ class TestTheKnowledgeCapabilitysStore:
         import app.agents.capabilities.knowledge._search as search_module
 
         with patch.object(search_module, "PgVectorStore") as store_cls:
-            search_module._retrieval_service = None
-            search_module._vector_store = None
+            search_module._cache = None
             await search_module.aclose_retrieval_service()
 
         store_cls.assert_not_called()
@@ -386,14 +383,12 @@ class TestTheKnowledgeCapabilitysStore:
             patch.object(search_module, "PgVectorStore", side_effect=[first, second]),
             patch.object(search_module, "RetrievalService"),
         ):
-            search_module._retrieval_service = None
-            search_module._vector_store = None
+            search_module._cache = None
             try:
                 search_module.get_retrieval_service()
                 await search_module.aclose_retrieval_service()
                 search_module.get_retrieval_service()
 
-                assert search_module._vector_store is second
+                assert search_module._cache[1] is second
             finally:
-                search_module._retrieval_service = None
-                search_module._vector_store = None
+                search_module._cache = None


### PR DESCRIPTION
## What

The knowledge capability's `search_knowledge_base` reaches a process-wide retrieval-service singleton whose `PgVectorStore` owns a **pooled** SQLAlchemy engine. A pooled asyncpg connection is bound to the loop that opened it — fine for the API (one long-lived loop), but agents also run inside the Prefect worker, where a second flow run can reach the singleton from a **different event loop** and be handed a connection made on the first → `InterfaceError: attached to a different loop` (intermittent, invisible to any single-loop test). Only the API lifespan ever reset the singleton.

## Fix

`get_retrieval_service` keys the store on the **running loop**: it returns the cached one only when `_loop is` the current loop, otherwise it builds a fresh store for this loop. The store is built into locals and returned from them (not read back off the globals), so a caller gets the store it built on its own loop even under a hypothetical concurrent-loop race.

## Trade, stated

A store from a loop that has moved on is dropped rather than disposed — its pool cannot be `aclose`d from another loop. The common paths keep exactly one store (the API's single loop, disposed at shutdown; the worker's usual subprocess-per-flow), so the leak is at-most-one-behind and only in the rare two-loops-in-one-process case — far cheaper than handing a live loop a dead one's connection. A per-loop **dict** was considered and rejected: it would only help a concurrent-alive-loops case this worker does not produce (subprocess-per-flow; same-loop `asyncio.create_task` fan-out) and still could not dispose a dead loop's pool.

`app/core/watchdog.py` and the per-request HTTP RAG path (`deps.get_vectorstore`) are untouched.

## Tests

A regression test runs `get_retrieval_service` on two fresh event loops and asserts two distinct stores — it **fails against the old singleton** (verified), which hands the second loop the first's store. The singleton and first-build tests move to async and stamp/reset `_loop`. `make lint` + `make test` green, coverage 100% including both arcs of the new branch (`_search.py` is in the `app/agents/**` gate).

Closes #1079
Refs #12, #948