### PR TITLE
fix(channels): upsert the identity on a /link confirm

### DIFF
--- a/backend/app/repositories/channel_link_request.py
+++ b/backend/app/repositories/channel_link_request.py
@@ -84,7 +84,13 @@ async def delete_for_identity(db: AsyncSession, *, platform: str, platform_user_
     await db.flush()
 
 
-async def delete_by_id(db: AsyncSession, request_id: UUID) -> None:
-    """Drop one request by id, once it has been confirmed."""
-    await db.execute(delete(ChannelLinkRequest).where(ChannelLinkRequest.id == request_id))
+async def delete_by_id(db: AsyncSession, request_id: UUID) -> bool:
+    """Consume one request by id, returning whether this call claimed it.
+
+    A `/link` token is single-use. The DELETE row-locks, so when two confirms
+    race the same token only the first deletes a row (True); the second waits,
+    finds it gone, and gets False - the loser must not relink the identity (#1132).
+    """
+    result = await db.execute(delete(ChannelLinkRequest).where(ChannelLinkRequest.id == request_id))
     await db.flush()
+    return (result.rowcount or 0) > 0  # ty: ignore[unresolved-attribute]

--- a/backend/app/services/channel_link.py
+++ b/backend/app/services/channel_link.py
@@ -135,21 +135,18 @@ class ChannelLinkService:
         if request is None:
             return None
 
-        identity = await channel_identity_repo.get_by_platform_user(
+        # get_or_create, not get-then-create: a concurrent inbound message could
+        # otherwise collide on the identity's unique key and 500 the confirm (#1113).
+        # The upsert leaves an existing user_id alone, so the link is the update below.
+        identity = await channel_identity_repo.get_or_create(
             self.db,
             platform=request.platform,
             platform_user_id=request.platform_user_id,
+            platform_username=request.platform_username,
+            platform_display_name=request.platform_display_name,
+            user_id=user_id,
         )
-        if identity is None:
-            await channel_identity_repo.create(
-                self.db,
-                platform=request.platform,
-                platform_user_id=request.platform_user_id,
-                platform_username=request.platform_username,
-                platform_display_name=request.platform_display_name,
-                user_id=user_id,
-            )
-        else:
+        if identity.user_id != user_id:
             await channel_identity_repo.update(
                 self.db, db_identity=identity, update_data={"user_id": user_id}
             )

--- a/backend/app/services/channel_link.py
+++ b/backend/app/services/channel_link.py
@@ -135,6 +135,13 @@ class ChannelLinkService:
         if request is None:
             return None
 
+        # Claim the single-use request before relinking. Two authenticated users
+        # confirming the same token both read it as valid, so consuming it first
+        # lets only the one whose DELETE claims the row proceed - the loser stops
+        # here rather than overwriting the winner's link (#1132).
+        if not await channel_link_request_repo.delete_by_id(self.db, request.id):
+            return None
+
         # get_or_create, not get-then-create: a concurrent inbound message could
         # otherwise collide on the identity's unique key and 500 the confirm (#1113).
         # The upsert leaves an existing user_id alone, so the link is the update below.
@@ -151,7 +158,6 @@ class ChannelLinkService:
                 self.db, db_identity=identity, update_data={"user_id": user_id}
             )
 
-        await channel_link_request_repo.delete_by_id(self.db, request.id)
         return request
 
     async def linked(self, user_id: UUID) -> list[ChannelIdentity]:

--- a/backend/tests/integration/test_channel_link_confirm_race.py
+++ b/backend/tests/integration/test_channel_link_confirm_race.py
@@ -111,3 +111,69 @@ async def test_a_confirm_racing_an_inbound_message_still_links_one_identity(
         )
         assert identity is not None
         assert identity.user_id == user_id  # the confirm's link landed
+
+
+async def test_two_confirms_of_one_token_leave_a_single_claimant(
+    engine: AsyncEngine,
+) -> None:
+    """A /link token is a single-use bearer credential. Two authenticated users
+    confirming it at once both read it as valid; consuming the request before
+    relinking lets only one win, so the token cannot be replayed to overwrite the
+    first claimant's link (#1132).
+    """
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    platform = "slack"
+    platform_user_id = uuid.uuid4().hex
+
+    async with factory() as setup:
+        user_a = User(
+            id=uuid.uuid4(),
+            email=f"{uuid.uuid4().hex}@example.com",
+            hashed_password="x",
+            is_active=True,
+        )
+        user_b = User(
+            id=uuid.uuid4(),
+            email=f"{uuid.uuid4().hex}@example.com",
+            hashed_password="x",
+            is_active=True,
+        )
+        setup.add_all([user_a, user_b])
+        await channel_link_request_repo.create(
+            setup,
+            token="tok-double",
+            platform=platform,
+            platform_user_id=platform_user_id,
+            platform_username=None,
+            platform_display_name=None,
+            expires_at=datetime.now(UTC) + timedelta(minutes=5),
+        )
+        await setup.commit()
+        a_id, b_id = user_a.id, user_b.id
+
+    async def confirm_as(user_id: uuid.UUID) -> object:
+        async with factory() as session:
+            spent = await ChannelLinkService(session).confirm("tok-double", user_id)
+            await session.commit()
+            return spent
+
+    results = await asyncio.gather(confirm_as(a_id), confirm_as(b_id))
+
+    # Exactly one confirm claimed the token; the other found it already spent.
+    assert sorted(r is None for r in results) == [False, True]
+
+    async with factory() as session:
+        identities = (
+            (
+                await session.execute(
+                    select(ChannelIdentity).where(
+                        ChannelIdentity.platform == platform,
+                        ChannelIdentity.platform_user_id == platform_user_id,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(identities) == 1  # one identity, linked to whichever confirm won
+        assert identities[0].user_id in {a_id, b_id}

--- a/backend/tests/integration/test_channel_link_confirm_race.py
+++ b/backend/tests/integration/test_channel_link_confirm_race.py
@@ -1,0 +1,113 @@
+"""A /link confirm racing a concurrent inbound message links one identity.
+
+`ChannelLinkService.confirm` used to get-then-create the identity - the same
+unlocked check-then-act #17 closed in the router. A user who sends a message (the
+router's own INSERT) at the moment they click the confirm could make confirm's
+INSERT collide on `uq_channel_identity_platform_user` and 500 the confirm
+(#1113). Routing confirm through `get_or_create` (SELECT-first, ON CONFLICT DO
+NOTHING) closes it, and only the database can show it, because what makes it work
+is the unique index across two transactions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
+
+from app.db.models.channel_identity import ChannelIdentity
+from app.db.models.user import User
+from app.repositories import channel_identity_repo, channel_link_request_repo
+from app.services.channel_link import ChannelLinkService
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_a_confirm_racing_an_inbound_message_still_links_one_identity(
+    engine: AsyncEngine,
+) -> None:
+    """One webhook's identity insert is held open (uncommitted, the unique-index
+    lock on the new row) while a /link confirm resolves the same platform user.
+
+    The confirm's `get_or_create` blocks on that lock and, once the inbound
+    commits, resolves the row it lost to and links it - one identity, no error,
+    the confirm's user_id landing on it. The get-then-create it replaces would
+    instead have the confirm's own INSERT unblock into a
+    `uq_channel_identity_platform_user` violation and 500 the confirm.
+    """
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    platform = "slack"
+    platform_user_id = uuid.uuid4().hex
+
+    async with factory() as setup:
+        user = User(
+            id=uuid.uuid4(),
+            email=f"{uuid.uuid4().hex}@example.com",
+            hashed_password="x",
+            is_active=True,
+        )
+        setup.add(user)
+        await channel_link_request_repo.create(
+            setup,
+            token="tok-race",
+            platform=platform,
+            platform_user_id=platform_user_id,
+            platform_username=None,
+            platform_display_name=None,
+            expires_at=datetime.now(UTC) + timedelta(minutes=5),
+        )
+        await setup.commit()
+        user_id = user.id
+
+    session_a = factory()
+    confirm_task: asyncio.Task[object] | None = None
+    try:
+        # The inbound message's transaction resolves (creates) the identity and
+        # holds it open: the unique-index lock on the new row, uncommitted.
+        await channel_identity_repo.get_or_create(
+            session_a, platform=platform, platform_user_id=platform_user_id, user_id=None
+        )
+
+        async def confirm() -> object:
+            async with factory() as session_b:
+                spent = await ChannelLinkService(session_b).confirm("tok-race", user_id)
+                await session_b.commit()
+                return spent
+
+        confirm_task = asyncio.create_task(confirm())
+        await asyncio.sleep(0.4)
+        assert not confirm_task.done()  # blocked on A's uncommitted insert
+
+        await session_a.commit()
+
+        spent = await confirm_task
+        confirm_task = None
+        assert spent is not None  # the confirm succeeded rather than 500ing
+    finally:
+        if confirm_task is not None:
+            confirm_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await confirm_task
+        await session_a.close()
+
+    async with factory() as session:
+        count = await session.scalar(
+            select(func.count())
+            .select_from(ChannelIdentity)
+            .where(
+                ChannelIdentity.platform == platform,
+                ChannelIdentity.platform_user_id == platform_user_id,
+            )
+        )
+        assert count == 1  # exactly one identity, not two
+
+        identity = await channel_identity_repo.get_by_platform_user(
+            session, platform=platform, platform_user_id=platform_user_id
+        )
+        assert identity is not None
+        assert identity.user_id == user_id  # the confirm's link landed

--- a/backend/tests/test_channel_link_requests.py
+++ b/backend/tests/test_channel_link_requests.py
@@ -194,19 +194,16 @@ class TestRequesting:
 
 
 class TestConfirming:
-    async def _confirm(self, found: MagicMock | None, identity: MagicMock | None) -> object:
+    async def _confirm(self, found: MagicMock | None, resolved: MagicMock | None) -> object:
         with (
             patch(
                 "app.services.channel_link.channel_link_request_repo.get_valid",
                 new=AsyncMock(return_value=found),
             ),
             patch(
-                "app.services.channel_link.channel_identity_repo.get_by_platform_user",
-                new=AsyncMock(return_value=identity),
-            ),
-            patch(
-                "app.services.channel_link.channel_identity_repo.create", new=AsyncMock()
-            ) as created,
+                "app.services.channel_link.channel_identity_repo.get_or_create",
+                new=AsyncMock(return_value=resolved),
+            ) as resolved_call,
             patch(
                 "app.services.channel_link.channel_identity_repo.update", new=AsyncMock()
             ) as updated,
@@ -216,31 +213,41 @@ class TestConfirming:
             ) as spent,
         ):
             result = await ChannelLinkService(MagicMock()).confirm("tok", self.user_id)
-        self.created, self.updated, self.spent = created, updated, spent
+        self.resolved, self.updated, self.spent = resolved_call, updated, spent
         return result
 
     def setup_method(self) -> None:
         self.user_id = uuid.uuid4()
 
-    async def test_the_chat_account_already_seen_gains_its_person(self):
-        """The common path: they messaged the bot, were refused, and are now
-        clicking the link that refusal carried - so the row is already there."""
-        assert await self._confirm(_request(), MagicMock()) is not None
+    async def test_confirm_resolves_through_the_upsert_not_get_then_create(self):
+        """The whole of #1113: the identity is resolved with the same SELECT-first
+        `get_or_create` the router uses, so a confirm racing an inbound message
+        cannot collide on the identity's unique key and 500."""
+        await self._confirm(_request(), MagicMock(user_id=None))
+        self.resolved.assert_awaited_once()
+
+    async def test_a_chat_account_linked_to_no_one_gains_its_person(self):
+        """The row the upsert returns carries no user_id - a fresh insert the
+        router won, or a never-linked one - so linking it is an explicit update."""
+        assert await self._confirm(_request(), MagicMock(user_id=None)) is not None
         assert self.updated.call_args.kwargs["update_data"] == {"user_id": self.user_id}
 
-    async def test_an_unseen_chat_account_is_created_already_linked(self):
-        assert await self._confirm(_request(), None) is not None
-        assert self.created.call_args.kwargs["user_id"] == self.user_id
+    async def test_the_row_the_confirm_itself_inserted_is_not_rewritten(self):
+        """On the miss, `get_or_create` inserts already carrying this user_id, so
+        there is nothing left to update."""
+        assert await self._confirm(_request(), MagicMock(user_id=self.user_id)) is not None
+        assert self.resolved.call_args.kwargs["user_id"] == self.user_id
+        assert self.updated.call_count == 0
 
     async def test_a_link_is_spent_once(self):
-        await self._confirm(_request(), MagicMock())
+        await self._confirm(_request(), MagicMock(user_id=None))
         assert self.spent.call_count == 1
 
     async def test_a_token_that_does_not_resolve_links_nothing(self):
         """Unknown and expired answer the same way: the difference is not
         something the person clicking can act on differently."""
         assert await self._confirm(None, MagicMock()) is None
-        assert self.created.call_count == 0
+        assert self.resolved.call_count == 0
         assert self.updated.call_count == 0
         assert self.spent.call_count == 0
 

--- a/backend/tests/test_channel_link_requests.py
+++ b/backend/tests/test_channel_link_requests.py
@@ -194,7 +194,9 @@ class TestRequesting:
 
 
 class TestConfirming:
-    async def _confirm(self, found: MagicMock | None, resolved: MagicMock | None) -> object:
+    async def _confirm(
+        self, found: MagicMock | None, resolved: MagicMock | None, *, claimed: bool = True
+    ) -> object:
         with (
             patch(
                 "app.services.channel_link.channel_link_request_repo.get_valid",
@@ -209,7 +211,7 @@ class TestConfirming:
             ) as updated,
             patch(
                 "app.services.channel_link.channel_link_request_repo.delete_by_id",
-                new=AsyncMock(),
+                new=AsyncMock(return_value=claimed),
             ) as spent,
         ):
             result = await ChannelLinkService(MagicMock()).confirm("tok", self.user_id)
@@ -250,6 +252,14 @@ class TestConfirming:
         assert self.resolved.call_count == 0
         assert self.updated.call_count == 0
         assert self.spent.call_count == 0
+
+    async def test_a_second_confirm_of_the_same_token_links_nothing(self):
+        """The token is single-use: a confirm whose claim of the request loses the
+        race - its DELETE removes no row - must not go on to relink the identity
+        and overwrite the winner's link (#1132)."""
+        assert await self._confirm(_request(), MagicMock(user_id=None), claimed=False) is None
+        assert self.resolved.call_count == 0
+        assert self.updated.call_count == 0
 
 
 class TestWhatTheBotSaysToAStranger:


### PR DESCRIPTION
## Summary

`ChannelLinkService.confirm` did an unguarded get-then-create on `(platform, platform_user_id)` — the same check-then-act #17 closes in the router's identity resolution. A user who sends a message (the router's own INSERT) at the moment they click a `/link` confirm could make confirm's INSERT collide on `uq_channel_identity_platform_user` and 500 the confirm.

## Changed

- `confirm` now resolves the identity through `channel_identity_repo.get_or_create` (SELECT-first, `INSERT ... ON CONFLICT DO NOTHING`, re-SELECT) instead of get-then-create. The upsert deliberately leaves an existing row's `user_id` untouched, so linking it to the confirming user is an explicit `update` after it — skipped on the miss path, where the row was just inserted already carrying this `user_id`.

## Testing

- **Integration** (`test_channel_link_confirm_race.py`): a held inbound-message INSERT is raced against a `/link` confirm for the same platform user; both succeed, exactly one identity row survives, and the confirm's `user_id` lands. Fails without the fix with an `IntegrityError`.
- **Unit** (`TestConfirming`): now asserts confirm routes through the upsert and relinks only when the resolved row does not already carry this user (fails against the old get-then-create).

## Notes for reviewers

Stacked on `fix/17-check-then-act-row-locks`, because it uses the `get_or_create` that PR adds. Retarget to `main` once #17 (#1114) merges.

Closes #1113