### PR TITLE
perf(organizations): batch the vault and org listing N+1 queries

### DIFF
--- a/backend/app/repositories/organization.py
+++ b/backend/app/repositories/organization.py
@@ -83,14 +83,37 @@ async def reassign_creator(
     return org
 
 
-async def list_for_user(db: AsyncSession, user_id: UUID) -> list[Organization]:
+async def list_for_user(db: AsyncSession, user_id: UUID) -> list[tuple[Organization, str]]:
+    """Each organization the user belongs to, with the role their membership carries.
+
+    The role comes off the same membership row the join already filters on, so a
+    caller needs no second per-organization lookup to learn it (#953).
+    """
     result = await db.execute(
-        select(Organization)
+        select(Organization, OrganizationMember.role)
         .join(OrganizationMember, OrganizationMember.organization_id == Organization.id)
         .where(OrganizationMember.user_id == user_id)
         .order_by(Organization.is_personal.desc(), Organization.created_at.asc())
     )
-    return list(result.scalars().all())
+    return [(org, role) for org, role in result.all()]
+
+
+async def member_counts_for(db: AsyncSession, org_ids: list[UUID]) -> dict[UUID, int]:
+    """How many members each of the named organizations has, in one grouped query.
+
+    One read for a whole page of organizations rather than a `count(*)` per row
+    (#953). An organization absent from the result has no members; every id the
+    caller passes for a listing has at least the caller, so in practice each is
+    present.
+    """
+    if not org_ids:
+        return {}
+    result = await db.execute(
+        select(OrganizationMember.organization_id, func.count(OrganizationMember.id))
+        .where(OrganizationMember.organization_id.in_(org_ids))
+        .group_by(OrganizationMember.organization_id)
+    )
+    return dict(result.all())
 
 
 async def slug_exists(db: AsyncSession, slug: str) -> bool:

--- a/backend/app/repositories/organization_secret.py
+++ b/backend/app/repositories/organization_secret.py
@@ -9,7 +9,6 @@ from uuid import UUID
 
 from sqlalchemy import bindparam, false, or_, select, text
 from sqlalchemy import update as sql_update
-from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -199,34 +198,50 @@ async def promote_owned_private_to_org(db: AsyncSession, *, owner_user_id: UUID)
     return result.rowcount  # ty: ignore[unresolved-attribute]
 
 
-async def agents_using(
-    db: AsyncSession, *, organization_id: UUID, secret_id: UUID
-) -> list[tuple[UUID, str]]:
-    """Agents whose draft spec binds this secret to a capability.
+async def agents_using_for_secrets(
+    db: AsyncSession, *, organization_id: UUID, secret_ids: list[UUID]
+) -> dict[UUID, list[tuple[UUID, str]]]:
+    """For each secret, the agents whose draft spec binds it - in one query.
 
-    A JSONB containment check rather than a column, because a binding lives
-    inside the spec - which is the right place for it: the spec is what gets
-    versioned, exported and reviewed. The draft is queried rather than the
-    published version because the question this answers is "what breaks if I
-    delete this key", and an agent that is *about* to be published with it
-    breaks just as thoroughly.
+    The vault listing asks this of every secret on the page, so it is answered
+    in one grouped read rather than one per secret (#953). A JSONB match rather
+    than a column, because a binding lives inside the spec - which is the right
+    place for it: the spec is what gets versioned, exported and reviewed. The
+    *draft* is queried rather than the published version because "what breaks if
+    I delete this key" includes an agent about to be published with it.
+
+    Every requested id is a key in the result, mapping to its agents in name
+    order; a secret nothing binds maps to an empty list.
     """
+    usage: dict[UUID, list[tuple[UUID, str]]] = {secret_id: [] for secret_id in secret_ids}
+    if not secret_ids:
+        return usage
+    # `jsonb_array_elements` errors on anything that is not an array, so the
+    # `CASE` hands it an empty one for an agent whose spec has no `capabilities`
+    # list - the same rows the per-secret `@>` containment quietly skipped.
     query = text(
         """
-        SELECT id, name FROM agents
-        WHERE organization_id = :organization_id
-          AND draft_spec -> 'capabilities' @> :binding
-        ORDER BY name
+        SELECT DISTINCT a.id, a.name, cap ->> 'secret_id' AS secret_id
+        FROM agents a
+        CROSS JOIN LATERAL jsonb_array_elements(
+            CASE
+                WHEN jsonb_typeof(a.draft_spec -> 'capabilities') = 'array'
+                THEN a.draft_spec -> 'capabilities'
+                ELSE '[]'::jsonb
+            END
+        ) AS cap
+        WHERE a.organization_id = :organization_id
+          AND cap ->> 'secret_id' IN :secret_ids
+        ORDER BY a.name
         """
     ).bindparams(
         bindparam("organization_id", type_=PG_UUID(as_uuid=True)),
-        bindparam("binding", type_=JSONB),
+        bindparam("secret_ids", expanding=True),
     )
     result = await db.execute(
         query,
-        {
-            "organization_id": organization_id,
-            "binding": [{"secret_id": str(secret_id)}],
-        },
+        {"organization_id": organization_id, "secret_ids": [str(s) for s in secret_ids]},
     )
-    return [(row[0], row[1]) for row in result.all()]
+    for agent_id, name, secret_id in result.all():
+        usage[UUID(secret_id)].append((agent_id, name))
+    return usage

--- a/backend/app/services/organization.py
+++ b/backend/app/services/organization.py
@@ -105,19 +105,14 @@ class OrganizationService:
         return OrganizationList(items=items, total=len(items))
 
     async def list_for_user(self, user_id: UUID) -> list[dict]:
-        orgs = await organization_repo.list_for_user(self.db, user_id)
-        result = []
-        for org in orgs:
-            membership = await member_repo.get(self.db, organization_id=org.id, user_id=user_id)
-            count = await organization_repo.count_members(self.db, org.id)
-            result.append(
-                {
-                    "org": org,
-                    "role": membership.role if membership else OrgRole.MEMBER.value,
-                    "member_count": count,
-                }
-            )
-        return result
+        # Role and member count in two grouped queries, not two per organization:
+        # the role rides the membership join the listing already makes, and the
+        # counts come back keyed by organization (#953).
+        pairs = await organization_repo.list_for_user(self.db, user_id)
+        counts = await organization_repo.member_counts_for(self.db, [org.id for org, _ in pairs])
+        return [
+            {"org": org, "role": role, "member_count": counts.get(org.id, 0)} for org, role in pairs
+        ]
 
     async def create(self, data: OrganizationCreate, owner_id: UUID) -> Organization:
         """Create a new team organization (non-personal).

--- a/backend/app/services/organization_secret.py
+++ b/backend/app/services/organization_secret.py
@@ -88,9 +88,9 @@ class OrganizationSecretService:
         a key nothing binds is one nobody can account for, and a key whose owner
         has left is one nobody will rotate.
 
-        Two extra queries for the page, not two per row: emails resolve in one
-        lookup and usage in one per secret, which is bounded by how many secrets
-        an organization has - tens, not thousands.
+        Three extra queries for the page, not three per row: the emails, the
+        grant counts and the agent usage each resolve in one grouped lookup,
+        however many secrets the organization has.
         """
         # `None` is the role already reaching every key; anything else is the
         # extra ids a grant opened up. One call answers both, so the scope is
@@ -127,15 +127,20 @@ class OrganizationSecretService:
             resource_type=SECRET.key,
             resource_ids=[secret.id for secret in secrets],
         )
+        # Which agents bind each key, in one grouped query rather than one per
+        # row: a thirty-secret vault loaded its page in thirty-one queries (#953).
+        usage = await organization_secret_repo.agents_using_for_secrets(
+            self.db,
+            organization_id=ctx.organization_id,
+            secret_ids=[secret.id for secret in secrets],
+        )
         rows: list[SecretRead] = []
         for secret in secrets:
             owner = people.get(secret.owner_user_id) if secret.owner_user_id else None
             author = people.get(secret.created_by_user_id) if secret.created_by_user_id else None
             owner = owner or member_repo.MemberIdentity(email=None, avatar_url=None)
             author = author or member_repo.MemberIdentity(email=None, avatar_url=None)
-            used = await organization_secret_repo.agents_using(
-                self.db, organization_id=ctx.organization_id, secret_id=secret.id
-            )
+            used = usage.get(secret.id, [])
             rows.append(
                 SecretRead(
                     id=secret.id,

--- a/backend/tests/integration/test_org_listing_batch.py
+++ b/backend/tests/integration/test_org_listing_batch.py
@@ -1,0 +1,81 @@
+"""The organization listing's role and member counts, in grouped queries (#953).
+
+`list_for_user` returns each organization with the role off the same membership
+row it joins on, and `member_counts_for` counts a whole page of organizations in
+one grouped read - both replacing a query per row. Only a real database shows
+the join carries the role and the `GROUP BY` keys the counts correctly.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+
+from app.db.models.organization import Organization, OrganizationMember, OrgRole
+from app.db.models.user import User
+from app.repositories import organization as organization_repo
+
+pytestmark = pytest.mark.anyio
+
+
+async def _user(db: Any) -> User:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"{uuid.uuid4().hex}@example.com",
+        hashed_password="x",
+        is_active=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _org(db: Any, creator: User, *, name: str, is_personal: bool = False) -> Organization:
+    org = Organization(
+        id=uuid.uuid4(),
+        name=name,
+        slug=f"{name.lower()}-{uuid.uuid4().hex[:8]}",
+        is_personal=is_personal,
+        created_by_user_id=creator.id,
+    )
+    db.add(org)
+    await db.flush()
+    return org
+
+
+async def _member(db: Any, org: Organization, user: User, role: str) -> None:
+    db.add(OrganizationMember(id=uuid.uuid4(), organization_id=org.id, user_id=user.id, role=role))
+    await db.flush()
+
+
+async def test_list_for_user_carries_the_membership_role(db: Any) -> None:
+    user = await _user(db)
+    owned = await _org(db, user, name="Owned")
+    joined_creator = await _user(db)
+    joined = await _org(db, joined_creator, name="Joined")
+    await _member(db, owned, user, OrgRole.OWNER.value)
+    await _member(db, joined, user, OrgRole.MEMBER.value)
+
+    pairs = await organization_repo.list_for_user(db, user.id)
+
+    by_name = {org.name: role for org, role in pairs}
+    assert by_name == {"Owned": OrgRole.OWNER.value, "Joined": OrgRole.MEMBER.value}
+
+
+async def test_member_counts_for_groups_by_organization(db: Any) -> None:
+    founder = await _user(db)
+    big = await _org(db, founder, name="Big")
+    small = await _org(db, founder, name="Small")
+    await _member(db, big, founder, OrgRole.OWNER.value)
+    await _member(db, big, await _user(db), OrgRole.MEMBER.value)
+    await _member(db, small, founder, OrgRole.OWNER.value)
+
+    counts = await organization_repo.member_counts_for(db, [big.id, small.id])
+
+    assert counts == {big.id: 2, small.id: 1}
+
+
+async def test_member_counts_for_no_ids_asks_nothing(db: Any) -> None:
+    assert await organization_repo.member_counts_for(db, []) == {}

--- a/backend/tests/integration/test_vault_usage_batch.py
+++ b/backend/tests/integration/test_vault_usage_batch.py
@@ -1,0 +1,135 @@
+"""Which agents bind each secret, resolved for a whole page in one query (#953).
+
+The vault listing used to ask this once per secret. Batched, it is one grouped
+JSONB read - which only a real database exercises: the query unnests each agent's
+draft-spec capabilities and matches the bound `secret_id`, and the guard that
+keeps `jsonb_array_elements` off a spec whose `capabilities` is not an array is
+exactly the kind of thing a mock cannot show.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+
+from app.db.models.agent import Agent
+from app.db.models.organization import Organization
+from app.db.models.user import User
+from app.repositories import organization_secret as organization_secret_repo
+
+pytestmark = pytest.mark.anyio
+
+
+async def _org(db: Any) -> Organization:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"{uuid.uuid4().hex}@example.com",
+        hashed_password="x",
+        is_active=True,
+    )
+    db.add(user)
+    await db.flush()
+    org = Organization(
+        id=uuid.uuid4(),
+        name="Acme",
+        slug=f"acme-{uuid.uuid4().hex[:8]}",
+        created_by_user_id=user.id,
+    )
+    db.add(org)
+    await db.flush()
+    return org
+
+
+async def _agent(db: Any, org: Organization, *, name: str, capabilities: Any) -> Agent:
+    agent = Agent(
+        id=uuid.uuid4(),
+        organization_id=org.id,
+        slug=f"{name.lower()}-{uuid.uuid4().hex[:8]}",
+        name=name,
+        draft_spec={"capabilities": capabilities} if capabilities is not None else {},
+    )
+    db.add(agent)
+    await db.flush()
+    return agent
+
+
+def _binds(*secret_ids: uuid.UUID) -> list[dict[str, str]]:
+    return [{"key": "knowledge", "secret_id": str(s)} for s in secret_ids]
+
+
+async def test_it_groups_agents_by_the_secret_their_draft_binds(db: Any) -> None:
+    org = await _org(db)
+    s1, s2, s3 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    beta = await _agent(db, org, name="Beta", capabilities=_binds(s1, s2))
+    alfa = await _agent(db, org, name="Alfa", capabilities=_binds(s1))
+
+    usage = await organization_secret_repo.agents_using_for_secrets(
+        db, organization_id=org.id, secret_ids=[s1, s2, s3]
+    )
+
+    # Name order, and every requested id is a key - one nothing binds included.
+    assert usage[s1] == [(alfa.id, "Alfa"), (beta.id, "Beta")]
+    assert usage[s2] == [(beta.id, "Beta")]
+    assert usage[s3] == []
+
+
+async def test_an_agent_in_another_organization_is_not_counted(db: Any) -> None:
+    org = await _org(db)
+    other = await _org(db)
+    secret = uuid.uuid4()
+    mine = await _agent(db, org, name="Mine", capabilities=_binds(secret))
+    await _agent(db, other, name="Theirs", capabilities=_binds(secret))
+
+    usage = await organization_secret_repo.agents_using_for_secrets(
+        db, organization_id=org.id, secret_ids=[secret]
+    )
+
+    assert usage[secret] == [(mine.id, "Mine")]
+
+
+async def test_a_spec_whose_capabilities_are_not_a_list_is_skipped(db: Any) -> None:
+    """`jsonb_array_elements` errors on a non-array; the query's `CASE` guard
+    hands it an empty one instead, so these agents are simply absent."""
+    org = await _org(db)
+    secret = uuid.uuid4()
+    binder = await _agent(db, org, name="Binder", capabilities=_binds(secret))
+    await _agent(db, org, name="NoCapsKey", capabilities=None)
+    await _agent(db, org, name="CapsNotAList", capabilities={"not": "a list"})
+
+    usage = await organization_secret_repo.agents_using_for_secrets(
+        db, organization_id=org.id, secret_ids=[secret]
+    )
+
+    assert usage[secret] == [(binder.id, "Binder")]
+
+
+async def test_the_same_secret_bound_twice_counts_the_agent_once(db: Any) -> None:
+    org = await _org(db)
+    secret = uuid.uuid4()
+    agent = await _agent(
+        db,
+        org,
+        name="Twice",
+        capabilities=[
+            {"key": "knowledge", "secret_id": str(secret)},
+            {"key": "mcp", "secret_id": str(secret)},
+        ],
+    )
+
+    usage = await organization_secret_repo.agents_using_for_secrets(
+        db, organization_id=org.id, secret_ids=[secret]
+    )
+
+    assert usage[secret] == [(agent.id, "Twice")]
+
+
+async def test_no_secret_ids_asks_nothing(db: Any) -> None:
+    org = await _org(db)
+    assert (
+        await organization_secret_repo.agents_using_for_secrets(
+            db, organization_id=org.id, secret_ids=[]
+        )
+        == {}
+    )

--- a/backend/tests/test_secrets.py
+++ b/backend/tests/test_secrets.py
@@ -335,8 +335,8 @@ class TestStoringASecret:
                 new=AsyncMock(return_value={}),
             ),
             patch(
-                "app.services.organization_secret.organization_secret_repo.agents_using",
-                new=AsyncMock(return_value=[]),
+                "app.services.organization_secret.organization_secret_repo.agents_using_for_secrets",
+                new=AsyncMock(return_value={}),
             ),
         ):
             rows = await OrganizationSecretService(_db()).list_secrets(ctx)

--- a/backend/tests/test_services_organizations.py
+++ b/backend/tests/test_services_organizations.py
@@ -638,6 +638,40 @@ class TestOrganizationResponses:
         assert listing.items == []
         assert listing.total == 0
 
+    @pytest.mark.anyio
+    async def test_the_listing_takes_the_role_and_the_count_in_grouped_queries(self, service):
+        """#953: the role rides the membership join the listing already makes,
+        and the sizes come back keyed by organization - so neither is a query
+        per row. The old per-organization `member_repo.get` and `count_members`
+        are gone."""
+        first, second = _org_row(name="Vstorm"), _org_row(name="Personal")
+        with (
+            patch(
+                "app.services.organization.organization_repo.list_for_user",
+                new=AsyncMock(
+                    return_value=[
+                        (first, OrgRole.MEMBER.value),
+                        (second, OrgRole.OWNER.value),
+                    ]
+                ),
+            ),
+            patch(
+                "app.services.organization.organization_repo.member_counts_for",
+                new=AsyncMock(return_value={first.id: 12, second.id: 1}),
+            ) as counts,
+            patch("app.services.organization.member_repo.get", new=AsyncMock()) as member_get,
+            patch(
+                "app.services.organization.organization_repo.count_members", new=AsyncMock()
+            ) as count_members,
+        ):
+            rows = await service.list_for_user(uuid.uuid4())
+
+        assert [row["role"] for row in rows] == [OrgRole.MEMBER.value, OrgRole.OWNER.value]
+        assert [row["member_count"] for row in rows] == [12, 1]
+        counts.assert_awaited_once()
+        member_get.assert_not_awaited()
+        count_members.assert_not_awaited()
+
 
 class TestUserServiceRegistrationWithOrg:
     """Tests that UserService.register creates a Personal Org."""


### PR DESCRIPTION
## What

Two list endpoints ran a query per row where the code beside them already batched (#953).

**Vault listing.** It resolved emails and grant counts in one grouped query each, then asked which agents bind each secret **one secret at a time** — a thirty-secret vault loaded in thirty-one queries. `agents_using_for_secrets` answers the whole page in one: it unnests each agent's draft-spec capabilities and matches the bound `secret_id` against the requested set, grouped back per secret in Python. Semantically the same as the per-secret `@>` containment it replaces — a `CASE` guards `jsonb_array_elements` off a spec whose `capabilities` is not an array (the rows the old containment skipped) — and it keeps the tenant scope and name ordering.

**Organization listing.** `list_for_user` ran two queries per org: one to re-read the caller's membership for its role, one to count members. The role now rides the membership join the listing already makes, and `member_counts_for` counts a whole page in one grouped read. The per-row `member_repo.get` (redundant — the org came from that very join) and `count_members` are gone from the listing; `count_members` stays for the single-org read.

## Tests

Real-Postgres integration tests pin the batched SQL — grouping by secret, the non-array guard, dedup, tenant isolation, the role-carrying join, the grouped counts. A service test asserts the listing no longer makes a per-row `member_repo.get`/`count_members` call. `make lint` + `make test` green, coverage 100% including the gated `agents_using_for_secrets`.

Closes #953