### PR TITLE
fix(api): decide an admin deletion on the app-admin set, under a lock

### DIFF
--- a/backend/app/repositories/user.py
+++ b/backend/app/repositories/user.py
@@ -22,6 +22,25 @@ async def get_by_id_for_update(db: AsyncSession, user_id: UUID) -> User | None:
     return result.scalar_one_or_none()
 
 
+async def app_admin_ids_for_update(db: AsyncSession) -> list[UUID]:
+    """Every app admin's id, locked, in a fixed order.
+
+    The lock is on the *set* rather than on one row, because what has to hold is
+    a fact about the set: a deployment keeps at least one administrator. Two
+    admins deleting each other locked different target rows, never contended,
+    and both committed - leaving nobody who could sign in to administer the
+    deployment and a direct database write as the only recovery (#1208).
+
+    `ORDER BY id` is what keeps that from being a deadlock instead: rows are
+    locked in the order they are returned, so two requests taking the same set
+    take it in the same order and one waits rather than both holding half of it.
+    """
+    result = await db.execute(
+        select(User.id).where(User.is_app_admin.is_(True)).order_by(User.id).with_for_update()
+    )
+    return list(result.scalars().all())
+
+
 async def get_by_email(db: AsyncSession, email: str) -> User | None:
     """Get user by email."""
     result = await db.execute(select(User).where(User.email == email))

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -464,10 +464,26 @@ class UserService:
         only ever shrinks by deletion - so refusing self-deletion is what keeps the
         last admin from being the one removed: any other admin deleting the *last*
         one would have to be deleting themselves.
+
+        **That held for one request at a time and not for two.** A and B deleting
+        each other both passed the not-self check, locked different target rows,
+        never contended, and both committed - nobody left who could sign in to
+        administer the deployment (#1208). So the second check is on the app-admin
+        *set*, taken under a lock in a fixed order: the later request waits, re-reads
+        after the first commits, and is refused because it would empty the set. The
+        set is locked on every admin deletion, target in it or not: taking it
+        first and always is what makes the order total, and deleting a user is an
+        administrator's action rather than a hot path.
         """
         if user_id == acting_admin_id:
             raise AuthorizationError(
                 message="You cannot delete your own account; ask another app admin to."
+            )
+        administrators = await user_repo.app_admin_ids_for_update(self.db)
+        if user_id in administrators and len(administrators) < 2:
+            raise AuthorizationError(
+                message="This is the deployment's last app admin; promote another one first.",
+                details={"app_admins": len(administrators)},
             )
         return await self.delete(user_id)
 

--- a/backend/tests/integration/test_app_admin_lockout.py
+++ b/backend/tests/integration/test_app_admin_lockout.py
@@ -1,0 +1,105 @@
+"""Two app admins deleting each other must not leave a deployment with none.
+
+`admin_delete` refuses an app admin deleting *themselves*, and that is what keeps
+the last administrator from being the one removed - because `is_app_admin` cannot
+be cleared over the API, so the set only ever shrinks by deletion. The guard is a
+comparison inside one request, and two requests both passed it: A deleting B and
+B deleting A are each not-self, they locked different target rows, they never
+contended, and both committed. Nobody was left who could sign in to administer the
+deployment, and the only recovery is a direct database write (#1208).
+
+Only a database can show either half of the fix - that the second request *waits*,
+and that it is refused once it can see the first one's commit - because what makes
+it work is `SELECT ... FOR UPDATE` over the app-admin set across two transactions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import uuid
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
+
+from app.core.exceptions import AuthorizationError
+from app.db.models.user import User
+from app.services.user import UserService
+
+pytestmark = pytest.mark.anyio
+
+
+async def _admin(db) -> User:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"{uuid.uuid4().hex}@example.com",
+        hashed_password="x",
+        is_active=True,
+        is_app_admin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _app_admins(factory) -> int:
+    async with factory() as session:
+        return await session.scalar(select(func.count(User.id)).where(User.is_app_admin.is_(True)))
+
+
+class TestTheSetIsWhatIsLocked:
+    async def test_the_second_of_two_mutual_deletes_is_refused(self, engine: AsyncEngine) -> None:
+        """Deterministic rather than raced: A's delete is held open, holding the
+        lock on the admin set, while B's mirror-image delete runs. B blocks, and
+        once A commits it re-reads a set of one and is refused."""
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        async with factory() as setup:
+            first = await _admin(setup)
+            second = await _admin(setup)
+            await setup.commit()
+
+        session_a = factory()
+        b_task: asyncio.Task[None] | None = None
+        try:
+            await UserService(session_a).admin_delete(second.id, acting_admin_id=first.id)
+
+            async def delete_the_other() -> None:
+                async with factory() as session_b:
+                    with pytest.raises(AuthorizationError):
+                        await UserService(session_b).admin_delete(
+                            first.id, acting_admin_id=second.id
+                        )
+                    await session_b.commit()
+
+            b_task = asyncio.create_task(delete_the_other())
+            await asyncio.sleep(0.4)
+            assert not b_task.done()  # blocked on A's lock over the admin set
+
+            await session_a.commit()
+
+            await b_task
+            b_task = None
+        finally:
+            if b_task is not None:
+                b_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await b_task
+            await session_a.close()
+
+        assert await _app_admins(factory) == 1
+
+    async def test_one_of_three_admins_may_still_go(self, engine: AsyncEngine) -> None:
+        """The refusal is about emptying the set, not about touching it."""
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        async with factory() as setup:
+            actor = await _admin(setup)
+            doomed = await _admin(setup)
+            await _admin(setup)
+            await setup.commit()
+
+        async with factory() as session:
+            await UserService(session).admin_delete(doomed.id, acting_admin_id=actor.id)
+            await session.commit()
+
+        assert await _app_admins(factory) == 2

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -432,8 +432,10 @@ class TestUserServicePostgresql:
         lone_admin = uuid4()
         with (
             patch("app.services.user.user_repo") as mock_repo,
+            patch("app.services.user.organization_repo") as mock_org_repo,
             patch.object(user_service, "_release_owned_rows", new=AsyncMock()),
         ):
+            mock_org_repo.list_created_by = AsyncMock(return_value=[])
             mock_repo.get_by_id_for_update = AsyncMock(return_value=mock_user)
             mock_repo.app_admin_ids_for_update = AsyncMock(return_value=[lone_admin])
             mock_repo.delete = AsyncMock(return_value=mock_user)

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -388,8 +388,48 @@ class TestUserServicePostgresql:
             patch.object(user_service, "_release_owned_rows", new=AsyncMock()),
         ):
             mock_repo.get_by_id_for_update = AsyncMock(return_value=mock_user)
+            mock_repo.app_admin_ids_for_update = AsyncMock(return_value=[uuid4(), uuid4()])
             mock_repo.delete = AsyncMock(return_value=mock_user)
 
             await user_service.admin_delete(mock_user.id, acting_admin_id=uuid4())
+
+            mock_repo.delete.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_the_last_app_admin_cannot_be_deleted_by_another_one(
+        self, user_service: UserService, mock_user: MockUser
+    ):
+        """The not-self check states a lockout invariant and only held for one
+        request at a time: A and B deleting each other both passed it, locked
+        different rows and both committed (#1208). The check is on the set now, so
+        whichever request re-reads it after the other commits is refused."""
+        with (
+            patch("app.services.user.user_repo") as mock_repo,
+            patch.object(user_service, "_release_owned_rows", new=AsyncMock()),
+        ):
+            mock_repo.app_admin_ids_for_update = AsyncMock(return_value=[mock_user.id])
+            mock_repo.delete = AsyncMock()
+
+            with pytest.raises(AuthorizationError):
+                await user_service.admin_delete(mock_user.id, acting_admin_id=uuid4())
+
+            mock_repo.delete.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_an_ordinary_user_is_deletable_when_one_admin_is_left(
+        self, user_service: UserService, mock_user: MockUser
+    ):
+        """The refusal is about the *set*, not about how small it is: a lone
+        administrator deleting somebody else is the ordinary case."""
+        lone_admin = uuid4()
+        with (
+            patch("app.services.user.user_repo") as mock_repo,
+            patch.object(user_service, "_release_owned_rows", new=AsyncMock()),
+        ):
+            mock_repo.get_by_id_for_update = AsyncMock(return_value=mock_user)
+            mock_repo.app_admin_ids_for_update = AsyncMock(return_value=[lone_admin])
+            mock_repo.delete = AsyncMock(return_value=mock_user)
+
+            await user_service.admin_delete(mock_user.id, acting_admin_id=lone_admin)
 
             mock_repo.delete.assert_awaited_once()

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -210,6 +210,18 @@ Removing an admin genuinely leaving is another admin's action, which is also wha
 keeps the audit trail readable. Recovery, if it is ever needed, is still
 `create-app-admin` from a shell on the deployment.
 
+That argument is about the *set*, and for a while the code was about one row.
+Two admins deleting each other were each not deleting themselves, locked
+different target rows, never contended, and both committed — zero app admins,
+recoverable only by writing to the database (#1208). So an admin deletion takes
+`SELECT ... FOR UPDATE` over the app-admin set, ordered by id, before it decides:
+the second request waits, re-reads the set once the first has committed, and is
+refused for emptying it. Ordered because two requests taking the same rows in
+different orders is a deadlock rather than a queue, and taken on every admin
+deletion rather than only on an admin's — deleting a user is an administrator's
+action, not a hot path, and a total order is worth more than the contention it
+costs.
+
 ## Notices, and closing the deployment
 
 **The announcement** is one sentence with one of three styles, shown above every


### PR DESCRIPTION
The not-self refusal in `admin_delete` states a lockout invariant — a deployment keeps at least one administrator — and it held only against one request at a time.

- request A: acting admin A, target B — not self, allowed
- request B: acting admin B, target A — not self, allowed

#1115's `SELECT ... FOR UPDATE` covers the **target** row, so the two locked different rows, touched different personal organizations and never contended. Both committed; `SELECT count(*) FROM users WHERE is_app_admin` was 0. Nobody can sign in to administer the deployment and the only recovery is a direct database write.

## The decision is now about the set it was always about

```python
async def app_admin_ids_for_update(db) -> list[UUID]:
    result = await db.execute(
        select(User.id).where(User.is_app_admin.is_(True)).order_by(User.id).with_for_update()
    )
```

`admin_delete` takes that before it decides, and refuses a deletion that would empty the set. The later of two mutual deletes waits on the lock, re-reads a set of one once the first commits, and is refused.

Two choices worth naming:

- **`ORDER BY id` is load-bearing.** Rows are locked in the order they are returned, so two requests taking the same set take it in the same order and one waits — where an unordered pair each holding half of it is #1134 in a new place.
- **Taken on every admin deletion, not only when the target is an admin.** That is what makes the order total; reading the target's flag first to decide whether to lock puts a window between the read and the lock. Deleting a user is an administrator's action, not a hot path.

## Verified

`backend/tests/integration/test_app_admin_lockout.py`, with the interleaving held open rather than raced through `gather` — the pair serialises and the first commits before the second reads:

- A's delete keeps its transaction, and the set lock, while B's mirror-image delete runs in another session; B is observed still blocked after 400ms; once A commits, B raises `AuthorizationError` and one app admin survives. **Fails without the fix.**
- One of three admins may still go, so the refusal is about emptying the set rather than touching it.

Plus two unit cases: the last admin refused even to another admin, and an ordinary user still deletable by a lone administrator.

`make test` at 100% on the platform layer, `make lint` and `make docs-build` green. `docs/deployment.md` already argued this invariant from the set; it now says what makes it true across two requests.

Closes #1208
