### PR TITLE
chore: cut 0.0.277

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,37 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.277] - 2026-08-26
+
+### Fixed
+
+- **A cancelled save orphaned its file.**
+  `asyncio.to_thread(path.write_bytes, data)` cannot interrupt the running write,
+  so a task cancelled mid-write unwound with the file created *after* `save()` had
+  raised - the caller never got `storage_path`, so it could neither record the file
+  nor delete it. `write_bytes_cancel_safe` shields the write and, on cancellation,
+  waits it out and removes the file before the cancellation propagates. (#1108,
+  #25)
+- **Parses shared the executor with `bcrypt` and DNS.** A burst of uploads could
+  occupy every worker on the loop's default pool and queue sign-in and outbound
+  requests behind them. Parsing and the storage byte operations run on a dedicated
+  `ThreadPoolExecutor` in `app/core/blocking.py` now, bounded by
+  `FILE_IO_MAX_WORKERS` (default 8), so a parse storm saturates its own pool and
+  nothing else. The new module is registered in the coverage `include`, the ty
+  override and `PLATFORM_MODULES` - new platform code held to the 100% gate rather
+  than the template's downgraded rules. (#1108, #25)
+- Two defects in the new pool, found by the reviewer on the branch and fixed
+  before merge, both defeating the guarantee it was added for. The gate released
+  its admission slot when the *caller* unwound, and an executor cannot interrupt a
+  running job - so a cancelled caller handed its permit on while its own worker
+  stayed occupied, and a wave of cancellations admitted arbitrarily many jobs into
+  the pool's unbounded pending queue. The release rides the future's own
+  completion now. And `await asyncio.shield(_discard(...))` shielded the cleanup
+  task but not the frame awaiting it, so a second cancellation raised straight out
+  and left the cleanup to be cancelled with everything else - leaving exactly the
+  orphaned file it exists to prevent. Cancellations arriving while it runs are
+  absorbed until it finishes. (#1108)
+
 ## [0.0.276] - 2026-08-26
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.276"
+version = "0.0.277"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.276"
+version = "0.0.277"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.276",
+  "version": "0.0.277",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.277. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.277 and adds the CHANGELOG entry.

Releases #1108, hardening the offload #25 introduced. `to_thread` cannot
interrupt a running write, so a task cancelled mid-write left a file the
caller had no path to and could neither record nor delete; the write is
shielded and the file removed before the cancellation propagates. And the
offload no longer shares the default executor with `bcrypt` and DNS, so a
burst of uploads cannot queue sign-in behind it.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1126 was green on the merged head.