### PR TITLE
chore: cut 0.0.282

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,38 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.282] - 2026-08-27
+
+### Fixed
+
+- **The BFF proxy-path guard did not see a composite segment.**
+  `unencodedSegments` matched a `${...}` only immediately after a `/`, so
+  `/api/v1/resources/prefix-${id}` slipped through - and an `id` such as
+  `x/../../admin/users` interpolated bare there normalises into another backend
+  path exactly as a segment-leading one does. So the invariant the sweep exists to
+  hold, that every interpolated path segment is encoded, was not enforced for
+  prefixed segments. No current route has that shape; this is hardening against the
+  next one. A small `pathInterpolations` parser replaces the inner regex: it scans
+  the path from `/api/v1`, skipping the host prefix, brace-matches each
+  interpolation so a query ternary's own inner `${...}` is consumed with it rather
+  than read as a bare segment, and stops at the query - the first literal `?`, or an
+  interpolation that attaches one. A query signal skips that interpolation and keeps
+  scanning rather than stopping, and optional chaining is excluded from the ternary
+  check, so a real segment after a query-looking or optional-chained one is still
+  checked. (#1118, #13, #30)
+- Four further holes in the same sweep, found by the reviewer on the branch and
+  closed before merge - each one a way for a security guard to report clean on a
+  route it had never actually read. **An apostrophe in a comment blinded it to a
+  whole file**: every `'` was treated as a string opener, so the scan ran from
+  the apostrophe in prose to the next one and swallowed what lay between, which
+  is why `admin/conversations/route.ts` - "drawer's", line 11 - had its template
+  skipped entirely. A **partly encoded** expression passed, so
+  `encodeURIComponent(id) + rawSuffix` and a look-alike
+  `encodeURIComponentAlias(rawId)` were both accepted. **Any `.search` access
+  ended the path**, so `/api/v1/x/${params.search}/${rawId}` reported neither
+  interpolation. And a template whose prefix carried no literal following slash -
+  `/api/v1${rawPath}` - was never read at all. (#1133)
+
 ## [0.0.281] - 2026-08-27
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.281"
+version = "0.0.282"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.281"
+version = "0.0.282"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.281",
+  "version": "0.0.282",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.282. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.282 and adds the CHANGELOG entry.

Releases #1118: the guard added with #13/#30 matched an interpolation only
immediately after a `/`, so a composite segment like `prefix-${id}` was never
checked - and a bare `id` there `%2f`-normalises into another backend path
exactly as a segment-leading one does. A brace-matching parser replaces the
regex, so a query ternary's inner interpolation is consumed rather than read
as a bare segment.

Test-only change to a security guard; no current route has the shape it now
catches.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1133 was green on the merged head.