### PR TITLE
chore: cut 0.0.255

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.255] - 2026-08-26
+
+### Fixed
+
+- **The only pages an unauthenticated visitor loads shipped all 89 brand marks.**
+  The sign-in and register pages drew three - Google, GitHub, Microsoft - through
+  `BrandIcon`, which reads the `BRAND_GLYPHS` table by dynamic key, and a dynamic
+  record access cannot be tree-shaken. So about 104 KB of source, 25 to 30 KB
+  gzipped, sat on the critical path and grew with every connector nobody signs in
+  with. The generator emits a second module, `auth-glyphs.generated.ts`, holding
+  just the three identity-provider marks and derived from the same fetched data so
+  the generator stays the single source of glyph data; `oauth-buttons` draws
+  `AUTH_GLYPHS` through `GlyphIcon` directly. A test guards the regression: the
+  auth component must not import `BrandIcon` or `brand-glyphs.generated`, and
+  `AUTH_GLYPHS` must hold exactly the three. (#955)
+
 ## [0.0.254] - 2026-08-26
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.254"
+version = "0.0.255"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.254"
+version = "0.0.255"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.254",
+  "version": "0.0.255",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.255. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.255 and adds the CHANGELOG entry.

Releases #955: the sign-in and register pages drew three identity-provider
marks through `BrandIcon`, which reads the 89-mark table by dynamic key - and
a dynamic record access cannot be tree-shaken, so the whole table shipped on
the critical path of the only pages an unauthenticated visitor loads, growing
with every connector nobody signs in with. A second generated module holds
just the three, derived from the same fetched data so the generator stays the
one source of glyph data.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1086 was green on the merged head.