### PR TITLE
perf(dashboard): read a usage window's scalars in one query, not six

### DIFF
--- a/backend/app/repositories/agent_run.py
+++ b/backend/app/repositories/agent_run.py
@@ -1098,6 +1098,33 @@ async def window_aggregates(
     )
 
 
+async def window_totals(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    start: datetime,
+    end: datetime,
+    where: RunFilter | None = None,
+) -> tuple[int, Decimal]:
+    """The count and cost of a window, in one SELECT and nothing more.
+
+    The previous window is a delta against the current one - it reports only how
+    many runs and how much they cost - so it does not pay for
+    `window_aggregates`' distinct-user count or its two ordered-set percentiles,
+    which make PostgreSQL sort the window's durations for numbers nobody reads.
+    """
+    conditions = _window_conditions(
+        organization_id=organization_id, start=start, end=end, where=where
+    )
+    result = await db.execute(
+        select(func.count(AgentRun.id), func.coalesce(func.sum(AgentRun.cost_usd), 0)).where(
+            *conditions
+        )
+    )
+    total, cost = result.one()
+    return int(total or 0), Decimal(cost or 0)
+
+
 async def runs_by_day(
     db: AsyncSession,
     *,

--- a/backend/app/repositories/agent_run.py
+++ b/backend/app/repositories/agent_run.py
@@ -1046,6 +1046,58 @@ async def latency_percentiles_ms(
     )
 
 
+@dataclass(frozen=True)
+class WindowAggregates:
+    """Every scalar the dashboard reads over one window, from one query."""
+
+    total: int
+    cost_usd: Decimal
+    distinct_users: int
+    p50_ms: float | None
+    p95_ms: float | None
+
+
+async def window_aggregates(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    start: datetime,
+    end: datetime,
+    where: RunFilter | None = None,
+) -> WindowAggregates:
+    """The five scalars over one window, in a single SELECT.
+
+    `count_runs`, `sum_cost_window`, `count_distinct_users` and
+    `latency_percentiles_ms` all read this window's exact same rows and WHERE, so
+    the dashboard asks for them once rather than four round trips. The count, sum
+    and distinct see every row in the window; the percentiles need no
+    `ended_at IS NOT NULL` of their own, because an unfinished run's duration is
+    null and `percentile_cont` ignores a null the way the standalone function's
+    explicit filter did - the same distribution, one query.
+    """
+    conditions = _window_conditions(
+        organization_id=organization_id, start=start, end=end, where=where
+    )
+    duration_ms = func.extract("epoch", AgentRun.ended_at - AgentRun.started_at) * 1000
+    result = await db.execute(
+        select(
+            func.count(AgentRun.id),
+            func.coalesce(func.sum(AgentRun.cost_usd), 0),
+            func.count(func.distinct(AgentRun.user_id)),
+            func.percentile_cont(0.5).within_group(duration_ms),
+            func.percentile_cont(0.95).within_group(duration_ms),
+        ).where(*conditions)
+    )
+    total, cost, distinct_users, p50, p95 = result.one()
+    return WindowAggregates(
+        total=int(total or 0),
+        cost_usd=Decimal(cost or 0),
+        distinct_users=int(distinct_users or 0),
+        p50_ms=float(p50) if p50 is not None else None,
+        p95_ms=float(p95) if p95 is not None else None,
+    )
+
+
 async def runs_by_day(
     db: AsyncSession,
     *,

--- a/backend/app/services/stats.py
+++ b/backend/app/services/stats.py
@@ -185,15 +185,16 @@ class StatsService:
         org = ctx.organization_id
 
         # The window's scalars - count, cost, distinct users, latency percentiles -
-        # share one WHERE, so each window is one query rather than four.
+        # share one WHERE, so the window is one query rather than four. The previous
+        # window is only a count and a cost, so it takes the lighter aggregate and
+        # does not sort durations for percentiles nobody reads.
         current = await agent_run_repo.window_aggregates(
             self.db, organization_id=org, start=window.start, end=window.end, where=where
         )
-        previous = await agent_run_repo.window_aggregates(
+        previous_total, previous_model_usd = await agent_run_repo.window_totals(
             self.db, organization_id=org, start=prev_start, end=prev_end, where=where
         )
         total = current.total
-        previous_total = previous.total
 
         day_rows = {
             row[0]: row
@@ -268,7 +269,6 @@ class StatsService:
         # agent - reports model spend alone rather than billing a card for a
         # collection somebody else synced.
         model_usd = current.cost_usd
-        previous_model_usd = previous.cost_usd
         ingestion_usd = Decimal(0)
         previous_ingestion_usd = Decimal(0)
         if where == RunFilter():

--- a/backend/app/services/stats.py
+++ b/backend/app/services/stats.py
@@ -184,12 +184,16 @@ class StatsService:
         prev_start, prev_end = window.previous
         org = ctx.organization_id
 
-        total = await agent_run_repo.count_runs(
+        # The window's scalars - count, cost, distinct users, latency percentiles -
+        # share one WHERE, so each window is one query rather than four.
+        current = await agent_run_repo.window_aggregates(
             self.db, organization_id=org, start=window.start, end=window.end, where=where
         )
-        previous_total = await agent_run_repo.count_runs(
+        previous = await agent_run_repo.window_aggregates(
             self.db, organization_id=org, start=prev_start, end=prev_end, where=where
         )
+        total = current.total
+        previous_total = previous.total
 
         day_rows = {
             row[0]: row
@@ -247,12 +251,9 @@ class StatsService:
             )
         ]
 
-        p50, p95 = await agent_run_repo.latency_percentiles_ms(
-            self.db, organization_id=org, start=window.start, end=window.end, where=where
-        )
         latency = LatencyMs(
-            p50=round(p50) if p50 is not None else None,
-            p95=round(p95) if p95 is not None else None,
+            p50=round(current.p50_ms) if current.p50_ms is not None else None,
+            p95=round(current.p95_ms) if current.p95_ms is not None else None,
         )
 
         # The whole bill, not the model half of it. `organization_spend_since`
@@ -266,12 +267,8 @@ class StatsService:
         # records neither. So any narrowed window - `scope=own`, a person, an
         # agent - reports model spend alone rather than billing a card for a
         # collection somebody else synced.
-        model_usd = await agent_run_repo.sum_cost_window(
-            self.db, organization_id=org, start=window.start, end=window.end, where=where
-        )
-        previous_model_usd = await agent_run_repo.sum_cost_window(
-            self.db, organization_id=org, start=prev_start, end=prev_end, where=where
-        )
+        model_usd = current.cost_usd
+        previous_model_usd = previous.cost_usd
         ingestion_usd = Decimal(0)
         previous_ingestion_usd = Decimal(0)
         if where == RunFilter():
@@ -305,9 +302,7 @@ class StatsService:
         pending_approvals = None
         if where.user_id is None:
             active_users = ActiveUsers(
-                active=await agent_run_repo.count_distinct_users(
-                    self.db, organization_id=org, start=window.start, end=window.end, where=where
-                ),
+                active=current.distinct_users,
                 total_members=await member_repo.count_for_org(self.db, org),
             )
         else:

--- a/backend/tests/api/test_platform_routes.py
+++ b/backend/tests/api/test_platform_routes.py
@@ -38,6 +38,7 @@ from app.core.exceptions import NotFoundError, RunExecutionError
 from app.core.permissions import ROLE_PERMS, AuthContext, OrgRoleName, Perm, Scope
 from app.db.models.resource_grant import Visibility
 from app.main import app
+from app.repositories.agent_run import WindowAggregates
 from app.schemas.agent import ParkedCall
 from app.services.agent_runner import RunSegment
 from app.services.sharing import SharingService
@@ -1143,6 +1144,13 @@ class TestStatsScopeIsDecidedInTheService:
             ("count_distinct_users", 0),
             ("count_pending_approval_runs", 0),
             ("usage_by_user", []),
+            (
+                "window_aggregates",
+                WindowAggregates(
+                    total=0, cost_usd=Decimal(0), distinct_users=0, p50_ms=None, p95_ms=None
+                ),
+            ),
+            ("window_totals", (0, Decimal(0))),
         ):
             monkeypatch.setattr(
                 f"app.services.stats.agent_run_repo.{name}", AsyncMock(return_value=value)

--- a/backend/tests/test_stats.py
+++ b/backend/tests/test_stats.py
@@ -19,6 +19,7 @@ import pytest
 
 from app.core.exceptions import AuthorizationError, ValidationError
 from app.core.permissions import AuthContext, OrgRoleName
+from app.repositories.agent_run import WindowAggregates
 from app.services.stats import StatsService, resolve_window
 
 pytestmark = pytest.mark.anyio
@@ -52,6 +53,25 @@ def repos(monkeypatch: pytest.MonkeyPatch) -> dict[str, AsyncMock]:
         mock = AsyncMock(return_value=value)
         monkeypatch.setattr(f"app.services.stats.agent_run_repo.{name}", mock)
         mocks[name] = mock
+
+    # `usage` reads its window's scalars from one `window_aggregates` query now;
+    # this stub composes the answer from the four per-aggregate mocks above, so a
+    # test still sets `count_runs`, `sum_cost_window`, `latency_percentiles_ms` or
+    # `count_distinct_users` and controls the field it maps to - one call per
+    # window, the same order the standalone calls used to run in.
+    async def _window_aggregates(db: object = None, **kwargs: object) -> WindowAggregates:
+        total = await mocks["count_runs"](db, **kwargs)
+        cost = await mocks["sum_cost_window"](db, **kwargs)
+        distinct = await mocks["count_distinct_users"](db, **kwargs)
+        p50, p95 = await mocks["latency_percentiles_ms"](db, **kwargs)
+        return WindowAggregates(
+            total=total, cost_usd=cost, distinct_users=distinct, p50_ms=p50, p95_ms=p95
+        )
+
+    window_aggregates = AsyncMock(side_effect=_window_aggregates)
+    monkeypatch.setattr("app.services.stats.agent_run_repo.window_aggregates", window_aggregates)
+    mocks["window_aggregates"] = window_aggregates
+
     ingestion = AsyncMock(return_value=Decimal(0))
     monkeypatch.setattr("app.services.stats.ingestion_spend_repo.sum_cost_window", ingestion)
     mocks["ingestion_sum_cost_window"] = ingestion
@@ -264,8 +284,9 @@ class TestTheComposedAnswer:
         )
 
         assert result.pending_approvals == 2
+        # The distinct-user count rides in the one window query now, so it is
+        # computed either way; what a `user_id` scope drops is reporting it.
         assert result.active_users is None
-        repos["count_distinct_users"].assert_not_called()
 
     async def test_the_slices_map_through_with_their_names(self, repos) -> None:
         agent_id = uuid4()

--- a/backend/tests/test_stats.py
+++ b/backend/tests/test_stats.py
@@ -72,6 +72,15 @@ def repos(monkeypatch: pytest.MonkeyPatch) -> dict[str, AsyncMock]:
     monkeypatch.setattr("app.services.stats.agent_run_repo.window_aggregates", window_aggregates)
     mocks["window_aggregates"] = window_aggregates
 
+    # The previous window takes the lighter count+cost aggregate; delegate it to the
+    # same two mocks so a test still drives it through `count_runs`/`sum_cost_window`.
+    async def _window_totals(db: object = None, **kwargs: object) -> tuple[int, Decimal]:
+        return await mocks["count_runs"](db, **kwargs), await mocks["sum_cost_window"](db, **kwargs)
+
+    window_totals = AsyncMock(side_effect=_window_totals)
+    monkeypatch.setattr("app.services.stats.agent_run_repo.window_totals", window_totals)
+    mocks["window_totals"] = window_totals
+
     ingestion = AsyncMock(return_value=Decimal(0))
     monkeypatch.setattr("app.services.stats.ingestion_spend_repo.sum_cost_window", ingestion)
     mocks["ingestion_sum_cost_window"] = ingestion


### PR DESCRIPTION
Stacked on #1185 (the `AsyncSession` lint fix) so its `ty` passes — retarget to `main` once that merges.

## What changed

`StatsService.usage` ran fifteen aggregates one after another. **Six are scalars over one window with the same WHERE** — the count and cost of the window and of the window before it, the distinct-user count, and the two latency percentiles — so they were six serial round trips for numbers a single SELECT answers.

- `agent_run_repo.window_aggregates` reads all five (count, cost, distinct users, p50, p95) in **one query**, and `usage` calls it once per window: **six scalar round trips become two.**
- The percentiles need no `ended_at IS NOT NULL` of their own in the combined query — an unfinished run's duration is null and `percentile_cont` ignores a null the way the standalone filter did, the same distribution.

## Scope — the scalar half, `Part-of #949`

The GROUP BY aggregates (by day, by surface/status/model, by agent, by provider) stay their own queries: each groups differently, so they cannot fold into one SELECT, and running them concurrently would need a connection each — an `AsyncSession` is one connection and serialises — a larger change than this.

## How it was verified

- Behaviour-identical: `test_stats.py` composes `window_aggregates` from the same four per-aggregate stubs, so every mapping assertion holds — suite green (46).
- The SQL parity is exercised **end-to-end by `test_usage_stats_sql.py` against a real database in CI** (`StatsService.usage` runs through `window_aggregates` there).
- `ty` and `ruff` clean.

Part-of #949