### PR TITLE
chore: cut 0.0.314

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,25 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.314] - 2026-08-27
+
+### Fixed
+
+- **The vault list kept the pre-write rows after a store or rotate**, roughly one
+  run in eight, so a new row never appeared and the spec timed out. The create
+  itself worked - the artifact showed the keys stored with an empty error alert, so
+  the write succeeded and the render was stale. Same dedup race as #154: the
+  mutation invalidated the list and relied on the refetch, and the vault page
+  issues its list read on load, so a read that began before the write committed
+  resolved with the pre-write body and marked the query fresh. The secrets hook's
+  one `invalidate` helper cancels the list query before invalidating. (#130, #154)
+- **Three `page.reload()` workarounds are retired with it** - the row appears on
+  its own now, which is the verification that it no longer flakes. On the issue's
+  two acceptance criteria: `submitDialog` already asserts the write's response
+  status and prints its body on a non-2xx, so a refused store fails at its source
+  before the row is awaited; and the create never failed - it answered 201, and the
+  list render was the stale half. (#130)
+
 ## [0.0.313] - 2026-08-27
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.313"
+version = "0.0.314"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.313"
+version = "0.0.314"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.313",
+  "version": "0.0.314",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.314. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.314 and adds the CHANGELOG entry.

Releases #130, the vault manifestation of #154's dedup race: the store or
rotate committed and the list refetch was deduped onto a read already in
flight, so the table kept the pre-write rows about one run in eight. The
create was never the problem - it answered 201; the render was stale.

Three `page.reload()` workarounds go with the fix, which is what proves it.

Verified: `scripts/check_backticks.py` and `make lint-spelling` clean. CI on
#1261 was green on the merged head.