### PR TITLE
fix(runs): put the open tab in the URL, and close a run when it changes

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -599,6 +599,19 @@ it. They were local state until #768, so the p95 figure was the only number on
 the dashboard that could reach the runs behind it and three cards carried no link
 at all — there was nothing honest to point them at.
 
+**Including which tab is open.** `?tab=approvals` and `?tab=spend` open the queue
+and the cost screen; the run history is the default and is never written. That is
+the address a link to a *decision* needs, and the reason the parameter exists: the
+approvals card's "See all" and the alert that says a run is parked both had to
+point at the run history, where nothing can be decided (#934). A tab named by a
+link is resolved against what the reader may open — `approvals` is gated on
+`approvals:decide`, so a link carrying it that reaches somebody without the
+permission opens the run history rather than a strip whose selected tab has no
+content. Switching tabs closes an open run detail and takes `?run=` with it: a
+panel that outlives the tab that opened it sits beside a queue it has nothing to
+do with, and below `lg` it replaces the list, so the strip stayed live while every
+tab's content was hidden.
+
 **Duration is computed in SQL, over the whole narrowed set.** That is what gets
 from *"p95 is 14.8s"* on the dashboard to **those runs** — sorting one page of
 twenty-five sorts the wrong set, because the slowest run of a month is not in

--- a/frontend/src/app/[locale]/(dashboard)/runs/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/runs/page.tsx
@@ -14,7 +14,12 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui";
 import { useApprovals, usePermissions, useRuns, useSpend, useUrlState } from "@/hooks";
 import { periodEnd, periodStart } from "@/lib/dashboard/period";
 import { formatPeriodParam, parsePeriodParam, type Period } from "@/lib/dashboard/period";
-import { parseRunFilters, writeRunFilters, type RunFilters } from "@/lib/runs/filter-params";
+import {
+  parseRunFilters,
+  parseRunsTab,
+  writeRunFilters,
+  type RunFilters,
+} from "@/lib/runs/filter-params";
 import { cn, setUrlParam } from "@/lib/utils";
 import { Perm } from "@/types/permissions";
 import { useTranslations } from "next-intl";
@@ -88,6 +93,13 @@ export default function RunsPage() {
     setFilters(next);
     writeRunFilters(next);
   };
+  // Which tab is open, mirrored into `?tab=` like everything else the page
+  // narrows itself with. Addressable at all for the first time here: the alert
+  // that says a run is parked has to send somebody to the decision, and until
+  // the queue had a URL the only honest link was the agent's Builder page
+  // (#935). Resolved against the permission below rather than trusted, so a
+  // link naming a tab the reader may not open lands on one they may.
+  const [tabParam, changeTab] = useUrlState("tab");
   const { can, isLoading: permissionsLoading } = usePermissions();
   // Run history and spend take `runs:view` - `GET /runs` and `GET /spend` both
   // carry it - so a caller without it is not asked for: the figures and the
@@ -136,22 +148,28 @@ export default function RunsPage() {
         <PeriodControl period={period} onChange={changePeriod} />
       </div>
 
-      {/* Not until the permission set has answered. `Tabs` is uncontrolled, so
-          Radix captures `defaultValue` on first mount and never reads it again -
-          mounted while `can()` still answers `false` for everything, the strip
-          opens on Runs and stays there even once the Approvals tab appears
-          beside it. The strip's *shape* depends on this permission, so drawing
-          it before the answer arrives is guessing at it. The badges wait with
-          it: mounted early they would count against a `can()` that simply has
-          not answered yet. */}
+      {/* Not until the permission set has answered. The strip's *shape* depends
+          on this permission - whether there is an Approvals tab at all - so
+          drawing it before the answer arrives is guessing at it, and a link
+          carrying `?tab=approvals` would resolve against a `can()` that has
+          simply not answered yet and open the run history instead. The badges
+          wait with it, for the second half of that reason. */}
       {permissionsLoading ? (
         <LoadingState variant="skeleton-table" columns={6} rows={6} />
       ) : (
         <>
           <Tabs
-            defaultValue="runs"
+            value={parseRunsTab(tabParam, canDecide)}
             className="flex min-h-0 flex-1 flex-col"
-            onValueChange={() => focusRun(null)}
+            onValueChange={(next) => {
+              changeTab(next);
+              // A focused run belongs to the tab that opened it. Left alone it
+              // sat beside a queue it has nothing to do with, and below `lg`
+              // it *replaced* the list - so the strip was live while every
+              // tab's content stayed hidden and switching appeared to do
+              // nothing at all (#934).
+              focusRun(null);
+            }}
           >
             <TabsList className="shrink-0" data-tour="activity-overview">
               {/* Runs first: the page's main question is what ran. The queue

--- a/frontend/src/app/[locale]/(dashboard)/runs/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/runs/page.tsx
@@ -162,7 +162,11 @@ export default function RunsPage() {
             value={parseRunsTab(tabParam, canDecide)}
             className="flex min-h-0 flex-1 flex-col"
             onValueChange={(next) => {
-              changeTab(next);
+              // `null` for the default, so switching back to Runs leaves no
+              // `?tab=runs` behind: an unset narrowing writes nothing on this
+              // page, which is what makes a pasted link carry only what it
+              // actually narrows.
+              changeTab(next === "runs" ? null : next);
               // A focused run belongs to the tab that opened it. Left alone it
               // sat beside a queue it has nothing to do with, and below `lg`
               // it *replaced* the list - so the strip was live while every

--- a/frontend/src/app/[locale]/(dashboard)/runs/tab-url.integration.test.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/runs/tab-url.integration.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import userEvent from "@testing-library/user-event";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -161,6 +161,19 @@ describe("the open tab in the URL", () => {
     );
   });
 
+  it("leaves no `tab=runs` behind when a reader switches back", async () => {
+    // An unset narrowing writes nothing on this page - that is what makes a
+    // pasted link carry only what it actually narrows.
+    serve(["runs:view", "approvals:decide"]);
+    arriveAt("tab=approvals");
+
+    render(<RunsPage />, { wrapper });
+    await userEvent.click(await screen.findByRole("tab", { name: /^Runs/ }));
+
+    expect(url().searchParams.get("tab")).toBeNull();
+    expect(tab(/^Runs/)).toHaveAttribute("aria-selected", "true");
+  });
+
   it("writes the tab a reader switches to, so a reload comes back to it", async () => {
     serve(["runs:view", "approvals:decide"]);
 
@@ -188,6 +201,36 @@ describe("a focused run and a tab switch", () => {
 
     expect(screen.queryByRole("complementary", { name: "Run detail" })).toBeNull();
     expect(listColumn(container)).not.toHaveClass("hidden");
+    expect(tab(/^Approvals/)).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("closes with a link that changes the tab and does not name the run", async () => {
+    // Radix does not call `onValueChange` for a prop-driven change, so this
+    // could look like the panel outliving the switch again. It does not: the
+    // navigation replaces the whole query string, and `useUrlState` resets a
+    // value whose parameter changed under it. There is nothing to clear.
+    serve(["runs:view", "approvals:decide"]);
+    arriveAt("run=run-1");
+
+    const { rerender } = render(<RunsPage />, { wrapper });
+    expect(await screen.findByRole("complementary", { name: "Run detail" })).toBeVisible();
+
+    arriveAt("tab=approvals");
+    rerender(<RunsPage />);
+
+    await waitFor(() =>
+      expect(screen.queryByRole("complementary", { name: "Run detail" })).toBeNull(),
+    );
+    expect(tab(/^Approvals/)).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("honours a link that names both, because that link is asking for both", async () => {
+    serve(["runs:view", "approvals:decide"]);
+    arriveAt("tab=approvals&run=run-1");
+
+    render(<RunsPage />, { wrapper });
+
+    expect(await screen.findByRole("complementary", { name: "Run detail" })).toBeVisible();
     expect(tab(/^Approvals/)).toHaveAttribute("aria-selected", "true");
   });
 

--- a/frontend/src/app/[locale]/(dashboard)/runs/tab-url.integration.test.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/runs/tab-url.integration.test.tsx
@@ -1,0 +1,205 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import RunsPage from "./page";
+import { apiClient } from "@/lib/api-client";
+import type { Permission } from "@/types/permissions";
+
+/**
+ * Which tab is open is the page's state and travels in `?tab=` (#934).
+ *
+ * Two things were wrong, and they were the same thing. `Tabs` was uncontrolled,
+ * so the tab was the only piece of this page's state not in the URL - there was
+ * no address for the approvals queue, which is why the alert that says a run is
+ * parked linked to the agent's Builder page instead (#935). And a focused run
+ * outlived the tab that opened it: the detail panel sat beside a queue it has
+ * nothing to do with, and below `lg` the focused run *replaces* the list, so the
+ * strip was live while every tab's content stayed hidden and clicking Approvals
+ * appeared to do nothing at all.
+ *
+ * The width case is asserted through the class that carries it. jsdom applies no
+ * stylesheet, so `hidden lg:block` is not observable as layout; what is
+ * observable is whether the page still asks for it, which is the decision under
+ * test.
+ */
+
+vi.mock("@/lib/api-client", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api-client")>("@/lib/api-client");
+  return { ...actual, apiClient: { ...actual.apiClient, get: vi.fn(), post: vi.fn() } };
+});
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+let params = new URLSearchParams();
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => params,
+  usePathname: () => "/runs",
+}));
+
+const EMPTY_SPEND = {
+  period_days: 30,
+  month_to_date_usd: "0.00",
+  by_agent: [],
+  by_provider: [],
+  by_key: [],
+};
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+/** Enough of a run for the detail panel to draw its header. */
+const RUN = {
+  id: "run-1",
+  agent_id: "agent-1",
+  agent_version_id: null,
+  user_id: null,
+  surface: "web",
+  status: "completed",
+  model_label: "claude-sonnet-4-5",
+  provider: "anthropic",
+  input_tokens: 1200,
+  output_tokens: 340,
+  cost_usd: "0.0182",
+  cost_is_partial: false,
+  logfire_trace_id: null,
+  prev_run_id: null,
+  next_run_id: null,
+  error: null,
+  down_rated: false,
+  conversation_id: null,
+  started_at: "2026-08-14T09:00:00Z",
+  ended_at: "2026-08-14T09:00:04Z",
+  parent_run_id: null,
+  subagent_task_id: null,
+};
+
+function serve(permissions: Permission[]) {
+  vi.mocked(apiClient.get).mockImplementation((path: string) => {
+    if (path === "/spend") return Promise.resolve(EMPTY_SPEND);
+    if (path === "/runs/run-1") return Promise.resolve(RUN);
+    if (path === "/me/permissions")
+      return Promise.resolve({
+        organization_id: "o1",
+        role: "operator",
+        is_app_admin: false,
+        permissions: permissions.map((permission) => ({ permission, scope: "all" })),
+      });
+    return Promise.resolve({ items: [], total: 0 });
+  });
+}
+
+/** Arrive at the page with this query string, as a pasted link would. */
+function arriveAt(query: string) {
+  params = new URLSearchParams(query);
+  window.history.replaceState({}, "", `/runs${query ? `?${query}` : ""}`);
+}
+
+const tab = (name: RegExp) => screen.getByRole("tab", { name });
+const url = () => new URL(window.location.href);
+
+/**
+ * The column the tab panels share. Below `lg` it is hidden whenever a run is
+ * focused, which is the half of the bug that made switching tabs read as a dead
+ * control.
+ */
+function listColumn(container: HTMLElement): HTMLElement {
+  const panel = container.querySelector<HTMLElement>(
+    "[data-tour='activity-runs'], [data-tour='activity-approvals'], [data-tour='activity-spend']",
+  );
+  if (!panel?.parentElement) throw new Error("no tab panel is mounted");
+  return panel.parentElement;
+}
+
+beforeEach(() => {
+  vi.mocked(apiClient.get).mockReset();
+  arriveAt("");
+});
+
+describe("the open tab in the URL", () => {
+  it("opens the queue for a link that names it", async () => {
+    serve(["runs:view", "approvals:decide"]);
+    arriveAt("tab=approvals");
+
+    render(<RunsPage />, { wrapper });
+
+    expect(await screen.findByRole("tab", { name: /^Approvals/ })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("opens the run history for a link naming a tab the reader may not open", async () => {
+    // A blank page under a live strip is what the alternative looks like: a
+    // selected value with no trigger and no content.
+    serve(["runs:view"]);
+    arriveAt("tab=approvals");
+
+    render(<RunsPage />, { wrapper });
+
+    expect(await screen.findByRole("tab", { name: /^Runs/ })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.queryByRole("tab", { name: /Approvals/ })).toBeNull();
+  });
+
+  it("opens the run history for a tab name this build does not have", async () => {
+    serve(["runs:view", "approvals:decide"]);
+    arriveAt("tab=budgets");
+
+    render(<RunsPage />, { wrapper });
+
+    expect(await screen.findByRole("tab", { name: /^Runs/ })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("writes the tab a reader switches to, so a reload comes back to it", async () => {
+    serve(["runs:view", "approvals:decide"]);
+
+    render(<RunsPage />, { wrapper });
+    await userEvent.click(await screen.findByRole("tab", { name: /^Spend/ }));
+
+    expect(url().searchParams.get("tab")).toBe("spend");
+    expect(tab(/^Spend/)).toHaveAttribute("aria-selected", "true");
+  });
+});
+
+describe("a focused run and a tab switch", () => {
+  it("closes the panel and gives the list back its column", async () => {
+    serve(["runs:view", "approvals:decide"]);
+    arriveAt("run=run-1");
+
+    const { container } = render(<RunsPage />, { wrapper });
+
+    expect(await screen.findByRole("complementary", { name: "Run detail" })).toBeVisible();
+    // The half that makes it read as a dead control below `lg`: with a run
+    // focused, every tab's content is hidden.
+    expect(listColumn(container)).toHaveClass("hidden");
+
+    await userEvent.click(tab(/^Approvals/));
+
+    expect(screen.queryByRole("complementary", { name: "Run detail" })).toBeNull();
+    expect(listColumn(container)).not.toHaveClass("hidden");
+    expect(tab(/^Approvals/)).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("takes the run out of the URL with it", async () => {
+    serve(["runs:view", "approvals:decide"]);
+    arriveAt("run=run-1");
+
+    render(<RunsPage />, { wrapper });
+    await userEvent.click(await screen.findByRole("tab", { name: /^Approvals/ }));
+
+    // Left behind, a reload would reopen a panel on a tab that never had it.
+    expect(url().searchParams.get("run")).toBeNull();
+    expect(url().searchParams.get("tab")).toBe("approvals");
+  });
+});

--- a/frontend/src/lib/dashboard/registry.test.ts
+++ b/frontend/src/lib/dashboard/registry.test.ts
@@ -108,9 +108,19 @@ describe("the widget catalog", () => {
     for (const id of WIDGET_IDS) {
       const destination = WIDGETS[id].seeAll;
       if (destination !== undefined) {
-        expect(known.has(destination), `${id} points at ${destination}`).toBe(true);
+        // A destination may narrow what it opens - the approvals card points at
+        // Activity's queue rather than its run history - so the route is the
+        // part before the query.
+        const { pathname } = new URL(destination, "http://dashboard.test");
+        expect(known.has(pathname), `${id} points at ${destination}`).toBe(true);
       }
     }
+  });
+
+  it("sends the approvals card to the queue rather than to the run history", () => {
+    // "See all" under a count of what is waiting used to open Activity on Runs,
+    // where nothing can be decided. There was no URL for the tab until #934.
+    expect(WIDGETS.approvals.seeAll).toBe("/runs?tab=approvals");
   });
 });
 

--- a/frontend/src/lib/dashboard/registry.ts
+++ b/frontend/src/lib/dashboard/registry.ts
@@ -17,6 +17,7 @@
  */
 
 import { ROUTES } from "@/lib/constants";
+import { runsHref } from "@/lib/runs/filter-params";
 import { Perm, type Permission } from "@/types/permissions";
 
 export type WidgetId =
@@ -401,7 +402,11 @@ export const WIDGETS: Record<WidgetId, WidgetDef> = {
     defaultSpan: "s7",
     defaultRows: "r3",
     category: "attention",
-    seeAll: ROUTES.RUNS,
+    // The queue, not the run history. "See all" on a card counting what is
+    // waiting used to open Activity on Runs, where nothing can be decided -
+    // the same wrong destination the approval alert had, for the same reason:
+    // there was no URL for the tab until #934.
+    seeAll: runsHref({ tab: "approvals" }),
   },
   "recent-failures": {
     id: "recent-failures",

--- a/frontend/src/lib/runs/filter-params.test.ts
+++ b/frontend/src/lib/runs/filter-params.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_RUN_FILTERS,
   isNarrowed,
   parseRunFilters,
+  parseRunsTab,
   runFilterParams,
   runsHref,
   type RunFilters,
@@ -73,6 +74,16 @@ describe("a link to a slice", () => {
     expect(href).not.toContain("2026-05-18");
   });
 
+  it("names the tab where a card hands over to the queue rather than the history", () => {
+    // What the approvals card links to, and what the parked-run alert needs an
+    // address for (#935).
+    expect(runsHref({ tab: "approvals" })).toBe("/runs?tab=approvals");
+  });
+
+  it("leaves the default tab out, like every other unset narrowing", () => {
+    expect(runsHref({ tab: "runs" })).toBe("/runs");
+  });
+
   it("carries an agent and a sort where a card hands those over", () => {
     const href = runsHref({ period, agentId: "agent-1", sort: "duration" });
 
@@ -82,5 +93,29 @@ describe("a link to a slice", () => {
 
   it("is the plain runs page when nothing narrows it", () => {
     expect(runsHref({})).toBe("/runs");
+  });
+});
+
+describe("which tab a link opens", () => {
+  it("reads back the tab it names", () => {
+    expect(parseRunsTab("approvals", true)).toBe("approvals");
+    expect(parseRunsTab("spend", true)).toBe("spend");
+  });
+
+  it("opens the run history when nothing names a tab", () => {
+    expect(parseRunsTab(null, true)).toBe("runs");
+    expect(parseRunsTab("  ", true)).toBe("runs");
+  });
+
+  it("opens the run history for a tab this build does not have", () => {
+    expect(parseRunsTab("budgets", true)).toBe("runs");
+  });
+
+  it("opens the run history for a reader who may not decide", () => {
+    // The alternative is a strip whose selected value has no trigger and no
+    // content: a blank page under a live set of tabs.
+    expect(parseRunsTab("approvals", false)).toBe("runs");
+    // And only that tab is gated - spend is not.
+    expect(parseRunsTab("spend", false)).toBe("spend");
   });
 });

--- a/frontend/src/lib/runs/filter-params.ts
+++ b/frontend/src/lib/runs/filter-params.ts
@@ -50,6 +50,26 @@ const PARAM: Record<keyof RunFilters, string> = {
 
 const RATINGS = new Set(["up", "down"]);
 
+/** Activity's three tabs, in the order the strip draws them. */
+export const RUNS_TABS = ["runs", "approvals", "spend"] as const;
+
+export type RunsTab = (typeof RUNS_TABS)[number];
+
+/**
+ * Read `?tab=` back, against what the caller may actually open.
+ *
+ * `approvals` is gated on `approvals:decide`, so a link carrying it that reaches
+ * somebody without the permission resolves to the run history rather than to a
+ * strip whose selected value has no trigger and no content - which draws as a
+ * blank page below the tabs. Anything unrecognised falls back the same way, for
+ * the reason {@link parseRunFilters} does: a pasted link naming a tab this build
+ * renamed should still open the page.
+ */
+export function parseRunsTab(param: string | null, canDecide: boolean): RunsTab {
+  const tab = RUNS_TABS.find((name) => name === param?.trim()) ?? "runs";
+  return tab === "approvals" && !canDecide ? "runs" : tab;
+}
+
 /**
  * Read a URL back into filters, forgivingly.
  *
@@ -113,8 +133,11 @@ export function runsHref(options: {
   /** `duration` is the p95 figure's hand-off: the slow runs, slowest first. */
   sort?: "duration";
   agentId?: string;
+  /** Which tab to open on. `runs` is the default and is never written. */
+  tab?: RunsTab;
 }): string {
   const params = new URLSearchParams(runFilterParams(options.filters ?? {}));
+  if (options.tab && options.tab !== "runs") params.set("tab", options.tab);
   if (options.agentId) params.set("agent", options.agentId);
   if (options.sort) params.set("sort", options.sort);
   if (options.period) params.set("period", formatPeriodParam(options.period));


### PR DESCRIPTION
Which of Activity's three tabs is open was the one piece of this page's state not in the address bar. Both halves of #934 follow from that.

## What was wrong

`Tabs` was uncontrolled (`defaultValue="runs"`), so **there was no URL for the approvals queue**. That is why the approvals dashboard card's "See all" opens the run history — where nothing can be decided — and why the alert saying a run is parked links to the agent's Builder page (#935). Neither had an honest destination to point at.

And a focused run outlived the tab that opened it: the detail panel sat beside a queue it has nothing to do with, and below `lg` the focused run *replaces* the list — so the strip was live while every tab's content stayed hidden and clicking **Approvals** appeared to do nothing at all.

## What changed

- **`?tab=approvals` / `?tab=spend`.** `runs` is the default and is never written, like every other unset narrowing on this page. `parseRunsTab` joins `parseRunFilters` in `lib/runs/filter-params.ts`, and `runsHref` takes a `tab`.
- **A tab named by a link is resolved against what the reader may open**, not trusted. `approvals` is gated on `approvals:decide`, so a link carrying it that reaches somebody without the permission opens the run history rather than a strip whose selected value has no trigger and no content — which draws as a blank page under a live set of tabs. An unrecognised name falls back the same way.
- **The focused run is cleared on a switch**, as it already was (it landed incidentally in #537, untested) — now with tests, and `?run=` goes with it. Left behind, a reload would reopen a panel on a tab that never had one.
- **The approvals widget's `seeAll` points at the queue.** Same wrong destination as the email, enabled by the same missing parameter, one line — so it is fixed here rather than filed.

The comment warning that Radix captures `defaultValue` on first mount is gone with the hazard. The permission gate that made it moot stays, and its remaining reasons are written down: the strip's *shape* depends on that answer, and so does resolving `?tab=approvals`.

## How it was verified

`tab-url.integration.test.tsx` — six cases. Three of them fail against the page as it was:

```
× opens the queue for a link that names it
× writes the tab a reader switches to, so a reload comes back to it
× takes the run out of the URL with it
```

The other three guard behaviour that already held (the two fallbacks, the panel closing). The narrow-width case is asserted through the class that carries it — jsdom applies no stylesheet, so `hidden lg:block` is not observable as layout; what is observable is whether the page still asks for it.

`make lint-frontend` clean. `bun run test:coverage` green: 100% statements/lines/functions, 97.67% branches.

## Unblocks

**#935** — the approval email can now address the queue instead of the Builder page.

Closes #934
