### PR TITLE
test(rag): build the deletion tests' store on the fixture's engine

### DIFF
--- a/backend/tests/integration/test_deletion_reconciliation.py
+++ b/backend/tests/integration/test_deletion_reconciliation.py
@@ -179,42 +179,38 @@ class TestDeletingAnOrg:
             settings=app_settings.rag,
             embedding_service=MagicMock(),
             resolver=MagicMock(),
+            engine=engine,
         )
         factory = async_sessionmaker(engine, expire_on_commit=False)
         collection = f"kbnine{uuid.uuid4().hex[:12]}"
         table = store._table(collection)
-        try:
-            async with factory() as s:
-                user = _user()
-                s.add(user)
-                await s.flush()
-                org = await _org(s, user)
-                s.add(_org_collection(org.id, collection))
-                await s.execute(text(f"CREATE TABLE {table} (id int)"))
-                await s.commit()
-                org_id = org.id
+        async with factory() as s:
+            user = _user()
+            s.add(user)
+            await s.flush()
+            org = await _org(s, user)
+            s.add(_org_collection(org.id, collection))
+            await s.execute(text(f"CREATE TABLE {table} (id int)"))
+            await s.commit()
+            org_id = org.id
 
-            async with factory() as s:
-                assert (
-                    await s.execute(text("SELECT to_regclass(:t)"), {"t": table})
-                ).scalar() is not None
+        async with factory() as s:
+            assert (
+                await s.execute(text("SELECT to_regclass(:t)"), {"t": table})
+            ).scalar() is not None
 
-            async with factory() as s:
-                org = await s.get(Organization, org_id)
-                await OrganizationService(s, vector_store=store).purge(org)
-                await s.commit()
+        async with factory() as s:
+            org = await s.get(Organization, org_id)
+            await OrganizationService(s, vector_store=store).purge(org)
+            await s.commit()
 
-            async with factory() as s:
-                remaining = await s.execute(
-                    select(KnowledgeBase).where(KnowledgeBase.organization_id == org_id)
-                )
-                assert remaining.scalars().all() == []
-                assert (
-                    await s.execute(text("SELECT to_regclass(:t)"), {"t": table})
-                ).scalar() is None
-                assert await s.get(Organization, org_id) is None
-        finally:
-            await store.aclose()
+        async with factory() as s:
+            remaining = await s.execute(
+                select(KnowledgeBase).where(KnowledgeBase.organization_id == org_id)
+            )
+            assert remaining.scalars().all() == []
+            assert (await s.execute(text("SELECT to_regclass(:t)"), {"t": table})).scalar() is None
+            assert await s.get(Organization, org_id) is None
 
     async def test_a_personal_collection_survives_its_orgs_deletion(
         self, engine: AsyncEngine
@@ -225,37 +221,35 @@ class TestDeletingAnOrg:
             settings=app_settings.rag,
             embedding_service=MagicMock(),
             resolver=MagicMock(),
+            engine=engine,
         )
         factory = async_sessionmaker(engine, expire_on_commit=False)
-        try:
-            async with factory() as s:
-                user = _user()
-                s.add(user)
-                await s.flush()
-                org = await _org(s, user)
-                personal = KnowledgeBase(
-                    id=uuid.uuid4(),
-                    name="My notes",
-                    scope=KBScope.PERSONAL.value,
-                    collection_name=f"kbnine{uuid.uuid4().hex[:12]}",
-                    embedding_model="text-embedding-3-small",
-                    embedding_dim=1536,
-                    organization_id=org.id,
-                    owner_user_id=user.id,
-                    visibility="private",
-                )
-                s.add(personal)
-                await s.commit()
-                org_id, kb_id = org.id, personal.id
+        async with factory() as s:
+            user = _user()
+            s.add(user)
+            await s.flush()
+            org = await _org(s, user)
+            personal = KnowledgeBase(
+                id=uuid.uuid4(),
+                name="My notes",
+                scope=KBScope.PERSONAL.value,
+                collection_name=f"kbnine{uuid.uuid4().hex[:12]}",
+                embedding_model="text-embedding-3-small",
+                embedding_dim=1536,
+                organization_id=org.id,
+                owner_user_id=user.id,
+                visibility="private",
+            )
+            s.add(personal)
+            await s.commit()
+            org_id, kb_id = org.id, personal.id
 
-            async with factory() as s:
-                org = await s.get(Organization, org_id)
-                await OrganizationService(s, vector_store=store).purge(org)
-                await s.commit()
+        async with factory() as s:
+            org = await s.get(Organization, org_id)
+            await OrganizationService(s, vector_store=store).purge(org)
+            await s.commit()
 
-            async with factory() as s:
-                surviving = await s.get(KnowledgeBase, kb_id)
-                assert surviving is not None
-                assert surviving.organization_id is None
-        finally:
-            await store.aclose()
+        async with factory() as s:
+            surviving = await s.get(KnowledgeBase, kb_id)
+            assert surviving is not None
+            assert surviving.organization_id is None


### PR DESCRIPTION
`main` has been red since #1112 merged: its integration tests construct
`PgVectorStore` with no `engine` and close it with `aclose()`, and #12 had
already made the engine a required keyword and deleted `aclose` when the store
stopped owning a pool. Both branches were green on their own - #1112's run
predated #12's merge - and neither could see the other, so the break only
appeared once both were on `main`.

The two tests already take the `engine` fixture, so they pass it, and the
`try/finally` that existed solely to close the store's own pool goes with the
method: the store borrows an engine the fixture owns and disposes.

Verified against a real `pgvector/pgvector:pg16` rather than inferred -
`tests/integration/test_deletion_reconciliation.py` is 7 passed, where it was
2 failed on `main`. This is why the failure survived two green pull requests:
the integration suite skips for want of a database, so a laptop run reports
success and only CI has one.