### PR TITLE
chore: cut 0.0.295

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.295] - 2026-08-27
+
+### Changed
+
+- **Four transport blocks were copied across the three channel adapters**, so a
+  change to any had to be made at six to ten sites by hand and a fourth channel
+  would copy them all again. `split_thread` replaces the partition-and-unpack at
+  three Mattermost and three Slack sites, and `channel_key` calls it too, so "which
+  channel is this" has one implementation. `SlackAdapter._web` holds the lazy
+  client import and construction that nine sites repeated - including a dynamic
+  import in the Socket Mode path - with the import still deferred, so a deployment
+  running no Slack bot does not pay for the SDK. `TelegramAdapter._bot` is an async
+  context manager wrapping the bot and the `try/finally` close that **ten** methods
+  repeated, each of them a TLS session leaked if the close was forgotten. And the
+  Mattermost client and bearer header, repeated at ten sites each, now have one
+  definition apiece, so the timeout and the auth shape do too. (#565, #547)
+
 ## [0.0.294] - 2026-08-27
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.294"
+version = "0.0.295"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.294"
+version = "0.0.295"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.294",
+  "version": "0.0.295",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.295. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.295 and adds the CHANGELOG entry.

Releases #565: four transport blocks copied across three channel adapters, at
six to ten sites each. The Telegram one is the sharpest - ten methods repeated
the bot construction and its `try/finally` close, and each was a TLS session
leaked if the close was forgotten. Behaviour-preserving throughout: every
session still closes on every exit path.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1173 was green on the merged head.