### PR TITLE
fix(rag): tear down a deleted user's personal knowledge bases

### DIFF
--- a/backend/app/repositories/knowledge_base.py
+++ b/backend/app/repositories/knowledge_base.py
@@ -208,6 +208,26 @@ async def list_org_scoped(db: AsyncSession, organization_id: UUID) -> list[Knowl
     return list(result.scalars().all())
 
 
+async def list_personal_by_owner(db: AsyncSession, owner_user_id: UUID) -> list[KnowledgeBase]:
+    """The personal-scoped knowledge bases a user owns - the ones their deletion
+    must remove.
+
+    `list_org_scoped` covers only the org-scoped rows an org teardown handles; a
+    personal collection's `owner_user_id` and `organization_id` are both
+    `ON DELETE SET NULL`, so deleting the user (and purging their personal org)
+    would otherwise leave the row, its documents, its files and its vector table
+    orphaned and unreachable, with the collection name still blocking reuse
+    (#1131). These are removed explicitly before the user row goes.
+    """
+    result = await db.execute(
+        select(KnowledgeBase).where(
+            KnowledgeBase.owner_user_id == owner_user_id,
+            KnowledgeBase.scope == KBScope.PERSONAL.value,
+        )
+    )
+    return list(result.scalars().all())
+
+
 async def list_by_collection_name(db: AsyncSession, collection_name: str) -> list[KnowledgeBase]:
     """Every knowledge base claiming this collection name, oldest first.
 

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -2,9 +2,11 @@ import asyncio
 import contextlib
 import logging
 import secrets
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from sqlalchemy import func, select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -25,9 +27,11 @@ from app.core.security import (
 from app.db.models.user import User
 from app.db.updates import writable
 from app.repositories import (
+    knowledge_base_repo,
     member_repo,
     organization_repo,
     organization_secret_repo,
+    rag_document_repo,
     session_repo,
     user_repo,
 )
@@ -44,6 +48,9 @@ from app.services.file_storage import avatar_filename, get_file_storage
 from app.services.organization import OrganizationService
 from app.services.signup_policy import check_may_register
 
+if TYPE_CHECKING:
+    from app.services.rag.vectorstore import BaseVectorStore
+
 logger = logging.getLogger(__name__)
 
 # A real bcrypt hash of a value nobody holds, computed once at import. An
@@ -54,8 +61,14 @@ _DUMMY_HASH = get_password_hash(secrets.token_urlsafe(32))
 
 
 class UserService:
-    def __init__(self, db: AsyncSession):
+    def __init__(self, db: AsyncSession, vector_store: "BaseVectorStore | None" = None):
         self.db = db
+        # Only the account-teardown path drops a departing user's vector tables.
+        # A caller may inject the store (the delete route, a test on its own
+        # engine); when none is given the teardown builds one on the process's
+        # shared vector pool, so every delete path cleans up and no other route
+        # pays for a store it never touches (#1131).
+        self._vector_store = vector_store
 
     async def _is_first_user(self) -> bool:
         count = (await self.db.execute(select(func.count()).select_from(User))).scalar_one()
@@ -394,10 +407,25 @@ class UserService:
         Owner of an org they did *not* create takes its last owner membership with
         them (`ON DELETE CASCADE`), leaving nobody who can manage it. That is
         refused here too (#1117).
+
+        A fifth is another silent orphan: the user's personal-scoped knowledge
+        bases. `owner_user_id` and `organization_id` are both `SET NULL`, so the
+        org purge below (which handles only org-scoped collections) never reaches
+        them, and their documents, files and vector table would be retained and
+        unreachable while the collection name kept blocking reuse. They are torn
+        down explicitly, with the same store the org purge needs (#1131).
         """
+        from app.services.rag.embeddings import EmbeddingService
+        from app.services.rag.vectorstore import process_vector_store
+
         await organization_secret_repo.promote_owned_private_to_org(self.db, owner_user_id=user_id)
 
-        org_service = OrganizationService(self.db)
+        vector_store = self._vector_store or process_vector_store(
+            settings.rag, EmbeddingService(settings=settings.rag)
+        )
+        await self._purge_personal_collections(vector_store, user_id)
+
+        org_service = OrganizationService(self.db, vector_store=vector_store)
         handled: set[UUID] = set()
         for org in await organization_repo.list_created_by(self.db, user_id):
             handled.add(org.id)
@@ -432,6 +460,36 @@ class UserService:
                     "transfer ownership or delete the organization first",
                     details={"user_id": user_id, "organization_id": org.id},
                 )
+
+    async def _purge_personal_collections(
+        self, vector_store: "BaseVectorStore", user_id: UUID
+    ) -> None:
+        """Remove the user's personal-scoped knowledge bases whole (#1131).
+
+        Mirrors `OrganizationService.purge`'s collection teardown for the rows the
+        org purge cannot see. Each base's document rows and stored files go first,
+        then the base row; the physical `rag_<collection>` table is dropped only
+        when no other base still references the name - it is not tenant-unique
+        (#913), so two of them can share one table. The document rows are keyed on
+        `knowledge_base_id`, so a shared collection's other rows are untouched; a
+        shared table is left in place, with only this base's uploads unlinked.
+        """
+        storage = get_file_storage()
+        for kb in await knowledge_base_repo.list_personal_by_owner(self.db, user_id):
+            collection = kb.collection_name
+            storage_paths = await rag_document_repo.delete_by_knowledge_base(self.db, kb.id)
+            await knowledge_base_repo.delete(self.db, kb.id)
+            for storage_path in storage_paths:
+                with contextlib.suppress(Exception):
+                    await storage.delete(storage_path)
+            still_shared = await knowledge_base_repo.list_by_collection_name(self.db, collection)
+            if still_shared:
+                continue
+            # Best-effort, and only against the database: a zero-document
+            # collection has no table yet (`DROP TABLE IF EXISTS` no-ops), and any
+            # other database failure is not a reason to abandon the rest.
+            with contextlib.suppress(SQLAlchemyError):
+                await vector_store.delete_collection(collection)
 
     async def admin_update(
         self, user_id: UUID, user_in: UserUpdate, *, acting_admin_id: UUID

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -418,19 +418,18 @@ class UserService:
         from app.services.rag.embeddings import EmbeddingService
         from app.services.rag.vectorstore import process_vector_store
 
-        await organization_secret_repo.promote_owned_private_to_org(self.db, owner_user_id=user_id)
-
-        vector_store = self._vector_store or process_vector_store(
-            settings.rag, EmbeddingService(settings=settings.rag)
-        )
-        await self._purge_personal_collections(vector_store, user_id)
-
-        org_service = OrganizationService(self.db, vector_store=vector_store)
-        handled: set[UUID] = set()
-        for org in await organization_repo.list_created_by(self.db, user_id):
-            handled.add(org.id)
+        # Every refusal is decided first, before any irreversible cleanup. The
+        # personal-KB and personal-org teardown below drop vector tables and
+        # unlink files through sessions of their own, and a BadRequestError raised
+        # afterwards cannot undo them: the request session rolls the relational
+        # deletes back, and the restored rows then point at data already gone
+        # (#1131). So the sole-owner checks run in a side-effect-free pass, and
+        # the heir each shared org is handed to is captured here and reused below
+        # rather than re-read after the cleanup.
+        created = await organization_repo.list_created_by(self.db, user_id)
+        heirs: dict[UUID, UUID] = {}
+        for org in created:
             if org.is_personal:
-                await org_service.purge(org)
                 continue
             heir = await member_repo.other_owner_id(
                 self.db, organization_id=org.id, exclude_user_id=user_id
@@ -441,15 +440,16 @@ class UserService:
                     "transfer ownership or delete the organization first",
                     details={"user_id": user_id, "organization_id": org.id},
                 )
-            await organization_repo.reassign_creator(self.db, org=org, new_creator_id=heir)
+            heirs[org.id] = heir
 
         # Ownership moves without the creator FK, so a user can be the sole Owner
         # of an org they did not create - one `list_created_by` never returns.
         # Deleting them cascades that last owner membership away and leaves the
         # org ownerless: no 500, but nobody can manage it through the owner-gated
         # APIs (#1117). Refuse, unless another owner is there to keep it.
+        created_ids = {org.id for org in created}
         for org in await organization_repo.list_owned_by(self.db, user_id):
-            if org.id in handled:
+            if org.id in created_ids:
                 continue
             other_owner = await member_repo.other_owner_id(
                 self.db, organization_id=org.id, exclude_user_id=user_id
@@ -459,6 +459,22 @@ class UserService:
                     message="Cannot delete the sole owner of a shared organization; "
                     "transfer ownership or delete the organization first",
                     details={"user_id": user_id, "organization_id": org.id},
+                )
+
+        await organization_secret_repo.promote_owned_private_to_org(self.db, owner_user_id=user_id)
+
+        vector_store = self._vector_store or process_vector_store(
+            settings.rag, EmbeddingService(settings=settings.rag)
+        )
+        await self._purge_personal_collections(vector_store, user_id)
+
+        org_service = OrganizationService(self.db, vector_store=vector_store)
+        for org in created:
+            if org.is_personal:
+                await org_service.purge(org)
+            else:
+                await organization_repo.reassign_creator(
+                    self.db, org=org, new_creator_id=heirs[org.id]
                 )
 
     async def _purge_personal_collections(

--- a/backend/tests/integration/test_deletion_reconciliation.py
+++ b/backend/tests/integration/test_deletion_reconciliation.py
@@ -23,7 +23,10 @@ from app.core.config import settings as app_settings
 from app.db.models.knowledge_base import KBScope, KnowledgeBase
 from app.db.models.organization import Organization, OrganizationMember
 from app.db.models.organization_secret import OrganizationSecret
+from app.db.models.rag_document import RAGDocument
 from app.db.models.user import User
+from app.repositories import knowledge_base_repo
+from app.services.file_storage import get_file_storage
 from app.services.organization import OrganizationService
 from app.services.rag.vectorstore import PgVectorStore
 from app.services.user import UserService
@@ -69,6 +72,38 @@ def _org_collection(org_id: uuid.UUID, collection_name: str) -> KnowledgeBase:
         embedding_dim=1536,
         organization_id=org_id,
         visibility="org",
+    )
+
+
+def _personal_kb(org_id: uuid.UUID, owner_id: uuid.UUID, collection_name: str) -> KnowledgeBase:
+    return KnowledgeBase(
+        id=uuid.uuid4(),
+        name="My notes",
+        scope=KBScope.PERSONAL.value,
+        collection_name=collection_name,
+        embedding_model="text-embedding-3-small",
+        embedding_dim=1536,
+        organization_id=org_id,
+        owner_user_id=owner_id,
+        visibility="private",
+    )
+
+
+def _kb_document(
+    collection_name: str, kb_id: uuid.UUID, org_id: uuid.UUID, storage_path: str
+) -> RAGDocument:
+    return RAGDocument(
+        id=uuid.uuid4(),
+        collection_name=collection_name,
+        filename="notes.txt",
+        filesize=5,
+        filetype="txt",
+        storage_path=storage_path,
+        status="completed",
+        chunk_count=0,
+        ingestion_config={},
+        knowledge_base_id=kb_id,
+        organization_id=org_id,
     )
 
 
@@ -167,6 +202,92 @@ class TestDeletingAUser:
         await db.refresh(org)
         assert org.created_by_user_id == heir.id
         assert await db.get(User, creator.id) is None
+
+    async def test_deleting_a_user_removes_their_personal_knowledge_base_whole(
+        self, engine: AsyncEngine
+    ) -> None:
+        """A personal-scoped KB the user owns is torn down whole - rows, files and
+        vector table - rather than orphaned by the `SET NULL` cascade with its
+        name still blocking reuse (#1131)."""
+        store = PgVectorStore(
+            settings=app_settings.rag,
+            embedding_service=MagicMock(),
+            resolver=MagicMock(),
+            engine=engine,
+        )
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        storage = get_file_storage()
+        stored_path = await storage.save("kb-owner", "notes.txt", b"hello")
+        collection = f"kbnine{uuid.uuid4().hex[:12]}"
+        table = store._table(collection)
+        async with factory() as s:
+            user = _user()
+            s.add(user)
+            await s.flush()
+            org = await _org(s, user, is_personal=True)
+            kb = _personal_kb(org.id, user.id, collection)
+            s.add(kb)
+            await s.flush()
+            s.add(_kb_document(collection, kb.id, org.id, stored_path))
+            await s.execute(text(f"CREATE TABLE {table} (id int)"))
+            await s.commit()
+            user_id, kb_id = user.id, kb.id
+
+        async with factory() as s:
+            await UserService(s, vector_store=store).delete(user_id)
+            await s.commit()
+
+        async with factory() as s:
+            assert await s.get(KnowledgeBase, kb_id) is None
+            docs = await s.execute(
+                select(RAGDocument).where(RAGDocument.knowledge_base_id == kb_id)
+            )
+            assert docs.scalars().all() == []
+            assert (await s.execute(text("SELECT to_regclass(:t)"), {"t": table})).scalar() is None
+            assert await s.get(User, user_id) is None
+            # The name is reusable: no surviving row claims it.
+            assert await knowledge_base_repo.get_by_collection_name(s, collection) is None
+
+        assert storage.get_full_path(stored_path) is None
+
+    async def test_a_personal_kb_sharing_a_collection_keeps_the_table(
+        self, engine: AsyncEngine
+    ) -> None:
+        """Two KBs can back onto one physical table (collection_name is not
+        tenant-unique, #913), so deleting one owner's personal KB removes its rows
+        but not the table the other still references (#1131)."""
+        store = PgVectorStore(
+            settings=app_settings.rag,
+            embedding_service=MagicMock(),
+            resolver=MagicMock(),
+            engine=engine,
+        )
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        collection = f"kbnine{uuid.uuid4().hex[:12]}"
+        table = store._table(collection)
+        async with factory() as s:
+            leaver = _user()
+            keeper = _user()
+            s.add_all([leaver, keeper])
+            await s.flush()
+            leaver_org = await _org(s, leaver, is_personal=True)
+            keeper_org = await _org(s, keeper, is_personal=True)
+            s.add(_personal_kb(leaver_org.id, leaver.id, collection))
+            keeper_kb = _personal_kb(keeper_org.id, keeper.id, collection)
+            s.add(keeper_kb)
+            await s.execute(text(f"CREATE TABLE {table} (id int)"))
+            await s.commit()
+            leaver_id, keeper_kb_id = leaver.id, keeper_kb.id
+
+        async with factory() as s:
+            await UserService(s, vector_store=store).delete(leaver_id)
+            await s.commit()
+
+        async with factory() as s:
+            assert await s.get(KnowledgeBase, keeper_kb_id) is not None
+            assert (
+                await s.execute(text("SELECT to_regclass(:t)"), {"t": table})
+            ).scalar() is not None
 
 
 class TestDeletingAnOrg:

--- a/backend/tests/integration/test_deletion_reconciliation.py
+++ b/backend/tests/integration/test_deletion_reconciliation.py
@@ -289,6 +289,52 @@ class TestDeletingAUser:
                 await s.execute(text("SELECT to_regclass(:t)"), {"t": table})
             ).scalar() is not None
 
+    async def test_a_refused_delete_leaves_the_personal_kb_intact(
+        self, engine: AsyncEngine
+    ) -> None:
+        """The sole-owner refusal is decided before any teardown, so a delete that
+        refuses does not leave the user's personal KB's files or table gone while
+        its row rolls back (#1131)."""
+        from app.core.exceptions import BadRequestError
+
+        store = PgVectorStore(
+            settings=app_settings.rag,
+            embedding_service=MagicMock(),
+            resolver=MagicMock(),
+            engine=engine,
+        )
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        storage = get_file_storage()
+        stored_path = await storage.save("kb-owner", "notes.txt", b"hello")
+        collection = f"kbnine{uuid.uuid4().hex[:12]}"
+        table = store._table(collection)
+        async with factory() as s:
+            user = _user()
+            s.add(user)
+            await s.flush()
+            await _org(s, user)  # a shared org solely owned -> the delete refuses
+            personal_org = await _org(s, user, is_personal=True)
+            kb = _personal_kb(personal_org.id, user.id, collection)
+            s.add(kb)
+            await s.flush()
+            s.add(_kb_document(collection, kb.id, personal_org.id, stored_path))
+            await s.execute(text(f"CREATE TABLE {table} (id int)"))
+            await s.commit()
+            user_id, kb_id = user.id, kb.id
+
+        async with factory() as s:
+            with pytest.raises(BadRequestError):
+                await UserService(s, vector_store=store).delete(user_id)
+            await s.rollback()
+
+        async with factory() as s:
+            assert await s.get(KnowledgeBase, kb_id) is not None
+            assert (
+                await s.execute(text("SELECT to_regclass(:t)"), {"t": table})
+            ).scalar() is not None
+        assert storage.get_full_path(stored_path) is not None
+        await storage.delete(stored_path)
+
 
 class TestDeletingAnOrg:
     async def test_it_drops_org_scoped_collections_and_their_vector_tables(


### PR DESCRIPTION
## Summary

Deleting a user orphaned their personal org's knowledge base. `UserService.delete`
→ `_release_owned_rows` purged the user's personal org through
`OrganizationService.purge`, but built the service **with no vector store** — and
`purge` only removes **org-scoped** collections (`list_org_scoped` returns
`scope==ORG`). A **personal-scoped** KB (both `owner_user_id` and
`organization_id` are `ON DELETE SET NULL`) was therefore never touched: the row
was orphaned and its `rag_documents` rows, uploaded files, and `rag_<collection>`
vector table were retained and unreachable, while the collection name kept
blocking reuse via `CollectionAccessService.claim` (#1131). The same missing store
also left the org-scoped collections in that personal org without their physical
tables.

## Changed

- `UserService` takes an optional `vector_store`; the account teardown uses it, or
  builds one on the process's shared vector pool when none is injected — so every
  delete path (route and CLI) cleans up, and no other `UserService` route pays for
  a store it never touches (mirrors `get_organization_teardown_service`).
- New `_purge_personal_collections`: for each personal-scoped KB the user owns,
  delete its document rows and unlink its stored files, delete the KB row, then
  drop the `rag_<collection>` table **only when no other base still references the
  name** (it is not tenant-unique, #913) — mirroring `purge`'s collection
  teardown for the rows the org purge cannot see.
- The org purge now receives the same store, so it drops its tables too.
- Adds `knowledge_base_repo.list_personal_by_owner` (the predicate previously lived
  only inline in `get_accessible`).

## Testing

- Integration: deleting a user whose personal org holds a personal KB with a real
  vector table, a `rag_documents` row and a stored file removes the row, the docs,
  the table and the file, and the collection name is reusable afterwards.
- Integration: a personal KB sharing a `collection_name` with another owner's KB —
  the shared table survives the delete (only the leaver's rows/files go).

## Notes for reviewers

- Kept entirely in `user.py` + `repositories/knowledge_base.py`; it does not touch
  `organization.py`, so it does not conflict with the deferred-cleanup rework in
  #1137. On this branch the drop is synchronous, matching `main`'s org purge; if
  #1137 lands first, converging both paths onto its post-commit cleanup is a
  follow-up.
- Two pre-existing leaks found while tracing this, filed separately: #1265
  (`DELETE /rag/collections/{name}` never unlinks upload files) and #1266 (`DELETE
  /kb/{id}` leaves the vector table, the `SET NULL`'d `rag_documents` rows and the
  files behind).

Closes #1131
