### PR TITLE
fix(i18n): delete the admin tenant-list caption nothing reads

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -3038,7 +3038,6 @@
       "eachRowSaysWhat": "Each row says what was checked. Auto-refreshes every 30s.",
       "everyCheckPassed": "Every check passed",
       "everyStatusHereComes": "Every status here comes from a probe that ran when this page loaded. There is no uptime history: nothing records one, and a number that looks like one would be made up.",
-      "everyTenantDeploymentOnly": "Every tenant in the deployment - only the platform admin sees this list.",
       "failedFetchHealth": "Failed to fetch health",
       "failingServices": "Failing: {names}",
       "inspect": "Inspect",


### PR DESCRIPTION
`main` has been red on `lint-frontend` since #922 merged. #921 added
`pages.admin.everyTenantDeploymentOnly` for the organizations page, #922
deleted the Overview that read it, and each was green before the other landed -
so the key reached `main` with no reader and `check:i18n` failed the whole
`test-frontend` job on the next branch to merge `main` in.

That is what the guard is for: a key nothing reads is a key a translator
translates for nobody. Deleted rather than given a reader, because the caption
it carried belonged to a page that no longer exists.

Verified: `bun run check:i18n` clean (4251 messages), `make lint-frontend`
green. The stale `.next` cache in a local tree still names the two sessions
route files #564 replaced with a catch-all - `rm -rf frontend/.next` clears it,
and CI builds fresh.