### PR TITLE
fix(rag): import AsyncSession, and give the index backfill one parent

### DIFF
--- a/backend/alembic/versions/0058_backfill_rag_lookup_indexes.py
+++ b/backend/alembic/versions/0058_backfill_rag_lookup_indexes.py
@@ -23,8 +23,8 @@ from sqlalchemy.engine import Connection
 
 from alembic import op
 
-revision: str = "0056_backfill_rag_lookup_indexes"
-down_revision: str | Sequence[str] | None = "0055_sandbox_operations"
+revision: str = "0058_backfill_rag_lookup_indexes"
+down_revision: str | Sequence[str] | None = "0057_kb_embedding_provider"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/app/services/rag/vectorstore.py
+++ b/backend/app/services/rag/vectorstore.py
@@ -224,7 +224,7 @@ from collections.abc import Awaitable, Callable
 from itertools import batched
 
 from sqlalchemy import text
-from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 from app.db.session import vector_engine
 from app.services.embedding_resolution import ResolvedEmbeddings, embeddings_for_collection


### PR DESCRIPTION
`main` was red on two counts, and neither branch could have seen its own half:
both were green before the other merged.

`lint` failed outright. #1102 annotates `_first_document(self, session:
AsyncSession, ...)` in `vectorstore.py`, and #12 had removed that import when
the store stopped building its own engine and moved to `async_sessionmaker` -
so `ruff` reported `F821 Undefined name` and every job after it was skipped.

The migration chain had **two heads**. #1102's backfill and the conversation
plan both claimed `0055_sandbox_operations` as their parent, so
`test_the_chain_has_exactly_one_head`, `test_no_two_migrations_claim_the same
parent` and all four of `test_migrations.py` failed - `alembic upgrade head`
cannot choose between two heads, which means a deployment could not migrate at
all. The backfill is re-parented onto the current head and renamed to
`0058_backfill_rag_lookup_indexes` to keep the filename ordering honest; it is
a `CREATE INDEX IF NOT EXISTS` sweep over runtime vector tables and does not
depend on anything the two revisions between add.

Verified against a real `pgvector/pgvector:pg16` rather than inferred, because
the integration suite and the migration chain both skip without a database and
that is exactly how this reached `main`: 7106 passed, 15 skipped, 0 failed,
including the forward-and-back migration cycle.

Refs #1102, #12