### PR TITLE
fix(rag): defer org-teardown side effects until after the commit

### DIFF
--- a/backend/app/services/organization.py
+++ b/backend/app/services/organization.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.background import spawn_after_commit
 from app.core.config import settings
 from app.core.exceptions import (
     AlreadyExistsError,
@@ -326,49 +327,72 @@ class OrganizationService:
         makes that insert wait, so the list sees every collection there is - a
         fresh read under READ COMMITTED (#1115).
 
-        Each collection's documents (rows and stored uploads) go before its
-        identifiers do: `rag_documents` authorization keys on `collection_name`,
-        so a row left behind is readable by a later collection permitted the same
-        name (#1116). Deleting by `knowledge_base_id` scopes this to the KB being
-        torn down; a doc row that shares the name but carries no KB link, and the
-        vectors that stay in a shared table kept below, are #913 residuals this
-        cannot reach without a tenant column to filter on.
+        Each collection's document rows go before its identifiers do:
+        `rag_documents` authorization keys on `collection_name`, so a row left
+        behind is readable by a later collection permitted the same name (#1116).
+        Deleting by `knowledge_base_id` scopes this to the KB being torn down; a
+        doc row that shares the name but carries no KB link, and the vectors that
+        stay in a shared table kept below, are #913 residuals this cannot reach
+        without a tenant column to filter on.
 
-        The physical vector table is dropped last, and only when no other
-        knowledge base still backs onto it - `collection_name` is not
-        tenant-unique (#913), so two organizations can share one table and
-        dropping it for one would destroy the other's vectors. Dropping last means
-        a failure among the relational deletes aborts before any table is gone.
-        The drops and the file unlinks are the residual this does not close: they
-        commit / unlink outside the request transaction, so if the final request
-        commit fails after them, the rows come back pointing at vectors and
-        uploads already gone. A retry-safe post-commit cleanup would close that
-        window (#1137).
+        The external side effects - dropping each physical vector table and
+        unlinking the stored uploads - are deferred to after the request commits,
+        via `spawn_after_commit`. They run only if the relational teardown
+        committed, so a final commit that fails rolls back the org, KB and doc
+        rows and leaves none of them pointing at a table or a file already gone
+        (#1137). A table is dropped only when no other knowledge base still backs
+        onto it: `collection_name` is not tenant-unique (#913), so two
+        organizations can share one table and dropping it for one would destroy
+        the other's vectors. That reference check reads under READ COMMITTED
+        against the org lock, not the collection name, so a same-named table a
+        second org creates between the check and the drop is a TOCTOU residual
+        (#913) this does not close either.
         """
         await organization_repo.get_by_id_for_update(self.db, org.id)
         collections: list[str] = []
+        storage_paths: list[str] = []
         for kb in await knowledge_base_repo.list_org_scoped(self.db, org.id):
-            await self._purge_documents(kb.id)
+            storage_paths.extend(await rag_document_repo.delete_by_knowledge_base(self.db, kb.id))
             collections.append(kb.collection_name)
             await knowledge_base_repo.delete(self.db, kb.id)
         await organization_repo.delete(self.db, org)
 
+        to_drop: list[str] = []
         if self._vector_store is not None:
             for collection in dict.fromkeys(collections):
-                if await self._collection_still_referenced(collection):
-                    continue
-                # Best-effort, and only against the database: a zero-document
-                # collection has no table yet, which is a `SQLAlchemyError`, not a
-                # reason to abandon the deletion. Mirrors the `drop_collection` route.
-                with contextlib.suppress(SQLAlchemyError):
-                    await self._vector_store.delete_collection(collection)
+                if not await self._collection_still_referenced(collection):
+                    to_drop.append(collection)
 
-    async def _purge_documents(self, kb_id: UUID) -> None:
-        """Delete a knowledge base's tracked documents and their stored files."""
+        if storage_paths or to_drop:
+            spawn_after_commit(
+                self.db,
+                self._clean_up_external_state(storage_paths, to_drop),
+                name="org_purge_cleanup",
+            )
+
+    async def _clean_up_external_state(
+        self, storage_paths: list[str], collections: list[str]
+    ) -> None:
+        """Unlink stored uploads and drop vector tables, after the purge commits.
+
+        Deferred with `spawn_after_commit`, so it runs only once the relational
+        teardown has committed: a commit that fails rolls the rows back and this
+        never runs, leaving nothing pointing at a dropped table or a missing file
+        (#1137). It touches no request-session state - only file storage and the
+        vector store's own engine - because the session that scheduled it is gone
+        by the time it runs.
+        """
         storage = get_file_storage()
-        for storage_path in await rag_document_repo.delete_by_knowledge_base(self.db, kb_id):
+        for storage_path in storage_paths:
             with contextlib.suppress(Exception):
                 await storage.delete(storage_path)
+        if self._vector_store is not None:
+            for collection in collections:
+                # Best-effort, and only against the database: a zero-document
+                # collection has no table yet, which is a `SQLAlchemyError`, not a
+                # reason to abandon the cleanup. Mirrors the `drop_collection` route.
+                with contextlib.suppress(SQLAlchemyError):
+                    await self._vector_store.delete_collection(collection)
 
     async def _collection_still_referenced(self, collection_name: str) -> bool:
         """Whether another knowledge base still backs onto this collection's table.

--- a/backend/app/services/organization.py
+++ b/backend/app/services/organization.py
@@ -53,19 +53,32 @@ async def _purge_external_state(
     dropped table or a missing file (#1137). A module function taking primitives
     and the process-lived store - not a method - so the queued coroutine holds
     nothing belonging to the request session, which is gone by the time it runs.
+
+    Because it runs after the commit that frees the collection name, a second
+    org can claim that name and back a table onto it before this drop fires -
+    `CollectionAccessService.claim` checks only `knowledge_bases` rows. So each
+    table is re-checked here, in its own session, and dropped only when no base
+    references the name again; deferral would otherwise widen the #913 TOCTOU
+    from a sub-request window to the whole gap before this runs, and drop the new
+    tenant's table.
     """
+    from app.db.session import get_db_context
+
     storage = get_file_storage()
     for storage_path in storage_paths:
         with contextlib.suppress(Exception):
             await storage.delete(storage_path)
-    if vector_store is not None:
-        for collection in collections:
-            # Best-effort, and only against the database: `delete_collection`
-            # issues `DROP TABLE IF EXISTS`, so a collection whose table was
-            # never created is not an error, and any other database failure is
-            # not a reason to abandon the rest of the cleanup.
-            with contextlib.suppress(SQLAlchemyError):
-                await vector_store.delete_collection(collection)
+    if vector_store is not None and collections:
+        async with get_db_context() as db:
+            for collection in collections:
+                if await knowledge_base_repo.list_by_collection_name(db, collection):
+                    continue
+                # Best-effort, and only against the database: `delete_collection`
+                # issues `DROP TABLE IF EXISTS`, so a collection whose table was
+                # never created is not an error, and any other database failure is
+                # not a reason to abandon the rest of the cleanup.
+                with contextlib.suppress(SQLAlchemyError):
+                    await vector_store.delete_collection(collection)
 
 
 def _org_read(org: Organization, member_count: int, role: str) -> OrganizationRead:

--- a/backend/app/services/organization.py
+++ b/backend/app/services/organization.py
@@ -40,6 +40,34 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+async def _purge_external_state(
+    storage_paths: list[str],
+    collections: list[str],
+    vector_store: "BaseVectorStore | None",
+) -> None:
+    """Unlink stored uploads and drop vector tables, after an org purge commits.
+
+    Deferred with `spawn_after_commit` (see `OrganizationService.purge`), so it
+    runs only once the relational teardown has committed: a commit that fails
+    rolls the rows back and this never runs, leaving nothing pointing at a
+    dropped table or a missing file (#1137). A module function taking primitives
+    and the process-lived store - not a method - so the queued coroutine holds
+    nothing belonging to the request session, which is gone by the time it runs.
+    """
+    storage = get_file_storage()
+    for storage_path in storage_paths:
+        with contextlib.suppress(Exception):
+            await storage.delete(storage_path)
+    if vector_store is not None:
+        for collection in collections:
+            # Best-effort, and only against the database: `delete_collection`
+            # issues `DROP TABLE IF EXISTS`, so a collection whose table was
+            # never created is not an error, and any other database failure is
+            # not a reason to abandon the rest of the cleanup.
+            with contextlib.suppress(SQLAlchemyError):
+                await vector_store.delete_collection(collection)
+
+
 def _org_read(org: Organization, member_count: int, role: str) -> OrganizationRead:
     """One organization as a member of it sees it.
 
@@ -366,33 +394,9 @@ class OrganizationService:
         if storage_paths or to_drop:
             spawn_after_commit(
                 self.db,
-                self._clean_up_external_state(storage_paths, to_drop),
+                _purge_external_state(storage_paths, to_drop, self._vector_store),
                 name="org_purge_cleanup",
             )
-
-    async def _clean_up_external_state(
-        self, storage_paths: list[str], collections: list[str]
-    ) -> None:
-        """Unlink stored uploads and drop vector tables, after the purge commits.
-
-        Deferred with `spawn_after_commit`, so it runs only once the relational
-        teardown has committed: a commit that fails rolls the rows back and this
-        never runs, leaving nothing pointing at a dropped table or a missing file
-        (#1137). It touches no request-session state - only file storage and the
-        vector store's own engine - because the session that scheduled it is gone
-        by the time it runs.
-        """
-        storage = get_file_storage()
-        for storage_path in storage_paths:
-            with contextlib.suppress(Exception):
-                await storage.delete(storage_path)
-        if self._vector_store is not None:
-            for collection in collections:
-                # Best-effort, and only against the database: a zero-document
-                # collection has no table yet, which is a `SQLAlchemyError`, not a
-                # reason to abandon the cleanup. Mirrors the `drop_collection` route.
-                with contextlib.suppress(SQLAlchemyError):
-                    await self._vector_store.delete_collection(collection)
 
     async def _collection_still_referenced(self, collection_name: str) -> bool:
         """Whether another knowledge base still backs onto this collection's table.

--- a/backend/tests/integration/test_deletion_reconciliation.py
+++ b/backend/tests/integration/test_deletion_reconciliation.py
@@ -24,7 +24,9 @@ from app.core.config import settings as app_settings
 from app.db.models.knowledge_base import KBScope, KnowledgeBase
 from app.db.models.organization import Organization, OrganizationMember
 from app.db.models.organization_secret import OrganizationSecret
+from app.db.models.rag_document import RAGDocument
 from app.db.models.user import User
+from app.services.file_storage import get_file_storage
 from app.services.organization import OrganizationService
 from app.services.rag.vectorstore import PgVectorStore
 from app.services.user import UserService
@@ -70,6 +72,24 @@ def _org_collection(org_id: uuid.UUID, collection_name: str) -> KnowledgeBase:
         embedding_dim=1536,
         organization_id=org_id,
         visibility="org",
+    )
+
+
+def _org_document(
+    collection_name: str, kb_id: uuid.UUID, org_id: uuid.UUID, storage_path: str
+) -> RAGDocument:
+    return RAGDocument(
+        id=uuid.uuid4(),
+        collection_name=collection_name,
+        filename="doc.txt",
+        filesize=7,
+        filetype="txt",
+        storage_path=storage_path,
+        status="completed",
+        chunk_count=0,
+        ingestion_config={},
+        knowledge_base_id=kb_id,
+        organization_id=org_id,
     )
 
 
@@ -262,6 +282,77 @@ class TestDeletingAnOrg:
                 await s.execute(text("SELECT to_regclass(:t)"), {"t": table})
             ).scalar() is not None
             assert await s.get(Organization, org_id) is not None
+
+    async def test_a_committed_teardown_unlinks_the_stored_files(self, engine: AsyncEngine) -> None:
+        """A document row goes in the transaction; its stored upload is unlinked
+        by the post-commit cleanup once the teardown commits (#1137)."""
+        store = PgVectorStore(
+            settings=app_settings.rag,
+            embedding_service=MagicMock(),
+            resolver=MagicMock(),
+            engine=engine,
+        )
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        storage = get_file_storage()
+        stored_path = await storage.save("teardown-user", "doc.txt", b"payload")
+        collection = f"kbnine{uuid.uuid4().hex[:12]}"
+        async with factory() as s:
+            user = _user()
+            s.add(user)
+            await s.flush()
+            org = await _org(s, user)
+            kb = _org_collection(org.id, collection)
+            s.add(kb)
+            await s.flush()
+            s.add(_org_document(collection, kb.id, org.id, stored_path))
+            await s.commit()
+            org_id = org.id
+
+        assert storage.get_full_path(stored_path) is not None
+
+        async with factory() as s:
+            org = await s.get(Organization, org_id)
+            await OrganizationService(s, vector_store=store).purge(org)
+            await s.commit()
+            start_deferred(s)
+        await drain()
+
+        assert storage.get_full_path(stored_path) is None
+
+    async def test_a_rolled_back_teardown_keeps_the_stored_files(self, engine: AsyncEngine) -> None:
+        """The file unlink defers past the commit too, so a teardown that rolls
+        back leaves the stored upload in place (#1137)."""
+        store = PgVectorStore(
+            settings=app_settings.rag,
+            embedding_service=MagicMock(),
+            resolver=MagicMock(),
+            engine=engine,
+        )
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        storage = get_file_storage()
+        stored_path = await storage.save("teardown-user", "doc.txt", b"payload")
+        collection = f"kbnine{uuid.uuid4().hex[:12]}"
+        async with factory() as s:
+            user = _user()
+            s.add(user)
+            await s.flush()
+            org = await _org(s, user)
+            kb = _org_collection(org.id, collection)
+            s.add(kb)
+            await s.flush()
+            s.add(_org_document(collection, kb.id, org.id, stored_path))
+            await s.commit()
+            org_id = org.id
+
+        async with factory() as s:
+            org = await s.get(Organization, org_id)
+            await OrganizationService(s, vector_store=store).purge(org)
+            await s.rollback()
+            discard_deferred(s)
+        await drain()
+
+        assert storage.get_full_path(stored_path) is not None
+        await storage.delete(stored_path)
 
     async def test_a_personal_collection_survives_its_orgs_deletion(
         self, engine: AsyncEngine

--- a/backend/tests/integration/test_deletion_reconciliation.py
+++ b/backend/tests/integration/test_deletion_reconciliation.py
@@ -354,6 +354,51 @@ class TestDeletingAnOrg:
         assert storage.get_full_path(stored_path) is not None
         await storage.delete(stored_path)
 
+    async def test_a_recreated_collection_survives_the_deferred_drop(
+        self, engine: AsyncEngine
+    ) -> None:
+        """The drop runs after the commit that frees the collection name, so a
+        second org can reclaim it before the cleanup fires; the deferred cleanup
+        re-checks references and leaves the new tenant's table in place (#1137)."""
+        store = PgVectorStore(
+            settings=app_settings.rag,
+            embedding_service=MagicMock(),
+            resolver=MagicMock(),
+            engine=engine,
+        )
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        collection = f"kbnine{uuid.uuid4().hex[:12]}"
+        table = store._table(collection)
+        async with factory() as s:
+            user = _user()
+            s.add(user)
+            await s.flush()
+            org = await _org(s, user)
+            s.add(_org_collection(org.id, collection))
+            await s.execute(text(f"CREATE TABLE {table} (id int)"))
+            await s.commit()
+            org_id = org.id
+
+        async with factory() as s:
+            org = await s.get(Organization, org_id)
+            await OrganizationService(s, vector_store=store).purge(org)
+            await s.commit()
+            # A second org claims the freed name before the deferred cleanup runs.
+            async with factory() as claimant:
+                other = _user()
+                claimant.add(other)
+                await claimant.flush()
+                other_org = await _org(claimant, other)
+                claimant.add(_org_collection(other_org.id, collection))
+                await claimant.commit()
+            start_deferred(s)
+        await drain()
+
+        async with factory() as s:
+            assert (
+                await s.execute(text("SELECT to_regclass(:t)"), {"t": table})
+            ).scalar() is not None
+
     async def test_a_personal_collection_survives_its_orgs_deletion(
         self, engine: AsyncEngine
     ) -> None:

--- a/backend/tests/integration/test_deletion_reconciliation.py
+++ b/backend/tests/integration/test_deletion_reconciliation.py
@@ -19,6 +19,7 @@ import pytest
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
 
+from app.core.background import discard_deferred, drain, start_deferred
 from app.core.config import settings as app_settings
 from app.db.models.knowledge_base import KBScope, KnowledgeBase
 from app.db.models.organization import Organization, OrganizationMember
@@ -203,6 +204,11 @@ class TestDeletingAnOrg:
             org = await s.get(Organization, org_id)
             await OrganizationService(s, vector_store=store).purge(org)
             await s.commit()
+            # The table drop and file unlinks defer to after commit (#1137); a
+            # real request runs this from `_managed_session`, a raw session runs
+            # it here.
+            start_deferred(s)
+        await drain()
 
         async with factory() as s:
             remaining = await s.execute(
@@ -211,6 +217,51 @@ class TestDeletingAnOrg:
             assert remaining.scalars().all() == []
             assert (await s.execute(text("SELECT to_regclass(:t)"), {"t": table})).scalar() is None
             assert await s.get(Organization, org_id) is None
+
+    async def test_a_failed_teardown_commit_leaves_the_vector_table(
+        self, engine: AsyncEngine
+    ) -> None:
+        """The drop and the unlinks defer past the request commit (#1137).
+
+        Before this, `purge` dropped the table and unlinked files inside the
+        request, so a final commit that rolled back left the org, KB and doc rows
+        alive but their vectors and uploads already gone. Deferring the external
+        side effects means a rolled-back teardown discards them: the table, the
+        rows and the org all survive together.
+        """
+        store = PgVectorStore(
+            settings=app_settings.rag,
+            embedding_service=MagicMock(),
+            resolver=MagicMock(),
+            engine=engine,
+        )
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        collection = f"kbnine{uuid.uuid4().hex[:12]}"
+        table = store._table(collection)
+        async with factory() as s:
+            user = _user()
+            s.add(user)
+            await s.flush()
+            org = await _org(s, user)
+            s.add(_org_collection(org.id, collection))
+            await s.execute(text(f"CREATE TABLE {table} (id int)"))
+            await s.commit()
+            org_id = org.id
+
+        async with factory() as s:
+            org = await s.get(Organization, org_id)
+            await OrganizationService(s, vector_store=store).purge(org)
+            # The request's final commit fails: mirror `_managed_session`'s
+            # failure path - roll back, then discard the deferred cleanup unrun.
+            await s.rollback()
+            discard_deferred(s)
+        await drain()
+
+        async with factory() as s:
+            assert (
+                await s.execute(text("SELECT to_regclass(:t)"), {"t": table})
+            ).scalar() is not None
+            assert await s.get(Organization, org_id) is not None
 
     async def test_a_personal_collection_survives_its_orgs_deletion(
         self, engine: AsyncEngine


### PR DESCRIPTION
## Summary

`OrganizationService.purge` dropped each org-scoped collection's vector table
and unlinked its stored uploads **inside the request**, before the session
committed the relational deletes. If that final commit failed, the org, KB and
document rows rolled back and came back pointing at vectors and files already
gone — residual 1 of #1116's review (#1137).

## Changed

- The relational deletes still run in the request transaction; the storage paths
  and the collections whose tables are no longer referenced are collected, and the
  DROP TABLE + file unlinks are handed to `spawn_after_commit`. They run only once
  the session has committed, so a commit that fails discards them unrun and leaves
  nothing dangling. The #1116 ordering (doc rows before identifiers, table dropped
  only when unreferenced) is unchanged.
- The cleanup is a module function taking the paths, the collections and the
  vector store — not a method — so the queued coroutine holds primitives and the
  process-lived store, never the request session (which is gone by the time it
  runs), per `spawn_after_commit`'s contract.

## Scope

Only residual 1 lands here. Residuals 2–4 of #1137 (a NULL-`knowledge_base_id`
doc sharing the collection name, a deleted tenant's vectors kept in a shared
table, and the TOCTOU on the reference check) all depend on tenant-unique
collection names — **#913, still open** — and are recorded on the `purge`
docstring, out of scope for this PR.

## Testing

- `test_it_drops_org_scoped_collections_and_their_vector_tables` now fires the
  deferred cleanup exactly as `_managed_session` does (`start_deferred` + `drain`)
  and still sees the table gone.
- New `test_a_failed_teardown_commit_leaves_the_vector_table`: a rolled-back
  teardown discards the cleanup, so the table, rows and org survive together —
  fails against the pre-fix in-request drop, which committed on the store's own
  session regardless of the request rollback.
- New `test_a_committed_teardown_unlinks_the_stored_files` /
  `test_a_rolled_back_teardown_keeps_the_stored_files` cover the file-unlink half:
  a committed purge removes the stored upload after commit, a rolled-back one
  leaves it in place.
- Reviewed adversarially (deferral correctness, #1116 ordering, the no-store
  user-delete path, the captured-`self` footgun).

Closes #1137
