### PR TITLE
perf(rag): reuse one HTTP client for web search and model listings

### DIFF
--- a/backend/app/agents/capabilities/web_research/_search.py
+++ b/backend/app/agents/capabilities/web_research/_search.py
@@ -43,6 +43,31 @@ _TIMEOUT_SECONDS = 15.0
 # model's context spent on text it will quote two sentences of.
 _SNIPPET_CHARS = 1000
 
+_client: httpx.AsyncClient | None = None
+
+
+def _http() -> httpx.AsyncClient:
+    """The shared client for the HTTP-based providers, built once and reused.
+
+    A search tool called several times in one run hits the same provider each
+    time, and a client per call threw the connection pool away before it was
+    reused (#1263). Built lazily and rebuilt if it was closed; `close_http_client`
+    closes it at shutdown. The timeout rides each request, so one client serves
+    every provider.
+    """
+    global _client
+    if _client is None or _client.is_closed:
+        _client = httpx.AsyncClient()
+    return _client
+
+
+async def close_http_client() -> None:
+    """Close the shared search client at shutdown."""
+    global _client
+    if _client is not None and not _client.is_closed:
+        await _client.aclose()
+    _client = None
+
 
 class WebSearchResult(BaseModel):
     """A single web search hit, as every provider is normalised into."""
@@ -192,14 +217,14 @@ async def _tavily(query: str, max_results: int, api_key: str) -> list[WebSearchR
 async def _brave(query: str, max_results: int, api_key: str) -> list[WebSearchResult]:
     """Brave, reached over plain HTTP - the SDK adds nothing over one GET."""
     try:
-        async with httpx.AsyncClient(timeout=_TIMEOUT_SECONDS) as client:
-            response = await client.get(
-                "https://api.search.brave.com/res/v1/web/search",
-                params={"q": query, "count": max_results},
-                headers={"Accept": "application/json", "X-Subscription-Token": api_key},
-            )
-            response.raise_for_status()
-            payload = response.json()
+        response = await _http().get(
+            "https://api.search.brave.com/res/v1/web/search",
+            params={"q": query, "count": max_results},
+            headers={"Accept": "application/json", "X-Subscription-Token": api_key},
+            timeout=_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        payload = response.json()
     except Exception as exc:
         logger.exception("Brave search failed")
         raise SearchUnavailable(_unavailable("Brave", exc)) from exc
@@ -213,18 +238,18 @@ async def _brave(query: str, max_results: int, api_key: str) -> list[WebSearchRe
 async def _exa(query: str, max_results: int, api_key: str) -> list[WebSearchResult]:
     """Exa, which searches by meaning. `text` is requested so there is a snippet."""
     try:
-        async with httpx.AsyncClient(timeout=_TIMEOUT_SECONDS) as client:
-            response = await client.post(
-                "https://api.exa.ai/search",
-                json={
-                    "query": query,
-                    "numResults": max_results,
-                    "contents": {"text": {"maxCharacters": _SNIPPET_CHARS}},
-                },
-                headers={"Content-Type": "application/json", "x-api-key": api_key},
-            )
-            response.raise_for_status()
-            payload = response.json()
+        response = await _http().post(
+            "https://api.exa.ai/search",
+            json={
+                "query": query,
+                "numResults": max_results,
+                "contents": {"text": {"maxCharacters": _SNIPPET_CHARS}},
+            },
+            headers={"Content-Type": "application/json", "x-api-key": api_key},
+            timeout=_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        payload = response.json()
     except Exception as exc:
         logger.exception("Exa search failed")
         raise SearchUnavailable(_unavailable("Exa", exc)) from exc

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -192,6 +192,13 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[LifespanState, None]:
     # background turn can still be mid-request on it (#952).
     for _adapter in (_telegram_adapter, _mattermost_adapter, _slack_adapter):
         await _adapter.aclose()
+    # The shared outbound clients web search and the model-catalog listings reuse,
+    # closed the same way now that nothing can still be mid-request on them (#1263).
+    from app.agents.capabilities.web_research._search import close_http_client
+    from app.services.model_catalog import close_listing_client
+
+    await close_http_client()
+    await close_listing_client()
     # The knowledge capability caches a store of its own, built on the first
     # search and reachable from no request; a shutdown followed by more work -
     # a test, a reload - must not search through it once `close_db` has run.

--- a/backend/app/services/model_catalog.py
+++ b/backend/app/services/model_catalog.py
@@ -244,16 +244,40 @@ def _modalities(row: dict[str, Any], path: str | None) -> tuple[str, ...]:
     return tuple(entry for entry in node if isinstance(entry, str) and entry)
 
 
+_listing_client: httpx.AsyncClient | None = None
+
+
+def _client() -> httpx.AsyncClient:
+    """The shared client for provider listing fetches, built once and reused.
+
+    A catalog refresh asks several providers in turn, and a client per call threw
+    the connection pool away before it was reused (#1263). Built lazily and
+    rebuilt if it was closed; `close_listing_client` closes it at shutdown. The
+    timeout rides each request, so one client serves every listing.
+    """
+    global _listing_client
+    if _listing_client is None or _listing_client.is_closed:
+        _listing_client = httpx.AsyncClient()
+    return _listing_client
+
+
+async def close_listing_client() -> None:
+    """Close the shared listing client at shutdown."""
+    global _listing_client
+    if _listing_client is not None and not _listing_client.is_closed:
+        await _listing_client.aclose()
+    _listing_client = None
+
+
 async def _fetch(spec: ListingSpec, api_key: str | None) -> list[CatalogModel]:
     headers = dict(spec.extra_headers)
     if spec.auth_header is not None:
         if api_key is None:
             raise ValueError("This provider's listing needs a key")
         headers[spec.auth_header] = spec.auth_template.format(key=api_key)
-    async with httpx.AsyncClient(timeout=LISTING_TIMEOUT_SECONDS) as client:
-        response = await client.get(spec.url, headers=headers)
-        response.raise_for_status()
-        return _read_listing(response.json(), spec)
+    response = await _client().get(spec.url, headers=headers, timeout=LISTING_TIMEOUT_SECONDS)
+    response.raise_for_status()
+    return _read_listing(response.json(), spec)
 
 
 def _fallback(curated: list[CatalogModel]) -> tuple[list[CatalogModel], CatalogSource]:

--- a/backend/tests/test_model_catalog.py
+++ b/backend/tests/test_model_catalog.py
@@ -24,8 +24,10 @@ MODULE = "app.services.model_catalog"
 @pytest.fixture(autouse=True)
 def _empty_cache():
     model_catalog._cache.clear()
+    model_catalog._listing_client = None
     yield
     model_catalog._cache.clear()
+    model_catalog._listing_client = None
 
 
 def _responds(payload: object) -> MagicMock:

--- a/backend/tests/test_web_search.py
+++ b/backend/tests/test_web_search.py
@@ -29,6 +29,17 @@ from app.agents.capabilities.web_research._search import (
 from app.core.secret_kinds import ApiKeySecret
 
 
+@pytest.fixture(autouse=True)
+def _reset_search_client():
+    """The HTTP providers share one client (#1263); reset it so each test's
+    `httpx.AsyncClient` patch is what the next `search()` builds."""
+    from app.agents.capabilities.web_research import _search
+
+    _search._client = None
+    yield
+    _search._client = None
+
+
 def _tool_ctx(*, retry: int = 0, max_retries: int = 1) -> RunContext[None]:
     """A context with a retry left, which is what a real call starts with."""
     return RunContext(
@@ -262,3 +273,58 @@ class TestParsing:
 
     def test_wrong_kind_returns_none(self):
         assert parse_web_search('{"kind": "chart"}') is None
+
+
+class TestSharedHttpClient:
+    """The HTTP-based providers reuse one client rather than opening one per call
+    (#1263), and it is closed at shutdown."""
+
+    @pytest.mark.anyio
+    async def test_the_client_is_built_once_and_reused(self):
+        from app.agents.capabilities.web_research import _search
+
+        made = 0
+
+        def _make(**_kwargs: object) -> MagicMock:
+            nonlocal made
+            made += 1
+            return MagicMock(is_closed=False)
+
+        with patch("httpx.AsyncClient", _make):
+            first = _search._http()
+            second = _search._http()
+
+        assert made == 1
+        assert first is second
+
+    @pytest.mark.anyio
+    async def test_a_closed_client_is_rebuilt(self):
+        from app.agents.capabilities.web_research import _search
+
+        _search._client = MagicMock(is_closed=True)
+        fresh = MagicMock(is_closed=False)
+        with patch("httpx.AsyncClient", MagicMock(return_value=fresh)):
+            assert _search._http() is fresh
+
+    @pytest.mark.anyio
+    async def test_close_closes_a_live_client(self):
+        from app.agents.capabilities.web_research import _search
+
+        client = MagicMock(is_closed=False, aclose=AsyncMock())
+        _search._client = client
+        await _search.close_http_client()
+        client.aclose.assert_awaited_once()
+        assert _search._client is None
+
+    @pytest.mark.anyio
+    async def test_close_skips_an_already_closed_client_and_a_missing_one(self):
+        from app.agents.capabilities.web_research import _search
+
+        already = MagicMock(is_closed=True, aclose=AsyncMock())
+        _search._client = already
+        await _search.close_http_client()
+        already.aclose.assert_not_awaited()
+        assert _search._client is None
+        # And a no-op when there is nothing to close.
+        await _search.close_http_client()
+        assert _search._client is None


### PR DESCRIPTION
## Summary

The two per-call `httpx.AsyncClient` sites the #952 audit (AUD-006) left out of
its channel-adapter scope: the HTTP-based web-search providers (Brave, Exa) and
the model-catalog listing fetch. Each opened a fresh client per call, so a search
tool invoked several times in one run — or a catalog refresh asking provider after
provider — paid a new TCP+TLS handshake against a host it had just talked to
(#1263).

Both are module-level functions with no adapter lifecycle, so the #1262 shape (a
client on the adapter, closed in its `aclose`) does not fit.

## Changed

- One client per module, built lazily and rebuilt if it was closed, with the
  timeout on each request so one client serves every provider:
  `web_research/_search.py` (`_http` / `close_http_client`, used by `_brave` and
  `_exa`) and `model_catalog.py` (`_client` / `close_listing_client`, used by
  `_fetch`).
- The app lifespan closes both at shutdown, after background work has drained —
  the same place it closes the channel adapters' clients.

## Testing

- `_search.py` is in the platform layer (100% gate), so its getter and close are
  covered both ways: built-once-and-reused, rebuilt-after-close, close a live
  client, and skip a closed or absent one.
- The provider test suites reset the module client between tests, so each test's
  `httpx.AsyncClient` patch is what the next call builds. `make lint`/`ty` clean;
  `test_web_search` + `test_model_catalog` green.

## Notes for reviewers

- Perf-internal: no behaviour a page describes changes, so `docs/models.md` and
  `docs/reference/capabilities.md` are unchanged (the per-call vs pooled client is
  not documented).
- `ddgs` (DuckDuckGo) and Tavily go through their own SDKs, not httpx, so they are
  untouched.

Closes #1263
