### PR TITLE
refactor(channels): lift the transport boilerplate into shared helpers

### DIFF
--- a/backend/app/services/channels/base.py
+++ b/backend/app/services/channels/base.py
@@ -73,7 +73,21 @@ def channel_key(platform_chat_id: str) -> str:
     in with the import - and two implementations of "which channel is this" is
     how one of them ends up asking Mattermost about a thread id.
     """
-    return platform_chat_id.partition(":")[0]
+    return split_thread(platform_chat_id)[0]
+
+
+def split_thread(platform_chat_id: str) -> tuple[str, str]:
+    """The chat and the thread a message's id folds together.
+
+    Slack packs `channel:thread_ts` into `platform_chat_id` and Mattermost packs
+    `channel:root_id` the same way; every other platform's id is the chat with an
+    empty thread. `channel_key` keeps the channel half alone; this keeps both, for
+    a reply that has to be posted back into the thread it came from. The empty
+    string when there is no colon is what an unthreaded reply passes on, which each
+    adapter reads as "top of the channel".
+    """
+    channel, _, thread = platform_chat_id.partition(":")
+    return channel, thread
 
 
 @dataclass(frozen=True)

--- a/backend/app/services/channels/mattermost.py
+++ b/backend/app/services/channels/mattermost.py
@@ -51,6 +51,7 @@ from app.services.channels.base import (
     IncomingAttachment,
     IncomingMessage,
     OutgoingMessage,
+    split_thread,
 )
 from app.services.channels.exceptions import ChannelNotConfigured
 from app.services.channels.router import ChannelMessageRouter
@@ -120,6 +121,21 @@ class MattermostAdapter(ChannelAdapter):
         """Record which Mattermost server a bot belongs to."""
         self._base_urls[bot_id] = api_base_url.rstrip("/")
 
+    @staticmethod
+    def _client() -> httpx.AsyncClient:
+        """An HTTP client carrying the shared timeout, for one request cycle.
+
+        Mattermost keeps an idle socket open only so long, so every call opens its
+        own `async with` client rather than holding one on the adapter - the one
+        place the timeout is set, so a new REST call cannot forget it.
+        """
+        return httpx.AsyncClient(timeout=_HTTP_TIMEOUT)
+
+    @staticmethod
+    def _headers(bot_token: str) -> dict[str, str]:
+        """The bearer auth header every REST call to this server carries."""
+        return {"Authorization": f"Bearer {bot_token}"}
+
     async def send_message(self, bot_token: str, msg: OutgoingMessage) -> None:
         """Post a reply.
 
@@ -139,10 +155,10 @@ class MattermostAdapter(ChannelAdapter):
         # and only replies failed - which is the confusing half of the bug.
         base_url = msg.api_base_url.rstrip("/")
 
-        channel_id, _, root_id = msg.platform_chat_id.partition(":")
-        headers = {"Authorization": f"Bearer {bot_token}"}
+        channel_id, root_id = split_thread(msg.platform_chat_id)
+        headers = self._headers(bot_token)
 
-        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+        async with self._client() as client:
             uploads: list[tuple[str, tuple[str, bytes, str]]] = []
             if msg.image_png is not None:
                 uploads.append(("files", (msg.image_filename, msg.image_png, "image/png")))
@@ -177,17 +193,17 @@ class MattermostAdapter(ChannelAdapter):
         """Post the message that will become the answer, and return its id."""
         if not msg.api_base_url:
             return None
-        channel_id, _, root_id = msg.platform_chat_id.partition(":")
+        channel_id, root_id = split_thread(msg.platform_chat_id)
         body: dict[str, Any] = {"channel_id": channel_id, "message": msg.text}
         if root_id:
             body["root_id"] = root_id
         elif msg.reply_to_message_id:
             body["root_id"] = msg.reply_to_message_id
 
-        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+        async with self._client() as client:
             response = await client.post(
                 f"{msg.api_base_url.rstrip('/')}/api/v4/posts",
-                headers={"Authorization": f"Bearer {bot_token}"},
+                headers=self._headers(bot_token),
                 json=body,
             )
         response.raise_for_status()
@@ -206,10 +222,10 @@ class MattermostAdapter(ChannelAdapter):
         # only thing that hands out a handle - but the type says otherwise and a
         # crash mid-answer is a worse way to find out.
         base_url = (msg.api_base_url or "").rstrip("/")
-        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+        async with self._client() as client:
             response = await client.put(
                 f"{base_url}/api/v4/posts/{handle}/patch",
-                headers={"Authorization": f"Bearer {bot_token}"},
+                headers=self._headers(bot_token),
                 json={"message": msg.text},
             )
         response.raise_for_status()
@@ -225,7 +241,7 @@ class MattermostAdapter(ChannelAdapter):
         socket = self._sockets.get(bot_id)
         if socket is None:
             return
-        channel_id, _, root_id = msg.platform_chat_id.partition(":")
+        channel_id, root_id = split_thread(msg.platform_chat_id)
         with contextlib.suppress(Exception):
             await socket.send(
                 json.dumps(
@@ -284,8 +300,8 @@ class MattermostAdapter(ChannelAdapter):
     ) -> ChannelDetails:
         """`GET /channels/{id}`, with the member count from `/stats` beside it."""
         base_url = self._server(api_base_url)
-        headers = {"Authorization": f"Bearer {bot_token}"}
-        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+        headers = self._headers(bot_token)
+        async with self._client() as client:
             channel = await client.get(f"{base_url}/api/v4/channels/{channel_id}", headers=headers)
             channel.raise_for_status()
             stats = await client.get(
@@ -339,8 +355,8 @@ class MattermostAdapter(ChannelAdapter):
         waiting for.
         """
         base_url = self._server(api_base_url)
-        headers = {"Authorization": f"Bearer {bot_token}"}
-        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+        headers = self._headers(bot_token)
+        async with self._client() as client:
             members = await client.get(
                 f"{base_url}/api/v4/channels/{channel_id}/members",
                 headers=headers,
@@ -384,10 +400,10 @@ class MattermostAdapter(ChannelAdapter):
         treats a question it could not ask as a refusal.
         """
         base_url = self._server(api_base_url)
-        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+        async with self._client() as client:
             found = await client.get(
                 f"{base_url}/api/v4/channels/{channel_id}/members/{platform_user_id}",
-                headers={"Authorization": f"Bearer {bot_token}"},
+                headers=self._headers(bot_token),
             )
         if found.status_code == 404:
             return False
@@ -405,8 +421,8 @@ class MattermostAdapter(ChannelAdapter):
         one most deployments would refuse outright.
         """
         base_url = self._server(api_base_url)
-        headers = {"Authorization": f"Bearer {bot_token}"}
-        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+        headers = self._headers(bot_token)
+        async with self._client() as client:
             channel = await client.get(f"{base_url}/api/v4/channels/{channel_id}", headers=headers)
             channel.raise_for_status()
             team_id = str(channel.json().get("team_id") or "")
@@ -446,8 +462,8 @@ class MattermostAdapter(ChannelAdapter):
         gets it the way a person would.
         """
         base_url = self._server(api_base_url)
-        headers = {"Authorization": f"Bearer {bot_token}"}
-        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+        headers = self._headers(bot_token)
+        async with self._client() as client:
             response = await client.get(
                 f"{base_url}/api/v4/channels/{channel_id}/posts",
                 headers=headers,
@@ -548,10 +564,10 @@ class MattermostAdapter(ChannelAdapter):
         if not base_url:
             return None
         try:
-            async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+            async with self._client() as client:
                 response = await client.get(
                     f"{base_url}/api/v4/users/me",
-                    headers={"Authorization": f"Bearer {bot_token}"},
+                    headers=self._headers(bot_token),
                 )
             response.raise_for_status()
             return str(response.json().get("id") or "") or None
@@ -790,10 +806,8 @@ class MattermostAdapter(ChannelAdapter):
                 "This Mattermost bot has no server URL recorded, so its files cannot be fetched."
             )
 
-        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
-            response = await client.get(
-                attachment.handle, headers={"Authorization": f"Bearer {bot_token}"}
-            )
+        async with self._client() as client:
+            response = await client.get(attachment.handle, headers=self._headers(bot_token))
         response.raise_for_status()
         return response.content
 

--- a/backend/app/services/channels/slack.py
+++ b/backend/app/services/channels/slack.py
@@ -15,7 +15,7 @@ import hmac
 import logging
 import time
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from app.agents.capabilities.channel_tools import (
     ChannelDetails,
@@ -30,9 +30,13 @@ from app.services.channels.base import (
     IncomingAttachment,
     IncomingMessage,
     OutgoingMessage,
+    split_thread,
 )
 from app.services.channels.exceptions import ChannelNotConfigured
 from app.services.channels.router import ChannelMessageRouter
+
+if TYPE_CHECKING:
+    from slack_sdk.web.async_client import AsyncWebClient
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +64,19 @@ class SlackAdapter(ChannelAdapter):
         """Register the app-level token Socket Mode will connect with."""
         self._app_tokens[bot_id] = app_token
 
+    @staticmethod
+    def _web(bot_token: str) -> "AsyncWebClient":
+        """A Web API client for one bot's token.
+
+        The `slack_sdk` import is deferred to the call rather than the module so a
+        deployment that runs no Slack bot does not pay for the SDK at import time,
+        which is why every caller builds a client per request rather than holding
+        one on the adapter.
+        """
+        from slack_sdk.web.async_client import AsyncWebClient
+
+        return AsyncWebClient(token=bot_token)
+
     async def begin_reply(self, bot_token: str, msg: OutgoingMessage) -> str | None:
         """Post the message that will become the answer, and return its `ts`.
 
@@ -68,30 +85,24 @@ class SlackAdapter(ChannelAdapter):
         which is why the channel and the thread are split apart here the same way
         `send_message` splits them.
         """
-        from slack_sdk.web.async_client import AsyncWebClient
-
-        channel, _, thread_ts = msg.platform_chat_id.partition(":")
+        channel, thread_ts = split_thread(msg.platform_chat_id)
         kwargs: dict[str, Any] = {"channel": channel, "text": msg.text}
         if thread_ts:
             kwargs["thread_ts"] = thread_ts
-        response = await AsyncWebClient(token=bot_token).chat_postMessage(**kwargs)
+        response = await self._web(bot_token).chat_postMessage(**kwargs)
         posted = response.get("ts")
         return str(posted) if posted else None
 
     async def update_reply(self, bot_token: str, msg: OutgoingMessage, handle: str) -> None:
         """Rewrite a message already in the channel."""
-        from slack_sdk.web.async_client import AsyncWebClient
-
-        channel, _, _thread_ts = msg.platform_chat_id.partition(":")
-        await AsyncWebClient(token=bot_token).chat_update(channel=channel, ts=handle, text=msg.text)
+        channel, _thread_ts = split_thread(msg.platform_chat_id)
+        await self._web(bot_token).chat_update(channel=channel, ts=handle, text=msg.text)
 
     async def send_message(self, bot_token: str, msg: OutgoingMessage) -> None:
         """Send a reply back to Slack via the Web API."""
-        from slack_sdk.web.async_client import AsyncWebClient
+        client = self._web(bot_token)
 
-        client = AsyncWebClient(token=bot_token)
-
-        channel, _, thread_ts = msg.platform_chat_id.partition(":")
+        channel, thread_ts = split_thread(msg.platform_chat_id)
 
         kwargs: dict[str, Any] = {
             "channel": channel,
@@ -156,9 +167,7 @@ class SlackAdapter(ChannelAdapter):
         self, bot_token: str, channel_id: str, *, api_base_url: str | None
     ) -> ChannelDetails:
         """`conversations.info`, with the member count Slack only sends on request."""
-        from slack_sdk.web.async_client import AsyncWebClient
-
-        response = await AsyncWebClient(token=bot_token).conversations_info(
+        response = await self._web(bot_token).conversations_info(
             channel=channel_id, include_num_members=True
         )
         found: dict[str, Any] = response.get("channel") or {}
@@ -181,9 +190,7 @@ class SlackAdapter(ChannelAdapter):
         bounded by `limit`, because this runs inside a tool call somebody is
         waiting on, and serially it is the length of the channel in round trips.
         """
-        from slack_sdk.web.async_client import AsyncWebClient
-
-        client = AsyncWebClient(token=bot_token)
+        client = self._web(bot_token)
         response = await client.conversations_members(channel=channel_id, limit=limit)
         user_ids = [str(user_id) for user_id in (response.get("members") or [])][:limit]
         if not user_ids:
@@ -218,9 +225,7 @@ class SlackAdapter(ChannelAdapter):
         bigger than it answers "not a member", logged, which is the participant
         model's safe default rather than a claim about the room.
         """
-        from slack_sdk.web.async_client import AsyncWebClient
-
-        client = AsyncWebClient(token=bot_token)
+        client = self._web(bot_token)
         cursor: str | None = None
         for _ in range(_MEMBERSHIP_PAGES):
             response = await client.conversations_members(
@@ -250,9 +255,7 @@ class SlackAdapter(ChannelAdapter):
         name and the purpose - the two fields somebody would have typed into a
         search box.
         """
-        from slack_sdk.web.async_client import AsyncWebClient
-
-        response = await AsyncWebClient(token=bot_token).conversations_list(
+        response = await self._web(bot_token).conversations_list(
             types="public_channel,private_channel", limit=1000, exclude_archived=True
         )
         needle = query.casefold()
@@ -285,11 +288,7 @@ class SlackAdapter(ChannelAdapter):
         the tool for turning ids into people, and the model can call it when the
         answer actually depends on who spoke.
         """
-        from slack_sdk.web.async_client import AsyncWebClient
-
-        response = await AsyncWebClient(token=bot_token).conversations_history(
-            channel=channel_id, limit=limit
-        )
+        response = await self._web(bot_token).conversations_history(channel=channel_id, limit=limit)
         messages = list(reversed(response.get("messages") or []))
         return [
             ChannelPost(
@@ -373,9 +372,7 @@ class SlackAdapter(ChannelAdapter):
 
         client = SocketModeClient(
             app_token=app_token,
-            web_client=__import__(
-                "slack_sdk.web.async_client", fromlist=["AsyncWebClient"]
-            ).AsyncWebClient(token=bot_token),
+            web_client=self._web(bot_token),
         )
 
         async def handler(client_: Any, req: SocketModeRequest) -> None:

--- a/backend/app/services/channels/telegram.py
+++ b/backend/app/services/channels/telegram.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import hmac
 import logging
+from collections.abc import AsyncIterator
 from typing import Any
 
 from aiogram import Bot, Dispatcher
@@ -46,10 +47,28 @@ class TelegramAdapter(ChannelAdapter):
     def __init__(self) -> None:
         self._polling_tasks: dict[str, asyncio.Task[None]] = {}
 
+    @staticmethod
+    @contextlib.asynccontextmanager
+    async def _bot(
+        bot_token: str, *, default: DefaultBotProperties | None = None
+    ) -> AsyncIterator[Bot]:
+        """A Telegram bot bound to one token, its TLS session closed on the way out.
+
+        aiogram opens a fresh session per `Bot` and leaks the connection if it is
+        not closed, so every send and every read goes through one of these rather
+        than repeating the try/finally. `default` is how the streamed replies ask
+        for Markdown parse mode while the plain sends take none; `None` builds a bot
+        with no default, the historic form the rest use.
+        """
+        bot = Bot(token=bot_token, default=default) if default is not None else Bot(token=bot_token)
+        try:
+            yield bot
+        finally:
+            await bot.session.close()
+
     async def begin_reply(self, bot_token: str, msg: OutgoingMessage) -> str | None:
         """Send the message that will become the answer, and return its id."""
-        bot = Bot(token=bot_token)
-        try:
+        async with self._bot(bot_token) as bot:
             sent = await bot.send_message(
                 chat_id=msg.platform_chat_id,
                 text=msg.text,
@@ -57,8 +76,6 @@ class TelegramAdapter(ChannelAdapter):
                 if msg.reply_to_message_id
                 else None,
             )
-        finally:
-            await bot.session.close()
         return str(sent.message_id)
 
     async def update_reply(self, bot_token: str, msg: OutgoingMessage, handle: str) -> None:
@@ -68,13 +85,10 @@ class TelegramAdapter(ChannelAdapter):
         being streamed, and Telegram rejects an unclosed `**` with a 400. The
         final send formats it, once the text is whole.
         """
-        bot = Bot(token=bot_token)
-        try:
+        async with self._bot(bot_token) as bot:
             await bot.edit_message_text(
                 chat_id=msg.platform_chat_id, message_id=int(handle), text=msg.text
             )
-        finally:
-            await bot.session.close()
 
     async def send_message(self, bot_token: str, msg: OutgoingMessage) -> None:
         """Send a reply back to Telegram.
@@ -82,12 +96,10 @@ class TelegramAdapter(ChannelAdapter):
         Tries Markdown parse mode first; falls back to plain text if
         Telegram rejects the formatting (common with LLM-generated markdown).
         """
-        bot = Bot(
-            token=bot_token,
-            default=DefaultBotProperties(parse_mode=ParseMode.MARKDOWN),
-        )
         reply_to = int(msg.reply_to_message_id) if msg.reply_to_message_id else None
-        try:
+        async with self._bot(
+            bot_token, default=DefaultBotProperties(parse_mode=ParseMode.MARKDOWN)
+        ) as bot:
             if msg.image_png is not None:
                 from aiogram.types import BufferedInputFile
 
@@ -115,8 +127,6 @@ class TelegramAdapter(ChannelAdapter):
                     parse_mode=None,
                     reply_to_message_id=reply_to,
                 )
-        finally:
-            await bot.session.close()
 
     @staticmethod
     async def _send_documents(bot: Bot, msg: OutgoingMessage, reply_to: int | None) -> None:
@@ -169,12 +179,9 @@ class TelegramAdapter(ChannelAdapter):
         A Telegram chat has a `description` and no separate topic, so `purpose`
         carries it and `topic` stays empty rather than repeating it.
         """
-        bot = Bot(token=bot_token)
-        try:
+        async with self._bot(bot_token) as bot:
             chat = await bot.get_chat(chat_id=channel_id)
             count = await bot.get_chat_member_count(chat_id=channel_id)
-        finally:
-            await bot.session.close()
 
         return ChannelDetails(
             channel_id=str(chat.id),
@@ -195,11 +202,8 @@ class TelegramAdapter(ChannelAdapter):
         while reading as "everybody here" would have the model tell somebody
         their colleague is not in the chat.
         """
-        bot = Bot(token=bot_token)
-        try:
+        async with self._bot(bot_token) as bot:
             administrators = await bot.get_chat_administrators(chat_id=channel_id)
-        finally:
-            await bot.session.close()
 
         return [
             ChannelMember(
@@ -229,13 +233,11 @@ class TelegramAdapter(ChannelAdapter):
             member_id = int(platform_user_id)
         except ValueError:
             return False
-        bot = Bot(token=bot_token)
-        try:
-            found = await bot.get_chat_member(chat_id=channel_id, user_id=member_id)
-        except TelegramBadRequest:
-            return False
-        finally:
-            await bot.session.close()
+        async with self._bot(bot_token) as bot:
+            try:
+                found = await bot.get_chat_member(chat_id=channel_id, user_id=member_id)
+            except TelegramBadRequest:
+                return False
         return found.status not in ("left", "kicked")
 
     async def start_polling(self, bot_id: str, bot_token: str) -> None:
@@ -273,44 +275,36 @@ class TelegramAdapter(ChannelAdapter):
 
     async def _run_polling_once(self, bot_id: str, bot_token: str) -> None:
         """Run one polling session using aiogram Dispatcher."""
-        bot = Bot(
-            token=bot_token,
-            default=DefaultBotProperties(parse_mode=ParseMode.MARKDOWN),
-        )
-        dp = Dispatcher()
+        async with self._bot(
+            bot_token, default=DefaultBotProperties(parse_mode=ParseMode.MARKDOWN)
+        ) as bot:
+            dp = Dispatcher()
 
-        @dp.message()
-        async def on_message(message: AiogramMessage) -> None:
-            await self._handle_update(message, bot_id)
+            @dp.message()
+            async def on_message(message: AiogramMessage) -> None:
+                await self._handle_update(message, bot_id)
 
-        try:
             await dp.start_polling(bot, handle_signals=False)
-        finally:
-            await bot.session.close()
 
     async def register_webhook(self, bot_token: str, url: str, secret: str | None) -> bool:
         """Register a webhook URL with Telegram."""
-        bot = Bot(token=bot_token)
-        try:
-            await bot.set_webhook(url=url, secret_token=secret)
-            return True
-        except Exception:
-            logger.exception("Failed to register Telegram webhook")
-            return False
-        finally:
-            await bot.session.close()
+        async with self._bot(bot_token) as bot:
+            try:
+                await bot.set_webhook(url=url, secret_token=secret)
+                return True
+            except Exception:
+                logger.exception("Failed to register Telegram webhook")
+                return False
 
     async def delete_webhook(self, bot_token: str) -> bool:
         """Remove the webhook from Telegram."""
-        bot = Bot(token=bot_token)
-        try:
-            await bot.delete_webhook()
-            return True
-        except Exception:
-            logger.exception("Failed to delete Telegram webhook")
-            return False
-        finally:
-            await bot.session.close()
+        async with self._bot(bot_token) as bot:
+            try:
+                await bot.delete_webhook()
+                return True
+            except Exception:
+                logger.exception("Failed to delete Telegram webhook")
+                return False
 
     def verify_webhook_signature(
         self, headers: dict[str, str], secret: str, body: str | None = None
@@ -432,8 +426,7 @@ class TelegramAdapter(ChannelAdapter):
         and the path it resolves to expires - so resolving it at parse time would
         hand the router a link that had gone stale by the time anybody used it.
         """
-        bot = Bot(token=bot_token)
-        try:
+        async with self._bot(bot_token) as bot:
             info = await bot.get_file(attachment.handle)
             if info.file_path is None:
                 raise ValueError(f"Telegram returned no path for {attachment.filename}")
@@ -441,8 +434,6 @@ class TelegramAdapter(ChannelAdapter):
             if buffer is None:
                 raise ValueError(f"Telegram returned no bytes for {attachment.filename}")
             return buffer.read()
-        finally:
-            await bot.session.close()
 
     async def _handle_update(self, message: AiogramMessage, bot_id: str) -> None:
         """Route one update from the polling loop, through the one parser.


### PR DESCRIPTION
Four transport blocks were copied across the three channel adapters, so a change to any had to be made at 6–10 sites by hand and a fourth channel would copy them all again.

## What changed

- **`split_thread(id) -> (channel, thread)`** in `base.py` — replaces the `channel, _, root = id.partition(":")` unpack at 3 Mattermost + 3 Slack sites; `channel_key` now calls it too, so "which channel is this" has one implementation.
- **`SlackAdapter._web(token)`** — the lazy `AsyncWebClient` import + construction, previously repeated at 9 sites (including a dynamic `__import__` in the Socket Mode path). The import stays deferred so a deployment running no Slack bot does not pay for the SDK at import time.
- **`TelegramAdapter._bot(token, *, default=None)`** — an async context manager wrapping `Bot(...)` and the `try/finally: bot.session.close()` that **10** methods repeated, each of which leaked a TLS session if the close was forgotten. `default` carries the Markdown parse mode the streamed replies ask for; plain sends pass none.
- **`MattermostAdapter._client()` / `_headers(token)`** — the `httpx.AsyncClient(timeout=…)` and the bearer header, each repeated at 10 sites, so the timeout and the auth shape now have one definition.

## Behaviour-preserving

Every session still closes on every exit path (normal, early `return`, exception, the `except`-clause `return`s); the no-default `Bot` construction is byte-identical; `split_thread` drops only the separator the old unpack already discarded.

## How it was verified

- An adversarial diff review across all six axes (session lifecycle on every exit path, `default` mapping, `split_thread` semantics, post-block value reads, the lazy-import path, leftover/undefined names) found **no behaviour change**.
- **540 channel tests green**; `make lint-backend` clean (ruff, ruff-format, ty, vulture, deptry, guards); `ty` adds zero diagnostics over baseline. The adapters are template-inherited and not on the coverage gate.

Enables #547 (one normaliser per adapter).

Closes #565