### PR TITLE
refactor: use status enums and precise dict typing (audit #545)

### DIFF
--- a/backend/app/repositories/skill.py
+++ b/backend/app/repositories/skill.py
@@ -6,7 +6,7 @@ predicate pieces the access layer resolved rather than re-deriving them here.
 """
 
 from collections.abc import Sequence
-from typing import Literal
+from typing import Any, Literal
 from uuid import UUID
 
 from sqlalchemy import and_, false, func, or_, select
@@ -177,7 +177,7 @@ async def create(
     return skill
 
 
-async def update(db: AsyncSession, *, skill: Skill, update_data: dict) -> Skill:
+async def update(db: AsyncSession, *, skill: Skill, update_data: dict[str, Any]) -> Skill:
     for field, value in update_data.items():
         setattr(skill, field, value)
     db.add(skill)
@@ -233,7 +233,7 @@ async def create_resource(
 
 
 async def update_resource(
-    db: AsyncSession, *, resource: SkillResource, update_data: dict
+    db: AsyncSession, *, resource: SkillResource, update_data: dict[str, Any]
 ) -> SkillResource:
     for field, value in update_data.items():
         setattr(resource, field, value)

--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -2988,7 +2988,7 @@ class AgentRunnerService:
         was parked before that map was stored, which is a step a surface cannot mark
         rather than a call it cannot decide.
         """
-        if run.status != "awaiting_approval":
+        if run.status != RunStatus.AWAITING_APPROVAL.value:
             return []
         approvals = await agent_run_repo.list_approvals_for_run(
             self.db, run_id=run.id, organization_id=ctx.organization_id
@@ -3003,7 +3003,7 @@ class AgentRunnerService:
                 tool_args=approval.tool_args or {},
             )
             for approval in approvals
-            if approval.status == "pending"
+            if approval.status == ApprovalStatus.PENDING.value
         ]
 
     async def resume(self, ctx: AuthContext, run_id: UUID) -> RunSegment:


### PR DESCRIPTION
A safe, mechanical subset of the #545 backend cleanup bag. Two commits, each self-contained; the bag stays open for the rest.

## What changed

- **`refactor(agents)`** — `parked_calls` compared `run.status`/`approval.status` against the raw strings `"awaiting_approval"`/`"pending"`, where every sibling in the file uses `RunStatus`/`ApprovalStatus`. A raw literal is invisible to a rename: change the enum member and the string silently stops matching. Now `RunStatus.AWAITING_APPROVAL.value` / `ApprovalStatus.PENDING.value`, matching the resume path a few methods down. Behaviour identical (both are `StrEnum`), existing `parked_calls` tests stay green.
- **`refactor(skills)`** — `skill` repository's `update` / `update_resource` took a bare `dict`; every other repo's `update` takes `dict[str, Any]`, the shape a dumped `*Update` has. Typing-only.

## One item was misdiagnosed — dropped, not done

> `InvitationCreate.email` drops the `max_length=255` its `UserCreate`/`UserUpdate` siblings carry → over-length address 500s at the DB instead of a clean 422.

This does not reproduce. `EmailStr` (via `email-validator`) enforces the RFC total-length limit of **254**, which is *below* the `invitations.email` column's `String(255)`. A format-valid address can never exceed the column, and an over-length one is refused with a clean **422 at the schema** before any insert — verified: `EmailStr` rejects a 310-char address on its own, with and without `max_length`. The `max_length=255` on `UserCreate` is itself belt-and-suspenders, not load-bearing. Adding it here would be an untestable constraint (no input reaches it), so I left it out and ticked the other two boxes on the issue instead.

## Verified

`make lint-backend` clean (ruff, ruff-format, ty, vulture, deptry, guards); `ty` adds zero diagnostics over baseline; `parked_calls` (12) and `test_skills.py` (77) green.

Part-of #545