### PR TITLE
chore: cut 0.0.268

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.268] - 2026-08-26
+
+### Fixed
+
+- **A non-ASCII credential was a 500 with a traceback rather than a refusal.**
+  `secrets.compare_digest` raises `TypeError` on a non-ASCII `str` instead of
+  answering `False`, and three checks compared `str` with the left operand taken
+  from the caller: `deps.verify_api_key` on the API-key header, the Mattermost
+  webhook bearer check, and the Slack signature check. So `{"token": "é"}` to the
+  *unauthenticated* Mattermost webhook, or a non-ASCII `X-Slack-Signature`, was a
+  logged 500 - a free log-flooding primitive. Not an auth bypass, since the
+  comparison never matched anyway. All three compare encoded bytes now: still
+  constant-time, and non-ASCII refuses cleanly. (#33)
+
 ## [0.0.267] - 2026-08-26
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.267"
+version = "0.0.268"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.267"
+version = "0.0.268"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.267",
+  "version": "0.0.268",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.268. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.268 and adds the CHANGELOG entry.

Releases one item of #33's batch: `compare_digest` raises `TypeError` on a
non-ASCII `str` rather than returning `False`, and three checks compared `str`
with the left operand from the caller - so a non-ASCII token to the
unauthenticated Mattermost webhook, or a non-ASCII Slack signature, was a
logged 500 instead of a 403. A free log-flooding primitive, not an auth
bypass. All three compare encoded bytes now.

The rest of the batch is itemised on #33 with why each is not sub-hour work,
so the issue stays open.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1105 was green on the merged head.