### PR TITLE
test(frontend): stop the layout spec from reaching the backend

### DIFF
--- a/frontend/src/app/layout.test.tsx
+++ b/frontend/src/app/layout.test.tsx
@@ -1,6 +1,8 @@
 import { getLocale } from "next-intl/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { BUILT_IN_BRANDING } from "@/lib/branding";
+
 import RootLayout from "./layout";
 
 vi.mock("next-intl/server", async (importOriginal) => ({
@@ -13,6 +15,13 @@ vi.mock("next/font/local", () => ({
 }));
 
 vi.mock("./globals.css", () => ({}));
+
+// The layout awaits `readBranding`, which reaches BACKEND_URL. Unmocked, this
+// spec's result depends on what is listening on :8000 - and a port that accepts
+// connections without answering hangs it until the 15s deadline (#1075).
+vi.mock("@/lib/branding-server", () => ({
+  readBranding: vi.fn(async () => BUILT_IN_BRANDING),
+}));
 
 /**
  * `<html lang>` follows the active locale (#619).


### PR DESCRIPTION
`src/app/layout.test.tsx` issued a real HTTP request. `RootLayout` awaits `readBranding()`, which calls `backendFetch("/api/v1/branding")` against `BACKEND_URL`, and the spec mocked `next-intl/server`, `next/font/local` and `./globals.css` but not the branding read.

That made the spec's result a function of what was listening on :8000:

- **Nothing listening** — the connection is refused, `readBranding` falls back to `BUILT_IN_BRANDING`, the spec passes. This is CI, which is why the suite has been green.
- **A healthy backend** — the request answers in ~25ms and the spec passes.
- **A port that accepts and never answers** — the fetch never settles and both cases die on `Test timed out in 15000ms`. A crash-looping `agenticos_backend` does exactly this: Docker publishes the port and its proxy accepts the TCP connection while nothing inside is listening.

## What changed

One mock, alongside the three already there:

```ts
vi.mock("@/lib/branding-server", () => ({
  readBranding: vi.fn(async () => BUILT_IN_BRANDING),
}));
```

The spec is about `<html lang>` following the active locale (#619, #646); the branding read is scenery.

## How it was verified

Against a listener that accepts connections and never answers (`socket.accept()` into a list):

| | Before | After |
|---|---|---|
| black-hole port | 30.5s, both cases fail on the 15s deadline | 0.63s, both pass |
| backend up | passes | passes |
| nothing listening | passes | passes |

`bun run test:coverage` green: 100% statements/lines/functions, 97.67% branches.

## Not fixed here

`readBranding` swallows every failure into `BUILT_IN_BRANDING` plus a `console.warn`, so a page rendered with default branding because the backend was unreachable is indistinguishable from one told to use the defaults. Noted in the issue; out of scope for a test-only fix.

Closes #1075
