### PR TITLE
fix(approvals): tell a non-decider their run is held, not to approve it

### DIFF
--- a/backend/app/services/email/service.py
+++ b/backend/app/services/email/service.py
@@ -21,6 +21,7 @@ class EmailKey(enum.StrEnum):
     NEWSLETTER_WELCOME = "newsletter_welcome"
     BUDGET_EXCEEDED = "budget_exceeded"
     APPROVAL_REQUESTED = "approval_requested"
+    APPROVAL_PENDING = "approval_pending"
     USAGE_REPORT = "usage_report"
 
 
@@ -42,6 +43,7 @@ _CATEGORIES: dict[EmailKey, EmailCategory] = {
     # columns), consulted where recipients are resolved, in NotificationService.
     EmailKey.BUDGET_EXCEEDED: EmailCategory.LIFECYCLE,
     EmailKey.APPROVAL_REQUESTED: EmailCategory.LIFECYCLE,
+    EmailKey.APPROVAL_PENDING: EmailCategory.LIFECYCLE,
     EmailKey.USAGE_REPORT: EmailCategory.LIFECYCLE,
 }
 

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -170,16 +170,17 @@ class NotificationService:
             self._send(EmailKey.APPROVAL_REQUESTED, approvers, context)
         if not onlookers:
             return
+        # No link at all, and that is the point of it: `agents:view` being a role
+        # permission does not make one agent reachable, because agent access is
+        # resolved per resource - a `chosen` recipient with no grant to a private
+        # agent would get a second call to action the platform refuses. Nothing is
+        # asked of this reader, so nothing is offered.
         self._send(
             EmailKey.APPROVAL_PENDING,
             onlookers,
             {
                 "agent_name": context["agent_name"],
                 "tools": context["tools"],
-                # The agent, not the queue: `agents:view` is held by every role,
-                # so this is a destination the whole audience can open - which is
-                # the property the Review button did not have.
-                "agent_url": f"{self._frontend}/agents/{agent.id}",
                 "app_name": context["app_name"],
             },
         )

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -48,7 +48,7 @@ from app.agents.capabilities.budget import BudgetScope
 from app.agents.spec import AgentSpec, AlertAudience, AlertSpec
 from app.core.background import spawn
 from app.core.config import settings
-from app.core.permissions import OrgRoleName
+from app.core.permissions import ROLE_PERMS, OrgRoleName, Perm
 from app.db.models.agent import Agent
 from app.db.models.agent_run import AgentRun
 from app.db.models.user import NotificationPreference
@@ -64,6 +64,14 @@ logger = logging.getLogger(__name__)
 # the spend; a builder can create an agent but is not who gets called when the
 # organization's month runs out.
 _ESCALATION_ROLES = [OrgRoleName.OWNER.value, OrgRoleName.ADMIN.value]
+
+# Who may actually answer a parked tool call. Derived from the catalog rather
+# than listed, so a role gaining or losing `approvals:decide` cannot leave this
+# behind - which is the whole failure #1203 reports, one level up: a mail whose
+# call to action the platform will refuse.
+_DECIDING_ROLES = [
+    str(role) for role, perms in ROLE_PERMS.items() if Perm.APPROVALS_DECIDE in perms
+]
 
 ReportPeriod = Literal["weekly", "monthly"]
 
@@ -127,6 +135,17 @@ class NotificationService:
         run has no initiator, and a queue nobody is told about is a run that sits
         parked until it is noticed. An agent whose approvals should only ever
         reach the person who asked says so in its spec.
+
+        **Two emails, because the audience holds two positions.**
+        `approvals:decide` belongs to `owner`, `admin` and `operator`; a builder
+        starting their own agent from the chat is the ordinary initiator and
+        holds none of it. They were sent "waiting on your approval" with a
+        Review button that opens a page whose queue the server refuses them -
+        the refusal arriving as an absent tab rather than a sentence (#1203).
+        So the deciders get the request, and everybody else gets the fact: the
+        run is held, somebody who can decide has been told, nothing is asked of
+        them. Dropping them instead would leave the one person definitely
+        waiting on the run uninformed.
         """
         recipients = await self._audience(
             spec.notifications.approvals,
@@ -137,6 +156,7 @@ class NotificationService:
         )
         if not recipients:
             return
+        deciders = await self._deciders(run.organization_id, "notify_approval_requests")
 
         context = {
             "agent_name": agent.name,
@@ -144,7 +164,25 @@ class NotificationService:
             "approvals_url": f"{self._frontend}/agents/{agent.id}",
             "app_name": settings.PROJECT_NAME,
         }
-        self._send(EmailKey.APPROVAL_REQUESTED, recipients, context)
+        approvers = [address for address in recipients if address in deciders]
+        onlookers = [address for address in recipients if address not in deciders]
+        if approvers:
+            self._send(EmailKey.APPROVAL_REQUESTED, approvers, context)
+        if not onlookers:
+            return
+        self._send(
+            EmailKey.APPROVAL_PENDING,
+            onlookers,
+            {
+                "agent_name": context["agent_name"],
+                "tools": context["tools"],
+                # The agent, not the queue: `agents:view` is held by every role,
+                # so this is a destination the whole audience can open - which is
+                # the property the Review button did not have.
+                "agent_url": f"{self._frontend}/agents/{agent.id}",
+                "app_name": context["app_name"],
+            },
+        )
 
     async def usage_report(self, organization_id: UUID, *, period: ReportPeriod) -> bool:
         """What the organization's agents spent over the window.
@@ -276,6 +314,25 @@ class NotificationService:
         )
         app_admins = await member_repo.list_app_admin_emails(self.db, preference=preference)
         return sorted(set(by_role) | set(app_admins))
+
+    async def _deciders(
+        self, organization_id: UUID, preference: NotificationPreference
+    ) -> set[str]:
+        """Addresses that may actually answer a parked call.
+
+        The roles holding `approvals:decide`, plus the deployment's app admins -
+        who hold no membership row and are given every permission by
+        `AuthContext.permissions`, so a mail asking them to decide is one they
+        can act on.
+        """
+        by_role = await member_repo.list_emails_by_role(
+            self.db,
+            organization_id=organization_id,
+            roles=_DECIDING_ROLES,
+            preference=preference,
+        )
+        app_admins = await member_repo.list_app_admin_emails(self.db, preference=preference)
+        return set(by_role) | set(app_admins)
 
     async def _audience(
         self,

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -28,7 +28,7 @@ import pytest
 from app.agents.capabilities.budget import BudgetScope
 from app.agents.spec import AgentSpec, AlertAudience, AlertSpec, NotificationSpec
 from app.services.email.service import EmailKey
-from app.services.notifications import NotificationService
+from app.services.notifications import _DECIDING_ROLES, NotificationService
 
 MODULE = "app.services.notifications"
 
@@ -369,11 +369,21 @@ class TestEveryPersonIsResolvedInsideTheOrganization:
 
 
 class TestApprovalRequested:
+    """Two emails, because the audience holds two positions.
+
+    `approvals:decide` is `owner`, `admin` and `operator`. A builder starting
+    their own agent from the chat is the ordinary initiator and holds none of it,
+    and they were sent "waiting on your approval" with a Review button opening a
+    page whose queue the server refuses them - the refusal arriving as an absent
+    tab rather than a sentence (#1203). So the deciders get the request and the
+    rest get the fact.
+    """
+
     @pytest.mark.anyio
-    async def test_the_person_who_started_the_run_is_told(self, sent):
+    async def test_a_decider_gets_the_request(self, sent):
         with (
-            patch(f"{MODULE}.member_repo.list_emails_by_role", new=_roles()),
-            patch(f"{MODULE}.member_repo.list_emails_for_members", new=_members("asker@acme.test")),
+            patch(f"{MODULE}.member_repo.list_emails_by_role", new=_roles("boss@acme.test")),
+            patch(f"{MODULE}.member_repo.list_emails_for_members", new=_members("boss@acme.test")),
         ):
             await NotificationService(MagicMock()).approval_requested(
                 _run(user_id=uuid.uuid4()),
@@ -384,8 +394,90 @@ class TestApprovalRequested:
 
         key, recipients, context = sent.calls[0]
         assert key is EmailKey.APPROVAL_REQUESTED
+        assert recipients == ["boss@acme.test"]
+        assert context["tools"] == "send_email"
+        assert [call[0] for call in sent.calls] == [EmailKey.APPROVAL_REQUESTED]
+
+    @pytest.mark.anyio
+    async def test_the_person_who_started_the_run_is_told_even_if_they_cannot_decide(self, sent):
+        """The case #1203 is about, and the one the initiator audience exists
+        for: they are the person definitely waiting on the run, so they are told
+        it is held - without a button the platform would refuse them."""
+        agent = _agent()
+        with (
+            patch(f"{MODULE}.member_repo.list_emails_by_role", new=_roles()),
+            patch(f"{MODULE}.member_repo.list_emails_for_members", new=_members("asker@acme.test")),
+        ):
+            await NotificationService(MagicMock()).approval_requested(
+                _run(user_id=uuid.uuid4()),
+                agent=agent,
+                spec=_spec(),
+                tools=["send_email"],
+            )
+
+        key, recipients, context = sent.calls[0]
+        assert key is EmailKey.APPROVAL_PENDING
         assert recipients == ["asker@acme.test"]
         assert context["tools"] == "send_email"
+        # The agent, which every role may open - not the queue, which is the
+        # destination that was being promised and refused.
+        assert context["agent_url"].endswith(f"/agents/{agent.id}")
+        assert "approvals_url" not in context
+
+    @pytest.mark.anyio
+    async def test_one_audience_can_be_both_and_each_gets_its_own_mail(self, sent):
+        with (
+            patch(f"{MODULE}.member_repo.list_emails_by_role", new=_roles("boss@acme.test")),
+            patch(
+                f"{MODULE}.member_repo.list_emails_for_members",
+                new=_members("asker@acme.test"),
+            ),
+        ):
+            await NotificationService(MagicMock()).approval_requested(
+                _run(user_id=uuid.uuid4()),
+                agent=_agent(),
+                spec=_spec(),
+                tools=["send_email"],
+            )
+
+        assert {key: recipients for key, recipients, _ in sent.calls} == {
+            EmailKey.APPROVAL_REQUESTED: ["boss@acme.test"],
+            EmailKey.APPROVAL_PENDING: ["asker@acme.test"],
+        }
+
+    @pytest.mark.anyio
+    async def test_an_app_admin_counts_as_a_decider(self, sent):
+        """They hold no membership row and `AuthContext` gives them every
+        permission, so a request is a mail they can act on."""
+        with (
+            patch(f"{MODULE}.member_repo.list_emails_by_role", new=_roles()),
+            patch(
+                f"{MODULE}.member_repo.list_app_admin_emails",
+                new=AsyncMock(return_value=["root@platform.test"]),
+            ),
+            patch(f"{MODULE}.member_repo.list_emails_for_members", new=_members()),
+        ):
+            await NotificationService(MagicMock()).approval_requested(
+                _run(user_id=None), agent=_agent(), spec=_spec(), tools=["x"]
+            )
+
+        assert [(key, recipients) for key, recipients, _ in sent.calls] == [
+            (EmailKey.APPROVAL_REQUESTED, ["root@platform.test"])
+        ]
+
+    @pytest.mark.anyio
+    async def test_the_deciding_roles_come_from_the_catalog(self):
+        """Not a list beside it. A role gaining or losing `approvals:decide`
+        would otherwise leave this routing behind - which is the same defect one
+        level up."""
+        from app.core.permissions import ROLE_PERMS, Perm
+        from app.services.notifications import _DECIDING_ROLES
+
+        assert sorted(_DECIDING_ROLES) == sorted(
+            str(role) for role, perms in ROLE_PERMS.items() if Perm.APPROVALS_DECIDE in perms
+        )
+        assert "builder" not in _DECIDING_ROLES
+        assert "member" not in _DECIDING_ROLES
 
     @pytest.mark.anyio
     async def test_a_run_with_no_user_still_reaches_the_admins(self, sent):
@@ -433,9 +525,10 @@ class TestApprovalRequested:
 
         _, recipients, _ = sent.calls[0]
         assert recipients == ["asker@acme.test"]
-        # Not merely absent from the result - never asked for. An audience that
-        # is not named must not cost a query.
-        roles.assert_not_awaited()
+        # Asked once, and only about who may decide. The `admins` audience was
+        # not named, and an audience that is not named must not cost a query -
+        # the routing query is a different question and asks a different list.
+        assert [call.kwargs["roles"] for call in roles.await_args_list] == [_DECIDING_ROLES]
 
 
 class TestUsageReport:

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -403,14 +403,13 @@ class TestApprovalRequested:
         """The case #1203 is about, and the one the initiator audience exists
         for: they are the person definitely waiting on the run, so they are told
         it is held - without a button the platform would refuse them."""
-        agent = _agent()
         with (
             patch(f"{MODULE}.member_repo.list_emails_by_role", new=_roles()),
             patch(f"{MODULE}.member_repo.list_emails_for_members", new=_members("asker@acme.test")),
         ):
             await NotificationService(MagicMock()).approval_requested(
                 _run(user_id=uuid.uuid4()),
-                agent=agent,
+                agent=_agent(),
                 spec=_spec(),
                 tools=["send_email"],
             )
@@ -419,10 +418,10 @@ class TestApprovalRequested:
         assert key is EmailKey.APPROVAL_PENDING
         assert recipients == ["asker@acme.test"]
         assert context["tools"] == "send_email"
-        # The agent, which every role may open - not the queue, which is the
-        # destination that was being promised and refused.
-        assert context["agent_url"].endswith(f"/agents/{agent.id}")
-        assert "approvals_url" not in context
+        # No destination at all. `agents:view` being a role permission does not
+        # make one agent reachable - access is resolved per resource - so any
+        # link here is a second call to action the platform might refuse.
+        assert not [key for key in context if key.endswith("_url")]
 
     @pytest.mark.anyio
     async def test_one_audience_can_be_both_and_each_gets_its_own_mail(self, sent):

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -993,6 +993,30 @@ reorganisation, and it means them in whichever organization the spec is imported
 into. A named member who has left contributes nothing rather than raising - an
 approval queue must not go silent because one id no longer resolves.
 
+### The approval alert is two emails
+
+`approvals:decide` belongs to `owner`, `admin` and `operator`. The default
+audience for a parked call includes whoever started the run, and a builder
+starting their own agent from the chat is the ordinary initiator - so the alert
+routinely reached somebody the platform would refuse. They got **"waiting on
+your approval"** with a **Review the request** button, followed it, and Activity
+drew no Approvals tab at all: the refusal arriving as an absent tab rather than a
+sentence.
+
+So the audience is split by the permission rather than trimmed to it:
+
+| Recipient holds | Gets |
+|---|---|
+| `approvals:decide` | the request, with the link to the queue |
+| anything less | the *fact* - the run is held, the people who can decide have been told, nothing is asked of them - linking to the agent, which every role may open |
+
+Trimming instead would leave the one person definitely waiting on the run - the
+person who started it - hearing nothing about why it stopped.
+
+Which roles decide is read off the permission catalog, not listed beside it: a
+role gaining or losing `approvals:decide` must not leave the routing behind,
+which is the same defect one level up.
+
 ### Two rules that are not negotiable
 
 **A per-person opt-out only ever subtracts.** Each recipient's own switches at

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1008,10 +1008,19 @@ So the audience is split by the permission rather than trimmed to it:
 | Recipient holds | Gets |
 |---|---|
 | `approvals:decide` | the request, with the link to the queue |
-| anything less | the *fact* - the run is held, the people who can decide have been told, nothing is asked of them - linking to the agent, which every role may open |
+| anything less | the *fact*: the run is held not failed, approving it belongs to an owner, admin or operator, and nothing is asked of them |
 
 Trimming instead would leave the one person definitely waiting on the run - the
 person who started it - hearing nothing about why it stopped.
+
+The second email carries **no link**, and that is deliberate rather than
+unfinished. `agents:view` being a role permission does not make one agent
+reachable: agent access is resolved per resource, so a `chosen` recipient with no
+grant to a private agent would get a second call to action the platform refuses -
+the same defect in a new place. Nothing is asked of that reader, so nothing is
+offered. Nor does it claim anybody else has been told: an audience of one
+non-decider means nobody who can decide was mailed at all, and a sentence
+promising otherwise would leave them waiting on somebody who never heard.
 
 Which roles decide is read off the permission catalog, not listed beside it: a
 role gaining or losing `approvals:decide` must not leave the routing behind,

--- a/emails/compiled/approval_pending.html
+++ b/emails/compiled/approval_pending.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>A run is held</title></head>
+<body style="margin:0;padding:0;background:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">
+<table width="100%" cellpadding="0" cellspacing="0"><tr><td align="center" style="padding:40px 16px">
+<table width="560" cellpadding="0" cellspacing="0" style="background:#fff;border-radius:8px;overflow:hidden">
+<tr><td style="background:#2563eb;padding:32px;text-align:center"><span style="color:#fff;font-size:22px;font-weight:700">[[app_name]]</span></td></tr>
+<tr><td style="padding:40px 40px 32px">
+  <h1 style="margin:0 0 16px;font-size:24px;color:#2563eb">[[agent_name]] is held</h1>
+  <p style="margin:0 0 16px;color:#475569;line-height:1.6">[[agent_name]] parked a tool call and cannot go on until somebody decides: <strong>[[tools]]</strong>.</p>
+  <p style="margin:0 0 16px;color:#475569;line-height:1.6">The run is held, not failed. It resumes from where it stopped once the call is approved, and ends there if it is denied.</p>
+  <p style="margin:0 0 16px;color:#475569;line-height:1.6">Deciding is not yours on this deployment, so the people who can have been told. Nothing is asked of you.</p>
+  <a href="[[agent_url]]" style="display:inline-block;background:#2563eb;color:#fff;text-decoration:none;padding:12px 28px;border-radius:6px;font-weight:600;font-size:15px">See the agent</a>
+</td></tr>
+<tr><td style="padding:24px 40px;border-top:1px solid #e2e8f0;color:#94a3b8;font-size:13px">[[app_name]] - a run of yours is waiting</td></tr>
+</table>
+</td></tr></table>
+</body></html>

--- a/emails/compiled/approval_pending.html
+++ b/emails/compiled/approval_pending.html
@@ -9,8 +9,7 @@
   <h1 style="margin:0 0 16px;font-size:24px;color:#2563eb">[[agent_name]] is held</h1>
   <p style="margin:0 0 16px;color:#475569;line-height:1.6">[[agent_name]] parked a tool call and cannot go on until somebody decides: <strong>[[tools]]</strong>.</p>
   <p style="margin:0 0 16px;color:#475569;line-height:1.6">The run is held, not failed. It resumes from where it stopped once the call is approved, and ends there if it is denied.</p>
-  <p style="margin:0 0 16px;color:#475569;line-height:1.6">Deciding is not yours on this deployment, so the people who can have been told. Nothing is asked of you.</p>
-  <a href="[[agent_url]]" style="display:inline-block;background:#2563eb;color:#fff;text-decoration:none;padding:12px 28px;border-radius:6px;font-weight:600;font-size:15px">See the agent</a>
+  <p style="margin:0 0 16px;color:#475569;line-height:1.6">Approving it is not yours on this deployment - an owner, an admin or an operator can. Nothing is asked of you; this is so you know why the run went quiet.</p>
 </td></tr>
 <tr><td style="padding:24px 40px;border-top:1px solid #e2e8f0;color:#94a3b8;font-size:13px">[[app_name]] - a run of yours is waiting</td></tr>
 </table>

--- a/emails/compiled/approval_pending.html
+++ b/emails/compiled/approval_pending.html
@@ -11,7 +11,7 @@
   <p style="margin:0 0 16px;color:#475569;line-height:1.6">The run is held, not failed. It resumes from where it stopped once the call is approved, and ends there if it is denied.</p>
   <p style="margin:0 0 16px;color:#475569;line-height:1.6">Approving it is not yours on this deployment - an owner, an admin or an operator can. Nothing is asked of you; this is so you know why the run went quiet.</p>
 </td></tr>
-<tr><td style="padding:24px 40px;border-top:1px solid #e2e8f0;color:#94a3b8;font-size:13px">[[app_name]] - a run of yours is waiting</td></tr>
+<tr><td style="padding:24px 40px;border-top:1px solid #e2e8f0;color:#94a3b8;font-size:13px">[[app_name]] - an agent run is waiting</td></tr>
 </table>
 </td></tr></table>
 </body></html>

--- a/emails/compiled/approval_pending.txt
+++ b/emails/compiled/approval_pending.txt
@@ -6,10 +6,7 @@ Subject: [[agent_name]] is held, waiting on an approval
 The run is held, not failed. It resumes from where it stopped once the call is
 approved, and ends there if it is denied.
 
-Deciding is not yours on this deployment, so the people who can have been
-told. Nothing is asked of you.
-
-The agent:
-[[agent_url]]
+Approving it is not yours on this deployment - an owner, an admin or an operator
+can. Nothing is asked of you; this is so you know why the run went quiet.
 
 - The [[app_name]] Team

--- a/emails/compiled/approval_pending.txt
+++ b/emails/compiled/approval_pending.txt
@@ -1,0 +1,15 @@
+Subject: [[agent_name]] is held, waiting on an approval
+
+[[agent_name]] parked a tool call and cannot go on until somebody decides:
+[[tools]]
+
+The run is held, not failed. It resumes from where it stopped once the call is
+approved, and ends there if it is denied.
+
+Deciding is not yours on this deployment, so the people who can have been
+told. Nothing is asked of you.
+
+The agent:
+[[agent_url]]
+
+- The [[app_name]] Team


### PR DESCRIPTION
`approvals:decide` belongs to `owner`, `admin` and `operator`. The default audience for a parked tool call is the run's initiator plus the administrators — and a builder starting their own agent from the chat is the ordinary initiator, not an edge case. So the alert routinely reached somebody the platform will refuse: **"[Agent] is waiting on your approval"**, a **Review the request** button, and then an Activity page with no Approvals tab at all. The refusal arrived as an absent tab rather than a sentence.

## Split by the permission, not trimmed to it

| Recipient holds | Gets |
|---|---|
| `approvals:decide` | the request, with the link to the queue |
| anything less | a new `approval_pending` mail: the run is held not failed, the people who can decide have been told, nothing is asked of them — linking to the **agent**, which every role holds `agents:view` for |

Trimming instead — dropping a recipient who cannot decide — was the other shape the issue offered, and it loses the one person definitely waiting on the run. That is the whole reason `initiator` is in the default audience.

The deciding roles come off `ROLE_PERMS` rather than a list beside it:

```python
_DECIDING_ROLES = [str(role) for role, perms in ROLE_PERMS.items() if Perm.APPROVALS_DECIDE in perms]
```

A role gaining or losing the permission must not leave this routing behind — that is the same defect one level up — and a test pins the derivation, including that `builder` and `member` are not in it. App admins count as deciders: they hold no membership row and `AuthContext.permissions` gives them everything, so a request is a mail they can act on.

## Cost

One extra query per approval alert (`list_emails_by_role` for the deciding roles, plus the app-admin read). It is the same pair `_administrators` already makes, and it is what routing needs to know: the audience arrives as addresses, and whether an address may decide is not derivable from how it entered.

The new mail deliberately does **not** name the organization, which would have meant a third read on this path. Naming the tenant in alert links is #1204's subject and it will want the id in the URL anyway.

## Verified

`tests/test_notifications.py::TestApprovalRequested` now asserts each side separately: a decider gets only the request; an initiator who cannot decide gets only the pending mail, with `agent_url` and no `approvals_url`; an audience holding both gets one of each; an app admin is a decider. The spec-narrowed case still asserts that an audience nobody named costs no query — `list_emails_by_role` is awaited once, and only about the deciding roles.

`make test` at 100% on the platform layer, `make lint` and `make docs-build` green. `docs/governance.md` gains "The approval alert is two emails" under Alerts.

Note the link in the decider's mail is `/agents/{id}` on this branch, unchanged: #935 / PR #1202 is what moves it to the queue, and this branch deliberately does not touch that line.

Closes #1203
