### PR TITLE
chore: cut 0.0.312

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,42 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.312] - 2026-08-27
+
+### Added
+
+- **The admin user drawer answers the question it is opened for.** It showed four
+  facts - the id, the email already in the table, the display name and a join date -
+  and offered four buttons, three of them rendered identically. **Where this person
+  has access was entirely absent**, though it is the answer the drawer exists to
+  give: an account with no membership anywhere is a different decision from one that
+  owns two organizations. It now carries the organizations and the role in each,
+  linked; when they were last here, with `last_seen_at` **null rather than blank**
+  for an account that has never signed in, because *created and never used* and
+  *dormant since March* are different decisions; and how many sessions are open with
+  when the newest began. All from one route rather than fields on the user, because
+  it is a view over three tables that a user is read in a dozen places without.
+  (#942)
+- **The actions are weighted by consequence.** All four used to be the same outline
+  button in one row - the two most consequential looking exactly like the least, and
+  two of them firing on a single click. Impersonate is the everyday one and stays
+  plain; suspend is confirmed, saying they are signed out immediately; promote and
+  demote are confirmed, naming what it grants - every permission in every
+  organization on the deployment, including ones they are not a member of; delete
+  stays last and apart. **Reactivate is deliberately not confirmed**: it is the
+  recoverable direction, and a question about undoing a refusal is a question about
+  nothing. (#942)
+- The conversations are links now - opening one is the thing an admin would do with
+  that list and the one thing it did not offer - and the two new blocks keep the
+  three states the conversations list already got right, with the failures saying
+  *different* sentences: a 502 on the memberships and an account in no organization
+  are not the same thing. Revoking a session is deliberately out of scope: it needs
+  a route with its own audit entry, which is a different thread. (#942, #941, #943)
+- The last-seen figure does not yet hold its own claim and is filed: both figures
+  are read with `active_only=True`, so a user who has signed out has no active
+  session rows and reads as "Never signed in" - the very case the field exists to
+  separate from *created and never used*. (#1256)
+
 ## [0.0.311] - 2026-08-27
 
 ### Added

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.311"
+version = "0.0.312"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.311"
+version = "0.0.312"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.311",
+  "version": "0.0.312",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.312. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.312 and adds the CHANGELOG entry.

Releases #942: on the one screen where a deployment admin decides something
about a person, the drawer answered almost nothing the decision needs - and
where that person has access was missing entirely. It carries the
memberships, the last-seen date (null rather than blank for an account never
used, because that is a different decision), and the open sessions. The four
actions are weighted by consequence rather than rendered identically, with
reactivate deliberately unconfirmed as the recoverable direction.

Revoking a session needs its own audited route and stays out.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1239 was green on the merged head.