### PR TITLE
chore: cut 0.0.258

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.258] - 2026-08-26
+
+### Fixed
+
+- **Nothing called `background.drain()`, though its docstring said the lifespan
+  did.** So shutting down mid-flight cancelled an ingestion or a sync that
+  `background.spawn` had handed off, and left a document stuck in `processing`
+  forever. The lifespan now awaits the drain after intake stops and before the
+  vector store, Redis and the session are disposed - the draining task reads all
+  three, so it has to finish or be cancelled first. `tests/test_lifespan_drain.py`
+  drives the real `main.lifespan` with startup's heavy collaborators stubbed,
+  spawns a task inside the serving window and asserts it runs to completion on
+  shutdown. (#11)
+
 ## [0.0.257] - 2026-08-26
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.257"
+version = "0.0.258"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.257"
+version = "0.0.258"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.257",
+  "version": "0.0.258",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.258. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.258 and adds the CHANGELOG entry.

Releases #11: `background.drain()` existed and its docstring claimed the
lifespan called it, but nothing did - so a shutdown mid-flight cancelled an
ingestion or a sync handed off with `spawn`, and the document stayed
`processing` for ever. The drain is awaited after intake stops and before the
vector store, Redis and the session are disposed, because the draining task
reads all three.

A pre-existing gap in `drain()` itself - a task spawned *during* the drain is
not awaited, and a cancelled task's `CancelledError` may process after the
stores are disposed - was filed separately rather than folded in here; #1097
is the branch that closes it.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1089 was green on the merged head.