### PR TITLE
chore: cut 0.0.284

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.284] - 2026-08-27
+
+### Fixed
+
+- **Deleting a user could leave an organization with no owner at all.**
+  `UserService._release_owned_rows` reconciled only organizations the user
+  *created*, but ownership moves without the creator FK - after a transfer, or
+  after the creator is reassigned away - so a user can be the sole Owner of an
+  organization they did not create. The created-organizations listing never returns
+  it, so deleting that user cascaded their last owner membership away and left a
+  silent orphan nobody can manage through the owner-gated APIs. Not a 500 like the
+  #9 cases, which is what made it quiet. A second pass over the organizations where
+  the user holds an Owner membership refuses the delete when they are the sole
+  owner - the same refusal the created-organization path already raises - and does
+  nothing when another owner remains. (#1117, #9)
+
 ## [0.0.283] - 2026-08-27
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.283"
+version = "0.0.284"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.283"
+version = "0.0.284"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.283",
+  "version": "0.0.284",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.284. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.284 and adds the CHANGELOG entry.

Releases #1117: the delete reconciliation looked only at organizations the
user created, but ownership moves without the creator FK - so the sole Owner
of an organization they did not create was deleted, their last owner
membership cascaded away, and the organization was left with no owner and no
error. A silent orphan rather than a 500, which is why it outlived #9.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1136 was green on the merged head.