### PR TITLE
chore: cut 0.0.259

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,25 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.259] - 2026-08-26
+
+### Fixed
+
+- **Every domain refusal was logged as an application error.** `_managed_session`
+  caught everything with `logger.exception(...)`, so a `NotFoundError` (404), an
+  `AuthorizationError` (403) and an `AlreadyExistsError` (409) each wrote a full
+  stack trace at ERROR - and on a platform whose value is mostly in what it
+  refuses, the refusals were the loudest lines in the log and a real 500 was buried
+  among them. A domain refusal rolls back and re-raises without a traceback now.
+  The ERROR line is kept for the unexpected and, deliberately, for a **5xx**
+  `AppException` such as `DatabaseError` or `ExternalServiceError`: that is a
+  server fault whose traceback the exception handler does not log, so suppressing
+  it here would lose it end to end. The gate is
+  `not isinstance(exc, AppException) or exc.status_code >= 500`, in a single branch
+  so the rollback stays wrapped on every path. The conftest mocks
+  `get_db_session`, which is why this lifecycle was off the tested path and the
+  noise went unseen. (#19)
+
 ## [0.0.258] - 2026-08-26
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.258"
+version = "0.0.259"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.258"
+version = "0.0.259"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.258",
+  "version": "0.0.259",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.259. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.259 and adds the CHANGELOG entry.

Releases #19: `_managed_session` logged every exception with
`logger.exception`, so a 404, a 403 and a 409 each wrote a stack trace at
ERROR - and on a platform whose value is mostly in what it refuses, the
refusals were the loudest lines in the log. A 5xx `AppException` keeps its
traceback deliberately: the exception handler does not log that one, so
suppressing it here would lose it end to end.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1091 was green on the merged head.