### PR TITLE
fix(concurrency): row-lock the reconcile before an org or user delete

### DIFF
--- a/backend/app/repositories/user.py
+++ b/backend/app/repositories/user.py
@@ -17,6 +17,12 @@ async def get_by_id(db: AsyncSession, user_id: UUID) -> User | None:
     return await db.get(User, user_id)
 
 
+async def get_by_id_for_update(db: AsyncSession, user_id: UUID) -> User | None:
+    """Fetch a user row and acquire a SELECT FOR UPDATE lock."""
+    result = await db.execute(select(User).where(User.id == user_id).with_for_update())
+    return result.scalar_one_or_none()
+
+
 async def get_by_email(db: AsyncSession, email: str) -> User | None:
     """Get user by email."""
     result = await db.execute(select(User).where(User.email == email))

--- a/backend/app/services/organization.py
+++ b/backend/app/services/organization.py
@@ -318,7 +318,15 @@ class OrganizationService:
         `ON DELETE SET NULL`, and nulling an org-scoped row violates
         `ck_knowledge_bases_org_scope_has_org` (#9). Personal collections that
         merely carry this org's id are left to the `SET NULL`.
+
+        FOR UPDATE first: listing the collections and then deleting the org is
+        check-then-act, so an org-scoped collection inserted concurrently (it
+        takes FOR KEY SHARE on this row) would slip in between the list and the
+        DELETE, be nulled by the `SET NULL`, and violate the same CHECK. The lock
+        makes that insert wait, so the list sees every collection there is - a
+        fresh read under READ COMMITTED (#1115).
         """
+        await organization_repo.get_by_id_for_update(self.db, org.id)
         for kb in await knowledge_base_repo.list_org_scoped(self.db, org.id):
             if self._vector_store is not None:
                 # Best-effort, and only against the database: a zero-document

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -308,7 +308,13 @@ class UserService:
         return str(full_path) if full_path is not None else None
 
     async def delete(self, user_id: UUID) -> User:
-        user = await user_repo.get_by_id(self.db, user_id)
+        # FOR UPDATE before the reconcile: releasing the rows that would block the
+        # delete and then deleting is check-then-act, so a private secret or
+        # personal org inserted concurrently (both take FOR KEY SHARE on this row)
+        # would land a fresh CHECK/RESTRICT blocker between the reconcile and the
+        # DELETE and 500 it. The lock makes that insert wait, so the reconcile
+        # sees every child there is - a fresh read under READ COMMITTED (#1115).
+        user = await user_repo.get_by_id_for_update(self.db, user_id)
         if not user:
             raise NotFoundError(
                 message="User not found",

--- a/backend/tests/integration/test_deletion_reconciliation.py
+++ b/backend/tests/integration/test_deletion_reconciliation.py
@@ -12,6 +12,8 @@ to neighbouring rows when one is deleted, which a mock cannot show.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import uuid
 from unittest.mock import MagicMock
 
@@ -259,3 +261,126 @@ class TestDeletingAnOrg:
                 assert surviving.organization_id is None
         finally:
             await store.aclose()
+
+
+class TestConcurrentInsertsDuringDeletion:
+    """The reconcile is check-then-act; a row inserted between the two would 500.
+
+    #9 reconciled the FK/CHECK cascades in the service, but listing (or promoting)
+    and then deleting is a check-then-act with no row lock, so a concurrent insert
+    reopens the exact 500 #9 closed. The teardown now takes FOR UPDATE on the row
+    it is about, so a concurrent insert - which takes FOR KEY SHARE on the same
+    row through its own FK - waits, and the reconcile sees every child there is
+    (#1115). Deterministic on purpose: the insert is held open (uncommitted) so
+    the delete blocks on the lock rather than racing it.
+    """
+
+    async def test_an_org_scoped_collection_inserted_during_an_org_delete(
+        self, engine: AsyncEngine
+    ) -> None:
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        async with factory() as setup:
+            user = _user()
+            setup.add(user)
+            await setup.flush()
+            org = await _org(setup, user)
+            await setup.commit()
+            org_id = org.id
+
+        session_a = factory()
+        delete_task: asyncio.Task[None] | None = None
+        try:
+            # A member inserts a new org-scoped collection and holds it open:
+            # FOR KEY SHARE on the org row, uncommitted.
+            session_a.add(_org_collection(org_id, f"kbrace{uuid.uuid4().hex[:12]}"))
+            await session_a.flush()
+
+            async def purge_org() -> None:
+                async with factory() as session_b:
+                    org = await session_b.get(Organization, org_id)
+                    await OrganizationService(session_b).purge(org)
+                    await session_b.commit()
+
+            delete_task = asyncio.create_task(purge_org())
+            await asyncio.sleep(0.4)
+            assert not delete_task.done()  # A's uncommitted insert holds the delete off
+
+            await session_a.commit()
+
+            await delete_task  # succeeds rather than a ck_knowledge_bases_org_scope_has_org 500
+            delete_task = None
+        finally:
+            if delete_task is not None:
+                delete_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await delete_task
+            await session_a.close()
+
+        async with factory() as s:
+            assert await s.get(Organization, org_id) is None
+            remaining = await s.execute(
+                select(KnowledgeBase).where(KnowledgeBase.organization_id == org_id)
+            )
+            assert remaining.scalars().all() == []  # the raced-in collection went too
+
+    async def test_a_private_secret_inserted_during_a_user_delete(
+        self, engine: AsyncEngine
+    ) -> None:
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        async with factory() as setup:
+            creator = _user()
+            setup.add(creator)
+            await setup.flush()
+            org = await _org(setup, creator)
+            leaver = _user()
+            setup.add(leaver)
+            await setup.flush()
+            await _member(setup, org.id, leaver.id, "member")
+            await setup.commit()
+            org_id, leaver_id = org.id, leaver.id
+
+        session_a = factory()
+        delete_task: asyncio.Task[None] | None = None
+        try:
+            # A private secret for the leaver, held open: FOR KEY SHARE on the
+            # leaver's user row through its owner FK, uncommitted.
+            session_a.add(_private_secret(org_id, leaver_id))
+            await session_a.flush()
+
+            async def delete_leaver() -> None:
+                async with factory() as session_b:
+                    await UserService(session_b).delete(leaver_id)
+                    await session_b.commit()
+
+            delete_task = asyncio.create_task(delete_leaver())
+            await asyncio.sleep(0.4)
+            assert not delete_task.done()  # A's uncommitted insert holds the delete off
+
+            await session_a.commit()
+
+            await delete_task  # succeeds rather than a ck_secret_private_needs_owner 500
+            delete_task = None
+        finally:
+            if delete_task is not None:
+                delete_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await delete_task
+            await session_a.close()
+
+        async with factory() as s:
+            assert await s.get(User, leaver_id) is None
+            secrets = (
+                (
+                    await s.execute(
+                        select(OrganizationSecret).where(
+                            OrganizationSecret.organization_id == org_id
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assert secrets  # the raced-in secret survived, promoted rather than orphaned
+            for secret in secrets:
+                assert secret.owner_user_id is None
+                assert secret.visibility == "org"

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -290,7 +290,7 @@ class TestUserServicePostgresql:
             patch("app.services.user.user_repo") as mock_repo,
             patch.object(user_service, "_release_owned_rows", new=AsyncMock()),
         ):
-            mock_repo.get_by_id = AsyncMock(return_value=mock_user)
+            mock_repo.get_by_id_for_update = AsyncMock(return_value=mock_user)
             mock_repo.delete = AsyncMock(return_value=mock_user)
 
             result = await user_service.delete(mock_user.id)
@@ -301,7 +301,7 @@ class TestUserServicePostgresql:
     async def test_delete_not_found(self, user_service: UserService):
         """A missing user is refused up front, before any teardown is attempted."""
         with patch("app.services.user.user_repo") as mock_repo:
-            mock_repo.get_by_id = AsyncMock(return_value=None)
+            mock_repo.get_by_id_for_update = AsyncMock(return_value=None)
 
             with pytest.raises(NotFoundError):
                 await user_service.delete(uuid4())
@@ -387,7 +387,7 @@ class TestUserServicePostgresql:
             patch("app.services.user.user_repo") as mock_repo,
             patch.object(user_service, "_release_owned_rows", new=AsyncMock()),
         ):
-            mock_repo.get_by_id = AsyncMock(return_value=mock_user)
+            mock_repo.get_by_id_for_update = AsyncMock(return_value=mock_user)
             mock_repo.delete = AsyncMock(return_value=mock_user)
 
             await user_service.admin_delete(mock_user.id, acting_admin_id=uuid4())

--- a/backend/tests/test_services_organizations.py
+++ b/backend/tests/test_services_organizations.py
@@ -338,6 +338,10 @@ class TestOrganizationService:
                 service, "get_for_user", new=AsyncMock(return_value=(mock_org, mock_membership))
             ),
             patch(
+                "app.services.organization.organization_repo.get_by_id_for_update",
+                new=AsyncMock(),
+            ),
+            patch(
                 "app.services.organization.knowledge_base_repo.list_org_scoped",
                 new=AsyncMock(return_value=[]),
             ),


### PR DESCRIPTION
## Summary

#9 reconciles the FK/CHECK cascades before a delete, but reconcile-then-delete is check-then-act with no row lock, so a concurrent insert reopens the exact 500 #9 closed (#1115):

- an **org-scoped KB** inserted between `purge`'s collection list and its `DELETE organizations` is `SET NULL`-ed into a `ck_knowledge_bases_org_scope_has_org` violation;
- a **private secret / personal org** inserted between a user delete's reconcile and its `DELETE users` lands the same CHECK/RESTRICT blocker.

## Changed

- `OrganizationService.purge` and `UserService.delete` take `SELECT ... FOR UPDATE` on the row they are about **before** enumerating. A concurrent child insert takes `FOR KEY SHARE` on that parent through its FK, which `FOR UPDATE` conflicts with, so the insert waits and the reconcile sees every child (a fresh read under READ COMMITTED).
- Adds `user_repo.get_by_id_for_update`, mirroring `organization_repo.get_by_id_for_update`.

## Testing

- Two integration regression tests (`TestConcurrentInsertsDuringDeletion`) hold an uncommitted child insert open and race a delete against it — both **fail against the lock-free code** (the delete 500s on the CHECK once the insert commits) and pass with the lock.
- Affected delete unit tests retarget `get_by_id_for_update`.

## Notes for reviewers

Found and filed while reviewing: a rare deadlock when two users who co-own each other's shared orgs self-delete simultaneously → **#1134** (Postgres aborts one with a 500; pre-existing-shape, out of scope here).

Stacked on `fix/9-delete-cascade-check-reconcile`, because it builds on that reconcile. Retarget to `main` once #9 (#1112) merges.

Closes #1115