### PR TITLE
chore: cut 0.0.267

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,25 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.267] - 2026-08-26
+
+### Changed
+
+- **`app/core/sanitize.py` is on the coverage gate and the type-checker overrides.**
+  It is the SSRF allow and deny every outbound URL a tenant chooses is checked
+  against - a webhook target, an MCP server address - and it was in neither list,
+  which is what #28 asks to extend to the modules implementing the refusals
+  CLAUDE.md names as must-cover. It sat at 95%: the two DNS-failure exits in
+  `resolve_pinned_url`, a lookup that raises `gaierror` and one that resolves to no
+  address, had no test. Both are covered now with a mocked `getaddrinfo`, and the
+  module is added to both lists verbatim and in the same position, beside
+  `pinned_http.py` - the validator paired with the client that dials what it
+  validated. (#28)
+- The rest of #28's tail stays open and is named on the issue: `agent_embed.py` at
+  85% needs substantial tests first, and the four channel modules hold open bugs
+  and need a real database to measure. The five-routes layering landed in #232, and
+  `audit.py` is gated by #20. (#28)
+
 ## [0.0.266] - 2026-08-26
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.266"
+version = "0.0.267"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.266"
+version = "0.0.267"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.266",
+  "version": "0.0.267",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.267. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.267 and adds the CHANGELOG entry.

Releases the coverage-gate tail of #28. `app/core/sanitize.py` is the SSRF
allow and deny every tenant-chosen outbound URL is checked against, and it was
on neither the coverage `include` nor the ty overrides - sitting at 95%, with
both DNS-failure exits in `resolve_pinned_url` untested. Covered, then gated
beside `pinned_http.py`.

The `_listing_key` narrowing the issue also asks for was declined, and the
remaining tail modules are named on the issue rather than gated blind, so #28
stays open.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1104 was green on the merged head.