### PR TITLE
fix(dashboard): the gate owns the clearance on its no-wrapper branch

### DIFF
--- a/frontend/src/components/branding/branding.integration.test.tsx
+++ b/frontend/src/components/branding/branding.integration.test.tsx
@@ -115,6 +115,10 @@ describe("a maintenance window", () => {
     );
 
     expect(container.firstElementChild).toHaveClass(...PAGE_CLEARANCE.split(" "));
+    // And the box has to grow with the message for that padding to land after
+    // it. `min-h-0` here capped it at the viewport, which left `main` unable to
+    // scroll to the end of a long message at all (Codex, P1 on this branch).
+    expect(container.firstElementChild).not.toHaveClass("min-h-0");
   });
 
   it("leaves it open for the administrator who has to end it", () => {

--- a/frontend/src/components/branding/branding.integration.test.tsx
+++ b/frontend/src/components/branding/branding.integration.test.tsx
@@ -11,6 +11,7 @@ import { DeploymentGate } from "./deployment-gate";
 import { MaintenanceScreen } from "./maintenance-screen";
 import { apiClient } from "@/lib/api-client";
 import { BUILT_IN_BRANDING, type Branding, type NoticeResponse } from "@/lib/branding";
+import { PAGE_CLEARANCE } from "@/lib/page-clearance";
 
 /**
  * What the deployment's own state does to the product.
@@ -98,6 +99,22 @@ describe("a maintenance window", () => {
     );
 
     expect(screen.queryByText("the dashboard")).not.toBeInTheDocument();
+  });
+
+  it("clears the mobile tab bar, on the one branch that renders no page wrapper", () => {
+    // `DeploymentGate` returns the maintenance screen *instead of*
+    // `PageTransition`, which is where every other page gets its bottom
+    // clearance - so a long custom message ended under the fixed tab bar with
+    // nothing below it to scroll to (#1241). The token rather than the literal,
+    // because a second copy of the calc is a second place to forget the inset.
+    const { container } = render(
+      <DeploymentGate>
+        <p>the dashboard</p>
+      </DeploymentGate>,
+      { wrapper: branded({ maintenanceMode: true }) },
+    );
+
+    expect(container.firstElementChild).toHaveClass(...PAGE_CLEARANCE.split(" "));
   });
 
   it("leaves it open for the administrator who has to end it", () => {

--- a/frontend/src/components/branding/deployment-gate.tsx
+++ b/frontend/src/components/branding/deployment-gate.tsx
@@ -9,6 +9,8 @@ import { useBranding } from "@/components/branding/branding-provider";
 import { MaintenanceScreen } from "@/components/branding/maintenance-screen";
 import { useAuth } from "@/hooks";
 import { useBrandingNotice } from "@/hooks/use-branding-notice";
+import { PAGE_CLEARANCE } from "@/lib/page-clearance";
+import { cn } from "@/lib/utils";
 
 /**
  * What the deployment's own state does to the page under it.
@@ -40,7 +42,17 @@ export function DeploymentGate({ children }: { children: ReactNode }) {
   const closed = notice?.maintenance_mode ?? maintenanceMode;
 
   if (closed && !user?.is_app_admin) {
-    return <MaintenanceScreen />;
+    // The clearance is here rather than on the screen, and it is the gate's
+    // because the gate is what knows this *is* the whole page. Every other page
+    // gets it from `PageTransition`, which this branch returns instead of - so
+    // a long custom maintenance message used to end under the mobile tab bar,
+    // with nothing below it to scroll to (#1241). One token, so the safe-area
+    // inset cannot be forgotten in one of the two places.
+    return (
+      <div className={cn("flex min-h-0 flex-1 flex-col", PAGE_CLEARANCE)}>
+        <MaintenanceScreen />
+      </div>
+    );
   }
 
   return (

--- a/frontend/src/components/branding/deployment-gate.tsx
+++ b/frontend/src/components/branding/deployment-gate.tsx
@@ -48,8 +48,16 @@ export function DeploymentGate({ children }: { children: ReactNode }) {
     // a long custom maintenance message used to end under the mobile tab bar,
     // with nothing below it to scroll to (#1241). One token, so the safe-area
     // inset cannot be forgotten in one of the two places.
+    //
+    // And no `min-h-0`, for the same reason `PageTransition`'s unconstrained
+    // branch has none: the floor is what lets this box grow with its content, so
+    // the padding paints after the message rather than at a box the message
+    // overflows. With it, a message taller than the viewport left `main` with a
+    // `scrollHeight` of exactly its own height - measured 400px against 900px of
+    // message, scrollTop stuck at 0 in Chromium 151 and WebKit 26.5, so the end
+    // of it could not be reached at all.
     return (
-      <div className={cn("flex min-h-0 flex-1 flex-col", PAGE_CLEARANCE)}>
+      <div className={cn("flex flex-1 flex-col", PAGE_CLEARANCE)}>
         <MaintenanceScreen />
       </div>
     );

--- a/frontend/src/components/branding/maintenance-screen.tsx
+++ b/frontend/src/components/branding/maintenance-screen.tsx
@@ -4,8 +4,6 @@ import { Wrench } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { useBranding } from "@/components/branding/branding-provider";
-import { PAGE_CLEARANCE } from "@/lib/page-clearance";
-import { cn } from "@/lib/utils";
 
 /**
  * What the product shows while a maintenance window is open.
@@ -24,15 +22,7 @@ export function MaintenanceScreen() {
   const { appName, maintenanceMessage } = useBranding();
 
   return (
-    // The clearance is this one's own because `DeploymentGate` returns it
-    // *instead of* rendering `PageTransition`, which is where every other page
-    // gets it. Same token, so there is still one answer (#933).
-    <div
-      className={cn(
-        "flex min-h-[60vh] flex-col items-center justify-center px-6 text-center",
-        PAGE_CLEARANCE,
-      )}
-    >
+    <div className="flex min-h-[60vh] flex-col items-center justify-center px-6 text-center">
       <span className="bg-muted text-foreground mb-6 inline-flex h-14 w-14 items-center justify-center rounded-2xl">
         <Wrench className="h-6 w-6" aria-hidden />
       </span>


### PR DESCRIPTION
`DeploymentGate` returns `MaintenanceScreen` **instead of** rendering `PageTransition`, which is where every other page takes its bottom clearance from. On mobile a long custom maintenance message therefore ended under the fixed `MobileTabBar` — the last 56px plus the safe-area inset stayed covered even at maximum scroll, on the one screen a visitor sees when nothing else is available.

## The decision the issue asks for

#1241 says to decide rather than paste the class: *"either the gate's maintenance branch carries it itself, or it is wrapped by the same padded container the ordinary pages get."*

The clearance moves **onto that branch**, and off `MaintenanceScreen`. The gate is what knows this *is* the whole page; on the screen it was a page property the component cannot know it has — it would inherit page padding anywhere else it were rendered — and the branch itself said nothing about needing any. Still one token, `PAGE_CLEARANCE`, so there is no second copy of the calc to forget `env(safe-area-inset-bottom)` in.

## The test it asks for

`page-clearance.test.ts` walks the *pages*, deliberately, so it cannot see this branch. The assertion is a render instead: the gate in maintenance, as a non-admin, and its root carries the token — spread as classes, so a token that loses the inset fails here too.

`make lint-frontend` clean · `bun run test:coverage` green (100% statements/lines/functions, 97.70% branches).

Closes #1241