### PR TITLE
chore: cut 0.0.304

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.304] - 2026-08-27
+
+### Changed
+
+- **`/admin` lands on Users, and the Overview is gone.** The page held six figures
+  and three links, and every one of them was already on screen somewhere the reader
+  had been. The figures came from the same endpoint the `platform` dashboard widget
+  reads, on a dashboard that has been arrangeable since #213 - so the page was a
+  fixed second copy of a card the reader can already place where they want it, and
+  two copies of six numbers disagree the first time one is edited. The three links
+  were three of the five tabs the section's own strip renders directly above them,
+  so a third of the page was navigation to where the reader already was. `/admin`
+  is the section index and redirects, exactly as `/settings` redirects to Profile:
+  a bookmark still works, and the sidebar entry still lights up, because
+  `isRouteActive` matches the section rather than the page. (#922, #213)
+
 ## [0.0.303] - 2026-08-27
 
 ### Added

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.303"
+version = "0.0.304"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.303"
+version = "0.0.304"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.303",
+  "version": "0.0.304",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.304. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.304 and adds the CHANGELOG entry.

Releases #922: the `/admin` Overview held six figures already available as an
arrangeable dashboard card, and three links to three of the five tabs rendered
directly above them. Two copies of six numbers disagree the first time one is
edited. `/admin` is the section index now and redirects to Users, the way
`/settings` redirects to Profile, with a test holding the page-and-tab pairing
the way the settings one does.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1211 was green on the merged head.