### PR TITLE
chore: cut 0.0.264

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,36 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.264] - 2026-08-26
+
+### Fixed
+
+- **A malformed sealed payload put the decrypted credential in the log.**
+  `unseal_secret` promised `BadRequestError` for an envelope holding something that
+  is not a secret payload, but `_STORABLE_ADAPTER.validate_json(...)` raises
+  `pydantic_core.ValidationError`, which is not an `AppException` - so it reached
+  `unhandled_exception_handler` and `logger.exception`. A pydantic `ValidationError`
+  embeds the offending input in its message, and here that input is the decrypted
+  credential, so the plaintext landed in the log line and, under
+  `logfire.instrument_fastapi`, on the exception span - breaking the guarantee
+  `docs/secrets.md` states. It is caught and re-raised as
+  `BadRequestError(message="Stored secret is not a usable payload")` naming only the
+  recorded kind. (#21)
+- Two parts, both load-bearing. The **type change** is the primary guard: a 4xx
+  `AppException` is logged at warning with no `exc_info`, so no traceback is
+  formatted on the HTTP path and it never reaches the `logger.exception` handler.
+  And **`from None`** covers the non-HTTP readers whose traceback *is* rendered - a
+  Prefect task failure, `doctor.py`'s own formatting - by setting
+  `__suppress_context__` and keeping the chained `ValidationError`, which still
+  holds the plaintext in `__context__`, out of the formatted traceback. The
+  regression test pins `__suppress_context__` rather than `__cause__`, because
+  `__cause__` is `None` with or without `from None` and asserting on it would let a
+  future edit reintroduce the leak silently. (#21)
+- Reachable from `resolve_for_bindings`, `ModelProfileService` and the provider
+  listing key whenever a stored payload no longer validates: a hand-edited row, a
+  rollback to a build whose `SecretKind` enum lacks a kind a newer build wrote, or a
+  future field tightening. (#21)
+
 ## [0.0.263] - 2026-08-26
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.263"
+version = "0.0.264"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.263"
+version = "0.0.264"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.263",
+  "version": "0.0.264",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.264. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.264 and adds the CHANGELOG entry.

Releases #21: `unseal_secret` promised `BadRequestError` for an envelope
holding a non-payload, but pydantic's `ValidationError` is not an
`AppException`, so it reached `logger.exception` - and a pydantic
`ValidationError` embeds the offending input, which here is the decrypted
credential. The plaintext reached the log line and the logfire exception span,
against the guarantee `docs/secrets.md` states. The type change keeps it off
the HTTP path; `from None` keeps it out of a rendered traceback for the Prefect
and CLI readers.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1098 was green on the merged head.