### PR TITLE
chore: cut 0.0.273

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,28 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.273] - 2026-08-26
+
+### Fixed
+
+- **The document listings had no stable order across pages.** `get_all` and
+  `get_for_kb` ordered by `created_at DESC` with no unique secondary key, and a
+  bulk import lands many `rag_documents` in one microsecond - so over tied
+  timestamps that is not a total order, and a client paging with `offset` and
+  `limit` could see a row twice or skip one across a page boundary, because each
+  page is a separate query whose sort of the tied rows is undefined. Both order by
+  `created_at DESC, id DESC` now, which is what the sibling
+  `vectorstore.get_documents` already did for this reason (#548). The change is
+  additive: a tiebreaker is consulted only when `created_at` ties, so rows with
+  distinct timestamps keep their exact prior order. (#1103)
+- **`main` was red between 0.0.270 and here**, and neither branch could have seen
+  it: #1112's integration tests built a `PgVectorStore` with no `engine` and closed
+  it with `aclose()`, while #12 had already made the engine a required keyword and
+  deleted the method when the store stopped owning a pool. Both were green on their
+  own - #1112's run predated #12's merge - so the break appeared only once both
+  were on `main`. The tests take the engine from the fixture that owns it now.
+  (#9, #12)
+
 ## [0.0.272] - 2026-08-26
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.272"
+version = "0.0.273"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.272"
+version = "0.0.273"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.272",
+  "version": "0.0.273",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.273. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.273 and adds the CHANGELOG entry.

Releases #1103: the two document listings ordered by `created_at DESC` with no
unique secondary key, and a bulk import lands many rows in one microsecond -
so a paging client could see a row twice or skip one, each page being a
separate query whose sort of the tied rows is undefined. The sibling
`vectorstore.get_documents` already had the tiebreaker; these two did not.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1121 was green on the merged head.