### PR TITLE
refactor(admin): land /admin on Users and delete the Overview

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1446,7 +1446,8 @@
         "organizations": "Organizations",
         "title": "Platform at a glance",
         "users": "Users",
-        "description": "Deployment-wide counts: organizations, people, agents, conversations."
+        "description": "Deployment-wide counts: organizations, people, agents, conversations.",
+        "messages": "{count, plural, =1 {1 message} other {# messages}}"
       },
       "platform-ratings": {
         "empty": {
@@ -2519,7 +2520,6 @@
     "slashCommands": "Slash commands",
     "startNewChat": "Start new chat",
     "system": "System",
-    "systemHealth": "System health",
     "team": "Team",
     "toggleMenu": "Toggle menu",
     "untitledConversation": "Untitled conversation",
@@ -3049,7 +3049,6 @@
       "json": "JSON",
       "latencyMs": "{ms} ms",
       "likes": "Likes",
-      "manageUsers": "Manage users",
       "members": "Members",
       "message": "Message",
       "messages": "Messages",
@@ -3061,12 +3060,10 @@
       "organizations": "Organizations",
       "organizations2": "Organizations",
       "overallStatus": "Overall status",
-      "perServiceStatusUptime": "Per-service status & uptime",
       "personal": "Personal",
       "refresh2": "Refresh",
       "resultCount": "{count, plural, =1 {1 result} other {# results}}",
       "searchByEmailName": "Search by email or name…",
-      "searchSuspendImpersonate": "Search, suspend, impersonate",
       "serviceDatabase": "Database",
       "serviceDatabaseDetail": "PostgreSQL primary",
       "serviceModelAccess": "Model access",
@@ -3084,9 +3081,7 @@
       "stateUnhealthy": "Failing",
       "status": "Status",
       "suspended": "Suspended",
-      "systemHealth": "System health",
       "totalCount": "{count, number} total",
-      "totalUsers": "Total users",
       "tryAgain": "Try again",
       "user": "User",
       "usersConversationsOrgsSystem": "Users, conversations, organizations, and system health.",

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -55,7 +55,6 @@
     "overview": "Przegląd",
     "users": "Użytkownicy",
     "conversations": "Rozmowy",
-    "systemHealth": "Stan systemu",
     "system": "System",
     "account": "Konto",
     "notifications": "Powiadomienia",
@@ -534,7 +533,8 @@
           "title": "Jeszcze nic tu nie ma",
           "description": "Świeża instalacja: brak organizacji poza startową, brak uruchomień."
         },
-        "description": "Liczby dla całej instalacji: organizacje, ludzie, agenci, rozmowy."
+        "description": "Liczby dla całej instalacji: organizacje, ludzie, agenci, rozmowy.",
+        "messages": "{count, plural, =1 {1 wiadomość} few {# wiadomości} many {# wiadomości} other {# wiadomości}}"
       },
       "health": {
         "title": "Zdrowie usług",

--- a/frontend/src/app/[locale]/(dashboard)/admin/admin-tabs.test.ts
+++ b/frontend/src/app/[locale]/(dashboard)/admin/admin-tabs.test.ts
@@ -1,0 +1,63 @@
+import { readdirSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { ADMIN_TABS } from "./admin-tabs";
+
+/**
+ * The admin tab row is the section's index, and this suite is what keeps it one.
+ *
+ * The same pairing `settings-tabs.test.ts` holds, for the same reason: a
+ * hand-written list beside a directory of routes drifts the moment somebody adds
+ * a page, and the two failures are a page no tab leads to and a link that 404s.
+ *
+ * `/admin/page.tsx` is deliberately not in the list. It is the section index and
+ * redirects to the first tab rather than being one - it used to render an
+ * Overview whose six figures were the `platform` widget again and whose three
+ * links were three of these tabs (#922).
+ */
+
+const ADMIN_DIR = path.join(process.cwd(), "src/app/[locale]/(dashboard)/admin");
+
+/** Every route segment under `/admin/` that actually renders a page. */
+function adminRouteSegments(): string[] {
+  return readdirSync(ADMIN_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .filter((entry) =>
+      readdirSync(path.join(ADMIN_DIR, entry.name)).some((file) => file === "page.tsx"),
+    )
+    .map((entry) => entry.name)
+    .sort();
+}
+
+/** The segment a tab points at, or `null` if the tab leaves the section. */
+function tabSegment(href: string): string | null {
+  const match = /^\/admin\/([^/]+)$/.exec(href);
+  return match?.[1] ?? null;
+}
+
+describe("the admin tab row", () => {
+  it("leads to every page under /admin", () => {
+    const tabbed = ADMIN_TABS.map((tab) => tabSegment(tab.href))
+      .filter((segment): segment is string => segment !== null)
+      .sort();
+
+    expect(tabbed).toEqual(adminRouteSegments());
+  });
+
+  it("does not offer the index as a tab", () => {
+    // An Overview tab beside the pages it linked to was a third of that page
+    // spent on navigation to where the reader already was.
+    expect(ADMIN_TABS.map((tab) => tab.href)).not.toContain("/admin");
+  });
+
+  it("stays inside the section it indexes", () => {
+    expect(ADMIN_TABS.filter((tab) => tabSegment(tab.href) === null)).toEqual([]);
+  });
+
+  it("names each destination once", () => {
+    const hrefs = ADMIN_TABS.map((tab) => tab.href);
+
+    expect(new Set(hrefs).size).toBe(hrefs.length);
+  });
+});

--- a/frontend/src/app/[locale]/(dashboard)/admin/admin-tabs.ts
+++ b/frontend/src/app/[locale]/(dashboard)/admin/admin-tabs.ts
@@ -1,4 +1,4 @@
-import { Activity, Building2, LayoutDashboard, Settings, Users } from "lucide-react";
+import { Activity, Building2, Settings, Users } from "lucide-react";
 
 import type { PageTab } from "@/components/dashboard/page-tabs";
 import { ROUTES } from "@/lib/constants";
@@ -12,7 +12,9 @@ import { ROUTES } from "@/lib/constants";
  * pages as jump targets and would otherwise restate them.
  */
 export const ADMIN_TABS: readonly PageTab[] = [
-  { labelKey: "overview", href: ROUTES.ADMIN, icon: LayoutDashboard, exact: true },
+  // No Overview. `/admin` is the section index and redirects here, the way
+  // `/settings` does - the page it used to render was the `platform` widget's
+  // six figures again, above links to three of these tabs (#922).
   { labelKey: "users", href: ROUTES.ADMIN_USERS, icon: Users },
   // Not `organizations`: the sidebar already offers the caller's own orgs page
   // under that name, and the palette lists both - two identical options with

--- a/frontend/src/app/[locale]/(dashboard)/admin/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/admin/page.tsx
@@ -1,142 +1,20 @@
-"use client";
+import { redirect } from "next/navigation";
 
-import Link from "next/link";
-import { useQuery } from "@tanstack/react-query";
-import {
-  Activity,
-  ArrowUpRight,
-  Bot,
-  Building2,
-  MessageSquare,
-  MessagesSquare,
-  Users,
-} from "lucide-react";
-import type { LucideIcon } from "lucide-react";
-
-import { FigureCard } from "@/components/ui";
-import { LoadingState } from "@/components/states";
-import { apiClient } from "@/lib/api-client";
 import { ROUTES } from "@/lib/constants";
-import { qk } from "@/lib/query-keys";
-import { useTranslations } from "next-intl";
-
-import type { AdminStats } from "@/types/admin";
 
 /**
- * The deployment at a glance: six figures and the doors to the detail pages.
+ * The section index, which redirects rather than rendering - the same shape
+ * `/settings/` takes.
  *
- * Deliberately nothing else. The organizations table has a tab of its own, and
- * the "recent activity" feed left with it - a feed synthesized from the newest
- * conversations answered a question nobody was asking here, below figures that
- * already say how much is happening.
+ * It used to be an Overview: six figures from `/admin/stats` and three links to
+ * the tabs directly above them. Both halves were already on screen elsewhere.
+ * The figures are the `platform` widget, reading the same endpoint through
+ * `useAdminStats`, on a dashboard the reader can arrange (#213); the links were
+ * three of the five tabs in this section's own strip, so a third of the page was
+ * navigation to where the reader already was. Two copies of six numbers disagree
+ * the first time one of them is edited, and the arrangeable dashboard is the
+ * answer to "where do the deployment's figures live" (#922).
  */
-export default function AdminOverviewPage() {
-  const t = useTranslations("pages.admin");
-  const statsQuery = useQuery({
-    queryKey: qk.admin.stats(),
-    queryFn: async (): Promise<AdminStats> => {
-      const data = await apiClient.get<AdminStats>("/admin/stats").catch(() => null);
-      if (data) return data;
-      const [usersResp, convsResp] = await Promise.allSettled([
-        apiClient.get<{ total: number }>("/admin/users?limit=1"),
-        apiClient.get<{ total: number }>("/admin/conversations?limit=1"),
-      ]);
-      return {
-        total_users: usersResp.status === "fulfilled" ? usersResp.value.total : undefined,
-        total_conversations: convsResp.status === "fulfilled" ? convsResp.value.total : undefined,
-      };
-    },
-  });
-
-  const stats = statsQuery.data;
-
-  return (
-    <div className="space-y-6">
-      {statsQuery.isLoading ? (
-        <LoadingState variant="stats" rows={6} />
-      ) : (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          <FigureCard
-            label={t("totalUsers")}
-            value={(stats?.total_users ?? 0).toLocaleString()}
-            icon={Users}
-          />
-          <FigureCard
-            label={t("active24h")}
-            value={(stats?.active_users_24h ?? 0).toLocaleString()}
-            icon={Activity}
-          />
-          <FigureCard
-            label={t("organizations")}
-            value={(stats?.total_organizations ?? 0).toLocaleString()}
-            icon={Building2}
-          />
-          <FigureCard
-            label={t("agents")}
-            value={(stats?.total_agents ?? 0).toLocaleString()}
-            icon={Bot}
-          />
-          <FigureCard
-            label={t("conversations")}
-            value={(stats?.total_conversations ?? 0).toLocaleString()}
-            icon={MessageSquare}
-          />
-          <FigureCard
-            label={t("messages")}
-            value={(stats?.total_messages ?? 0).toLocaleString()}
-            icon={MessagesSquare}
-          />
-        </div>
-      )}
-
-      <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        <QuickLink
-          href={ROUTES.ADMIN_USERS}
-          icon={Users}
-          title={t("manageUsers")}
-          description={t("searchSuspendImpersonate")}
-        />
-        <QuickLink
-          href={ROUTES.ADMIN_ORGANIZATIONS}
-          icon={Building2}
-          title={t("organizations2")}
-          description={t("everyTenantDeploymentOnly")}
-        />
-        <QuickLink
-          href={ROUTES.ADMIN_SYSTEM}
-          icon={Activity}
-          title={t("systemHealth")}
-          description={t("perServiceStatusUptime")}
-        />
-      </section>
-    </div>
-  );
-}
-
-function QuickLink({
-  href,
-  icon: Icon,
-  title,
-  description,
-}: {
-  href: string;
-  icon: LucideIcon;
-  title: string;
-  description: string;
-}) {
-  return (
-    <Link
-      href={href}
-      className="border-border hover:border-foreground/30 hover:bg-accent bg-card group flex items-center gap-3 rounded-xl border p-4 transition-colors"
-    >
-      <span className="bg-muted text-foreground inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg">
-        <Icon className="h-4 w-4" />
-      </span>
-      <div className="min-w-0 flex-1">
-        <p className="text-foreground text-sm font-semibold">{title}</p>
-        <p className="text-muted-foreground truncate text-xs">{description}</p>
-      </div>
-      <ArrowUpRight className="text-muted-foreground h-4 w-4" />
-    </Link>
-  );
+export default function AdminIndex() {
+  redirect(ROUTES.ADMIN_USERS);
 }

--- a/frontend/src/components/dashboard/widgets/platform.tsx
+++ b/frontend/src/components/dashboard/widgets/platform.tsx
@@ -29,7 +29,16 @@ export function PlatformWidget({ title, hint, seeAll, options }: DashboardWidget
               ["organizations", stats.total_organizations, null],
               ["users", stats.total_users, t("active24h", { count: stats.active_users_24h ?? 0 })],
               ["agents", stats.total_agents, null],
-              ["conversations", stats.total_conversations, null],
+              [
+                "conversations",
+                stats.total_conversations,
+                // The one figure the deleted admin Overview had that this card
+                // did not, and it is a caption rather than a fifth column: the
+                // card is two rows tall because four counters with no series
+                // behind them fill exactly that, and messages is to
+                // conversations what active-24h is to users (#922).
+                t("messages", { count: stats.total_messages ?? 0 }),
+              ],
             ] as const
           ).map(([key, value, sub]) => (
             <Figure

--- a/frontend/src/lib/dashboard/registry.ts
+++ b/frontend/src/lib/dashboard/registry.ts
@@ -263,15 +263,17 @@ export const WIDGETS: Record<WidgetId, WidgetDef> = {
     options: { period: true, agent: true, person: true },
     seeAll: ROUTES.RUNS,
   },
-  // Four counters and no series behind any of them, so two rows is the height:
-  // a third was a hand's width of nothing under the numbers.
+  // Counters and no series behind any of them, so two rows is the height: a
+  // third was a hand's width of nothing under the numbers.
   platform: {
     id: "platform",
     gate: adminOnly,
     defaultSpan: "s8",
     defaultRows: "r2",
     category: "platform",
-    seeAll: ROUTES.ADMIN,
+    // The people behind the counts. It pointed at `/admin`, which rendered
+    // these same figures a second time and now redirects here anyway (#922).
+    seeAll: ROUTES.ADMIN_USERS,
   },
   health: {
     id: "health",
@@ -288,7 +290,9 @@ export const WIDGETS: Record<WidgetId, WidgetDef> = {
     defaultSpan: "s7",
     defaultRows: "r3",
     category: "platform",
-    seeAll: ROUTES.ADMIN,
+    // The whole tenant list, which is what "see all" means on a card showing
+    // the largest few.
+    seeAll: ROUTES.ADMIN_ORGANIZATIONS,
   },
   // No seeAll: the deployment-wide ratings page left with the admin overhaul -
   // ratings are read where the runs are, on the Activity page, per org.


### PR DESCRIPTION
The question #922 asks is whether `/admin` Overview earns a route. It does not, and this takes option 1 — the one the issue recommends.

## Why

The page held six figures and three links, and every one of them was already on screen somewhere the reader had been.

- **The figures** came from `/admin/stats` — the same endpoint the `platform` widget reads through `useAdminStats`, on a dashboard that has been arrangeable since #213. So the page was a fixed, second copy of a card the reader can already place where they want it. Two copies of six numbers disagree the first time one of them is edited.
- **The three links** were three of the five tabs the section's own strip renders *directly above them*. A third of the page was navigation to where the reader already was.

## What changed

- **`/admin` is the section index and redirects to Users**, exactly as `/settings` redirects to Profile. A bookmark still works, and the sidebar entry still lights up — `isRouteActive` matches the section (`/admin/users`.startsWith(`/admin/`)) rather than the page.
- **`admin-tabs.test.ts`** holds the pairing the way `settings-tabs.test.ts` does: every page under `/admin/` has a tab, every tab has a page, the row stays inside its own section, and the index is not one of its tabs.
- **`total_messages`** — the one figure the widget lacked — arrives as a caption under Conversations rather than as a fifth counter. The card is two rows tall because four counters with no series behind them fill exactly that, and messages is to conversations what active-24h is to users. An ICU plural, in **en and pl**.
- **Two cards that pointed at the deleted page now point at their own detail**: `platform` at Users (the people behind the counts), and `top-orgs` at the whole tenant list, which is what "see all" means on a card showing the largest few.
- **Six keys nothing reads any more** are deleted from both catalogs — `check:i18n` fails on an unread key, and would have.

## Care-abouts from the issue

- `ROUTES.ADMIN` is still `/admin`, so the palette's jump target and the sidebar entry are untouched; the `exact: true` flag left with the tab that needed it.
- `tour.ts` has **no stop on any `/admin` page**, so there is none left dangling and no help button to lose. (`pageHasSteps` means those pages render no "?" today either — a separate gap, not this change's.)
- `/admin/stats` stays: the `platform` widget is its other caller.

## Verified

`make lint-frontend` clean, `bun run test:coverage` green (100% statements/lines/functions, 97.67% branches). The one e2e spec touching this section goes to `/admin/users` directly.

Closes #922
