### PR TITLE
chore: cut 0.0.306

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,26 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.306] - 2026-08-27
+
+### Changed
+
+- **Three sections of `docs/testing.md` described the generator's suite rather than
+  this one**, and each told a reader to do something that cannot work here: a
+  `tests/unit/` that does not exist, a `db_session` fixture that is called
+  something else, a `client` returning Starlette's `TestClient` where the rules
+  single out that it is not, and `auth_client`/`test_user` fixtures the conftest
+  explains the absence of. The worst was a sync test calling an async client -
+  which returns a coroutine and asserts on it, so it **passes while testing
+  nothing**. The page taught the two patterns the rules exist to prevent, and
+  nothing noticed because no code is generated from it. (#212)
+- The sections now carry the four layers and the actual tree, a new "anyio, not
+  pytest-asyncio" section because a missing `pytestmark` is the failure that looks
+  like a pass, the five fixtures that exist, and three examples each taken from a
+  test in the repository. Every name was checked against the conftests, `deps.py`
+  and the repository it cites. Running Tests, Frontend Tests and Test Database were
+  written for this repository and are left alone. (#212)
+
 ## [0.0.305] - 2026-08-27
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.305"
+version = "0.0.306"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.305"
+version = "0.0.306"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.305",
+  "version": "0.0.306",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.306. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.306 and adds the CHANGELOG entry.

Releases #212: three sections of the testing page were the generator's and had
never been written for this repository - a `tests/unit/` that does not exist,
fixtures under other names, and an example sync test calling an async client,
which passes while testing nothing. The page taught the two patterns the rules
exist to prevent, and nothing noticed because no code is generated from it.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1215 was green on the merged head.