### PR TITLE
chore: cut 0.0.283

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,26 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.283] - 2026-08-27
+
+### Fixed
+
+- **A concurrent insert reopened the exact 500 the delete reconciliation closed.**
+  Reconcile-then-delete is check-then-act, and with no row lock an org-scoped
+  collection inserted between the purge's collection list and its
+  `DELETE organizations` is SET NULL-ed into a
+  `ck_knowledge_bases_org_scope_has_org` violation - and a private secret or
+  personal organization inserted between a user delete's reconcile and its
+  `DELETE users` lands the same CHECK or RESTRICT blocker.
+  `OrganizationService.purge` and `UserService.delete` take
+  `SELECT ... FOR UPDATE` on the row they are about before enumerating: a
+  concurrent child insert takes `FOR KEY SHARE` on that parent through its FK,
+  which `FOR UPDATE` conflicts with, so the insert waits and the reconcile sees
+  every child on a fresh read under READ COMMITTED. (#1115, #9)
+- A rare deadlock when two users who co-own each other's shared organizations
+  self-delete simultaneously was found while reviewing this and filed rather than
+  folded in - Postgres aborts one with a 500. (#1134)
+
 ## [0.0.282] - 2026-08-27
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.282"
+version = "0.0.283"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.282"
+version = "0.0.283"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.282",
+  "version": "0.0.283",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.283. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.283 and adds the CHANGELOG entry.

Releases #1115: #9 reconciled the FK and CHECK cascades before a delete, but
reconcile-then-delete is check-then-act, so a child inserted between the
reconcile and the delete reopened the same 500. Both delete paths take
`SELECT ... FOR UPDATE` on the parent before enumerating - a concurrent child
insert takes `FOR KEY SHARE` on that parent through its FK, so it waits and
the reconcile sees it.

A co-owner self-delete deadlock found reviewing this is filed as #1134.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1135 was green on the merged head.