### PR TITLE
chore: cut 0.0.276

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,26 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.276] - 2026-08-26
+
+### Fixed
+
+- **A user who had ever invited anybody could not be deleted.** Three foreign keys
+  into `users.id` - `OrganizationMember.invited_by_user_id`,
+  `Invitation.invited_by_user_id` and `Invitation.accepted_by_user_id` - carried no
+  `ondelete`, so PostgreSQL's NO ACTION made each an absolute bar on deleting the
+  referenced user: `DELETE /users/{id}` failed with a foreign-key violation
+  surfaced as a 500, which is common in any real deployment. All three are
+  `ON DELETE SET NULL` now - who invited a member and who accepted an invitation
+  are audit context that should outlive the user, the way the secret and collection
+  attribution FKs already null. `Invitation.invited_by_user_id` was NOT NULL, so
+  the migration makes it nullable in the same step: set on every create, null only
+  once the inviter is gone. (#1110, #9)
+- `seed --clear`'s bulk `delete_non_admins` still 500s on
+  `organizations.created_by_user_id` RESTRICT for a user who owns a personal
+  organization - that path bypasses the reconciliation and hits a different FK, so
+  it was filed rather than folded in. (#1124)
+
 ## [0.0.275] - 2026-08-26
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.275"
+version = "0.0.276"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.275"
+version = "0.0.276"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.275",
+  "version": "0.0.276",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.276. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.276 and adds the CHANGELOG entry.

Releases #1110, the remainder #9 left: three FKs into `users.id` carried no
`ondelete`, so NO ACTION made each an absolute bar on deleting the referenced
user - anybody who had ever invited a member failed `DELETE /users/{id}` with
a foreign-key violation surfaced as a 500. All three SET NULL now, and the
migration makes `Invitation.invited_by_user_id` nullable in the same step.

`seed --clear`'s bulk path hits a different FK and was filed as #1124; #1139
is the branch that closes it.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1125 was green on the merged head.