### PR TITLE
chore: cut 0.0.272

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.272] - 2026-08-26
+
+### Fixed
+
+- **A malformed embed-token claim was a 500 rather than a refusal.**
+  `_verify_token` decoded a visitor token inside a `try/except jwt.PyJWTError`, but
+  a signed token whose `exp` or `iat` is `null`, `[]` or `{}` makes PyJWT's own
+  validation run `int()` on it - which raises a bare `TypeError`, not a
+  `PyJWTError`, so it escaped the handler and became an uncaught 500 with a logged
+  traceback. Not attacker-exploitable: claim validation runs after signature
+  verification, so minting such a token needs the customer's own signing secret,
+  and it fails closed. The catch covers `TypeError` now and raises `EmbedDenied`.
+  `ValueError` is left out deliberately - on the pinned PyJWT only these coercions
+  raise a bare `TypeError`, and every malformed-segment, base64, JSON or
+  non-numeric case is already a `PyJWTError` subclass, so catching it would be an
+  unreachable branch. (#1107)
+
 ## [0.0.271] - 2026-08-26
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.271"
+version = "0.0.272"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.271"
+version = "0.0.272"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.271",
+  "version": "0.0.272",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.272. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.272 and adds the CHANGELOG entry.

Releases #1107: a signed embed token whose `exp` or `iat` is `null`, `[]` or
`{}` made PyJWT's own validation run `int()` on it, raising a bare `TypeError`
rather than a `PyJWTError` - so it escaped the handler and became an uncaught
500. Not exploitable, since claim validation runs after signature
verification and it fails closed, but a customer's malformed-but-signed token
should be a 4xx. `ValueError` is deliberately not caught: on the pinned PyJWT
that branch is unreachable.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1120 was green on the merged head.