### PR TITLE
chore: cut 0.0.254

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.254] - 2026-08-26
+
+### Changed
+
+- Agent-framework dependencies: `logfire` 4.41.0, `pydantic-ai-slim` 2.33.0
+  (including its `mcp` extra), `genai-prices` 0.1.4 and `pydantic-ai-skills` 1.4.0.
+
 ## [0.0.253] - 2026-08-26
 
 Nothing holds a pooled connection across a model call, so the sixteenth request is

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.253"
+version = "0.0.254"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.253"
+version = "0.0.254"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.253",
+  "version": "0.0.254",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.254. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.254 and adds the CHANGELOG entry.

Releases the weekly agent-frameworks dependency group: `logfire` 4.41.0,
`pydantic-ai-slim` 2.33.0 with its `mcp` extra, `genai-prices` 0.1.4 and
`pydantic-ai-skills` 1.4.0 - the last a major, which is why the suite
answering green on the merged head is the whole verification here.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1085 was green on the merged head.