### PR TITLE
fix(rag): unlink a dropped collection's stored uploads

### DIFF
--- a/backend/app/repositories/rag_document.py
+++ b/backend/app/repositories/rag_document.py
@@ -271,13 +271,22 @@ async def counts_by_collection(
     }
 
 
-async def delete_by_collection(db: AsyncSession, collection_name: str) -> int:
-    """Delete all RAG document records for a collection. Returns affected row count."""
+async def delete_by_collection(db: AsyncSession, collection_name: str) -> list[str]:
+    """Delete a collection's document rows, returning their stored file paths.
+
+    Keyed on `collection_name`, so it removes every knowledge base's rows for
+    that physical collection - which is what the collection-drop route means. The
+    returned `storage_path`s are the uploads the caller still has to unlink; a
+    `NULL` one (nothing was stored) is dropped. The bulk delete used to return
+    only a rowcount, so the files were orphaned on disk (#1265).
+    """
     result = await db.execute(
-        sql_delete(RAGDocument).where(RAGDocument.collection_name == collection_name)
+        sql_delete(RAGDocument)
+        .where(RAGDocument.collection_name == collection_name)
+        .returning(RAGDocument.storage_path)
     )
     await db.flush()
-    return result.rowcount  # ty: ignore[unresolved-attribute]
+    return [path for path in result.scalars().all() if path]
 
 
 async def delete_by_knowledge_base(db: AsyncSession, kb_id: UUID) -> list[str]:

--- a/backend/app/services/rag_document.py
+++ b/backend/app/services/rag_document.py
@@ -2,6 +2,7 @@
 """RAG document service."""
 
 import anyio
+import contextlib
 import logging
 from datetime import UTC, datetime
 from pathlib import Path
@@ -476,13 +477,18 @@ class RAGDocumentService:
 
         await rag_document_repo.delete(self.db, doc.id)
 
-    async def delete_by_collection(self, collection_name: str) -> int:
-        """Delete all RAG document records for a collection.
+    async def delete_by_collection(self, collection_name: str) -> None:
+        """Delete a collection's document rows and unlink their stored uploads.
 
-        Returns:
-            Number of deleted records.
+        The bulk row delete used to return only a count, so nothing removed the
+        uploaded files and every one was orphaned on disk when a collection was
+        dropped (#1265). The unlink is best-effort - a file already gone is not a
+        reason to fail the drop - and mirrors the org purge's teardown.
         """
-        return await rag_document_repo.delete_by_collection(self.db, collection_name)
+        storage = get_file_storage()
+        for storage_path in await rag_document_repo.delete_by_collection(self.db, collection_name):
+            with contextlib.suppress(Exception):
+                await storage.delete(storage_path)
 
     async def get_parsed_content(
         self, doc_id: str, vector_store: BaseVectorStore

--- a/backend/app/services/rag_document.py
+++ b/backend/app/services/rag_document.py
@@ -484,11 +484,15 @@ class RAGDocumentService:
         uploaded files and every one was orphaned on disk when a collection was
         dropped (#1265). The unlink is best-effort - a file already gone is not a
         reason to fail the drop - and mirrors the org purge's teardown.
+
+        `get_file_storage()` is resolved inside the suppression, and only when
+        there is a path to unlink: it `mkdir`s `MEDIA_DIR` on construction, so a
+        misconfigured storage backend would otherwise raise here and 500 a drop
+        whose vector table the route has already removed.
         """
-        storage = get_file_storage()
         for storage_path in await rag_document_repo.delete_by_collection(self.db, collection_name):
             with contextlib.suppress(Exception):
-                await storage.delete(storage_path)
+                await get_file_storage().delete(storage_path)
 
     async def get_parsed_content(
         self, doc_id: str, vector_store: BaseVectorStore

--- a/backend/tests/test_synced_document_delete.py
+++ b/backend/tests/test_synced_document_delete.py
@@ -272,3 +272,36 @@ class TestTheCLISync:
         # And the stored document identifies itself the same way, so the row and
         # the vector agree on which file this is.
         assert ingestion.ingest_file.await_args.kwargs["source_path"] == expected
+
+
+class TestDroppingACollection:
+    async def test_it_unlinks_the_stored_uploads(self, monkeypatch):
+        """The bulk row delete returns the storage paths now, so each upload is
+        unlinked rather than orphaned on disk when a collection is dropped (#1265)."""
+        monkeypatch.setattr(
+            rag_document_repo,
+            "delete_by_collection",
+            AsyncMock(return_value=["rag/docs/a.pdf", "rag/docs/b.md"]),
+        )
+        storage = MagicMock(delete=AsyncMock())
+        monkeypatch.setattr("app.services.rag_document.get_file_storage", lambda: storage)
+
+        await RAGDocumentService(MagicMock()).delete_by_collection("docs")
+
+        assert storage.delete.await_count == 2
+        storage.delete.assert_any_await("rag/docs/a.pdf")
+        storage.delete.assert_any_await("rag/docs/b.md")
+
+    async def test_a_failed_unlink_does_not_fail_the_drop(self, monkeypatch):
+        """A file already gone is not a reason to leave the collection half-dropped."""
+        monkeypatch.setattr(
+            rag_document_repo,
+            "delete_by_collection",
+            AsyncMock(return_value=["rag/docs/gone.pdf"]),
+        )
+        storage = MagicMock(delete=AsyncMock(side_effect=FileNotFoundError()))
+        monkeypatch.setattr("app.services.rag_document.get_file_storage", lambda: storage)
+
+        await RAGDocumentService(MagicMock()).delete_by_collection("docs")
+
+        storage.delete.assert_awaited_once()


### PR DESCRIPTION
## Summary

`DELETE /rag/collections/{name}` (`drop_collection`) dropped the vector table and
deleted the `rag_documents` rows, but `delete_by_collection` was a bulk delete
returning only a rowcount — so nothing unlinked the uploaded files, and every one
was orphaned on disk when a collection was dropped (#1265).

## Changed

- `rag_document_repo.delete_by_collection` now deletes `RETURNING storage_path`
  and returns the non-null paths — the shape `delete_by_knowledge_base` already
  uses.
- `RAGDocumentService.delete_by_collection` unlinks each returned file,
  best-effort (a file already gone is not a reason to fail the drop), mirroring
  the org purge's teardown. Keyed on `collection_name`, so it clears the files for
  every knowledge base backing that physical collection — which is what the drop
  route means.

## Testing

- Unit tests: the service unlinks each returned path, and a failed unlink does not
  fail the drop. The repo's `RETURNING` mirrors `delete_by_knowledge_base`, which
  the integration suite already exercises. `make lint`/`ty` clean.

## Notes for reviewers

- The route's only caller ignored the old `int` return, so widening it to the
  path list is contained.
- Sibling of #1266 (`DELETE /kb/{id}` leaves everything behind); this closes the
  collections route's file half.

Closes #1265
