### PR TITLE
chore: cut 0.0.308

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,30 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.308] - 2026-08-27
+
+### Fixed
+
+- **A resumed run's own prior spend was counted twice, so it was refused with
+  headroom to spare.** A resumed run keeps its row, so by the time it continues
+  `finish_run` has committed what it spent - and two things then read that same
+  number: the budget baseline sums `agent_runs.cost_usd`, and the ledger is
+  re-seeded with it. Both are right on their own. The seeding has to happen, or
+  finishing the continuation overwrites the cost with only what the continuation
+  cost and the per-run budget resets every time somebody approves something -
+  exactly the run a budget is for. The baseline has to sum the column, because that
+  is where a month's spend is. Together, an agent capped at $10 that spent $6 and
+  parked came back to `6 + 6 = 12` on its first model request and was refused with
+  $4 left, while the alert told its owner it had reached a cap it was at 60% of.
+  The organization-wide cap double-counted identically. The baseline now excludes
+  the run asking. (#15)
+- **Not only on resume**, and deliberately so: a baseline is what *other* runs have
+  already spent, and what this one spends is the ledger's. On a fresh run the row
+  is there too, at zero, so the exclusion changes nothing there and needs no
+  branch - one rule instead of a resume-shaped exception. It is off by default,
+  because a figure a person reads is a different question and a report that hid the
+  run somebody was looking at would be wrong. (#15)
+
 ## [0.0.307] - 2026-08-27
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.307"
+version = "0.0.308"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.307"
+version = "0.0.308"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.307",
+  "version": "0.0.308",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.308. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.308 and adds the CHANGELOG entry.

Releases #15: a resumed run's own committed cost was both summed into the
budget baseline and re-seeded into its ledger, so it counted twice. An agent
capped at $10 that had spent $6 and parked was refused on its first model
request with $4 of headroom, and its owner was told it had reached a cap it
was at 60% of. Both readings are correct alone; the baseline now excludes the
run asking.

Applied on every run rather than only a resume, because a baseline is what
*other* runs have spent - on a fresh run the row is there at zero, so it needs
no branch. Off by default for the reporting path, where hiding the run
somebody is looking at would be wrong.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1218 was green on the merged head.