### PR TITLE
chore: cut 0.0.275

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,14 @@ Two things are versioned separately from this file and worth knowing about:
   `rag_tasks` and the `rag-*` commands are untouched. The document *listing* is
   still a full scan - that is the display path, not the ingest check. (#1102)
 
+- Two things this branch broke on `main`, fixed with it and each invisible to the
+  branch that caused it - both were green before the other merged. The
+  `_first_document` annotation referenced `AsyncSession` after #12 removed that
+  import, so `ruff` failed the whole `lint` job; and the index backfill claimed
+  `0055_sandbox_operations` as its parent while the conversation plan already had,
+  leaving the migration chain with **two heads** - `alembic upgrade head` cannot
+  choose between them, so a deployment could not migrate at all. The backfill is
+  re-parented onto the current head as `0058`. (#1102, #12)
 ## [0.0.274] - 2026-08-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,30 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.275] - 2026-08-26
+
+### Fixed
+
+- **The ingestion existence check read the whole collection, once per document.**
+  `IngestionService.existing_document` answered "does this collection already hold
+  this file" by reading every row of the runtime `rag_<collection>` table through
+  `get_documents` and grouping in Python - a full read into worker memory for each
+  ingested document, which on a 200k-chunk collection dominates a nightly sync. The
+  lookup belongs to the store now as `find_existing_document`, which `PgVectorStore`
+  answers with one indexed statement per key in the same precedence - `source_path`,
+  then an unaddressed `filename`, then `content_hash` - stopping at the first hit.
+  `_ensure_collection` builds an expression index on each of the three metadata keys
+  alongside the table, so an established collection gains them on its next ingest
+  through the write path's existing call. (#1102, #27)
+- The invariants are preserved rather than re-derived: the #548 single-document rule
+  and the #990 unaddressed-filename rule move into a reference implementation on
+  `BaseVectorStore` that scans, so a store with no index still answers correctly and
+  `PgVectorStore` overrides it with the indexed path. Index suffixes are kept no
+  longer than the HNSW one, so `MAX_COLLECTION_NAME_LENGTH` stays 45 and no
+  identifier truncates, and `existing_document`'s signature is unchanged so
+  `rag_tasks` and the `rag-*` commands are untouched. The document *listing* is
+  still a full scan - that is the display path, not the ingest check. (#1102)
+
 ## [0.0.274] - 2026-08-26
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.274"
+version = "0.0.275"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.274"
+version = "0.0.275"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.274",
+  "version": "0.0.275",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.275. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.275 and adds the CHANGELOG entry.

Releases #1102, the ingest-scan half of #27 whose pagination half shipped in
0.0.266. The existence check read every row of the runtime collection table
and grouped in Python, once per ingested document - which on a 200k-chunk
collection dominates a nightly sync. One indexed statement per key now, in the
same precedence, against expression indexes built alongside the table.

The #548 and #990 invariants move into a scanning reference implementation on
`BaseVectorStore`, so a store with no index still answers correctly.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1123 was green on the merged head.