### PR TITLE
chore: cut 0.0.298

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.298] - 2026-08-27
+
+### Fixed
+
+- **Every agent run began with one query per bound collection.**
+  `_collection_names` runs inside `prepare`, so an agent bound to five knowledge
+  bases added five serial round trips to the front of every turn - before the
+  model was called, to read rows very likely already in the session's identity
+  map. `get_by_ids` reads them in one `WHERE id IN (...)`, and the resolution
+  iterates the returned map. The tenant check and the degradation it exists for -
+  a collection gone or foreign narrows the agent's reach rather than failing the
+  run - are unchanged: they read from a dict instead of awaiting a query each, and
+  an id with no row is simply absent from the map. (#954)
+- The finding names six id-resolving loops as one habit; this is the only one on a
+  per-run path. The other five are publish-time or admin-path, where N is small
+  and the cost is invisible, and their line references predate a since-moved file,
+  so they want re-locating rather than a blind change. (#954)
+
 ## [0.0.297] - 2026-08-27
 
 ### Added

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.297"
+version = "0.0.298"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.297"
+version = "0.0.298"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.297",
+  "version": "0.0.298",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.298. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.298 and adds the CHANGELOG entry.

Releases the hot loop of #954: `_collection_names` runs inside `prepare`, so
an agent bound to five collections paid five serial round trips at the front of
every turn. One `IN` query now, with the tenant check and the
narrow-rather-than-fail degradation reading from a dict instead of awaiting
each.

The other five loops the finding names are publish-time or admin-path and
stay open, with a note that their line references have moved.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1181 was green on the merged head.