### PR TITLE
fix(dashboard): put the room under a page where it is painted

### DIFF
--- a/frontend/src/app/[locale]/(dashboard)/admin/layout.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/admin/layout.tsx
@@ -11,7 +11,7 @@ import { useTranslations } from "next-intl";
 export default function AdminLayout({ children }: { children: ReactNode }) {
   const t = useTranslations("pages.admin");
   return (
-    <div className="space-y-6 pb-8">
+    <div className="space-y-6">
       <PageHeader
         title={t("workspaceAdministration")}
         description={t("usersConversationsOrgsSystem")}

--- a/frontend/src/app/[locale]/(dashboard)/chat/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/chat/page.tsx
@@ -7,7 +7,7 @@ export default function ChatPage() {
   // it sets currentConversationId AND loads messages atomically. Pre-setting the
   // id here would short-circuit that loader and leave the chat empty on refresh.
   return (
-    <div className="-mx-3 -mt-4 -mb-20 flex min-h-0 flex-1 sm:-mx-6 sm:-mt-8 lg:-mb-16">
+    <div className="-mx-3 -mt-4 flex min-h-0 flex-1 sm:-mx-6 sm:-mt-8">
       <ConversationSidebar />
       <div className="min-w-0 flex-1">
         <ChatContainer />

--- a/frontend/src/app/[locale]/(dashboard)/dashboard/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/dashboard/page.tsx
@@ -117,7 +117,7 @@ export default function DashboardPage() {
   // brief default is never a wider page than the person may see.
   if (isLoading) {
     return (
-      <div className="space-y-6 pb-8">
+      <div className="space-y-6">
         <PageHeader title={t("title")} />
         <LoadingState variant="stats" />
       </div>
@@ -193,7 +193,7 @@ export default function DashboardPage() {
 
   if (editing) {
     return (
-      <div className="space-y-6 pb-8">
+      <div className="space-y-6">
         <PageHeader title={t("title")} description={t("edit.subtitle")} />
         <DashboardEditor
           initialEntries={initialItems}
@@ -243,7 +243,7 @@ export default function DashboardPage() {
   // to keep arranging, never a blank page that reads as broken.
   if (visible.length === 0) {
     return (
-      <div className="space-y-6 pb-8">
+      <div className="space-y-6">
         <PageHeader title={t("title")} description={t(`subtitles.${audience}`)} />
         <EmptyState
           icon={LayoutGrid}
@@ -261,7 +261,7 @@ export default function DashboardPage() {
   const firstOrgSectionId = sections.find((section) => section.id !== "deployment")?.id;
 
   return (
-    <div className="pb-12">
+    <div>
       <PageHeader
         title={t("title")}
         description={t(`subtitles.${audience}`)}

--- a/frontend/src/app/[locale]/(dashboard)/layout.test.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/layout.test.tsx
@@ -51,4 +51,20 @@ describe("the dashboard's scroll container", () => {
 
     expect((main?.props as { className: string }).className).toContain("overflow-auto");
   });
+
+  it("declares the room under a page here, and nowhere else", () => {
+    // Four surfaces used to re-add this inside their own content, at three
+    // different values, on top of the declaration that was already working -
+    // so "how far does a page clear the bottom" had three answers (#933). The
+    // larger value is for the mobile tab bar, which sits over the content
+    // below `lg`.
+    const className = (
+      find(DashboardLayout({ children: null }), "main")?.props as {
+        className: string;
+      }
+    ).className;
+
+    expect(className).toContain("pb-20");
+    expect(className).toContain("lg:pb-16");
+  });
 });

--- a/frontend/src/app/[locale]/(dashboard)/layout.test.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/layout.test.tsx
@@ -52,19 +52,17 @@ describe("the dashboard's scroll container", () => {
     expect((main?.props as { className: string }).className).toContain("overflow-auto");
   });
 
-  it("declares the room under a page here, and nowhere else", () => {
-    // Four surfaces used to re-add this inside their own content, at three
-    // different values, on top of the declaration that was already working -
-    // so "how far does a page clear the bottom" had three answers (#933). The
-    // larger value is for the mobile tab bar, which sits over the content
-    // below `lg`.
+  it("declares no room under a page, because its padding edge is not where a page ends", () => {
+    // `DeploymentGate` wraps every page in a `min-h-0 flex-1` box, so a long
+    // page overflows that and this element's bottom padding stays buried
+    // mid-content - 0px below the last card at every width. The room under a
+    // page is `PageTransition`'s, where it is painted (#933).
     const className = (
       find(DashboardLayout({ children: null }), "main")?.props as {
         className: string;
       }
     ).className;
 
-    expect(className).toContain("pb-20");
-    expect(className).toContain("lg:pb-16");
+    expect(className).not.toMatch(/(^|\s|:)pb-/);
   });
 });

--- a/frontend/src/app/[locale]/(dashboard)/layout.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/layout.tsx
@@ -48,7 +48,17 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
                 `relative` rather than `contain: paint`, which fixes it equally
                 and would also make this the containing block for every `fixed`
                 descendant - the chat's sources panel and two drop overlays are
-                `fixed` and rendered inline, so containment would move them. */}
+                `fixed` and rendered inline, so containment would move them.
+
+                `pb-20 lg:pb-16` is the **only** declaration of how much room is
+                under a page, and it is painted - measured at 80px and 64px in
+                Chromium 151, WebKit 26.5 and Firefox 153 against this app's own
+                stylesheet. Four surfaces used to re-add it inside their content
+                at three different values, on top of this one, which is what
+                made "how far does a page clear the bottom" three answers
+                (#933). `pb-20` is the larger because the mobile tab bar
+                (`min-h-[56px]` plus the safe-area inset) sits over the content
+                below `lg`. */}
             <main
               id="main"
               tabIndex={-1}

--- a/frontend/src/app/[locale]/(dashboard)/layout.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/layout.tsx
@@ -50,19 +50,17 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
                 descendant - the chat's sources panel and two drop overlays are
                 `fixed` and rendered inline, so containment would move them.
 
-                `pb-20 lg:pb-16` is the **only** declaration of how much room is
-                under a page, and it is painted - measured at 80px and 64px in
-                Chromium 151, WebKit 26.5 and Firefox 153 against this app's own
-                stylesheet. Four surfaces used to re-add it inside their content
-                at three different values, on top of this one, which is what
-                made "how far does a page clear the bottom" three answers
-                (#933). `pb-20` is the larger because the mobile tab bar
-                (`min-h-[56px]` plus the safe-area inset) sits over the content
-                below `lg`. */}
+                No bottom padding here, and that is the fix rather than an
+                omission: `DeploymentGate` wraps every page in a `min-h-0 flex-1`
+                box, so a long page overflows *that* and this element's padding
+                edge stays where the shorter box ended - buried mid-content.
+                Measured at 0px below the last card, at every width, in Chromium
+                151 and WebKit 26.5. The room under a page is declared once, on
+                `PageTransition`'s unconstrained branch, where it paints (#933). */}
             <main
               id="main"
               tabIndex={-1}
-              className="relative flex min-h-0 flex-1 flex-col overflow-auto px-3 pt-4 pb-20 sm:px-6 sm:pt-8 lg:pb-16"
+              className="relative flex min-h-0 flex-1 flex-col overflow-auto px-3 pt-4 sm:px-6 sm:pt-8"
             >
               {/* Inside `main` rather than around the whole shell: a
                   maintenance window still leaves the navigation and the account

--- a/frontend/src/app/[locale]/(dashboard)/page-clearance.test.ts
+++ b/frontend/src/app/[locale]/(dashboard)/page-clearance.test.ts
@@ -1,0 +1,58 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The room under a page is declared once, and this is what says "once" (#933).
+ *
+ * Four surfaces used to re-add it inside their own content, at three different
+ * values, on top of a declaration in the shell that painted nothing - so how far
+ * a page cleared the bottom had four answers and none of them was the one in the
+ * layout. Asserting that `PageTransition` carries the padding does not catch a
+ * fifth being added somewhere else, which is the regression that actually
+ * happened; this reads the pages.
+ *
+ * Only page-clearance sizes. `last:pb-0` closing a list and `pb-1.5` inside a
+ * menu are a page's own spacing and none of this file's business.
+ */
+
+const DASHBOARD = join(import.meta.dirname);
+const CLEARANCE = /(?:^|["\s:])(?:sm:|md:|lg:|xl:)?pb-(?:8|10|12|16|20|24|28|32)(?:["\s]|$)/;
+/** The component playground, which is not a page anybody navigates to. */
+const SKIP = new Set(["dev"]);
+
+function pageFiles(directory: string): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(directory)) {
+    const path = join(directory, entry);
+    if (statSync(path).isDirectory()) {
+      if (!SKIP.has(entry)) found.push(...pageFiles(path));
+    } else if (entry === "page.tsx" || entry === "layout.tsx") {
+      found.push(path);
+    }
+  }
+  return found;
+}
+
+describe("the room under a dashboard page", () => {
+  it("is declared by the page wrapper, and by no page or layout under it", () => {
+    const offenders = pageFiles(DASHBOARD)
+      // The shell itself, which is the element that used to declare it.
+      .filter((path) => path !== join(DASHBOARD, "layout.tsx"))
+      .filter((path) => CLEARANCE.test(readFileSync(path, "utf8")))
+      .map((path) => path.slice(DASHBOARD.length + 1));
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("recognises the shapes that were actually there", () => {
+    // The four that were removed, plus a responsive one, against the two kinds
+    // of inner spacing this must not object to.
+    for (const shape of ['"space-y-6 pb-8"', '"pb-12"', '"pb-20"', '"md:pb-16"']) {
+      expect(CLEARANCE.test(shape), shape).toBe(true);
+    }
+    for (const shape of ['"py-4 first:pt-0 last:pb-0"', '"px-2 pb-1.5"']) {
+      expect(CLEARANCE.test(shape), shape).toBe(false);
+    }
+  });
+});

--- a/frontend/src/app/[locale]/(dashboard)/settings/layout.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/settings/layout.tsx
@@ -11,7 +11,7 @@ import { useTranslations } from "next-intl";
 export default function SettingsLayout({ children }: { children: ReactNode }) {
   const t = useTranslations("pages.settings");
   return (
-    <div className="space-y-6 pb-8">
+    <div className="space-y-6">
       <PageHeader title={t("settings")} description={t("manageYourAccountIntegrations")} />
       <div data-tour="settings-tabs">
         <PageTabs tabs={SETTINGS_TABS} />

--- a/frontend/src/app/[locale]/(dashboard)/workspaces/[id]/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/workspaces/[id]/page.tsx
@@ -25,9 +25,10 @@ export default async function WorkspacePage({ params }: { params: Promise<{ id: 
     // Without every link the panes are as tall as their content - which for a
     // workspace holding one folder was 300 px under 600 px of nothing.
     //
-    // `flex-1` and not `h-full`: `main` carries `pb-20`, and a child at 100% of the
-    // content box plus that padding overflows it by exactly the padding, which is a
-    // scrollbar on every page that would otherwise have none.
+    // `flex-1` and not `h-full`: the page wrapper above carries the room under a
+    // page, and a child at 100% of the content box plus that padding overflows it
+    // by exactly the padding - a scrollbar on every page that would otherwise
+    // have none.
     <div className="flex min-h-0 flex-1 flex-col gap-6">
       <PageHeader title={t("workspace")} description={t("whatOneAgentKeeping")} />
       <div data-tour="workspace-files" className="flex min-h-0 flex-1 flex-col">

--- a/frontend/src/components/branding/maintenance-screen.tsx
+++ b/frontend/src/components/branding/maintenance-screen.tsx
@@ -4,6 +4,8 @@ import { Wrench } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { useBranding } from "@/components/branding/branding-provider";
+import { PAGE_CLEARANCE } from "@/lib/page-clearance";
+import { cn } from "@/lib/utils";
 
 /**
  * What the product shows while a maintenance window is open.
@@ -22,7 +24,15 @@ export function MaintenanceScreen() {
   const { appName, maintenanceMessage } = useBranding();
 
   return (
-    <div className="flex min-h-[60vh] flex-col items-center justify-center px-6 text-center">
+    // The clearance is this one's own because `DeploymentGate` returns it
+    // *instead of* rendering `PageTransition`, which is where every other page
+    // gets it. Same token, so there is still one answer (#933).
+    <div
+      className={cn(
+        "flex min-h-[60vh] flex-col items-center justify-center px-6 text-center",
+        PAGE_CLEARANCE,
+      )}
+    >
       <span className="bg-muted text-foreground mb-6 inline-flex h-14 w-14 items-center justify-center rounded-2xl">
         <Wrench className="h-6 w-6" aria-hidden />
       </span>

--- a/frontend/src/components/layout/page-transition.test.tsx
+++ b/frontend/src/components/layout/page-transition.test.tsx
@@ -26,8 +26,32 @@ describe("the page transition wrapper", () => {
     expect(rootClasses("/en/chat")).toContain("min-h-0");
   });
 
-  it("leaves long pages unconstrained so main's bottom padding lands after the content", () => {
+  it("leaves long pages unconstrained so the room under them lands after the content", () => {
     expect(rootClasses("/en/agents")).not.toContain("min-h-0");
+  });
+
+  it("declares the room under a page here, where it is painted", () => {
+    // Not on `main`, though `main` is what scrolls: `DeploymentGate` wraps this
+    // in a `min-h-0 flex-1` box, so a long page overflows that box and `main`'s
+    // padding edge stays where the shorter box ended - 0px below the last card
+    // at every width, measured in Chromium 151 and WebKit 26.5 (#933). This box
+    // grows with its content, so padding here lands after the last element.
+    const classes = rootClasses("/en/agents");
+
+    expect(classes).toContain("pb-[calc(5rem+env(safe-area-inset-bottom))]");
+    expect(classes).toContain("lg:pb-16");
+  });
+
+  it("counts the safe-area inset rather than assuming it away", () => {
+    // The mobile tab bar is `min-h-[56px]` plus `env(safe-area-inset-bottom)`,
+    // and `viewportFit: "cover"` makes that inset 34px on a modern iPhone - so
+    // a flat 80px leaves the last 10px of the page under the bar.
+    expect(rootClasses("/en/agents")).toContain("env(safe-area-inset-bottom)");
+  });
+
+  it("leaves the chat without it, so the composer sits on the bottom edge", () => {
+    // Room under a fixed control is a gap under it.
+    expect(rootClasses("/en/chat")).not.toContain("pb-");
   });
 
   it("constrains Activity too, where the list and the run detail scroll apart", () => {

--- a/frontend/src/components/layout/page-transition.test.tsx
+++ b/frontend/src/components/layout/page-transition.test.tsx
@@ -2,6 +2,7 @@ import { render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { PageTransition } from "./page-transition";
+import { PAGE_CLEARANCE } from "@/lib/page-clearance";
 
 let pathname = "/";
 vi.mock("next/navigation", () => ({
@@ -36,17 +37,14 @@ describe("the page transition wrapper", () => {
     // padding edge stays where the shorter box ended - 0px below the last card
     // at every width, measured in Chromium 151 and WebKit 26.5 (#933). This box
     // grows with its content, so padding here lands after the last element.
-    const classes = rootClasses("/en/agents");
-
-    expect(classes).toContain("pb-[calc(5rem+env(safe-area-inset-bottom))]");
-    expect(classes).toContain("lg:pb-16");
+    expect(rootClasses("/en/agents")).toContain(PAGE_CLEARANCE);
   });
 
   it("counts the safe-area inset rather than assuming it away", () => {
     // The mobile tab bar is `min-h-[56px]` plus `env(safe-area-inset-bottom)`,
     // and `viewportFit: "cover"` makes that inset 34px on a modern iPhone - so
     // a flat 80px leaves the last 10px of the page under the bar.
-    expect(rootClasses("/en/agents")).toContain("env(safe-area-inset-bottom)");
+    expect(PAGE_CLEARANCE).toContain("env(safe-area-inset-bottom)");
   });
 
   it("leaves the chat without it, so the composer sits on the bottom edge", () => {

--- a/frontend/src/components/layout/page-transition.tsx
+++ b/frontend/src/components/layout/page-transition.tsx
@@ -2,6 +2,7 @@
 
 import { usePathname } from "next/navigation";
 
+import { PAGE_CLEARANCE } from "@/lib/page-clearance";
 import { cn } from "@/lib/utils";
 
 /** Routes that scroll inside their own panes, not in `main`. */
@@ -27,17 +28,10 @@ export function PageTransition({ children }: { children: React.ReactNode }) {
     // with its content, so padding here is painted after the last element.
     //
     // Not on the constrained branch: chat's composer belongs on the bottom
-    // edge, and room beneath it would be a gap under a fixed control. The
-    // mobile figure is the tab bar's `min-h-[56px]` plus the inset it carries,
-    // plus room to breathe - and the inset is in the sum rather than assumed
-    // away, because `viewportFit: "cover"` makes it 34px on a modern iPhone,
-    // which a flat 80px does not clear.
+    // edge, and room beneath it would be a gap under a fixed control.
     <div
       key={pathname}
-      className={cn(
-        "page-enter flex flex-1 flex-col",
-        constrained ? "min-h-0" : "pb-[calc(5rem+env(safe-area-inset-bottom))] lg:pb-16",
-      )}
+      className={cn("page-enter flex flex-1 flex-col", constrained ? "min-h-0" : PAGE_CLEARANCE)}
     >
       {children}
     </div>

--- a/frontend/src/components/layout/page-transition.tsx
+++ b/frontend/src/components/layout/page-transition.tsx
@@ -16,10 +16,29 @@ export function PageTransition({ children }: { children: React.ReactNode }) {
     // a flex item's `min-height: 0` is a floor, not a ceiling, so the chat
     // page setting it on its own root does NOT stop this box's min-content
     // from growing to the transcript's height - without `min-h-0` here the
-    // whole page scrolls instead of the message pane. Everywhere else it must
-    // stay off: with it, a long page overflows this box and parks `main`'s
-    // bottom padding mid-content instead of after it.
-    <div key={pathname} className={cn("page-enter flex flex-1 flex-col", constrained && "min-h-0")}>
+    // whole page scrolls instead of the message pane.
+    //
+    // Everywhere else it stays off, and that is what makes this the one place
+    // the room under a page can be declared. `main` scrolls, but `main` is not
+    // where its own bottom padding lands: `DeploymentGate` wraps this in a
+    // `min-h-0 flex-1` box, so a long page overflows that box and `main`'s
+    // padding edge stays where the shorter box ended - buried mid-content,
+    // measured at 0px below the last card at every width (#933). This box grows
+    // with its content, so padding here is painted after the last element.
+    //
+    // Not on the constrained branch: chat's composer belongs on the bottom
+    // edge, and room beneath it would be a gap under a fixed control. The
+    // mobile figure is the tab bar's `min-h-[56px]` plus the inset it carries,
+    // plus room to breathe - and the inset is in the sum rather than assumed
+    // away, because `viewportFit: "cover"` makes it 34px on a modern iPhone,
+    // which a flat 80px does not clear.
+    <div
+      key={pathname}
+      className={cn(
+        "page-enter flex flex-1 flex-col",
+        constrained ? "min-h-0" : "pb-[calc(5rem+env(safe-area-inset-bottom))] lg:pb-16",
+      )}
+    >
       {children}
     </div>
   );

--- a/frontend/src/lib/page-clearance.ts
+++ b/frontend/src/lib/page-clearance.ts
@@ -1,0 +1,19 @@
+/**
+ * How much room there is under a page, as one class string.
+ *
+ * A token rather than a literal repeated at each site, for the reason
+ * `dialog-sizes.ts` is a token file: two places declaring it is two answers, and
+ * four of those is what #933 was. It is not on the scroll container - a page
+ * overflows `DeploymentGate`'s `min-h-0` wrapper, so `main`'s padding edge stays
+ * buried mid-content, measured at 0px below the last card at every width.
+ *
+ * The mobile figure counts the safe-area inset rather than assuming it away:
+ * `viewportFit: "cover"` makes it 34px on a modern iPhone and the tab bar is
+ * `min-h-[56px]` plus that, so a flat 80px leaves the last ten pixels of a page
+ * under the bar. The bar is `lg:hidden`, so `lg` needs no inset.
+ *
+ * Two places use it: `PageTransition`, for every page that scrolls in `main`,
+ * and the maintenance screen, which `DeploymentGate` returns *instead of*
+ * rendering that wrapper.
+ */
+export const PAGE_CLEARANCE = "pb-[calc(5rem+env(safe-area-inset-bottom))] lg:pb-16";


### PR DESCRIPTION
`main` declared `pb-20 lg:pb-16` and no dashboard page had any room under it. Both halves of #933 are fixed here — the duplicate declarations, and the one that painted nothing.

## The mechanism, corrected

My first reading of this was wrong, and the reviewer found how: the measurement omitted **`DeploymentGate`**, which wraps every page in `flex min-h-0 flex-1 flex-col` (`deployment-gate.tsx:47`). That box does not grow with its content, so a long page overflows it and `main`'s padding edge stays where the shorter box ended — buried mid-content.

Measured against the app's own stylesheet, on a transcription of the real chain (`main` → the gate's wrapper → `PageTransition` → a header and eleven cards), scrolled to the end:

```
                              gate wrapper present    absent
chromium 151  @390px                0px               80px
chromium 151  @1280px               0px               64px
webkit   26.5 @390px                0px               80px
webkit   26.5 @1280px               0px               64px
```

The right-hand column is what my earlier run measured, and why it read as working. #933 was right that the declaration was inert; the mechanism is the intervening wrapper rather than a flex-column scroll container failing to paint its own end padding — that part does paint.

## The fix

The room moves onto **`PageTransition`'s unconstrained branch**, exactly as #933 proposed. That box grows with its content, so the padding lands after the last element — measured back at 80px / 64px with the gate wrapper in place, in both engines. The constrained branch keeps none: chat's composer belongs on the bottom edge, and room beneath a fixed control is a gap under it.

```
where=main                     ->  0px
where=transition               -> 80px / 64px
where=transition&constrained   ->  0px   (chat)
```

**The mobile figure counts the safe-area inset** rather than assuming it away: `viewportFit: "cover"` (`app/layout.tsx:191`) makes it 34px on a modern iPhone and the tab bar is `min-h-[56px]` plus that, so a flat 80px left the last ten pixels of every page under the bar. It is `pb-[calc(5rem+env(safe-area-inset-bottom))] lg:pb-16` — the bar is `lg:hidden`, so `lg` needs no inset.

## And the four workarounds are gone

`admin/layout.tsx` and `settings/layout.tsx` at `pb-8`, `dashboard/page.tsx` at `pb-8` on three branches and `pb-12` on the fourth. Those four surfaces were the only ones with a visible gap, at three different values, and they are why nobody noticed the layout's own declaration was inert.

**`page-clearance.test.ts` reads the pages, not the wrapper.** Asserting that `PageTransition` carries the padding would not catch a fifth surface re-adding its own — which is the regression that actually happened. It walks every `page.tsx` / `layout.tsx` under `(dashboard)`, skipping the component playground and the shell, and fails naming the file; a second case pins the pattern against the four shapes that were really there and against the inner spacing it must not object to (`last:pb-0`, `pb-1.5`). Reintroducing `pb-8` on the admin layout fails it:

```
AssertionError: expected [ 'admin/layout.tsx' ] to deeply equal []
```

## Verified

`make lint-frontend` clean. `bun run test:coverage` green: 100% statements/lines/functions, 97.67% branches.

## Related

**#1206** — Activity has 0px under its last row for a different reason: `/runs` is in `FULL_HEIGHT_ROUTES` while its own page has been an ordinary scrolling one since #914, so it takes the constrained branch and gets no room by design. Fixing that moves the sticky run detail panel's top to -48px at maximum scroll, so it takes a decision about that two-column row and is filed rather than folded in here.

Closes #933
