### PR TITLE
chore: cut 0.0.274

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.274] - 2026-08-26
+
+### Fixed
+
+- **The Prefect RAG sync flows did their filesystem work on the worker's event
+  loop** - the defect #25 fixed on the request path and left as a lower-severity
+  follow-up. A large tree or file has no suspension point: `rglob` over a
+  directory, `sha256(read_bytes())` per file, `stat()` and a per-file `resolve()`
+  each stall the loop. Every per-file blocking call goes through
+  `asyncio.to_thread` now: the tree walk is one hop over `_walk_files` rather than
+  a hop per file, the per-file hash is `_hash_file` shared by the local and
+  connector paths, and `stat` and `resolve` are offloaded per file. Values are
+  unchanged - identical walks, hashes, sizes and resolved paths - only the thread
+  moves. The one-off resolve of the sync *target* path is O(1) per flow and stays
+  on the loop. (#1100, #25)
+
 ## [0.0.273] - 2026-08-26
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.273"
+version = "0.0.274"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.273"
+version = "0.0.274"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.273",
+  "version": "0.0.274",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.274. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.274 and adds the CHANGELOG entry.

Releases #1100, the worker half of the blocking-IO family #25 opened. The
Prefect RAG sync flows walked a tree, hashed every file and stat'd each one
synchronously on the worker's event loop. Each per-file call is offloaded now,
with the walk one hop rather than a hop per file. Values are identical; only
the thread moves.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1122 was green on the merged head.