### PR TITLE
chore: cut 0.0.300

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.300] - 2026-08-27
+
+### Fixed
+
+- **Six of a usage window's scalars were six serial round trips for numbers one
+  SELECT answers.** `StatsService.usage` ran fifteen aggregates one after another,
+  and six of them are scalars over one window with the same WHERE - the count and
+  cost of the window and of the window before it, the distinct-user count, and the
+  two latency percentiles. `window_aggregates` reads all five in one query and
+  `usage` calls it once per window, so six scalar round trips become two. The
+  percentiles need no `ended_at IS NOT NULL` of their own there: an unfinished
+  run's duration is null, and `percentile_cont` ignores a null exactly as the
+  standalone filter did. (#949)
+- The GROUP BY aggregates stay their own queries. Each groups differently, so they
+  cannot fold into one SELECT, and running them concurrently would need a
+  connection each - an `AsyncSession` is one connection and serialises. (#949)
+
 ## [0.0.299] - 2026-08-27
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.299"
+version = "0.0.300"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.299"
+version = "0.0.300"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.299",
+  "version": "0.0.300",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.300. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.300 and adds the CHANGELOG entry.

Releases the scalar half of #949: six of a usage window's aggregates share one
WHERE and were six serial round trips. One query per window now, so six become
two. The percentile filter is dropped deliberately - `percentile_cont` ignores
the null an unfinished run's duration already is.

The GROUP BY aggregates stay separate: each groups differently, and an
`AsyncSession` is one connection, so concurrency there is a larger change.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1187 was green on the merged head.