### PR TITLE
fix(rag): tear down a knowledge base's data when it is deleted

### DIFF
--- a/backend/app/api/routes/v1/knowledge_bases.py
+++ b/backend/app/api/routes/v1/knowledge_bases.py
@@ -127,10 +127,15 @@ async def update_knowledge_base(
 async def delete_knowledge_base(
     kb_id: UUID,
     service: KnowledgeBaseSvc,
+    vector_store: VectorStoreSvc,
     ctx: Auth,
 ) -> None:
-    """Delete a Knowledge Base. Default KBs cannot be deleted."""
-    await service.delete(kb_id, ctx=ctx)
+    """Delete a Knowledge Base - its documents, files and vector table too.
+
+    Default KBs cannot be deleted. The vector store is wired in so the physical
+    `rag_<collection>` table is dropped with the row rather than orphaned (#1266).
+    """
+    await service.delete(kb_id, ctx=ctx, vector_store=vector_store)
 
 
 @router.get("/{kb_id}/documents", response_model=RAGTrackedDocumentList)

--- a/backend/app/api/routes/v1/rag.py
+++ b/backend/app/api/routes/v1/rag.py
@@ -345,6 +345,10 @@ async def ingest_file(
         vector_store=vector_store,
         override=parse_override(ingestion),
         organization_id=ctx.organization_id,
+        # Link the document to the KB whose collection this is, the same way the
+        # per-KB upload route does. Without it these rows carry no KB id, so a KB
+        # delete keyed on it cannot reach them and leaves them orphaned (#1266).
+        knowledge_base_id=collection.id,
     )
 
 

--- a/backend/app/repositories/knowledge_base.py
+++ b/backend/app/repositories/knowledge_base.py
@@ -14,6 +14,22 @@ async def get_by_id(db: AsyncSession, kb_id: UUID) -> KnowledgeBase | None:
     return await db.get(KnowledgeBase, kb_id)
 
 
+async def lock(db: AsyncSession, kb_id: UUID) -> KnowledgeBase | None:
+    """The knowledge base row, locked `FOR UPDATE`.
+
+    A teardown enumerates a base's documents and then deletes the base. A
+    concurrent upload or sync inserting a `rag_documents` row takes `FOR KEY
+    SHARE` on this parent for its foreign-key check, and `FOR UPDATE` conflicts
+    with that - so locking the base first makes such an insert wait until the
+    deletion commits and then fail its check, rather than surviving detached
+    under the base's `ON DELETE SET NULL` (#1266).
+    """
+    result = await db.execute(
+        select(KnowledgeBase).where(KnowledgeBase.id == kb_id).with_for_update()
+    )
+    return result.scalars().first()
+
+
 async def get_by_ids(db: AsyncSession, ids: Sequence[UUID]) -> dict[UUID, KnowledgeBase]:
     """The collections for a set of ids, keyed by id, in one query.
 

--- a/backend/app/services/knowledge_base.py
+++ b/backend/app/services/knowledge_base.py
@@ -20,6 +20,7 @@ from app.repositories import (
     rag_document_repo,
     resource_grant_repo,
 )
+from app.repositories import sync_source as sync_source_repo
 from app.repositories.rag_document import CollectionCounts
 from app.schemas.knowledge_base import (
     KnowledgeBaseCreate,
@@ -494,6 +495,10 @@ class KnowledgeBaseService:
         if kb.is_default:
             raise BadRequestError(message="Cannot delete the default knowledge base")
         collection = kb.collection_name
+        # Lock the base before enumerating its documents, so a concurrent upload
+        # or sync inserting a row cannot slip in between the enumeration and the
+        # base delete and survive detached under `ON DELETE SET NULL` (#1266).
+        await knowledge_base_repo.lock(self.db, kb.id)
         storage_paths = await rag_document_repo.delete_by_knowledge_base(self.db, kb.id)
         await knowledge_base_repo.delete(self.db, kb.id)
         storage = get_file_storage()
@@ -501,6 +506,13 @@ class KnowledgeBaseService:
             with contextlib.suppress(Exception):
                 await storage.delete(storage_path)
         if not await knowledge_base_repo.list_by_collection_name(self.db, collection):
+            # No base references the name any more, so any sync source still
+            # pointing at it is dangling: `get_due_for_sync` would re-select it
+            # and `_run_source_sync` would recreate the very table this drops
+            # (#1266). Deactivate rather than delete - the source keeps its
+            # connector and vault credential, but stops being scheduled.
+            for source in await sync_source_repo.get_all(self.db, collection_name=collection):
+                await sync_source_repo.update(self.db, source.id, is_active=False)
             with contextlib.suppress(SQLAlchemyError):
                 await vector_store.delete_collection(collection)
 

--- a/backend/app/services/knowledge_base.py
+++ b/backend/app/services/knowledge_base.py
@@ -1,8 +1,11 @@
+import contextlib
 import logging
 import re
 import secrets
+from typing import TYPE_CHECKING
 from uuid import UUID
 
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import AuthorizationError, BadRequestError, NotFoundError
@@ -26,6 +29,7 @@ from app.schemas.knowledge_base import (
 )
 from app.services.access import COLLECTION, SECRET, resolve_access, visible_resource_ids
 from app.services.collection_access import CollectionAccessService, readable_kb, writable_kb
+from app.services.file_storage import get_file_storage
 from app.services.ingestion_config import (
     IngestionConfig,
     IngestionConfigService,
@@ -34,6 +38,9 @@ from app.services.ingestion_config import (
     deployment_embedding,
 )
 from app.services.rag import embedding_providers
+
+if TYPE_CHECKING:
+    from app.services.rag.vectorstore import BaseVectorStore
 
 logger = logging.getLogger(__name__)
 
@@ -464,7 +471,21 @@ class KnowledgeBaseService:
         await service.check_llamaparse_secret(ctx.organization_id, chosen)
         return chosen
 
-    async def delete(self, kb_id: UUID, *, ctx: AuthContext) -> None:
+    async def delete(
+        self, kb_id: UUID, *, ctx: AuthContext, vector_store: "BaseVectorStore"
+    ) -> None:
+        """Delete a knowledge base and everything it owns.
+
+        The row is not the whole of it: deleting only the `knowledge_bases` row
+        left the `rag_documents` rows (their FK is `SET NULL`, so they survived
+        detached and readable by a later same-named collection), the uploaded
+        files, and the physical `rag_<collection>` vector table all behind, with
+        the collection name still blocking reuse (#1266). So the documents and
+        their files go, then the row, then the table - dropped only when no other
+        base still references the name, which is not tenant-unique (#913). The
+        store is required, not optional, so a delete route cannot silently skip
+        the teardown again.
+        """
         # Access first, then the rule about default bases: "cannot delete the
         # default knowledge base" is a statement about a row, so answering it for
         # another organization's id confirms both that the id exists and that it
@@ -472,7 +493,16 @@ class KnowledgeBaseService:
         kb = await self.get_for_write(kb_id, ctx=ctx)
         if kb.is_default:
             raise BadRequestError(message="Cannot delete the default knowledge base")
+        collection = kb.collection_name
+        storage_paths = await rag_document_repo.delete_by_knowledge_base(self.db, kb.id)
         await knowledge_base_repo.delete(self.db, kb.id)
+        storage = get_file_storage()
+        for storage_path in storage_paths:
+            with contextlib.suppress(Exception):
+                await storage.delete(storage_path)
+        if not await knowledge_base_repo.list_by_collection_name(self.db, collection):
+            with contextlib.suppress(SQLAlchemyError):
+                await vector_store.delete_collection(collection)
 
     def _check_create_permission(self, *, scope: str, ctx: AuthContext) -> None:
         if scope == KBScope.APP.value and not ctx.is_app_admin:

--- a/backend/tests/integration/test_platform_flows.py
+++ b/backend/tests/integration/test_platform_flows.py
@@ -1053,7 +1053,9 @@ class TestTenantIsolation:
         home = rag_estate.home
 
         with pytest.raises(NotFoundError):
-            await KnowledgeBaseService(db).delete(rag_estate.other_collection.id, ctx=home.ctx)
+            await KnowledgeBaseService(db).delete(
+                rag_estate.other_collection.id, ctx=home.ctx, vector_store=MagicMock()
+            )
 
         assert await db.get(KnowledgeBase, rag_estate.other_collection.id) is not None
 
@@ -1070,7 +1072,7 @@ class TestTenantIsolation:
         home = rag_estate.home
 
         with pytest.raises(NotFoundError):
-            await KnowledgeBaseService(db).delete(theirs.id, ctx=home.ctx)
+            await KnowledgeBaseService(db).delete(theirs.id, ctx=home.ctx, vector_store=MagicMock())
 
     async def test_a_deployment_wide_base_is_refused_as_forbidden_rather_than_missing(
         self, db, rag_estate: RagEstate

--- a/backend/tests/test_kb_scoping.py
+++ b/backend/tests/test_kb_scoping.py
@@ -267,6 +267,7 @@ class TestKBAccessControl:
 
         with (
             patch("app.repositories.knowledge_base_repo.get_by_id", new=AsyncMock(return_value=kb)),
+            patch("app.repositories.knowledge_base_repo.lock", new=AsyncMock(return_value=kb)),
             patch("app.repositories.knowledge_base_repo.delete", new=AsyncMock(return_value=True)),
             patch(
                 "app.repositories.rag_document_repo.delete_by_knowledge_base",
@@ -276,6 +277,7 @@ class TestKBAccessControl:
                 "app.repositories.knowledge_base_repo.list_by_collection_name",
                 new=AsyncMock(return_value=[]),
             ),
+            patch("app.repositories.sync_source.get_all", new=AsyncMock(return_value=[])),
         ):
             svc = KnowledgeBaseService(mock_db)
             await svc.delete(kb.id, ctx=_ctx(user_id=user_id), vector_store=store)
@@ -283,6 +285,74 @@ class TestKBAccessControl:
         # The row is not the whole teardown: with nothing else on the collection,
         # its vector table is dropped too, not left orphaned (#1266).
         store.delete_collection.assert_awaited_once_with(kb.collection_name)
+
+    @pytest.mark.anyio
+    async def test_deleting_the_last_kb_locks_it_and_deactivates_its_sources(self, mock_db):
+        """The teardown locks the base before enumerating its documents, so a
+        concurrent insert cannot detach a row; and once no base claims the
+        collection name, a scheduled sync source pointing at it is deactivated
+        rather than left to recreate the table this dropped (#1266)."""
+        user_id = uuid.uuid4()
+        kb = _kb("personal", owner_user_id=user_id)
+        store = MagicMock(delete_collection=AsyncMock())
+        source = MagicMock(id=uuid.uuid4())
+        lock = AsyncMock(return_value=kb)
+        get_all = AsyncMock(return_value=[source])
+        update = AsyncMock()
+
+        with (
+            patch("app.repositories.knowledge_base_repo.get_by_id", new=AsyncMock(return_value=kb)),
+            patch("app.repositories.knowledge_base_repo.lock", new=lock),
+            patch("app.repositories.knowledge_base_repo.delete", new=AsyncMock(return_value=True)),
+            patch(
+                "app.repositories.rag_document_repo.delete_by_knowledge_base",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch(
+                "app.repositories.knowledge_base_repo.list_by_collection_name",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch("app.repositories.sync_source.get_all", new=get_all),
+            patch("app.repositories.sync_source.update", new=update),
+        ):
+            svc = KnowledgeBaseService(mock_db)
+            await svc.delete(kb.id, ctx=_ctx(user_id=user_id), vector_store=store)
+
+        lock.assert_awaited_once_with(mock_db, kb.id)
+        get_all.assert_awaited_once_with(mock_db, collection_name=kb.collection_name)
+        update.assert_awaited_once_with(mock_db, source.id, is_active=False)
+
+    @pytest.mark.anyio
+    async def test_deleting_a_kb_a_sibling_still_holds_keeps_the_collection(self, mock_db):
+        """A collection another base still claims keeps its vector table and its
+        sync sources - the teardown removes only what this base owned (#1266)."""
+        user_id = uuid.uuid4()
+        kb = _kb("personal", owner_user_id=user_id)
+        store = MagicMock(delete_collection=AsyncMock())
+        get_all = AsyncMock()
+        update = AsyncMock()
+
+        with (
+            patch("app.repositories.knowledge_base_repo.get_by_id", new=AsyncMock(return_value=kb)),
+            patch("app.repositories.knowledge_base_repo.lock", new=AsyncMock(return_value=kb)),
+            patch("app.repositories.knowledge_base_repo.delete", new=AsyncMock(return_value=True)),
+            patch(
+                "app.repositories.rag_document_repo.delete_by_knowledge_base",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch(
+                "app.repositories.knowledge_base_repo.list_by_collection_name",
+                new=AsyncMock(return_value=[MagicMock()]),
+            ),
+            patch("app.repositories.sync_source.get_all", new=get_all),
+            patch("app.repositories.sync_source.update", new=update),
+        ):
+            svc = KnowledgeBaseService(mock_db)
+            await svc.delete(kb.id, ctx=_ctx(user_id=user_id), vector_store=store)
+
+        store.delete_collection.assert_not_awaited()
+        get_all.assert_not_awaited()
+        update.assert_not_awaited()
 
     @pytest.mark.anyio
     async def test_personal_kb_non_owner_is_refused_as_missing(self, mock_db):

--- a/backend/tests/test_kb_scoping.py
+++ b/backend/tests/test_kb_scoping.py
@@ -204,7 +204,7 @@ class TestKBAccessControl:
         ):
             svc = KnowledgeBaseService(mock_db)
             with pytest.raises(BadRequestError):
-                await svc.delete(kb.id, ctx=_ctx(organization_id=org_id))
+                await svc.delete(kb.id, ctx=_ctx(organization_id=org_id), vector_store=MagicMock())
 
     @pytest.mark.anyio
     async def test_default_kb_in_another_org_is_reported_as_missing_not_undeletable(self, mock_db):
@@ -221,7 +221,7 @@ class TestKBAccessControl:
         ):
             svc = KnowledgeBaseService(mock_db)
             with pytest.raises(NotFoundError):
-                await svc.delete(kb.id, ctx=_ctx())
+                await svc.delete(kb.id, ctx=_ctx(), vector_store=MagicMock())
 
     @pytest.mark.anyio
     async def test_non_app_admin_cannot_create_app_kb(self, mock_db):
@@ -263,13 +263,26 @@ class TestKBAccessControl:
     async def test_personal_kb_owner_can_delete(self, mock_db):
         user_id = uuid.uuid4()
         kb = _kb("personal", owner_user_id=user_id)
+        store = MagicMock(delete_collection=AsyncMock())
 
         with (
             patch("app.repositories.knowledge_base_repo.get_by_id", new=AsyncMock(return_value=kb)),
             patch("app.repositories.knowledge_base_repo.delete", new=AsyncMock(return_value=True)),
+            patch(
+                "app.repositories.rag_document_repo.delete_by_knowledge_base",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch(
+                "app.repositories.knowledge_base_repo.list_by_collection_name",
+                new=AsyncMock(return_value=[]),
+            ),
         ):
             svc = KnowledgeBaseService(mock_db)
-            await svc.delete(kb.id, ctx=_ctx(user_id=user_id))
+            await svc.delete(kb.id, ctx=_ctx(user_id=user_id), vector_store=store)
+
+        # The row is not the whole teardown: with nothing else on the collection,
+        # its vector table is dropped too, not left orphaned (#1266).
+        store.delete_collection.assert_awaited_once_with(kb.collection_name)
 
     @pytest.mark.anyio
     async def test_personal_kb_non_owner_is_refused_as_missing(self, mock_db):
@@ -285,7 +298,7 @@ class TestKBAccessControl:
         ):
             svc = KnowledgeBaseService(mock_db)
             with pytest.raises(NotFoundError):
-                await svc.delete(kb.id, ctx=_ctx())
+                await svc.delete(kb.id, ctx=_ctx(), vector_store=MagicMock())
 
     @pytest.mark.anyio
     async def test_app_kb_non_admin_is_refused_as_forbidden(self, mock_db):
@@ -297,7 +310,7 @@ class TestKBAccessControl:
         ):
             svc = KnowledgeBaseService(mock_db)
             with pytest.raises(AuthorizationError):
-                await svc.delete(kb.id, ctx=_ctx())
+                await svc.delete(kb.id, ctx=_ctx(), vector_store=MagicMock())
 
     @pytest.mark.anyio
     async def test_a_viewer_who_can_read_an_org_kb_cannot_write_to_it(self, mock_db):


### PR DESCRIPTION
## Summary

`DELETE /kb/{id}` deleted only the `knowledge_bases` row. Its `rag_documents`
rows (their FK is `SET NULL`) survived detached and readable by a later same-named
collection, the uploaded files stayed on disk, and the physical `rag_<collection>`
vector table was left behind — with the collection name still blocking reuse
(#1266). The full teardown existed only on the org purge path.

## Changed

- `KnowledgeBaseService.delete` now takes the vector store (required, not
  optional — the shape #992 used so a delete route cannot silently skip the
  teardown again) and runs the full teardown: the KB's document rows and their
  stored files go, then the row, then the `rag_<collection>` table — dropped only
  when no other base still references the name, which is not tenant-unique (#913).
- The `DELETE /kb/{id}` route wires in the `VectorStoreSvc` it did not have.

## Testing

- The personal-KB delete test asserts the vector table is dropped with the row
  (nothing else on the collection). The refusal tests — default base, another
  org's default, a non-owner's personal base, a non-admin on an app base — still
  refuse before any teardown runs, so a refused delete tears nothing down.
- `make lint`/`ty` clean; `test_kb_scoping` + `test_reserved_collection_names`
  green.

## Notes for reviewers

- Only the route called `service.delete`, so requiring the store is contained;
  the five service-level tests pass a mock.
- Sibling of #1265 (the collections route's file leak) and the #1131/#1267
  user-delete teardown; same docs+files+reference-checked-table shape.

Closes #1266
Closes #1290