### PR TITLE
test(chat): cover the two-digit ordered-list indent deterministically

### DIFF
--- a/frontend/src/components/chat/markdown-content.impl.test.tsx
+++ b/frontend/src/components/chat/markdown-content.impl.test.tsx
@@ -130,6 +130,12 @@ describe("rendering an answer", () => {
     expect(short.container.querySelector("ol")).toHaveClass("pl-6");
     short.unmount();
 
+    // The two-digit band: covered here deterministically so it does not depend on
+    // some other suite happening to render a 10-99 item list (#1264).
+    const tens = markdown(Array.from({ length: 15 }, (_, i) => `${i + 1}. item`).join("\n"));
+    expect(tens.container.querySelector("ol")).toHaveClass("pl-8");
+    tens.unmount();
+
     const long = markdown(Array.from({ length: 120 }, (_, i) => `${i + 1}. item`).join("\n"));
     expect(long.container.querySelector("ol")).toHaveClass("pl-10");
     long.unmount();


### PR DESCRIPTION
## Summary

`make test-frontend-cov` intermittently failed the 100% statement gate at 99.98%,
the one miss being `markdown-content.impl.tsx:37` — the `pl-8` return in
`orderedIndent`, the indent band for a 10-99 item ordered list. Nothing in the
markdown-content suite renders a list that size; the statement was covered only
when some *other* suite happened to render one, and under parallel scheduling that
render is not guaranteed, so the statement flipped uncovered and the gate went red
on a clean tree (#1264).

## Changed

- The ordered-list indent test already pins the 1-9 (`pl-6`), 100+ (`pl-10`) and
  1000+ (`pl-12`) bands. Added the missing two-digit case — a 15-item list
  asserting `pl-8` — so the band is covered here, deterministically, rather than
  by accident.

## Testing

- `bunx vitest run markdown-content.impl.test.tsx` green (23 tests).
- `bun run test:coverage` green: 100% statements/lines/functions, 97.83% branches.

Test-only; the branch is live (a 10-99 item list is reachable), so it is covered,
not removed.

Closes #1264
