### PR TITLE
chore: cut 0.0.313

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,25 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.313] - 2026-08-27
+
+### Fixed
+
+- **A mutation's invalidation could be answered with pre-write data**, which is
+  what made `sharing.spec.ts` and `skills.spec.ts` flake. A mutation's `onSuccess`
+  invalidated and relied on the refetch - but `invalidateQueries` **dedupes its
+  refetch onto a fetch already in flight**, and both the sharing panel and the
+  skills gallery fan out several reads on mount. A read that began before the
+  mutation committed resolved with the pre-write body, marked the query fresh, and
+  the panel kept the old value until a reload. It hit the *second* mutation in a
+  sequence and never the first, which is exactly the shape the issue describes.
+  Each hook's one `invalidate` helper cancels the query before invalidating now, so
+  the invalidation dispatches a genuinely new post-commit fetch rather than
+  awaiting the stale one it meant to replace. (#154)
+- Worth being clear about what this was not: the read is ordered after the commit
+  and reaches Postgres, and `no-store` has been in effect since #405 - the client
+  simply dropped the fresh answer. (#154, #405, #230)
+
 ## [0.0.312] - 2026-08-27
 
 ### Added

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.312"
+version = "0.0.313"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.312"
+version = "0.0.313"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.312",
+  "version": "0.0.313",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.313. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.313 and adds the CHANGELOG entry.

Releases #154, and it turned out to be a client bug rather than stale data on
the wire: `invalidateQueries` dedupes its refetch onto a read already in
flight, so a read that started before the mutation committed resolved with the
pre-write body and marked the query fresh. Cancelling before invalidating
dispatches a genuinely new post-commit fetch.

That is why it always hit the second mutation in a sequence and never the
first.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1260 was green on the merged head.