### PR TITLE
fix(channels): upsert the identity on a /link confirm

### DIFF
--- a/backend/app/repositories/agent_run.py
+++ b/backend/app/repositories/agent_run.py
@@ -1378,14 +1378,24 @@ async def create_approval(
 
 
 async def get_approval(
-    db: AsyncSession, approval_id: UUID, *, organization_id: UUID
+    db: AsyncSession, approval_id: UUID, *, organization_id: UUID, for_update: bool = False
 ) -> ToolApproval | None:
-    result = await db.execute(
-        select(ToolApproval).where(
-            ToolApproval.id == approval_id,
-            ToolApproval.organization_id == organization_id,
-        )
+    """Read one approval; with `for_update`, hold its row for the transaction.
+
+    Deciding twice is a check-then-act race: two approvers open the queue, one
+    rejects and one approves within the same read-committed window, both read
+    `pending`, both pass the guard, and the audit trail ends with two
+    contradictory entries for one decision. `decide` takes the lock so the second
+    caller waits and then finds the row no longer pending - the same shape as
+    `claim_parked_run`.
+    """
+    query = select(ToolApproval).where(
+        ToolApproval.id == approval_id,
+        ToolApproval.organization_id == organization_id,
     )
+    if for_update:
+        query = query.with_for_update()
+    result = await db.execute(query)
     return result.scalar_one_or_none()
 
 

--- a/backend/app/repositories/channel_identity.py
+++ b/backend/app/repositories/channel_identity.py
@@ -3,6 +3,7 @@
 from uuid import UUID
 
 from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models.channel_identity import ChannelIdentity
@@ -64,6 +65,67 @@ async def create(
     await db.flush()
     await db.refresh(identity)
     return identity
+
+
+async def get_or_create(
+    db: AsyncSession,
+    *,
+    platform: str,
+    platform_user_id: str,
+    platform_username: str | None = None,
+    platform_display_name: str | None = None,
+    user_id: UUID | None = None,
+) -> ChannelIdentity:
+    """The identity for this platform user, inserted once under contention.
+
+    One person messaging two chats at once produces two webhooks whose sessions
+    race here: both miss the `SELECT`, both `INSERT`, and the second violates
+    `uq_channel_identity_platform_user` - the whole event fails and the user gets
+    no reply (#17). The router's in-process lock does not help, because it is
+    keyed on the chat, not on the identity, so the two webhooks hold different
+    locks.
+
+    The insert runs only on a miss, so an existing identity - every message after
+    the first - is a plain read that takes no lock and writes nothing. That
+    matters here because the whole inbound message runs in one transaction, right
+    through the agent's model call, and the identity is keyed per platform user
+    rather than per chat: an unconditional upsert would row-lock the identity on
+    every message and hold it across the LLM call, serialising a user active in
+    two chats at once. The old get-then-create read without locking on a hit; this
+    keeps that.
+
+    On the miss the insert closes the creation race with `ON CONFLICT DO UPDATE`,
+    not `DO NOTHING`: a `DO NOTHING` that loses to a concurrent *uncommitted*
+    insert writes nothing and returns nothing, and a re-`SELECT` in this
+    transaction would not see the other's uncommitted row. `DO UPDATE` waits on
+    that row's lock instead, so the following `SELECT` reads a committed row. The
+    update is a no-op - it sets the key to itself - so a linked `user_id`, a
+    username or a display name on the existing row is left as it was.
+    """
+    existing = await get_by_platform_user(db, platform, platform_user_id)
+    if existing is not None:
+        return existing
+
+    insert_stmt = pg_insert(ChannelIdentity).values(
+        platform=platform,
+        platform_user_id=platform_user_id,
+        platform_username=platform_username,
+        platform_display_name=platform_display_name,
+        user_id=user_id,
+    )
+    await db.execute(
+        insert_stmt.on_conflict_do_update(
+            index_elements=["platform", "platform_user_id"],
+            set_={"platform_user_id": insert_stmt.excluded.platform_user_id},
+        )
+    )
+    result = await db.execute(
+        select(ChannelIdentity).where(
+            ChannelIdentity.platform == platform,
+            ChannelIdentity.platform_user_id == platform_user_id,
+        )
+    )
+    return result.scalar_one()
 
 
 async def update(

--- a/backend/app/repositories/channel_identity.py
+++ b/backend/app/repositories/channel_identity.py
@@ -86,21 +86,22 @@ async def get_or_create(
     locks.
 
     The insert runs only on a miss, so an existing identity - every message after
-    the first - is a plain read that takes no lock and writes nothing. That
-    matters here because the whole inbound message runs in one transaction, right
-    through the agent's model call, and the identity is keyed per platform user
-    rather than per chat: an unconditional upsert would row-lock the identity on
-    every message and hold it across the LLM call, serialising a user active in
-    two chats at once. The old get-then-create read without locking on a hit; this
-    keeps that.
+    the first - is a plain read that writes nothing and holds no lock. That matters
+    because the whole inbound message runs in one transaction, right through the
+    agent's model call, and the identity is keyed per platform user rather than per
+    chat: anything that wrote or locked the row here would hold it across the LLM
+    call and serialise a user active in two chats at once.
 
-    On the miss the insert closes the creation race with `ON CONFLICT DO UPDATE`,
-    not `DO NOTHING`: a `DO NOTHING` that loses to a concurrent *uncommitted*
-    insert writes nothing and returns nothing, and a re-`SELECT` in this
-    transaction would not see the other's uncommitted row. `DO UPDATE` waits on
-    that row's lock instead, so the following `SELECT` reads a committed row. The
-    update is a no-op - it sets the key to itself - so a linked `user_id`, a
-    username or a display name on the existing row is left as it was.
+    On the miss the insert closes the creation race with `ON CONFLICT DO NOTHING`
+    and a re-`SELECT`. `DO NOTHING` waits on a concurrent *uncommitted* insert of
+    the same key - it cannot decide whether to insert until that transaction ends -
+    so by the time it returns the other row is committed, and the re-`SELECT`, a
+    fresh statement under `READ COMMITTED`, reads it. The loser writes nothing and
+    takes no row lock, so it does not hold one through its own run; `DO UPDATE`
+    would, which is the difference on a first-message burst. The row is always
+    present by the `SELECT` - inserted here, or committed by the winner this one
+    lost to - so `scalar_one` cannot come up empty, and an existing `user_id`,
+    username or display name is left untouched.
     """
     existing = await get_by_platform_user(db, platform, platform_user_id)
     if existing is not None:
@@ -114,10 +115,7 @@ async def get_or_create(
         user_id=user_id,
     )
     await db.execute(
-        insert_stmt.on_conflict_do_update(
-            index_elements=["platform", "platform_user_id"],
-            set_={"platform_user_id": insert_stmt.excluded.platform_user_id},
-        )
+        insert_stmt.on_conflict_do_nothing(index_elements=["platform", "platform_user_id"])
     )
     result = await db.execute(
         select(ChannelIdentity).where(

--- a/backend/app/repositories/channel_link_request.py
+++ b/backend/app/repositories/channel_link_request.py
@@ -84,7 +84,13 @@ async def delete_for_identity(db: AsyncSession, *, platform: str, platform_user_
     await db.flush()
 
 
-async def delete_by_id(db: AsyncSession, request_id: UUID) -> None:
-    """Drop one request by id, once it has been confirmed."""
-    await db.execute(delete(ChannelLinkRequest).where(ChannelLinkRequest.id == request_id))
+async def delete_by_id(db: AsyncSession, request_id: UUID) -> bool:
+    """Consume one request by id, returning whether this call claimed it.
+
+    A `/link` token is single-use. The DELETE row-locks, so when two confirms
+    race the same token only the first deletes a row (True); the second waits,
+    finds it gone, and gets False - the loser must not relink the identity (#1132).
+    """
+    result = await db.execute(delete(ChannelLinkRequest).where(ChannelLinkRequest.id == request_id))
     await db.flush()
+    return (result.rowcount or 0) > 0  # ty: ignore[unresolved-attribute]

--- a/backend/app/repositories/invitation.py
+++ b/backend/app/repositories/invitation.py
@@ -13,8 +13,21 @@ from app.db.models.organization import Invitation, InvitationStatus, OrgRole
 _INVITE_TTL_DAYS = 7
 
 
-async def get_by_token(db: AsyncSession, token: str) -> Invitation | None:
-    result = await db.execute(select(Invitation).where(Invitation.token == token))
+async def get_by_token(
+    db: AsyncSession, token: str, *, for_update: bool = False
+) -> Invitation | None:
+    """Read an invitation by its token; with `for_update`, lock the row.
+
+    `accept` reads `used_count`, checks it against `max_uses` in Python, and then
+    increments it - a check-then-act that, unlocked, admits two people through a
+    one-use link posted in a channel and clicked at once. Locking the row in
+    `accept` serializes the second caller behind the first, which then re-reads
+    the bumped count and is refused.
+    """
+    query = select(Invitation).where(Invitation.token == token)
+    if for_update:
+        query = query.with_for_update()
+    result = await db.execute(query)
     return result.scalar_one_or_none()
 
 

--- a/backend/app/services/approvals.py
+++ b/backend/app/services/approvals.py
@@ -149,7 +149,7 @@ class ApprovalService:
                 make the audit trail ambiguous about who authorised the action.
         """
         approval = await agent_run_repo.get_approval(
-            self.db, approval_id, organization_id=ctx.organization_id
+            self.db, approval_id, organization_id=ctx.organization_id, for_update=True
         )
         if approval is None:
             raise NotFoundError(

--- a/backend/app/services/channel_link.py
+++ b/backend/app/services/channel_link.py
@@ -135,21 +135,18 @@ class ChannelLinkService:
         if request is None:
             return None
 
-        identity = await channel_identity_repo.get_by_platform_user(
+        # get_or_create, not get-then-create: a concurrent inbound message could
+        # otherwise collide on the identity's unique key and 500 the confirm (#1113).
+        # The upsert leaves an existing user_id alone, so the link is the update below.
+        identity = await channel_identity_repo.get_or_create(
             self.db,
             platform=request.platform,
             platform_user_id=request.platform_user_id,
+            platform_username=request.platform_username,
+            platform_display_name=request.platform_display_name,
+            user_id=user_id,
         )
-        if identity is None:
-            await channel_identity_repo.create(
-                self.db,
-                platform=request.platform,
-                platform_user_id=request.platform_user_id,
-                platform_username=request.platform_username,
-                platform_display_name=request.platform_display_name,
-                user_id=user_id,
-            )
-        else:
+        if identity.user_id != user_id:
             await channel_identity_repo.update(
                 self.db, db_identity=identity, update_data={"user_id": user_id}
             )

--- a/backend/app/services/channel_link.py
+++ b/backend/app/services/channel_link.py
@@ -135,6 +135,13 @@ class ChannelLinkService:
         if request is None:
             return None
 
+        # Claim the single-use request before relinking. Two authenticated users
+        # confirming the same token both read it as valid, so consuming it first
+        # lets only the one whose DELETE claims the row proceed - the loser stops
+        # here rather than overwriting the winner's link (#1132).
+        if not await channel_link_request_repo.delete_by_id(self.db, request.id):
+            return None
+
         # get_or_create, not get-then-create: a concurrent inbound message could
         # otherwise collide on the identity's unique key and 500 the confirm (#1113).
         # The upsert leaves an existing user_id alone, so the link is the update below.
@@ -151,7 +158,6 @@ class ChannelLinkService:
                 self.db, db_identity=identity, update_data={"user_id": user_id}
             )
 
-        await channel_link_request_repo.delete_by_id(self.db, request.id)
         return request
 
     async def linked(self, user_id: UUID) -> list[ChannelIdentity]:

--- a/backend/app/services/channels/router.py
+++ b/backend/app/services/channels/router.py
@@ -782,20 +782,14 @@ class ChannelMessageRouter:
         policy: dict[str, Any] = self._parse_policy(bot)
         mode: str = policy.get("mode", "open")
 
-        identity = await channel_identity_repo.get_by_platform_user(
+        identity = await channel_identity_repo.get_or_create(
             db,
             platform=incoming.platform,
             platform_user_id=incoming.platform_user_id,
+            platform_username=incoming.platform_username,
+            platform_display_name=incoming.platform_display_name,
+            user_id=None,
         )
-        if not identity:
-            identity = await channel_identity_repo.create(
-                db,
-                platform=incoming.platform,
-                platform_user_id=incoming.platform_user_id,
-                platform_username=incoming.platform_username,
-                platform_display_name=incoming.platform_display_name,
-                user_id=None,
-            )
 
         if mode == "jwt_linked" and policy.get("require_link", False) and not identity.user_id:
             raise AuthorizationError(

--- a/backend/app/services/invitation.py
+++ b/backend/app/services/invitation.py
@@ -176,7 +176,11 @@ class InvitationService:
         )
 
     async def accept(self, token: str, accepting_user_id: UUID):
-        invite = await invitation_repo.get_by_token(self.db, token)
+        # Locked for the rest of the request: the `used_count`/`max_uses` guard
+        # below and the increment in `record_use` are a check-then-act, and two
+        # accepts of a one-use link arriving together would otherwise both pass
+        # (#17).
+        invite = await invitation_repo.get_by_token(self.db, token, for_update=True)
         if not invite:
             raise NotFoundError(message="Invitation not found or already used")
 

--- a/backend/tests/integration/test_approvals_queue.py
+++ b/backend/tests/integration/test_approvals_queue.py
@@ -318,3 +318,95 @@ class TestTheOrderTheQueueDrainsIn:
         # the one the tiebreaker fixes.
         assert paged == expected
         assert len(set(paged)) == 5
+
+
+class TestDecidingTwiceIsRefused:
+    """Two approvers, one decision: the row is locked so the second is refused.
+
+    `decide` reads the approval, checks it is pending, and writes - a check-then-act
+    that, unlocked, lets a concurrent reject and approve both pass the guard and
+    both write, leaving the audit trail with two contradictory entries for one
+    decision (#17). The `with_for_update` in `get_approval` serializes them.
+
+    Deterministic on purpose: one approver's decision is held open (uncommitted,
+    lock still on the row) while the other's runs. With the lock the second
+    blocks on the *read* and, once the first commits, re-reads a decided row and
+    is refused - one audit entry. Without it the second blocks on the *write*
+    instead, having already passed the guard against a `pending` read, and writes
+    a second, contradictory decision. Racing the two through `gather` alone does
+    not reproduce this: the pair serialises, and the first commits before the
+    second reads.
+    """
+
+    async def test_a_held_decision_blocks_the_second_which_is_then_refused(
+        self, db, engine
+    ) -> None:
+        import asyncio
+        import contextlib
+
+        from sqlalchemy import func, select
+        from sqlalchemy.ext.asyncio import async_sessionmaker
+
+        from app.core.exceptions import BadRequestError
+        from app.db.models.audit_log import AppAdminAuditLog
+
+        org, owner = await _org(db)
+        approver_a = await _user(db)
+        approver_b = await _user(db)
+        db.add_all(
+            [
+                OrganizationMember(
+                    id=uuid.uuid4(), organization_id=org.id, user_id=approver_a.id, role="admin"
+                ),
+                OrganizationMember(
+                    id=uuid.uuid4(), organization_id=org.id, user_id=approver_b.id, role="admin"
+                ),
+            ]
+        )
+        await db.flush()
+        agent = await _agent(db, org)
+        run = await _run(db, org, agent, started_by=owner)
+        approval = await _approval(db, org, run)
+        await db.commit()
+
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        session_a = factory()
+        b_task: asyncio.Task[None] | None = None
+        try:
+            # A decides and holds it open: the row lock stays on the approval.
+            await ApprovalService(session_a).decide(
+                _ctx(org, approver_a), approval.id, approved=True
+            )
+
+            async def decide_b() -> None:
+                async with factory() as session_b:
+                    await ApprovalService(session_b).decide(
+                        _ctx(org, approver_b), approval.id, approved=False
+                    )
+                    await session_b.commit()
+
+            b_task = asyncio.create_task(decide_b())
+            await asyncio.sleep(0.4)
+            assert not b_task.done()  # blocked on A's lock
+
+            await session_a.commit()
+
+            with pytest.raises(BadRequestError):
+                await b_task
+            b_task = None
+        finally:
+            if b_task is not None:
+                b_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await b_task
+            await session_a.close()
+
+        async with factory() as session:
+            decided = await session.get(ToolApproval, approval.id)
+            assert decided.status == ApprovalStatus.APPROVED.value
+            audit_rows = await session.scalar(
+                select(func.count())
+                .select_from(AppAdminAuditLog)
+                .where(AppAdminAuditLog.target_id == str(approval.id))
+            )
+            assert audit_rows == 1

--- a/backend/tests/integration/test_channel_identity_race.py
+++ b/backend/tests/integration/test_channel_identity_race.py
@@ -1,0 +1,86 @@
+"""One person, two chats, two webhooks at once: still one identity row.
+
+A Slack user messaging two channels at the same moment produces two webhooks
+whose sessions both resolve the same identity. Unlocked get-then-create had them
+both miss the `SELECT` and both `INSERT`, and the second violated
+`uq_channel_identity_platform_user` - so the whole event failed and that user got
+no reply (#17). The in-process lock did not help: it is keyed on the chat, so the
+two webhooks held different locks. Only the database can show the fix, because
+what makes it work is `ON CONFLICT` against the unique index across two
+transactions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import uuid
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
+
+from app.db.models.channel_identity import ChannelIdentity
+from app.repositories import channel_identity_repo
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_a_held_insert_does_not_make_the_second_resolve_fail(
+    engine: AsyncEngine,
+) -> None:
+    """Deterministic on purpose: one webhook's insert is held open (uncommitted,
+    the unique-index lock on the new row) while the other resolves the same user.
+
+    With `ON CONFLICT DO UPDATE` the second blocks on that lock and, once the
+    first commits, resolves the existing row - one identity, no error. The naive
+    get-then-create it replaces would instead have the second's own `INSERT`
+    unblock into a `uq_channel_identity_platform_user` violation and fail the
+    event. Racing two resolves through `gather` alone does not reproduce this: the
+    pair serialises and the first commits before the second inserts.
+    """
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    platform = "slack"
+    platform_user_id = uuid.uuid4().hex
+
+    session_a = factory()
+    b_task: asyncio.Task[uuid.UUID] | None = None
+    try:
+        first = await channel_identity_repo.get_or_create(
+            session_a, platform=platform, platform_user_id=platform_user_id
+        )
+
+        async def resolve_b() -> uuid.UUID:
+            async with factory() as session_b:
+                identity = await channel_identity_repo.get_or_create(
+                    session_b, platform=platform, platform_user_id=platform_user_id
+                )
+                await session_b.commit()
+                return identity.id
+
+        b_task = asyncio.create_task(resolve_b())
+        await asyncio.sleep(0.4)
+        assert not b_task.done()  # blocked on A's uncommitted insert
+
+        await session_a.commit()
+
+        second = await b_task
+        b_task = None
+        assert second == first.id  # the same identity, no error
+    finally:
+        if b_task is not None:
+            b_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await b_task
+        await session_a.close()
+
+    async with factory() as session:
+        rows = await session.scalar(
+            select(func.count())
+            .select_from(ChannelIdentity)
+            .where(
+                ChannelIdentity.platform == platform,
+                ChannelIdentity.platform_user_id == platform_user_id,
+            )
+        )
+        assert rows == 1

--- a/backend/tests/integration/test_channel_link_confirm_race.py
+++ b/backend/tests/integration/test_channel_link_confirm_race.py
@@ -111,3 +111,69 @@ async def test_a_confirm_racing_an_inbound_message_still_links_one_identity(
         )
         assert identity is not None
         assert identity.user_id == user_id  # the confirm's link landed
+
+
+async def test_two_confirms_of_one_token_leave_a_single_claimant(
+    engine: AsyncEngine,
+) -> None:
+    """A /link token is a single-use bearer credential. Two authenticated users
+    confirming it at once both read it as valid; consuming the request before
+    relinking lets only one win, so the token cannot be replayed to overwrite the
+    first claimant's link (#1132).
+    """
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    platform = "slack"
+    platform_user_id = uuid.uuid4().hex
+
+    async with factory() as setup:
+        user_a = User(
+            id=uuid.uuid4(),
+            email=f"{uuid.uuid4().hex}@example.com",
+            hashed_password="x",
+            is_active=True,
+        )
+        user_b = User(
+            id=uuid.uuid4(),
+            email=f"{uuid.uuid4().hex}@example.com",
+            hashed_password="x",
+            is_active=True,
+        )
+        setup.add_all([user_a, user_b])
+        await channel_link_request_repo.create(
+            setup,
+            token="tok-double",
+            platform=platform,
+            platform_user_id=platform_user_id,
+            platform_username=None,
+            platform_display_name=None,
+            expires_at=datetime.now(UTC) + timedelta(minutes=5),
+        )
+        await setup.commit()
+        a_id, b_id = user_a.id, user_b.id
+
+    async def confirm_as(user_id: uuid.UUID) -> object:
+        async with factory() as session:
+            spent = await ChannelLinkService(session).confirm("tok-double", user_id)
+            await session.commit()
+            return spent
+
+    results = await asyncio.gather(confirm_as(a_id), confirm_as(b_id))
+
+    # Exactly one confirm claimed the token; the other found it already spent.
+    assert sorted(r is None for r in results) == [False, True]
+
+    async with factory() as session:
+        identities = (
+            (
+                await session.execute(
+                    select(ChannelIdentity).where(
+                        ChannelIdentity.platform == platform,
+                        ChannelIdentity.platform_user_id == platform_user_id,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(identities) == 1  # one identity, linked to whichever confirm won
+        assert identities[0].user_id in {a_id, b_id}

--- a/backend/tests/integration/test_channel_link_confirm_race.py
+++ b/backend/tests/integration/test_channel_link_confirm_race.py
@@ -1,0 +1,113 @@
+"""A /link confirm racing a concurrent inbound message links one identity.
+
+`ChannelLinkService.confirm` used to get-then-create the identity - the same
+unlocked check-then-act #17 closed in the router. A user who sends a message (the
+router's own INSERT) at the moment they click the confirm could make confirm's
+INSERT collide on `uq_channel_identity_platform_user` and 500 the confirm
+(#1113). Routing confirm through `get_or_create` (SELECT-first, ON CONFLICT DO
+NOTHING) closes it, and only the database can show it, because what makes it work
+is the unique index across two transactions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
+
+from app.db.models.channel_identity import ChannelIdentity
+from app.db.models.user import User
+from app.repositories import channel_identity_repo, channel_link_request_repo
+from app.services.channel_link import ChannelLinkService
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_a_confirm_racing_an_inbound_message_still_links_one_identity(
+    engine: AsyncEngine,
+) -> None:
+    """One webhook's identity insert is held open (uncommitted, the unique-index
+    lock on the new row) while a /link confirm resolves the same platform user.
+
+    The confirm's `get_or_create` blocks on that lock and, once the inbound
+    commits, resolves the row it lost to and links it - one identity, no error,
+    the confirm's user_id landing on it. The get-then-create it replaces would
+    instead have the confirm's own INSERT unblock into a
+    `uq_channel_identity_platform_user` violation and 500 the confirm.
+    """
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    platform = "slack"
+    platform_user_id = uuid.uuid4().hex
+
+    async with factory() as setup:
+        user = User(
+            id=uuid.uuid4(),
+            email=f"{uuid.uuid4().hex}@example.com",
+            hashed_password="x",
+            is_active=True,
+        )
+        setup.add(user)
+        await channel_link_request_repo.create(
+            setup,
+            token="tok-race",
+            platform=platform,
+            platform_user_id=platform_user_id,
+            platform_username=None,
+            platform_display_name=None,
+            expires_at=datetime.now(UTC) + timedelta(minutes=5),
+        )
+        await setup.commit()
+        user_id = user.id
+
+    session_a = factory()
+    confirm_task: asyncio.Task[object] | None = None
+    try:
+        # The inbound message's transaction resolves (creates) the identity and
+        # holds it open: the unique-index lock on the new row, uncommitted.
+        await channel_identity_repo.get_or_create(
+            session_a, platform=platform, platform_user_id=platform_user_id, user_id=None
+        )
+
+        async def confirm() -> object:
+            async with factory() as session_b:
+                spent = await ChannelLinkService(session_b).confirm("tok-race", user_id)
+                await session_b.commit()
+                return spent
+
+        confirm_task = asyncio.create_task(confirm())
+        await asyncio.sleep(0.4)
+        assert not confirm_task.done()  # blocked on A's uncommitted insert
+
+        await session_a.commit()
+
+        spent = await confirm_task
+        confirm_task = None
+        assert spent is not None  # the confirm succeeded rather than 500ing
+    finally:
+        if confirm_task is not None:
+            confirm_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await confirm_task
+        await session_a.close()
+
+    async with factory() as session:
+        count = await session.scalar(
+            select(func.count())
+            .select_from(ChannelIdentity)
+            .where(
+                ChannelIdentity.platform == platform,
+                ChannelIdentity.platform_user_id == platform_user_id,
+            )
+        )
+        assert count == 1  # exactly one identity, not two
+
+        identity = await channel_identity_repo.get_by_platform_user(
+            session, platform=platform, platform_user_id=platform_user_id
+        )
+        assert identity is not None
+        assert identity.user_id == user_id  # the confirm's link landed

--- a/backend/tests/integration/test_invitation_reservations.py
+++ b/backend/tests/integration/test_invitation_reservations.py
@@ -15,6 +15,7 @@ is the row lock and the `WHERE` being re-evaluated against the version it locked
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import secrets
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -171,3 +172,70 @@ async def test_two_registrations_racing_on_the_last_use_do_not_both_get_it(db, e
     assert [first, second].count(True) == 1
     await db.refresh(invite)
     assert len(invite.reserved_emails) == 1
+
+
+async def _acceptor(db) -> User:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"{uuid.uuid4().hex}@example.com",
+        hashed_password="x",
+        is_active=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def test_two_accepts_of_a_one_use_link_admit_exactly_one_member(db, engine) -> None:
+    """The acceptance-side race, which `reserve_use` does not cover.
+
+    `accept` reads `used_count`, checks it against `max_uses`, and increments -
+    unlocked, two accepts of a one-use link both read zero and both create a
+    member (#17). Locking the invitation row in `accept` serializes them.
+
+    Deterministic on purpose: one acceptance is held open (uncommitted, lock on
+    the invitation row) while the other runs. With the lock the second blocks on
+    the `get_by_token` read and, once the first commits, re-reads an exhausted
+    link and is refused; without it the second blocks later on the `record_use`
+    write, having already passed the guard against a `used_count` of zero, and a
+    second member is created. `gather` alone does not reproduce it - the pair
+    serialises and the first commits before the second reads.
+    """
+    from app.core.exceptions import BadRequestError
+    from app.repositories import member_repo
+    from app.services.invitation import InvitationService
+
+    invite = await _link(db, max_uses=1)
+    one = await _acceptor(db)
+    two = await _acceptor(db)
+    await db.commit()
+
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    session_a = factory()
+    b_task: asyncio.Task[None] | None = None
+    try:
+        await InvitationService(session_a).accept(invite.token, accepting_user_id=one.id)
+
+        async def accept_b() -> None:
+            async with factory() as session_b:
+                await InvitationService(session_b).accept(invite.token, accepting_user_id=two.id)
+                await session_b.commit()
+
+        b_task = asyncio.create_task(accept_b())
+        await asyncio.sleep(0.4)
+        assert not b_task.done()  # blocked on A's lock
+
+        await session_a.commit()
+
+        with pytest.raises(BadRequestError):
+            await b_task
+        b_task = None
+    finally:
+        if b_task is not None:
+            b_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await b_task
+        await session_a.close()
+
+    members = await member_repo.count_for_org(db, invite.organization_id)
+    assert members == 1

--- a/backend/tests/test_channel_link_requests.py
+++ b/backend/tests/test_channel_link_requests.py
@@ -194,19 +194,16 @@ class TestRequesting:
 
 
 class TestConfirming:
-    async def _confirm(self, found: MagicMock | None, identity: MagicMock | None) -> object:
+    async def _confirm(self, found: MagicMock | None, resolved: MagicMock | None) -> object:
         with (
             patch(
                 "app.services.channel_link.channel_link_request_repo.get_valid",
                 new=AsyncMock(return_value=found),
             ),
             patch(
-                "app.services.channel_link.channel_identity_repo.get_by_platform_user",
-                new=AsyncMock(return_value=identity),
-            ),
-            patch(
-                "app.services.channel_link.channel_identity_repo.create", new=AsyncMock()
-            ) as created,
+                "app.services.channel_link.channel_identity_repo.get_or_create",
+                new=AsyncMock(return_value=resolved),
+            ) as resolved_call,
             patch(
                 "app.services.channel_link.channel_identity_repo.update", new=AsyncMock()
             ) as updated,
@@ -216,31 +213,41 @@ class TestConfirming:
             ) as spent,
         ):
             result = await ChannelLinkService(MagicMock()).confirm("tok", self.user_id)
-        self.created, self.updated, self.spent = created, updated, spent
+        self.resolved, self.updated, self.spent = resolved_call, updated, spent
         return result
 
     def setup_method(self) -> None:
         self.user_id = uuid.uuid4()
 
-    async def test_the_chat_account_already_seen_gains_its_person(self):
-        """The common path: they messaged the bot, were refused, and are now
-        clicking the link that refusal carried - so the row is already there."""
-        assert await self._confirm(_request(), MagicMock()) is not None
+    async def test_confirm_resolves_through_the_upsert_not_get_then_create(self):
+        """The whole of #1113: the identity is resolved with the same SELECT-first
+        `get_or_create` the router uses, so a confirm racing an inbound message
+        cannot collide on the identity's unique key and 500."""
+        await self._confirm(_request(), MagicMock(user_id=None))
+        self.resolved.assert_awaited_once()
+
+    async def test_a_chat_account_linked_to_no_one_gains_its_person(self):
+        """The row the upsert returns carries no user_id - a fresh insert the
+        router won, or a never-linked one - so linking it is an explicit update."""
+        assert await self._confirm(_request(), MagicMock(user_id=None)) is not None
         assert self.updated.call_args.kwargs["update_data"] == {"user_id": self.user_id}
 
-    async def test_an_unseen_chat_account_is_created_already_linked(self):
-        assert await self._confirm(_request(), None) is not None
-        assert self.created.call_args.kwargs["user_id"] == self.user_id
+    async def test_the_row_the_confirm_itself_inserted_is_not_rewritten(self):
+        """On the miss, `get_or_create` inserts already carrying this user_id, so
+        there is nothing left to update."""
+        assert await self._confirm(_request(), MagicMock(user_id=self.user_id)) is not None
+        assert self.resolved.call_args.kwargs["user_id"] == self.user_id
+        assert self.updated.call_count == 0
 
     async def test_a_link_is_spent_once(self):
-        await self._confirm(_request(), MagicMock())
+        await self._confirm(_request(), MagicMock(user_id=None))
         assert self.spent.call_count == 1
 
     async def test_a_token_that_does_not_resolve_links_nothing(self):
         """Unknown and expired answer the same way: the difference is not
         something the person clicking can act on differently."""
         assert await self._confirm(None, MagicMock()) is None
-        assert self.created.call_count == 0
+        assert self.resolved.call_count == 0
         assert self.updated.call_count == 0
         assert self.spent.call_count == 0
 

--- a/backend/tests/test_channel_link_requests.py
+++ b/backend/tests/test_channel_link_requests.py
@@ -194,7 +194,9 @@ class TestRequesting:
 
 
 class TestConfirming:
-    async def _confirm(self, found: MagicMock | None, resolved: MagicMock | None) -> object:
+    async def _confirm(
+        self, found: MagicMock | None, resolved: MagicMock | None, *, claimed: bool = True
+    ) -> object:
         with (
             patch(
                 "app.services.channel_link.channel_link_request_repo.get_valid",
@@ -209,7 +211,7 @@ class TestConfirming:
             ) as updated,
             patch(
                 "app.services.channel_link.channel_link_request_repo.delete_by_id",
-                new=AsyncMock(),
+                new=AsyncMock(return_value=claimed),
             ) as spent,
         ):
             result = await ChannelLinkService(MagicMock()).confirm("tok", self.user_id)
@@ -250,6 +252,14 @@ class TestConfirming:
         assert self.resolved.call_count == 0
         assert self.updated.call_count == 0
         assert self.spent.call_count == 0
+
+    async def test_a_second_confirm_of_the_same_token_links_nothing(self):
+        """The token is single-use: a confirm whose claim of the request loses the
+        race - its DELETE removes no row - must not go on to relink the identity
+        and overwrite the winner's link (#1132)."""
+        assert await self._confirm(_request(), MagicMock(user_id=None), claimed=False) is None
+        assert self.resolved.call_count == 0
+        assert self.updated.call_count == 0
 
 
 class TestWhatTheBotSaysToAStranger:

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -81,6 +81,18 @@ one expensive call every time.
     to the session context - which rolls back on any exception and is never
     reached at all on cancellation.
 
+The guard is a hard stop for a run that *sees* the spend, and a run's own cost
+only lands on its row when it finishes. So the baseline a run reads is the sum of
+runs that have already finished, and concurrent runs are invisible to one
+another: fifty runs starting together against an organization one call short of
+its cap each read the same under-cap baseline and each proceed, overshooting by
+up to their combined cost. This is a property of an aggregate with no single row
+to lock - unlike the per-run and per-loop overshoot above, which the
+before-the-request check does bound - and it is why the cap is a ceiling on
+committed spend rather than a gate that serialises simultaneous runs. A
+deployment that needs a strict cap runs its agents through one queue rather than
+in parallel.
+
 ### A run costs more than its model requests
 
 A knowledge search embeds the question before it can search it, and that embedding


### PR DESCRIPTION
## Summary

`ChannelLinkService.confirm` did an unguarded get-then-create on `(platform, platform_user_id)` — the same check-then-act #17 closes in the router's identity resolution. A user who sends a message (the router's own INSERT) at the moment they click a `/link` confirm could make confirm's INSERT collide on `uq_channel_identity_platform_user` and 500 the confirm.

## Changed

- `confirm` now resolves the identity through `channel_identity_repo.get_or_create` (SELECT-first, `INSERT ... ON CONFLICT DO NOTHING`, re-SELECT) instead of get-then-create. The upsert deliberately leaves an existing row's `user_id` untouched, so linking it to the confirming user is an explicit `update` after it — skipped on the miss path, where the row was just inserted already carrying this `user_id`.

## Testing

- **Integration** (`test_channel_link_confirm_race.py`): a held inbound-message INSERT is raced against a `/link` confirm for the same platform user; both succeed, exactly one identity row survives, and the confirm's `user_id` lands. Fails without the fix with an `IntegrityError`.
- **Unit** (`TestConfirming`): now asserts confirm routes through the upsert and relinks only when the resolved row does not already carry this user (fails against the old get-then-create).

## Notes for reviewers

Stacked on `fix/17-check-then-act-row-locks`, because it uses the `get_or_create` that PR adds. Retarget to `main` once #17 (#1114) merges.

Closes #1113


Replaces #1132, which GitHub closed automatically when its base branch `fix/1113-channel-link-confirm-race` was deleted on merge. Same branch, retargeted to `main`.
