### PR TITLE
perf(agents): resolve a run's bound collections in one query, not N

### DIFF
--- a/backend/app/repositories/knowledge_base.py
+++ b/backend/app/repositories/knowledge_base.py
@@ -14,6 +14,19 @@ async def get_by_id(db: AsyncSession, kb_id: UUID) -> KnowledgeBase | None:
     return await db.get(KnowledgeBase, kb_id)
 
 
+async def get_by_ids(db: AsyncSession, ids: Sequence[UUID]) -> dict[UUID, KnowledgeBase]:
+    """The collections for a set of ids, keyed by id, in one query.
+
+    An id with no row is simply absent from the map, the same way `get_by_id`
+    answers `None`: the caller decides what a reference to a collection that is
+    gone means, and here it degrades an agent's reach rather than failing a run.
+    """
+    if not ids:
+        return {}
+    result = await db.execute(select(KnowledgeBase).where(KnowledgeBase.id.in_(ids)))
+    return {kb.id: kb for kb in result.scalars()}
+
+
 async def get_accessible(
     db: AsyncSession,
     *,

--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -1430,9 +1430,10 @@ class AgentRunnerService:
         Resolved server-side and passed through deps: the model asks *what* to
         search, never *where*.
         """
+        found = await knowledge_base_repo.get_by_ids(self.db, spec.collection_ids)
         names: list[str] = []
         for collection_id in spec.collection_ids:
-            collection = await knowledge_base_repo.get_by_id(self.db, collection_id)
+            collection = found.get(collection_id)
             if collection is None or collection.organization_id != ctx.organization_id:
                 # A collection deleted after publish degrades the agent's reach
                 # rather than failing the run - the answer is worse, not absent.

--- a/backend/tests/test_agent_runner.py
+++ b/backend/tests/test_agent_runner.py
@@ -216,8 +216,10 @@ class TestPrepare:
         agent = MagicMock(id=uuid.uuid4(), current_version_id=uuid.uuid4())
         spec = AgentSpec(name="Support", collection_ids=[live_id, deleted_id, foreign_id])
 
-        async def get_collection(_db, collection_id):
-            return collections[collection_id]
+        async def get_collections(_db, ids):
+            # A batched read: an id with no row is absent from the map, the way
+            # `deleted_id` is here, rather than returning a None value.
+            return {cid: collections[cid] for cid in ids if collections.get(cid) is not None}
 
         with (
             patch.object(
@@ -230,8 +232,8 @@ class TestPrepare:
             ),
             patch.object(service.skills, "resolve_for_agent", new=AsyncMock(return_value=[])),
             patch(
-                "app.services.agent_runner.knowledge_base_repo.get_by_id",
-                new=AsyncMock(side_effect=get_collection),
+                "app.services.agent_runner.knowledge_base_repo.get_by_ids",
+                new=AsyncMock(side_effect=get_collections),
             ),
             patch(
                 "app.services.agent_runner.agent_run_repo.create_run",

--- a/backend/tests/test_subagent_resolution.py
+++ b/backend/tests/test_subagent_resolution.py
@@ -269,8 +269,8 @@ async def _prepare(
         name = "delegate" if pinned is None else str(pinned.spec["name"])
         return _agent_row(delegate_id, slug=_slug(name))
 
-    async def get_collection(_db: Any, collection_id: uuid.UUID) -> Any:
-        return known_collections.get(collection_id)
+    async def get_collections(_db: Any, ids: Any) -> Any:
+        return {cid: known_collections[cid] for cid in ids if cid in known_collections}
 
     catalog = [_profile("fast")] if profiles is None else profiles
     by_id = {profile.id: profile for profile in catalog}
@@ -306,7 +306,9 @@ async def _prepare(
             new=AsyncMock(return_value=None if workspace is None else MagicMock(backend=workspace)),
         ),
         patch(f"{RUNNER}.workspace_snapshot", new=AsyncMock(return_value=set())),
-        patch(f"{RUNNER}.knowledge_base_repo.get_by_id", new=AsyncMock(side_effect=get_collection)),
+        patch(
+            f"{RUNNER}.knowledge_base_repo.get_by_ids", new=AsyncMock(side_effect=get_collections)
+        ),
         patch(
             f"{RUNNER}.agent_repo.get_version", new=AsyncMock(side_effect=get_version)
         ) as fetch_version,


### PR DESCRIPTION
The hot-path loop of #954.

## What changed

`_collection_names` runs inside `prepare` — **on every agent run** — and fetched one collection row per bound id in a serial loop. An agent bound to five knowledge bases added five serial round trips to the front of every turn, before the model was called, to read rows very likely already in the session's identity map.

- `knowledge_base_repo.get_by_ids` reads them in one `WHERE id IN (...)`.
- `_collection_names` iterates `spec.collection_ids` over the returned map. The tenant check and the *"a collection gone or foreign narrows the agent's reach rather than failing the run"* degradation are unchanged — they read from a dict instead of awaiting a query each. An id with no row is absent from the map, the way `get_by_id` answered `None`.

## Scope — the hot loop, `Part-of #954`

The finding names six id-resolving loops as "one habit". This does the sixth — the only one on a per-run path. The other five are publish-time or admin-path where N is small and the cost is invisible (the finding says so), and their `2026-08-19` line references predate a since-moved file, so they want re-locating in a follow-up rather than a blind change.

## How it was verified

- Behaviour-identical: the degradation test (a live, a deleted and a foreign collection resolve to just the live name) passes with the mock moved to `get_by_ids`.
- 100 `test_agent_runner.py` tests green; `ty` adds zero diagnostics; `ruff` clean.

Part-of #954