### PR TITLE
fix(budgets): count a resumed run's own prior spend once

### DIFF
--- a/backend/app/repositories/agent_run.py
+++ b/backend/app/repositories/agent_run.py
@@ -575,6 +575,7 @@ async def sum_cost_since(
     since: datetime,
     agent_id: UUID | None = None,
     include_delegations: bool = False,
+    exclude_run_id: UUID | None = None,
 ) -> Decimal:
     """Total run spend in a window - what a monthly budget is checked against.
 
@@ -609,6 +610,17 @@ async def sum_cost_since(
     delegation the parent's caps bind, see `app/agents/factory.py` - but it is what
     makes "the researcher agent cost $40 this month" answerable and what a budget
     alert on that agent fires on.
+
+    `exclude_run_id` leaves one run's row out, and the budget guard is the only
+    caller that wants it: a baseline is what *other* runs have already spent, and
+    the asking run's own spend is its ledger's. It matters on a resume, where the
+    run keeps its row: a run that spent $6 and parked has `cost_usd = 6.00`
+    committed, and the ledger is re-seeded with the same $6 so that finishing
+    does not overwrite the cost with only what the continuation cost. Summed as
+    well, the first model request of the continuation saw $12 against a $10 cap
+    and refused a run with $4 of headroom (#15). A figure a person reads is not
+    this - a report that hid the run somebody is looking at would be wrong - so
+    it is off by default.
     """
     query = select(func.coalesce(func.sum(AgentRun.cost_usd), 0)).where(
         AgentRun.organization_id == organization_id,
@@ -618,6 +630,8 @@ async def sum_cost_since(
         query = query.where(AgentRun.agent_id == agent_id)
     if not include_delegations:
         query = query.where(AgentRun.parent_run_id.is_(None))
+    if exclude_run_id is not None:
+        query = query.where(AgentRun.id != exclude_run_id)
     result = await db.scalar(query)
     return Decimal(result or 0)
 

--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -1700,6 +1700,15 @@ class AgentRunnerService:
         # made on one flow's event loop breaks whoever checks it out on the
         # next, and this read happens on whatever loop the run is on. One
         # connect per run, next to a model call.
+        # Both leave this run's own row out. A baseline is what *other* runs have
+        # already spent; what this one spends is the ledger's, and on a resume
+        # the two are the same money. A run that spent $6 and parked has
+        # `cost_usd = 6.00` committed, and the ledger is re-seeded with that $6
+        # so finishing does not overwrite the cost with only the continuation's -
+        # summed as well, the first model request after an approval saw $12
+        # against a $10 cap and refused a run with $4 of headroom (#15). On a
+        # fresh run the row is there too, at zero, so this changes nothing and
+        # needs no branch.
         async def agent_period_spend() -> Decimal:
             async with get_worker_db_context() as db:
                 return await agent_run_repo.sum_cost_since(
@@ -1708,11 +1717,14 @@ class AgentRunnerService:
                     since=month_start(),
                     agent_id=agent.id,
                     include_delegations=True,
+                    exclude_run_id=run.id,
                 )
 
         async def org_period_spend() -> Decimal:
             async with get_worker_db_context() as db:
-                return await organization_monthly_spend(db, ctx.organization_id)
+                return await organization_monthly_spend(
+                    db, ctx.organization_id, exclude_run_id=run.id
+                )
 
         # Opened after the run row, because a run-scoped workspace keys on it,
         # and before the agent, because the capability reads the backend out of

--- a/backend/app/services/spend.py
+++ b/backend/app/services/spend.py
@@ -38,7 +38,11 @@ def month_start(now: datetime | None = None) -> datetime:
 
 
 async def organization_spend_since(
-    db: AsyncSession, organization_id: UUID, since: datetime
+    db: AsyncSession,
+    organization_id: UUID,
+    since: datetime,
+    *,
+    exclude_run_id: UUID | None = None,
 ) -> Decimal:
     """Runs plus ingestion in a window - the organization's bill for it.
 
@@ -47,9 +51,14 @@ async def organization_spend_since(
     the calendar month, and the usage email covers the past week or month. Summing
     a per-agent breakdown instead is how that email came to overstate the bill -
     it counted every delegated run a second time and left ingestion out.
+
+    `exclude_run_id` is the budget guard's, and only its: a baseline is what other
+    runs have spent, and the asking run's own spend is in its ledger. See
+    :func:`app.repositories.agent_run.sum_cost_since` for what counting it twice
+    did to a resumed run (#15).
     """
     run_spend = await agent_run_repo.sum_cost_since(
-        db, organization_id=organization_id, since=since
+        db, organization_id=organization_id, since=since, exclude_run_id=exclude_run_id
     )
     ingestion_spend = await ingestion_spend_repo.sum_cost_since(
         db, organization_id=organization_id, since=since
@@ -57,9 +66,13 @@ async def organization_spend_since(
     return run_spend + ingestion_spend
 
 
-async def organization_monthly_spend(db: AsyncSession, organization_id: UUID) -> Decimal:
+async def organization_monthly_spend(
+    db: AsyncSession, organization_id: UUID, *, exclude_run_id: UUID | None = None
+) -> Decimal:
     """Runs plus ingestion since the first of the month - what a cap is checked on."""
-    return await organization_spend_since(db, organization_id, month_start())
+    return await organization_spend_since(
+        db, organization_id, month_start(), exclude_run_id=exclude_run_id
+    )
 
 
 async def assert_organization_within_budget(db: AsyncSession, organization_id: UUID) -> None:

--- a/backend/tests/integration/test_resumed_run_baseline.py
+++ b/backend/tests/integration/test_resumed_run_baseline.py
@@ -1,0 +1,261 @@
+"""A resumed run's own prior spend, counted once, against Postgres.
+
+A run that parks on an approval keeps its row, and by then `finish_run` has
+committed what it spent. Two things then read that number: the budget baseline,
+which sums `agent_runs.cost_usd`, and `_spend_already_booked`, which re-seeds
+the ledger with it so that finishing the continuation does not overwrite the
+cost with only what the continuation cost.
+
+Both are right on their own and wrong together. An agent capped at $10 that
+spent $6 and parked came back to `6 + 6 = 12 >= 10` on its first model request
+and was refused with $4 of headroom (#15). The organization's cap double-counted
+identically, through `organization_monthly_spend`.
+
+The exclusion is a `WHERE` and the seeding is arithmetic on real `Decimal`
+columns, so this is the layer that can show it: a mocked session answers with
+whatever the test told it to.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic_ai.usage import RequestUsage
+
+from app.agents.capabilities.budget import (
+    BudgetExceeded,
+    BudgetGuard,
+    BudgetScope,
+    SpendEntry,
+    SpendLedger,
+    SpendLimit,
+)
+from app.db.models.agent import Agent
+from app.db.models.agent_run import AgentRun, RunStatus
+from app.db.models.organization import Organization, OrganizationMember
+from app.db.models.user import User
+from app.repositories import agent_run_repo
+from app.services.spend import month_start, organization_monthly_spend
+
+pytestmark = pytest.mark.anyio
+
+
+async def _org(db) -> Organization:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"{uuid.uuid4().hex}@example.com",
+        hashed_password="x",
+        is_active=True,
+    )
+    db.add(user)
+    await db.flush()
+    org = Organization(
+        id=uuid.uuid4(),
+        name="Acme",
+        slug=f"acme-{uuid.uuid4().hex[:8]}",
+        created_by_user_id=user.id,
+    )
+    db.add(org)
+    await db.flush()
+    db.add(
+        OrganizationMember(id=uuid.uuid4(), organization_id=org.id, user_id=user.id, role="owner")
+    )
+    await db.flush()
+    return org
+
+
+async def _agent(db, org: Organization) -> Agent:
+    agent = Agent(
+        id=uuid.uuid4(),
+        organization_id=org.id,
+        slug=f"support-{uuid.uuid4().hex[:8]}",
+        name="Support",
+        draft_spec={},
+    )
+    db.add(agent)
+    await db.flush()
+    return agent
+
+
+async def _run_that_spent(db, *, org: Organization, agent: Agent, cost: Decimal) -> AgentRun:
+    """A run that spent, finished and had its cost committed - as a parked one has."""
+    run = await agent_run_repo.create_run(
+        db,
+        organization_id=org.id,
+        agent_id=agent.id,
+        agent_version_id=None,
+        user_id=None,
+        conversation_id=None,
+        surface="api",
+        model_label="gpt-4.1",
+        provider="openai",
+        secret_id=None,
+        started_at=datetime.now(UTC),
+    )
+    return await agent_run_repo.finish_run(
+        db,
+        run=run,
+        status=RunStatus.COMPLETED.value,
+        input_tokens=1000,
+        output_tokens=100,
+        cost_usd=cost,
+        cost_is_partial=False,
+        ended_at=datetime.now(UTC),
+    )
+
+
+async def _agent_baseline(db, *, org, agent, exclude_run_id=None) -> Decimal:
+    return await agent_run_repo.sum_cost_since(
+        db,
+        organization_id=org.id,
+        since=month_start(),
+        agent_id=agent.id,
+        include_delegations=True,
+        exclude_run_id=exclude_run_id,
+    )
+
+
+class TestTheBaselineLeavesTheAskingRunOut:
+    async def test_the_agents_own_baseline_excludes_the_named_run(self, db) -> None:
+        org = await _org(db)
+        agent = await _agent(db, org)
+        parked = await _run_that_spent(db, org=org, agent=agent, cost=Decimal("6.00"))
+
+        assert await _agent_baseline(db, org=org, agent=agent) == Decimal("6.00")
+        assert await _agent_baseline(db, org=org, agent=agent, exclude_run_id=parked.id) == (
+            Decimal("0")
+        )
+
+    async def test_it_leaves_out_that_run_and_no_other(self, db) -> None:
+        """The exclusion is one row, not the agent's whole month."""
+        org = await _org(db)
+        agent = await _agent(db, org)
+        earlier = await _run_that_spent(db, org=org, agent=agent, cost=Decimal("2.50"))
+        parked = await _run_that_spent(db, org=org, agent=agent, cost=Decimal("6.00"))
+
+        assert await _agent_baseline(db, org=org, agent=agent, exclude_run_id=parked.id) == (
+            Decimal("2.50")
+        )
+        assert await _agent_baseline(db, org=org, agent=agent, exclude_run_id=earlier.id) == (
+            Decimal("6.00")
+        )
+
+    async def test_the_organizations_baseline_excludes_it_too(self, db) -> None:
+        """The organization-wide cap double-counted identically."""
+        org = await _org(db)
+        agent = await _agent(db, org)
+        parked = await _run_that_spent(db, org=org, agent=agent, cost=Decimal("6.00"))
+
+        assert await organization_monthly_spend(db, org.id) == Decimal("6.00")
+        assert await organization_monthly_spend(db, org.id, exclude_run_id=parked.id) == (
+            Decimal("0")
+        )
+
+
+class TestWhatTheGuardThenSees:
+    @staticmethod
+    def _guard(baseline: Decimal, *, already_spent: Decimal, cap: Decimal) -> BudgetGuard:
+        """The resumed run's guard: its ledger re-seeded, its baseline read once."""
+        ledger = SpendLedger()
+        ledger.book(
+            SpendEntry(
+                model_name="gpt-4.1",
+                input_tokens=1000,
+                output_tokens=100,
+                cost_usd=already_spent,
+                priced=True,
+            )
+        )
+        return BudgetGuard(
+            ledger=ledger,
+            limits=[
+                SpendLimit(
+                    scope=BudgetScope.AGENT,
+                    limit_usd=cap,
+                    period_spend=lambda: _answer(baseline),
+                )
+            ],
+        )
+
+    async def test_a_resumed_run_is_not_refused_under_its_own_cap(self, db) -> None:
+        """The acceptance criterion, end to end on real rows: $6 spent, $10 cap.
+
+        Before the exclusion the guard saw $12 and raised; it sees $6 and lets
+        the continuation make its next request.
+        """
+        org = await _org(db)
+        agent = await _agent(db, org)
+        parked = await _run_that_spent(db, org=org, agent=agent, cost=Decimal("6.00"))
+
+        baseline = await _agent_baseline(db, org=org, agent=agent, exclude_run_id=parked.id)
+        guard = self._guard(baseline, already_spent=Decimal("6.00"), cap=Decimal("10.00"))
+
+        await _one_request(guard)
+
+        # The continuation's own request is on top of the $6 it arrived with.
+        assert guard.ledger.total_usd > Decimal("6.00")
+
+    async def test_counting_it_twice_is_what_refused_it(self, db) -> None:
+        """The defect itself, shown rather than described.
+
+        The same run and the same cap, with its own row left in the baseline:
+        `6 + 6 = 12 >= 10`, and a run with $4 of headroom is stopped. This is
+        what the exclusion above is measured against, so removing it fails the
+        pair rather than only the half that says what should happen.
+        """
+        org = await _org(db)
+        agent = await _agent(db, org)
+        await _run_that_spent(db, org=org, agent=agent, cost=Decimal("6.00"))
+
+        baseline = await _agent_baseline(db, org=org, agent=agent)
+        guard = self._guard(baseline, already_spent=Decimal("6.00"), cap=Decimal("10.00"))
+
+        with pytest.raises(BudgetExceeded):
+            await _one_request(guard)
+
+    async def test_and_is_still_refused_once_it_really_reaches_the_cap(self, db) -> None:
+        """The cap still binds - this is not a hole in enforcement.
+
+        The same run, continued until its own ledger holds $10.
+        """
+        org = await _org(db)
+        agent = await _agent(db, org)
+        parked = await _run_that_spent(db, org=org, agent=agent, cost=Decimal("10.00"))
+
+        baseline = await _agent_baseline(db, org=org, agent=agent, exclude_run_id=parked.id)
+        guard = self._guard(baseline, already_spent=Decimal("10.00"), cap=Decimal("10.00"))
+
+        with pytest.raises(BudgetExceeded) as refused:
+            await _one_request(guard)
+
+        assert refused.value.scope is BudgetScope.AGENT
+
+    async def test_a_neighbours_spend_still_counts_against_the_organization(self, db) -> None:
+        """Excluding the asking run must not exclude anybody else's."""
+        org = await _org(db)
+        agent = await _agent(db, org)
+        await _run_that_spent(db, org=org, agent=agent, cost=Decimal("9.00"))
+        parked = await _run_that_spent(db, org=org, agent=agent, cost=Decimal("1.00"))
+
+        baseline = await organization_monthly_spend(db, org.id, exclude_run_id=parked.id)
+
+        assert baseline == Decimal("9.00")
+
+
+async def _answer(value: Decimal) -> Decimal:
+    return value
+
+
+async def _one_request(guard: BudgetGuard) -> None:
+    """One model request through the guard - the moment a cap is checked."""
+    response = MagicMock(
+        model_name="gpt-4.1",
+        usage=RequestUsage(input_tokens=1000, output_tokens=1000),
+    )
+    await guard.wrap_model_request(
+        MagicMock(), request_context=MagicMock(), handler=AsyncMock(return_value=response)
+    )

--- a/backend/tests/test_agent_runner.py
+++ b/backend/tests/test_agent_runner.py
@@ -429,6 +429,7 @@ class TestPrepare:
         """The two spend lookups the runner hands the factory, by argument name."""
         service = AgentRunnerService(_db())
         agent = MagicMock(id=uuid.uuid4(), current_version_id=uuid.uuid4())
+        run = MagicMock(id=uuid.uuid4())
 
         with (
             patch.object(
@@ -444,13 +445,13 @@ class TestPrepare:
             patch.object(service.skills, "resolve_for_agent", new=AsyncMock(return_value=[])),
             patch(
                 "app.services.agent_runner.agent_run_repo.create_run",
-                new=AsyncMock(return_value=MagicMock(id=uuid.uuid4())),
+                new=AsyncMock(return_value=run),
             ),
             patch("app.services.agent_runner.build_agent") as build,
         ):
             await service.prepare(ctx, agent.id)
 
-        return {"agent_id": agent.id, **build.call_args.kwargs}
+        return {"agent_id": agent.id, "run_id": run.id, **build.call_args.kwargs}
 
     @pytest.mark.anyio
     async def test_the_spend_the_agent_checks_its_budget_against_is_this_calendar_month(self):
@@ -504,6 +505,44 @@ class TestPrepare:
         assert total.call_args.kwargs["agent_id"] == built["agent_id"]
         assert total.call_args.kwargs["organization_id"] == ctx.organization_id
         assert total.call_args.kwargs["since"] == month_start()
+
+    @pytest.mark.anyio
+    async def test_a_resumed_runs_own_prior_spend_is_not_counted_twice(self):
+        """Both baselines leave this run's own row out, and the resume path is why.
+
+        A resumed run keeps its row. It spent $6 and parked, so `finish_run` has
+        committed `cost_usd = 6.00`, and `_spend_already_booked` re-seeds the
+        ledger with the same $6 - which it must, or finishing the continuation
+        would overwrite the cost with only what the continuation cost. Summed
+        into the baseline as well, the first model request after the approval
+        saw $12 against a $10 cap and refused a run with $4 of headroom (#15).
+
+        A baseline is what *other* runs have already spent; what this one spends
+        is the ledger's. On a fresh run the row is there too, at zero, so there
+        is no branch to get wrong.
+        """
+        ctx = _ctx()
+        built = await self._period_lookups(ctx)
+
+        with (
+            patch(
+                "app.services.agent_runner.agent_run_repo.sum_cost_since",
+                new=AsyncMock(return_value=Decimal("0")),
+            ) as total,
+            patch(
+                "app.services.spend.ingestion_spend_repo.sum_cost_since",
+                new=AsyncMock(return_value=Decimal("0")),
+            ),
+        ):
+            await built["agent_period_spend"]()
+            agent_scoped = total.call_args.kwargs
+            await built["org_period_spend"]()
+            organization_scoped = total.call_args.kwargs
+
+        assert agent_scoped["exclude_run_id"] == built["run_id"]
+        # The organization's cap double-counted identically, through
+        # `organization_monthly_spend`.
+        assert organization_scoped["exclude_run_id"] == built["run_id"]
 
 
 class TestSpendReporting:

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -81,6 +81,17 @@ one expensive call every time.
     to the session context - which rolls back on any exception and is never
     reached at all on cancellation.
 
+!!! important "A baseline is what *other* runs have spent"
+
+    Both lookups leave the asking run's own row out. A resumed run keeps its
+    row, and by then `finish_run` has committed what it spent — while the
+    ledger is re-seeded with the same figure, which it must be, or finishing
+    the continuation would overwrite the cost with only what the continuation
+    cost. Counted in both places, an agent capped at $10 that spent $6 and
+    parked came back to `6 + 6 = 12` on its first model request and was
+    refused with $4 of headroom, telling its owner it had reached a cap it was
+    at 60% of. The organization's cap double-counted identically.
+
 The guard is a hard stop for a run that *sees* the spend, and a run's own cost
 only lands on its row when it finishes. So the baseline a run reads is the sum of
 runs that have already finished, and concurrent runs are invisible to one


### PR DESCRIPTION
A resumed run keeps its row, so by the time it continues `finish_run` has committed what it spent. **Two things then read that same number.**

- `sum_cost_since` / `organization_monthly_spend` sum `agent_runs.cost_usd` for the budget baseline.
- `_spend_already_booked` re-seeds the ledger with it.

Both are right on their own. The seeding has to happen, or finishing the continuation overwrites the cost with only what the continuation cost and the per-run budget resets every time somebody approves something — which is exactly the run a budget is for. The baseline has to sum the column, because that is where a month's spend is.

Together they double-count. An agent capped at $10 that spent $6 and parked came back to `6 + 6 = 12 >= 10` on its first model request and was **refused with $4 of headroom**, and the alert told its owner it had reached a cap it was at 60% of. The organization-wide cap double-counted identically.

## What changed

`sum_cost_since` takes an `exclude_run_id`, threaded through `organization_spend_since` and `organization_monthly_spend`, and both lookups in `_assemble` pass `run.id`.

**Not only on resume.** A baseline is what *other* runs have already spent; what this one spends is the ledger's. On a fresh run the row is there too, at zero, so this changes nothing there and needs no branch — one rule instead of a resume-shaped exception. It is off by default because a figure a person reads is a different question: a report that hid the run somebody was looking at would be wrong.

## How it was verified

The defect needed all three levels to be visible, so there is a test at each:

| | |
|---|---|
| **The wiring** — `test_a_resumed_runs_own_prior_spend_is_not_counted_twice` | both closures pass `run.id`. Fails if either drops it |
| **The SQL** — `tests/integration/test_resumed_run_baseline.py` | the exclusion takes out that row and no other, for the agent's baseline and the organization's |
| **The arithmetic**, on real rows | $6 spent against a $10 cap passes; the same run **refused** when its own row is left in the baseline; still refused once its ledger really reaches $10; and a neighbour's $9 still counts |

That third file includes the defect itself as a case (`test_counting_it_twice_is_what_refused_it`), so removing the exclusion fails the pair rather than only the half that says what should happen.

`make test` green against a real pgvector: **7150 passed, 100.00% coverage**. `make lint-backend` clean.

## Docs

`docs/governance.md` gains **"A baseline is what *other* runs have spent"** under *Enforcement is before the request* — beside the paragraph that already explains why a resumed run's *messages* must not restate the row's cumulative figure. Same shape of double-count, one level up.

Closes #15
