### PR TITLE
test(rag): construct PgVectorStore with the engine it now requires

### DIFF
--- a/backend/tests/integration/test_deletion_reconciliation.py
+++ b/backend/tests/integration/test_deletion_reconciliation.py
@@ -179,42 +179,38 @@ class TestDeletingAnOrg:
             settings=app_settings.rag,
             embedding_service=MagicMock(),
             resolver=MagicMock(),
+            engine=engine,
         )
         factory = async_sessionmaker(engine, expire_on_commit=False)
         collection = f"kbnine{uuid.uuid4().hex[:12]}"
         table = store._table(collection)
-        try:
-            async with factory() as s:
-                user = _user()
-                s.add(user)
-                await s.flush()
-                org = await _org(s, user)
-                s.add(_org_collection(org.id, collection))
-                await s.execute(text(f"CREATE TABLE {table} (id int)"))
-                await s.commit()
-                org_id = org.id
+        async with factory() as s:
+            user = _user()
+            s.add(user)
+            await s.flush()
+            org = await _org(s, user)
+            s.add(_org_collection(org.id, collection))
+            await s.execute(text(f"CREATE TABLE {table} (id int)"))
+            await s.commit()
+            org_id = org.id
 
-            async with factory() as s:
-                assert (
-                    await s.execute(text("SELECT to_regclass(:t)"), {"t": table})
-                ).scalar() is not None
+        async with factory() as s:
+            assert (
+                await s.execute(text("SELECT to_regclass(:t)"), {"t": table})
+            ).scalar() is not None
 
-            async with factory() as s:
-                org = await s.get(Organization, org_id)
-                await OrganizationService(s, vector_store=store).purge(org)
-                await s.commit()
+        async with factory() as s:
+            org = await s.get(Organization, org_id)
+            await OrganizationService(s, vector_store=store).purge(org)
+            await s.commit()
 
-            async with factory() as s:
-                remaining = await s.execute(
-                    select(KnowledgeBase).where(KnowledgeBase.organization_id == org_id)
-                )
-                assert remaining.scalars().all() == []
-                assert (
-                    await s.execute(text("SELECT to_regclass(:t)"), {"t": table})
-                ).scalar() is None
-                assert await s.get(Organization, org_id) is None
-        finally:
-            await store.aclose()
+        async with factory() as s:
+            remaining = await s.execute(
+                select(KnowledgeBase).where(KnowledgeBase.organization_id == org_id)
+            )
+            assert remaining.scalars().all() == []
+            assert (await s.execute(text("SELECT to_regclass(:t)"), {"t": table})).scalar() is None
+            assert await s.get(Organization, org_id) is None
 
     async def test_a_personal_collection_survives_its_orgs_deletion(
         self, engine: AsyncEngine
@@ -225,37 +221,35 @@ class TestDeletingAnOrg:
             settings=app_settings.rag,
             embedding_service=MagicMock(),
             resolver=MagicMock(),
+            engine=engine,
         )
         factory = async_sessionmaker(engine, expire_on_commit=False)
-        try:
-            async with factory() as s:
-                user = _user()
-                s.add(user)
-                await s.flush()
-                org = await _org(s, user)
-                personal = KnowledgeBase(
-                    id=uuid.uuid4(),
-                    name="My notes",
-                    scope=KBScope.PERSONAL.value,
-                    collection_name=f"kbnine{uuid.uuid4().hex[:12]}",
-                    embedding_model="text-embedding-3-small",
-                    embedding_dim=1536,
-                    organization_id=org.id,
-                    owner_user_id=user.id,
-                    visibility="private",
-                )
-                s.add(personal)
-                await s.commit()
-                org_id, kb_id = org.id, personal.id
+        async with factory() as s:
+            user = _user()
+            s.add(user)
+            await s.flush()
+            org = await _org(s, user)
+            personal = KnowledgeBase(
+                id=uuid.uuid4(),
+                name="My notes",
+                scope=KBScope.PERSONAL.value,
+                collection_name=f"kbnine{uuid.uuid4().hex[:12]}",
+                embedding_model="text-embedding-3-small",
+                embedding_dim=1536,
+                organization_id=org.id,
+                owner_user_id=user.id,
+                visibility="private",
+            )
+            s.add(personal)
+            await s.commit()
+            org_id, kb_id = org.id, personal.id
 
-            async with factory() as s:
-                org = await s.get(Organization, org_id)
-                await OrganizationService(s, vector_store=store).purge(org)
-                await s.commit()
+        async with factory() as s:
+            org = await s.get(Organization, org_id)
+            await OrganizationService(s, vector_store=store).purge(org)
+            await s.commit()
 
-            async with factory() as s:
-                surviving = await s.get(KnowledgeBase, kb_id)
-                assert surviving is not None
-                assert surviving.organization_id is None
-        finally:
-            await store.aclose()
+        async with factory() as s:
+            surviving = await s.get(KnowledgeBase, kb_id)
+            assert surviving is not None
+            assert surviving.organization_id is None


### PR DESCRIPTION
## `main` is red — this unblocks it

The last **three** pushes to `main` failed CI in the `test` job's `coverage-all` step:

```
PgVectorStore.__init__() missing 1 required keyword-only argument: 'engine'
```

`TestDeletingAnOrg` (in `test_deletion_reconciliation.py`, added by #1112) built `PgVectorStore` with no `engine` and closed it with `store.aclose()`. The store was reshaped to **borrow** an injected engine rather than build and dispose its own (#1084): `engine` is now a required keyword-only argument and there is no `aclose`. The two pull requests were each green against a base without the other, so the incompatibility only surfaced once both were on `main` — and every backend branch now inherits the red on merge (it is why #1173's `test` job failed).

## Fix

- Pass the test's own `engine` fixture to `PgVectorStore(...)` — the same engine the `factory` already uses.
- Drop the `try/finally: await store.aclose()`; the store borrows the engine and the `engine` fixture disposes it.

No coverage or assertion changes — the reconciliation the two tests prove is unchanged.

## Verified

As far as a laptop without a database allows: `ruff`, `ruff format` and `ty` clean, and `ty` no longer reports the missing argument or the absent `aclose` (6 diagnostics on the file → 2, both pre-existing `MagicMock` resolver typing). The integration run itself needs the database CI has — please let CI confirm before merge.