### PR TITLE
fix(chat): cancel in-flight reads before a mutation invalidates them

### DIFF
--- a/frontend/src/hooks/use-sharing.test.tsx
+++ b/frontend/src/hooks/use-sharing.test.tsx
@@ -135,6 +135,33 @@ describe("useSharing", () => {
     expect(toast.error).toHaveBeenCalledTimes(2);
   });
 
+  it("cancels the in-flight read before invalidating, so a stale refetch cannot win (#154)", async () => {
+    // invalidateQueries dedupes its refetch onto a fetch already running; a read
+    // that began before the mutation committed would otherwise resolve with the
+    // pre-write body and leave the panel stale. Cancelling first forces a new
+    // post-commit fetch.
+    vi.mocked(apiClient.put).mockResolvedValue({});
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const cancelSpy = vi.spyOn(client, "cancelQueries");
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+    const scoped = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useSharing("agent", "a1"), { wrapper: scoped });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await result.current.share.mutateAsync({ subject_user_id: "u-sam", level: "read" });
+
+    const key = ["sharing", "agent", "a1"];
+    expect(cancelSpy).toHaveBeenCalledWith({ queryKey: key });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: key });
+    const cancelOrder = cancelSpy.mock.invocationCallOrder[0] ?? 0;
+    const invalidateOrder = invalidateSpy.mock.invocationCallOrder[0] ?? 0;
+    expect(cancelOrder).toBeGreaterThan(0);
+    expect(cancelOrder).toBeLessThan(invalidateOrder);
+  });
+
   it("addresses a collection at the plural of its own noun", async () => {
     // Four routes exist per type and the paths are not derivable from the type
     // name; a wrong stem shares a resource that does not exist.

--- a/frontend/src/hooks/use-sharing.ts
+++ b/frontend/src/hooks/use-sharing.ts
@@ -52,13 +52,16 @@ export function useSharing(resourceType: SharingResourceType, resourceId: string
     enabled: !!resourceId,
   });
 
-  const invalidate = useCallback(
-    () =>
-      queryClient.invalidateQueries({
-        queryKey: qk.sharing.detail(resourceType, resourceId ?? ""),
-      }),
-    [queryClient, resourceType, resourceId],
-  );
+  const invalidate = useCallback(async () => {
+    const queryKey = qk.sharing.detail(resourceType, resourceId ?? "");
+    // Cancel an in-flight read before invalidating: invalidateQueries dedupes
+    // its refetch onto a fetch already running, so a read that began before this
+    // mutation committed resolves with the pre-write body, marks the query
+    // fresh, and the panel keeps the old value until a reload (#154). Cancelling
+    // first makes the invalidation dispatch a genuinely new, post-commit fetch.
+    await queryClient.cancelQueries({ queryKey });
+    await queryClient.invalidateQueries({ queryKey });
+  }, [queryClient, resourceType, resourceId]);
 
   const share = useMutation({
     mutationFn: (input: ShareInput) => apiClient.put<ResourceGrant>(`${base}/grants`, input),

--- a/frontend/src/hooks/use-skills.test.tsx
+++ b/frontend/src/hooks/use-skills.test.tsx
@@ -107,6 +107,31 @@ describe("useSkills", () => {
     );
   });
 
+  it("cancels the in-flight list read before invalidating, so a stale refetch cannot win (#154)", async () => {
+    // invalidateQueries dedupes onto a fetch already running; a list read that
+    // began before the create committed would otherwise resolve with the
+    // pre-write body and leave the gallery a skill short. Cancel first.
+    vi.mocked(apiClient.post).mockResolvedValue({ name: "refunds" });
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const cancelSpy = vi.spyOn(client, "cancelQueries");
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+    const scoped = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useSkills(), { wrapper: scoped });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await result.current.create.mutateAsync({ name: "refunds", description: "", content: "" });
+
+    expect(cancelSpy).toHaveBeenCalledWith({ queryKey: ["skills"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["skills"] });
+    const cancelOrder = cancelSpy.mock.invocationCallOrder[0] ?? 0;
+    const invalidateOrder = invalidateSpy.mock.invocationCallOrder[0] ?? 0;
+    expect(cancelOrder).toBeGreaterThan(0);
+    expect(cancelOrder).toBeLessThan(invalidateOrder);
+  });
+
   it("says an edit reaches every agent at once", async () => {
     // Skills are bound by reference. That is the whole point, and the person
     // editing one should know it before they hit save.

--- a/frontend/src/hooks/use-skills.ts
+++ b/frontend/src/hooks/use-skills.ts
@@ -71,10 +71,14 @@ export function useSkills({
     placeholderData: (previous) => previous,
   });
 
-  const invalidate = useCallback(
-    () => queryClient.invalidateQueries({ queryKey: qk.skills.all() }),
-    [queryClient],
-  );
+  const invalidate = useCallback(async () => {
+    // Cancel an in-flight read before invalidating: invalidateQueries dedupes
+    // its refetch onto a fetch already running, so a list read that began before
+    // this mutation committed resolves with the pre-write body, marks the query
+    // fresh, and the gallery keeps the old count until a reload (#154).
+    await queryClient.cancelQueries({ queryKey: qk.skills.all() });
+    await queryClient.invalidateQueries({ queryKey: qk.skills.all() });
+  }, [queryClient]);
 
   // No `onError` here, unlike its neighbours: every way this fails - the name
   // is taken, the description is too long - is something the reader can fix in
@@ -152,10 +156,18 @@ export function useSkill(skillId: string | null) {
     enabled: skillId !== null,
   });
 
+  const invalidate = useCallback(async () => {
+    // Cancel in-flight skills reads before invalidating, so a fetch that began
+    // before this mutation committed cannot be what invalidateQueries dedupes
+    // onto and win with its pre-write body (#154).
+    await queryClient.cancelQueries({ queryKey: qk.skills.all() });
+    await queryClient.invalidateQueries({ queryKey: qk.skills.all() });
+  }, [queryClient]);
+
   const save = useMutation({
     mutationFn: (edit: SkillEdit) => apiClient.patch<Skill>(`/skills/${skillId}`, edit),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: qk.skills.all() });
+      await invalidate();
       // Agents bind to the skill, not to a version of it, so this is already live.
       toast.success(t("savedAgentsCurrent"));
     },
@@ -174,7 +186,7 @@ export function useSkill(skillId: string | null) {
     mutationFn: (resource: NewSkillResource) =>
       apiClient.post<SkillResource>(`/skills/${skillId}/resources`, resource),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: qk.skills.all() });
+      await invalidate();
       toast.success(t("fileAdded"));
     },
     onError: (error) => toast.error(getErrorMessage(error, tErrors)),
@@ -184,7 +196,7 @@ export function useSkill(skillId: string | null) {
     mutationFn: ({ id, ...edit }: { id: string; description?: string | null; content?: string }) =>
       apiClient.patch<SkillResource>(`/skills/${skillId}/resources/${id}`, edit),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: qk.skills.all() });
+      await invalidate();
       toast.success(t("fileSaved"));
     },
     onError: (error) => toast.error(getErrorMessage(error, tErrors)),
@@ -194,7 +206,7 @@ export function useSkill(skillId: string | null) {
     mutationFn: (resourceId: string) =>
       apiClient.delete<void>(`/skills/${skillId}/resources/${resourceId}`),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: qk.skills.all() });
+      await invalidate();
       toast.success(t("fileRemoved"));
     },
     onError: (error) => toast.error(getErrorMessage(error, tErrors)),
@@ -218,7 +230,7 @@ export function useSkill(skillId: string | null) {
         (file) => file.webkitRelativePath || file.name,
       ),
     onSuccess: async (result) => {
-      await queryClient.invalidateQueries({ queryKey: qk.skills.all() });
+      await invalidate();
       toast.success(t("filesUploaded", { count: result.items.length }));
     },
     onError: (error) => toast.error(getErrorMessage(error, tErrors)),


### PR DESCRIPTION
## Summary

`sharing.spec.ts` and `skills.spec.ts` flaked because a mutation's cache
invalidation could be answered with pre-write data. A mutation's `onSuccess`
called `invalidateQueries` and relied on the refetch to show the new state —
but `invalidateQueries` **dedupes its refetch onto a fetch already in flight**.
Both the sharing panel and the skills gallery fan out several reads on mount, so
a read that began before the mutation committed resolved with the pre-write body,
marked the query fresh, and the panel kept the old value until a reload. It hit
the *second* mutation in a sequence, never the first — the exact shape of #154.

This is a client bug, not stale data on the wire: the read is ordered after the
commit and hits Postgres (no-store is already in effect since #405/#230), the
client just dropped the fresh answer.

## Changed

- Each hook funnels its mutations through one `invalidate` helper; that helper now
  **cancels the query before invalidating**, so the invalidation dispatches a
  genuinely new post-commit fetch rather than awaiting the stale in-flight one it
  meant to replace.
  - `use-sharing.ts` — covers `share` / `revoke` / `setVisibility`.
  - `use-skills.ts` — covers `create` / `update` / `remove` in `useSkills`, and
    `save` / `addResource` / `saveResource` / `removeResource` / `uploadResources`
    in `useSkill`.

## Testing

- New unit test per hook asserts `cancelQueries` runs (and before
  `invalidateQueries`) on a mutation success — the ordering the fix depends on.
- The existing `sharing.spec.ts` / `skills.spec.ts` panel-refresh assertions are
  what this makes reliable; they are left asserting the real re-render (no masking
  reload added). `make test-frontend-cov` green (100% stmts/funcs/lines, 97.7%
  branches).
- Reviewed the mechanism against TanStack Query v5 refetch dedup; `cancelQueries`
  before `invalidateQueries` is the standard idiom and behaviour-preserving on the
  happy path.

## Notes for reviewers

- The same in-flight-dedup shape exists in other hooks (e.g. `use-secrets`, the
  vault manifestation tracked as #130); this PR is scoped to the two hooks #154
  names. #130 is handled separately.
- `#230` is already closed (no-store, #405); the stale "nobody has closed it"
  notes in `.claude/rules/testing.md` / `docs/testing.md` are a separate
  documentation fix.

Closes #154
