### PR TITLE
fix(agents): stop a new turn starting from a finished checklist

### DIFF
--- a/backend/app/agents/capabilities/planning/__init__.py
+++ b/backend/app/agents/capabilities/planning/__init__.py
@@ -31,6 +31,7 @@ from app.agents.capabilities.planning._capability import (
     dump_plan,
     new_plan_store,
     open_plan_store,
+    still_open,
 )
 
 __all__ = [
@@ -41,6 +42,7 @@ __all__ = [
     "dump_plan",
     "new_plan_store",
     "open_plan_store",
+    "still_open",
 ]
 
 

--- a/backend/app/agents/capabilities/planning/_capability.py
+++ b/backend/app/agents/capabilities/planning/_capability.py
@@ -50,6 +50,10 @@ from app.agents.capabilities._tool_text import ToolText
 if TYPE_CHECKING:
     from pydantic_ai_harness.planning import PlanStore
 
+# What "this step needs no more work" looks like in a stored `PlanItem` dump. A
+# `blocked` step is not one of them: something still has to unblock it.
+_FINISHED_STATUSES = frozenset({"completed", "cancelled"})
+
 PLANNING_STORE_RESOURCE = "planning_store"
 """Resource key under which the runner injects the run's :class:`PlanStore`.
 
@@ -61,6 +65,10 @@ run (its own default), which is the honest behaviour for a build with no run to 
 The store the runner injects is seeded from the conversation's `plan_items`, or from
 `PausedRunState.plan` on a resume, and written back to the conversation when the run
 ends - so the plan belongs to the thread rather than to one turn of it (#1077).
+
+A **finished** checklist is not seeded: see :func:`still_open`. The row keeps it;
+a new turn starts without it, because a plan whose every step is ticked is history
+rather than working state (#1221).
 """
 
 WRITE_PLAN_TEXT = ToolText(
@@ -302,6 +310,39 @@ async def open_plan_store(items: list[dict[str, Any]] | None) -> InMemoryPlanSto
     store = InMemoryPlanStore()
     await store.set_items([PlanItem.model_validate(item) for item in items or []])
     return store
+
+
+def still_open(items: list[dict[str, Any]] | None) -> list[dict[str, Any]] | None:
+    """The stored checklist, unless it is finished - in which case nothing.
+
+    **A finished plan is history, not working state.** `keep_plan` records whatever
+    the store held when the run ended, completed steps included, so a thread whose
+    three steps were all ticked off in August would open in November with the tail
+    reminder calling them "your current plan" and `read_plan` answering with them:
+    an agent working to a checklist about a task nobody is doing (#1221).
+
+    Filtered at the *seed* rather than cleared when the last step is ticked, and
+    that is the whole of the choice. Within the turn that finishes a plan the store
+    still holds it, so `read_plan` and the reminder agree with the transcript and
+    the agent can summarise what it just did. It is the **next** turn - a new
+    question - that starts with no plan, which is what a reader expects and what
+    the messages above it already say: the ticked checklist is still in the
+    transcript, as history.
+
+    Nothing is dropped from the row either. The conversation keeps the finished
+    plan; this decides only what a fresh turn is seeded with. A resume seeds from
+    `PausedRunState.plan` and does not come through here, so a run parked mid-plan
+    is untouched.
+
+    Finished means at least one step and every step `completed` or `cancelled`.
+    `pending`, `in_progress` and `blocked` are all work outstanding - a blocked
+    step most of all, since something has to unblock it.
+    """
+    if not items:
+        return items
+    if all(item.get("status") in _FINISHED_STATUSES for item in items):
+        return None
+    return items
 
 
 async def dump_plan(store: PlanStore) -> list[dict[str, Any]]:

--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -956,6 +956,17 @@ class PreparedRun:
     rather than `None`; `_assemble` replaces it with the run's seeded one.
     """
 
+    finished_plan_withheld: bool = False
+    """Whether this run's store was opened empty over a *finished* stored plan.
+
+    A finished checklist is history and is not seeded (#1221), which leaves the
+    store empty - and `finish` writes the store back to the conversation, so the
+    next ordinary turn would dump `[]` over the row and delete the plan the fix
+    promises to keep. So the write is skipped while the store is still empty:
+    there is nothing this turn did to the checklist to record. An agent that
+    writes a new plan dumps a non-empty one and replaces the row as usual.
+    """
+
     @property
     def deps(self) -> AgentDeps:
         return self.built.deps
@@ -1672,9 +1683,9 @@ class AgentRunnerService:
         # history, and seeding it would have the tail reminder call a task nobody
         # is doing "your current plan" (#1221). A resume is mid-plan by
         # construction and goes through untouched.
-        plan_store = await open_plan_store(
-            plan_items if plan_items is not None else still_open(recorded.plan)
-        )
+        seeded_from = plan_items if plan_items is not None else still_open(recorded.plan)
+        finished_plan_withheld = seeded_from is None and bool(recorded.plan)
+        plan_store = await open_plan_store(seeded_from)
         resources[PLANNING_STORE_RESOURCE] = plan_store
         # Only on a channel run, and bound to the channel the message arrived in
         # before it got here. Absent everywhere else, and `channel_tools` then
@@ -1896,6 +1907,7 @@ class AgentRunnerService:
             stash=stash,
             ctx=ctx,
             plan_store=plan_store,
+            finished_plan_withheld=finished_plan_withheld,
         )
 
     async def _delegation_runtime(
@@ -3556,13 +3568,17 @@ class AgentRunnerService:
                             prepared.built.reminder_state.snapshot(),
                         )
                     # The checklist the turn ended on, so the next turn starts
-                    # from it rather than from nothing. Unconditional: `keep_plan`
-                    # treats an empty list as no plan, so an agent that binds no
-                    # planning capability writes nothing, and a run that emptied a
-                    # stored plan records that it did.
-                    await conversations.keep_plan(
-                        prepared.run.conversation_id, await dump_plan(prepared.plan_store)
-                    )
+                    # from it rather than from nothing. `keep_plan` treats an empty
+                    # list as no plan, so an agent that binds no planning
+                    # capability writes nothing, and a run that emptied a stored
+                    # plan records that it did.
+                    #
+                    # The one turn that writes nothing is the one whose store was
+                    # opened empty over a finished plan: it did nothing to the
+                    # checklist, and `[]` would delete the row #1221 keeps.
+                    checklist = await dump_plan(prepared.plan_store)
+                    if checklist or not prepared.finished_plan_withheld:
+                        await conversations.keep_plan(prepared.run.conversation_id, checklist)
                 await self.db.commit()
             except Exception:
                 if finished_cleanly:

--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -965,6 +965,15 @@ class PreparedRun:
     promises to keep. So the write is skipped while the store is still empty:
     there is nothing this turn did to the checklist to record. An agent that
     writes a new plan dumps a non-empty one and replaces the row as usual.
+
+    This tracks *what was seeded*, not whether the store was touched, and the
+    difference is one case: a turn that writes a plan and then empties it leaves
+    the withheld checklist in the row rather than clearing it. Nothing observes
+    that - `plan_items` has one reader, the seed, and the seed withholds a
+    finished plan either way - so the row differs only in holding a list nobody
+    will be seeded with. Tracking the store's dirtiness instead would need a
+    delegating `PlanStore`: `write_plan` goes through `set_items`, which the
+    library emits no event for.
     """
 
     @property

--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -97,6 +97,7 @@ from app.agents.capabilities.planning import (
     dump_plan,
     new_plan_store,
     open_plan_store,
+    still_open,
 )
 from app.agents.capabilities.sandbox import WORKSPACE_BACKEND_RESOURCE, WorkspaceIdentity
 from app.agents.capabilities.sandbox._identity import SessionScope
@@ -1666,7 +1667,14 @@ class AgentRunnerService:
         # itself seeded from the conversation when that run began, and then worked
         # on. Without the conversation's copy the store is empty every turn, which
         # is an agent denying the plan it wrote in the previous message (#1077).
-        plan_store = await open_plan_store(plan_items if plan_items is not None else recorded.plan)
+        #
+        # `still_open` on the conversation's copy only: a finished checklist is
+        # history, and seeding it would have the tail reminder call a task nobody
+        # is doing "your current plan" (#1221). A resume is mid-plan by
+        # construction and goes through untouched.
+        plan_store = await open_plan_store(
+            plan_items if plan_items is not None else still_open(recorded.plan)
+        )
         resources[PLANNING_STORE_RESOURCE] = plan_store
         # Only on a channel run, and bound to the channel the message arrived in
         # before it got here. Absent everywhere else, and `channel_tools` then

--- a/backend/tests/test_agent_runner.py
+++ b/backend/tests/test_agent_runner.py
@@ -1773,6 +1773,59 @@ class TestParking:
         assert [item["content"] for item in kept.await_args.args[1]] == ["Write the fix"]
 
     @pytest.mark.anyio
+    async def test_a_turn_that_was_not_seeded_a_finished_plan_does_not_delete_it(self):
+        """A finished checklist is not seeded, so the store is empty - and writing
+        an empty store back would delete the row #1221 promises to keep, on the
+        very next ordinary turn."""
+        service = AgentRunnerService(_db())
+        prepared = _prepared(conversation_id=uuid.uuid4())
+        prepared.finished_plan_withheld = True
+        result = MagicMock(output="done")
+        result.all_messages = MagicMock(return_value=[])
+        result.new_messages = MagicMock(return_value=[])
+        prepared.built.agent.run = AsyncMock(return_value=result)
+
+        with (
+            patch.object(service, "prepare", new=AsyncMock(return_value=prepared)),
+            patch("app.services.agent_runner.agent_run_repo.finish_run", new=AsyncMock()),
+            patch.object(service.transcript, "record", new=AsyncMock()),
+            patch("app.services.agent_runner.ConversationService") as conversations,
+        ):
+            conversations.return_value.keep_overhead = AsyncMock()
+            conversations.return_value.keep_reminder_state = AsyncMock()
+            conversations.return_value.keep_plan = AsyncMock()
+            await service.execute(_ctx(), uuid.uuid4(), "something else entirely")
+
+        conversations.return_value.keep_plan.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_a_new_plan_written_over_a_withheld_one_still_replaces_the_row(self):
+        """The withholding is only about an empty store. An agent that starts new
+        work writes a plan, and that is what the conversation should hold."""
+        service = AgentRunnerService(_db())
+        prepared = _prepared(conversation_id=uuid.uuid4())
+        prepared.finished_plan_withheld = True
+        await prepared.plan_store.set_items([PlanItem(content="Write the next fix")])
+        result = MagicMock(output="done")
+        result.all_messages = MagicMock(return_value=[])
+        result.new_messages = MagicMock(return_value=[])
+        prepared.built.agent.run = AsyncMock(return_value=result)
+
+        with (
+            patch.object(service, "prepare", new=AsyncMock(return_value=prepared)),
+            patch("app.services.agent_runner.agent_run_repo.finish_run", new=AsyncMock()),
+            patch.object(service.transcript, "record", new=AsyncMock()),
+            patch("app.services.agent_runner.ConversationService") as conversations,
+        ):
+            conversations.return_value.keep_overhead = AsyncMock()
+            conversations.return_value.keep_reminder_state = AsyncMock()
+            conversations.return_value.keep_plan = AsyncMock()
+            await service.execute(_ctx(), uuid.uuid4(), "start the next thing")
+
+        kept = conversations.return_value.keep_plan
+        assert [item["content"] for item in kept.await_args.args[1]] == ["Write the next fix"]
+
+    @pytest.mark.anyio
     async def test_a_parked_runs_transcript_marks_the_call_that_is_waiting(self):
         """The transcript rows are the only account of the turn a reload has, and
         they used to say `running` for the very call somebody has to decide about -

--- a/backend/tests/test_agent_runner.py
+++ b/backend/tests/test_agent_runner.py
@@ -652,6 +652,48 @@ class TestAPlanThatOutlivesTheTurn:
         ]
 
     @pytest.mark.anyio
+    async def test_a_fresh_turn_does_not_seed_a_finished_one(self):
+        """The other half of #1077, filed as #1221: `keep_plan` stores completed
+        steps too, so a thread whose plan was finished in August opened in
+        November with the tail reminder calling it "your current plan"."""
+        ctx = _ctx()
+        service = AgentRunnerService(_db())
+        agent = MagicMock(id=uuid.uuid4(), current_version_id=uuid.uuid4())
+        spec = AgentSpec(name="Support", model_profile_id=uuid.uuid4())
+        conversation = MagicMock(
+            overhead_tokens=None,
+            reminder_state=None,
+            plan_items=[
+                {"id": "aa11", "content": "Write the fix", "status": "completed"},
+                {"id": "bb22", "content": "Ship it", "status": "cancelled"},
+            ],
+        )
+
+        with (
+            patch.object(
+                service.registry,
+                "get_runnable_spec",
+                new=AsyncMock(return_value=(agent, spec, agent.current_version_id)),
+            ),
+            patch.object(
+                service.models, "resolve", new=AsyncMock(return_value=MagicMock(label="gpt-4.1"))
+            ),
+            patch.object(service.skills, "resolve_for_agent", new=AsyncMock(return_value=[])),
+            patch(
+                "app.services.agent_runner.agent_run_repo.create_run",
+                new=AsyncMock(return_value=MagicMock(id=uuid.uuid4())),
+            ),
+            patch(
+                "app.services.agent_runner.conversation_repo.get_conversation_by_id",
+                new=AsyncMock(return_value=conversation),
+            ),
+            patch("app.services.agent_runner.build_agent"),
+        ):
+            prepared = await service.prepare(ctx, agent.id, conversation_id=uuid.uuid4())
+
+        assert await prepared.plan_store.get_items() == []
+
+    @pytest.mark.anyio
     async def test_a_resume_starts_from_the_plan_the_run_parked_with(self):
         """Both copies exist on a resume, and the park's is the newer one: it was
         seeded from the conversation when that run began and then worked on."""

--- a/backend/tests/test_planning.py
+++ b/backend/tests/test_planning.py
@@ -23,6 +23,7 @@ from app.agents.capabilities.planning import (
     dump_plan,
     new_plan_store,
     open_plan_store,
+    still_open,
 )
 from app.agents.capabilities.planning._capability import (
     _TEXTS,
@@ -271,3 +272,77 @@ class TestParkSurvival:
 
     def test_a_default_store_is_empty_and_in_memory(self):
         assert isinstance(new_plan_store(), InMemoryPlanStore)
+
+
+class TestAFinishedPlanIsHistory:
+    """What a *new* turn is seeded with (#1221).
+
+    `keep_plan` stores whatever the store held when the run ended, completed steps
+    included, and a fresh turn seeds from it - so a thread whose three steps were
+    all ticked off in August opened in November with the tail reminder calling them
+    "your current plan" and `read_plan` answering with them. The agent was working
+    to a checklist about a task nobody was doing.
+
+    Filtered at the seed rather than cleared when the last step is ticked: within
+    the turn that finishes a plan the store still holds it, so the agent can
+    summarise what it just did and nothing contradicts the transcript. It is the
+    next question that starts clean.
+    """
+
+    def test_a_plan_with_every_step_ticked_is_not_seeded(self):
+        items = [
+            PlanItem(content="Read the code", status=TaskStatus.completed).model_dump(mode="json"),
+            PlanItem(content="Write the fix", status=TaskStatus.completed).model_dump(mode="json"),
+        ]
+
+        assert still_open(items) is None
+
+    def test_cancelled_counts_as_finished(self):
+        """A step nobody is going to do is not work outstanding."""
+        items = [
+            PlanItem(content="Read the code", status=TaskStatus.completed).model_dump(mode="json"),
+            PlanItem(content="Ship it", status=TaskStatus.cancelled).model_dump(mode="json"),
+        ]
+
+        assert still_open(items) is None
+
+    def test_one_step_left_seeds_the_whole_plan(self):
+        """Including the finished steps: what is left only makes sense beside what
+        is done, and `write_plan` takes the whole list every time."""
+        items = [
+            PlanItem(content="Read the code", status=TaskStatus.completed).model_dump(mode="json"),
+            PlanItem(content="Write the fix", status=TaskStatus.pending).model_dump(mode="json"),
+        ]
+
+        assert still_open(items) == items
+
+    def test_a_blocked_step_is_work_outstanding(self):
+        """The one status that could read either way. Something still has to
+        unblock it, so the plan is not finished."""
+        items = [
+            PlanItem(id="a", content="Migration", status=TaskStatus.completed).model_dump(
+                mode="json"
+            ),
+            PlanItem(
+                id="b", content="Backfill", status=TaskStatus.blocked, depends_on=["a"]
+            ).model_dump(mode="json"),
+        ]
+
+        assert still_open(items) == items
+
+    def test_no_plan_is_left_alone_either_way(self):
+        """`None` and `[]` both mean no plan, and both have to survive as
+        themselves - `open_plan_store` reads them the same but `keep_plan` does
+        not, and turning one into the other would rewrite a row for nothing."""
+        assert still_open(None) is None
+        assert still_open([]) == []
+
+    async def test_the_seeded_store_holds_what_survived(self):
+        """End to end through the helper the runner actually calls."""
+        finished = [
+            PlanItem(content="Done", status=TaskStatus.completed).model_dump(mode="json"),
+        ]
+
+        store = await open_plan_store(still_open(finished))
+
+        assert await store.get_items() == []

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -796,11 +796,24 @@ newer copy, and written back to the conversation when the run stops. A surface w
 no conversation — a bare API call — keeps a plan for the length of its run, which is
 all it has.
 
-A finished checklist is kept rather than cleared. That is what the run which
-finished it saw too: every step ticked in the tail reminder, until `write_plan`
-replaces the plan wholesale — which is what starting new work does. An agent that
-does not bind the capability pays nothing: no tools, no reminder, and nothing stored,
-because an empty checklist against a column that is null is not a change to write.
+**A finished checklist is history, and a new turn does not start from it.** The
+row keeps it — nothing is deleted — but a plan whose every step is `completed` or
+`cancelled` is not seeded into the next turn: the tail reminder would call a task
+nobody is doing "your current plan", and `read_plan` would answer with it
+(agenticos#1221).
+
+The filter is at the *seed*, not at the moment the last step is ticked, and that
+is the whole of the choice. Within the turn that finishes a plan the store still
+holds it, so the agent can summarise what it just did and nothing contradicts the
+transcript. It is the next question that starts clean — and the ticked checklist
+is still in the messages above it, where it reads as what was done rather than as
+what is being done. A `blocked` step is work outstanding, so a plan holding one is
+seeded: something still has to unblock it. A resume seeds from `paused_state` and
+is untouched, being mid-plan by construction.
+
+An agent that does not bind the capability pays nothing: no tools, no reminder, and
+nothing stored, because an empty checklist against a column that is null is not a
+change to write.
 
 **It spends no tokens of its own.** The tools are local checklist edits with no model
 or embedding request behind them, so unlike knowledge or delegation there is no

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -802,6 +802,12 @@ row keeps it — nothing is deleted — but a plan whose every step is `complete
 nobody is doing "your current plan", and `read_plan` would answer with it
 (agenticos#1221).
 
+Keeping the row takes one more rule, because a turn writes its store back when it
+ends: the turn whose store was opened empty *over* a finished plan writes nothing.
+It did nothing to the checklist, and an empty dump would delete the row on the
+very next ordinary message. An agent that starts new work dumps a plan and
+replaces it as usual.
+
 The filter is at the *seed*, not at the moment the last step is ticked, and that
 is the whole of the choice. Within the turn that finishes a plan the store still
 holds it, so the agent can summarise what it just did and nothing contradicts the


### PR DESCRIPTION
The half of #1077 its implementation left open. `keep_plan` records whatever the store held when the run ended — completed steps included — and the next turn seeds from it. So a thread whose three steps were all ticked off in August opens in November with the tail reminder calling them **"your current plan"** and `read_plan` answering with them. The agent works to a checklist about a task nobody is doing.

## The shape chosen

The issue offered three and expected the third. This is the **first, moved**: the filter is at the *seed* rather than at the moment the last step is ticked — which is what answers the issue's objection to clearing ("the last message shows three ticked steps and the next turn denies them").

- Within the turn that finishes a plan the store still holds it. `read_plan`, the tail reminder and the transcript all agree, and the agent can summarise what it just did.
- It is the **next** question that starts clean. The ticked checklist is still in the messages above it, where it reads as what *was* done rather than as what is being done — so nothing is denied, and there is no contradiction on screen.

The third shape ("seed it, and say it is finished") needs the library's tail reminder to say so: `_reminder_text` in `pydantic_ai_harness.planning` opens with "Your current plan (keep it updated with the planning tools)" unconditionally, so seeding a finished plan and labelling it correctly is a change in that package rather than here.

Nothing is deleted. The row keeps the finished plan; `still_open` decides only what a fresh turn is seeded with. A resume seeds from `PausedRunState.plan` and does not come through it, being mid-plan by construction.

**Finished** means at least one step and every step `completed` or `cancelled`. `blocked` is work outstanding — something still has to unblock it — which is the one status that could read either way, so it has its own test.

## Verified

Six cases on the helper: every step ticked, a cancelled step counting as finished, one step left seeding the whole plan, a `blocked` step keeping it, `None` and `[]` surviving as themselves (they mean different things to `keep_plan`), and the store `open_plan_store` actually opens. One on the runner — a conversation whose stored plan is all `completed`/`cancelled` prepares with an empty store — which fails without the change.

`make test` at 100% on the platform layer, `make lint` and `make docs-build` green.

The rule is written down in both places the issue asked for: `planning/_capability.py`'s docstring beside the seeding rule, and `docs/reference/capabilities.md`, whose paragraph said the opposite ("A finished checklist is kept rather than cleared").

Closes #1221
