### PR TITLE
chore: cut 0.0.269

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,29 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.269] - 2026-08-26
+
+### Fixed
+
+- **An embed token with no `iat` was accepted for ever.**
+  `AgentEmbedService._verify_token` checked max-age only
+  `if isinstance(iat, int | float)` - opportunistically - and PyJWT requires
+  neither `iat` nor `exp`, so a correctly signed `{"sub": "user-42"}` carried no
+  freshness claim at all. One token scraped from a browser's network tab kept the
+  widget answering on the organization's bill indefinitely, which is the exact
+  failure the surrounding code twice names as the dangerous one. A within-window
+  `iat` is required unconditionally now: no `iat`, or one older than the 12h
+  ceiling, is refused. (#23)
+- **`exp` is deliberately not an alternative freshness claim.** Treating it as one
+  would let a customer's ordinary far-future `exp` override the ceiling, so a copied
+  token could replay until it expired - a milder version of the same leak. `exp`,
+  when present, is still validated by PyJWT, so it can only shorten the window,
+  never extend it past 12h. Behaviour is unchanged for every token that carries an
+  `iat`. (#23)
+- A pre-existing robustness gap left out of scope and filed: a malformed `null` or
+  `[]` `exp`/`iat` raises a raw `TypeError` inside `jwt.decode` and 500s. Not
+  exploitable - it fails closed. (#1107)
+
 ## [0.0.268] - 2026-08-26
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.268"
+version = "0.0.269"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.268"
+version = "0.0.269"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.268",
+  "version": "0.0.269",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.269. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.269 and adds the CHANGELOG entry.

Releases #23: the embed token's max-age was checked only when an `iat` was
present, and PyJWT requires neither `iat` nor `exp` - so a correctly signed
`{"sub": "user-42"}` was accepted for ever, and a token scraped from a network
tab kept the widget answering on the organization's bill. A within-window
`iat` is now required unconditionally, and `exp` is deliberately not accepted
as an alternative: an ordinary far-future `exp` would otherwise override the
12h ceiling.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1106 was green on the merged head.