### PR TITLE
chore: cut 0.0.256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.256] - 2026-08-26
+
+### Changed
+
+- Backend dependencies: `uvicorn` 0.52.4, `pydantic-ai-harness` 0.24.0,
+  `llama-cloud` 2.14.1, `google-api-python-client` 2.199.0, `boto3` 1.43.78,
+  `subagents-pydantic-ai` 0.2.21, `ruff` 0.16.4 and `ty` 0.0.74. Applied on a
+  branch off current `main` and re-locked rather than merged from Dependabot's,
+  whose branch predated the agent-frameworks group and would have reverted it.
+  (#1153)
+
 ## [0.0.255] - 2026-08-26
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.255"
+version = "0.0.256"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.255"
+version = "0.0.256"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.255",
+  "version": "0.0.256",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.256. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.256 and adds the CHANGELOG entry.

Releases the backend dependency group: `uvicorn` 0.52.4,
`pydantic-ai-harness` 0.24.0, `llama-cloud` 2.14.1,
`google-api-python-client` 2.199.0, `boto3` 1.43.78,
`subagents-pydantic-ai` 0.2.21, `ruff` 0.16.4 and `ty` 0.0.74. The two
linters moving is what matters - a new `ruff` or `ty` is what turns a green
tree red - so `make lint-backend` on the merged head is the verification.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1157 was green on the merged head.