### PR TITLE
fix(i18n): stop exempting any sentence that contains a unit word

### DIFF
--- a/frontend/scripts/check-i18n.test.ts
+++ b/frontend/scripts/check-i18n.test.ts
@@ -524,6 +524,17 @@ describe("a .ts file", () => {
     ]);
   });
 
+  it("reports a sentence that merely contains a unit word (#741)", () => {
+    // A unit word inside a sentence does not make it a measurement label - `isFormatter`
+    // exempts a phrase only when every word is a unit, and this is prose either way.
+    expect(saidTs('const x = "Use rem instead of pixels for spacing";\n')).toEqual([
+      "string 'Use rem instead of pixels for spacing'",
+    ]);
+    expect(saidTs('const x = "Change the deg value before saving";\n')).toEqual([
+      "string 'Change the deg value before saving'",
+    ]);
+  });
+
   it("refuses a label on an export const, which the keyword skip used to hide", () => {
     expect(saidTs('export const LABEL = "Provider default";\n')).toEqual([
       "string 'Provider default'",

--- a/frontend/scripts/check-i18n.test.ts
+++ b/frontend/scripts/check-i18n.test.ts
@@ -535,6 +535,14 @@ describe("a .ts file", () => {
     ]);
   });
 
+  it("reports the same unit-word sentence in a template literal (#741)", () => {
+    // The template path carried the same defect: `MACHINE_READ` exempted any body
+    // holding a standalone unit word, so a sentence with `rem` in it was read as a
+    // machine value. A phrase made only of units is still exempt, via `isFormatter`.
+    expect(isTemplateCopy(`Use ${HOLE} rem instead of pixels for spacing`)).toBe(true);
+    expect(isTemplateCopy(`${HOLE} rem`)).toBe(false);
+  });
+
   it("refuses a label on an export const, which the keyword skip used to hide", () => {
     expect(saidTs('export const LABEL = "Provider default";\n')).toEqual([
       "string 'Provider default'",

--- a/frontend/scripts/check-i18n.ts
+++ b/frontend/scripts/check-i18n.ts
@@ -201,7 +201,16 @@ const UNITS = new Set([
 const MACHINE_WORD = /^[A-Z0-9_]+$/;
 /**
  * What `NOT_A_SENTENCE` keeps out of the string-literal rule: a label built from title
- * case around a separator, a short acronym label, a CSS measurement.
+ * case around a separator, and a short acronym label.
+ *
+ * A phrase made of units - `12px`, `{bytes} KiB` - is not a third alternative here:
+ * `isFormatter` answers it by asking that *every* word be a unit or an acronym. A
+ * `.*\b(?:px|rem|vh|vw|deg)\b` alternative once tried to, and did the opposite of its
+ * docstring (#741): `.*` on both sides exempted any sentence that merely contained a
+ * unit word ("Use rem instead of pixels for spacing"), while the `\bpx\b` boundary it
+ * needed never matched the `12px` it was written for - no boundary sits between a digit
+ * and a letter. It was the same defect as #656 and #678, and dead: deleting it left the
+ * whole-tree sweep clean.
  *
  * The separator joins *two capitalised tokens* - `Model / Provider`, `URL / Endpoint`,
  * `Agent - Settings`. Either token may be an acronym: the acronym alternative used to
@@ -221,7 +230,7 @@ const MACHINE_WORD = /^[A-Z0-9_]+$/;
  * through.
  */
 const NOT_A_SENTENCE =
-  /^(?:(?:[A-Z][a-z]+|[A-Z]{2,})(?:\s[A-Z][a-z]+)*\s?[-/]\s?[A-Z]|[A-Z]{2,}\s+[a-z][A-Za-z-]*$|.*\b(?:px|rem|vh|vw|deg)\b)/;
+  /^(?:(?:[A-Z][a-z]+|[A-Z]{2,})(?:\s[A-Z][a-z]+)*\s?[-/]\s?[A-Z]|[A-Z]{2,}\s+[a-z][A-Za-z-]*$)/;
 
 export interface Offence {
   line: number;

--- a/frontend/scripts/check-i18n.ts
+++ b/frontend/scripts/check-i18n.ts
@@ -156,8 +156,15 @@ const ENTITY = /&(?:[a-zA-Z]+|#\d+);/g;
  * the character class cannot see - `` `Bearer ${token}` `` holds no punctuation at all,
  * so it reads as a word, a space and an interpolation, which is exactly the prose shape
  * `isTemplateCopy` looks for.
+ *
+ * Unit words (`px`, `rem`, `deg`, `vh`, `vw`) are deliberately *not* here, and #741 is
+ * why: a `\b(?:px|rem|…)\b` alternative exempted any template that merely contained the
+ * word - `` `Use ${x} rem instead of pixels for spacing` `` - the same defect the
+ * string-literal path carried. A phrase genuinely made of units is answered by
+ * `isFormatter` below, which asks that *every* word be a unit or an acronym; a sentence
+ * with one unit word in it is prose and is reported.
  */
-const MACHINE_READ = /[/&=<>#]|\b(?:px|rem|deg|vh|vw|attachment|Bearer|Basic)\b/;
+const MACHINE_READ = /[/&=<>#]|\b(?:attachment|Bearer|Basic)\b/;
 /**
  * A unit, and the answer to the fourteen number-and-unit formatters #395 left open -
  * `` `${Math.round(bytes / 1024)} KiB` ``,


### PR DESCRIPTION
## What breaks

`NOT_A_SENTENCE`'s third alternative, `.*\b(?:px|rem|vh|vw|deg)\b`, is the same defect as #656 and #678 and the widest of the three: `.*` on both sides means a unit token *anywhere* in a string exempts the whole sentence.

```
"Use rem instead of pixels for spacing"   -> was exempt
"Change the deg value before saving"      -> was exempt
"This px setting is wrong"                -> was exempt
```

It also never did its stated job. A CSS measurement is written `12px`, and `\bpx\b` needs a word boundary before `px` — there is none between `2` and `p` — so `"Set the width to 12px"` was reported anyway. The alternative caught the standalone unit token it was never written for and missed the measurement it was.

And it was **dead**: a phrase genuinely made of units is already answered by `isFormatter`, which asks that *every* word be a unit or an acronym, not that one of them be.

## Fix

Delete the alternative. Its docstring now records why there is no unit alternative, so it is not re-added.

## How it was verified

- New regression spec pins `"Use rem instead of pixels for spacing"` to one offence — it returned `[]` under the old regex, so it fails without the fix.
- `bun run check:i18n` clean over the whole tree (4222 messages, no offences) — deleting it reports nothing new.
- `check-i18n.test.ts` 74 green; `tsc` / `eslint` / `prettier` clean.

Closes #741