### PR TITLE
chore: cut 0.0.281

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.281] - 2026-08-27
+
+### Fixed
+
+- **`/link` confirm could 500 on a message arriving at the same moment.**
+  `ChannelLinkService.confirm` did an unguarded get-then-create on
+  `(platform, platform_user_id)` - the same check-then-act #17 closed in the
+  router's identity resolution - so a user who sends a message while clicking a
+  confirm could make the confirm's INSERT collide on
+  `uq_channel_identity_platform_user`. It resolves through
+  `channel_identity_repo.get_or_create` now: SELECT first,
+  `INSERT ... ON CONFLICT DO NOTHING`, re-SELECT. The upsert deliberately leaves an
+  existing row's `user_id` untouched, so linking it to the confirming user is an
+  explicit update after it, skipped on the miss path where the inserted row already
+  carries that user. (#1113, #17)
+
 ## [0.0.280] - 2026-08-27
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.280"
+version = "0.0.281"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.280"
+version = "0.0.281"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.280",
+  "version": "0.0.281",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.281. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.281 and adds the CHANGELOG entry.

Releases #1113, the sibling race #17 left: `ChannelLinkService.confirm` did an
unguarded get-then-create on the identity key, so a message arriving as the
user clicks a `/link` confirm could collide on
`uq_channel_identity_platform_user` and 500 the confirm. It goes through the
same `get_or_create` upsert now, with the relink an explicit update so an
existing row's owner is never silently rewritten by the upsert itself.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1132 was green on the merged head.