### PR TITLE
refactor(dashboard): one ratings-by-day type, unconfuse the summaries

### DIFF
--- a/frontend/src/components/dashboard/primitives/ratings-trend.impl.tsx
+++ b/frontend/src/components/dashboard/primitives/ratings-trend.impl.tsx
@@ -2,18 +2,15 @@
 
 import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 
-export interface RatingsPoint {
-  date: string;
-  likes: number;
-  dislikes: number;
-}
+import type { RatingsByDay } from "@/types/stats";
 
 /**
  * Likes/dislikes per day. A dashboard-local copy of the admin ratings chart's
  * configuration rather than an import from that route's folder - a page must
- * not become a component library by accident.
+ * not become a component library by accident. The day-point is the shared
+ * `RatingsByDay`, the one shape the summaries and this chart agree on (#559).
  */
-export function RatingsTrendImpl({ data }: { data: RatingsPoint[] }) {
+export function RatingsTrendImpl({ data }: { data: RatingsByDay[] }) {
   return (
     <ResponsiveContainer width="100%" height="100%">
       <BarChart data={data} margin={{ top: 4, right: 4, bottom: 0, left: 0 }} barGap={2}>

--- a/frontend/src/components/dashboard/primitives/ratings-trend.tsx
+++ b/frontend/src/components/dashboard/primitives/ratings-trend.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from "next-intl";
 
 import { CHART_MIN_HEIGHT } from "@/lib/dashboard/system";
 import { cn } from "@/lib/utils";
-import type { RatingsPoint } from "./ratings-trend.impl";
+import type { RatingsByDay } from "@/types/stats";
 
 const RatingsTrendImpl = dynamic(
   () => import("./ratings-trend.impl").then((m) => m.RatingsTrendImpl),
@@ -26,7 +26,7 @@ export function RatingsTrend({
 }: {
   positivePercent: number;
   subline: string;
-  data: RatingsPoint[];
+  data: RatingsByDay[];
 }) {
   const t = useTranslations("dashboard");
   return (
@@ -65,5 +65,3 @@ export function RatingsTrend({
     </div>
   );
 }
-
-export type { RatingsPoint };

--- a/frontend/src/hooks/use-dashboard-data.ts
+++ b/frontend/src/hooks/use-dashboard-data.ts
@@ -8,7 +8,7 @@ import { listSyncSources } from "@/lib/rag-api";
 import { useOrgStore } from "@/stores";
 import type { UsagePeriod } from "./use-usage-stats";
 import type { AdminOrganization, AdminStats, SystemHealth } from "@/types/admin";
-import type { Conversation, RatingSummary } from "@/types/conversation";
+import type { AdminRatingsSummary, Conversation } from "@/types/conversation";
 import type { AgentRunList } from "@/types/runs";
 
 /** Failed or out-of-budget runs, newest first - the recent-failures card. */
@@ -137,7 +137,7 @@ export function useAdminRatingsSummary(period: UsagePeriod, options?: { enabled?
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: qk.admin.ratings({ from: period.from, to: period.to }),
     queryFn: () =>
-      apiClient.get<RatingSummary>("/admin/ratings/summary", {
+      apiClient.get<AdminRatingsSummary>("/admin/ratings/summary", {
         params: { from: period.from, to: period.to },
       }),
     enabled: options?.enabled ?? true,

--- a/frontend/src/types/conversation.ts
+++ b/frontend/src/types/conversation.ts
@@ -1,4 +1,5 @@
 import { RatingValue, type ChatMessageFile, type UserRating } from "./chat";
+import type { RatingsByDay } from "./stats";
 
 /**
  * An agent that answered in a conversation.
@@ -127,13 +128,16 @@ export interface MessageRatingListResponse {
   total: number;
 }
 
-export interface RatingSummary {
+// Distinct from `RatingsSummary` in `./stats` (which carries a from/to/scope
+// window): this is the admin `/admin/ratings/summary` response, named apart so
+// the two are not confused on import by a single trailing `s` (#559).
+export interface AdminRatingsSummary {
   total_ratings: number;
   like_count: number;
   dislike_count: number;
   average_rating: number;
   with_comments: number;
-  ratings_by_day: Array<{ date: string; likes: number; dislikes: number }>;
+  ratings_by_day: RatingsByDay[];
 }
 
 export interface ConversationShare {


### PR DESCRIPTION
## Summary

The `{date, likes, dislikes}` day-point was declared **four times** feeding one chart — `RatingsByDay` (stats), an inline array in `RatingSummary` (conversation), and `RatingsPoint` (the chart) — so adding a field to one left the others silently unchanged. And the two summaries `RatingSummary` vs `RatingsSummary` differed by a single trailing `s`, trivially confused on import (#559).

## Changed

- `RatingsByDay` is now the single day-point: the chart prop, its wrapper, and the admin summary all reference it; `RatingsPoint` is deleted.
- The admin `/admin/ratings/summary` response is renamed `RatingSummary` → `AdminRatingsSummary`, so it no longer collides with `RatingsSummary` (which carries the from/to/scope window the admin one does not).

## Testing

Pure type consolidation, no behaviour change — `tsc --noEmit` is clean and the full frontend suite passes under coverage (5662 tests). Drift is now impossible: one source of truth for the day-point.

Closes #559