### PR TITLE
chore: cut 0.0.299

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.299] - 2026-08-27
+
+### Fixed
+
+- **The BFF proxy read every request and response body fully into memory before
+  forwarding either.** `MAX_UPLOAD_SIZE_MB` is 50 and the knowledge-base path
+  allows it, so a 50 MB document was held whole in the Node process before one
+  byte reached the backend - ten concurrent uploads is 500 MB of heap, and the
+  container's memory limit decides what happens next. In the other direction a
+  workspace file, a document or a run export gave the browser nothing until the
+  last byte had reached the proxy, so time-to-first-byte was the whole transfer
+  and a large export read as a hung page. Both directions stream now, with
+  `duplex: "half"` for the outbound body as undici requires. Bytes stay bytes, so
+  a multipart boundary and a PDF survive the hop, a 204 still carries a null body,
+  and an error body still reaches the client verbatim. (#951)
+
 ## [0.0.298] - 2026-08-27
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.298"
+version = "0.0.299"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.298"
+version = "0.0.299"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.298",
+  "version": "0.0.299",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.299. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.299 and adds the CHANGELOG entry.

Releases #951: the proxy buffered whole bodies in both directions. A 50 MB
upload sat in the Node heap before a byte reached the backend, and a download
gave the browser nothing until the last byte arrived - so a large export read
as a hung page rather than a slow one. Both stream now, bytes unchanged.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1184 was green on the merged head.