### PR TITLE
chore: cut 0.0.287

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.287] - 2026-08-27
+
+### Fixed
+
+- **A bot activated moments before shutdown reopened intake at exit.** It leaves a
+  committed, tracked `open_inbound_stream` task that may not have run yet: the
+  lifespan stops the adapter tasks that exist, then drains - and that task's final
+  step creates a new, *untracked* polling or socket task after the stop loops have
+  passed. The supervisor carries a shutting-down flag now; `open_inbound_stream`
+  declines to open when it is set, re-checked after `stop_polling` so a task
+  suspended there when shutdown begins cannot slip a reopen through either. The
+  lifespan sets it as the first shutdown statement, before the stop loops and the
+  drain, and clears it at startup so a following lifespan - a test, a reload -
+  serves again. The flag is the lifespan's alone, so the in-process drain the RAG
+  sync command issues while the server keeps serving never touches it and a
+  legitimate reopen still opens. (#1119, #1095)
+
 ## [0.0.286] - 2026-08-27
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.286"
+version = "0.0.287"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.286"
+version = "0.0.287"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.286",
+  "version": "0.0.287",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.287. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.287 and adds the CHANGELOG entry.

Releases #1119, the third gap of #1095 and the one that is ordering rather
than draining. A bot activated moments before shutdown leaves a tracked
`open_inbound_stream` that may not have run: the lifespan stops the adapter
tasks that exist, then drains it - and its final step creates a new, untracked
polling task after the stop loops have passed, reopening intake at exit. A
shutting-down flag set as the first shutdown statement declines the open, and
is re-checked after `stop_polling` so a task suspended there cannot slip one
through.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1140 was green on the merged head.