### PR TITLE
chore: cut 0.0.265

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,30 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.265] - 2026-08-26
+
+### Fixed
+
+- **Upload parsing and local file storage were `async def` over pure blocking work,
+  with no suspension point at all.** `FileUploadService.parse_content` ran pymupdf
+  over every page and openpyxl over every cell, and `LocalFileStorage.save`/`load`
+  decoded and wrote or read up to `MAX_UPLOAD_SIZE` - so one user uploading a large
+  PDF, or an agent turn loading three attached images, froze every other request and
+  every in-flight agent WebSocket stream on that uvicorn worker until the work
+  landed. Every branch of the parse and both byte operations are offloaded with
+  `asyncio.to_thread`. The codebase already knew the pattern: `agents/mcp.py` routes
+  DNS through a thread, and `rag_document.py` switched a write to anyio for exactly
+  this reason - while writing the identical bytes twice, only one of which had been
+  fixed. (#25)
+- The now-dead `ASYNC230` per-file ruff ignore on `file_upload.py` is gone: the only
+  blocking open left is `pymupdf.open` inside a sync helper, so the rule no longer
+  fires. Three thread-identity regression tests assert the parse and the two byte
+  operations each run off the event loop's thread, and each fails if its
+  `to_thread` is reverted. (#25)
+- Scope is the two request-path functions. The worker-side blocking IO the issue
+  also lists is the worker rather than the request path, and is tracked separately.
+  (#25)
+
 ## [0.0.264] - 2026-08-26
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.264"
+version = "0.0.265"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.264"
+version = "0.0.265"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.264",
+  "version": "0.0.265",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.265. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.265 and adds the CHANGELOG entry.

Releases #25: `parse_content` and the local storage byte operations were
`async def` over pymupdf, openpyxl and `Path.write_bytes` with no suspension
point, so one large PDF upload froze every other request and every in-flight
agent stream on that worker. Each branch is offloaded with
`asyncio.to_thread`, and the dead `ASYNC230` ignore on the file goes with it.

The worker-side blocking IO the issue also lists is the worker rather than the
request path and is tracked separately; #1122 is the branch that closes it.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1099 was green on the merged head.