### PR TITLE
fix(rag): import AsyncSession, which vectorstore annotates but never imported

### DIFF
--- a/backend/app/services/rag/vectorstore.py
+++ b/backend/app/services/rag/vectorstore.py
@@ -224,7 +224,7 @@ from collections.abc import Awaitable, Callable
 from itertools import batched
 
 from sqlalchemy import text
-from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 from app.db.session import vector_engine
 from app.services.embedding_resolution import ResolvedEmbeddings, embeddings_for_collection


### PR DESCRIPTION
## The lint half of main being red

`app/services/rag/vectorstore.py` annotates `_delete_where(session: AsyncSession, …)` but imports only `AsyncEngine` and `async_sessionmaker` from `sqlalchemy.ext.asyncio`. `ty` reads that annotation as an **`unresolved-reference` error**, so `uv run ty check` exits non-zero and the **`lint` job is red**.

This is the second half of main's red, alongside the deletion-reconciliation test (#1178): the same vectorstore reshape that made `engine` a required argument also left this name unimported. Every backend branch inherits both on merge.

## Fix

One import — `AsyncSession` added to the existing line. `ty` is clean (exit 0, no errors); `ruff` confirms the name is now used. Runtime was never affected (`from __future__ import annotations` makes the annotation a string), but the type gate is, and a red gate blocks every backend merge.