### PR TITLE
chore: cut 0.0.296

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.296] - 2026-08-27
+
+### Changed
+
+- **The two sessions BFF routes hand-rolled the forwarder block** - read the
+  cookie or 401, set the bearer, map the error, answer JSON - which is what
+  `platformProxy()` already does, *plus* the active-organization header, byte-
+  accurate bodies and the `no-store` those hand-rolled copies drop (#546, #553,
+  #106). Both are a `sessions/[[...path]]` mount now, the same shape `kb` and
+  `rag` use, and the query handling and id escaping they did by hand are the
+  proxy's passthrough. No endpoint behaviour changed. (#564)
+- The remaining clusters are deliberately left, each with a blocker on the issue
+  rather than a mechanical swap: `orgs/**` keeps a binary avatar route that cannot
+  coexist with an optional catch-all, and the header the proxy adds is a behaviour
+  change wanting an end-to-end check; `admin/**` carries a frontend admin gate
+  rather than a plain cookie read; and the MCP OAuth callback redirects rather than
+  forwards. (#564)
+
 ## [0.0.295] - 2026-08-27
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.295"
+version = "0.0.296"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.295"
+version = "0.0.296"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.295",
+  "version": "0.0.296",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.296. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.296 and adds the CHANGELOG entry.

Releases the sessions cluster of #564: two routes hand-rolled the forwarder
`platformProxy` already provides, while dropping the organization header,
byte-accurate bodies and `no-store` that it adds. One catch-all mount now.

The other clusters stay open with their blockers named on the issue - a
catch-all conflict on `orgs/**`, an admin gate on `admin/**`, and a redirect
rather than a forward on the OAuth callback.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1176 was green on the merged head.