### PR TITLE
chore: cut 0.0.285

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,29 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.285] - 2026-08-27
+
+### Fixed
+
+- **Deleting one organization dropped another tenant's vectors.**
+  `collection_name` is not tenant-unique (#913), so two organizations can back onto
+  one `rag_<name>` table, and the teardown dropped it unconditionally. The physical
+  table is dropped only when no other collection still references it, and last -
+  after the relational deletes flush, so a failure among them aborts before any
+  table is gone. (#1116, #9)
+- **Tracked documents outlived their collection and stayed reachable by name.**
+  `rag_documents` authorizes on `collection_name`, so a row outliving its knowledge
+  base was listable and downloadable by a later collection permitted the same name.
+  Each collection's document rows and their stored uploads are deleted before its
+  identifiers go, keyed on `knowledge_base_id` so a shared collection's co-tenant
+  rows are untouched. (#1116)
+- The residuals are documented on `purge` rather than left implied: the drop and
+  the file unlinks still commit outside the request transaction, and three
+  reachability residuals remain - a document with a null knowledge base sharing the
+  name, the deleted tenant's vectors inside a kept shared table, and a TOCTOU on the
+  reference check. All of them are rooted in the `collection_name` tenant-scoping of
+  #913. (#1137, #913)
+
 ## [0.0.284] - 2026-08-27
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.284"
+version = "0.0.285"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.284"
+version = "0.0.285"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.284",
+  "version": "0.0.285",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.285. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.285 and adds the CHANGELOG entry.

Releases #1116, three gaps in #9's collection teardown. `collection_name` is
not tenant-unique, so two organizations can back onto one physical table and
deleting either destroyed the other's vectors; tracked documents outlived
their collection and stayed reachable by name, because `rag_documents`
authorizes on that name; and the vector drop was interleaved with the row
deletes rather than last.

The residuals are documented on `purge` and tracked in #1137, all rooted in
the `collection_name` tenant-scoping of #913.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1138 was green on the merged head.