### PR TITLE
fix(migrations): re-parent the fork that left two alembic heads

### DIFF
--- a/backend/alembic/versions/0056_conversation_plan.py
+++ b/backend/alembic/versions/0056_conversation_plan.py
@@ -30,7 +30,12 @@ from sqlalchemy.dialects import postgresql
 from alembic import op
 
 revision: str = "0056_conversation_plan"
-down_revision: str | None = "0055_sandbox_operations"
+# Re-parented onto 0056_backfill_rag_lookup_indexes rather than sharing
+# 0055_sandbox_operations with it: both were cut from 0055 in parallel, which left
+# two heads and failed every `alembic upgrade head`. The two are independent
+# (collection indexes vs conversations.plan), so chaining them linearises the
+# graph without a merge revision, which is what test_migration_chain.py wants.
+down_revision: str | None = "0056_backfill_rag_lookup_indexes"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 


### PR DESCRIPTION
## The migration half of main being red

`0055_sandbox_operations` grew **two children in parallel** that never chained onto each other — `0056_backfill_rag_lookup_indexes` (#1102) and `0056_conversation_plan` → `0057_kb_embedding_provider`. So `alembic upgrade head` had two heads and refused: **"Multiple head revisions are present"**. Every migration step then failed — the **e2e** job's `alembic upgrade head` errors before a single spec runs (that is why #1184's e2e was red), and `make test-migrations` is red the same way, on `main` and every branch cut from it.

## Fix — re-parent, not merge

`test_migration_chain.py::test_no_two_migrations_claim_the_same_parent` forbids two revisions sharing a parent, and its remediation is to **point the later one's `down_revision` at the earlier** — a linear history, not a merge revision (a merge leaves the fork and fails that test, which is why the first pass here was wrong). So `0056_conversation_plan` now descends from `0056_backfill_rag_lookup_indexes`. The two are independent (collection indexes vs `conversations.plan`), so the order does not matter and nothing else moves.

## Verified

`alembic heads` reports one head (`0057_kb_embedding_provider`); `alembic history` shows the linear chain; `test_migration_chain.py` passes (3, checked with the `AsyncSession` import #1185 restores); ruff clean. The forward-and-back chain runs against a database in CI's `test-migrations`.

> This PR's `lint` job stays red until #1185 merges (the whole-tree ruff/ty hits the unrelated `AsyncSession` bug) — the two are the same main-red, split by concern.