### PR TITLE
fix(chat): answer with the reader's star, and star idempotently

### DIFF
--- a/backend/app/api/routes/v1/conversations.py
+++ b/backend/app/api/routes/v1/conversations.py
@@ -437,6 +437,7 @@ async def list_workspace_files(
         organization_id=active_org.id,
         include_messages=False,
         user_id=current_user.id,
+        include_favourite=False,
     )
     found = await workspaces.listing(ctx, conversation_id=conversation_id)
     if found is None:
@@ -494,6 +495,7 @@ async def read_workspace_file(
         organization_id=active_org.id,
         include_messages=False,
         user_id=current_user.id,
+        include_favourite=False,
     )
     content = await workspaces.read_text(ctx, conversation_id=conversation_id, path=path)
     if content is None:
@@ -536,6 +538,7 @@ async def read_workspace_bytes(
         organization_id=active_org.id,
         include_messages=False,
         user_id=current_user.id,
+        include_favourite=False,
     )
     data = await workspaces.read_bytes(ctx, conversation_id=conversation_id, path=path)
     return file_response(data, path=path, download=download)

--- a/backend/app/repositories/conversation.py
+++ b/backend/app/repositories/conversation.py
@@ -7,7 +7,9 @@ from typing import Any, NamedTuple
 from uuid import UUID
 
 from sqlalchemy import ColumnElement, distinct, func, or_, select
+from sqlalchemy import delete as sql_delete
 from sqlalchemy import update as sql_update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -407,18 +409,38 @@ async def set_favourite(
 ) -> None:
     """Star or unstar one conversation for one reader.
 
-    Idempotent in both directions: starring what is already starred is not an
-    error, and neither is unstarring what was never starred. A star is a
-    preference rather than a transaction, and a toast saying "already a
-    favourite" would be the interface apologising for agreeing.
+    Idempotent in both directions, and under contention as well as on a retry.
+    A star is a preference rather than a transaction, and a toast saying
+    "already a favourite" would be the interface apologising for agreeing.
+
+    **A read-then-insert is not enough.** Two overlapping POSTs for the same
+    pair both saw `existing is None` and the second `flush()` raised on the
+    primary key - an integrity error out of an endpoint that promises success,
+    which a double-click or a retried request reaches (#1254). `ON CONFLICT DO
+    NOTHING` is the shape `channel_identity_repo.get_or_create` already uses for
+    this: `DO NOTHING` waits on a concurrent *uncommitted* insert of the same
+    key, because it cannot decide until that transaction ends, and then writes
+    nothing.
+
+    The delete is a statement rather than a fetch-then-delete for the same
+    reason: `DELETE ... WHERE` on a row another transaction is removing affects
+    zero rows instead of raising, and "it was already gone" is the outcome the
+    caller asked for.
     """
-    existing = await db.get(ConversationFavourite, (user_id, conversation_id))
-    if favourite and existing is None:
-        db.add(ConversationFavourite(user_id=user_id, conversation_id=conversation_id))
-        await db.flush()
-    elif not favourite and existing is not None:
-        await db.delete(existing)
-        await db.flush()
+    if favourite:
+        await db.execute(
+            pg_insert(ConversationFavourite)
+            .values(user_id=user_id, conversation_id=conversation_id)
+            .on_conflict_do_nothing(index_elements=["user_id", "conversation_id"])
+        )
+    else:
+        await db.execute(
+            sql_delete(ConversationFavourite).where(
+                ConversationFavourite.user_id == user_id,
+                ConversationFavourite.conversation_id == conversation_id,
+            )
+        )
+    await db.flush()
 
 
 async def get_conversations_by_user(

--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -143,6 +143,9 @@ async def _resolve_in_org(
             conversation_id,
             organization_id=organization_id,
             user_id=user_id,
+            # Every turn of an existing chat resolves the thread through here and
+            # serializes none of it, so the star would be a query per message.
+            include_favourite=False,
         )
     except NotFoundError as exc:
         raise AuthorizationError(

--- a/backend/app/services/conversation.py
+++ b/backend/app/services/conversation.py
@@ -207,6 +207,7 @@ class ConversationService:
         include_messages: bool = False,
         user_id: UUID | None = None,
         for_write: bool = False,
+        include_favourite: bool = True,
         ctx: AuthContext | None = None,
     ) -> Conversation:
         """One conversation, checked against the tenant first and the reader second.
@@ -218,6 +219,13 @@ class ConversationService:
         `for_write` picks which of the two questions is asked. Reading and
         writing stopped being one question when participation became a way in:
         see `_may_read` and `_may_write`.
+
+        `include_favourite` is on by default so that a route cannot forget it -
+        that is the whole of #1254, and the flag reached two responses out of
+        eight while each route had to remember. It is turned **off** by the
+        callers that use this only to authorize and then discard the row:
+        `GET /conversations/{id}/messages` resolves it twice, through
+        `list_messages` and `conversation_cost`, and neither serializes a star.
         """
         conversation = await conversation_repo.get_conversation_by_id(
             self.db, conversation_id, include_messages=include_messages
@@ -265,7 +273,8 @@ class ConversationService:
         # caller who really had starred the thread (#1254). Skipped entirely for a
         # call with no reader: an internal read pays no query, and a star belongs
         # to nobody in particular there.
-        await self._attach_favourites([conversation], user_id=user_id)
+        if include_favourite:
+            await self._attach_favourites([conversation], user_id=user_id)
         return conversation
 
     async def _may_read(
@@ -528,7 +537,11 @@ class ConversationService:
         caller may read through `runs:view` is one they could not star.
         """
         conversation = await self.get_conversation(
-            conversation_id, organization_id=organization_id, user_id=user_id, ctx=ctx
+            conversation_id,
+            organization_id=organization_id,
+            user_id=user_id,
+            include_favourite=False,
+            ctx=ctx,
         )
         await conversation_repo.set_favourite(
             self.db, user_id=user_id, conversation_id=conversation.id, favourite=favourite
@@ -649,6 +662,7 @@ class ConversationService:
             organization_id=organization_id,
             user_id=user_id,
             for_write=True,
+            include_favourite=False,
         )
         await conversation_repo.delete_conversation(self.db, db_conversation=conversation)
         return True
@@ -686,7 +700,11 @@ class ConversationService:
         authorizing half was missed for so long.
         """
         await self.get_conversation(
-            conversation_id, organization_id=organization_id, user_id=user_id, ctx=ctx
+            conversation_id,
+            organization_id=organization_id,
+            user_id=user_id,
+            include_favourite=False,
+            ctx=ctx,
         )
         items = await conversation_repo.get_messages_by_conversation(
             self.db,
@@ -740,7 +758,11 @@ class ConversationService:
         turns" while the label says "this conversation".
         """
         await self.get_conversation(
-            conversation_id, organization_id=organization_id, user_id=user_id, ctx=ctx
+            conversation_id,
+            organization_id=organization_id,
+            user_id=user_id,
+            include_favourite=False,
+            ctx=ctx,
         )
         totals = await conversation_repo.conversation_cost(self.db, conversation_id)
         if totals is None:
@@ -793,7 +815,11 @@ class ConversationService:
         would silently reopen it.
         """
         conversation = await self.get_conversation(
-            conversation_id, organization_id=organization_id, user_id=user_id, for_write=True
+            conversation_id,
+            organization_id=organization_id,
+            user_id=user_id,
+            for_write=True,
+            include_favourite=False,
         )
         if conversation.is_archived:
             raise BadRequestError(

--- a/backend/app/services/conversation.py
+++ b/backend/app/services/conversation.py
@@ -258,6 +258,14 @@ class ConversationService:
                 msg.rating_count = rating_counts.get(msg.id)  # ty: ignore[unresolved-attribute]
         if include_messages and conversation.messages:
             await self._attach_authors(conversation.messages)
+        # Here rather than at each route, because this is the one read every
+        # reader-scoped one goes through - `update`, `archive` and `set_favourite`
+        # all return the object it hands back. Only two responses carried the flag
+        # before, so `GET /conversations/{id}` and the PATCH answered `false` to a
+        # caller who really had starred the thread (#1254). Skipped entirely for a
+        # call with no reader: an internal read pays no query, and a star belongs
+        # to nobody in particular there.
+        await self._attach_favourites([conversation], user_id=user_id)
         return conversation
 
     async def _may_read(

--- a/backend/app/services/conversation_share.py
+++ b/backend/app/services/conversation_share.py
@@ -134,11 +134,22 @@ class ConversationShareService:
     async def list_shared_with_me(
         self, user_id: UUID, *, skip: int = 0, limit: int = 50
     ) -> tuple[list, int]:
-        """List conversations shared with the current user."""
+        """List conversations shared with the current user.
+
+        The star is stamped here too. A thread somebody was *shared* is exactly
+        the kind they favourite - a shared conversation may be starred by anyone
+        who can read it - so a list that answered `false` for every row was
+        wrong on the surface where it matters most (#1254).
+        """
         items = await conversation_share_repo.get_conversations_shared_with_user(
             self.db, user_id, skip=skip, limit=limit
         )
         total = await conversation_share_repo.count_conversations_shared_with_user(self.db, user_id)
+        starred = await conversation_repo.favourite_ids(
+            self.db, user_id=user_id, conversation_ids=[item.id for item in items]
+        )
+        for item in items:
+            item.is_favourite = item.id in starred  # ty: ignore[unresolved-attribute]
         return items, total
 
     async def get_by_token(self, token: str) -> dict:

--- a/backend/tests/integration/test_conversation_favourites.py
+++ b/backend/tests/integration/test_conversation_favourites.py
@@ -13,11 +13,14 @@ different sidebars.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import uuid
 from datetime import UTC, datetime, timedelta
 
 import pytest
 from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
 
 from app.db.models.conversation import Conversation
 from app.db.models.conversation_favourite import ConversationFavourite
@@ -224,3 +227,57 @@ class TestArchivingKeepsTheStarAndDropsTheBand:
         assert await conversation_repo.favourite_ids(
             db, user_id=reader.id, conversation_ids=[thread.id]
         ) == {thread.id}
+
+
+class TestTwoClicksAtOnceStillLeaveOneRow:
+    async def test_a_held_star_does_not_make_the_second_one_fail(self, engine: AsyncEngine) -> None:
+        """Deterministic on purpose, the shape #17's identity race uses: one
+        request's insert is held open - uncommitted, holding the unique-index
+        lock on the new row - while a second stars the same thread.
+
+        `ON CONFLICT DO NOTHING` has the second block on that lock and, once the
+        first commits, do nothing: one row, no error. The read-then-insert it
+        replaces had both requests miss the `SELECT` and both `INSERT`, and the
+        second violated the primary key - so a double click answered 500 and the
+        sidebar rolled the star back off a thread that was in fact starred
+        (#1254). Racing two calls through `gather` does not reproduce it: the
+        pair serialises and the first commits before the second inserts.
+        """
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        async with factory() as setup:
+            organization = await _org(setup)
+            reader = await _user(setup)
+            thread = await _conversation(setup, organization, reader, title="rota")
+            await setup.commit()
+
+        session_a = factory()
+        b_task: asyncio.Task[None] | None = None
+        try:
+            await conversation_repo.set_favourite(
+                session_a, user_id=reader.id, conversation_id=thread.id, favourite=True
+            )
+
+            async def star_again() -> None:
+                async with factory() as session_b:
+                    await conversation_repo.set_favourite(
+                        session_b, user_id=reader.id, conversation_id=thread.id, favourite=True
+                    )
+                    await session_b.commit()
+
+            b_task = asyncio.create_task(star_again())
+            await asyncio.sleep(0.4)
+            assert not b_task.done()  # blocked on A's uncommitted insert
+
+            await session_a.commit()
+
+            await b_task
+            b_task = None
+        finally:
+            if b_task is not None:
+                b_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await b_task
+            await session_a.close()
+
+        async with factory() as session:
+            assert await session.scalar(select(func.count(ConversationFavourite.user_id))) == 1

--- a/backend/tests/test_conversation_share.py
+++ b/backend/tests/test_conversation_share.py
@@ -154,3 +154,29 @@ async def test_an_id_outside_the_organization_is_refused_as_not_found(
             await service.share_conversation(uuid.uuid4(), owner, shared_with=outsider)
 
         share_repo.create.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_a_thread_shared_with_you_says_whether_you_starred_it(
+    service: ConversationShareService,
+):
+    """The listing answered `false` for every row, on the surface where the star
+    is most useful: a thread somebody sent you is exactly the kind you keep
+    (#1254)."""
+    mine, theirs = uuid.uuid4(), uuid.uuid4()
+    reader = uuid.uuid4()
+    with (
+        patch(f"{MODULE}.conversation_share_repo") as share_repo,
+        patch(f"{MODULE}.conversation_repo") as conv_repo,
+    ):
+        share_repo.get_conversations_shared_with_user = AsyncMock(
+            return_value=[MagicMock(id=mine), MagicMock(id=theirs)]
+        )
+        share_repo.count_conversations_shared_with_user = AsyncMock(return_value=2)
+        conv_repo.favourite_ids = AsyncMock(return_value={mine})
+
+        items, total = await service.list_shared_with_me(reader)
+
+        assert total == 2
+        assert [item.is_favourite for item in items] == [True, False]
+        assert conv_repo.favourite_ids.await_args.kwargs["user_id"] == reader

--- a/backend/tests/test_services_conversation.py
+++ b/backend/tests/test_services_conversation.py
@@ -2130,6 +2130,32 @@ class TestAFavouriteBelongsToTheReader:
 
         assert read.is_favourite is True
 
+    async def test_a_read_that_only_authorizes_asks_for_no_stars(self, monkeypatch):
+        """`GET /conversations/{id}/messages` resolves the conversation twice -
+        through `list_messages` and `conversation_cost` - and serializes neither
+        it nor its star, so the flag being on by default would cost two queries
+        per transcript opened."""
+        conversation = MockConversation()
+        monkeypatch.setattr(
+            conversation_repo, "get_conversation_by_id", AsyncMock(return_value=conversation)
+        )
+        monkeypatch.setattr(
+            conversation_repo, "agents_in_conversations", AsyncMock(return_value={})
+        )
+        asked = AsyncMock(return_value=set())
+        monkeypatch.setattr(conversation_repo, "favourite_ids", asked)
+        service = ConversationService(AsyncMock())
+        monkeypatch.setattr(service, "_may_read", AsyncMock(return_value=True))
+
+        await service.get_conversation(
+            conversation.id,
+            organization_id=TEST_ORG_ID,
+            user_id=uuid4(),
+            include_favourite=False,
+        )
+
+        asked.assert_not_awaited()
+
     async def test_a_read_with_no_reader_asks_for_nobodys_stars(self, monkeypatch):
         """An internal read - the run path resolving a thread - has no reader to
         answer for, and must not pay a query to say so."""

--- a/backend/tests/test_services_conversation.py
+++ b/backend/tests/test_services_conversation.py
@@ -225,6 +225,7 @@ class TestConversationServiceGetConversation:
 
         with patch("app.services.conversation.conversation_repo") as mock_repo:
             mock_repo.get_conversation_by_id = AsyncMock(return_value=mock_conv)
+            mock_repo.favourite_ids = AsyncMock(return_value=set())
 
             result = await service.get_conversation(
                 conv_id, user_id=user_id, organization_id=TEST_ORG_ID
@@ -285,6 +286,7 @@ class TestConversationServiceGetConversation:
             patch("app.services.conversation.channel_membership") as mock_membership,
         ):
             mock_repo.get_conversation_by_id = AsyncMock(return_value=mock_conv)
+            mock_repo.favourite_ids = AsyncMock(return_value=set())
             mock_share_repo.get_share = AsyncMock(return_value=None)
             mock_membership.confirms_participation = AsyncMock(return_value=True)
 
@@ -325,6 +327,7 @@ class TestATriggerRunLogReadsThroughItsAgent:
             patch("app.services.conversation.resolve_access") as resolve,
         ):
             repo.get_conversation_by_id = AsyncMock(return_value=conv)
+            repo.favourite_ids = AsyncMock(return_value=set())
             share.get_share = AsyncMock(return_value=None)
             membership.confirms_participation = AsyncMock(return_value=False)
             triggers.get_by_conversation_id = AsyncMock(return_value=trigger)
@@ -337,6 +340,45 @@ class TestATriggerRunLogReadsThroughItsAgent:
 
             assert result.id == conv_id
             agents.get.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_that_viewer_may_also_star_it(self, service: ConversationService):
+        """`set_favourite` reached `get_conversation` without the context, so
+        `_may_read_trigger_log` answered false and both favourite endpoints
+        returned 404 on a thread the caller could open - a refusal to somebody
+        permitted, on the surface the run-log work deliberately opened (#1254).
+        """
+        conv = MockConversation(user_id=None)
+        ctx = MagicMock()
+        ctx.has.return_value = True
+        with (
+            patch("app.services.conversation.conversation_repo") as repo,
+            patch("app.services.conversation.conversation_share_repo") as share,
+            patch("app.services.conversation.channel_membership") as membership,
+            patch("app.services.conversation.agent_trigger_repo") as triggers,
+            patch("app.services.conversation.agent_repo") as agents,
+            patch("app.services.conversation.resolve_access") as resolve,
+        ):
+            repo.get_conversation_by_id = AsyncMock(return_value=conv)
+            repo.favourite_ids = AsyncMock(return_value=set())
+            repo.set_favourite = AsyncMock()
+            repo.agents_in_conversations = AsyncMock(return_value={})
+            share.get_share = AsyncMock(return_value=None)
+            membership.confirms_participation = AsyncMock(return_value=False)
+            triggers.get_by_conversation_id = AsyncMock(return_value=MagicMock(agent_id=uuid4()))
+            agents.get = AsyncMock(return_value=MagicMock())
+            resolve.return_value = True
+
+            starred = await service.set_favourite(
+                conv.id,
+                organization_id=TEST_ORG_ID,
+                user_id=uuid4(),
+                favourite=True,
+                ctx=ctx,
+            )
+
+            assert starred.is_favourite is True
+            assert repo.set_favourite.await_args.kwargs["favourite"] is True
 
     @pytest.mark.anyio
     async def test_without_runs_view_the_run_log_is_refused(self, service: ConversationService):
@@ -490,6 +532,7 @@ class TestParticipationDoesNotCarryTheWrite:
             patch("app.services.conversation.channel_membership") as mock_membership,
         ):
             mock_repo.get_conversation_by_id = AsyncMock(return_value=conversation)
+            mock_repo.favourite_ids = AsyncMock(return_value=set())
             mock_share_repo.get_share = AsyncMock(return_value=None)
             mock_membership.confirms_participation = AsyncMock(return_value=True)
 
@@ -594,6 +637,7 @@ class TestParticipationDoesNotCarryTheWrite:
             patch("app.services.conversation.conversation_share_repo") as mock_share_repo,
         ):
             mock_repo.get_conversation_by_id = AsyncMock(return_value=conversation)
+            mock_repo.favourite_ids = AsyncMock(return_value=set())
             mock_repo.archive_conversation = AsyncMock(return_value=conversation)
             mock_share_repo.get_share = AsyncMock(return_value=MagicMock())
 
@@ -610,6 +654,7 @@ class TestParticipationDoesNotCarryTheWrite:
 
         with patch("app.services.conversation.conversation_repo") as mock_repo:
             mock_repo.get_conversation_by_id = AsyncMock(return_value=conversation)
+            mock_repo.favourite_ids = AsyncMock(return_value=set())
             mock_repo.archive_conversation = AsyncMock(return_value=conversation)
 
             archived = await service.archive_conversation(
@@ -658,6 +703,7 @@ class TestParticipationDoesNotCarryTheWrite:
             patch("app.services.conversation.channel_membership") as mock_membership,
         ):
             mock_repo.get_conversation_by_id = AsyncMock(return_value=conversation)
+            mock_repo.favourite_ids = AsyncMock(return_value=set())
             mock_repo.delete_conversation = AsyncMock()
             mock_share_repo.get_share = AsyncMock(return_value=None)
             mock_membership.confirms_participation = AsyncMock(return_value=True)
@@ -1635,6 +1681,7 @@ class TestSayingATurnWasStopped:
             mock_repo.get_conversation_by_id = AsyncMock(
                 return_value=MockConversation(id=conv_id, organization_id=TEST_ORG_ID)
             )
+            mock_repo.favourite_ids = AsyncMock(return_value=set())
             mock_repo.get_messages_by_conversation = AsyncMock(
                 return_value=[MockMessage(run_id=run_id)]
             )
@@ -1653,6 +1700,7 @@ class TestSayingATurnWasStopped:
             mock_repo.get_conversation_by_id = AsyncMock(
                 return_value=MockConversation(id=conv_id, organization_id=TEST_ORG_ID)
             )
+            mock_repo.favourite_ids = AsyncMock(return_value=set())
             mock_repo.get_messages_by_conversation = AsyncMock(return_value=[MockMessage()])
             mock_repo.count_messages = AsyncMock(return_value=1)
             mock_repo.run_statuses = AsyncMock(return_value={})
@@ -2039,6 +2087,7 @@ class TestAFavouriteBelongsToTheReader:
         monkeypatch.setattr(
             conversation_repo, "agents_in_conversations", AsyncMock(return_value={})
         )
+        monkeypatch.setattr(conversation_repo, "favourite_ids", AsyncMock(return_value=set()))
         stored = AsyncMock()
         monkeypatch.setattr(conversation_repo, "set_favourite", stored)
         service = ConversationService(AsyncMock())
@@ -2056,6 +2105,50 @@ class TestAFavouriteBelongsToTheReader:
         assert may_read.await_count == 1
         assert result.is_favourite is True
         assert stored.await_args.kwargs["favourite"] is True
+
+    async def test_a_single_read_says_whether_this_reader_starred_it(self, monkeypatch):
+        """The star reached exactly two responses before this - the listing and
+        the POST that set it - so `GET /conversations/{id}` and the PATCH told a
+        caller who really had starred the thread that they had not, and the
+        sidebar un-starred it on the next render (#1254)."""
+        conversation = MockConversation()
+        monkeypatch.setattr(
+            conversation_repo, "get_conversation_by_id", AsyncMock(return_value=conversation)
+        )
+        monkeypatch.setattr(
+            conversation_repo, "agents_in_conversations", AsyncMock(return_value={})
+        )
+        monkeypatch.setattr(
+            conversation_repo, "favourite_ids", AsyncMock(return_value={conversation.id})
+        )
+        service = ConversationService(AsyncMock())
+        monkeypatch.setattr(service, "_may_read", AsyncMock(return_value=True))
+
+        read = await service.get_conversation(
+            conversation.id, organization_id=TEST_ORG_ID, user_id=uuid4()
+        )
+
+        assert read.is_favourite is True
+
+    async def test_a_read_with_no_reader_asks_for_nobodys_stars(self, monkeypatch):
+        """An internal read - the run path resolving a thread - has no reader to
+        answer for, and must not pay a query to say so."""
+        conversation = MockConversation()
+        monkeypatch.setattr(
+            conversation_repo, "get_conversation_by_id", AsyncMock(return_value=conversation)
+        )
+        monkeypatch.setattr(
+            conversation_repo, "agents_in_conversations", AsyncMock(return_value={})
+        )
+        asked = AsyncMock(return_value=set())
+        monkeypatch.setattr(conversation_repo, "favourite_ids", asked)
+
+        read = await ConversationService(AsyncMock()).get_conversation(
+            conversation.id, organization_id=TEST_ORG_ID
+        )
+
+        asked.assert_not_awaited()
+        assert read.is_favourite is False
 
     async def test_a_thread_in_another_tenant_is_missing_rather_than_starrable(self, monkeypatch):
         conversation = MockConversation(organization_id=uuid4())

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -618,10 +618,14 @@ Four consequences worth knowing:
   `GET` or a PATCH told somebody who had starred a thread that they had not
   (#1254). A read with no reader — the admin listing, the run path resolving a
   thread — asks for nobody's stars and pays no query to say so, and a read that
-  only *authorizes* turns it off explicitly: `GET /conversations/{id}/messages`
-  resolves the conversation twice, through `list_messages` and
-  `conversation_cost`, and serializes neither it nor its star. On by default is
-  what keeps a route from forgetting; off is a deliberate act inside a service.
+  only *authorizes* turns it off explicitly with `include_favourite=False`. Those
+  are the reads whose result is discarded or is not a conversation:
+  `GET /conversations/{id}/messages`, which resolves the thread twice through
+  `list_messages` and `conversation_cost`; the three workspace routes; every turn
+  of an existing chat, through `agent._resolve_in_org`; and the writes —
+  `add_message`, `delete_conversation`, and `set_favourite`, which overwrites the
+  flag itself. On by default is what keeps a route that *does* serialize a
+  conversation from forgetting; off is a deliberate act at the call site.
 - **Starring is idempotent under contention**, because the insert is
   `ON CONFLICT DO NOTHING` rather than a read followed by an insert. Two
   overlapping POSTs for the same pair both saw no row and the second violated

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -602,16 +602,28 @@ boolean on `conversations`, because a conversation can be shared and a channel
 thread has participants rather than an owner: a column would let one person's
 star decide where the thread sits for everybody who can see it.
 
-Three consequences worth knowing:
+Four consequences worth knowing:
 
 - **`POST`/`DELETE /conversations/{id}/favourite` are authorized as a *read*.**
   A star says where a thread sits in the starrer's own sidebar and changes
   nothing about the thread, so somebody a conversation was shared with may star
   it exactly as its owner may. `for_write` there would refuse the reader the
-  feature exists for.
-- **`is_favourite` on a listed row is the caller's**, filled in one query per
-  page — so the admin listing, which has no reader, answers `false` throughout
-  rather than a different person's stars each request.
+  feature exists for. Both routes carry `Auth` for the same reason every other
+  read of one does: without a context `_may_read_trigger_log` answers false, and
+  a trigger's run-log the caller may open through `runs:view` would be one they
+  could not star (#1254).
+- **`is_favourite` is the caller's, and it is stamped in `get_conversation`** —
+  the one read every reader-scoped one goes through, rather than at each route.
+  It reached two responses out of eight while each route had to remember, so a
+  `GET` or a PATCH told somebody who had starred a thread that they had not
+  (#1254). A read with no reader — the admin listing, the run path resolving a
+  thread — asks for nobody's stars and pays no query to say so.
+- **Starring is idempotent under contention**, because the insert is
+  `ON CONFLICT DO NOTHING` rather than a read followed by an insert. Two
+  overlapping POSTs for the same pair both saw no row and the second violated
+  the primary key; the client also serializes its own pending star per
+  conversation, so a double click cannot have the DELETE answered before the
+  POST it followed.
 - **The band is an `ORDER BY`, not a grouping of the page.** The sidebar is
   paged, so a favourite sorted into page two by recency would sit under fifty
   threads that are not one. Within each band the chosen sort still applies, and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -617,7 +617,11 @@ Four consequences worth knowing:
   It reached two responses out of eight while each route had to remember, so a
   `GET` or a PATCH told somebody who had starred a thread that they had not
   (#1254). A read with no reader — the admin listing, the run path resolving a
-  thread — asks for nobody's stars and pays no query to say so.
+  thread — asks for nobody's stars and pays no query to say so, and a read that
+  only *authorizes* turns it off explicitly: `GET /conversations/{id}/messages`
+  resolves the conversation twice, through `list_messages` and
+  `conversation_cost`, and serializes neither it nor its star. On by default is
+  what keeps a route from forgetting; off is a deliberate act inside a service.
 - **Starring is idempotent under contention**, because the insert is
   `ON CONFLICT DO NOTHING` rather than a read followed by an insert. Two
   overlapping POSTs for the same pair both saw no row and the second violated

--- a/frontend/src/hooks/use-conversations.test.tsx
+++ b/frontend/src/hooks/use-conversations.test.tsx
@@ -907,6 +907,57 @@ describe("starring a conversation", () => {
     expect(toast.error).toHaveBeenCalledWith("Could not change the favourite");
   });
 
+  it("drops a queued click when the account changed while it waited", async () => {
+    // The queue's own hazard: a click waiting its turn is sent with whatever
+    // cookies the browser holds when it gets one, so waiting out a sign-out
+    // would land A's star as B's on a thread they can both read. The account is
+    // checked before the request goes, not only after it answers.
+    const result = await hook();
+    let settle: (value: unknown) => void = () => {};
+    vi.mocked(apiClient.post).mockReturnValue(
+      new Promise((resolve) => {
+        settle = resolve;
+      }),
+    );
+
+    act(() => {
+      void result.current.setFavourite("c-1", true);
+      void result.current.setFavourite("c-1", false);
+    });
+    await waitFor(() => expect(apiClient.post).toHaveBeenCalled());
+
+    act(() => {
+      useAuthStore.getState().setUser({ id: "u-next", email: "next@example.com" } as never);
+    });
+    await act(async () => {
+      settle({});
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(apiClient.delete).not.toHaveBeenCalled();
+  });
+
+  it("does not hold the next click behind the list refetch", async () => {
+    // The refetch is outside the chain, because what has to be serialized is
+    // the write. Behind it, a slow GET leaves an unstar optimistic while the
+    // server keeps the star - and a reload then loses the reader's last choice.
+    const result = await hook();
+    vi.mocked(apiClient.post).mockResolvedValue({});
+    vi.mocked(apiClient.delete).mockResolvedValue({});
+    vi.mocked(apiClient.get).mockImplementation(() => new Promise(() => {}));
+
+    await act(async () => {
+      void result.current.setFavourite("c-1", true);
+      await waitFor(() => expect(apiClient.post).toHaveBeenCalled());
+      void result.current.setFavourite("c-1", false);
+    });
+
+    await waitFor(() =>
+      expect(apiClient.delete).toHaveBeenCalledWith("/conversations/c-1/favourite"),
+    );
+  });
+
   it("puts the star back when the request is refused", async () => {
     // The cost of patching first: a refusal has to undo it, or the row keeps a
     // star the server never recorded and a reload takes it away without a word.

--- a/frontend/src/hooks/use-conversations.test.tsx
+++ b/frontend/src/hooks/use-conversations.test.tsx
@@ -6,7 +6,13 @@ import { toast } from "sonner";
 
 import { useConversations, type ConversationQuery } from "./use-conversations";
 import { apiClient } from "@/lib/api-client";
-import { useAgentSelectionStore, useAuthStore, useChatStore, useConversationStore } from "@/stores";
+import {
+  useAgentSelectionStore,
+  useAuthStore,
+  useChatStore,
+  useConversationStore,
+  useOrgStore,
+} from "@/stores";
 
 vi.mock("@/lib/api-client", () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
@@ -58,6 +64,7 @@ beforeEach(() => {
   useConversationStore.getState().reset();
   useChatStore.setState({ messages: [], isStreaming: false });
   useAgentSelectionStore.setState({ selectedAgentId: null, defaultAgentId: null });
+  useOrgStore.setState({ activeOrgId: null });
   serve();
   vi.mocked(apiClient.post).mockResolvedValue(conversation("c-new"));
   vi.mocked(apiClient.patch).mockResolvedValue({});
@@ -1018,6 +1025,79 @@ describe("starring a conversation", () => {
     await waitFor(() =>
       expect(apiClient.delete).toHaveBeenCalledWith("/conversations/c-1/favourite"),
     );
+  });
+
+  it("drops a queued click when the organization changed while it waited", async () => {
+    // `apiClient` stamps `X-Organization-Id` from the store when the request is
+    // sent, so a click queued across a switch is refused for a conversation in
+    // the tenant it was made in - and the server keeps the previous click's
+    // answer with nothing on screen saying so.
+    useOrgStore.setState({ activeOrgId: "org-a" });
+    const result = await hook();
+    let settle: (value: unknown) => void = () => {};
+    vi.mocked(apiClient.post).mockReturnValue(
+      new Promise((resolve) => {
+        settle = resolve;
+      }),
+    );
+
+    act(() => {
+      void result.current.setFavourite("c-1", true);
+      void result.current.setFavourite("c-1", false);
+    });
+    await waitFor(() => expect(apiClient.post).toHaveBeenCalled());
+
+    act(() => {
+      useOrgStore.setState({ activeOrgId: "org-b" });
+    });
+    await act(async () => {
+      settle({});
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(apiClient.delete).not.toHaveBeenCalled();
+  });
+
+  it("leaves the refetch to the newest click", async () => {
+    // A superseded click would answer with the state its own request left
+    // behind - the server's star, while the reader has since unstarred it - and
+    // patch that over the newer row.
+    const result = await hook();
+    let settle: (value: unknown) => void = () => {};
+    vi.mocked(apiClient.post).mockReturnValue(
+      new Promise((resolve) => {
+        settle = resolve;
+      }),
+    );
+    let release: (value: unknown) => void = () => {};
+    vi.mocked(apiClient.delete).mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve;
+      }),
+    );
+
+    act(() => {
+      void result.current.setFavourite("c-1", true);
+      void result.current.setFavourite("c-1", false);
+    });
+    await waitFor(() => expect(apiClient.post).toHaveBeenCalled());
+    const before = vi.mocked(apiClient.get).mock.calls.length;
+
+    await act(async () => {
+      settle({});
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // The POST answered and was superseded, so it refetched nothing; the DELETE
+    // that replaced it will, once it lands.
+    expect(vi.mocked(apiClient.get).mock.calls.length).toBe(before);
+    expect(result.current.conversations.find((c) => c.id === "c-1")?.is_favourite).toBe(false);
+    await act(async () => {
+      release({});
+      await Promise.resolve();
+    });
   });
 
   it("puts the star back when the request is refused", async () => {

--- a/frontend/src/hooks/use-conversations.test.tsx
+++ b/frontend/src/hooks/use-conversations.test.tsx
@@ -1100,6 +1100,39 @@ describe("starring a conversation", () => {
     });
   });
 
+  it("does not queue the next account behind a hung request", async () => {
+    // A request that hangs never drains its chain, so a key shared across
+    // accounts would leave whoever signs in next waiting on a promise that will
+    // not settle - on a thread they can genuinely see.
+    useAuthStore.getState().setUser({ id: "u-a", email: "a@example.com" } as never);
+    const first = await hook();
+    let settle: (value: unknown) => void = () => {};
+    vi.mocked(apiClient.post).mockReturnValue(
+      new Promise((resolve) => {
+        settle = resolve;
+      }),
+    );
+    vi.mocked(apiClient.delete).mockResolvedValue({});
+
+    act(() => {
+      void first.current.setFavourite("c-1", true);
+    });
+    await waitFor(() => expect(apiClient.post).toHaveBeenCalled());
+
+    act(() => {
+      useAuthStore.getState().setUser({ id: "u-b", email: "b@example.com" } as never);
+    });
+    const second = await hook();
+    act(() => {
+      void second.current.setFavourite("c-1", false);
+    });
+
+    await waitFor(() =>
+      expect(apiClient.delete).toHaveBeenCalledWith("/conversations/c-1/favourite"),
+    );
+    act(() => settle({}));
+  });
+
   it("puts the star back when the request is refused", async () => {
     // The cost of patching first: a refusal has to undo it, or the row keeps a
     // star the server never recorded and a reload takes it away without a word.

--- a/frontend/src/hooks/use-conversations.test.tsx
+++ b/frontend/src/hooks/use-conversations.test.tsx
@@ -704,6 +704,12 @@ describe("creating, renaming and removing a conversation", () => {
 
 describe("starring a conversation", () => {
   /**
+   * A pending star is the tab's, not this render's - `favouriteChains` is a
+   * module constant, because a request does not stop when the sidebar unmounts.
+   * So a test that holds a star or an unstar open has to release it before it
+   * finishes, or that promise stays at the head of the conversation's chain for
+   * every test after it.
+   *
    * The star is the one thing this hook patches rather than refetching, and the
    * boundary is exact: which list a thread belongs to is the server's answer,
    * but whether *this reader* starred it is a fact about the row the client
@@ -862,7 +868,12 @@ describe("starring a conversation", () => {
 
   it("queues per conversation, so one slow star does not hold another thread's", async () => {
     const result = await hook();
-    vi.mocked(apiClient.post).mockReturnValue(new Promise(() => {}));
+    let settle: (value: unknown) => void = () => {};
+    vi.mocked(apiClient.post).mockReturnValue(
+      new Promise((resolve) => {
+        settle = resolve;
+      }),
+    );
     vi.mocked(apiClient.delete).mockResolvedValue({});
 
     act(() => {
@@ -873,6 +884,7 @@ describe("starring a conversation", () => {
     await waitFor(() =>
       expect(apiClient.delete).toHaveBeenCalledWith("/conversations/c-2/favourite"),
     );
+    act(() => settle({}));
   });
 
   it("does not roll back from a refusal two clicks old", async () => {
@@ -887,9 +899,16 @@ describe("starring a conversation", () => {
         refuse = reject;
       }),
     );
-    // The queued DELETE never answers, so nothing refetches the list and what
-    // is asserted below is the patched cache rather than a fresh page.
-    vi.mocked(apiClient.delete).mockReturnValue(new Promise(() => {}));
+    // The queued DELETE is held rather than answered, so nothing refetches the
+    // list and what is asserted below is the patched cache rather than a fresh
+    // page. Released at the end, because the queue is the tab's: a star left
+    // pending here would be at the head of c-1's chain for every test after it.
+    let release: (value: unknown) => void = () => {};
+    vi.mocked(apiClient.delete).mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve;
+      }),
+    );
 
     act(() => {
       void result.current.setFavourite("c-1", true);
@@ -905,6 +924,10 @@ describe("starring a conversation", () => {
 
     expect(result.current.conversations.find((c) => c.id === "c-1")?.is_favourite).toBe(true);
     expect(toast.error).toHaveBeenCalledWith("Could not change the favourite");
+    await act(async () => {
+      release({});
+      await Promise.resolve();
+    });
   });
 
   it("drops a queued click when the account changed while it waited", async () => {
@@ -953,6 +976,45 @@ describe("starring a conversation", () => {
       void result.current.setFavourite("c-1", false);
     });
 
+    await waitFor(() =>
+      expect(apiClient.delete).toHaveBeenCalledWith("/conversations/c-1/favourite"),
+    );
+  });
+
+  it("still queues behind a star that outlived the sidebar", async () => {
+    // Leaving the chat unmounts the sidebar; the request it started carries on,
+    // because nothing aborts it. A queue that lived on the hook would be
+    // discarded with it, and the unstar on the way back would be sent without
+    // waiting - which is the ordering bug the queue exists to prevent, reached
+    // by a different route.
+    const first = renderHook(() => useConversations({}), { wrapper });
+    await waitFor(() => expect(first.result.current.isLoading).toBe(false));
+    let settle: (value: unknown) => void = () => {};
+    vi.mocked(apiClient.post).mockReturnValue(
+      new Promise((resolve) => {
+        settle = resolve;
+      }),
+    );
+    vi.mocked(apiClient.delete).mockResolvedValue({});
+
+    act(() => {
+      void first.result.current.setFavourite("c-1", true);
+    });
+    await waitFor(() => expect(apiClient.post).toHaveBeenCalled());
+    first.unmount();
+
+    const second = await hook();
+    await act(async () => {
+      void second.current.setFavourite("c-1", false);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(apiClient.delete).not.toHaveBeenCalled();
+
+    await act(async () => {
+      settle({});
+      await Promise.resolve();
+    });
     await waitFor(() =>
       expect(apiClient.delete).toHaveBeenCalledWith("/conversations/c-1/favourite"),
     );

--- a/frontend/src/hooks/use-conversations.test.tsx
+++ b/frontend/src/hooks/use-conversations.test.tsx
@@ -824,6 +824,89 @@ describe("starring a conversation", () => {
     expect(vi.mocked(apiClient.get).mock.calls.length).toBe(before);
   });
 
+  it("holds a second click until the first request has answered", async () => {
+    // The POST and the DELETE are separate requests and nothing made the second
+    // wait for the first, so a double click could have them answered out of
+    // order - the DELETE first, the POST committing after it - leaving the
+    // thread starred with nothing on screen saying so and no further click to
+    // reconcile them (#1254).
+    const result = await hook();
+    let settle: (value: unknown) => void = () => {};
+    vi.mocked(apiClient.post).mockReturnValue(
+      new Promise((resolve) => {
+        settle = resolve;
+      }),
+    );
+    vi.mocked(apiClient.delete).mockResolvedValue({});
+
+    act(() => {
+      void result.current.setFavourite("c-1", true);
+      void result.current.setFavourite("c-1", false);
+    });
+
+    await waitFor(() => expect(apiClient.post).toHaveBeenCalled());
+    expect(apiClient.delete).not.toHaveBeenCalled();
+    // The screen is already showing the second click, which is the point of
+    // patching first: only the request is queued.
+    expect(result.current.conversations.find((c) => c.id === "c-1")?.is_favourite).toBe(false);
+
+    await act(async () => {
+      settle({});
+      await Promise.resolve();
+    });
+
+    await waitFor(() =>
+      expect(apiClient.delete).toHaveBeenCalledWith("/conversations/c-1/favourite"),
+    );
+  });
+
+  it("queues per conversation, so one slow star does not hold another thread's", async () => {
+    const result = await hook();
+    vi.mocked(apiClient.post).mockReturnValue(new Promise(() => {}));
+    vi.mocked(apiClient.delete).mockResolvedValue({});
+
+    act(() => {
+      void result.current.setFavourite("c-1", true);
+      void result.current.setFavourite("c-2", false);
+    });
+
+    await waitFor(() =>
+      expect(apiClient.delete).toHaveBeenCalledWith("/conversations/c-2/favourite"),
+    );
+  });
+
+  it("does not roll back from a refusal two clicks old", async () => {
+    // Star, unstar, star: the row is starred and the first POST is the one that
+    // fails. Undoing it would take the star off a thread the reader has since
+    // put it back on, and the queued requests still decide what the server
+    // holds - so only the newest click owns what is on screen.
+    const result = await hook();
+    let refuse: (reason: unknown) => void = () => {};
+    vi.mocked(apiClient.post).mockReturnValueOnce(
+      new Promise((_resolve, reject) => {
+        refuse = reject;
+      }),
+    );
+    // The queued DELETE never answers, so nothing refetches the list and what
+    // is asserted below is the patched cache rather than a fresh page.
+    vi.mocked(apiClient.delete).mockReturnValue(new Promise(() => {}));
+
+    act(() => {
+      void result.current.setFavourite("c-1", true);
+      void result.current.setFavourite("c-1", false);
+      void result.current.setFavourite("c-1", true);
+    });
+    await waitFor(() => expect(apiClient.post).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      refuse("boom");
+      await Promise.resolve();
+    });
+
+    expect(result.current.conversations.find((c) => c.id === "c-1")?.is_favourite).toBe(true);
+    expect(toast.error).toHaveBeenCalledWith("Could not change the favourite");
+  });
+
   it("puts the star back when the request is refused", async () => {
     // The cost of patching first: a refusal has to undo it, or the row keeps a
     // star the server never recorded and a reload takes it away without a word.

--- a/frontend/src/hooks/use-conversations.ts
+++ b/frontend/src/hooks/use-conversations.ts
@@ -431,14 +431,18 @@ export function useConversations(query: Partial<ConversationQuery> = {}) {
       const startedAs = useAuthStore.getState().user?.id;
       patchFavourite(id, favourite);
       const chains = favouriteChains.current;
+      let sent = false;
       const send = async (): Promise<void> => {
+        // Checked here as well as after, and this is the half that matters: a
+        // click queued behind a slow request is sent with whatever cookies the
+        // browser holds when its turn comes, so waiting out a sign-out would
+        // have A's queued star land as B's on a thread they both can read. The
+        // checks after the call only protect the cache.
+        if (!stillSameAccount(startedAs)) return;
         try {
           if (favourite) await apiClient.post(`/conversations/${id}/favourite`, {});
           else await apiClient.delete(`/conversations/${id}/favourite`);
-          if (!stillSameAccount(startedAs)) return;
-          // The band is an ordering the server applies, so the list is refetched
-          // to move the row - the star itself is already right on screen.
-          await invalidateLists();
+          sent = true;
         } catch (err) {
           if (!stillSameAccount(startedAs)) return;
           // Only the newest click owns the row's displayed state; rolling back
@@ -453,6 +457,13 @@ export function useConversations(query: Partial<ConversationQuery> = {}) {
       chains.set(id, mine);
       await mine;
       if (chains.get(id) === mine) chains.delete(id);
+      // Outside the chain: what has to be serialized is the write, and holding
+      // the next click behind a refetch of the lists means a slow GET can leave
+      // an unstar optimistic while the server keeps the star indefinitely.
+      if (!sent || !stillSameAccount(startedAs)) return;
+      // The band is an ordering the server applies, so the list is refetched to
+      // move the row - the star itself is already right on screen.
+      await invalidateLists();
     },
     [patchFavourite, invalidateLists, setError, t, tErrors],
   );

--- a/frontend/src/hooks/use-conversations.ts
+++ b/frontend/src/hooks/use-conversations.ts
@@ -16,6 +16,25 @@ import type {
   ConversationMessage,
 } from "@/types";
 
+/**
+ * One chain of pending stars per conversation, so two clicks on the same star
+ * cannot land out of order.
+ *
+ * The POST and the DELETE are separate requests and nothing made the second wait
+ * for the first, so a double click could have the DELETE answered first and the
+ * POST commit after it - leaving the thread starred while the screen said
+ * otherwise, with no further click to reconcile them (#1254). The optimistic
+ * patch still happens at once; only the request is queued, so the star is as
+ * instant as it was.
+ *
+ * Module scope rather than a ref, because what is being ordered is requests in
+ * flight in this tab and a request does not stop when the sidebar unmounts. Two
+ * components reading this hook are two refs, and navigating away from the chat
+ * and back is a third - each of which would send its click without waiting for
+ * a pending one it cannot see. An entry is removed when its chain drains.
+ */
+const favouriteChains = new Map<string, Promise<void>>();
+
 interface CreateConversationResponse {
   id: string;
   title?: string;
@@ -413,15 +432,6 @@ export function useConversations(query: Partial<ConversationQuery> = {}) {
     [queryClient],
   );
 
-  // One chain per conversation, so two clicks on the same star cannot land
-  // out of order. The POST and the DELETE are separate requests and nothing
-  // made the second wait for the first, so a double click could have the
-  // DELETE answered first and the POST commit after it - leaving the thread
-  // starred while the screen said otherwise, with no further click to
-  // reconcile them (#1254). The optimistic patch still happens at once; only
-  // the request is queued, so the star is as instant as it was.
-  const favouriteChains = useRef(new Map<string, Promise<void>>());
-
   const setFavourite = useCallback(
     async (id: string, favourite: boolean) => {
       // The account this started as, for the same reason every other request
@@ -430,7 +440,7 @@ export function useConversations(query: Partial<ConversationQuery> = {}) {
       // account's error.
       const startedAs = useAuthStore.getState().user?.id;
       patchFavourite(id, favourite);
-      const chains = favouriteChains.current;
+      const chains = favouriteChains;
       let sent = false;
       const send = async (): Promise<void> => {
         // Checked here as well as after, and this is the half that matters: a

--- a/frontend/src/hooks/use-conversations.ts
+++ b/frontend/src/hooks/use-conversations.ts
@@ -8,7 +8,13 @@ import { getErrorMessage } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client";
 import { qk } from "@/lib/query-keys";
 import { setUrlParam } from "@/lib/utils";
-import { useAgentSelectionStore, useAuthStore, useConversationStore, useChatStore } from "@/stores";
+import {
+  useAgentSelectionStore,
+  useAuthStore,
+  useConversationStore,
+  useChatStore,
+  useOrgStore,
+} from "@/stores";
 import type {
   Conversation,
   ConversationCost,
@@ -439,22 +445,30 @@ export function useConversations(query: Partial<ConversationQuery> = {}) {
       // would roll back *their* cached row and show them the previous
       // account's error.
       const startedAs = useAuthStore.getState().user?.id;
+      // The organization too, for the same reason and one layer down:
+      // `apiClient` stamps `X-Organization-Id` from the store when the request
+      // is *sent*, so a click queued across a switch would be refused for a
+      // conversation in the tenant it was made in - leaving the server on the
+      // previous click's answer with nothing on screen saying so.
+      const startedIn = useOrgStore.getState().activeOrgId;
       patchFavourite(id, favourite);
       const chains = favouriteChains;
       let sent = false;
+      const stillHere = () =>
+        stillSameAccount(startedAs) && useOrgStore.getState().activeOrgId === startedIn;
       const send = async (): Promise<void> => {
         // Checked here as well as after, and this is the half that matters: a
         // click queued behind a slow request is sent with whatever cookies the
         // browser holds when its turn comes, so waiting out a sign-out would
         // have A's queued star land as B's on a thread they both can read. The
         // checks after the call only protect the cache.
-        if (!stillSameAccount(startedAs)) return;
+        if (!stillHere()) return;
         try {
           if (favourite) await apiClient.post(`/conversations/${id}/favourite`, {});
           else await apiClient.delete(`/conversations/${id}/favourite`);
           sent = true;
         } catch (err) {
-          if (!stillSameAccount(startedAs)) return;
+          if (!stillHere()) return;
           // Only the newest click owns the row's displayed state; rolling back
           // from an older one would undo a star the reader has since set.
           if (chains.get(id) === mine) patchFavourite(id, !favourite);
@@ -466,11 +480,16 @@ export function useConversations(query: Partial<ConversationQuery> = {}) {
       const mine = (chains.get(id) ?? Promise.resolve()).then(send);
       chains.set(id, mine);
       await mine;
-      if (chains.get(id) === mine) chains.delete(id);
+      // Only the newest click refetches. A superseded one would answer with the
+      // state its own request left behind - the server's star, while the reader
+      // has since unstarred it - and patch that over the newer optimistic row.
+      // The click that supersedes it invalidates when its own write lands.
+      const newest = chains.get(id) === mine;
+      if (newest) chains.delete(id);
       // Outside the chain: what has to be serialized is the write, and holding
       // the next click behind a refetch of the lists means a slow GET can leave
       // an unstar optimistic while the server keeps the star indefinitely.
-      if (!sent || !stillSameAccount(startedAs)) return;
+      if (!sent || !newest || !stillHere()) return;
       // The band is an ordering the server applies, so the list is refetched to
       // move the row - the star itself is already right on screen.
       await invalidateLists();

--- a/frontend/src/hooks/use-conversations.ts
+++ b/frontend/src/hooks/use-conversations.ts
@@ -23,8 +23,8 @@ import type {
 } from "@/types";
 
 /**
- * One chain of pending stars per conversation, so two clicks on the same star
- * cannot land out of order.
+ * One chain of pending stars per reader, tenant and conversation, so two clicks
+ * on the same star cannot land out of order.
  *
  * The POST and the DELETE are separate requests and nothing made the second wait
  * for the first, so a double click could have the DELETE answered first and the
@@ -38,8 +38,18 @@ import type {
  * components reading this hook are two refs, and navigating away from the chat
  * and back is a third - each of which would send its click without waiting for
  * a pending one it cannot see. An entry is removed when its chain drains.
+ *
+ * The account and the organization are in the key because ordering is only owed
+ * *within* one reader's view of one thread. A request that hangs is a request
+ * that never drains, so a shared key would leave the next account - or the same
+ * person after a switch - queued behind a promise that will not settle, on a
+ * conversation they can genuinely see.
  */
 const favouriteChains = new Map<string, Promise<void>>();
+
+/** Who, where, and which thread - see `favouriteChains`. */
+const chainKey = (id: string, account: string | undefined, organization: string | null) =>
+  `${account ?? "-"}:${organization ?? "-"}:${id}`;
 
 interface CreateConversationResponse {
   id: string;
@@ -453,6 +463,7 @@ export function useConversations(query: Partial<ConversationQuery> = {}) {
       const startedIn = useOrgStore.getState().activeOrgId;
       patchFavourite(id, favourite);
       const chains = favouriteChains;
+      const key = chainKey(id, startedAs, startedIn);
       let sent = false;
       const stillHere = () =>
         stillSameAccount(startedAs) && useOrgStore.getState().activeOrgId === startedIn;
@@ -471,21 +482,21 @@ export function useConversations(query: Partial<ConversationQuery> = {}) {
           if (!stillHere()) return;
           // Only the newest click owns the row's displayed state; rolling back
           // from an older one would undo a star the reader has since set.
-          if (chains.get(id) === mine) patchFavourite(id, !favourite);
+          if (chains.get(key) === mine) patchFavourite(id, !favourite);
           const message = getErrorMessage(err, tErrors, t("failedFavouriteConversation"));
           setError(message);
           toast.error(message);
         }
       };
-      const mine = (chains.get(id) ?? Promise.resolve()).then(send);
-      chains.set(id, mine);
+      const mine = (chains.get(key) ?? Promise.resolve()).then(send);
+      chains.set(key, mine);
       await mine;
       // Only the newest click refetches. A superseded one would answer with the
       // state its own request left behind - the server's star, while the reader
       // has since unstarred it - and patch that over the newer optimistic row.
       // The click that supersedes it invalidates when its own write lands.
-      const newest = chains.get(id) === mine;
-      if (newest) chains.delete(id);
+      const newest = chains.get(key) === mine;
+      if (newest) chains.delete(key);
       // Outside the chain: what has to be serialized is the write, and holding
       // the next click behind a refetch of the lists means a slow GET can leave
       // an unstar optimistic while the server keeps the star indefinitely.

--- a/frontend/src/hooks/use-conversations.ts
+++ b/frontend/src/hooks/use-conversations.ts
@@ -413,6 +413,15 @@ export function useConversations(query: Partial<ConversationQuery> = {}) {
     [queryClient],
   );
 
+  // One chain per conversation, so two clicks on the same star cannot land
+  // out of order. The POST and the DELETE are separate requests and nothing
+  // made the second wait for the first, so a double click could have the
+  // DELETE answered first and the POST commit after it - leaving the thread
+  // starred while the screen said otherwise, with no further click to
+  // reconcile them (#1254). The optimistic patch still happens at once; only
+  // the request is queued, so the star is as instant as it was.
+  const favouriteChains = useRef(new Map<string, Promise<void>>());
+
   const setFavourite = useCallback(
     async (id: string, favourite: boolean) => {
       // The account this started as, for the same reason every other request
@@ -421,20 +430,29 @@ export function useConversations(query: Partial<ConversationQuery> = {}) {
       // account's error.
       const startedAs = useAuthStore.getState().user?.id;
       patchFavourite(id, favourite);
-      try {
-        if (favourite) await apiClient.post(`/conversations/${id}/favourite`, {});
-        else await apiClient.delete(`/conversations/${id}/favourite`);
-        if (!stillSameAccount(startedAs)) return;
-        // The band is an ordering the server applies, so the list is refetched
-        // to move the row - the star itself is already right on screen.
-        await invalidateLists();
-      } catch (err) {
-        if (!stillSameAccount(startedAs)) return;
-        patchFavourite(id, !favourite);
-        const message = getErrorMessage(err, tErrors, t("failedFavouriteConversation"));
-        setError(message);
-        toast.error(message);
-      }
+      const chains = favouriteChains.current;
+      const send = async (): Promise<void> => {
+        try {
+          if (favourite) await apiClient.post(`/conversations/${id}/favourite`, {});
+          else await apiClient.delete(`/conversations/${id}/favourite`);
+          if (!stillSameAccount(startedAs)) return;
+          // The band is an ordering the server applies, so the list is refetched
+          // to move the row - the star itself is already right on screen.
+          await invalidateLists();
+        } catch (err) {
+          if (!stillSameAccount(startedAs)) return;
+          // Only the newest click owns the row's displayed state; rolling back
+          // from an older one would undo a star the reader has since set.
+          if (chains.get(id) === mine) patchFavourite(id, !favourite);
+          const message = getErrorMessage(err, tErrors, t("failedFavouriteConversation"));
+          setError(message);
+          toast.error(message);
+        }
+      };
+      const mine = (chains.get(id) ?? Promise.resolve()).then(send);
+      chains.set(id, mine);
+      await mine;
+      if (chains.get(id) === mine) chains.delete(id);
     },
     [patchFavourite, invalidateLists, setError, t, tErrors],
   );


### PR DESCRIPTION
Three of the five things #1254 found in the conversation-favourites feature. Items 1 and 5 — the missing `AuthContext` on both favourite routes, and the optimistic rollback crossing an account change — are already on `main`.

## `is_favourite` was false on six responses out of eight

Only `list_conversations` and `set_favourite` passed rows through `_attach_favourites`, so `GET /conversations/{id}`, the PATCH, the archive response and `/shared-with-me` serialized ORM objects that never carried the flag — the schema default answered `false` to a caller who really had starred the thread, and the sidebar un-starred it on the next render.

Stamped in `get_conversation` instead: the one read every reader-scoped one goes through, so a route cannot forget. `list_shared_with_me` has its own repository call and gets its own stamp. A read with no reader — the admin listing, the run path resolving a thread — still asks for nobody's stars and pays no query to say so.

## Starring twice at once raised

`set_favourite` read the row and inserted when it saw none, so two overlapping POSTs for the same `(user_id, conversation_id)` both saw nothing and the second `flush()` violated the primary key: a 500 on an endpoint that promises idempotent success, and a retried request did it too. Now `INSERT ... ON CONFLICT DO NOTHING` — the shape `channel_identity_repo.get_or_create` already uses (#17) — and the unstar is an unconditional `DELETE` rather than a read followed by one.

## A double click could leave it starred

The POST and the DELETE were separate requests with nothing making the second wait, so the DELETE could be answered first and the POST commit after it, leaving the thread starred with nothing on screen saying so and no further click to reconcile them. One promise chain per conversation now, so the requests land in click order. The optimistic patch still happens at once — only the request is queued, so the star is as instant as it was — and a refusal rolls the row back only if its click is still the newest, which star/unstar/star makes observable.

## How it was verified

Both races are pinned deterministically rather than raced through `gather`, which the issue asked for and which does not reproduce either of them:

- one session's insert held open — uncommitted, holding the unique-index lock — while a second session stars the same thread, the shape `test_channel_identity_race.py` uses;
- star, unstar, star with the first POST refused and the queued DELETE never answering, so what is asserted is the patched cache rather than a fresh page.

Both fail without the fix, as do the two read tests (`is_favourite` true on a `GET` after a star, and a run-log conversation starred by a `runs:view` caller).

Nine tests in `test_services_conversation.py` gained a `favourite_ids` stub: they patch `conversation_repo` wholesale and now go through a read that asks the question.

`make check` green. `make test` at 100% on the platform layer, `tests/integration/test_conversation_favourites.py` green against pgvector on 5433 (9 passed), `make test-frontend-cov` green with the new guard's branch covered. `docs/architecture.md#a-favourite-belongs-to-the-reader-not-to-the-thread` updated: the second bullet said "on a listed row", which is what this change makes untrue.

Closes #1254
