### PR TITLE
fix(approvals): send the parked-run alert to the queue, not the Builder

### DIFF
--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -141,7 +141,14 @@ class NotificationService:
         context = {
             "agent_name": agent.name,
             "tools": ", ".join(tools) if tools else "a tool call",
-            "approvals_url": f"{self._frontend}/agents/{agent.id}",
+            # The queue, not the agent. This addressed `/agents/{id}` - the
+            # Builder - where there is nothing to approve, so the one email whose
+            # whole purpose is "somebody has to decide, now" landed a search away
+            # from the decision while the run aged towards `expire_stale` (#935).
+            # Not `&run=`: the Approve and Reject controls are on the queue row,
+            # and below `lg` a focused run replaces the list - which would hide
+            # them from the reader most likely to be on a phone.
+            "approvals_url": f"{self._frontend}/runs?tab=approvals",
             "app_name": settings.PROJECT_NAME,
         }
         self._send(EmailKey.APPROVAL_REQUESTED, recipients, context)

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -705,6 +705,37 @@ class TestPreferences:
         roles.assert_not_awaited()
 
 
+class TestWhereAnAlertSends:
+    """The link is the whole point of an alert, and nothing else checks it.
+
+    An email that says a run is parked is read by somebody who has to decide, and
+    the only thing they can do with it is click. Every one of these URLs is a
+    hand-built f-string that no route table, no type and no other test looks at -
+    so a page that moves, or a surface built somewhere other than where the string
+    guessed, is found by a person following the link and not finding the control.
+    """
+
+    @pytest.mark.anyio
+    async def test_the_approval_alert_addresses_the_queue_not_the_builder(self, sent):
+        """The regression. `/agents/{id}` is the Builder: it holds one sentence of
+        prose about tool calls reaching a queue, and no queue. So the click landed
+        on a page whose own subject is editing the agent, while the parked run
+        aged towards `ApprovalService.expire_stale` (#935)."""
+        with (
+            patch(f"{MODULE}.member_repo.list_emails_by_role", new=_roles("ops@acme.test")),
+            patch(f"{MODULE}.member_repo.list_emails_for_members", new=_members()),
+        ):
+            await NotificationService(MagicMock()).approval_requested(
+                _run(), agent=_agent(), spec=_spec(), tools=["send_email"]
+            )
+
+        _, _, context = sent.calls[0]
+        assert context["approvals_url"].endswith("/runs?tab=approvals")
+        # Named because it is what the link used to be, and the agent id is still
+        # in scope at the call site.
+        assert "/agents/" not in context["approvals_url"]
+
+
 class TestDelivery:
     @pytest.mark.anyio
     async def test_a_send_is_handed_to_the_background(self, monkeypatch):

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -982,6 +982,24 @@ reorganisation, and it means them in whichever organization the spec is imported
 into. A named member who has left contributes nothing rather than raising - an
 approval queue must not go silent because one id no longer resolves.
 
+### An alert links to where the decision is
+
+**Approvals mail opens the queue** — `/runs?tab=approvals`, Activity's Approvals
+tab, which is the only surface carrying Approve and Reject. It used to open
+`/agents/{id}`, the Builder: one sentence of prose about tool calls reaching a
+queue, and no queue. So the one email whose whole purpose is *somebody has to
+decide, now* landed a search away from the decision, while the parked run aged
+towards `ApprovalService.expire_stale` (#935). There was no URL for the tab
+until #934 put it in `?tab=`.
+
+It deliberately does **not** name the run with `&run=`, though the alert holds
+one: the decide controls are on the queue row, and below `lg` a focused run
+replaces the list — which would hide them from the reader most likely to be on a
+phone.
+
+Budget mail opens the agent, and that is the right destination for it: the cap
+it reports is edited there.
+
 ### Two rules that are not negotiable
 
 **A per-person opt-out only ever subtracts.** Each recipient's own switches at


### PR DESCRIPTION
The email that says a run is parked sent you to the Builder page for the agent, where there is nothing to approve.

`app/services/notifications.py`:

```python
"approvals_url": f"{self._frontend}/agents/{agent.id}",
```

`/agents/{id}` holds one sentence of prose about tool calls reaching a queue, and no queue — there is no approvals surface on it at all. So the one email whose whole purpose is *somebody has to decide, now* landed a search away from the decision, behind a button that says **Review the request**, while the parked run aged towards `ApprovalService.expire_stale`.

## What changed

`approvals_url` addresses `/runs?tab=approvals` — Activity's Approvals tab, the only surface carrying Approve and Reject. The tab had no URL until #934 put it in `?tab=`, which is why this was not simply a wrong string.

**Not `&run=`**, though the notification holds the `AgentRun` and `?run=` does deep-link the run detail panel, as the issue suggested. The decide controls are on the queue *row*, and below `lg` a focused run replaces the list — so naming the run would hide the buttons from the reader most likely to be reading this on a phone.

The templates need no change; they interpolate `[[approvals_url]]`.

## How it was verified

A new `TestWhereAnAlertSends` asserts the URL, because every one of these links is a hand-built f-string that no route table, no type and no other test looks at — the failure mode is a person following the link and not finding the control. It fails against the old string:

```
FAILED tests/test_notifications.py::TestWhereAnAlertSends::test_the_approval_alert_addresses_the_queue_not_the_builder
```

`make test` green against a real pgvector: **7129 passed, 100.00% coverage**. `make lint-backend` clean.

## Docs

`docs/governance.md` gains **An alert links to where the decision is** under Alerts: where approvals mail points and why, why it does not name the run, and that budget mail opening the agent is correct — the cap it reports is edited there.

## Depends on

**#934** (PR #1199) for `?tab=` to be honoured. Merged before it, this link opens Activity on the run history; the tab parameter is simply ignored.

Closes #935
