### PR TITLE
chore: cut 0.0.297

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.297] - 2026-08-27
+
+### Added
+
+- **The Builder speaks Polish.** `pl.json` held no `agents` namespace at all - 0 of
+  563 keys - so the whole Builder rendered in English under `/pl`, the largest
+  single gap in the catalog. All 563 are translated as one namespace rather than
+  piecemeal, because a namespace is the unit a person reads and seventy Polish
+  strings among four hundred English ones reads worse than a consistently English
+  panel. The product's own nouns stay English and are inflected into Polish
+  grammar - agent, spec, capability, skill, embed, budget, run, prompt, provider,
+  token, vault, workspace, sandbox, MCP - so a Polish reader meets the same words
+  the docs, the API and an exported YAML use; `secret` follows the convention
+  already in the file and becomes `sekret`. Counts are ICU `plural` with Polish's
+  `few` and `many` arms rather than ternaries, with any noun the number agrees
+  with inside the plural, and every interpolation and `t.rich` tag is preserved.
+  (#643)
+
 ## [0.0.296] - 2026-08-27
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.296"
+version = "0.0.297"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.296"
+version = "0.0.297"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.296",
+  "version": "0.0.297",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.297. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.297 and adds the CHANGELOG entry.

Releases #643: `pl.json` had no `agents` namespace at all, so the entire
Builder rendered in English under `/pl` - 563 keys, the catalog's largest gap.
Translated as one namespace, because that is the unit a person reads. The
product's own nouns stay English and are inflected rather than replaced, so a
Polish reader meets the same vocabulary as the docs and an exported spec.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1180 was green on the merged head.