### PR TITLE
fix(api): carry the magic link's destination in the token it signs

### DIFF
--- a/backend/app/api/routes/v1/auth.py
+++ b/backend/app/api/routes/v1/auth.py
@@ -27,7 +27,7 @@ from app.schemas.password_reset import (
     PasswordResetRequest,
     PasswordResetResponse,
 )
-from app.schemas.token import RefreshTokenRequest, Token
+from app.schemas.token import MagicLinkToken, RefreshTokenRequest, Token
 from app.schemas.user import UserCreate, UserRead
 from app.services.email.service import get_email_service
 
@@ -174,7 +174,7 @@ async def request_magic_link(
     Symmetric response to request_password_reset to avoid email enumeration.
     """
     await enforce_auth_limit(request, surface="auth_magic_link", identifier=body.email)
-    issued = await user_service.issue_magic_link_token(body.email)
+    issued = await user_service.issue_magic_link_token(body.email, return_to=body.return_to)
     if issued is not None:
         link_user, token = issued
         try:
@@ -190,16 +190,21 @@ async def request_magic_link(
     return PasswordResetResponse(message="Check your email for a sign-in link.")
 
 
-@router.post("/magic-link/verify", response_model=Token)
+@router.post("/magic-link/verify", response_model=MagicLinkToken)
 async def verify_magic_link(
     request: Request,
     body: MagicLinkVerifyRequest,
     user_service: UserSvc,
     session_service: SessionSvc,
 ) -> Any:
-    """Exchange a magic-link token for an access + refresh token pair."""
+    """Exchange a magic-link token for an access + refresh token pair.
+
+    Answers with the return path the link was minted for, unapplied: the client
+    navigates, and `postSignInDestination` there is the one place that decides
+    whether a path is safe to honour - the same judgement for every door in.
+    """
     await enforce_auth_limit(request, surface="auth_magic_link_verify")
-    user = await user_service.consume_magic_link_token(body.token)
+    user, return_to = await user_service.consume_magic_link_token(body.token)
     access_token = create_access_token(subject=str(user.id))
     refresh_token = create_refresh_token(subject=str(user.id))
     await session_service.create_session(
@@ -208,4 +213,6 @@ async def verify_magic_link(
         ip_address=request.client.host if request.client else None,
         user_agent=request.headers.get("User-Agent"),
     )
-    return Token(access_token=access_token, refresh_token=refresh_token)
+    return MagicLinkToken(
+        access_token=access_token, refresh_token=refresh_token, return_to=return_to
+    )

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -91,10 +91,21 @@ def create_password_reset_token(
 def create_magic_link_token(
     subject: str | Any,
     expires_delta: timedelta | None = None,
+    return_to: str | None = None,
 ) -> str:
-    """Sign-in-by-email JWT. Short-lived (15 min default)."""
+    """Sign-in-by-email JWT. Short-lived (15 min default).
+
+    `return_to` rides in the token because a magic link is followed from an
+    email - a different tab, often a different application, sometimes a
+    different browser - so the tab-local store the OAuth round trip uses is
+    empty by construction there (#1214). Signed, so the path cannot be edited
+    between the mint and the landing; validated before it gets here, by
+    `MagicLinkRequest`, so nothing unchecked is ever put in a token.
+    """
     expire = datetime.now(UTC) + (expires_delta or timedelta(minutes=15))
-    to_encode = {"exp": expire, "sub": str(subject), "type": "magic_link"}
+    to_encode: dict[str, Any] = {"exp": expire, "sub": str(subject), "type": "magic_link"}
+    if return_to is not None:
+        to_encode["rt"] = return_to
     return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
 
 

--- a/backend/app/schemas/password_reset.py
+++ b/backend/app/schemas/password_reset.py
@@ -1,8 +1,20 @@
 """Password-reset and magic-link request/confirm schemas."""
 
-from pydantic import EmailStr, Field
+import re
+
+from pydantic import EmailStr, Field, field_validator
 
 from app.schemas.base import BaseSchema
+
+# Where a magic link may land: a path on this deployment, and nothing else. A
+# value with a scheme ("https://evil.example"), a protocol-relative one
+# ("//evil.example"), a backslash variant ("/\evil.example", which browsers
+# normalise to "//") or a control character ("/\t/evil.example", which the URL
+# parser strips before parsing) would each turn the link into an open redirect -
+# and this one is *signed into a token* and followed from an email, so it must
+# not be storable in the first place. `frontend/src/lib/auth-landing.ts` refuses
+# the same shapes again at the landing; this is what keeps them out of the token.
+_SAFE_RETURN_PATH = re.compile(r"^/(?![/\\])[^\s\\\x00-\x1f\x7f]*$")
 
 
 class PasswordResetRequest(BaseSchema):
@@ -33,9 +45,24 @@ class PasswordResetConfirmResponse(BaseSchema):
 
 
 class MagicLinkRequest(BaseSchema):
-    """Email-only request - symmetric with password reset."""
+    """Email, and where the link should land.
+
+    `return_to` is the path the visitor was headed to when they were asked to
+    sign in. It travels *in the token* rather than in a session store, because a
+    magic link is followed from an email: a different tab, often a different
+    application, sometimes a different browser, where `sessionStorage` is empty
+    by construction (#1214).
+    """
 
     email: EmailStr
+    return_to: str | None = Field(default=None, max_length=512)
+
+    @field_validator("return_to")
+    @classmethod
+    def _only_a_path_on_this_deployment(cls, value: str | None) -> str | None:
+        if value is not None and not _SAFE_RETURN_PATH.match(value):
+            raise ValueError("must be a path on this deployment, beginning with a single '/'")
+        return value
 
 
 class MagicLinkVerifyRequest(BaseSchema):

--- a/backend/app/schemas/token.py
+++ b/backend/app/schemas/token.py
@@ -13,6 +13,18 @@ class Token(BaseSchema):
     token_type: str = "bearer"
 
 
+class MagicLinkToken(Token):
+    """A token pair, and where the link that produced it was headed.
+
+    Its own schema rather than a nullable field on :class:`Token`: every other
+    token response - the password login, the refresh - has no return path to
+    carry, and a field that is always null on three of four responses is one a
+    client learns to ignore (#1214).
+    """
+
+    return_to: str | None = None
+
+
 class TokenPayload(BaseSchema):
     """JWT token payload."""
 

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -505,15 +505,24 @@ class UserService:
         await session_repo.deactivate_all_user_sessions(self.db, user.id)
         return user
 
-    async def issue_magic_link_token(self, email: str) -> tuple[User, str] | None:
+    async def issue_magic_link_token(
+        self, email: str, *, return_to: str | None = None
+    ) -> tuple[User, str] | None:
         user = await user_repo.get_by_email(self.db, email)
         if user is None or not user.is_active:
             return None
-        token = create_magic_link_token(subject=str(user.id))
+        token = create_magic_link_token(subject=str(user.id), return_to=return_to)
         return user, token
 
-    async def consume_magic_link_token(self, token: str) -> User:
-        """Caller is responsible for minting access/refresh tokens for the returned user."""
+    async def consume_magic_link_token(self, token: str) -> tuple[User, str | None]:
+        """The account the link is for, and where it was headed.
+
+        Caller is responsible for minting access/refresh tokens for the returned
+        user. The return path comes back rather than being applied here: it is
+        the client that navigates, and `postSignInDestination` on that side is
+        the one place deciding whether a path is safe to honour - the same
+        judgement for a password login, an OAuth callback and this (#1214).
+        """
         payload = verify_special_token(token, expected_type="magic_link")
         if payload is None or "sub" not in payload:
             raise AuthenticationError(message="Magic link is invalid or has expired")
@@ -525,4 +534,5 @@ class UserService:
         user = await self.get_by_id(user_id)
         if not user.is_active:
             raise AuthenticationError(message="Account is disabled")
-        return user
+        claimed = payload.get("rt")
+        return user, claimed if isinstance(claimed, str) else None

--- a/backend/tests/api/test_magic_link_return_to.py
+++ b/backend/tests/api/test_magic_link_return_to.py
@@ -1,0 +1,149 @@
+"""Where a magic link lands, and what may be signed into one.
+
+The link answered `/dashboard` for everybody, so which of the three doors
+somebody came through still decided where they ended up - the drift #121 removed
+on the roles axis and #135 on the provider axis, on the last door that had it
+(#1214).
+
+It cannot take #135's fix. That one carries the path in `sessionStorage`, which
+is allowed because the OAuth round trip starts and ends in the same tab on this
+origin; a magic link is followed from an email - another tab, often another
+application, sometimes another browser - where that store is empty by
+construction. So the path travels *in the token*, signed, and the request refuses
+anything that is not a path on this deployment rather than storing it and
+checking later: a token that can be made to hold an arbitrary string is a
+stored-redirect surface even when the read is checked.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.api.deps import get_db_session, get_redis, get_session_service, get_user_service
+from app.core.config import settings
+from app.core.security import create_magic_link_token
+from app.main import app
+from app.services.user import UserService
+
+pytestmark = pytest.mark.anyio
+
+REQUEST = f"{settings.API_V1_STR}/auth/magic-link/request"
+VERIFY = f"{settings.API_V1_STR}/auth/magic-link/verify"
+
+
+class _User:
+    def __init__(self) -> None:
+        self.id = uuid4()
+        self.email = "kacper@example.com"
+        self.full_name = "Kacper"
+        self.is_active = True
+
+
+@pytest.fixture
+async def client(mock_redis: MagicMock, mock_db_session) -> AsyncGenerator[AsyncClient, None]:
+    service = MagicMock()
+    service.issue_magic_link_token = AsyncMock(return_value=None)
+    service.consume_magic_link_token = AsyncMock(return_value=(_User(), None))
+    sessions = MagicMock()
+    sessions.create_session = AsyncMock()
+    app.dependency_overrides[get_user_service] = lambda: service
+    app.dependency_overrides[get_session_service] = lambda: sessions
+    app.dependency_overrides[get_redis] = lambda: mock_redis
+    app.dependency_overrides[get_db_session] = lambda: mock_db_session
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        ac.service = service  # ty: ignore[unresolved-attribute]
+        yield ac
+    app.dependency_overrides.clear()
+
+
+class TestWhatMayBeSignedIntoALink:
+    async def test_a_path_on_this_deployment_reaches_the_service(self, client: AsyncClient) -> None:
+        response = await client.post(
+            REQUEST, json={"email": "kacper@example.com", "return_to": "/agents/a-1"}
+        )
+
+        assert response.status_code == 200
+        service = client.service  # ty: ignore[unresolved-attribute]
+        assert service.issue_magic_link_token.await_args.kwargs["return_to"] == "/agents/a-1"
+
+    async def test_a_request_with_no_path_asks_for_none(self, client: AsyncClient) -> None:
+        response = await client.post(REQUEST, json={"email": "kacper@example.com"})
+
+        assert response.status_code == 200
+        service = client.service  # ty: ignore[unresolved-attribute]
+        assert service.issue_magic_link_token.await_args.kwargs["return_to"] is None
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            pytest.param("https://evil.example", id="absolute"),
+            pytest.param("//evil.example", id="protocol_relative"),
+            pytest.param("/\\evil.example", id="backslash"),
+            pytest.param("/\tevil", id="control_character"),
+            pytest.param("agents", id="relative"),
+        ],
+    )
+    async def test_anything_else_is_refused_before_it_is_signed(
+        self, client: AsyncClient, path: str
+    ) -> None:
+        """Refused at the request, not merely ignored at the landing: the value
+        is signed into a token that arrives by email, so the shortest life it can
+        have is none."""
+        response = await client.post(
+            REQUEST, json={"email": "kacper@example.com", "return_to": path}
+        )
+
+        assert response.status_code == 422
+        assert [problem["field"] for problem in response.json()["error"]["details"]["fields"]] == [
+            "return_to"
+        ]
+        service = client.service  # ty: ignore[unresolved-attribute]
+        service.issue_magic_link_token.assert_not_awaited()
+
+
+class TestTheLandingIsToldWhereItWasHeaded:
+    async def test_the_verify_answers_with_the_path(self, client: AsyncClient) -> None:
+        service = client.service  # ty: ignore[unresolved-attribute]
+        service.consume_magic_link_token = AsyncMock(return_value=(_User(), "/agents/a-1"))
+
+        response = await client.post(VERIFY, json={"token": "a" * 20})
+
+        assert response.status_code == 200
+        assert response.json()["return_to"] == "/agents/a-1"
+
+    async def test_a_link_minted_without_one_answers_null(self, client: AsyncClient) -> None:
+        response = await client.post(VERIFY, json={"token": "a" * 20})
+
+        assert response.status_code == 200
+        assert response.json()["return_to"] is None
+
+
+class TestTheTokenCarriesIt:
+    async def test_the_path_survives_the_round_trip(self, mock_db_session) -> None:
+        """Signed, so it cannot be edited between the email and the landing."""
+        user = _User()
+        service = UserService(mock_db_session)
+        token = create_magic_link_token(subject=str(user.id), return_to="/agents/a-1")
+
+        with pytest.MonkeyPatch.context() as patched:
+            patched.setattr(service, "get_by_id", AsyncMock(return_value=user))
+            consumed, return_to = await service.consume_magic_link_token(token)
+
+        assert consumed is user
+        assert return_to == "/agents/a-1"
+
+    async def test_a_token_with_no_claim_answers_none(self, mock_db_session) -> None:
+        user = _User()
+        service = UserService(mock_db_session)
+        token = create_magic_link_token(subject=str(user.id))
+
+        with pytest.MonkeyPatch.context() as patched:
+            patched.setattr(service, "get_by_id", AsyncMock(return_value=user))
+            _, return_to = await service.consume_magic_link_token(token)
+
+        assert return_to is None

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -494,6 +494,38 @@ The project supports two authentication methods, both always available:
    - A single shared key set via the `API_KEY` environment variable.
    - Uses constant-time comparison (`secrets.compare_digest`) to prevent timing attacks.
 
+### Where a fresh session lands
+
+Three doors establish a session by three routes - the password form, the OAuth
+callback, and a magic link - and exactly one of them decides where the visitor
+ends up: `postSignInDestination` in `frontend/src/lib/auth-landing.ts`, which
+honours a deep link only when it is a same-origin path and answers the dashboard
+otherwise. Three answers in three places is drift, and the drift has been real
+twice: on the roles axis, where the landing forked by role, and on the provider
+axis, where the OAuth round trip lost `?returnTo=`.
+
+What differs per door is only how the path *travels*:
+
+| Door | How the path reaches the landing |
+|---|---|
+| Password form | it never left the tab - read straight off `?returnTo=` |
+| OAuth callback | `sessionStorage`, which is allowed because the round trip starts and ends in the same tab on this origin |
+| Magic link | a signed claim in the token, because the link is followed from an email - another tab, often another application, where `sessionStorage` is empty by construction |
+
+The magic link's path is refused at the **request** rather than filtered at the
+landing: `MagicLinkRequest.return_to` accepts a path on this deployment and
+nothing with a scheme, a second leading slash, a backslash or a control
+character, so a token that could be made to hold an arbitrary string never
+exists. The landing judges it again anyway - a check that runs once, on the
+server, on a value that then travels through an email, is a check the client
+cannot rely on having happened.
+
+`POST /auth/magic-link/verify` therefore answers with `MagicLinkToken` - the
+token pair plus `return_to`, unapplied. Its own schema rather than a nullable
+field on `Token`, because the other three token responses have no return path to
+carry and a field that is always null on most of them is one a client learns to
+ignore.
+
 ### Authorization
 
 There is no role column on the user and no role-based route dependency. What a

--- a/frontend/src/app/[locale]/auth/magic-link/page.tsx
+++ b/frontend/src/app/[locale]/auth/magic-link/page.tsx
@@ -9,8 +9,12 @@ import { AlertCircle, CheckCircle2, Loader2 } from "lucide-react";
 import { getErrorMessage } from "@/lib/api-error";
 import { apiClient, ApiError } from "@/lib/api-client";
 import { useReauthenticate } from "@/hooks/use-auth";
-import { postSignInDestination } from "@/lib/auth-landing";
+import { goToDestination, postSignInDestination } from "@/lib/auth-landing";
 import { ROUTES } from "@/lib/constants";
+
+interface MagicLinkVerified {
+  return_to?: string | null;
+}
 
 /**
  * Magic-link verification page.
@@ -40,14 +44,21 @@ export default function MagicLinkVerifyPage() {
     if (!token) return;
     let active = true;
     apiClient
-      .post("/auth/magic-link/verify", { token })
-      .then(async () => {
+      .post<MagicLinkVerified>("/auth/magic-link/verify", { token })
+      .then(async (verified) => {
         if (!active) return;
         // The link may be for a different account than the tab already had.
         await reauthenticate();
         if (!active) return;
         setState("success");
-        router.replace(postSignInDestination());
+        // The path travels in the token rather than in `sessionStorage`, which
+        // is what the OAuth round trip uses and which is empty here: a magic
+        // link is followed from an email, in another tab and often another
+        // application (#1214). `postSignInDestination` still decides whether it
+        // is safe to honour, and `goToDestination` picks the navigation that
+        // survives a fragment - the two halves the password form and the OAuth
+        // callback already share.
+        goToDestination(postSignInDestination(verified?.return_to), (href) => router.replace(href));
       })
       .catch((err: unknown) => {
         if (!active) return;

--- a/frontend/src/app/[locale]/auth/session-adoption.integration.test.tsx
+++ b/frontend/src/app/[locale]/auth/session-adoption.integration.test.tsx
@@ -174,6 +174,47 @@ describe("the magic link", () => {
     expect(client.getQueryData(["sessions", "list", 0])).toBeUndefined();
     expect(useConversationStore.getState().currentConversationId).toBeNull();
   });
+
+  it("lands where the link was minted for", async () => {
+    // The path travels in the token, which is why this page reads it off the
+    // verify response rather than out of `sessionStorage`: a magic link is
+    // followed from an email, in another tab and often another application,
+    // where the store the OAuth round trip uses is empty (#1214).
+    searchParams.set("token", "m-1");
+    vi.mocked(apiClient.post).mockResolvedValue({
+      access_token: "t-new",
+      return_to: "/agents/a-1",
+    });
+    vi.mocked(apiClient.get).mockResolvedValue(arriving);
+    mountOver(<MagicLinkPage />);
+
+    await waitFor(() => expect(replace).toHaveBeenCalledWith("/agents/a-1"));
+  });
+
+  it("lands on the dashboard when the link named nowhere", async () => {
+    searchParams.set("token", "m-1");
+    vi.mocked(apiClient.post).mockResolvedValue({ access_token: "t-new", return_to: null });
+    vi.mocked(apiClient.get).mockResolvedValue(arriving);
+    mountOver(<MagicLinkPage />);
+
+    await waitFor(() => expect(replace).toHaveBeenCalledWith("/dashboard"));
+  });
+
+  it("refuses a path the token should never have carried", async () => {
+    // Belt and braces: the request refuses these before signing one, so this is
+    // about the landing making its own judgement rather than trusting the
+    // token - the same `postSignInDestination` every other door resolves
+    // through.
+    searchParams.set("token", "m-1");
+    vi.mocked(apiClient.post).mockResolvedValue({
+      access_token: "t-new",
+      return_to: "https://evil.example",
+    });
+    vi.mocked(apiClient.get).mockResolvedValue(arriving);
+    mountOver(<MagicLinkPage />);
+
+    await waitFor(() => expect(replace).toHaveBeenCalledWith("/dashboard"));
+  });
 });
 
 describe("the dashboard guard", () => {

--- a/frontend/src/app/api/auth/magic-link/verify/route.ts
+++ b/frontend/src/app/api/auth/magic-link/verify/route.ts
@@ -6,6 +6,10 @@ interface TokenResponse {
   access_token: string;
   refresh_token: string;
   token_type?: string;
+  /** Where the link was minted to land. Signed into the token, so it cannot
+      have been edited between the email and here; still judged again by
+      `postSignInDestination` at the landing (#1214). */
+  return_to?: string | null;
 }
 
 export async function POST(request: NextRequest) {
@@ -23,6 +27,7 @@ export async function POST(request: NextRequest) {
     const response = bffJson({
       user,
       access_token: data.access_token,
+      return_to: data.return_to ?? null,
     });
 
     const isProd = process.env.NODE_ENV === "production";

--- a/frontend/src/app/api/auth/session-routes.test.ts
+++ b/frontend/src/app/api/auth/session-routes.test.ts
@@ -388,9 +388,25 @@ describe("signing in without a password", () => {
     await expect(response.json()).resolves.toMatchObject({
       user: { id: "u-1" },
       access_token: "at",
+      // Null rather than absent: the landing reads this to decide where to go,
+      // and a link minted without a path says so (#1214).
+      return_to: null,
     });
     expect(cookie(response, "access_token")).toMatchObject({ value: "at" });
     expect(cookie(response, "refresh_token")).toMatchObject({ value: "rt" });
+  });
+
+  it("passes on the path the link was minted for", async () => {
+    // The path travels in the token because a magic link is followed from an
+    // email, where the tab-local store the OAuth round trip uses is empty. This
+    // route is the only thing between the token and the page that reads it.
+    vi.mocked(backendFetch)
+      .mockResolvedValueOnce({ access_token: "at", refresh_token: "rt", return_to: "/agents/a-1" })
+      .mockResolvedValueOnce({ id: "u-1" });
+
+    const response = await magicLinkVerify(request({}, { token: "one-time" }));
+
+    await expect(response.json()).resolves.toMatchObject({ return_to: "/agents/a-1" });
   });
 
   it("refuses a link that did not verify, without a session", async () => {


### PR DESCRIPTION
`/auth/magic-link` called `postSignInDestination()` with nothing, so a visitor headed somewhere landed on `/dashboard` — which door somebody came through still deciding where they end up. #121 removed that drift on the roles axis and #135 on the provider axis; this was the last door with it.

## Why it does not take #135's fix

#135 carries the path in `sessionStorage`, which is allowed because the OAuth round trip starts and ends in the same tab on this origin. A magic link is followed from an email — another tab, often another application, sometimes another browser — where that store is empty by construction.

So the path travels **in the token**, as a signed claim. No schema change (the token is a JWT, not a row), and nothing between the mint and the landing can edit it.

| Door | How the path reaches the landing |
|---|---|
| Password form | never left the tab — read off `?returnTo=` |
| OAuth callback | `sessionStorage` |
| Magic link | a signed `rt` claim in the token |

## Refused before it is signed, and judged again at the landing

`MagicLinkRequest.return_to` accepts a path on this deployment and nothing with a scheme, a second leading slash, a backslash or a control character — the same five shapes `frontend/src/lib/auth-landing.ts` refuses, and for the reasons its comment gives. A token that could be made to hold an arbitrary string never exists, rather than existing and being filtered on read.

`postSignInDestination` judges it again anyway: a check that ran once, on the server, on a value that then travelled through an email is not a check the client can rely on having happened.

`POST /auth/magic-link/verify` answers with `MagicLinkToken` — the pair plus `return_to`, unapplied, because the client navigates and the landing owns that judgement. Its own schema rather than a nullable field on `Token`: the login and refresh responses have no return path to carry, and a field that is always null on most responses is one a client learns to ignore.

The page also goes through `goToDestination` now, which it did not — a destination carrying a fragment was double-appended by `next@16.2`'s segment cache. That is the other half of the drift #135 removed, and the half this door still had.

## Verified

Eleven backend cases in `tests/api/test_magic_link_return_to.py`: the claim's round trip through mint and consume, the five refused shapes (each asserting the service was never asked to mint), and the verify response with and without a path. Three at the landing in `session-adoption.integration.test.tsx`: the path honoured, no path → dashboard, and an off-origin path refused there too. Plus the BFF pass-through, which is the only thing between the token and the page.

The landing tests fail without the page change; the refusals fail without the validator.

`make test` at 100% on the platform layer, `make lint`, `make test-frontend-cov` and `make docs-build` green. `docs/architecture.md` gains "Where a fresh session lands" — the one decision, and the three transports.

## What is not here

**No surface in the product requests a magic link.** The endpoint is API-only and `/magic-link-sent` is linked from nowhere, so the issue's "requested from `/login?returnTo=/agents/a-1`" is exercised at the API and the landing rather than from a form. Adding an "email me a link" control is a feature, not this fix — worth saying plainly because the first "done when" reads as a UI journey.

Closes #1214
