### PR TITLE
fix(auth): keep the deep link across the OAuth round trip

### DIFF
--- a/frontend/src/app/[locale]/auth/callback/page.tsx
+++ b/frontend/src/app/[locale]/auth/callback/page.tsx
@@ -7,6 +7,7 @@ import { Spinner } from "@/components/ui";
 import { apiClient } from "@/lib/api-client";
 import { useAdoptSession } from "@/hooks/use-auth";
 import { postSignInDestination } from "@/lib/auth-landing";
+import { takeReturnTo } from "@/lib/oauth-return";
 import type { User } from "@/types";
 import { useTranslations } from "next-intl";
 
@@ -68,11 +69,10 @@ export default function AuthCallbackPage() {
         const data = await exchangeCode(code);
         if (cancelled) return;
         adoptSession(data.user, data.access_token);
-        // No deep link here yet - nothing carries a returnTo through the
-        // provider round trip. It would not need the OAuth `state` parameter:
-        // the trip starts and ends in the same tab on this origin, so
-        // sessionStorage set beside the provider link is enough.
-        router.replace(postSignInDestination());
+        // The deep link the visitor was headed to, written beside the provider
+        // link they clicked and consumed here. Not the OAuth `state` parameter:
+        // the trip starts and ends in the same tab on this origin (#135).
+        router.replace(postSignInDestination(takeReturnTo()));
       } catch {
         if (!cancelled) {
           setExchangeFailed(true);

--- a/frontend/src/app/[locale]/auth/callback/page.tsx
+++ b/frontend/src/app/[locale]/auth/callback/page.tsx
@@ -6,7 +6,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Spinner } from "@/components/ui";
 import { apiClient } from "@/lib/api-client";
 import { useAdoptSession } from "@/hooks/use-auth";
-import { postSignInDestination } from "@/lib/auth-landing";
+import { goToDestination, postSignInDestination } from "@/lib/auth-landing";
 import { takeReturnTo } from "@/lib/oauth-return";
 import type { User } from "@/types";
 import { useTranslations } from "next-intl";
@@ -72,7 +72,12 @@ export default function AuthCallbackPage() {
         // The deep link the visitor was headed to, written beside the provider
         // link they clicked and consumed here. Not the OAuth `state` parameter:
         // the trip starts and ends in the same tab on this origin (#135).
-        router.replace(postSignInDestination(takeReturnTo()));
+        //
+        // Through `goToDestination`, which the password form also goes through:
+        // a destination with a fragment has to load the document, and a branch
+        // only one door takes is a deep link that behaves differently depending
+        // on which button was pressed.
+        goToDestination(postSignInDestination(takeReturnTo()), (href) => router.replace(href));
       } catch {
         if (!cancelled) {
           setExchangeFailed(true);

--- a/frontend/src/app/[locale]/auth/session-adoption.integration.test.tsx
+++ b/frontend/src/app/[locale]/auth/session-adoption.integration.test.tsx
@@ -7,6 +7,7 @@ import CallbackPage from "./callback/page";
 import MagicLinkPage from "./magic-link/page";
 import { AuthGuard } from "@/components/layout/auth-guard";
 import { apiClient } from "@/lib/api-client";
+import { rememberReturnTo } from "@/lib/oauth-return";
 import { useAuthStore, useConversationStore } from "@/stores";
 
 /**
@@ -61,6 +62,7 @@ beforeEach(() => {
   searchParams.forEach((_, key) => searchParams.delete(key));
   useAuthStore.getState().logout();
   useConversationStore.getState().reset();
+  window.sessionStorage.clear();
   client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 });
 
@@ -105,6 +107,54 @@ describe("the OAuth callback", () => {
     resolve({ user: arriving, access_token: "t-new" });
     await waitFor(() => expect(useAuthStore.getState().user?.id).toBe("u-new"));
     expect(apiClient.post).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * Where the round trip ends (#135).
+ *
+ * A visitor at `/login?returnTo=/agents/a-1` who signed in with the password
+ * form resumed the deep link; one who clicked a provider button landed on the
+ * dashboard, so which button they picked decided where they ended up. The path
+ * is written beside the provider link - `oauth-buttons.test.tsx` holds that
+ * half - and read back here.
+ */
+describe("where the OAuth callback lands", () => {
+  async function signIn() {
+    searchParams.set("code", "one-time");
+    vi.mocked(apiClient.post).mockResolvedValue({ user: arriving, access_token: "t-new" });
+    render(
+      <QueryClientProvider client={client}>
+        <CallbackPage />
+      </QueryClientProvider>,
+    );
+    await waitFor(() => expect(replace).toHaveBeenCalled());
+    return vi.mocked(replace).mock.calls[0]?.[0];
+  }
+
+  it("resumes the deep link the visitor was headed to", async () => {
+    rememberReturnTo("/agents/a-1");
+
+    expect(await signIn()).toBe("/agents/a-1");
+  });
+
+  it("consumes it, so a second sign-in in this tab does not resume it", async () => {
+    rememberReturnTo("/agents/a-1");
+    await signIn();
+
+    expect(window.sessionStorage.getItem("oauthReturnTo")).toBeNull();
+  });
+
+  it("lands on the dashboard when the trip carried no deep link", async () => {
+    expect(await signIn()).toBe("/dashboard");
+  });
+
+  it("refuses a path that leaves this origin", async () => {
+    // `postSignInDestination` is the one place that decides this, and it stays
+    // the one place: nothing on the way here re-implements the check.
+    rememberReturnTo("//evil.example/agents");
+
+    expect(await signIn()).toBe("/dashboard");
   });
 });
 

--- a/frontend/src/components/auth/login-form.tsx
+++ b/frontend/src/components/auth/login-form.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { ArrowRight } from "lucide-react";
 
 import { OAuthBlock } from "@/components/auth/oauth-buttons";
+import { returnToForAttempt } from "@/lib/oauth-return";
 import { Button, Input, Label } from "@/components/ui";
 import { useAuth } from "@/hooks";
 import { ApiError } from "@/lib/api-client";
@@ -147,7 +148,7 @@ export function LoginForm() {
         </Button>
       </form>
 
-      <OAuthBlock label={t("orSignInWith")} returnTo={search.get("returnTo")} />
+      <OAuthBlock label={t("orSignInWith")} returnTo={returnToForAttempt(search)} />
     </div>
   );
 }

--- a/frontend/src/components/auth/login-form.tsx
+++ b/frontend/src/components/auth/login-form.tsx
@@ -147,7 +147,7 @@ export function LoginForm() {
         </Button>
       </form>
 
-      <OAuthBlock label={t("orSignInWith")} />
+      <OAuthBlock label={t("orSignInWith")} returnTo={search.get("returnTo")} />
     </div>
   );
 }

--- a/frontend/src/components/auth/oauth-buttons.test.tsx
+++ b/frontend/src/components/auth/oauth-buttons.test.tsx
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { OAuthBlock } from "./oauth-buttons";
@@ -13,7 +14,15 @@ const SAVED = process.env.NEXT_PUBLIC_OAUTH_PROVIDERS;
 afterEach(() => {
   if (SAVED === undefined) delete process.env.NEXT_PUBLIC_OAUTH_PROVIDERS;
   else process.env.NEXT_PUBLIC_OAUTH_PROVIDERS = SAVED;
+  window.sessionStorage.clear();
 });
+
+/** Click the provider button without letting jsdom follow the link out. */
+async function press(name: RegExp) {
+  const link = screen.getByRole("link", { name });
+  link.addEventListener("click", (event) => event.preventDefault());
+  await userEvent.click(link);
+}
 
 describe("the OAuth buttons", () => {
   it("renders a link and a mark per configured provider", () => {
@@ -36,6 +45,29 @@ describe("the OAuth buttons", () => {
       "href",
       expect.stringContaining("invitation=tok"),
     );
+  });
+
+  it("remembers the deep link the visitor was headed to", async () => {
+    // Not sent to the provider and not in the OAuth `state`: the trip starts
+    // and ends in this tab, and `/auth/callback` reads it back (#135).
+    process.env.NEXT_PUBLIC_OAUTH_PROVIDERS = "google";
+    render(<OAuthBlock label="or" returnTo="/agents/a-1" />);
+
+    await press(/continueWith/);
+
+    expect(window.sessionStorage.getItem("oauthReturnTo")).toBe("/agents/a-1");
+    // The provider is told nothing about it.
+    expect(screen.getByRole("link")).toHaveAttribute("href", expect.not.stringContaining("a-1"));
+  });
+
+  it("forgets an abandoned one, rather than resuming it on the next attempt", async () => {
+    process.env.NEXT_PUBLIC_OAUTH_PROVIDERS = "google";
+    window.sessionStorage.setItem("oauthReturnTo", "/agents/gone");
+    render(<OAuthBlock label="or" />);
+
+    await press(/continueWith/);
+
+    expect(window.sessionStorage.getItem("oauthReturnTo")).toBeNull();
   });
 
   it("renders nothing when no provider is configured", () => {

--- a/frontend/src/components/auth/oauth-buttons.tsx
+++ b/frontend/src/components/auth/oauth-buttons.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { BACKEND_URL } from "@/lib/constants";
+import { rememberReturnTo } from "@/lib/oauth-return";
 
 import { GlyphIcon } from "@/components/icons/glyph";
 import { AUTH_GLYPHS, type AuthProvider } from "@/lib/auth-glyphs.generated";
@@ -25,7 +26,6 @@ function readProviders(): Provider[] {
 }
 
 interface OAuthButtonsProps {
-  next?: string;
   /** Override label suffix when used in register page. */
   variant?: "signin" | "signup";
   /**
@@ -38,15 +38,20 @@ interface OAuthButtonsProps {
    * it off the query here and holds it in the session across the round trip.
    */
   invitation?: string | null;
+  /**
+   * Where the visitor was headed. Written to `sessionStorage` as the button is
+   * clicked rather than sent to the provider: the trip starts and ends in this
+   * tab, so nothing has to hold it for us (#135).
+   */
+  returnTo?: string | null;
 }
 
-function OAuthButtons({ next, variant = "signin", invitation }: OAuthButtonsProps) {
+function OAuthButtons({ variant = "signin", invitation, returnTo }: OAuthButtonsProps) {
   const t = useTranslations("auth");
   const providers = readProviders();
   if (providers.length === 0) return null;
 
   const query = new URLSearchParams();
-  if (next) query.set("next", next);
   if (invitation) query.set("invitation", invitation);
   const search = query.size > 0 ? `?${query.toString()}` : "";
 
@@ -62,6 +67,9 @@ function OAuthButtons({ next, variant = "signin", invitation }: OAuthButtonsProp
           <a
             key={provider}
             href={url}
+            // Also when there is nothing to remember: an abandoned deep link
+            // left in storage would be resumed by the next sign-in from this tab.
+            onClick={() => rememberReturnTo(returnTo)}
             className="border-foreground/15 hover:border-foreground/40 hover:bg-foreground/[0.03] text-foreground inline-flex h-11 w-full items-center justify-center gap-3 rounded-full border px-5 text-sm font-medium transition-colors"
           >
             <GlyphIcon glyph={AUTH_GLYPHS[provider]} className="h-4 w-4" aria-hidden />
@@ -77,16 +85,18 @@ export function OAuthBlock({
   label,
   variant,
   invitation,
+  returnTo,
 }: {
   label: string;
   variant?: "signin" | "signup";
   invitation?: string | null;
+  returnTo?: string | null;
 }) {
   if (!process.env.NEXT_PUBLIC_OAUTH_PROVIDERS) return null;
   return (
     <div className="space-y-5">
       <OAuthDivider label={label} />
-      <OAuthButtons variant={variant} invitation={invitation} />
+      <OAuthButtons variant={variant} invitation={invitation} returnTo={returnTo} />
     </div>
   );
 }

--- a/frontend/src/components/auth/register-form.tsx
+++ b/frontend/src/components/auth/register-form.tsx
@@ -269,7 +269,12 @@ export function RegisterForm() {
 
       {/* The token travels with the provider too: an `invite_only` deployment
           otherwise refuses the button beside a form that accepts the same person. */}
-      <OAuthBlock label={t("orSignUpWith")} variant="signup" invitation={invitationToken} />
+      <OAuthBlock
+        label={t("orSignUpWith")}
+        variant="signup"
+        invitation={invitationToken}
+        returnTo={returnTo}
+      />
     </div>
   );
 }

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -9,7 +9,7 @@ import { toast } from "sonner";
 import { resetSessionState, useAuthStore } from "@/stores";
 import { apiClient, ApiError } from "@/lib/api-client";
 import type { User, LoginRequest, RegisterRequest } from "@/types";
-import { postSignInDestination } from "@/lib/auth-landing";
+import { goToDestination, postSignInDestination } from "@/lib/auth-landing";
 import { ROUTES } from "@/lib/constants";
 
 // Session-level singletons so /auth/me runs ONCE per page load no matter how
@@ -177,19 +177,7 @@ export function useAuth() {
         adoptUser(queryClient, setUser, response.user);
         useAuthStore.getState().setAccessToken(response.access_token);
         authChecked = true; // login already populated user + token; skip /auth/me
-        const destination = postSignInDestination(returnTo);
-        if (destination.includes("#")) {
-          // next@16.2's segment cache appends the fragment a second time on a
-          // soft navigation (/path#x becomes /path#x#x in a production build),
-          // so a destination with a fragment must load the document instead.
-          // The branches are not equivalent: a document load drops the
-          // in-memory access token (re-adopted via /auth/me on arrival), and
-          // anything the caller runs after login() fires into an unloading
-          // page.
-          window.location.assign(destination);
-        } else {
-          router.push(destination);
-        }
+        goToDestination(postSignInDestination(returnTo), (href) => router.push(href));
         return response;
       } finally {
         setLoading(false);

--- a/frontend/src/lib/auth-landing.test.ts
+++ b/frontend/src/lib/auth-landing.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { postSignInDestination } from "./auth-landing";
+import { goToDestination, postSignInDestination } from "./auth-landing";
 import { ROUTES } from "./constants";
 
 describe("postSignInDestination", () => {
@@ -32,5 +32,35 @@ describe("postSignInDestination", () => {
     "/\r/evil.example",
   ])("refuses %j and falls back to the dashboard", (path) => {
     expect(postSignInDestination(path)).toBe(ROUTES.DASHBOARD);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("getting to where a fresh session lands", () => {
+  it("navigates softly when the path carries no fragment", () => {
+    const navigate = vi.fn();
+
+    goToDestination("/agents/a-1", navigate);
+
+    expect(navigate).toHaveBeenCalledWith("/agents/a-1");
+  });
+
+  it("loads the document when it does", () => {
+    // next@16.2's segment cache appends the fragment a second time on a soft
+    // navigation, so `/path#x` arrives as `/path#x#x` in a production build.
+    const assign = vi.fn();
+    vi.spyOn(window, "location", "get").mockReturnValue({
+      ...window.location,
+      assign,
+    } as unknown as Location);
+    const navigate = vi.fn();
+
+    goToDestination("/agents/a-1#tools", navigate);
+
+    expect(assign).toHaveBeenCalledWith("/agents/a-1#tools");
+    expect(navigate).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/lib/auth-landing.ts
+++ b/frontend/src/lib/auth-landing.ts
@@ -37,3 +37,27 @@ function isSafeReturnPath(path: string | null | undefined): path is string {
     new URL(path, window.location.origin).origin === window.location.origin
   );
 }
+
+/**
+ * Go to where a fresh session lands, by whichever navigation survives the path.
+ *
+ * `next@16.2`'s segment cache appends a fragment a second time on a soft
+ * navigation - `/path#x` becomes `/path#x#x` in a production build - so a
+ * destination carrying one has to load the document instead. The branches are
+ * **not** equivalent: a document load drops the in-memory access token, which is
+ * re-adopted from `/auth/me` on arrival, and anything the caller runs afterwards
+ * fires into an unloading page.
+ *
+ * Here rather than at each sign-in path, for the reason
+ * {@link postSignInDestination} is: the password form had this branch and the
+ * OAuth callback did not, so a deep link with an anchor behaved differently
+ * depending on which button somebody pressed - which is the drift #135 is
+ * about, one axis over.
+ */
+export function goToDestination(destination: string, navigate: (href: string) => void): void {
+  if (destination.includes("#")) {
+    window.location.assign(destination);
+    return;
+  }
+  navigate(destination);
+}

--- a/frontend/src/lib/oauth-return.test.ts
+++ b/frontend/src/lib/oauth-return.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { rememberReturnTo, takeReturnTo } from "./oauth-return";
+import { rememberReturnTo, returnToForAttempt, takeReturnTo } from "./oauth-return";
 
 afterEach(() => {
   window.sessionStorage.clear();
@@ -62,5 +62,47 @@ describe("carrying a return path across the provider round trip", () => {
     });
 
     expect(() => rememberReturnTo(null)).not.toThrow();
+  });
+});
+
+describe("what an attempt started from this URL should remember", () => {
+  const url = (query: string) => new URLSearchParams(query);
+
+  it("takes the deep link the visitor arrived with", () => {
+    expect(returnToForAttempt(url("returnTo=/agents/a-1"))).toBe("/agents/a-1");
+  });
+
+  it("takes nothing from a plain sign-in page", () => {
+    rememberReturnTo("/agents/abandoned");
+
+    expect(returnToForAttempt(url(""))).toBeNull();
+  });
+
+  it("keeps the path across a retry, where the URL has lost it", () => {
+    // A failed provider attempt comes back to `/login?error=oauth_failed` with
+    // no `returnTo` on it. Clearing there drops a path nobody abandoned.
+    rememberReturnTo("/agents/a-1");
+
+    expect(returnToForAttempt(url("error=oauth_failed"))).toBe("/agents/a-1");
+  });
+
+  it("prefers the URL's own deep link over what is stored", () => {
+    rememberReturnTo("/agents/older");
+
+    expect(returnToForAttempt(url("error=oauth_failed&returnTo=/agents/newer"))).toBe(
+      "/agents/newer",
+    );
+  });
+
+  it("answers with nothing on a retry that never carried one", () => {
+    expect(returnToForAttempt(url("error=oauth_failed"))).toBeNull();
+  });
+
+  it("survives a browser that refuses to be read", () => {
+    vi.spyOn(window.sessionStorage, "getItem").mockImplementation(() => {
+      throw new Error("denied");
+    });
+
+    expect(returnToForAttempt(url("error=oauth_failed"))).toBeNull();
   });
 });

--- a/frontend/src/lib/oauth-return.test.ts
+++ b/frontend/src/lib/oauth-return.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { rememberReturnTo, takeReturnTo } from "./oauth-return";
+
+afterEach(() => {
+  window.sessionStorage.clear();
+  vi.restoreAllMocks();
+});
+
+/**
+ * The deep link's ride across the provider round trip (#135).
+ *
+ * A visitor at `/login?returnTo=/agents/a-1` who signs in with the password form
+ * resumes the deep link; one who clicked a provider button landed on the
+ * dashboard, so which button they picked decided where they ended up.
+ */
+describe("carrying a return path across the provider round trip", () => {
+  it("hands back what was remembered", () => {
+    rememberReturnTo("/agents/a-1");
+
+    expect(takeReturnTo()).toBe("/agents/a-1");
+  });
+
+  it("consumes it, so an abandoned deep link is not resumed later", () => {
+    rememberReturnTo("/agents/a-1");
+    takeReturnTo();
+
+    expect(takeReturnTo()).toBeNull();
+  });
+
+  it("forgets an earlier path when there is nothing to remember", () => {
+    // A visitor who arrives at /login with a deep link, gives up, and comes
+    // back plainly should land on the dashboard rather than where they were
+    // going the first time.
+    rememberReturnTo("/agents/a-1");
+    rememberReturnTo(null);
+
+    expect(takeReturnTo()).toBeNull();
+  });
+
+  it("answers with nothing where the trip did not start", () => {
+    expect(takeReturnTo()).toBeNull();
+  });
+
+  it("still lets a browser that refuses site data sign in", () => {
+    // The cost of a throwing accessor is landing on the dashboard, not a
+    // sign-in that dies on the way back.
+    vi.spyOn(window.sessionStorage, "setItem").mockImplementation(() => {
+      throw new Error("denied");
+    });
+    vi.spyOn(window.sessionStorage, "getItem").mockImplementation(() => {
+      throw new Error("denied");
+    });
+
+    expect(() => rememberReturnTo("/agents/a-1")).not.toThrow();
+    expect(takeReturnTo()).toBeNull();
+  });
+
+  it("survives a refusal to clear as well as one to write", () => {
+    vi.spyOn(window.sessionStorage, "removeItem").mockImplementation(() => {
+      throw new Error("denied");
+    });
+
+    expect(() => rememberReturnTo(null)).not.toThrow();
+  });
+});

--- a/frontend/src/lib/oauth-return.ts
+++ b/frontend/src/lib/oauth-return.ts
@@ -1,0 +1,55 @@
+/**
+ * Carrying `?returnTo=` across the provider round trip.
+ *
+ * A visitor at `/login?returnTo=/agents/a-1` who signs in with the password form
+ * resumes the deep link; one who clicked a provider button landed on the
+ * dashboard, so which button they picked decided where they ended up (#135).
+ * Nothing carried the path: the browser leaves this origin for the provider and
+ * comes back to `/auth/callback?code=`, and neither hop has room for it.
+ *
+ * `sessionStorage`, not the OAuth `state` parameter, because the whole trip
+ * starts and ends in the same tab on this origin - so a value written beside the
+ * provider link is there to be read when the browser returns, and no server has
+ * to hold it. A flow that ends somewhere else (a link opened in a new tab, a
+ * different browser) finds nothing and lands on the dashboard, which is where it
+ * landed before.
+ *
+ * Every read consumes the value. One left behind would resume a deep link
+ * somebody had already abandoned, on the next sign-in from that tab.
+ *
+ * Nothing here validates the path: {@link postSignInDestination} is the one
+ * place that decides whether a return path is safe to honour, and a second copy
+ * of that rule is a second answer to it.
+ */
+
+const KEY = "oauthReturnTo";
+
+/**
+ * Remember where to land, or forget a path from an earlier attempt.
+ *
+ * Always one or the other. Leaving a stale value in place is how a second
+ * sign-in with no deep link resumes the first one's.
+ */
+export function rememberReturnTo(path: string | null | undefined): void {
+  try {
+    if (path) {
+      window.sessionStorage.setItem(KEY, path);
+    } else {
+      window.sessionStorage.removeItem(KEY);
+    }
+  } catch {
+    // A browser that refuses site data still has to be able to sign in; the
+    // cost is landing on the dashboard.
+  }
+}
+
+/** The remembered path, removed as it is read. */
+export function takeReturnTo(): string | null {
+  try {
+    const path = window.sessionStorage.getItem(KEY);
+    window.sessionStorage.removeItem(KEY);
+    return path;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/lib/oauth-return.ts
+++ b/frontend/src/lib/oauth-return.ts
@@ -43,6 +43,33 @@ export function rememberReturnTo(path: string | null | undefined): void {
   }
 }
 
+/**
+ * What an attempt started from this URL should remember.
+ *
+ * `?returnTo=` when the visitor arrived with one. Otherwise nothing - *except*
+ * on a retry: a failed provider attempt comes back to `/login?error=…` with the
+ * deep link gone from the URL and the one written before the attempt still in
+ * storage, so clearing there would drop a path nobody abandoned. Only the OAuth
+ * callback and the provider redirect mint that `error`, which is what makes it
+ * a reliable "this is the second attempt at the same thing".
+ */
+export function returnToForAttempt(search: {
+  get: (name: string) => string | null;
+}): string | null {
+  const named = search.get("returnTo");
+  if (named) return named;
+  return search.get("error") ? peek() : null;
+}
+
+/** Read without consuming - only {@link returnToForAttempt} needs this. */
+function peek(): string | null {
+  try {
+    return window.sessionStorage.getItem(KEY);
+  } catch {
+    return null;
+  }
+}
+
 /** The remembered path, removed as it is read. */
 export function takeReturnTo(): string | null {
   try {


### PR DESCRIPTION
A visitor at `/login?returnTo=/agents/a-1` who signed in with the password form resumed the deep link; one who clicked a provider button landed on `/dashboard`. Which button they picked decided where they ended up — the drift #121 removed on the roles axis, still present on the provider axis.

Nothing carried the path: the browser leaves this origin for the provider and comes back to `/auth/callback?code=`, and neither hop had room for it, so the callback called `postSignInDestination()` with nothing.

## What changed

`sessionStorage`, not the OAuth `state` parameter — the shape the issue prescribes, and the reason is that the whole trip **starts and ends in the same tab on this origin**. A value written beside the provider link is there to be read when the browser returns, and no server has to hold it. A flow that ends somewhere else (a link opened in a new tab, another browser) finds nothing and lands on the dashboard, which is where it landed before.

Two things the shape gets right, each with a test:

- **The value is consumed as it is read**, so a deep link somebody abandoned is not resumed by the next sign-in from that tab.
- **A click with nothing to remember clears rather than skips**, for the same reason.

Nothing in the new module validates the path: `postSignInDestination` stays the one place that decides whether a return path is safe to honour, and it still refuses `//evil.example`. A second copy of that rule would be a second answer to it.

`OAuthButtons` had a `next` prop that `OAuthBlock` never passed and the backend never read — `oauth/{provider}/login` takes `invitation` and nothing else. It is gone with the dead query parameter it built.

## Not an E2E spec, and why

The issue asks for one mirroring `a deep link survives the login round trip`. The file the tests went into already writes down why that is not available here:

> An integration test rather than a Playwright spec, which is what `.claude/rules/frontend.md` asks for: the assertion is about what the page does to the client's own state, and **none of these journeys are reachable in the E2E environment — OAuth needs a provider** and a magic link needs an email.

`playwright.config.ts`'s web server sets `NEXT_PUBLIC_OAUTH_PROVIDERS` nowhere, so `OAuthBlock` renders nothing to click. Enabling a provider there would put provider buttons on the sign-in page of all 87 specs in order to assert a redirect that never leaves the frontend.

The round trip is covered end to end across the two halves instead:

| | |
|---|---|
| `oauth-buttons.test.tsx` | the click writes the path, and tells the provider nothing about it; a click with none clears a stale one |
| `session-adoption.integration.test.tsx` | the callback lands on it, consumes it, defaults to `/dashboard` with none, and refuses one that leaves this origin |
| `oauth-return.test.ts` | the carrier itself, including a browser that refuses site data — which must still be able to sign in |

## Related, not fixed here

`/auth/magic-link` has the same defect and cannot take the same fix: the link is followed from an email, so `sessionStorage` — which is per tab — is empty by construction. Carrying a deep link there means storing it with the token. Filed separately rather than folded in.

## Verified

`make lint-frontend` clean. `bun run test:coverage` green: 100% statements/lines/functions, 97.67% branches.

Closes #135
