### PR TITLE
chore: cut 0.0.279

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,27 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.279] - 2026-08-27
+
+### Fixed
+
+- **A terminal write could mask the cancellation that ended the run.** Both run
+  surfaces end in a `finally` that records the run and commits it, and any of those
+  raising - a serialization failure, a constraint the delegation savepoints did not
+  catch, a connection dropped mid-turn - replaces the exception that ended the run.
+  When that exception is the `CancelledError` from a stop, the turn was recorded and
+  surfaced as FAILED and the cancellation never reached the task that asked for it.
+  The whole terminal-persistence sequence runs under one guard now: the in-flight
+  exception is captured before it, and a write or commit that raises while the run
+  is already unwinding is logged while the original exception propagates. A clean
+  run still surfaces a persistence failure, and the guard catches `Exception` rather
+  than `BaseException`, so a second cancellation raised by the commit itself still
+  propagates. (#235)
+- The issue names the commit, but `finish` and the record hit the same connection
+  first, so guarding only the commit left the same masking one line earlier - which
+  is why `finish` already wraps its notify call for exactly this reason. The guard
+  covers all of it. (#235)
+
 ## [0.0.278] - 2026-08-26
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.278"
+version = "0.0.279"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.278"
+version = "0.0.279"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.278",
+  "version": "0.0.279",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.279. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.279 and adds the CHANGELOG entry.

Releases #235: both run surfaces end in a `finally` that records and commits,
and any of those raising replaces the exception that ended the run - so a
`CancelledError` from a stop was recorded and surfaced as FAILED, and the
cancellation never reached the task that requested it. The whole terminal
sequence is guarded now, not just the commit: `finish` and the record hit the
same connection first, so guarding the commit alone moved the masking one line
earlier.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1129 was green on the merged head.