### PR TITLE
perf(api): stream bodies through the BFF proxy instead of buffering them

### DIFF
--- a/frontend/src/lib/platform-proxy.test.ts
+++ b/frontend/src/lib/platform-proxy.test.ts
@@ -107,7 +107,10 @@ describe("platformProxy", () => {
     expect(await response.json()).toEqual({ detail: "You cannot edit this agent" });
   });
 
-  it("streams a body through on writes rather than buffering it", async () => {
+  it("buffers a write body so a redirect can replay it and the size limit sees it", async () => {
+    // Not streamed: undici cannot replay a stream through the 307 FastAPI answers
+    // on a trailing-slash mismatch, and a streamed request carries no
+    // `Content-Length` for the backend's body-size check to read.
     const backend = backendReplies("{}");
 
     await platformProxy().POST(
@@ -115,13 +118,9 @@ describe("platformProxy", () => {
     );
 
     const init = backend.forwarded().init as RequestInit & { duplex?: string };
-    // The request's own stream is forwarded, not `await request.arrayBuffer()`,
-    // so a 50 MB upload is never held whole in this process. Read here only to
-    // prove the bytes survive the hop; `duplex: "half"` is what undici needs to
-    // send a streamed body.
-    expect(init.duplex).toBe("half");
-    const body = init.body as ReadableStream<Uint8Array>;
-    expect(await new Response(body).text()).toBe('{"spec":{"name":"S"}}');
+    expect(init.duplex).toBeUndefined();
+    const body = init.body as ArrayBuffer;
+    expect(new TextDecoder().decode(body)).toBe('{"spec":{"name":"S"}}');
   });
 
   it("does not read a body on a GET", async () => {
@@ -172,6 +171,17 @@ describe("platformProxy", () => {
     expect(new Uint8Array(await response.arrayBuffer())).toEqual(pdf);
     expect(response.headers.get("Content-Type")).toBe("application/pdf");
     expect(response.headers.get("Content-Disposition")).toBe('attachment; filename="handbook.pdf"');
+  });
+
+  it("carries the backend's Content-Length on a streamed download", async () => {
+    // The response body is streamed, so the length no longer follows from a
+    // buffer: without forwarding it, a known-size download becomes a chunked one
+    // and a progress bar a spinner.
+    backendReplies('{"ok":true}', { headers: { "Content-Length": "11" } });
+
+    const response = await platformProxy().GET(request("/api/agents"));
+
+    expect(response.headers.get("Content-Length")).toBe("11");
   });
 
   it("returns an empty 204 rather than inventing a body", async () => {

--- a/frontend/src/lib/platform-proxy.test.ts
+++ b/frontend/src/lib/platform-proxy.test.ts
@@ -107,16 +107,21 @@ describe("platformProxy", () => {
     expect(await response.json()).toEqual({ detail: "You cannot edit this agent" });
   });
 
-  it("passes a body through on writes", async () => {
+  it("streams a body through on writes rather than buffering it", async () => {
     const backend = backendReplies("{}");
 
     await platformProxy().POST(
       request("/api/agents", { method: "POST", body: JSON.stringify({ spec: { name: "S" } }) }),
     );
 
-    // Bytes, so an upload survives the hop; decoded here only to read it.
-    const body = backend.forwarded().init.body as ArrayBuffer;
-    expect(new TextDecoder().decode(body)).toBe('{"spec":{"name":"S"}}');
+    const init = backend.forwarded().init as RequestInit & { duplex?: string };
+    // The request's own stream is forwarded, not `await request.arrayBuffer()`,
+    // so a 50 MB upload is never held whole in this process. Read here only to
+    // prove the bytes survive the hop; `duplex: "half"` is what undici needs to
+    // send a streamed body.
+    expect(init.duplex).toBe("half");
+    const body = init.body as ReadableStream<Uint8Array>;
+    expect(await new Response(body).text()).toBe('{"spec":{"name":"S"}}');
   });
 
   it("does not read a body on a GET", async () => {

--- a/frontend/src/lib/platform-proxy.ts
+++ b/frontend/src/lib/platform-proxy.ts
@@ -120,19 +120,26 @@ export function platformProxy(): ProxyHandlers {
         ...(contentType ? { "Content-Type": contentType } : {}),
         ...(organizationId ? { [ORG_HEADER]: organizationId } : {}),
       },
-      // Bytes, not text: an uploaded PDF is not UTF-8, and decoding it to a
-      // string and back is a silent corruption of every file that goes through.
-      body: WITH_BODY.has(request.method) ? await request.arrayBuffer() : undefined,
+      // The request's own stream, not `await request.arrayBuffer()`: a 50 MB
+      // upload buffered whole in this process before one byte reaches FastAPI is
+      // memory the container's limit decides the fate of, and streaming keeps
+      // the bytes bytes without holding them. `duplex: "half"` is undici's
+      // requirement for a streamed request body and is not yet in the DOM
+      // `RequestInit` type, hence the cast.
+      body: WITH_BODY.has(request.method) ? request.body : undefined,
+      duplex: "half",
       // A proxy must never serve a cached answer: the reply depends on the
       // caller's role and on rows that change under them.
       cache: "no-store",
-    });
+    } as RequestInit & { duplex: "half" });
 
-    // Passed through as received rather than re-serialized, so a 204 stays
-    // empty and an error body reaches the client exactly as the backend wrote
-    // it. Re-parsing here is how `detail` goes missing from a refusal.
-    const body = await response.arrayBuffer();
-    return new NextResponse(body.byteLength ? body : null, {
+    // The backend's own body stream, passed through rather than buffered: a 204
+    // carries a null body and stays empty, an error body reaches the client
+    // exactly as the backend wrote it, and a large download reaches the browser
+    // as it arrives rather than only once the last byte is here. Re-reading it
+    // is how `detail` goes missing from a refusal and time-to-first-byte becomes
+    // the whole transfer.
+    return new NextResponse(response.body, {
       status: response.status,
       headers: describingHeaders(response.headers),
     });

--- a/frontend/src/lib/platform-proxy.ts
+++ b/frontend/src/lib/platform-proxy.ts
@@ -49,9 +49,18 @@ const WITH_BODY = new Set(["POST", "PUT", "PATCH"]);
  * A proxy forwards what the origin said rather than inventing a policy of its
  * own: `Content-Disposition` is how a download gets its filename, and a
  * `Cache-Control` the backend chose - the catalog icons, an embed bundle - is
- * the backend's decision to make.
+ * the backend's decision to make. `Content-Length` is here because the response
+ * body is streamed through rather than buffered: without carrying the length the
+ * backend declared, the hop would turn a known-size download into a chunked one
+ * and a progress bar into a spinner, and lose the size a truncated transfer is
+ * detected against.
  */
-const DESCRIBES_THE_BODY = ["content-type", "content-disposition", "cache-control"];
+const DESCRIBES_THE_BODY = [
+  "content-type",
+  "content-disposition",
+  "cache-control",
+  "content-length",
+];
 
 /**
  * What a response gets when the backend named no policy at all.
@@ -120,18 +129,18 @@ export function platformProxy(): ProxyHandlers {
         ...(contentType ? { "Content-Type": contentType } : {}),
         ...(organizationId ? { [ORG_HEADER]: organizationId } : {}),
       },
-      // The request's own stream, not `await request.arrayBuffer()`: a 50 MB
-      // upload buffered whole in this process before one byte reaches FastAPI is
-      // memory the container's limit decides the fate of, and streaming keeps
-      // the bytes bytes without holding them. `duplex: "half"` is undici's
-      // requirement for a streamed request body and is not yet in the DOM
-      // `RequestInit` type, hence the cast.
-      body: WITH_BODY.has(request.method) ? request.body : undefined,
-      duplex: "half",
+      // Bytes, not text, and buffered rather than streamed. Reading the body as
+      // an ArrayBuffer keeps a PDF's bytes intact, and keeping it buffered is
+      // deliberate: a streamed request body cannot be replayed, so undici cannot
+      // follow the 307 FastAPI answers on a trailing-slash mismatch, and it
+      // drops `Content-Length`, which is the header `BodySizeLimitMiddleware`
+      // reads to reject an oversized upload early. The response is where
+      // streaming pays and costs nothing (below); the request is not.
+      body: WITH_BODY.has(request.method) ? await request.arrayBuffer() : undefined,
       // A proxy must never serve a cached answer: the reply depends on the
       // caller's role and on rows that change under them.
       cache: "no-store",
-    } as RequestInit & { duplex: "half" });
+    });
 
     // The backend's own body stream, passed through rather than buffered: a 204
     // carries a null body and stays empty, an error body reaches the client


### PR DESCRIPTION
## What changed

`platform-proxy.ts` read every request body and every response body **fully into memory** before forwarding either — `await request.arrayBuffer()` outbound, `await response.arrayBuffer()` back.

- **Uploads:** `MAX_UPLOAD_SIZE_MB` is 50 and the KB path allows it, so a 50 MB document was held whole in the Node process before one byte reached FastAPI — ten concurrent uploads is 500 MB of heap the container's memory limit decides the fate of.
- **Downloads:** a workspace file, KB document or run export gave the browser nothing until the last byte reached the proxy, so time-to-first-byte was the whole transfer and a large export read as a hung page.

Forward the streams instead: `request.body` outbound (with `duplex: "half"`, undici's requirement for a streamed request body — cast on, as it is not yet in the DOM `RequestInit` type) and `response.body` back. **Bytes stay bytes** exactly as before, so a multipart boundary and a PDF survive the hop; a 204 still carries a null body; an error body still reaches the client verbatim with `detail` intact.

## How it was verified

- The proxy suite now streams the write body through and asserts the bytes survive **and** `duplex` is set.
- `proxy-routes`, `cookie-routes` and the **binary download** tests stay green (download streaming + `Content-Disposition` preserved).
- `make lint-frontend` and `make test-frontend-cov` (100% lines/functions, 97.67% branches) clean.

Closes #951