### PR TITLE
test(e2e): capture a trace on the one failure a flake gets

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -91,14 +91,24 @@ export default defineConfig({
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: BASE_URL,
 
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: "on-first-retry",
+    // `retain-on-failure`, not `on-first-retry`, because `retries` above is 0: a
+    // test that flakes never gets a second attempt, so `on-first-retry` collected
+    // a trace on none of them and the one artifact that names which locator was
+    // waited on - the trace viewer's DOM timeline, network and console - was
+    // absent from exactly the runs that needed it (#162). A flake here fails once
+    // and the trace of that one failure is what turns "it flaked again" into a
+    // diagnosis. Traces are kept only for the failed test and the HTML report
+    // embeds them, so the `playwright-report` artifact the e2e job already uploads
+    // carries them with no change there.
+    trace: "retain-on-failure",
 
     /* Capture screenshot on failure */
     screenshot: "only-on-failure",
 
-    /* Video recording on failure */
-    video: "on-first-retry",
+    // Same as trace: `on-first-retry` recorded no video with `retries: 0`. A
+    // failing UI journey is worth a video, and it is kept only for the test that
+    // failed.
+    video: "retain-on-failure",
   },
 
   /* Configure projects for major browsers */


### PR DESCRIPTION
## What changed

`playwright.config.ts` had `trace: "on-first-retry"` and `video: "on-first-retry"`, but `retries` is **0** — deliberately, so a real failure cannot go green on a second attempt. With no retry, `on-first-retry` never fires: on a flake the CI job kept a screenshot and nothing else. The **trace** is the one artifact that answers #162's question — *which locator was it waiting on, and why* (it carries the DOM timeline, the network log and the console) — and it was absent from exactly the runs that needed it.

- `trace` and `video` → **`retain-on-failure`**: captured on the first (only) failure, kept for the failed test alone.
- The e2e job already uploads `playwright-report/` on failure and the HTML report embeds the trace, so **no workflow change is needed** to carry it.

## Scope — this Refs, it does not Close

This does **not** fix the flake. Its root cause is unknown until a failure is actually captured, and this is what makes that capture possible. #162's own done-criteria — *the spec names the locator and reason, and passes twenty consecutive runs on `main`* — can only be met once a real trace has been read. So the issue stays open after this merges; it now produces a diagnosable artifact the next time `journey.spec.ts` (or any of the four specs flaking this way) fails.

## How it was verified

- `tsc --noEmit` clean — both literals are valid `TraceMode` / `VideoMode`, so the config still compiles.
- The comment guard passes. No product or spec behaviour changes; only which artifacts survive a failure.

Refs #162