### PR TITLE
refactor(chat): rate messages through a hook, not raw fetch

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -824,10 +824,8 @@
     "failedDeleteConversation": "Failed to delete conversation",
     "failedFetchMessages": "Failed to fetch messages",
     "failedLoadCommands": "Failed to load commands",
-    "failedRemoveRating": "Failed to remove rating",
     "failedRenameConversation": "Failed to rename conversation",
     "failedRestoreConversation": "Failed to restore conversation",
-    "failedSubmitRating": "Failed to submit rating",
     "failedToGenerateLink": "Failed to generate link",
     "failedToRevoke": "Failed to revoke access",
     "failedToShare": "Failed to share conversation",
@@ -907,7 +905,6 @@
     "rating": {
       "unknownError": "Unknown error"
     },
-    "ratingFailed": "Failed to submit rating",
     "ratingRemoved": "Rating removed",
     "regenerate": "Regenerate response",
     "reject": "Reject",

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -218,7 +218,6 @@
     "saveConversationToRate": "Najpierw zapisz konwersację, aby ocenić",
     "ratingRemoved": "Ocena usunięta",
     "thankYouFeedback": "Dziękujemy za opinię!",
-    "ratingFailed": "Nie udało się przesłać oceny",
     "whatWentWrong": "Co poszło nie tak?",
     "feedbackHelp": "Pomóż nam się poprawić - opcjonalnie opisz, co było nieprzydatne.",
     "describeIssue": "Opisz problem... (opcjonalnie)",

--- a/frontend/src/components/chat/rating-buttons.test.tsx
+++ b/frontend/src/components/chat/rating-buttons.test.tsx
@@ -11,18 +11,12 @@ vi.mock("next-intl", async () => ({
 }));
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
-let fetchMock: ReturnType<typeof vi.fn>;
-
-function respond(response: Partial<Response> = {}) {
-  fetchMock = vi.fn().mockResolvedValue({
-    ok: true,
-    status: 200,
-    json: () => Promise.resolve({}),
-    ...response,
-  });
-  vi.stubGlobal("fetch", fetchMock);
-  return fetchMock;
-}
+const rateMessage =
+  vi.fn<(body: { rating: RatingValue; comment: string | null }) => Promise<unknown>>();
+const removeRating = vi.fn<() => Promise<unknown>>();
+vi.mock("@/hooks/use-message-rating", () => ({
+  useMessageRating: () => ({ rateMessage, removeRating }),
+}));
 
 function mount({
   currentRating = null as UserRating,
@@ -54,7 +48,8 @@ const down = () => screen.getByTitle("notHelpful");
 
 beforeEach(() => {
   vi.clearAllMocks();
-  respond();
+  rateMessage.mockResolvedValue({});
+  removeRating.mockResolvedValue({});
 });
 
 afterEach(() => vi.unstubAllGlobals());
@@ -62,23 +57,14 @@ afterEach(() => vi.unstubAllGlobals());
 /**
  * Rating an answer.
  *
- * Three rules, and each one is about not lying to the person who clicked.
- *
- * A thumbs-down opens the comment box; a thumbs-up does not. The asymmetry is
- * deliberate - "that was wrong" is worth a sentence, and asking for one after
- * every good answer would train people to ignore the dialog.
- *
- * Clicking the rating already given removes it. Sending the same rating twice
- * would be a no-op the server has to deduplicate, and there would be no way to
- * take back a mis-click.
- *
- * The counts are computed locally rather than refetched, so the number moves as
- * soon as the click lands - which means the arithmetic has to hold for every
- * transition, including a switch from up to down where two counts change at once.
+ * A thumbs-down opens the comment box; a thumbs-up does not - "that was wrong"
+ * is worth a sentence, and asking after every good answer trains people to
+ * ignore the dialog. Clicking the rating already given removes it. The counts
+ * move locally as soon as the click lands, so the arithmetic has to hold for
+ * every transition, including a switch where two counts change at once.
  */
 describe("rating an answer", () => {
   it("shows nothing at all on a person's own message", () => {
-    // There is nothing to rate about what somebody typed themselves.
     const { container } = render(
       <RatingButtons
         messageId="m-1"
@@ -96,12 +82,7 @@ describe("rating an answer", () => {
 
     await userEvent.click(up());
 
-    expect(fetchMock).toHaveBeenCalledWith("/api/conversations/c-1/messages/m-1/rate", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      credentials: "include",
-      body: JSON.stringify({ rating: RatingValue.LIKE, comment: null }),
-    });
+    expect(rateMessage).toHaveBeenCalledWith({ rating: RatingValue.LIKE, comment: null });
     await waitFor(() =>
       expect(onRatingChange).toHaveBeenCalledWith({
         rating: RatingValue.LIKE,
@@ -117,7 +98,7 @@ describe("rating an answer", () => {
     await userEvent.click(down());
 
     expect(screen.getByText("whatWentWrong")).toBeInTheDocument();
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(rateMessage).not.toHaveBeenCalled();
   });
 
   it("sends the comment somebody wrote", async () => {
@@ -127,12 +108,10 @@ describe("rating an answer", () => {
     await userEvent.type(screen.getByRole("textbox"), "It cited the wrong document.");
     await userEvent.click(screen.getByRole("button", { name: "submit" }));
 
-    expect(fetchMock.mock.calls[0]![1].body).toBe(
-      JSON.stringify({
-        rating: RatingValue.DISLIKE,
-        comment: "It cited the wrong document.",
-      }),
-    );
+    expect(rateMessage).toHaveBeenCalledWith({
+      rating: RatingValue.DISLIKE,
+      comment: "It cited the wrong document.",
+    });
     await waitFor(() =>
       expect(onRatingChange).toHaveBeenCalledWith({
         rating: RatingValue.DISLIKE,
@@ -142,28 +121,22 @@ describe("rating an answer", () => {
   });
 
   it("sends a whitespace-only comment as no comment", async () => {
-    // Otherwise the ratings screen shows a row with an empty comment on it.
     mount();
     await userEvent.click(down());
 
     await userEvent.type(screen.getByRole("textbox"), "   ");
     await userEvent.click(screen.getByRole("button", { name: "submit" }));
 
-    expect(fetchMock.mock.calls[0]![1].body).toBe(
-      JSON.stringify({ rating: RatingValue.DISLIKE, comment: null }),
-    );
+    expect(rateMessage).toHaveBeenCalledWith({ rating: RatingValue.DISLIKE, comment: null });
   });
 
   it("records the rating when the comment is skipped", async () => {
-    // The rating is the signal; the sentence is a bonus.
     mount();
     await userEvent.click(down());
 
     await userEvent.click(screen.getByRole("button", { name: "skipComment" }));
 
-    expect(fetchMock.mock.calls[0]![1].body).toBe(
-      JSON.stringify({ rating: RatingValue.DISLIKE, comment: null }),
-    );
+    expect(rateMessage).toHaveBeenCalledWith({ rating: RatingValue.DISLIKE, comment: null });
   });
 
   it("sends nothing when the dialog is dismissed", async () => {
@@ -173,7 +146,7 @@ describe("rating an answer", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "cancel" }));
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(rateMessage).not.toHaveBeenCalled();
     await waitFor(() => expect(screen.queryByText("whatWentWrong")).toBeNull());
   });
 
@@ -199,8 +172,6 @@ describe("rating an answer", () => {
   });
 
   it("removes the rating when the same one is clicked again", async () => {
-    // A mis-click has to be retractable, and re-sending the same rating would be
-    // a no-op the server has to deduplicate.
     const onRatingChange = mount({
       currentRating: RatingValue.LIKE,
       ratingCount: { likes: 3, dislikes: 1 },
@@ -208,10 +179,7 @@ describe("rating an answer", () => {
 
     await userEvent.click(up());
 
-    expect(fetchMock).toHaveBeenCalledWith("/api/conversations/c-1/messages/m-1/rate", {
-      method: "DELETE",
-      credentials: "include",
-    });
+    expect(removeRating).toHaveBeenCalled();
     await waitFor(() =>
       expect(onRatingChange).toHaveBeenCalledWith({
         rating: null,
@@ -222,8 +190,6 @@ describe("rating an answer", () => {
   });
 
   it("moves both counts when a rating is switched", async () => {
-    // The arithmetic nobody notices until the numbers drift: the old rating comes
-    // off as the new one goes on.
     const onRatingChange = mount({
       currentRating: RatingValue.LIKE,
       ratingCount: { likes: 3, dislikes: 1 },
@@ -241,9 +207,6 @@ describe("rating an answer", () => {
   });
 
   it("moves both counts the other way round too", async () => {
-    // The mirror of the case above, and a separate branch: switching off a
-    // dislike decrements a different counter than switching off a like, and
-    // only one of the two was ever exercised.
     const onRatingChange = mount({
       currentRating: RatingValue.DISLIKE,
       ratingCount: { likes: 3, dislikes: 2 },
@@ -260,9 +223,6 @@ describe("rating an answer", () => {
   });
 
   it("never counts below zero, however out of step the tally was", async () => {
-    // The count arrives from the server and the rating from the local store; they
-    // can disagree after a reload, and a negative count on screen is worse than
-    // one that is briefly stale.
     const onRatingChange = mount({
       currentRating: RatingValue.LIKE,
       ratingCount: { likes: 0, dislikes: 0 },
@@ -279,7 +239,6 @@ describe("rating an answer", () => {
   });
 
   it("shows each count only once there is one", () => {
-    // A zero beside a thumb reads as a rating of zero rather than as no ratings.
     const first = mount({ ratingCount: { likes: 2, dislikes: 0 } });
     expect(screen.getByText("2")).toBeInTheDocument();
     expect(screen.queryByText("0")).toBeNull();
@@ -312,151 +271,79 @@ describe("rating an answer", () => {
   });
 
   it("cannot rate a turn in a conversation the server has not saved yet", async () => {
-    // The first turn of a new chat has no id until the socket answers, and the
-    // rating endpoint is addressed by conversation. The disabled button is the
-    // enforcement as well as the explanation - React fires no click on it.
     mount({ conversationId: "" });
-    // Both thumbs say the same thing, because neither can be used yet.
     const [thumbUp, thumbDown] = screen.getAllByTitle("saveConversationToRate");
 
     expect(thumbUp).toBeDisabled();
     expect(thumbDown).toBeDisabled();
     await userEvent.click(thumbUp!);
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(rateMessage).not.toHaveBeenCalled();
   });
 
-  it("says why a refused rating was refused", async () => {
-    respond({
-      ok: false,
-      status: 403,
-      json: () => Promise.resolve({ message: "This conversation is not yours" }),
-    });
+  it("reports a refused rating and leaves the counts alone", async () => {
+    rateMessage.mockRejectedValueOnce(new Error("This conversation is not yours"));
     const onRatingChange = mount();
 
     await userEvent.click(up());
 
-    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("This conversation is not yours"));
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
     expect(onRatingChange).not.toHaveBeenCalled();
   });
 
-  it("falls back to its own sentence when the refusal carries none", async () => {
-    respond({ ok: false, status: 500, json: () => Promise.resolve({}) });
-    mount();
-
-    await userEvent.click(up());
-
-    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("failedSubmitRating"));
-  });
-
-  it("still says something when the refusal is not JSON", async () => {
-    respond({ ok: false, status: 502, json: () => Promise.reject(new Error("not json")) });
-    mount();
-
-    await userEvent.click(up());
-
-    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("unknownError"));
-  });
-
   it("reports a failure to remove a rating, and keeps the rating", async () => {
-    respond({ ok: false, status: 500, json: () => Promise.resolve({}) });
+    removeRating.mockRejectedValueOnce(new Error("nope"));
     const onRatingChange = mount({ currentRating: RatingValue.LIKE });
 
     await userEvent.click(up());
 
-    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("failedRemoveRating"));
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
     expect(onRatingChange).not.toHaveBeenCalled();
   });
 
-  it("says what the server said about a refused removal", async () => {
-    respond({
-      ok: false,
-      status: 409,
-      json: () => Promise.resolve({ message: "Already removed" }),
-    });
-    mount({ currentRating: RatingValue.DISLIKE });
-
-    await userEvent.click(down());
-
-    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Already removed"));
-  });
-
-  it("survives a removal whose refusal is not JSON", async () => {
-    respond({ ok: false, status: 502, json: () => Promise.reject(new Error("not json")) });
-    mount({ currentRating: RatingValue.LIKE });
-
-    await userEvent.click(up());
-
-    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("unknownError"));
-  });
-
   it("accepts no second click while the first is in flight", async () => {
-    // Two ratings for one message is a tally that never settles.
     let release: (value: unknown) => void = () => {};
-    fetchMock = vi.fn().mockReturnValue(
+    rateMessage.mockReturnValue(
       new Promise((resolve) => {
         release = resolve;
       }),
     );
-    vi.stubGlobal("fetch", fetchMock);
     mount();
 
     await userEvent.click(up());
     await waitFor(() => expect(up()).toBeDisabled());
     expect(down()).toBeDisabled();
 
-    release({ ok: true, status: 200, json: () => Promise.resolve({}) });
+    release({});
     await waitFor(() => expect(up()).toBeEnabled());
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(rateMessage).toHaveBeenCalledTimes(1);
   });
 
   it("spins on the thumb that was pressed, not on both", async () => {
-    // Which one is working is the whole point of a spinner.
     let release: (value: unknown) => void = () => {};
-    fetchMock = vi.fn().mockReturnValue(
+    rateMessage.mockReturnValue(
       new Promise((resolve) => {
         release = resolve;
       }),
     );
-    vi.stubGlobal("fetch", fetchMock);
     mount({ currentRating: RatingValue.LIKE });
 
-    await userEvent.click(up());
+    await userEvent.click(down());
+    await userEvent.click(screen.getByRole("button", { name: "skipComment" }));
 
-    await waitFor(() => expect(up().querySelector(".animate-spin")).not.toBeNull());
-    expect(down().querySelector(".animate-spin")).toBeNull();
+    await waitFor(() => expect(down().querySelector(".animate-spin")).not.toBeNull());
+    expect(up().querySelector(".animate-spin")).toBeNull();
 
-    release({ ok: true, status: 200, json: () => Promise.resolve({}) });
-  });
-
-  it("spins one thumb on a message nobody has rated yet", async () => {
-    // An unrated message has currentRating === null, the case a spinner keyed
-    // on the rating cannot tell apart - and the normal one.
-    let release: (value: unknown) => void = () => {};
-    fetchMock = vi.fn().mockReturnValue(
-      new Promise((resolve) => {
-        release = resolve;
-      }),
-    );
-    vi.stubGlobal("fetch", fetchMock);
-    mount();
-
-    await userEvent.click(up());
-
-    await waitFor(() => expect(up().querySelector(".animate-spin")).not.toBeNull());
-    expect(down().querySelector(".animate-spin")).toBeNull();
-
-    release({ ok: true, status: 200, json: () => Promise.resolve({}) });
+    release({});
   });
 
   it("spins one thumb when a rating is being removed", async () => {
     let release: (value: unknown) => void = () => {};
-    fetchMock = vi.fn().mockReturnValue(
+    removeRating.mockReturnValue(
       new Promise((resolve) => {
         release = resolve;
       }),
     );
-    vi.stubGlobal("fetch", fetchMock);
     mount({ currentRating: RatingValue.DISLIKE });
 
     await userEvent.click(down());
@@ -464,6 +351,6 @@ describe("rating an answer", () => {
     await waitFor(() => expect(down().querySelector(".animate-spin")).not.toBeNull());
     expect(up().querySelector(".animate-spin")).toBeNull();
 
-    release({ ok: true, status: 200, json: () => Promise.resolve({}) });
+    release({});
   });
 });

--- a/frontend/src/components/chat/rating-buttons.tsx
+++ b/frontend/src/components/chat/rating-buttons.tsx
@@ -3,6 +3,8 @@ import { useState, useCallback, useMemo } from "react";
 import { Loader2, ThumbsUp, ThumbsDown } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
+import { getErrorMessage } from "@/lib/api-error";
+import { useMessageRating } from "@/hooks/use-message-rating";
 import { toast } from "sonner";
 import { RatingValue, type UserRating } from "@/types";
 import { Button } from "@/components/ui/button";
@@ -37,6 +39,8 @@ export function RatingButtons({
 }: RatingButtonsProps) {
   const t = useTranslations("chat");
   const tc = useTranslations("common");
+  const tErrors = useTranslations("errors");
+  const { rateMessage, removeRating } = useMessageRating(conversationId, messageId);
   const [showCommentDialog, setShowCommentDialog] = useState(false);
   const [pendingRating, setPendingRating] = useState<RatingValue>(RatingValue.DISLIKE);
   const [comment, setComment] = useState("");
@@ -68,36 +72,19 @@ export function RatingButtons({
     async (rating: RatingValue, commentText: string | null) => {
       setInFlight(rating);
       try {
-        const response = await fetch(
-          `/api/conversations/${conversationId}/messages/${messageId}/rate`,
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            credentials: "include",
-            body: JSON.stringify({
-              rating,
-              comment: commentText,
-            }),
-          },
-        );
-
-        if (!response.ok) {
-          const error = await response.json().catch(() => ({ message: t("unknownError") }));
-          throw new Error(error.message || t("failedSubmitRating"));
-        }
-
+        await rateMessage({ rating, comment: commentText });
         const newCounts = calculateNewCounts(currentRating, rating);
         onRatingChange?.({ rating, rating_count: newCounts });
         toast.success(t("thankYouFeedback"));
         setShowCommentDialog(false);
         setComment("");
       } catch (error) {
-        toast.error(error instanceof Error ? error.message : t("ratingFailed"));
+        toast.error(getErrorMessage(error, tErrors));
       } finally {
         setInFlight(null);
       }
     },
-    [conversationId, messageId, currentRating, calculateNewCounts, onRatingChange, t],
+    [rateMessage, currentRating, calculateNewCounts, onRatingChange, t, tErrors],
   );
 
   // No guard against a missing conversation id here: both buttons are
@@ -109,24 +96,12 @@ export function RatingButtons({
       if (currentRating === rating) {
         setInFlight(rating);
         try {
-          const response = await fetch(
-            `/api/conversations/${conversationId}/messages/${messageId}/rate`,
-            {
-              method: "DELETE",
-              credentials: "include",
-            },
-          );
-
-          if (!response.ok) {
-            const error = await response.json().catch(() => ({ message: t("unknownError") }));
-            throw new Error(error.message || t("failedRemoveRating"));
-          }
-
+          await removeRating();
           const newCounts = calculateNewCounts(currentRating, null);
           onRatingChange?.({ rating: null, rating_count: newCounts });
           toast.success(t("ratingRemoved"));
         } catch (error) {
-          toast.error(error instanceof Error ? error.message : t("failedRemoveRating"));
+          toast.error(getErrorMessage(error, tErrors));
         } finally {
           setInFlight(null);
         }
@@ -139,7 +114,7 @@ export function RatingButtons({
         }
       }
     },
-    [conversationId, messageId, currentRating, calculateNewCounts, onRatingChange, submitRating],
+    [removeRating, currentRating, calculateNewCounts, onRatingChange, submitRating, t, tErrors],
   );
 
   const handleCloseDialog = useCallback(() => {

--- a/frontend/src/hooks/use-message-rating.test.tsx
+++ b/frontend/src/hooks/use-message-rating.test.tsx
@@ -1,0 +1,61 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useMessageRating } from "./use-message-rating";
+import * as api from "@/lib/message-rating-api";
+import { RatingValue } from "@/types/chat";
+
+vi.mock("@/lib/message-rating-api", () => ({
+  rateMessage: vi.fn(),
+  removeRating: vi.fn(),
+}));
+
+function wrapperFor(client: QueryClient) {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  Wrapper.displayName = "TestWrapper";
+  return Wrapper;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(api.rateMessage).mockResolvedValue({});
+  vi.mocked(api.removeRating).mockResolvedValue(undefined);
+});
+
+describe("useMessageRating", () => {
+  it("rates through the client and invalidates the rating summaries", async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidate = vi.spyOn(client, "invalidateQueries");
+    const { result } = renderHook(() => useMessageRating("c-1", "m-1"), {
+      wrapper: wrapperFor(client),
+    });
+
+    await result.current.rateMessage({ rating: RatingValue.LIKE, comment: null });
+
+    expect(api.rateMessage).toHaveBeenCalledWith("c-1", "m-1", {
+      rating: RatingValue.LIKE,
+      comment: null,
+    });
+    await waitFor(() => {
+      expect(invalidate).toHaveBeenCalledWith({ queryKey: ["ratings"] });
+      expect(invalidate).toHaveBeenCalledWith({ queryKey: ["admin", "ratings"] });
+    });
+  });
+
+  it("removes through the client and invalidates the summaries", async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidate = vi.spyOn(client, "invalidateQueries");
+    const { result } = renderHook(() => useMessageRating("c-1", "m-1"), {
+      wrapper: wrapperFor(client),
+    });
+
+    await result.current.removeRating();
+
+    expect(api.removeRating).toHaveBeenCalledWith("c-1", "m-1");
+    await waitFor(() => expect(invalidate).toHaveBeenCalledWith({ queryKey: ["ratings"] }));
+  });
+});

--- a/frontend/src/hooks/use-message-rating.ts
+++ b/frontend/src/hooks/use-message-rating.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { rateMessage, removeRating } from "@/lib/message-rating-api";
+
+import type { RatingValue } from "@/types/chat";
+
+/**
+ * Rating one assistant message, as mutations over the lib client.
+ *
+ * The chat's own thumb counts live in its message store, not a query, so the
+ * caller still reconciles those; what goes through the query layer is the
+ * invalidation of the ratings summaries the dashboard plots, so a rating cast in
+ * chat is reflected there rather than left stale until the next mount.
+ */
+export function useMessageRating(conversationId: string, messageId: string) {
+  const queryClient = useQueryClient();
+
+  const invalidateSummaries = () => {
+    // The roots of `qk.stats.ratings` (["ratings", "summary", …]) and
+    // `qk.admin.ratings` (["admin", "ratings", …]) - both summary queries the
+    // dashboard reads, matched by prefix.
+    void queryClient.invalidateQueries({ queryKey: ["ratings"] });
+    void queryClient.invalidateQueries({ queryKey: ["admin", "ratings"] });
+  };
+
+  const rate = useMutation({
+    mutationFn: (body: { rating: RatingValue; comment: string | null }) =>
+      rateMessage(conversationId, messageId, body),
+    onSuccess: invalidateSummaries,
+  });
+
+  const remove = useMutation({
+    mutationFn: () => removeRating(conversationId, messageId),
+    onSuccess: invalidateSummaries,
+  });
+
+  return { rateMessage: rate.mutateAsync, removeRating: remove.mutateAsync };
+}

--- a/frontend/src/lib/message-rating-api.test.ts
+++ b/frontend/src/lib/message-rating-api.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { rateMessage, removeRating } from "./message-rating-api";
+import { apiClient } from "./api-client";
+import { RatingValue } from "@/types/chat";
+
+vi.mock("./api-client", () => ({
+  apiClient: { post: vi.fn(), delete: vi.fn() },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(apiClient.post).mockResolvedValue({});
+  vi.mocked(apiClient.delete).mockResolvedValue(undefined);
+});
+
+describe("the message rating API", () => {
+  it("posts a rating to the message's rate endpoint through the shared client", async () => {
+    await rateMessage("c-1", "m-1", { rating: RatingValue.LIKE, comment: null });
+
+    expect(apiClient.post).toHaveBeenCalledWith("/conversations/c-1/messages/m-1/rate", {
+      rating: RatingValue.LIKE,
+      comment: null,
+    });
+  });
+
+  it("encodes ids that are not path-safe", async () => {
+    await rateMessage("c/1", "m 1", { rating: RatingValue.DISLIKE, comment: "x" });
+
+    expect(apiClient.post).toHaveBeenCalledWith("/conversations/c%2F1/messages/m%201/rate", {
+      rating: RatingValue.DISLIKE,
+      comment: "x",
+    });
+  });
+
+  it("removes a rating with a DELETE", async () => {
+    await removeRating("c-1", "m-1");
+
+    expect(apiClient.delete).toHaveBeenCalledWith("/conversations/c-1/messages/m-1/rate");
+  });
+});

--- a/frontend/src/lib/message-rating-api.ts
+++ b/frontend/src/lib/message-rating-api.ts
@@ -1,0 +1,27 @@
+import { apiClient } from "./api-client";
+
+import type { RatingValue } from "@/types/chat";
+
+/**
+ * Rate one assistant message, or clear a rating - through the shared client so
+ * the calls carry the session and active-organization headers, and the rating
+ * endpoints are visible to `query-keys.ts` rather than two raw `fetch`es in a
+ * component (#563). The response body is not read: the chat reconciles its own
+ * thumb counts in its store, and the dashboard summaries are invalidated.
+ */
+export function rateMessage(
+  conversationId: string,
+  messageId: string,
+  body: { rating: RatingValue; comment: string | null },
+): Promise<unknown> {
+  return apiClient.post(
+    `/conversations/${encodeURIComponent(conversationId)}/messages/${encodeURIComponent(messageId)}/rate`,
+    body,
+  );
+}
+
+export function removeRating(conversationId: string, messageId: string): Promise<unknown> {
+  return apiClient.delete(
+    `/conversations/${encodeURIComponent(conversationId)}/messages/${encodeURIComponent(messageId)}/rate`,
+  );
+}


### PR DESCRIPTION
## What changed

`rating-buttons.tsx` hand-rolled two `fetch` calls (POST/DELETE the message `/rate` endpoint) with their own headers, `response.ok` handling and error parsing — the shape `frontend.md` forbids: *all API access goes through `src/lib` clients via a hook, no `fetch` in a component*. The two error-parse blocks were duplicated and free to drift, and the endpoints were invisible to the query layer, so a rating cast in chat left the dashboard's ratings summaries stale until the next mount.

- **`src/lib/message-rating-api.ts`** (new) — `rateMessage` / `removeRating` over `apiClient`, ids `encodeURIComponent`'d.
- **`src/hooks/use-message-rating.ts`** (new) — the two as mutations; `onSuccess` invalidates the ratings and admin-ratings summary roots so the dashboard reflects a rating at once. The chat's own thumb counts live in the message store, so the component still reconciles those locally.
- **`rating-buttons.tsx`** — both `fetch` blocks gone; errors surface through `getErrorMessage`. Removed the three now-unused i18n keys the hand-rolled catches used (`chat.failedSubmitRating` / `failedRemoveRating` / `ratingFailed`).

## How it was verified

- Component test rewritten to mock the hook and assert the calls + the local count arithmetic (unchanged behaviour).
- New tests for the hook (client call, invalidation) and the lib client (post/delete, id encoding).
- `make test-frontend-cov` green — 100% statements/functions/lines, 97.7% branches. `make lint-frontend`, `tsc`, `check:i18n` clean.

Closes #563