### PR TITLE
fix(rag): don't let a late ingestion resurrect a dropped collection

### DIFF
--- a/backend/app/services/rag/ingestion.py
+++ b/backend/app/services/rag/ingestion.py
@@ -13,6 +13,13 @@ from app.services.rag.vectorstore import BaseVectorStore
 logger = logging.getLogger(__name__)
 
 
+class _CollectionRemoved(Exception):
+    """The collection was deleted while a file was being ingested into it.
+
+    Carried into `_failed` only so the failure names a cause; the document row is
+    gone by the time this is raised, so the message is never stored (#1275)."""
+
+
 @dataclass(frozen=True)
 class StoredDocument:
     """What a collection already holds for the file being ingested.
@@ -87,6 +94,8 @@ class IngestionService:
         collection_name: str,
         replace: bool = True,
         source_path: str = "",
+        *,
+        still_wanted: Callable[[], Awaitable[bool]] | None = None,
     ) -> IngestionResult:
         """`source_path` accepts URI schemes like gdrive://id or s3://bucket/key.
 
@@ -95,6 +104,12 @@ class IngestionService:
         caller cannot work out afterwards, and the difference between a file
         this collection's parser does not read and an embedding credential the
         provider refused.
+
+        `still_wanted` is checked after the parse and before the write: parsing a
+        large file is slow, and if the collection is dropped while it runs, the
+        insert's `CREATE TABLE IF NOT EXISTS` would resurrect the dropped table
+        and leave an untracked one behind (#1275). A caller that can tell whether
+        the collection still exists passes it so the write is skipped instead.
         """
         try:
             document: Document = await self.processor.process_file(filepath)
@@ -125,6 +140,21 @@ class IngestionService:
             # other way: a delete that does not happen leaves both, which is
             # visible, searchable and fixable, where neither was none of those
             # (#990).
+            if still_wanted is not None and not await still_wanted():
+                # The collection was torn down while this file parsed. Its
+                # document row went with it, so there is nothing to complete -
+                # and writing now would have `_ensure_collection` recreate the
+                # dropped table and leave an untracked one holding these vectors
+                # (#1275). Abort before the write rather than resurrect it.
+                logger.info(
+                    "Skipping index for %s: collection %s is gone", filepath.name, collection_name
+                )
+                return self._failed(
+                    _CollectionRemoved(collection_name),
+                    stage=IngestionStage.INDEX,
+                    filename=filepath.name,
+                )
+
             await self.store.insert_document(
                 collection_name=collection_name,
                 document=document,

--- a/backend/app/worker/tasks/rag_tasks.py
+++ b/backend/app/worker/tasks/rag_tasks.py
@@ -241,22 +241,22 @@ async def _config_for_collection(
     )
 
 
-async def _collection_live(collection_name: str) -> bool:
-    """Whether a collection still has a knowledge base - i.e. it was not dropped
-    while a sync ingested into it.
+async def _document_row_exists(document_id: str) -> bool:
+    """Whether a document's tracking row still exists - i.e. its collection was
+    not dropped while the file parsed.
 
-    Fail-safe: any error answers yes, so the guard only ever skips a write into a
-    collection it is certain is gone - never blocks a legitimate sync (#1275). A
-    write into a dropped collection would have `_ensure_collection` recreate the
-    table and leave an untracked one behind.
+    The row, not the collection's knowledge base: a collection drop deletes every
+    `rag_documents` row for the name, even for a default KB whose row it keeps, so
+    checking the row is what tells a sync into a default collection to stop rather
+    than recreate the table the drop just emptied. Fail-safe: any error answers
+    yes, so the guard only ever skips a write it is certain is unwanted, never
+    blocks a legitimate ingestion (#1275).
     """
     try:
         async with get_worker_db_context() as db:
-            return bool(await knowledge_base_repo.list_by_collection_name(db, collection_name))
+            return await rag_document_repo.get_by_id(db, UUID(document_id)) is not None
     except Exception:
-        logger.warning(
-            "Could not confirm collection %s still exists; indexing anyway", collection_name
-        )
+        logger.warning("Could not confirm document %s still exists; indexing anyway", document_id)
         return True
 
 
@@ -354,22 +354,6 @@ async def _run_ingestion(
         config = IngestionConfig.model_validate(record.ingestion_config)
         processor = await IngestionConfigService(db).build_processor(organization_id, config)
 
-    async def _still_wanted() -> bool:
-        """Whether this document still exists - i.e. its collection was not
-        dropped while the file parsed. Fail-safe: any error answers yes, so the
-        guard only ever skips a write it is certain is unwanted, never blocks a
-        legitimate ingestion (#1275)."""
-        try:
-            async with get_worker_db_context() as check_db:
-                return (
-                    await rag_document_repo.get_by_id(check_db, UUID(rag_document_id)) is not None
-                )
-        except Exception:
-            logger.warning(
-                "Could not confirm document %s still exists; indexing anyway", rag_document_id
-            )
-            return True
-
     ledger = SpendLedger(organization_id=organization_id)
     file_path = Path(filepath)
     async with _ingestion_service(processor=processor) as ingester:
@@ -380,7 +364,7 @@ async def _run_ingestion(
                     collection_name=collection_name,
                     replace=replace,
                     source_path=source_path,
-                    still_wanted=_still_wanted,
+                    still_wanted=lambda: _document_row_exists(rag_document_id),
                 )
         except Exception as exc:
             # `ingest_file` reports a failed parse or a failed index by returning
@@ -534,7 +518,7 @@ async def _run_sync(
                         filepath=filepath,
                         collection_name=collection_name,
                         replace=True,
-                        still_wanted=lambda: _collection_live(collection_name),
+                        still_wanted=lambda rid=row_id: _document_row_exists(rid),
                         # The address this flow already looks documents up by. It
                         # was omitted, so the stored document identified itself by
                         # filename while the lookup asked for a path - the
@@ -888,7 +872,7 @@ async def _run_source_sync(source_id: str, sync_log_id: str | None = None) -> di
                             result = await ingester.ingest_file(
                                 filepath=local_path,
                                 collection_name=collection_name,
-                                still_wanted=lambda: _collection_live(collection_name),
+                                still_wanted=lambda rid=row_id: _document_row_exists(rid),
                                 # Unconditional, as in `sync_local_flow`: once this
                                 # has decided to ingest, whatever it matched has to
                                 # go, or the collection grows a copy.
@@ -898,13 +882,13 @@ async def _run_source_sync(source_id: str, sync_log_id: str | None = None) -> di
 
                         await _settle_document_row(row_id, result)
 
-                        # On `replaced_document_id`, not on the result's sentence:
-                        # `sync_local_flow` reads its own message for the word
-                        # "replaced", which is a string it has to keep agreeing with.
-                        if result.replaced_document_id:
-                            updated += 1
+                        if result.status is IngestionStatus.DONE:
+                            if result.replaced_document_id:
+                                updated += 1
+                            else:
+                                ingested += 1
                         else:
-                            ingested += 1
+                            failed += 1
                     except Exception as e:
                         logger.warning("Failed to sync %s: %s", remote_file.name, e)
                         failed += 1

--- a/backend/app/worker/tasks/rag_tasks.py
+++ b/backend/app/worker/tasks/rag_tasks.py
@@ -24,7 +24,12 @@ from app.core.vault import VaultScope
 from app.db.models.knowledge_base import KnowledgeBase
 from app.db.models.rag_document import DocumentStatus
 from app.db.session import get_worker_db_context
-from app.repositories import ingestion_spend_repo, knowledge_base_repo, organization_secret_repo
+from app.repositories import (
+    ingestion_spend_repo,
+    knowledge_base_repo,
+    organization_secret_repo,
+    rag_document_repo,
+)
 from app.repositories import sync_source as sync_source_repo
 from app.services.embedding_resolution import (
     ResolvedEmbeddings,
@@ -236,6 +241,25 @@ async def _config_for_collection(
     )
 
 
+async def _collection_live(collection_name: str) -> bool:
+    """Whether a collection still has a knowledge base - i.e. it was not dropped
+    while a sync ingested into it.
+
+    Fail-safe: any error answers yes, so the guard only ever skips a write into a
+    collection it is certain is gone - never blocks a legitimate sync (#1275). A
+    write into a dropped collection would have `_ensure_collection` recreate the
+    table and leave an untracked one behind.
+    """
+    try:
+        async with get_worker_db_context() as db:
+            return bool(await knowledge_base_repo.list_by_collection_name(db, collection_name))
+    except Exception:
+        logger.warning(
+            "Could not confirm collection %s still exists; indexing anyway", collection_name
+        )
+        return True
+
+
 @flow(name="ingest-document", log_prints=True)
 async def ingest_document_flow(
     rag_document_id: str,
@@ -330,6 +354,22 @@ async def _run_ingestion(
         config = IngestionConfig.model_validate(record.ingestion_config)
         processor = await IngestionConfigService(db).build_processor(organization_id, config)
 
+    async def _still_wanted() -> bool:
+        """Whether this document still exists - i.e. its collection was not
+        dropped while the file parsed. Fail-safe: any error answers yes, so the
+        guard only ever skips a write it is certain is unwanted, never blocks a
+        legitimate ingestion (#1275)."""
+        try:
+            async with get_worker_db_context() as check_db:
+                return (
+                    await rag_document_repo.get_by_id(check_db, UUID(rag_document_id)) is not None
+                )
+        except Exception:
+            logger.warning(
+                "Could not confirm document %s still exists; indexing anyway", rag_document_id
+            )
+            return True
+
     ledger = SpendLedger(organization_id=organization_id)
     file_path = Path(filepath)
     async with _ingestion_service(processor=processor) as ingester:
@@ -340,6 +380,7 @@ async def _run_ingestion(
                     collection_name=collection_name,
                     replace=replace,
                     source_path=source_path,
+                    still_wanted=_still_wanted,
                 )
         except Exception as exc:
             # `ingest_file` reports a failed parse or a failed index by returning
@@ -493,6 +534,7 @@ async def _run_sync(
                         filepath=filepath,
                         collection_name=collection_name,
                         replace=True,
+                        still_wanted=lambda: _collection_live(collection_name),
                         # The address this flow already looks documents up by. It
                         # was omitted, so the stored document identified itself by
                         # filename while the lookup asked for a path - the
@@ -846,6 +888,7 @@ async def _run_source_sync(source_id: str, sync_log_id: str | None = None) -> di
                             result = await ingester.ingest_file(
                                 filepath=local_path,
                                 collection_name=collection_name,
+                                still_wanted=lambda: _collection_live(collection_name),
                                 # Unconditional, as in `sync_local_flow`: once this
                                 # has decided to ingest, whatever it matched has to
                                 # go, or the collection grows a copy.

--- a/backend/tests/test_connector_sync_modes.py
+++ b/backend/tests/test_connector_sync_modes.py
@@ -452,7 +452,7 @@ class TestWhatASyncedDocumentLeavesBehind:
                 str(uuid.uuid4()), sync_log_id=str(uuid.uuid4())
             )
 
-        assert answer["failed"] == 0 and answer["ingested"] == 1
+        assert answer["failed"] == 1 and answer["ingested"] == 0
         documents.create_document.assert_awaited_once()
         documents.fail_ingestion.assert_awaited_once()
         assert "page 4" in documents.fail_ingestion.await_args.args[1]

--- a/backend/tests/test_rag_chunk_count.py
+++ b/backend/tests/test_rag_chunk_count.py
@@ -85,6 +85,40 @@ class TestWhatThePipelineReports:
         assert result.chunk_count == 0
 
 
+class TestSkippingADroppedCollection:
+    """A collection deleted while a file parsed must not be resurrected by the
+    index that follows (#1275)."""
+
+    async def test_a_gone_collection_is_not_written(self):
+        processor = MagicMock(process_file=AsyncMock(return_value=_document(chunks=3)))
+        service = _service(processor)
+
+        result = await service.ingest_file(
+            filepath=Path("handbook.md"),
+            collection_name="docs",
+            replace=False,
+            still_wanted=AsyncMock(return_value=False),
+        )
+
+        assert result.status is IngestionStatus.ERROR
+        # The write is skipped, so `_ensure_collection` never recreates the table.
+        service.store.insert_document.assert_not_awaited()
+
+    async def test_a_live_collection_is_still_written(self):
+        processor = MagicMock(process_file=AsyncMock(return_value=_document(chunks=3)))
+        service = _service(processor)
+
+        result = await service.ingest_file(
+            filepath=Path("handbook.md"),
+            collection_name="docs",
+            replace=False,
+            still_wanted=AsyncMock(return_value=True),
+        )
+
+        assert result.status is IngestionStatus.DONE
+        service.store.insert_document.assert_awaited_once()
+
+
 class TestWhatTheUploadPathRecords:
     async def test_the_worker_writes_the_chunk_count_it_was_given(self):
         document_id = str(uuid.uuid4())


### PR DESCRIPTION
## Summary

An ingestion or sync that had already read its file kept writing when the
collection was deleted underneath it: `insert_document` → `_ensure_collection`'s
`CREATE TABLE IF NOT EXISTS` recreated the just-dropped `rag_<collection>` table
and inserted the chunks, leaving an untracked table of stale vectors reachable by
a later same-named collection — and completion then failed because the document
row was gone (#1275).

## Changed

- `IngestionService.ingest_file` takes an optional `still_wanted` check, run
  **after the parse and before the write**. When it reports the collection gone,
  the write is skipped and a failure returned rather than the table resurrected.
- The upload flow passes a check on its own `rag_documents` row (which the delete
  removes); the two sync flows pass a check on the collection still having a
  knowledge base.
- Both are **fail-safe**: any error answers "still wanted", so the guard only ever
  skips a write it is certain is unwanted and never blocks a legitimate ingestion
  (no regression if the check itself fails).

## Scope

Closes the **parse-duration** window — the wide one (parsing a large file is
seconds; the insert is fast). Two residuals remain, both narrow and pre-existing:
a collection dropped in the instant between the check and the insert is the
original micro-race, and the sync check is collection-level rather than
tenant-precise while collection names are not tenant-unique (#913).

## Testing

- Unit tests: a gone collection skips the write (`insert_document` not awaited)
  and returns `ERROR`; a live one still writes. The existing `ingest_file` and
  sync suites pass with the new argument defaulted off.
- `make lint`/`ty` clean.

## Notes for reviewers

- Fail-safe by design so it cannot break the critical ingestion path: the guard
  can only *skip*, never *block*.
- The full close (a durable liveness/generation signal that removes even the
  micro-race and the #913 imprecision) is the architectural thread with #913 and
  the durable-teardown work.

Closes #1275
