### PR TITLE
chore: cut 0.0.263

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,30 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.263] - 2026-08-26
+
+### Fixed
+
+- **`drain()` waited on one snapshot of `_running`**, so a task that handed off
+  more work while draining - a channel run finishing an agent turn spawns each of
+  its notifications - could leave the freshly spawned task in flight when `drain()`
+  returned. It waits until `_running` is quiescent under one overall deadline now,
+  re-snapshotting each pass, so work spawned mid-drain is awaited while a task that
+  keeps spawning work cannot postpone shutdown for ever. (#1095)
+- **After the timeout it called `task.cancel()` and returned immediately**, so a
+  caller that disposes shared resources next - the Redis client, the database
+  engine - raced a cancelled task still unwinding through its own `finally` on those
+  very resources. Whatever overran is cancelled and `gather`ed to a terminal state
+  before `drain()` returns. (#1095)
+- One edge is deliberately left: the post-deadline cancel and gather snapshots the
+  overrunning set once, so a cancelled task whose `finally` spawned fresh work while
+  unwinding would not be awaited. No `finally` in the codebase spawns background
+  work, and looping that phase would reintroduce the unbounded wait the single shot
+  avoids. (#1095)
+- The third gap in the issue - a bot created just before shutdown whose deferred
+  `open_inbound_stream` reopens intake during teardown - is a shutdown *ordering*
+  concern rather than a `drain()` one, and is #1119. (#1095, #1119)
+
 ## [0.0.262] - 2026-08-26
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.262"
+version = "0.0.263"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.262"
+version = "0.0.263"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.262",
+  "version": "0.0.263",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.263. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.263 and adds the CHANGELOG entry.

Releases #1095, both of its `drain()`-internal gaps. The drain waited on one
snapshot of `_running`, so work handed off while draining could still be in
flight when it returned; and after the timeout it cancelled and returned at
once, racing a caller that disposes Redis and the database engine next against
a task still unwinding through its `finally` on them. It now waits to
quiescence under one deadline, re-snapshotting each pass, then gathers what
overran to a terminal state.

The issue's third gap is shutdown ordering rather than drain, and is #1119.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1097 was green on the merged head.