### PR TITLE
chore: cut 0.0.294

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.294] - 2026-08-27
+
+### Changed
+
+- **Both run surfaces turned a finished result into `(status, output, paused)`
+  with the same block, copied verbatim** - a `DeferredToolRequests` output builds
+  a `PausedRunState` and becomes `AWAITING_APPROVAL`, anything else is the
+  completed answer. That is the delicate half: a new `PausedRunState` field, or a
+  change to how a park is recorded, had to move in lockstep across two files. It
+  is `_classify_output` now, beside `_outcome`, which `agent_chat` already imports
+  from there. The **exception paths stay with each surface**, because they
+  genuinely differ - the chat runner re-raises `BudgetExceeded` and
+  `GuardrailBlocked` so the waiting visitor is told why, while the batch runner
+  records and moves on - so extracting those would have been a behaviour change.
+  (#567)
+
 ## [0.0.293] - 2026-08-27
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.293"
+version = "0.0.294"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.293"
+version = "0.0.294"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.293",
+  "version": "0.0.294",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.294. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.294 and adds the CHANGELOG entry.

Releases #567: the two run surfaces classified a finished result with the same
block copied verbatim, so a new `PausedRunState` field had to move in lockstep
across two files. One `_classify_output` now. The exception paths deliberately
stay per-surface, because they differ in behaviour rather than in shape.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1149 was green on the merged head.