### PR TITLE
chore: cut 0.0.260

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,26 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.260] - 2026-08-26
+
+### Fixed
+
+- **`SecurityHeadersMiddleware` was fully written and never registered**, so no API
+  response carried a Content-Security-Policy, `X-Content-Type-Options`,
+  `X-Frame-Options`, `Referrer-Policy` or `Permissions-Policy`. The bundled nginx
+  sets a weaker subset and no CSP, so a self-hosted deployment not fronted by that
+  exact nginx got nothing at all. The sharpest sign it was an oversight: `files.py`
+  already opts its framed endpoint down to `SAMEORIGIN`, against a default that was
+  not there. Registered in `create_app` with `setdefault`, so the file download's
+  per-response `X-Frame-Options: SAMEORIGIN` still wins. (#18)
+- Two things the registration made live for the first time, fixed with it:
+  `X-XSS-Protection: 0` rather than the deprecated `1; mode=block`, per OWASP - the
+  CSP is the real defence - and the doc pages excluded by their *real* mounted
+  paths, since the schema is under the API prefix rather than at `/openapi.json`,
+  so the exclusion is not a dead entry and the CSP cannot break Swagger or ReDoc.
+  `docs/deploy.md` records the app-level headers for an operator running their own
+  proxy. (#18)
+
 ## [0.0.259] - 2026-08-26
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.259"
+version = "0.0.260"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.259"
+version = "0.0.260"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.259",
+  "version": "0.0.260",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.260. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.260 and adds the CHANGELOG entry.

Releases #18: `SecurityHeadersMiddleware` was written and never registered, so
no API response carried a CSP, `X-Content-Type-Options`, `X-Frame-Options`,
`Referrer-Policy` or `Permissions-Policy` - and a deployment not fronted by
the bundled nginx got nothing. Registered with `setdefault` so the file
download's `SAMEORIGIN` still wins. Two things the registration made live for
the first time are fixed with it: `X-XSS-Protection: 0` per OWASP, and the doc
pages excluded by their real mounted paths rather than a dead `/openapi.json`
entry.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1092 was green on the merged head.