### PR TITLE
perf(channels): reuse one HTTP client per adapter, not one per call

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -188,6 +188,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[LifespanState, None]:
     # is left stuck in `processing` forever (#417 is the same row, from the other
     # end).
     await background.drain()
+    # Close each adapter's reused HTTP client now that no polling task or drained
+    # background turn can still be mid-request on it (#952).
+    for _adapter in (_telegram_adapter, _mattermost_adapter, _slack_adapter):
+        await _adapter.aclose()
     # The knowledge capability caches a store of its own, built on the first
     # search and reachable from no request; a shutdown followed by more work -
     # a test, a reload - must not search through it once `close_db` has run.

--- a/backend/app/services/channels/base.py
+++ b/backend/app/services/channels/base.py
@@ -342,6 +342,15 @@ class ChannelAdapter(ABC):
     async def stop_polling(self, bot_id: str) -> None:
         """Stop polling for this bot."""
 
+    async def aclose(self) -> None:
+        """Release long-lived resources at shutdown.
+
+        A no-op by default; an adapter that holds a reused HTTP client (#952)
+        overrides this to close it. Called once, after polling has stopped and
+        background work has drained.
+        """
+        return
+
     @abstractmethod
     async def register_webhook(self, bot_token: str, url: str, secret: str | None) -> bool:
         """Register webhook URL with the platform. Returns True on success."""

--- a/backend/app/services/channels/mattermost.py
+++ b/backend/app/services/channels/mattermost.py
@@ -104,6 +104,11 @@ class MattermostAdapter(ChannelAdapter):
     platform: str = "mattermost"
 
     def __init__(self) -> None:
+        # One client per adapter, not one per call. A streamed turn is dozens of
+        # REST calls to the same host - an edit a second, plus typing and each
+        # attachment - and a fresh client per call throws the connection pool
+        # away before it is reused, paying a TLS handshake every time (#952).
+        self._http = httpx.AsyncClient(timeout=_HTTP_TIMEOUT)
         self._socket_tasks: dict[str, asyncio.Task[None]] = {}
         # Where each bot's server lives. Set by the service when a bot starts,
         # because the adapter is a singleton and the URL is per bot.
@@ -121,15 +126,18 @@ class MattermostAdapter(ChannelAdapter):
         """Record which Mattermost server a bot belongs to."""
         self._base_urls[bot_id] = api_base_url.rstrip("/")
 
-    @staticmethod
-    def _client() -> httpx.AsyncClient:
-        """An HTTP client carrying the shared timeout, for one request cycle.
+    def _client(self) -> contextlib.AbstractAsyncContextManager[httpx.AsyncClient]:
+        """The adapter's shared HTTP client, borrowed for one request cycle.
 
-        Mattermost keeps an idle socket open only so long, so every call opens its
-        own `async with` client rather than holding one on the adapter - the one
-        place the timeout is set, so a new REST call cannot forget it.
+        Wrapped in `nullcontext` so a call site's `async with` hands back the
+        shared client and does not close it on exit - the pool stays warm across
+        a streamed turn's many calls (#952). The client is built once in
+        `__init__`, the one place the timeout is set, and closed in `aclose`.
         """
-        return httpx.AsyncClient(timeout=_HTTP_TIMEOUT)
+        return contextlib.nullcontext(self._http)
+
+    async def aclose(self) -> None:
+        await self._http.aclose()
 
     @staticmethod
     def _headers(bot_token: str) -> dict[str, str]:

--- a/backend/app/services/channels/slack.py
+++ b/backend/app/services/channels/slack.py
@@ -17,6 +17,8 @@ import time
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+import httpx
+
 from app.agents.capabilities.channel_tools import (
     ChannelDetails,
     ChannelMember,
@@ -54,6 +56,11 @@ class SlackAdapter(ChannelAdapter):
     platform: str = "slack"
 
     def __init__(self) -> None:
+        # One client per adapter for the file downloads below, not one per call,
+        # so fetching several attachments from one Slack turn reuses the
+        # connection rather than handshaking each time (#952). Sends go through
+        # the slack-sdk WebClient, which is per bot token, not through this.
+        self._http = httpx.AsyncClient(timeout=30.0, follow_redirects=True)
         self._socket_tasks: dict[str, asyncio.Task[None]] = {}
         # Each bot is its own Slack app, so Socket Mode connects with that
         # bot's xapp- token. Registered before polling starts, the same way
@@ -63,6 +70,9 @@ class SlackAdapter(ChannelAdapter):
     def remember_app_token(self, bot_id: str, app_token: str) -> None:
         """Register the app-level token Socket Mode will connect with."""
         self._app_tokens[bot_id] = app_token
+
+    async def aclose(self) -> None:
+        await self._http.aclose()
 
     @staticmethod
     def _web(bot_token: str) -> "AsyncWebClient":
@@ -515,12 +525,9 @@ class SlackAdapter(ChannelAdapter):
         content-type check - the failure mode here is silent corruption, not an
         error.
         """
-        import httpx
-
-        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
-            response = await client.get(
-                attachment.handle, headers={"Authorization": f"Bearer {bot_token}"}
-            )
+        response = await self._http.get(
+            attachment.handle, headers={"Authorization": f"Bearer {bot_token}"}
+        )
         response.raise_for_status()
         if response.headers.get("content-type", "").startswith("text/html"):
             raise ValueError(

--- a/backend/tests/test_lifespan_drain.py
+++ b/backend/tests/test_lifespan_drain.py
@@ -48,6 +48,8 @@ class _FakeAdapter:
 
     async def stop_polling(self, _bid: str) -> None: ...
 
+    async def aclose(self) -> None: ...
+
 
 _ADAPTER_CLASSES = {
     "telegram": "TelegramAdapter",

--- a/backend/tests/test_mattermost_channel.py
+++ b/backend/tests/test_mattermost_channel.py
@@ -202,3 +202,42 @@ class TestSending:
         )
 
         assert posted["url"] == "https://mattermost.acme.com/api/v4/posts"
+
+    @pytest.mark.anyio
+    async def test_two_sends_reuse_one_http_client(self, monkeypatch):
+        """One client per adapter, not one per call: a streamed turn is dozens of
+        REST calls to one host, and a fresh client each time throws the pool away
+        before it is reused, paying a handshake every time (#952)."""
+        made = 0
+        posts: list[str] = []
+
+        class _Response:
+            def raise_for_status(self) -> None:
+                return None
+
+        class _Client:
+            async def post(self, url: str, **_kwargs: object) -> _Response:
+                posts.append(url)
+                return _Response()
+
+        def _make(**_kwargs: object) -> _Client:
+            nonlocal made
+            made += 1
+            return _Client()
+
+        monkeypatch.setattr(httpx, "AsyncClient", _make)
+
+        adapter = MattermostAdapter()
+        for _ in range(2):
+            await adapter.send_message(
+                "token",
+                OutgoingMessage(
+                    platform_chat_id="c1", text="hi", api_base_url="https://mattermost.acme.com"
+                ),
+            )
+
+        assert made == 1  # built once, in __init__, not per send
+        assert posts == [
+            "https://mattermost.acme.com/api/v4/posts",
+            "https://mattermost.acme.com/api/v4/posts",
+        ]


### PR DESCRIPTION
## Summary

Every REST helper in the Mattermost adapter opened its own `httpx.AsyncClient`,
and Slack's attachment download did too, so each call paid a fresh TCP connection
and TLS handshake against a host it had just talked to. A streamed channel turn is
not one call — `LiveReply` pushes an edit roughly every second, plus `typing`,
`begin_reply`, the final edit, and an attachment download per file — so a
minute-long answer spent seconds of wall clock re-establishing connections it
already had, and the bot host saw the socket churn of a client that never keeps one
open (#952).

## Changed

- **One client per adapter**, built in `__init__` and closed in `aclose` at
  shutdown.
  - Mattermost: `_client()` now returns the shared client wrapped in
    `contextlib.nullcontext`, so its ten `async with self._client()` call sites
    borrow it without closing it and keep the connection pool warm. No call site
    changed.
  - Slack: `download_attachment` uses the shared client directly (sends still go
    through the per-token slack-sdk `WebClient`, unchanged).
- `ChannelAdapter` grows a no-op `aclose`; the lifespan calls it on every adapter
  **after** polling has stopped and background work has drained, so a turn still
  finishing an edit is never cut off from its client.

## Scope

The issue's acceptance criteria are all about the channel adapters, and that is
what this covers. The two non-channel per-call clients it also lists
(`web_research/_search.py`, `model_catalog.py`) have no adapter lifecycle to hang a
reused client on; they are a separate follow-up (filed).

## Testing

- Regression test: two consecutive Mattermost sends construct **one** client, not
  two, and both posts go out on it.
- The channel suites (561 tests) and `test_lifespan_drain` pass; the lifespan
  fake adapter gains the `aclose` the shutdown now calls.

## Notes for reviewers

- Perf-internal: no channel behaviour changes, so `docs/channels.md` is unchanged
  (the per-call vs pooled client is not something a page describes).
- `httpx.AsyncClient` is constructed in `__init__` without a running loop, which is
  supported — it binds to the loop lazily on first request, and an adapter that is
  built and never used (as in many unit tests) holds no connection to close.

Closes #952
