### PR TITLE
chore: cut 0.0.280

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,26 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.280] - 2026-08-27
+
+### Fixed
+
+- **Two list endpoints ran a query per row** where the code beside them already
+  batched. The vault listing resolved emails and grant counts in one grouped query
+  each, then asked which agents bind each secret one secret at a time - a
+  thirty-secret vault loaded in thirty-one queries. `agents_using_for_secrets`
+  answers a whole page in one: it unnests each agent's draft-spec capabilities and
+  matches the bound `secret_id` against the requested set, grouped back per secret,
+  with a `CASE` guarding `jsonb_array_elements` off a spec whose `capabilities` is
+  not an array - the rows the old containment skipped - and keeping the tenant scope
+  and name ordering. (#953)
+- The organization listing ran two queries per organization: one to re-read the
+  caller's membership for its role, one to count members. The role rides the
+  membership join the listing already makes, and `member_counts_for` counts a whole
+  page in one grouped read. The per-row membership read was redundant anyway - the
+  organization came from that very join. `count_members` stays for the single
+  organization read. (#953)
+
 ## [0.0.279] - 2026-08-27
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.279"
+version = "0.0.280"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.279"
+version = "0.0.280"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.279",
+  "version": "0.0.280",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.280. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.280 and adds the CHANGELOG entry.

Releases #953: two listings ran a query per row beside code that already
batched. A thirty-secret vault took thirty-one queries to ask which agents
bind each secret; one grouped statement answers the page now, with a `CASE`
guarding `jsonb_array_elements` off a spec whose `capabilities` is not an
array. The organization listing dropped two queries per row - the role rides
the join it already made, and the member counts come back grouped.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1130 was green on the merged head.