### PR TITLE
fix(api): name the organization in every alert link, and adopt it

### DIFF
--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -112,7 +112,7 @@ class NotificationService:
             "org_name": organization.name if organization else "your organization",
             "reason": reason,
             "spent": f"{run.cost_usd:.2f}" if run.cost_usd is not None else "0.00",
-            "run_url": f"{self._frontend}/agents/{agent.id}",
+            "run_url": self._link(f"/agents/{agent.id}", run.organization_id),
             "app_name": settings.PROJECT_NAME,
         }
         self._send(EmailKey.BUDGET_EXCEEDED, recipients, context)
@@ -141,7 +141,7 @@ class NotificationService:
         context = {
             "agent_name": agent.name,
             "tools": ", ".join(tools) if tools else "a tool call",
-            "approvals_url": f"{self._frontend}/agents/{agent.id}",
+            "approvals_url": self._link(f"/agents/{agent.id}", run.organization_id),
             "app_name": settings.PROJECT_NAME,
         }
         self._send(EmailKey.APPROVAL_REQUESTED, recipients, context)
@@ -184,7 +184,7 @@ class NotificationService:
             "total": f"{total:.2f}",
             "runs": str(sum(row[3] for row in rows)),
             "agents": str(len({row[0] for row in rows})),
-            "dashboard_url": f"{self._frontend}/agents",
+            "dashboard_url": self._link("/agents", organization_id),
             "app_name": settings.PROJECT_NAME,
         }
         self._send(EmailKey.USAGE_REPORT, recipients, context)
@@ -249,7 +249,7 @@ class NotificationService:
             "total": f"{sum((row[2] for row in mine), Decimal(0)):.2f}",
             "runs": str(sum(row[3] for row in mine)),
             "agents": agent.name,
-            "dashboard_url": f"{self._frontend}/agents/{agent.id}",
+            "dashboard_url": self._link(f"/agents/{agent.id}", agent.organization_id),
             "app_name": settings.PROJECT_NAME,
         }
         self._send(EmailKey.USAGE_REPORT, recipients, context)
@@ -258,6 +258,23 @@ class NotificationService:
     @property
     def _frontend(self) -> str:
         return settings.FRONTEND_URL.rstrip("/")
+
+    def _link(self, path: str, organization_id: UUID) -> str:
+        """A console link that says which organization it is about.
+
+        Every alert URL used to be organization-agnostic, and the page it opens
+        acts on whichever organization the reader last used - `apiClient` stamps
+        `X-Organization-Id` from a selection persisted per browser. So somebody in
+        two organizations who was last working in Globex opened the approval alert
+        for a run in Acme and read *Globex's* queue: very likely empty, and
+        reading as "nothing is waiting" about a run that is parked and ageing
+        towards `ApprovalService.expire_stale` (#1204).
+
+        `?org=` is the parameter, decided here rather than at four call sites, and
+        the console adopts it the way it already adopts the id in `/orgs/{id}` -
+        a page that names an organization *is* that organization (#1032).
+        """
+        return f"{self._frontend}{path}?org={organization_id}"
 
     async def _administrators(
         self, organization_id: UUID, preference: NotificationPreference

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -633,6 +633,99 @@ class TestPerAgentUsageReport:
         assert sent.calls == []
 
 
+class TestEveryLinkNamesItsOrganization:
+    """An alert opens the tenant it is about, not the one the reader last used.
+
+    `apiClient` stamps `X-Organization-Id` from a selection persisted per
+    browser, and every alert URL was organization-agnostic - so somebody in two
+    organizations who was last working in Globex opened the approval alert for a
+    run in Acme and read Globex's queue: very likely empty, and reading as
+    "nothing is waiting" about a run that is parked and ageing towards
+    `ApprovalService.expire_stale` (#1204). The agent links were worse in a
+    quieter way: `/agents/{id}` under the wrong organization is a refusal for an
+    agent the reader can genuinely see, one switch away.
+
+    One parameter name, decided in `_link` rather than at four call sites.
+    """
+
+    @pytest.mark.anyio
+    async def test_the_budget_alert_names_the_runs_organization(self, sent):
+        run = _run()
+        with (
+            patch(f"{MODULE}.member_repo.list_emails_by_role", new=_roles("admin@acme.test")),
+            patch(f"{MODULE}.member_repo.list_emails_for_members", new=_members()),
+            patch(f"{MODULE}.organization_repo.get_by_id", new=AsyncMock(return_value=None)),
+        ):
+            await NotificationService(MagicMock()).budget_exceeded(
+                run,
+                agent=_agent(),
+                spec=_spec(),
+                reason="cap",
+                scope=BudgetScope.AGENT,
+            )
+
+        _, _, context = sent.calls[0]
+        assert context["run_url"].endswith(f"?org={run.organization_id}")
+
+    @pytest.mark.anyio
+    async def test_the_approval_alert_names_the_runs_organization(self, sent):
+        """The run's, not the agent's: they are the same today and the run is what
+        the alert is about, so a delegated run in another tenant would still open
+        the queue holding it."""
+        run = _run(org_id=uuid.uuid4())
+        with (
+            patch(f"{MODULE}.member_repo.list_emails_by_role", new=_roles("boss@acme.test")),
+            patch(f"{MODULE}.member_repo.list_emails_for_members", new=_members("boss@acme.test")),
+        ):
+            await NotificationService(MagicMock()).approval_requested(
+                run, agent=_agent(), spec=_spec(), tools=["send_email"]
+            )
+
+        _, _, context = sent.calls[0]
+        assert context["approvals_url"].endswith(f"?org={run.organization_id}")
+
+    @pytest.mark.anyio
+    async def test_the_organization_report_names_the_organization_it_reports_on(self, sent):
+        organization_id = uuid.uuid4()
+        rows = [(uuid.uuid4(), "gpt-5", Decimal("2.00"), 3)]
+        with (
+            patch(f"{MODULE}.agent_run_repo.cost_breakdown", new=AsyncMock(return_value=rows)),
+            patch(f"{MODULE}.organization_spend_since", new=_bill("2.00")),
+            patch(f"{MODULE}.member_repo.list_emails_by_role", new=_roles("admin@acme.test")),
+            patch(f"{MODULE}.organization_repo.get_by_id", new=AsyncMock(return_value=None)),
+        ):
+            await NotificationService(MagicMock()).usage_report(organization_id, period="weekly")
+
+        _, _, context = sent.calls[0]
+        assert context["dashboard_url"].endswith(f"?org={organization_id}")
+
+    @pytest.mark.anyio
+    async def test_the_agent_report_names_the_agents_organization(self, sent):
+        agent = _agent(org_id=uuid.uuid4(), owner_user_id=uuid.uuid4())
+        rows = [(agent.id, "gpt-5", Decimal("1.00"), 2)]
+        with (
+            patch(f"{MODULE}.agent_run_repo.cost_breakdown", new=AsyncMock(return_value=rows)),
+            patch(f"{MODULE}.member_repo.list_emails_by_role", new=_roles("admin@acme.test")),
+            patch(f"{MODULE}.member_repo.list_emails_for_members", new=_members()),
+            patch(f"{MODULE}.organization_repo.get_by_id", new=AsyncMock(return_value=None)),
+        ):
+            await NotificationService(MagicMock()).agent_usage_report(
+                agent,
+                _spec(usage=AlertSpec(enabled=True, to=[AlertAudience.ADMINS])),
+                period="weekly",
+            )
+
+        _, _, context = sent.calls[0]
+        assert context["dashboard_url"].endswith(f"?org={agent.organization_id}")
+
+    def test_the_parameter_name_is_decided_in_one_place(self):
+        """Four call sites inventing one is what the issue is about, one level up."""
+        service = NotificationService(MagicMock())
+        organization_id = uuid.uuid4()
+
+        assert service._link("/agents", organization_id).endswith(f"/agents?org={organization_id}")
+
+
 class TestPreferences:
     """The opt-outs from `/settings/notifications`, honoured at the send site.
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -993,6 +993,32 @@ reorganisation, and it means them in whichever organization the spec is imported
 into. A named member who has left contributes nothing rather than raising - an
 approval queue must not go silent because one id no longer resolves.
 
+### Every link says which organization it is about
+
+The console acts on whichever organization the reader last used: `apiClient`
+stamps `X-Organization-Id` from a selection persisted per browser. Every alert
+URL used to carry none, so somebody in two organizations who was last working in
+Globex opened the approval alert for a run in Acme and read **Globex's** queue —
+very likely empty, and reading as *nothing is waiting* about a run that is parked
+and ageing towards `ApprovalService.expire_stale`. The agent links were wrong
+more quietly: `/agents/{id}` under the wrong organization is a refusal for an
+agent the reader can genuinely see, one switch away.
+
+So every link carries `?org=<id>`, built in one place — `NotificationService._link`
+— rather than at each of the four call sites, and the console adopts it exactly
+as it adopts the id in `/orgs/{id}`: a page that names an organization *is* that
+organization. The adoption is a layout effect in `ActiveOrgGuard`, before the
+tenant cache reset and before the page's own queries, so the first request the
+page makes already carries the right tenant. The path outranks the parameter — a
+link says which organization an alert was about, and cannot move somebody off the
+page they are standing on.
+
+A reader who has since left that organization is told so, rather than moved
+quietly: the refusal names the link as the reason, because being switched in
+silence is how another organization's page becomes the answer to the alert. It
+cannot name the organization — they are not a member, so it is not in their
+list.
+
 ### Two rules that are not negotiable
 
 **A per-person opt-out only ever subtracts.** Each recipient's own switches at

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -3021,6 +3021,8 @@
   "organizations": {
     "accessLost": "You no longer have access to that organization.",
     "accessLostSwitched": "You no longer have access to that organization. Switched to {name}.",
+    "accessLostLink": "That link is for an organization you no longer have access to.",
+    "accessLostLinkSwitched": "That link is for an organization you no longer have access to. Showing {name} instead.",
     "created": "Organization created",
     "creating": "Creating...",
     "deleted": "Organization deleted",

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -313,6 +313,8 @@
     "deleted": "Organizacja usunięta",
     "accessLost": "Nie masz już dostępu do tej organizacji.",
     "accessLostSwitched": "Nie masz już dostępu do tej organizacji. Przełączono na {name}.",
+    "accessLostLink": "Ten link dotyczy organizacji, do której nie masz już dostępu.",
+    "accessLostLinkSwitched": "Ten link dotyczy organizacji, do której nie masz już dostępu. Pokazujemy {name}.",
     "failedDelete": "Nie udało się usunąć organizacji",
     "failedUpdate": "Nie udało się zaktualizować organizacji"
   },

--- a/frontend/src/components/layout/active-org-guard.integration.test.tsx
+++ b/frontend/src/components/layout/active-org-guard.integration.test.tsx
@@ -11,6 +11,9 @@ import { useOrgStore } from "@/stores";
 
 vi.mock("next/navigation", () => ({
   usePathname: () => "/dashboard",
+  // An alert link names its organization in `?org=`, which the recovery adopts
+  // the way it adopts the id in `/orgs/{id}` (#1204). Nothing here carries one.
+  useSearchParams: () => new URLSearchParams(),
   // next-intl's createNavigation wraps these at module scope; see `vitest.setup.ts`.
   redirect: vi.fn(),
   permanentRedirect: vi.fn(),

--- a/frontend/src/hooks/use-active-organization.test.tsx
+++ b/frontend/src/hooks/use-active-organization.test.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 
 import {
   organizationInPath,
+  organizationInQuery,
   refusesOrganization,
   useActiveOrganizationRecovery,
 } from "./use-active-organization";
@@ -22,9 +23,10 @@ vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 // exports are the ones `vitest.setup.ts` provides for the same reason it does:
 // next-intl's `createNavigation` reads them at module scope.
 const path = vi.fn(() => "/");
+const search = vi.fn(() => new URLSearchParams());
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => search(),
   usePathname: () => path(),
   useParams: () => ({}),
   redirect: vi.fn(),
@@ -147,11 +149,35 @@ describe("organizationInPath", () => {
   });
 });
 
+describe("organizationInQuery", () => {
+  const ORG = "44444444-4444-4444-4444-444444444444";
+
+  it("reads the organization an alert link carries", () => {
+    // Every notification email opens a page whose path names no organization,
+    // and the page then acts on whichever one the reader last used (#1204).
+    expect(organizationInQuery(new URLSearchParams(`org=${ORG}`))).toBe(ORG);
+  });
+
+  it("names none when the link carries none", () => {
+    expect(organizationInQuery(new URLSearchParams())).toBeNull();
+    expect(organizationInQuery(new URLSearchParams("tab=approvals"))).toBeNull();
+  });
+
+  it("takes a UUID and nothing else, lower-cased", () => {
+    // The same two rules the path's reader has, and for the same reasons: a
+    // non-UUID would be adopted as a tenant id and refused on every request,
+    // and an upper-case spelling would be stored and match nothing.
+    expect(organizationInQuery(new URLSearchParams("org=new"))).toBeNull();
+    expect(organizationInQuery(new URLSearchParams(`org=${ORG.toUpperCase()}`))).toBe(ORG);
+  });
+});
+
 describe("useActiveOrganizationRecovery", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     useOrgStore.setState({ activeOrgId: null, refusedOrgIds: [] });
     path.mockReturnValue("/");
+    search.mockReturnValue(new URLSearchParams());
     client = new QueryClient({
       // Matching `app/providers.tsx`. At the library default of 0 a switch
       // refetches whether or not anything dropped the cache, which is the
@@ -319,6 +345,72 @@ describe("useActiveOrganizationRecovery", () => {
     renderHook(() => useActiveOrganizationRecovery(), { wrapper });
 
     await waitFor(() => expect(useOrgStore.getState().activeOrgId).toBe(OTHER));
+  });
+
+  it("adopts the organization an alert link carries", async () => {
+    // The whole of #1204: every notification email opens a page whose path
+    // names no organization, so the reader saw whichever tenant they last used
+    // - most often the wrong one's empty approvals queue.
+    const OTHER = "33333333-3333-3333-3333-333333333333";
+    answerWith([{ id: PERSONAL, is_personal: true }], { permissions: [] });
+    useOrgStore.setState({ activeOrgId: PERSONAL });
+    path.mockReturnValue("/agents/a-1");
+    search.mockReturnValue(new URLSearchParams(`org=${OTHER}`));
+
+    renderHook(() => useActiveOrganizationRecovery(), { wrapper });
+
+    await waitFor(() => expect(useOrgStore.getState().activeOrgId).toBe(OTHER));
+  });
+
+  it("lets the path outrank a link", async () => {
+    // `/orgs/{id}` *is* that organization; `?org=` only says which one an alert
+    // was about. A parameter cannot move the page somebody is standing on.
+    const PAGE = "33333333-3333-3333-3333-333333333333";
+    const LINK = "44444444-4444-4444-4444-444444444444";
+    answerWith([{ id: PERSONAL, is_personal: true }], { permissions: [] });
+    useOrgStore.setState({ activeOrgId: PERSONAL });
+    path.mockReturnValue(`/orgs/${PAGE}/members`);
+    search.mockReturnValue(new URLSearchParams(`org=${LINK}`));
+
+    renderHook(() => useActiveOrganizationRecovery(), { wrapper });
+
+    await waitFor(() => expect(useOrgStore.getState().activeOrgId).toBe(PAGE));
+  });
+
+  it("adopts a second link to the same page", async () => {
+    // `?org=` does not change the path, so two alerts about two organizations
+    // arrive at the same one - and an adoption keyed on the path alone would
+    // leave the second reading the first one's tenant.
+    const FIRST = "33333333-3333-3333-3333-333333333333";
+    const SECOND = "44444444-4444-4444-4444-444444444444";
+    answerWith([{ id: PERSONAL, is_personal: true }], { permissions: [] });
+    useOrgStore.setState({ activeOrgId: PERSONAL });
+    path.mockReturnValue("/agents/a-1");
+    search.mockReturnValue(new URLSearchParams(`org=${FIRST}`));
+    const { rerender } = renderHook(() => useActiveOrganizationRecovery(), { wrapper });
+    await waitFor(() => expect(useOrgStore.getState().activeOrgId).toBe(FIRST));
+
+    search.mockReturnValue(new URLSearchParams(`org=${SECOND}`));
+    rerender();
+
+    expect(useOrgStore.getState().activeOrgId).toBe(SECOND);
+  });
+
+  it("says the link is the reason when the organization it named is refused", async () => {
+    // Being moved silently would have them read another organization's page as
+    // the answer to the alert - which is the failure the id in the URL exists
+    // to prevent, arriving one step later.
+    answerWith([{ id: PERSONAL, is_personal: true }], organizationRefused(STALE));
+    useOrgStore.setState({ activeOrgId: PERSONAL });
+    path.mockReturnValue("/agents/a-1");
+    search.mockReturnValue(new URLSearchParams(`org=${STALE}`));
+
+    renderHook(() => useActiveOrganizationRecovery(), { wrapper });
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(expect.stringContaining("That link is for")),
+    );
+    expect(useOrgStore.getState().activeOrgId).toBe(PERSONAL);
   });
 
   it("leaves the selection alone on a page that names no organization", async () => {

--- a/frontend/src/hooks/use-active-organization.test.tsx
+++ b/frontend/src/hooks/use-active-organization.test.tsx
@@ -396,6 +396,32 @@ describe("useActiveOrganizationRecovery", () => {
     expect(useOrgStore.getState().activeOrgId).toBe(SECOND);
   });
 
+  it("adopts the same link again after a page that named nothing", async () => {
+    // The dashboard layout outlives every navigation inside it, so the marker
+    // that stops the adoption fighting the switcher would otherwise outlive the
+    // link too: open an alert, switch deliberately, go elsewhere, come Back -
+    // and the alert reads under the organization switched to.
+    const LINK = "33333333-3333-3333-3333-333333333333";
+    answerWith([{ id: PERSONAL, is_personal: true }], { permissions: [] });
+    useOrgStore.setState({ activeOrgId: PERSONAL });
+    path.mockReturnValue("/agents/a-1");
+    search.mockReturnValue(new URLSearchParams(`org=${LINK}`));
+    const { rerender } = renderHook(() => useActiveOrganizationRecovery(), { wrapper });
+    await waitFor(() => expect(useOrgStore.getState().activeOrgId).toBe(LINK));
+
+    useOrgStore.setState({ activeOrgId: PERSONAL });
+    path.mockReturnValue("/skills");
+    search.mockReturnValue(new URLSearchParams());
+    rerender();
+    expect(useOrgStore.getState().activeOrgId).toBe(PERSONAL);
+
+    path.mockReturnValue("/agents/a-1");
+    search.mockReturnValue(new URLSearchParams(`org=${LINK}`));
+    rerender();
+
+    expect(useOrgStore.getState().activeOrgId).toBe(LINK);
+  });
+
   it("says the link is the reason when the organization it named is refused", async () => {
     // Being moved silently would have them read another organization's page as
     // the answer to the alert - which is the failure the id in the URL exists

--- a/frontend/src/hooks/use-active-organization.ts
+++ b/frontend/src/hooks/use-active-organization.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useLayoutEffect, useRef } from "react";
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
@@ -73,6 +73,27 @@ export function organizationInPath(pathname: string): string | null {
   if (segments[start] !== "orgs") return null;
   const id = segments[start + 1];
   return id !== undefined && UUID.test(id) ? id.toLowerCase() : null;
+}
+
+/**
+ * The organization a link *carries*, for a page whose path names none.
+ *
+ * Every alert email opens a page that acts on whichever organization the reader
+ * last used - `apiClient` stamps `X-Organization-Id` from a selection persisted
+ * per browser - and none of those URLs said which organization the alert was
+ * about. So somebody in two organizations who was last working in Globex opened
+ * the approval alert for a run in Acme and read Globex's queue: very likely
+ * empty, and reading as "nothing is waiting" about a run that is parked and
+ * ageing out (#1204).
+ *
+ * The same rule as the path's, for the same reasons: a UUID only, so a future
+ * `?org=new` is not adopted as a tenant id and refused on every request; and
+ * lower-cased, because the value is *stored* and found by `===` against ids the
+ * server serialises in canonical lower case.
+ */
+export function organizationInQuery(search: URLSearchParams): string | null {
+  const id = search.get("org");
+  return id !== null && UUID.test(id) ? id.toLowerCase() : null;
 }
 
 /**
@@ -179,7 +200,11 @@ export function useActiveOrganizationRecovery(): void {
   const { error } = usePermissions();
   const { data: orgs } = useOrganizationList();
   const pathname = usePathname();
-  const named = organizationInPath(pathname);
+  const search = useSearchParams();
+  // The path wins. `/orgs/{id}` *is* that organization, where `?org=` is a link
+  // saying which one it was about - so a query parameter cannot override the
+  // page a reader is standing on.
+  const named = organizationInPath(pathname) ?? organizationInQuery(search);
   // A refused organization is not adopted from a URL either, or opening its
   // page would hand the selection straight back to the one the recovery below
   // has just moved off - the shape an infinite switch loop takes.
@@ -203,11 +228,15 @@ export function useActiveOrganizationRecovery(): void {
    * `OrgSwitcher` handles the other direction by taking the scoped route with it.
    */
   const adoptedFor = useRef<string | null>(null);
+  // The path *and* what was adopted from it, because `?org=` does not change the
+  // path: two alerts about two organizations open the same page, and keying on
+  // the path alone would leave the second reading the first one's tenant.
+  const arrival = `${pathname}#${adopted ?? ""}`;
   useLayoutEffect(() => {
-    if (adopted === null || pathname === adoptedFor.current) return;
-    adoptedFor.current = pathname;
+    if (adopted === null || arrival === adoptedFor.current) return;
+    adoptedFor.current = arrival;
     if (adopted !== activeOrgId) setActiveOrgId(adopted);
-  }, [adopted, activeOrgId, pathname, setActiveOrgId]);
+  }, [adopted, activeOrgId, arrival, setActiveOrgId]);
 
   // Whatever moved the selection - the switcher, the URL above, or the recovery
   // below - the cache follows it. The URL's organization is passed rather than
@@ -224,8 +253,30 @@ export function useActiveOrganizationRecovery(): void {
     const replacement = preferredOrg(orgs, [...refusedOrgIds, activeOrgId]);
     setActiveOrgId(replacement?.id ?? null);
 
+    // Which organization it was about, when a link named one. Somebody following
+    // an alert into a tenant they have since left would otherwise be moved
+    // silently and read another organization's page as the answer to it - the
+    // reason the id is in the URL in the first place (#1204). The name is not
+    // available: they are not a member, so it is not in their list.
+    const fromLink = adopted === activeOrgId;
     toast.error(
-      replacement ? t("accessLostSwitched", { name: replacement.name }) : t("accessLost"),
+      fromLink
+        ? replacement
+          ? t("accessLostLinkSwitched", { name: replacement.name })
+          : t("accessLostLink")
+        : replacement
+          ? t("accessLostSwitched", { name: replacement.name })
+          : t("accessLost"),
     );
-  }, [error, activeOrgId, orgs, refusedOrgIds, markOrgRefused, setActiveOrgId, queryClient, t]);
+  }, [
+    error,
+    activeOrgId,
+    adopted,
+    orgs,
+    refusedOrgIds,
+    markOrgRefused,
+    setActiveOrgId,
+    queryClient,
+    t,
+  ]);
 }

--- a/frontend/src/hooks/use-active-organization.ts
+++ b/frontend/src/hooks/use-active-organization.ts
@@ -233,7 +233,17 @@ export function useActiveOrganizationRecovery(): void {
   // the path alone would leave the second reading the first one's tenant.
   const arrival = `${pathname}#${adopted ?? ""}`;
   useLayoutEffect(() => {
-    if (adopted === null || arrival === adoptedFor.current) return;
+    // A URL that names no organization forgets the last one that did. The
+    // dashboard layout outlives every navigation inside it, so without this a
+    // reader who opened an alert, switched organization deliberately, went
+    // somewhere else and came back with Back would arrive at the same URL with
+    // the marker still set - reading the alert under the organization they
+    // switched to.
+    if (adopted === null) {
+      adoptedFor.current = null;
+      return;
+    }
+    if (arrival === adoptedFor.current) return;
     adoptedFor.current = arrival;
     if (adopted !== activeOrgId) setActiveOrgId(adopted);
   }, [adopted, activeOrgId, arrival, setActiveOrgId]);


### PR DESCRIPTION
Every notification link was organization-agnostic, and the page it opens acts on whichever organization the reader last used — `apiClient` stamps `X-Organization-Id` from a selection persisted per browser. So somebody in two organizations who was last working in Globex opened the approval alert for a run in Acme and read **Globex's** queue: very likely empty, and reading as *nothing is waiting* about a run that is parked and ageing towards `ApprovalService.expire_stale`. The agent links were wrong more quietly — `/agents/{id}` under the wrong organization is a refusal for an agent the reader can genuinely see, one switch away.

`run.organization_id` and `agent.organization_id` were in scope at all four call sites and discarded.

## One parameter, decided once

```python
def _link(self, path: str, organization_id: UUID) -> str:
    return f"{self._frontend}{path}?org={organization_id}"
```

Four call sites inventing a parameter name is the same defect one level up, so there is one helper and a test that pins it.

| Email | Link | Organization |
|---|---|---|
| Approval requested | `/agents/{id}?org=…` | the **run's** |
| Budget exceeded | `/agents/{id}?org=…` | the run's |
| Usage report (org) | `/agents?org=…` | the one it reports on |
| Usage report (agent) | `/agents/{id}?org=…` | the agent's |

## The console adopts it, the way it adopts `/orgs/{id}`

`organizationInQuery` reads it under the same two rules as the path's reader, for the same reasons #1032 gives: a UUID only (so a future `?org=new` is not adopted as a tenant id and refused on every request) and lower-cased (the value is stored and found by `===` against ids the server serialises in canonical lower case). The adoption is the existing layout effect in the recovery hook — before the tenant cache reset and before the page's own queries, so the first request the page makes already carries the right tenant.

Two rules follow from what the parameter *is*:

- **The path outranks it.** `/orgs/{id}` *is* that organization; `?org=` only says which one an alert was about, so it cannot move somebody off the page they are standing on.
- **Adoption is keyed on the path and the adopted id together.** `?org=` does not change the path, so two alerts about two organizations arrive at the same page — keyed on the path alone, the second would read the first one's tenant.

A reader who has since left that organization is told the link is the reason, rather than being moved in silence and reading another organization's page as the answer to the alert. It cannot name the organization: they are not a member, so it is not in their list.

## Verified

Backend: one case per email kind asserting the id is in the URL, plus one that the parameter is built in a single place. Client: three on `organizationInQuery` (present, absent, UUID-only and lower-cased) and four on the hook — adoption from a link, the path winning over one, a second link to the same page, and the refusal naming the link.

`make test` at 100% on the platform layer, `make lint`, `make test-frontend-cov` and `make docs-build` green. `docs/governance.md` gains "Every link says which organization it is about" under Alerts.

One note: `/runs?tab=approvals` is #935's destination and is not on `main` yet, so the approval link here is still `/agents/{id}`. It gains the parameter either way — `_link` takes the path.

Closes #1204
