### PR TITLE
fix(concurrency): order the user-row locks a self-delete takes

### DIFF
--- a/backend/app/repositories/user.py
+++ b/backend/app/repositories/user.py
@@ -22,6 +22,22 @@ async def get_by_id_for_update(db: AsyncSession, user_id: UUID) -> User | None:
     return result.scalar_one_or_none()
 
 
+async def get_by_id_for_no_key_update(db: AsyncSession, user_id: UUID) -> User | None:
+    """Fetch a user row and acquire a SELECT FOR NO KEY UPDATE lock.
+
+    Weaker than FOR UPDATE: it serialises against another FOR UPDATE (so two
+    ordered self-deletes still queue on a shared row) but does *not* conflict
+    with the FOR KEY SHARE an unrelated foreign-key write takes on this row - a
+    channel identity relinked to this user, say - so locking a delete's heirs
+    this way does not deadlock against those writes (#1134). `key_share=True`
+    is SQLAlchemy's spelling of FOR NO KEY UPDATE.
+    """
+    result = await db.execute(
+        select(User).where(User.id == user_id).with_for_update(key_share=True)
+    )
+    return result.scalar_one_or_none()
+
+
 async def get_by_email(db: AsyncSession, email: str) -> User | None:
     """Get user by email."""
     result = await db.execute(select(User).where(User.email == email))

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -365,20 +365,46 @@ class UserService:
         return str(full_path) if full_path is not None else None
 
     async def delete(self, user_id: UUID) -> User:
-        # FOR UPDATE before the reconcile: releasing the rows that would block the
-        # delete and then deleting is check-then-act, so a private secret or
-        # personal org inserted concurrently (both take FOR KEY SHARE on this row)
-        # would land a fresh CHECK/RESTRICT blocker between the reconcile and the
-        # DELETE and 500 it. The lock makes that insert wait, so the reconcile
-        # sees every child there is - a fresh read under READ COMMITTED (#1115).
-        user = await user_repo.get_by_id_for_update(self.db, user_id)
-        if not user:
-            raise NotFoundError(
-                message="User not found",
-                details={"user_id": user_id},
-            )
+        user = await self._lock_for_delete(user_id)
         await self._release_owned_rows(user_id)
         await user_repo.delete(self.db, user_id)
+        return user
+
+    async def _lock_for_delete(self, user_id: UUID) -> User:
+        """Lock this user's row and every heir's, in ascending id order (#1134).
+
+        The self lock serves #1115: held before the reconcile's reads, it makes a
+        private secret or personal org inserted concurrently (both take FOR KEY
+        SHARE on this row) wait, so the reconcile sees every child there is - a
+        fresh read under READ COMMITTED - rather than 500ing on a CHECK/RESTRICT
+        blocker that landed between the reconcile and the DELETE.
+
+        The heirs are locked here too, and in a stable order with self, because
+        `reassign_creator` hands a solely-created shared org to an heir and so
+        takes FOR KEY SHARE on the heir's user row through the FK. Two users who
+        co-own each other's shared orgs self-deleting at once would each hold FOR
+        UPDATE on their own row and then wait for the other's - a cycle Postgres
+        breaks by aborting one with a 40P01 500. Taking every user-row lock in
+        ascending id order makes both requests queue on the lower id first, so
+        the cycle cannot form (#1134).
+        """
+        heir_ids: set[UUID] = set()
+        for org in await organization_repo.list_created_by(self.db, user_id):
+            if org.is_personal:
+                continue
+            heir = await member_repo.other_owner_id(
+                self.db, organization_id=org.id, exclude_user_id=user_id
+            )
+            if heir is not None:
+                heir_ids.add(heir)
+
+        user: User | None = None
+        for uid in sorted({user_id, *heir_ids}):
+            locked = await user_repo.get_by_id_for_update(self.db, uid)
+            if uid == user_id:
+                user = locked
+        if user is None:
+            raise NotFoundError(message="User not found", details={"user_id": user_id})
         return user
 
     async def _release_owned_rows(self, user_id: UUID) -> None:

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -382,11 +382,18 @@ class UserService:
         The heirs are locked here too, and in a stable order with self, because
         `reassign_creator` hands a solely-created shared org to an heir and so
         takes FOR KEY SHARE on the heir's user row through the FK. Two users who
-        co-own each other's shared orgs self-deleting at once would each hold FOR
-        UPDATE on their own row and then wait for the other's - a cycle Postgres
+        co-own each other's shared orgs self-deleting at once would each hold a
+        lock on their own row and then wait for the other's - a cycle Postgres
         breaks by aborting one with a 40P01 500. Taking every user-row lock in
         ascending id order makes both requests queue on the lower id first, so
         the cycle cannot form (#1134).
+
+        Self is FOR UPDATE (for #1115); the heirs are FOR NO KEY UPDATE, one step
+        weaker. It still conflicts with the other self-delete's FOR UPDATE, so the
+        ordering holds, but it does *not* conflict with the FOR KEY SHARE an
+        unrelated foreign-key write takes on an heir - a channel identity relinked
+        to them, say - which FOR UPDATE would have, turning that write into a fresh
+        cross-table deadlock this fix must not introduce.
         """
         heir_ids: set[UUID] = set()
         for org in await organization_repo.list_created_by(self.db, user_id):
@@ -400,9 +407,10 @@ class UserService:
 
         user: User | None = None
         for uid in sorted({user_id, *heir_ids}):
-            locked = await user_repo.get_by_id_for_update(self.db, uid)
             if uid == user_id:
-                user = locked
+                user = await user_repo.get_by_id_for_update(self.db, uid)
+            else:
+                await user_repo.get_by_id_for_no_key_update(self.db, uid)
         if user is None:
             raise NotFoundError(message="User not found", details={"user_id": user_id})
         return user

--- a/backend/tests/integration/test_deletion_reconciliation.py
+++ b/backend/tests/integration/test_deletion_reconciliation.py
@@ -12,14 +12,17 @@ to neighbouring rows when one is deleted, which a mock cannot show.
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy import select, text
+from sqlalchemy.exc import DBAPIError, OperationalError
 from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
 
 from app.core.config import settings as app_settings
+from app.core.exceptions import BadRequestError
 from app.db.models.knowledge_base import KBScope, KnowledgeBase
 from app.db.models.organization import Organization, OrganizationMember
 from app.db.models.organization_secret import OrganizationSecret
@@ -141,8 +144,6 @@ class TestDeletingAUser:
     async def test_the_sole_owner_of_a_shared_org_is_refused_not_500ed(self, db):
         """A shared org with no other owner has nobody to hand the creator FK to,
         so the delete is a clean refusal rather than a foreign-key 500."""
-        from app.core.exceptions import BadRequestError
-
         owner = _user()
         db.add(owner)
         await db.flush()
@@ -253,3 +254,57 @@ class TestDeletingAnOrg:
             surviving = await s.get(KnowledgeBase, kb_id)
             assert surviving is not None
             assert surviving.organization_id is None
+
+
+class TestConcurrentSelfDeletes:
+    async def test_mutual_co_owners_deleting_at_once_never_deadlock(
+        self, engine: AsyncEngine
+    ) -> None:
+        """Two users who each solely own a shared org the other co-owns, deleting
+        their own accounts at the same moment.
+
+        `delete` reassigns each solely-created shared org to its heir, taking FOR
+        KEY SHARE on the heir's user row through the FK while holding FOR UPDATE on
+        its own. Before #1134 the two requests took those locks in opposite orders
+        - each holding its own row and waiting for the other's - so Postgres broke
+        the cycle by aborting one with a 40P01, surfacing as a 500. Locking every
+        user row in ascending id order serialises the two on the lower id, so one
+        completes and the other, now the sole owner of its org, gets a clean domain
+        refusal - never a DeadlockDetected. Integration because the deadlock is a
+        property of two transactions the database arbitrates, which a mock cannot
+        show.
+        """
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+
+        async with factory() as setup:
+            a = _user()
+            b = _user()
+            setup.add_all([a, b])
+            await setup.flush()
+            org_a = await _org(setup, a)
+            await _member(setup, org_a.id, b.id, "owner")
+            org_b = await _org(setup, b)
+            await _member(setup, org_b.id, a.id, "owner")
+            await setup.commit()
+            a_id, b_id = a.id, b.id
+
+        async def run_delete(user_id: uuid.UUID) -> object:
+            async with factory() as session:
+                user = await UserService(session).delete(user_id)
+                await session.commit()
+                return user
+
+        results = await asyncio.gather(run_delete(a_id), run_delete(b_id), return_exceptions=True)
+
+        for result in results:
+            assert not isinstance(result, (OperationalError, DBAPIError)), result
+
+        deleted = [r for r in results if isinstance(r, User)]
+        refused = [r for r in results if isinstance(r, BadRequestError)]
+        assert len(deleted) == 1
+        assert len(refused) == 1
+
+        async with factory() as check:
+            assert await check.get(User, deleted[0].id) is None
+            survivor = a_id if deleted[0].id == b_id else b_id
+            assert await check.get(User, survivor) is not None

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -288,8 +288,10 @@ class TestUserServicePostgresql:
         """Test deleting user."""
         with (
             patch("app.services.user.user_repo") as mock_repo,
+            patch("app.services.user.organization_repo") as mock_org_repo,
             patch.object(user_service, "_release_owned_rows", new=AsyncMock()),
         ):
+            mock_org_repo.list_created_by = AsyncMock(return_value=[])
             mock_repo.get_by_id_for_update = AsyncMock(return_value=mock_user)
             mock_repo.delete = AsyncMock(return_value=mock_user)
 
@@ -300,7 +302,11 @@ class TestUserServicePostgresql:
     @pytest.mark.anyio
     async def test_delete_not_found(self, user_service: UserService):
         """A missing user is refused up front, before any teardown is attempted."""
-        with patch("app.services.user.user_repo") as mock_repo:
+        with (
+            patch("app.services.user.user_repo") as mock_repo,
+            patch("app.services.user.organization_repo") as mock_org_repo,
+        ):
+            mock_org_repo.list_created_by = AsyncMock(return_value=[])
             mock_repo.get_by_id_for_update = AsyncMock(return_value=None)
 
             with pytest.raises(NotFoundError):
@@ -385,8 +391,10 @@ class TestUserServicePostgresql:
     ):
         with (
             patch("app.services.user.user_repo") as mock_repo,
+            patch("app.services.user.organization_repo") as mock_org_repo,
             patch.object(user_service, "_release_owned_rows", new=AsyncMock()),
         ):
+            mock_org_repo.list_created_by = AsyncMock(return_value=[])
             mock_repo.get_by_id_for_update = AsyncMock(return_value=mock_user)
             mock_repo.delete = AsyncMock(return_value=mock_user)
 


### PR DESCRIPTION
## Summary

Two users who co-own each other's shared organizations, deleting their own
accounts at the same moment, could deadlock. `UserService.delete` took
`FOR UPDATE` on its own user row (the #1115 reconcile lock) and then, reassigning
a solely-created shared org to an heir, took `FOR KEY SHARE` on the heir's user
row through the FK. Each request held its own row and waited for the other's, so
Postgres broke the cycle by aborting one with `40P01` — a 500 rather than a
result.

## Changed

- New `UserService._lock_for_delete`: discover the heirs a delete will reassign
  to (a lock-free read, used only to decide lock order), then lock every user row
  the delete needs — **self and every heir — in ascending id order**, before the
  reconcile. Two concurrent self-deletes now queue on the lower id first, so the
  cycle cannot form: one completes and the other, now the sole owner of its org,
  gets the existing clean domain refusal.
- The self `FOR UPDATE` still precedes the reconcile's authoritative reads and is
  held through the `DELETE`, so the #1115 guarantee (a concurrent child insert
  waits, the reconcile sees every child) is unchanged.

## Testing

- `backend/tests/test_services.py`: the three delete unit tests stub
  `organization_repo.list_created_by` (`[]`), the read `_lock_for_delete` now
  makes; assertions are unchanged (result / `delete` awaited / `NotFoundError`).
- `backend/tests/integration/test_deletion_reconciliation.py`:
  `TestConcurrentSelfDeletes` races two mutual co-owners' self-deletes with
  `asyncio.gather` and asserts exactly one resolves, one is refused, and neither
  raises `DeadlockDetected`. It fails against the pre-fix code (the two reassigns
  overlap and Postgres aborts one) and passes with the ordering.
- Reviewed adversarially (concurrency correctness, #1115 regression, test
  determinism): confirmed the ordering removes the only cross-user-row lock
  inversion in the path.

## Notes for reviewers

- A membership change committed *between* the lock-free discovery read and the
  reconcile's re-read could route a reassign to a heir that was not pre-locked —
  a window strictly narrower than the bug this closes (it needs a third
  concurrent mutation) and still bounded by deadlock detection, not a hang.
- `delete_non_admins` still pre-locks the candidate before `delete` (for the
  #1139 admin recheck); its sole caller is the offline `seed --clear` command,
  which never races user self-deletes, so the ordering invariant is not needed
  there.

Closes #1134
