### PR TITLE
docs: a readability pass over the whole site, and the four pages that were wrong

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,9 +4,7 @@ The state of the platform and what is left, written so someone picking this up
 cold knows both what exists and *why it was built that way*. Sections match the
 board in the working plan (`VstormOS — MVP`).
 
-Updated: 2026-07-27.
-
----
+Updated: 2026-08-27.
 
 ## Where the platform stands
 
@@ -19,14 +17,12 @@ Updated: 2026-07-27.
 | Agent registry | Done. Draft → validate → publish → frozen version |
 | Runs, budgets, approvals | Done, resume included |
 | Skills and collections | Done, backend and UI |
-| MCP | Catalog, per-user connections, and agent bindings resolved at run time. Org-scoped connection *management* missing (R8) |
-| Surfaces | Web chat, Playground, API, Slack and Telegram `@mention` — one run path, one set of books |
+| MCP | Catalog, per-user **and** org-scoped connections, agent bindings resolved at run time |
+| Surfaces | Web chat, Playground, API, an embeddable widget, a raw WebSocket, a hosted page, Slack, Telegram and Mattermost — one run path, one set of books |
 | Ingestion | Per-collection parser, chunking, OCR and image-description model; overridable per upload. Embedding model fixed at creation |
 | Frontend | Agents, Builder, Skills, Sharing, Providers, MCP catalog, Activity, Roles, ingestion settings |
-| Tests | 1,644 backend, 564 frontend, E2E present. **Coverage gate is red at 97.51%** — see R12 |
+| Tests | Four layers plus Playwright. The platform layer is at **100%, enforced in CI**; the frontend gate is 100% lines/statements/functions and 97.5% branches |
 | CI | Lint, types, tests, migrations forwards and back, frontend, E2E, security |
-
----
 
 ## Architecture, in the order it matters
 
@@ -47,8 +43,6 @@ someone is looking at a form, not at 3am in a customer conversation.
 
 **Every surface goes through one runner.** If each surface assembled its own
 agent, budgets and history would hold whatever each one remembered to record.
-
----
 
 ## Delivered since the last revision
 
@@ -120,58 +114,44 @@ means no ingestion path had ever been exercised locally or in CI, and an E2E
 upload spec was sitting skipped because of it. Now `pgvector/pgvector:pg16`.
 **Applying it locally needs the container recreated, which drops the dev volume.**
 
+## Closed since that revision
+
+**R12 the 100% gate** — restored, and `fail_under = 100` in
+`backend/pyproject.toml` is what holds it. Adding a module to the platform layer
+means editing two lists in that file, and `tests/test_coverage_gate.py` fails if
+they drift.
+
+**R8 organization-scoped MCP connections** — `scope`, `organization_id` and
+`catalog_key` are written; `org_mcp_connections.py` and `me_mcp_connections.py`
+are the two route modules, the org half gated on `connections:manage`, and a
+binding resolves at run time. See
+[MCP](mcp.md#personal-or-organization-wide).
+
+**R9 a public agent link** — a [hosted page](channels.md#a-hosted-page) is one
+kind of embed, served at `/e/{publicKey}`, with variables from the address bar and
+a thread a visitor can come back to. It reuses the run path, so budgets and
+history apply identically.
+
 ## Remaining work
-
-### R12 — Restore the 100% gate
-**Why:** it is the one rule that stops untested code landing, and it is currently
-not being enforced by anything except a red build. `app/services/skills.py` is at
-53%, `app/services/mcp_connection.py` at 94%, `app/repositories/mcp_connection.py`
-at 97% — roughly 108 statements arrived in gated modules without tests. The
-suite itself is green, which is the trap: `make test-fast` and a plain `pytest`
-both pass, and only `--cov` says otherwise.
-
-Some of the gap is security-relevant (skill path traversal, the UTF-8 guard on
-resources), so it needs tests that prove the refusal, not tests that execute the
-line.
-
-### R8 — Organization-scoped MCP connections
-**Why:** `AgentSpec.mcp_server_ids` exists and, until now, nothing read it. A
-published agent cannot depend on whose session runs it, so binding a *personal*
-connection to it is the wrong model — which is why `McpConnection` already has a
-`scope`, an `organization_id` and a `catalog_key`, from a migration now inside
-`0001_baseline`. Nothing writes those columns yet.
-
-- Repo and service for org-scoped rows, credential sealed per organization
-- Routes gated on `connections:manage`
-- Org UI, and mount `McpServerPicker` on the Builder once a binding can exist
-
-Until then the binding is refused at publish rather than silently ignored.
-
-### R9 — Public agent link
-**Why:** the answer to "can you just give me a link to it".
-
-- `/a/{slug}` hosted chat for one agent
-- Share token for org-wide or link access
-- Reuses the run path, so budgets and history apply identically
 
 ### R10 — Python SDK and a versioning contract (board I1)
 **Why:** the API is public from the first commit and has no client and no stated
 compatibility promise.
 
 ### R11 — Logfire dashboard (board H4)
-**Why:** `logfire_trace_id` is recorded on every run and nothing reads it.
-
----
+**Why:** `logfire_trace_id` is recorded on every run and still nothing reads it —
+it reaches `frontend/src/types/runs.ts` and stops there.
 
 ## Testing
 
 The bar and the layers are documented in [Testing](testing.md), and in
 [`CLAUDE.md`](https://github.com/vstorm-co/agenticos/blob/main/CLAUDE.md#testing)
 for anyone working in the repository.
-Short version: the platform layer is at 100% and CI enforces it;
-template-inherited subsystems are reported but do not gate the build, because
-mock-heavy tests over code we did not design buy a number rather than
-confidence.
+!!! abstract "Short version"
+
+    The platform layer is at 100% and CI enforces it; template-inherited
+    subsystems are reported but do not gate the build, because mock-heavy tests
+    over code we did not design buy a number rather than confidence.
 
 What is worth testing here specifically — tenant isolation, permission scopes,
 budget enforcement, spec validation, and that no response or log ever contains a

--- a/docs/adding_features.md
+++ b/docs/adding_features.md
@@ -2,178 +2,20 @@
 
 ## Adding a New API Endpoint
 
-This example adds a "Notification" feature end-to-end, following the
-repository + service pattern used throughout the codebase. **Routes never
-contain direct database calls** — all data access goes through a service,
-which delegates to a repository.
+!!! abstract "One walkthrough, in the Guides"
 
-1. **Create schema** in `schemas/`
-   ```python
-   # schemas/notification.py
-   from datetime import datetime
-   from uuid import UUID
+    [How to: Add a New API Endpoint](howto/add-api-endpoint.md) is the worked
+    example — schema, model, repository, service, dependency, route, router,
+    migration, tests. There is deliberately no second copy of it here: two
+    copies written for the same reader are two copies that disagree.
 
-   from pydantic import BaseModel
-
-
-   class NotificationCreate(BaseModel):
-       title: str
-       body: str
-       channel: str = "email"
-
-
-   class NotificationResponse(BaseModel):
-       id: UUID
-       title: str
-       body: str
-       channel: str
-       is_read: bool
-       created_at: datetime
-   ```
-
-2. **Create model** in `db/models/`
-   ```python
-   # db/models/notification.py
-   from uuid import uuid4
-
-   from sqlalchemy import Boolean, DateTime, String, func
-   from sqlalchemy.dialects.postgresql import UUID
-   from sqlalchemy.orm import Mapped, mapped_column
-
-   from app.db.base import Base
-
-
-   class Notification(Base):
-       __tablename__ = "notifications"
-
-       id: Mapped[UUID] = mapped_column(
-           UUID(as_uuid=True), primary_key=True, default=uuid4
-       )
-       title: Mapped[str] = mapped_column(String(255))
-       body: Mapped[str] = mapped_column(String)
-       channel: Mapped[str] = mapped_column(String(50), default="email")
-       is_read: Mapped[bool] = mapped_column(Boolean, default=False)
-       created_at: Mapped[DateTime] = mapped_column(
-           DateTime(timezone=True), server_default=func.now()
-       )
-   ```
-
-   Don't forget to import it in `db/models/__init__.py`.
-
-3. **Create repository** in `repositories/`
-   ```python
-   # repositories/notification.py
-   from uuid import UUID
-
-   from sqlalchemy import select
-   from sqlalchemy.ext.asyncio import AsyncSession
-
-   from app.db.models.notification import Notification
-
-
-   class NotificationRepository:
-       async def create(self, db: AsyncSession, **kwargs) -> Notification:
-           notification = Notification(**kwargs)
-           db.add(notification)
-           await db.flush()
-           await db.refresh(notification)
-           return notification
-
-       async def get_by_id(self, db: AsyncSession, notification_id: UUID) -> Notification | None:
-           return await db.get(Notification, notification_id)
-
-       async def list_unread(self, db: AsyncSession, limit: int = 50) -> list[Notification]:
-           result = await db.execute(
-               select(Notification)
-               .where(Notification.is_read.is_(False))
-               .order_by(Notification.created_at.desc())
-               .limit(limit)
-           )
-           return list(result.scalars().all())
-   ```
-
-4. **Create service** in `services/`
-   ```python
-   # services/notification.py
-   from uuid import UUID
-
-   from sqlalchemy.ext.asyncio import AsyncSession
-
-   from app.core.exceptions import NotFoundError
-   from app.repositories.notification import NotificationRepository
-   from app.schemas.notification import NotificationCreate
-
-
-   class NotificationService:
-       def __init__(self, db: AsyncSession):
-           self.db = db
-           self.repo = NotificationRepository()
-
-       async def create(self, data: NotificationCreate) -> "Notification":
-           return await self.repo.create(self.db, **data.model_dump())
-
-       async def get_or_raise(self, notification_id: UUID) -> "Notification":
-           notification = await self.repo.get_by_id(self.db, notification_id)
-           if not notification:
-               raise NotFoundError(
-                   message="Notification not found",
-                   details={"id": notification_id},
-               )
-           return notification
-
-       async def list_unread(self) -> list["Notification"]:
-           return await self.repo.list_unread(self.db)
-   ```
-
-5. **Register dependency** in `api/deps.py`
-   ```python
-   from app.services.notification import NotificationService
-
-
-   def get_notification_service(db: DBSession) -> NotificationService:
-       """Create NotificationService instance with database session."""
-       return NotificationService(db)
-
-
-   NotificationSvc = Annotated[NotificationService, Depends(get_notification_service)]
-   ```
-
-6. **Create route** in `api/routes/v1/`
-   ```python
-   # api/routes/v1/notifications.py
-   from fastapi import APIRouter, status
-
-   from app.api.deps import CurrentUser, NotificationSvc
-   from app.schemas.notification import NotificationCreate, NotificationResponse
-
-   router = APIRouter()
-
-
-   @router.post("/", response_model=NotificationResponse, status_code=status.HTTP_201_CREATED)
-   async def create_notification(
-       data: NotificationCreate,
-       current_user: CurrentUser,
-       service: NotificationSvc,
-   ):
-       return await service.create(data)
-
-
-   @router.get("/", response_model=list[NotificationResponse])
-   async def list_unread(
-       current_user: CurrentUser,
-       service: NotificationSvc,
-   ):
-       return await service.list_unread()
-   ```
-
-7. **Register router** in `api/routes/v1/__init__.py`
-   ```python
-   from app.api.routes.v1 import notifications
-
-   v1_router.include_router(
-       notifications.router, prefix="/notifications", tags=["notifications"]
-   )
-   ```
+The shape it teaches, in one paragraph: a **schema** per operation
+(`*Create`/`*Update`/`*Read`/`*List`), a **model** on `Base, TimestampMixin`
+with a `__repr__`, a **repository** of stateless functions using
+`flush()`/`refresh()` and never `commit()`, a **service** holding only the
+session and raising domain exceptions, an `Annotated` **dependency** in
+`api/deps.py`, and a **route** returning `-> Any` with `response_model` doing the
+serialization.
 
 ## Adding a Custom CLI Command
 
@@ -181,17 +23,30 @@ Commands are auto-discovered from `app/commands/`.
 
 ```python
 # app/commands/my_command.py
-from app.commands import command, success, error
 import click
 
-@command("my-command", help="Description of what this does")
-@click.option("--name", "-n", required=True, help="Name parameter")
-def my_command(name: str):
-    # Your logic here
+from app.commands import command, success
+
+
+@command("my-command", help="What this does")
+@click.option("--name", "-n", required=True, help="Whose name")
+def my_command(name: str) -> None:
+    """One line, because `--help` prints it."""
     success(f"Done: {name}")
 ```
 
-Run with: `uv run agenticos cmd my-command --name test`
+`success`, `error`, `warning` and `info` are the output helpers — a command says
+what happened through those rather than through `print`, so every command in the
+CLI reads the same way. Run it with:
+
+```bash
+uv run agenticos cmd my-command --name test
+```
+
+!!! note "A new command owes `docs/commands.md` a row"
+
+    That page is the reference an operator reads; a command absent from it is a
+    command nobody finds.
 
 ## Adding a tool the agent can call
 
@@ -205,13 +60,22 @@ part of a **capability**:
 - A third-party API that already publishes an MCP server → no code at all, see
   [MCP](mcp.md).
 
-The declared list in `@register(tools=...)` is what per-tool approval and per-agent
-renaming key on. A tool the registry does not know about still runs; it just cannot
-be gated or renamed, which is the failure worth avoiding.
+!!! danger "A tool the registry does not declare cannot be gated or renamed"
+
+    The list in `@register(tools=...)` is what per-tool approval and per-agent
+    renaming key on. An undeclared tool still runs — it just runs ungated, which
+    is the failure worth avoiding.
 
 What ships today is in the [capability catalog](reference/capabilities.md).
 
 ## Adding a Database Migration
+
+!!! warning "A model change with no migration fails `make check`"
+
+    `make db-check` runs `alembic check`, and it is part of `check` and of CI's
+    `lint` job. Autogenerate is a draft, not an answer: read the revision before
+    committing it, and give it a downgrade that actually reverses it —
+    `make test-migrations` cycles the whole chain both ways.
 
 ```bash
 # Create migration

--- a/docs/adding_features.md
+++ b/docs/adding_features.md
@@ -70,12 +70,18 @@ What ships today is in the [capability catalog](reference/capabilities.md).
 
 ## Adding a Database Migration
 
-!!! warning "A model change with no migration fails `make check`"
+!!! warning "`make db-check` skips itself when no database is listening"
 
-    `make db-check` runs `alembic check`, and it is part of `check` and of CI's
-    `lint` job. Autogenerate is a draft, not an answer: read the revision before
-    committing it, and give it a downgrade that actually reverses it —
-    `make test-migrations` cycles the whole chain both ways.
+    `alembic check` needs one, so the target prints a warning and **exits 0**
+    without a database on `CHECK_DB_PORT` — a model change with no migration then
+    passes local `make check`. CI's **`test`** job has a Postgres beside it and so
+    does not skip, which is where that mistake is actually caught. Run
+    `make docker-db` first if you want the local answer.
+
+!!! tip "Autogenerate is a draft, not an answer"
+
+    Read the revision before committing it, and give it a downgrade that actually
+    reverses it — `make test-migrations` cycles the whole chain both ways.
 
 ```bash
 # Create migration

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,11 +27,8 @@ services, which in turn delegate to repositories.
     repository - and fails just as loudly if its allowlist keeps an exemption
     that no longer applies.
 
-`backend/tests/test_route_layering.py` fails if any module under
-`app/api/routes/` imports from `app.repositories`, and fails just as loudly if its
-allowlist keeps an exemption that no longer applies. The rule had drifted in five
-modules before anything read for it — none of them a leak, because each handler
-passed the scope it happened to know. That is the cost: a scope a route owns is a
+The rule had drifted in five modules before anything read for it — none of them a
+leak, because each handler passed the scope it happened to know. That is the cost: a scope a route owns is a
 scope no service test can see, and the next reader of the entity has to know to pass
 the same thing. The single exemption is a `Literal` of sort orders, imported as a
 type rather than as data access.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,16 +6,27 @@ the same pattern: **Models → Schemas → Repositories → Services → Endpoin
 
 ## Request Flow
 
-```
-HTTP Request → API Route → Service → Repository → Database
-                  ↓
-              Response ← Service ← Repository ←
+```mermaid
+flowchart LR
+    Q([HTTP request]) --> R[API route]
+    R --> S[Service]
+    S --> P[Repository]
+    P --> D[(PostgreSQL)]
+    D -.-> P
+    P -.-> S
+    S -.-> R
+    R -.-> A([Response])
 ```
 
 Routes never contain direct database calls. All data access goes through
 services, which in turn delegate to repositories.
 
-**That is a test rather than a convention.**
+!!! info "It is a test, not a convention"
+
+    `backend/tests/test_route_layering.py` fails if a route imports a
+    repository - and fails just as loudly if its allowlist keeps an exemption
+    that no longer applies.
+
 `backend/tests/test_route_layering.py` fails if any module under
 `app/api/routes/` imports from `app.repositories`, and fails just as loudly if its
 allowlist keeps an exemption that no longer applies. The rule had drifted in five
@@ -137,8 +148,29 @@ code on the exit stack FastAPI unwinds between the path operation returning and
 4. the response is written to the socket;
 5. the session is closed.
 
-That ordering is the whole contract, and it is what lets a client act on its own
-answer: **a 2xx means the write is readable, not merely accepted.** FastAPI's
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Client
+    participant R as Route
+    participant S as Session
+    C->>R: request
+    R->>S: flush (ids, constraints)
+    R-->>R: return, response_model serializes
+    R->>S: COMMIT
+    S-->>R: committed
+    R->>R: start deferred background work
+    R-->>C: 2xx written
+    R->>S: close
+```
+
+!!! danger "A 2xx means the write is readable, not merely accepted"
+
+    That ordering is the whole contract. A bare `Depends(get_db_session)`
+    anywhere reintroduces FastAPI's default and swaps steps 2 and 4 -
+    `tests/api/test_db_session_scope.py` fails on one.
+
+That ordering is what lets a client act on its own answer. FastAPI's
 default for a dependency with `yield` is `scope="request"`, which puts steps 2
 and 4 the other way round — and did here until [#353][353], where an acceptance
 answered 204 while the membership row it created stayed invisible to the very

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -43,14 +43,20 @@ workflow is how a build ends up passing on nothing.
 
 ### A required check may legitimately report `skipped`
 
+!!! info "A `skipped` required check is a pass, not a problem"
+
+    GitHub satisfies a required status check with `success`, `skipped` **or**
+    `neutral`. So a backend-only branch gets no frontend answer at all - which
+    means "green" on such a branch is a claim about fewer jobs than `make check`
+    runs.
+
 Three of those six do not run on every pull request. `test`, `test-frontend` and
 `e2e` are 8.2, 5.3 and 5.1 billed minutes each, and a `changes` job decides which
 of them a change set can provably not affect — `scripts/ci_changed_scope.py`, so
 the rule is testable rather than a glob in a YAML file
 ([#317](https://github.com/vstorm-co/agenticos/issues/317)).
 
-This is legal because GitHub satisfies a required status check with **`success`,
-`skipped` or `neutral`**. It is why the gate is a job-level `if:` and **not** a
+That is why the gate is a job-level `if:` and **not** a
 `paths:` filter on the workflow: a filtered-out workflow never posts its checks at
 all, so the ruleset waits for six contexts that will never arrive and the merge
 button stays grey forever.
@@ -204,18 +210,24 @@ then reports as somebody else's cancellation.
 
 ## Squash, and why the pull request title matters
 
-`main` keeps one commit per pull request, built from the **pull request title and
-body** rather than from the branch's own commits. So `wip`, `fixup` and `try
-again` never reach it — and the description is not a courtesy, it is the commit
-message that survives. `CLAUDE.md` has the format.
+!!! important "The pull request description *is* the commit message that survives"
+
+    `main` keeps one commit per pull request, built from the title and body rather
+    than from the branch's own commits. `CLAUDE.md` has the format.
+
+So `wip`, `fixup` and `try again` never reach it — and the description is not a
+courtesy.
 
 ## The escape hatch
 
-There are **no bypass actors**. An owner who needs to merge something now
-disables the ruleset, merges, and turns it back on. That is deliberate: a bypass
-that is always available is a bypass that gets used weekly, and a release path
-nobody can describe. Three clicks and an audit entry is the right amount of
-friction for something that should be rare.
+!!! warning "There are no bypass actors"
+
+    An owner who needs to merge something now disables the ruleset, merges, and
+    turns it back on - three clicks and an audit entry, which is the right amount
+    of friction for something that should be rare.
+
+That is deliberate: a bypass that is always available is a bypass that gets used
+weekly, and a release path nobody can describe.
 
 ## Dependency updates
 

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -29,14 +29,10 @@ checks — the surface changes, the agent does not.
     fixed at creation, because a tag already pasted, a client already written and
     a link already sent all name the same row.
 
-**Three of those eight are one table, and its rows differ by a `kind`.** A
-widget, a raw socket and a hosted page are each an *embed*: one public key, one
-rate bucket, one budget, one pause switch, and one set of refusals. What differs
-is what there is to configure and what admits a visitor — which is why the
-Builder asks which one you want before it asks anything else, and why a page has
-no allowed-origins list rather than an ignored one. A kind is fixed at creation:
-a tag already pasted, a client already written and a link already sent all name
-the same row.
+One public key, one rate bucket, one budget, one pause switch, and one set of
+refusals. What differs is what there is to configure and what admits a visitor —
+which is why the Builder asks which one you want before it asks anything else,
+and why a page has no allowed-origins list rather than an ignored one.
 
 Every run records the surface that admitted it — `web`, `embed`, `api`, `slack`,
 `telegram` or `mattermost` — which is what the dashboard's by-surface chart
@@ -248,11 +244,7 @@ over it would take the conversation with it.
     page used to show one lump of text after thirty seconds of nothing, and that
     was the loop rather than the transport.
 
-**This is the dashboard's own frame vocabulary, not a second one.** The chat in
-`/chat` and this socket drive one loop (`app/services/run_stream.py`), so an
-answer arrives here a word at a time the same way it does there — a hosted page
-used to show one lump of text after thirty seconds of nothing, and that was the
-loop rather than the transport. Every frame carries `{ "type": …, "data": { … } }`.
+Every frame carries `{ "type": …, "data": { … } }`.
 
 | `type` | `data` | Meaning |
 |---|---|---|

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -16,11 +16,18 @@ checks — the surface changes, the agent does not.
 | **Telegram** | a bot token | a Telegram account, optionally linked |
 | **Mattermost** | a bot token and your server URL | a Mattermost account, optionally linked |
 
-Three rules hold everywhere, and all three are enforced in the runner rather
-than per surface: **a run always belongs to exactly one organization**, **a
-spending limit is checked before each model request, never after**, and **a run
-that failed is still in history with what it spent** — the tokens were spent
-before it broke, and a budget that ignores that is not a budget.
+!!! abstract "Three rules hold on every surface, enforced in the runner"
+
+    - **A run always belongs to exactly one organization.**
+    - **A spending limit is checked before each model request, never after.**
+    - **A run that failed is still in history with what it spent** — the tokens
+      were spent before it broke, and a budget that ignores that is not a budget.
+
+!!! info "Three of those eight are one table, and its rows differ by a `kind`"
+
+    A widget, a raw socket and a hosted page are each an *embed* — and a kind is
+    fixed at creation, because a tag already pasted, a client already written and
+    a link already sent all name the same row.
 
 **Three of those eight are one table, and its rows differ by a `kind`.** A
 widget, a raw socket and a hosted page are each an *embed*: one public key, one
@@ -82,6 +89,13 @@ In the Builder, open the agent → **Availability** → *Website widget*. You ch
   pricing page"*, *"Answer in German"*. It never replaces the agent's own
   instructions, which belong to the published version.
 - **Rate limit** — messages per visitor per minute.
+
+!!! danger "An empty origin list allows nothing, and that is on purpose"
+
+    The key in the script tag is public by construction, so the origin list is
+    the only thing stopping somebody else running your agent on your bill.
+    Publishing without one is refused rather than producing a widget that
+    answers nowhere.
 
 ### 2. Paste the snippet
 
@@ -156,7 +170,12 @@ token = jwt.encode(
   that leaks out of a browser cannot work forever. An `exp` you set is honoured
   too, but only to **shorten** that window (an expired token is rejected); it
   cannot extend a token past the 12-hour ceiling.
-- Mint it per page load, server-side. Never ship the signing secret to a browser.
+- Mint it per page load, server-side.
+
+!!! danger "Never ship the signing secret to a browser"
+
+    It signs *any* visitor. The token it mints is the thing the browser is
+    allowed to hold, and only for the twelve hours `iat` gives it.
 
 ---
 
@@ -179,11 +198,30 @@ there: in `jwt` mode the token is minted per visitor by your backend, and a real
 one on a dashboard screen is a working credential somebody can read over a
 shoulder.
 
-The handshake must carry an `Origin` on the embed's allow-list. **A browser sends
-it for you; a client of your own sends nothing unless you set it** - a mobile app,
-a kiosk, a server-side relay. That is the first thing that goes wrong, and what
-it looks like when it does is `4003` in the table below rather than an error
-message.
+!!! bug "The first thing that goes wrong: a missing `Origin`"
+
+    The handshake must carry one on the embed's allow-list. **A browser sends it
+    for you; a client of your own sends nothing unless you set it** - a mobile
+    app, a kiosk, a server-side relay. What it looks like when it does not is
+    `4003` in the table below, not an error message.
+
+```mermaid
+sequenceDiagram
+    participant C as Your client
+    participant E as /embed/{key}/ws
+    participant R as run_stream
+    C->>E: handshake (Origin, optional ?token=)
+    alt origin not allowed, token bad, embed paused
+        E-->>C: close 4003 - do not retry
+    else admitted
+        E-->>C: ready { visitor }
+        C->>E: message { text }
+        E->>R: the same loop /chat drives
+        R-->>C: model_request_start
+        R-->>C: text_delta … (a word at a time)
+        R-->>C: final_result, then complete
+    end
+```
 
 **Frames you send**
 
@@ -202,6 +240,13 @@ cached in somebody's browser may be older than this server, and closing the sock
 over it would take the conversation with it.
 
 **Frames you receive**
+
+!!! note "This is the dashboard's own frame vocabulary, not a second one"
+
+    `/chat` and this socket drive one loop (`app/services/run_stream.py`), so an
+    answer arrives here a word at a time the same way it does there. A hosted
+    page used to show one lump of text after thirty seconds of nothing, and that
+    was the loop rather than the transport.
 
 **This is the dashboard's own frame vocabulary, not a second one.** The chat in
 `/chat` and this socket drive one loop (`app/services/run_stream.py`), so an
@@ -1415,6 +1460,19 @@ pasted into the instructions, is a prompt injection with a public edit button.
 
 ## Choosing
 
+```mermaid
+flowchart TD
+    A{a site of your own?} -->|no| L{a link will do?}
+    L -->|yes| H[a hosted page]
+    L -->|no| T[Slack, Telegram or Mattermost]
+    A -->|yes| U{your own interface?}
+    U -->|yes| WS[the raw WebSocket]
+    U -->|no| P{visitors signed in to your product?}
+    P -->|yes| J["the widget, <code>jwt</code> mode"]
+    P -->|no| PB["the widget, <code>public</code> mode"]
+    A -->|another system entirely| API["the REST API"]
+```
+
 - Your own site, no accounts → **widget, `public` mode**.
 - Inside your product, per-user → **widget, `jwt` mode**.
 - Your own interface entirely → **WebSocket**.
@@ -1422,7 +1480,9 @@ pasted into the instructions, is a prompt injection with a public edit button.
 - Where the team already talks → **Slack, Telegram or Mattermost**.
 - Another system entirely → the REST API (`POST /api/v1/agents/{id}/run`).
 
-The first four are one object. A widget, a socket client and a hosted page are
-three ways of reaching the same embed, with one set of refusals between them —
-so "who may talk to this agent" has exactly one answer whichever of the three
-somebody arrives through.
+!!! success "The first four are one object"
+
+    A widget, a socket client and a hosted page are three ways of reaching the
+    same embed, with one set of refusals between them — so "who may talk to this
+    agent" has exactly one answer whichever of the three somebody arrives
+    through.

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -68,21 +68,26 @@ Deliberately **not** on `synchronize`. Two developers, a dozen pushes per pull
 request: a review on every one of them is a review nobody reads. Ask for a
 re-run when the fixes are in.
 
-"When the fixes are in" means **all of them**, not one at a time. Each run reads
-the whole diff and costs minutes and money, and the question it answers is "is
-this branch finished" — so ask it when you believe the branch is finished. It is
-fine to go round more than once: label, fix everything it found plus whatever
-reviewing your own work turns up, label again, until it comes back clean. What
-is not fine is a label per finding, which asks the same question of the same
-diff over and over.
+!!! important "Ask it when you believe the branch is finished"
 
-Re-running is the label, and there is no `/review` comment trigger — that is a
-security property, not an omission. `issue_comment` is a **privileged** event:
-it runs from the default branch *with secrets*, for a comment on any pull
-request including one from a fork. Checking out the pull request's own code in
-that context, inside the job holding `OPENAI_API_KEY`, is exactly the shape
-CodeQL flags as `actions/untrusted-checkout` — and it was right to. The label
-does the same job through `pull_request`, which hands a fork neither the secret
+    Each run reads the whole diff and costs minutes and money, and the question
+    it answers is "is this branch finished". A label per finding asks the same
+    question of the same diff over and over; the work between the labels is where
+    most defects are actually found.
+
+It is fine to go round more than once: label, fix everything it found plus
+whatever reviewing your own work turns up, label again, until it comes back
+clean.
+
+!!! danger "There is no `/review` comment trigger, and that is a security property"
+
+    `issue_comment` is a **privileged** event: it runs from the default branch
+    *with secrets*, for a comment on any pull request including one from a fork.
+    Checking out the pull request's own code in that context, inside the job
+    holding `OPENAI_API_KEY`, is exactly what CodeQL flags as
+    `actions/untrusted-checkout`.
+
+The label does the same job through `pull_request`, which hands a fork neither the secret
 nor a writable token, so the exposure is gone rather than argued about.
 
 Adding a label needs write access, which is the same bar the comment trigger
@@ -93,15 +98,26 @@ was checking with `author_association`.
 `.github/workflows/ai-review.yml` splits the work by privilege, because the
 middle job runs a model over code the pull request controls.
 
+```mermaid
+flowchart LR
+    C["context<br/><i>pull-requests: read</i><br/>refuses a fork head, before checkout"]
+    R["review<br/><i>contents: read</i><br/><b>holds OPENAI_API_KEY</b>"]
+    P["publish<br/><i>pull-requests: write</i><br/>no key"]
+    C -->|the diff, as an artifact| R
+    R -->|findings, as an artifact| P
+    P --> PR[a comment on the pull request]
+```
+
 | Job | Permissions | Holds the key |
 |---|---|---|
 | `context` | `pull-requests: read` | no |
 | `review` | `contents: read` | **yes** |
 | `publish` | `pull-requests: write`, `actions: read` | no |
 
-The job with `OPENAI_API_KEY` can write nothing back — no comment, no label, no
-ref — whatever the model is talked into. The job that writes has never seen the
-key. Findings travel between them as an artifact, because a split like this
+!!! success "The job holding the key can write nothing back"
+
+    No comment, no label, no ref — whatever the model is talked into. The job
+    that writes has never seen the key. Findings travel between them as an artifact, because a split like this
 means job outputs can carry a summary string but not a file.
 
 `context` also refuses a fork head, via the API and **before checkout**. Forks

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -101,10 +101,10 @@ middle job runs a model over code the pull request controls.
 ```mermaid
 flowchart LR
     C["context<br/><i>pull-requests: read</i><br/>refuses a fork head, before checkout"]
-    R["review<br/><i>contents: read</i><br/><b>holds OPENAI_API_KEY</b>"]
+    R["review<br/><i>contents: read</i><br/>checks out the head and<br/>assembles the diff itself<br/><b>holds OPENAI_API_KEY</b>"]
     P["publish<br/><i>pull-requests: write</i><br/>no key"]
-    C -->|the diff, as an artifact| R
-    R -->|findings, as an artifact| P
+    C -->|"title and body, as an artifact"| R
+    R -->|"findings.json, as an artifact"| P
     P --> PR[a comment on the pull request]
 ```
 
@@ -117,8 +117,11 @@ flowchart LR
 !!! success "The job holding the key can write nothing back"
 
     No comment, no label, no ref — whatever the model is talked into. The job
-    that writes has never seen the key. Findings travel between them as an artifact, because a split like this
-means job outputs can carry a summary string but not a file.
+    that writes has never seen the key. Findings travel to `publish` as an artifact, because a split like this means job
+outputs can carry a summary string but not a file. Note where the pull request's
+own code enters: `context` hands over only the title and body, and the **`review`**
+job checks out the head and assembles the diff itself — inside the job that holds
+the key, which is why that job can write nothing back.
 
 `context` also refuses a fork head, via the API and **before checkout**. Forks
 are disabled on this repository today; this is what keeps the guarantee true on

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -36,10 +36,15 @@ Run these from the project root directory.
 
 ### Before a pull request
 
-`make check` is every CI job except one, and the equality is deliberate rather
-than approximate: `.github/workflows/ci.yml` calls these same Make targets rather
-than repeating their commands, and `backend/tests/test_ci_parity.py` fails if a
-gating job grows a step `check` does not run — or the reverse.
+!!! success "`make check` is every CI job except `e2e`"
+
+    The equality is maintained rather than asserted, and
+    `backend/tests/test_ci_parity.py` is what keeps it true. It has drifted four
+    times.
+
+`.github/workflows/ci.yml` calls these same Make targets rather than repeating
+their commands, so a gating job that grows a step `check` does not run fails the
+parity test — as does the reverse.
 
 ```bash
 make check   # lint, test, db-check, test-frontend-cov, build-frontend, docs-build, audit
@@ -53,10 +58,12 @@ About five minutes, serial, on a warm cache. What it deliberately leaves out:
 | The image build and Trivy scan | CI runs those only on a push to `main` |
 | `make test-migrations` | CI cycles the chain against a throwaway `test_db`. On a laptop `alembic downgrade base` points at whatever `backend/.env` says, which is usually the database with your own work in it — `uv run pytest tests/test_migrations.py` asks the same question against a database of its own, and `make test` already runs it |
 
-One gap no command can close: CI's `test` job has a Postgres beside it, so
-`tests/integration/` runs there, and locally it skips itself when nothing answers
-on 5432. `make check` says so at the end when that happens — `make docker-db`
-first if the change is anywhere near the database.
+!!! warning "One gap no command can close"
+
+    CI's `test` job has a Postgres beside it, so `tests/integration/` runs there;
+    locally it skips itself when nothing answers on 5432. `make check` says so at
+    the end when that happens — run `make docker-db` first if the change is
+    anywhere near the database.
 
 ### What a red `make audit` means
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -168,11 +168,8 @@ starting its work again.
     one spend ledger. There is no `delegated` status: how a run *ended* and how
     it *started* are two questions.
 
-A run can also contain another run. When an agent delegates to a published agent,
-that delegation gets an `agent_runs` row of its own carrying `parent_run_id` - so
-"what did the researcher cost this month" has an answer - while both share one
-spend ledger. There is no `delegated` status, because how a run *ended* and how it
-*started* are two questions and `parent_run_id` answers the second.
+`parent_run_id` answers "how did this run start"; the status answers "how did it
+end".
 
 ### A run and its transcript
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -47,14 +47,15 @@ instead of pretending the bad version never existed.
 **Environments** are named pointers at versions, and each says whether a publish
 may move it.
 
-*Publishing mints a version; putting it somewhere is a separate decision.* An
-environment either **waits to be promoted onto** - which is what `production`,
-the default, does - or **follows every publish**, which is what a `dev`
-somebody is iterating in usually wants. Publish used to repoint the default
-whatever it was, so fixing a prompt changed what the live bot answered with, in
-the same click, with nothing on screen saying so.
+!!! important "Publishing mints a version; putting it somewhere is a separate decision"
 
-Two consequences worth stating. The **first** publish creates `production` on
+    Publish used to repoint the default environment whatever it was, so fixing a
+    prompt changed what the live bot answered with, in the same click, with
+    nothing on screen saying so.
+
+An environment either **waits to be promoted onto** - which is what `production`,
+the default, does - or **follows every publish**, which is what a `dev`
+somebody is iterating in usually wants. Two consequences worth stating. The **first** publish creates `production` on
 the version it just minted, because an agent with no environment has nowhere to
 run at all. And a **rollback lands the same way** as a publish - it is a publish
 of an older spec - so putting an old version back in front of people is one
@@ -69,10 +70,11 @@ environment resolves through - so it moves when that environment moves.
 **Where an agent is reachable, and by whom.** Web chat, an HTTP API key, a public
 link, a Slack or Telegram bot, an embedded widget.
 
-The important property: *every surface goes through one runner*. Budgets,
-approvals, the audit trail and the permission checks are identical whether a run
-came from the chat window or a Slack mention, because there is exactly one code
-path that executes an agent.
+!!! success "Every surface goes through one runner"
+
+    Budgets, approvals, the audit trail and the permission checks are identical
+    whether a run came from the chat window or a Slack mention, because there is
+    exactly one code path that executes an agent.
 
 Channels have two rules worth stating on their own. **A bot answers as one
 agent** - it is a single identity in the chat, so binding a second agent to one
@@ -143,19 +145,28 @@ story.
 **One execution.** It has a subject, a version, a surface, a status, token counts
 and a cost.
 
-A run that fails still records what it spent. A run that stops on its budget is
-recorded as `budget_exceeded` rather than `failed`, so an operator filtering for
-problems does not wade through the platform working correctly. A run a
-[guardrail](reference/capabilities.md#guardrails) blocked is `guardrail_blocked`
-for the same reason - a refusal is the platform working, not a malfunction. A run somebody
-stopped - the composer's stop button, a socket that went away, a delegation
-cancelled from above - is `cancelled` for the same reason, on every surface and
-not only the streaming one. A run that parks on an approval is
-`awaiting_approval` and is resumable - its message history is
-stored so the decision can be applied to the conversation it belongs to. A run that
-parks *inside a delegation* stores one level per agent, each with its own
-conversation, so approving continues the delegate that stopped rather than starting
-its work again.
+**A run that fails still records what it spent.** How it *ended* is a status of
+its own rather than `failed`, because an operator filtering for problems should
+not wade through the platform working correctly:
+
+| Status | The run |
+|---|---|
+| `failed` | broke |
+| `budget_exceeded` | reached a cap - a spending limit doing its job |
+| `guardrail_blocked` | was refused by a [guardrail](reference/capabilities.md#guardrails) |
+| `cancelled` | was stopped: the composer's stop button, a socket that went away, a delegation cancelled from above. On every surface, not only the streaming one |
+| `awaiting_approval` | parked on an approval, and is **resumable** - its message history is stored so the decision applies to the conversation it belongs to |
+
+A run that parks *inside a delegation* stores one level per agent, each with its
+own conversation, so approving continues the delegate that stopped rather than
+starting its work again.
+
+!!! note "A run can contain another run"
+
+    A delegation gets an `agent_runs` row of its own carrying `parent_run_id`, so
+    "what did the researcher cost this month" has an answer - while both share
+    one spend ledger. There is no `delegated` status: how a run *ended* and how
+    it *started* are two questions.
 
 A run can also contain another run. When an agent delegates to a published agent,
 that delegation gets an `agent_runs` row of its own carrying `parent_run_id` - so

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -260,7 +260,7 @@ is needed.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `OPENROUTER_API_KEY` | (empty) | The fallback embeddings credential, for collections that chose no vault key of their own — and the one a degraded choice falls back to. Not "every collection embeds on it": see [File processing](file-processing.md#embeddings-the-model-and-whose-key-pays) |
+| `OPENROUTER_API_KEY` | (empty) | The fallback embeddings credential, for collections that chose no vault key of their own — and the one a degraded choice falls back to. Not "every collection embeds on it": see [File processing](file-processing.md#embeddings-the-model-whose-endpoint-answers-and-whose-key-pays) |
 | `EMBEDDING_MODEL` | `text-embedding-3-large` | What a **new** collection is built with. The width is recorded on the row and never changes afterwards, so changing this does not invalidate existing collections — they keep embedding with the model they were created with |
 
 ### Document Parsing — configured per collection, not here

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,11 +27,14 @@ openssl rand -hex 32   # SECRET_KEY — signs every access token
 openssl rand -hex 32   # VAULT_MASTER_KEY — unwraps every credential stored at rest
 ```
 
-`SECRET_KEY` ships as a published string, and an empty `VAULT_MASTER_KEY` falls
-back to it so a fresh checkout runs at all. Both are fine on a laptop and are the
-whole security of a deployment anywhere else — which is why the config refuses an
-unset `VAULT_MASTER_KEY` outside `local`/`development`. Setting it explicitly is
-also what lets stored secrets survive a `SECRET_KEY` rotation.
+!!! danger "`SECRET_KEY` ships as a published string"
+
+    An empty `VAULT_MASTER_KEY` falls back to it so a fresh checkout runs at all.
+    Both are fine on a laptop and are the whole security of a deployment anywhere
+    else. Setting `VAULT_MASTER_KEY` explicitly is also what lets stored secrets
+    survive a `SECRET_KEY` rotation.
+
+The config refuses an unset `VAULT_MASTER_KEY` outside `local`/`development`.
 
 ## Project Settings
 
@@ -783,9 +786,12 @@ changing the number:
   after one reads a stale stamp that says nothing.
 
 The local stack's reload supervisor reads the same variable for the judgement it
-makes from *outside* the worker, so one number covers both. Set it to `0` while
-debugging: a breakpoint blocks the event loop and nothing can tell that from a
-deadlock, so a worker sitting on one is otherwise killed under you.
+makes from *outside* the worker, so one number covers both.
+
+!!! tip "Set it to `0` while debugging"
+
+    A breakpoint blocks the event loop and nothing can tell that from a deadlock,
+    so a worker sitting on one is otherwise killed under you.
 
 It cannot see a process that is not running at all — `kill -STOP`, a frozen
 cgroup — because a watchdog inside a stopped process is stopped too. That case
@@ -802,14 +808,17 @@ stale and production's pipe ping goes unanswered.
 
 ## Production Checklist
 
-Before deploying to production, ensure these variables are properly set:
-1. `SECRET_KEY` -- Generate a unique 64-character hex key: `openssl rand -hex 32`
-2. `API_KEY` -- Generate a unique key: `openssl rand -hex 32`
-3. `VAULT_MASTER_KEY` -- Generate a unique key: `openssl rand -hex 32`. The config
-   refuses an empty one outside `local`/`development`
-4. `ENVIRONMENT` -- Set to `production`
-5. `DEBUG` -- Set to `false`
-6. `POSTGRES_PASSWORD` -- Use a strong, unique password
-7. `CORS_ORIGINS` -- List only your actual frontend domain(s)
-8. `REDIS_PASSWORD` -- Set a strong password
-9. `OPENROUTER_API_KEY` -- Your production API key
+!!! danger "Every one of these ships with a default that is wrong in production"
+
+    A deployment reachable from anywhere else has all nine set deliberately.
+
+- [ ] `SECRET_KEY` — a unique 64-character hex key: `openssl rand -hex 32`
+- [ ] `API_KEY` — a unique key: `openssl rand -hex 32`
+- [ ] `VAULT_MASTER_KEY` — a unique key: `openssl rand -hex 32`. The config
+      refuses an empty one outside `local`/`development`
+- [ ] `ENVIRONMENT` — `production`
+- [ ] `DEBUG` — `false`
+- [ ] `POSTGRES_PASSWORD` — a strong, unique password
+- [ ] `REDIS_PASSWORD` — a strong password
+- [ ] `CORS_ORIGINS` — only your actual frontend domain(s)
+- [ ] `OPENROUTER_API_KEY` — your production API key

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,15 +1,13 @@
 # Deployment
 
-This project was generated with the following deployment-related flags:
+What this repository ships for getting the platform onto a host: Docker and
+`docker-compose.yml`, an Nginx config, and GitHub Actions. There are no Kubernetes
+manifests.
 
-- ✅ Docker / `docker-compose.yml`
-- ❌ No Kubernetes manifests
-- CI: `github`
-- Reverse proxy: Nginx
+!!! tip "Read [configuration](configuration.md#production-checklist) first"
 
-
----
-
+    The production checklist is the list of settings whose generated defaults are
+    fine on a laptop and are not fine on a host somebody else can reach.
 
 ## Docker Compose (single host)
 
@@ -26,61 +24,79 @@ docker compose up -d --build
 # 3. Apply migrations
 docker compose exec app uv run alembic upgrade head
 
-
 # 4. Verify
 curl http://localhost:8000/api/v1/health
 # Frontend: http://localhost:3000
 ```
 
 ### Reverse proxy
-Nginx config in `nginx/` proxies `/` → frontend, `/api` → backend, `/ws` → backend WebSocket. Update `server_name` and TLS cert paths in `nginx/conf.d/app.conf`.
 
-The backend sets its own security headers on every response — a Content-Security-Policy, `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy` and `Permissions-Policy` — so a deployment behind any proxy, not only the bundled Nginx, is covered. A response for an unhandled exception is turned into a 500 outside the middleware stack, so its handler stamps the same headers itself. The interactive API docs (`/docs`, `/redoc`, `/api/v1/openapi.json`) are the one exception, and only for the CSP: Swagger and ReDoc load assets a strict policy forbids, so those pages drop the CSP while keeping their framing and MIME protections. HSTS is deliberately left to the proxy, which is where TLS terminates; a front proxy that sets its own CSP should make sure it is at least as strict.
+The Nginx config in `nginx/` proxies `/` → frontend, `/api` → backend, `/ws` →
+backend WebSocket. Update `server_name` and the TLS certificate paths in
+`nginx/conf.d/app.conf`.
 
+!!! info "The security headers come from the backend, not from the proxy"
 
+    A Content-Security-Policy, `X-Frame-Options: DENY`,
+    `X-Content-Type-Options: nosniff`, `Referrer-Policy` and `Permissions-Policy`
+    are set on every response, so a deployment behind *any* proxy is covered.
+    Two edges: a 500 for an unhandled exception is built outside the middleware
+    stack and stamps the same headers itself; and the interactive API docs
+    (`/docs`, `/redoc`, `/api/v1/openapi.json`) drop the **CSP** only, because
+    Swagger and ReDoc load assets a strict policy forbids — their framing and
+    MIME protections stay.
 
+    **HSTS is deliberately left to the proxy**, which is where TLS terminates. A
+    front proxy setting its own CSP should be at least as strict as this one.
 
 ## Platform-specific quickstarts
 
-### Fly.io
+=== "Fly.io"
 
-```bash
-fly launch --name agenticos-backend --region waw
-fly postgres create --name agenticos-db
-fly postgres attach agenticos-db
-# Redis: use Upstash (`fly redis create`) or Fly's Tigris
-fly secrets set $(cat backend/.env | grep -v '^#' | xargs)
-fly deploy
-```
+    ```bash
+    fly launch --name agenticos-backend --region waw
+    fly postgres create --name agenticos-db
+    fly postgres attach agenticos-db
+    # Redis: use Upstash (`fly redis create`) or Fly's Tigris
+    fly secrets set $(cat backend/.env | grep -v '^#' | xargs)
+    fly deploy
+    ```
 
-### Railway
+=== "Railway"
 
-1. Connect repo, pick Dockerfile-based deploy.
-2. Add env vars from `backend/.env` to Railway service.
-3. Provision PostgreSQL plugin → `DATABASE_URL` auto-injected.
-4. Provision Redis plugin → `REDIS_URL` auto-injected.
-5. Deploy.
+    1. Connect the repo, pick Dockerfile-based deploy.
+    2. Add env vars from `backend/.env` to the Railway service.
+    3. Provision the PostgreSQL plugin → `DATABASE_URL` auto-injected.
+    4. Provision the Redis plugin → `REDIS_URL` auto-injected.
+    5. Deploy.
 
-### Render
+=== "Render"
 
-1. Create Web Service → docker, point at `backend/Dockerfile`.
-2. Create Static Site for frontend (build cmd: `bun install && bun run build`, output dir: `.next`).
-3. Create PostgreSQL → copy DATABASE_URL.
-4. Add env vars; deploy.
+    1. Create a Web Service → docker, pointed at `backend/Dockerfile`.
+    2. Create a Static Site for the frontend (build command
+       `bun install && bun run build`, output directory `.next`).
+    3. Create PostgreSQL → copy `DATABASE_URL`.
+    4. Add env vars; deploy.
 
-### Vercel (frontend only)
+=== "Vercel (frontend only)"
 
-The frontend is a Next.js app — works on Vercel out of the box.
+    The frontend is a Next.js app and works on Vercel out of the box.
 
-```bash
-cd frontend
-vercel
-```
+    ```bash
+    cd frontend
+    vercel
+    ```
 
-Set `BACKEND_URL` and `NEXT_PUBLIC_API_URL` env vars in Vercel dashboard pointing to your backend host.
+    Set `BACKEND_URL` and `NEXT_PUBLIC_API_URL` in the Vercel dashboard, pointing
+    at your backend host.
 
+!!! warning "Whatever the platform, the database must be pgvector"
 
----
+    The RAG store issues `CREATE EXTENSION IF NOT EXISTS vector` the first time a
+    collection is written to, and stock Postgres answers
+    `extension "vector" is not available`. A managed Postgres that cannot enable
+    the extension cannot hold knowledge collections. See
+    [install](install.md#the-database-must-be-pgvector).
 
 ## Environment validation in production
 
@@ -90,19 +106,26 @@ Before promoting to prod, run:
 docker compose exec app uv run python -c "from app.core.config import settings; print('OK')"
 ```
 
-Catches missing required env vars early. See [Configuration](configuration.md) for the full list.
+That catches missing required env vars early. See [Configuration](configuration.md)
+for the full list.
 
 ## Post-deploy checks
 
 - [ ] `/api/v1/health` returns `{"status": "ok"}`
-- [ ] `alembic current` matches expected revision
-- [ ] Frontend renders, login flow works end-to-end
-- [ ] Test email sends (trigger password-reset flow)
-- [ ] Logs flowing to your aggregator + Logfire receiving traces
-- [ ] Reverse proxy enforces HTTPS
+- [ ] `alembic current` matches the expected revision
+- [ ] The frontend renders, and the login flow works end to end
+- [ ] A test email sends (trigger the password-reset flow)
+- [ ] Logs are flowing to your aggregator, and Logfire is receiving traces
+- [ ] The reverse proxy enforces HTTPS
 
 ## Rollback
 
-- **Schema:** `alembic downgrade -1` rolls back one migration. Test on staging first.
-- **Code:** redeploy previous image tag. Pin tags (`v1.2.3`), never deploy `latest` to prod.
-- **Data:** restore from your most recent backup; verify `alembic current` matches the data version.
+| | How |
+|---|---|
+| **Schema** | `alembic downgrade -1` rolls back one migration. Test on staging first |
+| **Code** | Redeploy the previous image tag |
+| **Data** | Restore from your most recent backup, then check `alembic current` matches the data's version |
+
+!!! danger "Pin image tags; never deploy `latest` to production"
+
+    A rollback is only a rollback if there is a specific tag to go back to.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -22,7 +22,13 @@ authority that already administers users and tenants across the installation.
 | Footer text | Under the sign-in form |
 | Terms URL, Privacy URL | Every link that otherwise offers the built-in `/legal/*` pages |
 
-**A null column means "the built-in", not "empty".** An operator who has never
+!!! note "A null column means *the built-in*, not *empty*"
+
+    An operator who clears a field is asking for the default back, not for a
+    sign-in header with no name on it. The API answers *overrides* and each
+    renderer resolves a null against its own built-in.
+
+An operator who has never
 opened the page has no row at all, and one who clears a field is asking for the
 default back rather than for a sign-in header with no name on it. So the API
 answers *overrides* and each renderer resolves a null against its own built-in —
@@ -46,8 +52,12 @@ are served from the origin the app's own pages run on and `logo.html` there is a
 script.
 
 JPEG, PNG, WebP and GIF, up to 2MB, which is the one definition of "an image this
-platform accepts". SVG is deliberately absent: it is a document that may carry
-script. ICO buys nothing a PNG favicon does not.
+platform accepts".
+
+!!! danger "SVG is deliberately absent"
+
+    It is a document that may carry script, and these files are served from the
+    origin the app's own pages run on. ICO buys nothing a PNG favicon does not.
 
 The branding response carries a **version**, not a URL. The address is constant
 (`GET /api/v1/branding/{logo,favicon}`) and the bytes are served `immutable` for a
@@ -193,6 +203,12 @@ injection surface.
 
 ## An app admin cannot lock the deployment out through the console
 
+!!! warning "The self-inflicted lockout this prevents"
+
+    On the single-admin install `make platform-bootstrap` produces, a stray click
+    on your own row ended administration until somebody reached a terminal.
+    Recovery is `agenticos cmd create-app-admin` from a shell.
+
 `is_active` is enforced on the next request and `is_app_admin` is what the admin
 pages read, so an app admin acting on **their own** row from `/admin/users` could
 sign themselves out, drop `/admin`, or delete the account — and on the
@@ -335,7 +351,19 @@ audit row outlives the request body it came from.
 
 Worth saying here because closing a deployment is the feature most likely to produce
 one a person has never seen. `app/api/exception_handlers.py` puts **every** refusal in
-`{"error": {"code", "message", "details"}}` — domain exceptions, schema validation,
+`{"error": {"code", "message", "details"}}`:
+
+```json
+{
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "Agent not found",
+    "details": { "agent_id": "…" }
+  }
+}
+```
+
+That covers domain exceptions, schema validation,
 and since #917 `HTTPException` too, which covers a 405, an unmatched path and the
 twenty-two routes that raise one directly. Two shapes on the wire means every caller
 either handles both or silently mishandles one.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -28,12 +28,9 @@ authority that already administers users and tenants across the installation.
     sign-in header with no name on it. The API answers *overrides* and each
     renderer resolves a null against its own built-in.
 
-An operator who has never
-opened the page has no row at all, and one who clears a field is asking for the
-default back rather than for a sign-in header with no name on it. So the API
-answers *overrides* and each renderer resolves a null against its own built-in —
-the console against `APP_NAME` and `SITE` in `frontend/src/lib/`, the backend
-against `settings.PROJECT_NAME` for the mail it sends itself.
+An operator who has never opened the page has no row at all. The console resolves
+a null against `APP_NAME` and `SITE` in `frontend/src/lib/`; the backend resolves
+it against `settings.PROJECT_NAME` for the mail it sends itself.
 
 Two constants for one product name can drift, so
 `backend/tests/test_deployment_settings.py` pins them equal. It reads the
@@ -211,9 +208,8 @@ injection surface.
 
 `is_active` is enforced on the next request and `is_app_admin` is what the admin
 pages read, so an app admin acting on **their own** row from `/admin/users` could
-sign themselves out, drop `/admin`, or delete the account — and on the
-single-admin install `make platform-bootstrap` produces, a stray click ended
-administration until somebody reached a terminal. `UserService.admin_update` and
+sign themselves out, drop `/admin`, or delete the account.
+`UserService.admin_update` and
 `admin_delete` refuse the self-suspend and the self-delete, and the drawer does
 not offer Suspend, Demote or Impersonate on your own row (Delete stays, visible
 and refused, because "why can I not delete myself" has an answer worth showing).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -204,7 +204,8 @@ injection surface.
 
     On the single-admin install `make platform-bootstrap` produces, a stray click
     on your own row ended administration until somebody reached a terminal.
-    Recovery is `agenticos cmd create-app-admin` from a shell.
+    Recovery is `agenticos cmd create-app-admin <email>` from a shell — the
+    email is a required argument.
 
 `is_active` is enforced on the next request and `is_app_admin` is what the admin
 pages read, so an app admin acting on **their own** row from `/admin/users` could

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -193,6 +193,14 @@ not define.
 
 ### Size Limits
 
+!!! warning "Two ceilings, and the browser has its own copy of one"
+
+    A chat attachment is refused by `CHAT_MAX_UPLOAD_SIZE_MB` (10 MB); a
+    knowledge-base document by `MAX_UPLOAD_SIZE_MB` (50 MB). Set
+    `NEXT_PUBLIC_CHAT_MAX_UPLOAD_SIZE_MB` to match the first: too high and the
+    composer accepts a file the API refuses, too low and it refuses one the API
+    would take.
+
 - Maximum attachment size: `CHAT_MAX_UPLOAD_SIZE_MB` (default: **10 MB**). This is
   the section's own limit — a chat attachment is refused by this number, not by the
   knowledge base's larger `MAX_UPLOAD_SIZE_MB`, and the two are separate settings
@@ -838,11 +846,18 @@ the collection name it had then, and those used to be dropped from the page afte
 
 ### What a sync source is not allowed to decide
 
+!!! danger "Whoever can drop a file in a shared folder chooses the string the next sync handles"
+
+    Two of those strings used to be taken at face value: a file name that was a
+    path (`../../../../home/app/.ssh/authorized_keys` is a legal Drive name), and
+    a folder id that reached Drive's query language. `remote_names.py` refuses
+    both, and `BaseSyncConnector` - not a connector - decides where a byte lands,
+    so a connector added later inherits the refusal rather than having to
+    remember it.
+
 A source's contents are not the deployment's to trust, and on a Drive folder
 shared outside the organization they are not even the tenant's: sharing is what
-folder sharing is *for*, so whoever can drop a file in one chooses the string
-the next sync handles. Two of those strings used to be taken at face value, and
-`app/services/rag/remote_names.py` is where both are now refused.
+folder sharing is *for*.
 
 **A file name is a label, not a path component.** `../../../../home/app/.ssh/authorized_keys`
 is a legal Drive file name, and the connector wrote `dest_dir / file.name`
@@ -874,9 +889,14 @@ been shared. The fallback is gone; the setting now serves only the
 
 ### The credential is a vault secret, not a config field
 
-`sync_sources.config` says how to *find* the documents — a folder id, a bucket, a
-prefix — and holds nothing that has to be kept. What authenticates is a vault
-secret the source names in `secret_id`: a `gcp_service_account` for Drive, an
+!!! danger "A credential never goes in a connector's `CONFIG_SCHEMA`"
+
+    `sync_sources.config` says how to *find* the documents. What authenticates is
+    a vault secret the source names in `secret_id` - and there is no
+    deployment-wide fallback, because a fallback means one tenant's folder id
+    choosing what is read under the operator's identity.
+
+What the source names in `secret_id` is a `gcp_service_account` for Drive or an
 `aws_credentials` pair for S3, declared by the connector as `SECRET_KIND` and
 offered to the wizard as `secret_kind` on the connector listing.
 

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -11,22 +11,15 @@ When a user uploads a file in the chat interface, the following pipeline runs:
 
 ### Flow
 
-```
-1. Upload     POST /api/v1/files/upload
-               |
-2. Validate    Check MIME type against allowed list + enforce size limit
-               |
-3. Classify    Determine file_type: "image", "pdf", "docx", "spreadsheet", "text"
-               |
-4. Parse       Extract text content (images skip this step)
-               |
-5. Store       Save file to media/{user_id}/ via FileStorageService
-               |
-6. Record      Create ChatFile row in database
-               |
-7. Link        When message is sent, ChatFile is attached via message_id FK
-               |
-8. Display     Composer shows a card per attachment: name, excerpt, type, size
+```mermaid
+flowchart TD
+    U["Upload<br/><code>POST /api/v1/files/upload</code>"] --> V["Validate<br/>MIME against the allowed list, size limit"]
+    V --> C["Classify<br/>image · pdf · docx · spreadsheet · text"]
+    C --> P["Parse<br/>extract text — images skip this"]
+    P --> S["Store<br/><code>media/{user_id}/</code>"]
+    S --> R["Record<br/>a <code>ChatFile</code> row"]
+    R --> L["Link<br/>attached to the message by <code>message_id</code>"]
+    L --> D["Display<br/>a card per attachment: name, excerpt, type, size"]
 ```
 
 The upload response carries a `preview` — the first three lines of the extracted
@@ -265,23 +258,21 @@ different pipeline handles parsing, chunking, and embedding.
 
 ### Ingestion Flow
 
-```
-1. Input       File path (CLI) or uploaded file (API)
-                |
-2. Parse       DocumentProcessor selects parser by file type
-                |
-3. Chunk       Text split into segments (configurable size/overlap/strategy)
-                |
-4. Embed       Chunks embedded via configured provider
-                |
-5. Store       Vectors written to vector database
-                |
-6. Track       RAGDocument record created in SQL (status tracking)
+```mermaid
+flowchart TD
+    I["Input<br/>a path (CLI) or an upload (API)"] --> P["Parse<br/><code>DocumentProcessor</code> picks a parser by type"]
+    P --> C["Chunk<br/>size, overlap and strategy are configurable"]
+    C --> E["Embed<br/>through the collection's provider"]
+    E --> S["Store<br/>vectors in <code>rag_&lt;collection&gt;</code>"]
+    S --> T["Track<br/>a <code>RAGDocument</code> row carries the status"]
 ```
 
-Over the API the order is the other way round: the `RAGDocument` row is written
-first and steps 2–5 run in a background task against a session of their own,
-which is why an upload answers `{"status": "processing"}` rather than waiting.
+!!! note "Over the API the order is the other way round"
+
+    The `RAGDocument` row is written **first** and the middle four steps run in a
+    background task with a session of their own - which is why an upload answers
+    `202 {"status": "processing"}` rather than waiting.
+
 There are two addresses an upload can arrive at — `POST /rag/collections/{name}/ingest`
 and `POST /kb/{kb_id}/documents` — and both answer **202** with the same
 `RAGIngestResponse`, every field of it, `"document_id": null` included: the vector

--- a/docs/first-agent.md
+++ b/docs/first-agent.md
@@ -8,9 +8,16 @@ You need a running stack - see [Install](install.md).
 
 ## The guided way
 
-The steps below are the manual path, and worth reading once. But a new user does
-not start here: the first time anyone signs in, a walkthrough opens on the
-dashboard and points out each section in turn. It shows **once** - finishing,
+!!! tip "A new user does not start with the steps below"
+
+    The first time anyone signs in, a walkthrough opens on the dashboard and
+    points out each section in turn - and finishing it offers to build the first
+    agent *together*, operating the real dialogs. The manual path is still worth
+    reading once, which is what the rest of this page is.
+
+### It shows once, and the **?** replays it
+
+It shows **once** - finishing,
 skipping or closing it is remembered against the account, not the browser, so it
 does not return on the next device - and the **?** in the header of any walked page
 replays that page's tips whenever they are wanted. It is offered only where there
@@ -19,7 +26,9 @@ deployment-admin pages - simply has no **?** rather than one that does nothing.
 Leaving the walkthrough, finished or skipped, says exactly that, so nobody
 discovers the "?" by accident or not at all.
 
-Finishing the walkthrough offers to build the first agent *together*. That is an
+### Finishing it offers to build the first agent together
+
+That is an
 interactive flow, not a spotlight: it points at the real controls, the reader
 operates the real dialogs, and it advances the moment the thing is actually
 created. While it runs the page is **frozen** - everything dims but the one
@@ -31,6 +40,8 @@ only stops where something is missing, teaching a workspace with no model how to
 add one - or, for a builder who lacks the permission to add one, saying so rather
 than walking them in silence to a publish that will refuse an agent with no model
 - and skipping straight past a prerequisite already in place.
+
+### Where it does the most: knowledge, skills and MCP
 
 Knowledge, skills and MCP servers are where it does the most. With one already,
 the flow just points at where it attaches. With none, it crosses to that
@@ -50,10 +61,14 @@ server connects with an inline dialog right there in the Toolbox, so a "yes"
 points at that button and the flow picks up the moment the connection lands -
 no trip to another page, and none back.
 
-And building is not where it ends. After Publish lands, the flow carries the
+### It does not end at Publish
+
+After Publish lands, the flow carries the
 reader into the chat, has them pick the agent they just built, and closes only
 once they have sent it a first message - because a first agent nobody has run
 is a tour that stopped one step short of the point.
+
+### Every other section has its own
 
 Declining guides nobody; the offer returns at the end of the Agents **?** walk.
 Every other section's **?** ends the same way, offering to create that section's

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -882,13 +882,11 @@ hourly sweep denies by timeout anything still pending past `APPROVAL_EXPIRY_HOUR
 
 !!! warning "It is the run that matters, not the row"
 
-    An approval left pending keeps its run in `awaiting_approval` indefinitely:
+    A pending approval keeps its run in `awaiting_approval` indefinitely:
     work that is neither finished nor going to be.
 
-An approval left pending keeps its run
-in `awaiting_approval` indefinitely: work that is neither finished nor going to be,
-sitting in run history and in the oldest-waiting age on the dashboard. So the sweep
-follows each expired call down to the run behind it and ends it, `cancelled` —
+Such a run sits in history and in the oldest-waiting age on the dashboard, so the
+sweep follows each expired call down to the run behind it and ends it, `cancelled` —
 nobody came back, and what it spent before it parked stands.
 
 Three things it deliberately does not do:

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -29,7 +29,11 @@ reaches the runner at all.
 
 ## Budgets
 
-Two levels, and they are not variations on one number.
+!!! abstract "Two levels, and they are not variations on one number"
+
+    An agent's cap measured against the organization's total is exhausted by its
+    neighbours' runs; the organization's measured against one agent is no ceiling
+    at all. See [why they cannot be collapsed](#why-they-cannot-be-collapsed).
 
 | Level | Set in | Meters | Raised by |
 |---|---|---|---|
@@ -70,9 +74,10 @@ card joins these against `GET /spend`, so a cap can be seen approaching before
 
 ### Enforcement is before the request
 
-Checked *before* each model request, not after. Checking afterwards means the
-request that broke the budget was already paid for, and a loop can overshoot by
-one expensive call every time.
+!!! danger "Before, not after"
+
+    Checking afterwards means the request that broke the budget was already paid
+    for - and a loop can overshoot by one expensive call every time.
 
 !!! important "A failed run still records what it spent"
 
@@ -774,6 +779,25 @@ Resolution is most-specific-first:
 The Builder states the outcome in words rather than describing the rule, because a
 rule the reader has to run in their head is a setting nobody dares touch.
 
+```mermaid
+sequenceDiagram
+    autonumber
+    participant M as Model
+    participant G as ApprovalGate
+    participant Q as Approvals queue
+    participant P as A person
+    M->>G: call a gated tool
+    G->>Q: park it, with the arguments
+    G-->>M: run ends `awaiting_approval`
+    P->>Q: reads the arguments, decides
+    alt approved
+        Q->>G: resume with the arguments that were read
+        G->>M: execute those, not what it proposes now
+    else rejected or expired
+        Q->>M: a refusal it can relay, not a crash
+    end
+```
+
 Four properties worth knowing:
 
 - **A parked run is resumable.** Its message history is stored, so the decision is
@@ -856,7 +880,12 @@ a request path can end one — the whole premise is that no request is coming �
 hourly sweep denies by timeout anything still pending past `APPROVAL_EXPIRY_HOURS`
 (three days by default, which spans a weekend).
 
-**It is the run that matters, not the row.** An approval left pending keeps its run
+!!! warning "It is the run that matters, not the row"
+
+    An approval left pending keeps its run in `awaiting_approval` indefinitely:
+    work that is neither finished nor going to be.
+
+An approval left pending keeps its run
 in `awaiting_approval` indefinitely: work that is neither finished nor going to be,
 sitting in run history and in the oldest-waiting age on the dashboard. So the sweep
 follows each expired call down to the run behind it and ends it, `cancelled` —

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -793,8 +793,11 @@ sequenceDiagram
     alt approved
         Q->>G: resume with the arguments that were read
         G->>M: execute those, not what it proposes now
-    else rejected or expired
-        Q->>M: a refusal it can relay, not a crash
+    else rejected
+        Q->>G: resume, replaying the denial
+        G->>M: a refusal it can relay, not a crash
+    else expired
+        Q--xM: the run ends `cancelled`. No further model request
     end
 ```
 

--- a/docs/howto/add-api-endpoint.md
+++ b/docs/howto/add-api-endpoint.md
@@ -83,10 +83,9 @@ the model in `app/db/models/__init__.py` or Alembic will not see it.
 
 ```python
 # app/repositories/notification.py
-from typing import Any
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models.notification import Notification
@@ -112,7 +111,20 @@ async def list_unread(db: AsyncSession, limit: int = 50) -> list[Notification]:
         .limit(limit)
     )
     return list(result.scalars().all())
+
+
+async def count_unread(db: AsyncSession) -> int:
+    result = await db.execute(
+        select(func.count()).select_from(Notification).where(Notification.is_read.is_(False))
+    )
+    return result.scalar_one()
 ```
+
+!!! warning "A paged list needs a real count, not `len(items)`"
+
+    `*List`'s `total` is how many rows **match**, which is what a client pages
+    against. `len(items)` is how many came back — equal only until the first page
+    fills up, and then quietly wrong in the direction that hides rows.
 
 !!! danger "`flush()` + `refresh()`, never `commit()`"
 
@@ -159,8 +171,9 @@ class NotificationService:
             )
         return notification
 
-    async def list_unread(self) -> list[Notification]:
-        return await notification_repo.list_unread(self.db)
+    async def list_unread(self) -> tuple[list[Notification], int]:
+        items = await notification_repo.list_unread(self.db)
+        return items, await notification_repo.count_unread(self.db)
 ```
 
 The service holds the session and nothing else; repositories are imported as
@@ -204,8 +217,8 @@ async def create_notification(
 
 @router.get("", response_model=NotificationList)
 async def list_unread(service: NotificationSvc, user: CurrentUser) -> Any:
-    items = await service.list_unread()
-    return NotificationList(items=items, total=len(items))
+    items, total = await service.list_unread()
+    return NotificationList(items=items, total=total)
 ```
 
 !!! note "`-> Any`, on purpose"

--- a/docs/howto/add-api-endpoint.md
+++ b/docs/howto/add-api-endpoint.md
@@ -221,10 +221,13 @@ async def list_unread(service: NotificationSvc, user: CurrentUser) -> Any:
     return NotificationList(items=items, total=total)
 ```
 
-!!! note "`-> Any`, on purpose"
+!!! note "`-> Any`, by convention here"
 
-    `response_model` does the serialization. Annotating the real return type
-    makes Pydantic validate the same object twice.
+    `response_model` is what serializes and validates the response, and every
+    route in this codebase leaves the annotation at `Any` so that there is one
+    answer to "where is the response shape declared" rather than two that can
+    disagree. Follow it for consistency with the surrounding code — not because
+    an annotation would cost a second validation pass, which it does not.
 
 Anything org-scoped takes a permission from the catalog on the **collection**
 route — `dependencies=[Depends(require(Perm.X))]` — while a per-resource route

--- a/docs/howto/add-api-endpoint.md
+++ b/docs/howto/add-api-endpoint.md
@@ -1,8 +1,13 @@
 # How to: Add a New API Endpoint
 
-This example adds a "Notification" endpoint following the repository + service
-pattern. Routes **never** contain direct database calls — all data access goes
-through a service, which delegates to a repository.
+This example adds a "Notification" endpoint end to end, following the layering
+every domain here uses.
+
+!!! important "Routes → Services → Repositories, and never a shortcut"
+
+    A route validates, delegates and returns. A **route never imports a
+    repository**, and a repository never contains business logic. See
+    [Architecture](../architecture.md).
 
 ## Step-by-Step
 
@@ -13,58 +18,72 @@ through a service, which delegates to a repository.
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from app.schemas.base import BaseSchema
 
 
-class NotificationCreate(BaseModel):
+class NotificationCreate(BaseSchema):
     title: str = Field(max_length=255)
     body: str
     channel: str = "email"
 
 
-class NotificationResponse(BaseModel):
+class NotificationRead(BaseSchema):
     id: UUID
     title: str
     body: str
     channel: str
     is_read: bool
     created_at: datetime
+
+
+class NotificationList(BaseSchema):
+    items: list[NotificationRead]
+    total: int
 ```
+
+One schema per operation — `*Create`, `*Update` (every field optional), `*Read`
+(with `id` and timestamps) and `*List` (`items` plus `total`).
+[Schemas and models](../architecture.md) has the rule.
 
 ### 2. Create the database model (`app/db/models/`)
 
 ```python
 # app/db/models/notification.py
-from uuid import uuid4
+import uuid
 
-from sqlalchemy import Boolean, DateTime, String, func
+from sqlalchemy import Boolean, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
-from app.db.base import Base
+from app.db.base import Base, TimestampMixin
 
 
-class Notification(Base):
+class Notification(Base, TimestampMixin):
+    """One notification sent to somebody, and whether they have read it."""
+
     __tablename__ = "notifications"
 
-    id: Mapped[UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid4
-    )
-    title: Mapped[str] = mapped_column(String(255))
-    body: Mapped[str] = mapped_column(String)
-    channel: Mapped[str] = mapped_column(String(50), default="email")
-    is_read: Mapped[bool] = mapped_column(Boolean, default=False)
-    created_at: Mapped[DateTime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    body: Mapped[str] = mapped_column(String, nullable=False)
+    channel: Mapped[str] = mapped_column(String(50), default="email", nullable=False)
+    is_read: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+
+    def __repr__(self) -> str:
+        return f"<Notification(id={self.id}, title={self.title})>"
 ```
 
-Don't forget to import it in `app/db/models/__init__.py`.
+`TimestampMixin` supplies `created_at` and `updated_at`, so neither is declared
+here. `__repr__` is not optional — every model in this codebase has one. Import
+the model in `app/db/models/__init__.py` or Alembic will not see it.
 
 ### 3. Create the repository (`app/repositories/`)
 
 ```python
 # app/repositories/notification.py
+from typing import Any
 from uuid import UUID
 
 from sqlalchemy import select
@@ -73,26 +92,40 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.db.models.notification import Notification
 
 
-class NotificationRepository:
-    async def create(self, db: AsyncSession, **kwargs) -> Notification:
-        notification = Notification(**kwargs)
-        db.add(notification)
-        await db.flush()
-        await db.refresh(notification)
-        return notification
+async def get_by_id(db: AsyncSession, notification_id: UUID) -> Notification | None:
+    return await db.get(Notification, notification_id)
 
-    async def get_by_id(self, db: AsyncSession, notification_id: UUID) -> Notification | None:
-        return await db.get(Notification, notification_id)
 
-    async def list_unread(self, db: AsyncSession, limit: int = 50) -> list[Notification]:
-        result = await db.execute(
-            select(Notification)
-            .where(Notification.is_read.is_(False))
-            .order_by(Notification.created_at.desc())
-            .limit(limit)
-        )
-        return list(result.scalars().all())
+async def create(db: AsyncSession, *, title: str, body: str, channel: str) -> Notification:
+    notification = Notification(title=title, body=body, channel=channel)
+    db.add(notification)
+    await db.flush()
+    await db.refresh(notification)
+    return notification
+
+
+async def list_unread(db: AsyncSession, limit: int = 50) -> list[Notification]:
+    result = await db.execute(
+        select(Notification)
+        .where(Notification.is_read.is_(False))
+        .order_by(Notification.created_at.desc())
+        .limit(limit)
+    )
+    return list(result.scalars().all())
 ```
+
+!!! danger "`flush()` + `refresh()`, never `commit()`"
+
+    The request's session commits once, after the route returns and *before* the
+    response is written — which is what makes a 2xx mean the write is readable
+    ([#353](https://github.com/vstorm-co/agenticos/issues/353)). A repository
+    that commits takes that ordering away from the one place that owns it.
+
+A repository is a **module of stateless functions**, not a class: `db` first,
+everything after it keyword-only, and the entity returned rather than an id or a
+dict. Re-export it from `app/repositories/__init__.py` the way every other one is
+— `from app.repositories import notification as notification_repo` — so callers
+import the alias rather than the module path.
 
 ### 4. Create the service (`app/services/`)
 
@@ -103,39 +136,45 @@ from uuid import UUID
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import NotFoundError
-from app.repositories.notification import NotificationRepository
+from app.db.models.notification import Notification
+from app.repositories import notification_repo
 from app.schemas.notification import NotificationCreate
 
 
 class NotificationService:
     def __init__(self, db: AsyncSession):
         self.db = db
-        self.repo = NotificationRepository()
 
-    async def create(self, data: NotificationCreate) -> "Notification":
-        return await self.repo.create(self.db, **data.model_dump())
+    async def create(self, data: NotificationCreate) -> Notification:
+        return await notification_repo.create(
+            self.db, title=data.title, body=data.body, channel=data.channel
+        )
 
-    async def get_or_raise(self, notification_id: UUID) -> "Notification":
-        notification = await self.repo.get_by_id(self.db, notification_id)
+    async def get_or_raise(self, notification_id: UUID) -> Notification:
+        notification = await notification_repo.get_by_id(self.db, notification_id)
         if not notification:
             raise NotFoundError(
                 message="Notification not found",
-                details={"id": notification_id},
+                details={"notification_id": notification_id},
             )
         return notification
 
-    async def list_unread(self) -> list["Notification"]:
-        return await self.repo.list_unread(self.db)
+    async def list_unread(self) -> list[Notification]:
+        return await notification_repo.list_unread(self.db)
 ```
 
-### 5. Register dependency (`app/api/deps.py`)
+The service holds the session and nothing else; repositories are imported as
+modules. It is also the **only** layer that raises a domain exception, and
+`details` carries the value rather than a string of it — the handler encodes with
+`jsonable_encoder`.
+
+### 5. Register the dependency (`app/api/deps.py`)
 
 ```python
 from app.services.notification import NotificationService
 
 
 def get_notification_service(db: DBSession) -> NotificationService:
-    """Create NotificationService instance with database session."""
     return NotificationService(db)
 
 
@@ -146,33 +185,40 @@ NotificationSvc = Annotated[NotificationService, Depends(get_notification_servic
 
 ```python
 # app/api/routes/v1/notifications.py
+from typing import Any
+
 from fastapi import APIRouter, status
 
-from app.api.deps import NotificationSvc
-from app.schemas.notification import NotificationCreate, NotificationResponse
-from app.api.deps import CurrentUser
+from app.api.deps import CurrentUser, NotificationSvc
+from app.schemas.notification import NotificationCreate, NotificationList, NotificationRead
 
 router = APIRouter()
 
 
-@router.post("/", response_model=NotificationResponse, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=NotificationRead, status_code=status.HTTP_201_CREATED)
 async def create_notification(
-    data: NotificationCreate,
-    service: NotificationSvc,
-    current_user: CurrentUser,
-):
+    data: NotificationCreate, service: NotificationSvc, user: CurrentUser
+) -> Any:
     return await service.create(data)
 
 
-@router.get("/", response_model=list[NotificationResponse])
-async def list_unread(
-    service: NotificationSvc,
-    current_user: CurrentUser,
-):
-    return await service.list_unread()
+@router.get("", response_model=NotificationList)
+async def list_unread(service: NotificationSvc, user: CurrentUser) -> Any:
+    items = await service.list_unread()
+    return NotificationList(items=items, total=len(items))
 ```
 
-### 7. Register the route
+!!! note "`-> Any`, on purpose"
+
+    `response_model` does the serialization. Annotating the real return type
+    makes Pydantic validate the same object twice.
+
+Anything org-scoped takes a permission from the catalog on the **collection**
+route — `dependencies=[Depends(require(Perm.X))]` — while a per-resource route
+hands the decision to a service calling `resolve_access`. See
+[Permissions](../permissions.md).
+
+### 7. Register the router
 
 In `app/api/routes/v1/__init__.py`:
 
@@ -184,13 +230,17 @@ v1_router.include_router(
 )
 ```
 
-### 8. Create and apply migration
+### 8. Create and apply the migration
 
 ```bash
-make db-migrate    # Enter message: "Add notifications table"
+make db-migrate    # message: "Add notifications table"
 make db-upgrade
+make db-check      # a model change with no migration fails here, and in `make check`
 ```
 
 ### 9. Test it
 
-Visit `http://localhost:8000/docs` and try the new endpoint.
+A route ships with tests, not after them: one that its gate is wired
+(`tests/api/`), one per service branch including the refusal, and an integration
+test if a constraint or a cascade is what you actually changed. Then
+`http://localhost:8000/docs` to try it by hand.

--- a/docs/howto/add-background-task.md
+++ b/docs/howto/add-background-task.md
@@ -67,15 +67,19 @@ both log a failure with the `name` you gave them - which is the only context tha
 error will ever carry, so be specific.
 
 ### 3. Add scheduling (optional)
-In `app/worker/prefect_app.py`, register a scheduled deployment in `main()`:
+
+A schedule fires with **fixed** parameters, so the flow it names has to be one
+that needs none — `send_notification_flow` above takes the id of a row somebody
+wrote and there is no such id at nine in the morning. Register the flow that goes
+looking for its own work:
+
 ```python
 from prefect.client.schemas.schedules import CronSchedule
 
-from app.worker.tasks.notifications import send_notification_flow
+from app.worker.tasks.reports import nightly_digest_flow
 
-deployments.append(await send_notification_flow.ato_deployment(
+deployments.append(await nightly_digest_flow.ato_deployment(
     name="daily-digest",
-    parameters={"user_id": "broadcast", "message": "Daily digest"},
     schedules=[CronSchedule(cron="0 9 * * *")],  # Daily at 9 AM
 ))
 ```

--- a/docs/howto/add-background-task.md
+++ b/docs/howto/add-background-task.md
@@ -1,8 +1,8 @@
 # How to: Add a Background Task
 
-## Overview
-
-Background tasks run asynchronously outside the request-response cycle. Your project uses **prefect** as the task queue.
+Background work runs outside the request-response cycle. This project uses
+**Prefect** for anything scheduled or long-running, and `app/core/background.py`
+for work a request hands over.
 
 ## Step-by-Step
 
@@ -20,17 +20,35 @@ async def send_notification_flow(user_id: str, message: str) -> dict:
     return {"status": "sent", "user_id": user_id}
 ```
 
-### 2. Call it from your API
+### 2. Call it from a service
+
+!!! danger "Work that reads a row this request wrote takes `spawn_after_commit`"
+
+    `spawn` creates the task at once and the loop starts it before the request
+    commits, so the flow opens its own session and cannot see the row it was
+    given the id of - an upload that answered `processing` and stayed that way
+    ([#417](https://github.com/vstorm-co/agenticos/issues/417)). A bare
+    `asyncio.create_task` has that problem *and* loses the exception, because
+    nothing holds a reference to the task or reads its result.
 
 ```python
-# In any route or service:
-import asyncio
-
+from app.core.background import spawn, spawn_after_commit
 from app.worker.tasks.notifications import send_notification_flow
 
-# Fire and forget — runs the flow in the background (tracked in the Prefect UI)
-asyncio.create_task(send_notification_flow("user_123", "Your order is ready!"))
+# In a service, handing over work about a row this request just wrote:
+spawn_after_commit(
+    self.db,
+    send_notification_flow(str(notification.id), "Your order is ready!"),
+    name=f"notify:{notification.id}",
+)
+
+# Work that reads nothing this request wrote can start immediately:
+spawn(send_notification_flow("broadcast", "Nightly digest"), name="notify:digest")
 ```
+
+Both keep a reference to the task so it is not garbage-collected mid-flight, and
+both log a failure with the `name` you gave them - which is the only context that
+error will ever carry, so be specific.
 
 ### 3. Add scheduling (optional)
 In `app/worker/prefect_app.py`, register a scheduled deployment in `main()`:
@@ -54,6 +72,12 @@ deployments.append(await send_notification_flow.ato_deployment(
 uv run --directory backend python -m app.worker.prefect_app
 # Prefect UI: http://localhost:4200
 ```
+
+!!! warning "A short schedule is cheap to add but not free"
+
+    At most `PREFECT_RUNNER_LIMIT` runs execute at once (default 5) and the rest
+    queue. Every run is a process that imports the whole application, so prefer
+    the longest interval that still answers the question.
 
 At most `PREFECT_RUNNER_LIMIT` runs execute at once (default 5) and the rest queue,
 so a short schedule is cheap to add but not free: the interval decides how much

--- a/docs/howto/add-background-task.md
+++ b/docs/howto/add-background-task.md
@@ -79,7 +79,4 @@ uv run --directory backend python -m app.worker.prefect_app
     queue. Every run is a process that imports the whole application, so prefer
     the longest interval that still answers the question.
 
-At most `PREFECT_RUNNER_LIMIT` runs execute at once (default 5) and the rest queue,
-so a short schedule is cheap to add but not free: the interval decides how much
-work is waiting after downtime, and every run is a process that imports the whole
-application. Prefer the longest interval that still answers the question.
+The interval also decides how much work is waiting after downtime.

--- a/docs/howto/add-background-task.md
+++ b/docs/howto/add-background-task.md
@@ -9,16 +9,30 @@ for work a request hands over.
 ### 1. Create the task
 ```python
 # app/worker/tasks/notifications.py
+from uuid import UUID
+
 from prefect import flow
+
+from app.db.session import get_db_context
+from app.repositories import notification_repo
 
 
 @flow(name="send-notification", log_prints=True)
-async def send_notification_flow(user_id: str, message: str) -> dict:
-    """Send a notification to a user."""
-    # Your async logic here
-    print(f"Sending to {user_id}: {message}")
-    return {"status": "sent", "user_id": user_id}
+async def send_notification_flow(notification_id: str) -> dict:
+    """Send a notification that a request has already written."""
+    # A flow opens its own session: the request's is long gone by now.
+    async with get_db_context() as db:
+        notification = await notification_repo.get_by_id(db, UUID(notification_id))
+        if notification is None:
+            # Reachable, and the whole reason for `spawn_after_commit` below.
+            raise ValueError(f"notification {notification_id} not found")
+        print(f"Sending {notification.title} on {notification.channel}")
+    return {"status": "sent", "notification_id": notification_id}
 ```
+
+The flow takes an **id and reads the row**, which is the shape almost every real
+flow has and the reason the handover below matters. A flow that only prints its
+arguments would work either way and would teach nothing.
 
 ### 2. Call it from a service
 
@@ -34,16 +48,18 @@ async def send_notification_flow(user_id: str, message: str) -> dict:
 ```python
 from app.core.background import spawn, spawn_after_commit
 from app.worker.tasks.notifications import send_notification_flow
+from app.worker.tasks.reports import nightly_digest_flow
 
-# In a service, handing over work about a row this request just wrote:
+# A row this request just wrote. The flow reads it by id, so the task must not
+# start before the commit that makes it readable.
 spawn_after_commit(
     self.db,
-    send_notification_flow(str(notification.id), "Your order is ready!"),
+    send_notification_flow(str(notification.id)),
     name=f"notify:{notification.id}",
 )
 
-# Work that reads nothing this request wrote can start immediately:
-spawn(send_notification_flow("broadcast", "Nightly digest"), name="notify:digest")
+# Work that reads nothing this request wrote can start immediately.
+spawn(nightly_digest_flow(), name="digest:nightly")
 ```
 
 Both keep a reference to the task so it is not garbage-collected mid-flight, and

--- a/docs/howto/add-capability.md
+++ b/docs/howto/add-capability.md
@@ -10,9 +10,10 @@ also covers things that are not tools at all: a budget guard, an approval gate,
 a compaction strategy. One concept covers the whole assembly instead of two that
 overlap awkwardly.
 
-Code defines what exists; configuration only composes it. Nothing an operator
-types can bring a new capability into being, which is what makes the set of
-things an agent can do reviewable.
+!!! abstract "Code defines what exists; configuration only composes it"
+
+    Nothing an operator types can bring a new capability into being, which is
+    what makes the set of things an agent can do reviewable.
 
 ## The shape
 
@@ -25,6 +26,13 @@ weather/
   _toolset.py       the tools, and the text the model reads before calling them
   README.md         why this exists and what it deliberately does not do
 ```
+
+!!! warning "The layout is enforced, and one rule of it is a silent failure"
+
+    `@register` appears in `__init__.py` and nowhere else. A registration in a
+    submodule only fires if something imports that module — which is how a
+    capability vanishes from the Builder with every test still green.
+    `tests/test_capability_layout.py` is what fails instead.
 
 This layout is not a suggestion — `tests/test_capability_layout.py` enforces it.
 Every package has a `_capability.py`, every package offering tools of its own
@@ -138,11 +146,7 @@ def _build(ctx: CapabilityBuildContext) -> Weather | None:
 
 - **`id`** goes into every published spec and is the one thing that must never
   change. Rename freely; re-id never.
-- **`tools`** has no default, on purpose. It is what the Builder offers per-tool
-  approval for and what the approval gate matches on, so a capability that declares
-  nothing is a capability whose tools cannot be gated — and the dangerous half of
-  that failure is silent: an author adds a second, side-effecting tool, forgets to
-  declare it, and it runs unattended forever. Omitting the argument is a
+- **`tools`** has no default, on purpose. Omitting the argument is a
   `TypeError`; a capability with genuinely no tools says `tools=()`. Each entry's
   `id` is what a spec's `tool_approval` and `tool_overrides` key on, and its
   `description` should be the tool's own docstring summary — the person choosing
@@ -162,6 +166,15 @@ def _build(ctx: CapabilityBuildContext) -> Weather | None:
   collection names, skills. A capability never queries for them itself; the
   model asks *what* to search, never *where*.
 
+!!! danger "An undeclared tool runs ungated, and nothing says so"
+
+    `tools=` is what the Builder offers per-tool approval for and what the
+    approval gate matches on. The dangerous half of the failure is silent: an
+    author adds a second, side-effecting tool, forgets to declare it, and it runs
+    unattended forever. `tests/test_capability_registry.py` compares the declared
+    list against the tools the model is actually offered — which is the only
+    thing that catches it.
+
 **The builder may return a capability we did not write.** Its signature is
 `CapabilityBuildContext -> AbstractCapability[Any] | None`, so anything Pydantic
 AI ships is a valid return — `thinking/` registers `pydantic_ai.capabilities.Thinking`
@@ -175,9 +188,10 @@ The `isinstance` narrowing rather than a cast is how every builtin does it:
 schema this capability declared, and a capability bound with no config at all
 gets its defaults instead of a crash.
 
-Then add the module to `load_builtins()` in `_registry.py`. A module nobody
-imports does not exist as far as the Builder is concerned, which is the intended
-coupling — registration is an import, not a scan.
+!!! important "Then add the module to `load_builtins()` in `_registry.py`"
+
+    A module nobody imports does not exist as far as the Builder is concerned.
+    That coupling is intended — registration is an import, not a scan.
 
 ## 3. Write the README
 
@@ -187,8 +201,12 @@ reasoning lives, not in the commit message.
 
 ## 4. Test it
 
-`app/agents/**` is held to **100% coverage and it is enforced in CI** — a new
-capability with an untested branch fails the build. See `## Testing` in
+!!! danger "`app/agents/**` is at 100% coverage, enforced in CI"
+
+    A new capability with an untested branch fails the build. Adding a module to
+    the platform layer also means editing **two** lists in
+    `backend/pyproject.toml` — `[tool.coverage.run] include` and
+    `[[tool.ty.overrides]] include` — verbatim and in the same order. See `## Testing` in
 `CLAUDE.md`, and `tests/test_capability_registry.py` for the style.
 
 Worth covering specifically:
@@ -243,11 +261,12 @@ Three steps, and the second is the one that gets forgotten:
    capability's three come from `pydantic-ai-skills`, so their names are somebody
    else's to change.
 
-If the new tool has side effects and the existing ones do not, that is a signal the
-capability is now two decisions wearing one name. Prefer a second capability;
-`side_effecting` is per capability, and per-tool `approval` in a spec is a way for
-an *agent author* to be stricter than the default, not a substitute for declaring
-the truth.
+!!! tip "A side-effecting tool beside read-only ones is a signal"
+
+    `side_effecting` is per capability, so the capability is now two decisions
+    wearing one name. Prefer a second capability; per-tool `approval` in a spec
+    lets an *agent author* be stricter than the default, and is not a substitute
+    for declaring the truth.
 
 ## Adding a tool nobody here has to write
 

--- a/docs/howto/add-capability.md
+++ b/docs/howto/add-capability.md
@@ -200,10 +200,12 @@ reasoning lives, not in the commit message.
 
 !!! danger "`app/agents/**` is at 100% coverage, enforced in CI"
 
-    A new capability with an untested branch fails the build. Adding a module to
-    the platform layer also means editing **two** lists in
-    `backend/pyproject.toml` — `[tool.coverage.run] include` and
-    `[[tool.ty.overrides]] include` — verbatim and in the same order. See `## Testing` in
+    A new capability with an untested branch fails the build. You do **not** need
+    to widen the gate for it: both lists in `backend/pyproject.toml` already carry
+    the `app/agents/**` glob, and
+    `test_every_file_in_a_platform_package_is_gated` exists to keep that true.
+    Editing those lists is for a new platform *package*, outside the ones already
+    globbed. See `## Testing` in
 `CLAUDE.md`, and `tests/test_capability_registry.py` for the style.
 
 Worth covering specifically:

--- a/docs/howto/add-capability.md
+++ b/docs/howto/add-capability.md
@@ -35,11 +35,8 @@ weather/
     `tests/test_capability_layout.py` is what fails instead.
 
 This layout is not a suggestion — `tests/test_capability_layout.py` enforces it.
-Every package has a `_capability.py`, every package offering tools of its own
-has a `_toolset.py`, and `@register` appears in `__init__.py` and nowhere else
-(a registration in a submodule only fires if something imports that module,
-which is how a capability vanishes from the Builder with every test still
-green). A capability with no tools — `clock`, `thinking` — is listed in that
+Every package has a `_capability.py` and every package offering tools of its own
+has a `_toolset.py`. A capability with no tools — `clock`, `thinking` — is listed in that
 test with the reason why, rather than carrying an empty module.
 
 The tools live apart from the capability class because a tool's **name and

--- a/docs/howto/add-mcp-server.md
+++ b/docs/howto/add-mcp-server.md
@@ -4,10 +4,11 @@ The [catalog](../mcp.md#the-catalog) is what makes the connection picker useful
 instead of a blank URL field. Adding an entry is data, not code: one object in
 `backend/app/core/catalog/mcp_servers.json`.
 
-**You do not need to do this to use a server.** Any MCP server reachable by URL
-connects through the *Custom server* entry and its tools are introspected on
-connect. The catalog saves somebody a URL lookup and a paragraph of setup
-guesswork; it is not a gate.
+!!! tip "You do not need to do this to use a server"
+
+    Any MCP server reachable by URL connects through the *Custom server* entry,
+    and its tools are introspected on connect. The catalog saves somebody a URL
+    lookup and a paragraph of setup guesswork; it is not a gate.
 
 ## The entry
 
@@ -37,13 +38,18 @@ guesswork; it is not a gate.
 | `token_hint` | Only for `token`. See below |
 | `icon` | A `BrandIcon` name, or empty |
 
-The file is validated against `CatalogEntry` at **import time**, so a malformed
-entry refuses to start the app rather than silently vanishing from the picker.
+!!! note "Validated at import time"
+
+    The file is checked against `CatalogEntry` when the module loads, so a
+    malformed entry refuses to start the app rather than silently vanishing from
+    the picker.
 
 ## Write the token hint
 
-This is the field that earns the entry. Generic instructions are the main reason
-token setup fails, and "an API token" tells nobody where to click.
+!!! important "This is the field that earns the entry"
+
+    Generic instructions are the main reason token setup fails, and "an API
+    token" tells nobody where to click.
 
 Say where the token comes from and what it needs to be able to do:
 
@@ -67,10 +73,11 @@ missing one: every icon set is finite and this catalog is not.
 
 ## Before you commit it
 
-An entry is a promise — that somebody looked at the server, that the auth flow
-works, that the description is honest. That is the whole reason this is a
-hand-maintained list rather than a mirror of the public registry, so make the
-promise true:
+!!! warning "An entry is a promise"
+
+    That somebody looked at the server, that the auth flow works, that the
+    description is honest. It is the whole reason this is a hand-maintained list
+    rather than a mirror of the public registry — so make the promise true:
 
 1. Connect it in a running deployment.
 2. Run `POST /api/v1/mcp-connections/{id}/test` (the **Test** button) and read the

--- a/docs/howto/add-sync-connector.md
+++ b/docs/howto/add-sync-connector.md
@@ -22,6 +22,17 @@ Sync connectors are pluggable adapters that fetch files from external systems
 
 ### Flow
 
+```mermaid
+flowchart TD
+    A[a SyncSource: connector type, config, collection, secret id] --> B[a sync is triggered - API, CLI or schedule]
+    B --> C["the caller unseals the vault secret and hands it in"]
+    C --> D["list_files() -> list[RemoteFile]"]
+    D --> E["download_file() resolves the name and confirms containment"]
+    E --> F["_fetch(dest_path) writes the bytes"]
+    F --> G[the ingestion pipeline parses, chunks, embeds, stores]
+    G --> H[a SyncLog row records the result]
+```
+
 1. User creates a **SyncSource** (connector type + config + collection name +
    the id of the vault secret that authenticates it)
 2. User triggers a **sync** (via API, CLI, or scheduled task)
@@ -34,13 +45,16 @@ Sync connectors are pluggable adapters that fetch files from external systems
 
 ### A connector does not choose the destination
 
+!!! danger "A remote name is attacker-controlled"
+
+    Anyone who can share a file into a synced folder chooses it, and
+    `../../../etc/…` is a legal name on Google Drive. **Write to the `dest_path`
+    you are given, and nothing else** - a connector that picked its own path
+    would be one refusal per connector to remember.
+
 `download_file()` is concrete and is not overridden. It resolves
 `RemoteFile.name` against the sync directory and confirms containment before a
-byte is written, then hands `_fetch()` a `dest_path` to write to. A remote name
-is attacker-controlled from this system's point of view — anyone who can share a
-file into a synced folder chooses it, and `../../../etc/…` is a legal name on
-Google Drive — so a connector that picked its own path would be one refusal per
-connector to remember. Write to the path you are given, and nothing else.
+byte is written, then hands `_fetch()` a `dest_path` to write to.
 
 The same applies to any caller-supplied value a connector puts into a **query**:
 check it where the query is built, against what the remote system can actually
@@ -54,11 +68,13 @@ runs the sync and handed in as `credential` — so a connector declares what kin
 of secret it needs (`SECRET_KIND`) and reads nothing from `config` to
 authenticate with.
 
-A field for a token in `CONFIG_SCHEMA` is a credential in a JSONB column, which
-is what migration `0042` and #937 removed. There is no deployment-wide fallback
-to reach for either: a source runs on the credential it names or it does not run,
-because a fallback means one tenant's `folder_id` chooses what is read under the
-*operator's* identity.
+!!! danger "A field for a token in `CONFIG_SCHEMA` is a credential in a JSONB column"
+
+    That is what `0042_sync_source_secret_id` and
+    [#937](https://github.com/vstorm-co/agenticos/issues/937) removed. There is
+    no deployment-wide fallback to reach for either: a source runs on the
+    credential it names or it does not run, because a fallback means one tenant's
+    `folder_id` chooses what is read under the *operator's* identity.
 
 ## Step-by-Step: Notion Connector
 

--- a/docs/howto/configure-sync-sources.md
+++ b/docs/howto/configure-sync-sources.md
@@ -3,10 +3,10 @@
 
 ## Overview
 
-Sync sources let you automatically pull documents from external services
-(Google Drive, S3/MinIO) into your RAG collections. Each source is a
-persistent configuration that stores a connector type, target collection,
-connector-specific settings, a sync mode, and an optional schedule.
+Sync sources pull documents from external services (Google Drive, S3/MinIO) into
+knowledge collections on their own. Each source stores a connector type, a target
+collection, connector-specific settings, a sync mode, an optional schedule, and
+the id of the [vault secret](../secrets.md) that authenticates it.
 
 When a sync runs, the connector lists remote files, downloads them to a
 temporary directory, and feeds them through the standard ingestion pipeline
@@ -18,15 +18,13 @@ every sync operation.
 | Component | Location | Role |
 |-----------|----------|------|
 | `BaseSyncConnector` | `app/services/rag/connectors/__init__.py` | Abstract base for all connectors |
-| `RemoteFile` | `app/rag/connectors/__init__.py` | Pydantic model describing a remote file |
-| `CONNECTOR_REGISTRY` | `app/rag/connectors/__init__.py` | Maps connector type strings to classes |
+| `RemoteFile` | `app/services/rag/connectors/__init__.py` | Pydantic model describing a remote file |
+| `CONNECTOR_REGISTRY` | `app/services/rag/connectors/__init__.py` | Maps connector type strings to classes |
 | `SyncSource` (DB model) | `app/db/models/sync_source.py` | Persists source configurations |
 | `SyncLog` (DB model) | `app/db/models/sync_log.py` | Tracks individual sync operations |
 | `SyncSourceService` | `app/services/sync_source.py` | Business logic for CRUD + trigger |
 | RAG CLI commands | `app/commands/rag.py` | CLI interface for managing sources |
 | RAG API routes | `app/api/routes/v1/rag.py` | REST API for managing sources |
-
----
 
 ## Quick Start -- CLI
 
@@ -82,8 +80,6 @@ uv run agenticos cmd rag-source-remove <source-id>
 The `<source-id>` is a UUID printed when you create the source and shown
 in the `rag-sources` listing.
 
----
-
 ## Quick Start -- UI
 
 1. Navigate to **Knowledge Base** and open the **Sync** tab.
@@ -100,8 +96,6 @@ in the `rag-sources` listing.
 The UI calls the same REST API documented below, so anything you can do
 in the UI you can also do with `curl` or any HTTP client.
 
----
-
 ## Sync Modes
 
 | Mode | Behavior |
@@ -110,12 +104,11 @@ in the UI you can also do with `curl` or any HTTP client.
 | `new_only` | Add new files + update changed files. Uses SHA-256 hash to detect changes — unchanged files are skipped. |
 | `update_only` | Only update files already in the collection. New files are skipped. Uses SHA-256 hash to skip unchanged files. |
 
-Choose `new_only` for most workflows — it adds new files and updates
-modified ones while skipping unchanged files (fastest incremental sync).
-Choose `update_only` when you only want to refresh existing documents
-without adding new ones. Choose `full` for a clean re-import every time.
+!!! tip "`new_only` for most workflows"
 
----
+    It adds new files and updates modified ones while skipping unchanged files,
+    which is the fastest incremental sync. `update_only` refreshes existing
+    documents without adding new ones; `full` is a clean re-import every time.
 
 ## Schedule
 
@@ -129,11 +122,12 @@ automatically:
 | `120` | Every 2 hours |
 | `1440` | Once per day |
 
-Scheduled syncs require a running background task system:
+!!! warning "A schedule needs the Prefect runner"
 
-Without a background task system, only manual triggers (CLI or API) work.
-
----
+    `check_scheduled_syncs_flow` is a Prefect deployment that wakes every 60
+    seconds and fires whatever is due, so `schedule_minutes` does nothing without
+    the `prefect-server` and `prefect-runner` containers `make dev` starts. With
+    neither running, only a manual trigger (CLI, API or the UI) syncs anything.
 
 ## Google Drive Setup
 
@@ -197,8 +191,6 @@ formats (PDF, XLSX, PPTX) during download. A file whose Drive name contains path
 separators is written as one file inside the sync directory, never at the path
 its name spells.
 
----
-
 ## S3 / MinIO Setup
 
 ### 1. Configure the environment
@@ -221,8 +213,6 @@ For MinIO, the endpoint is typically `http://minio:9000` (Docker) or
 |-------|------|----------|---------|-------------|
 | `bucket` | string | Yes | -- | S3 bucket name |
 | `prefix` | string | No | `""` | Key prefix to limit sync scope (e.g. `documents/legal/`). Leave empty for the entire bucket. |
-
----
 
 ## API Reference
 
@@ -293,8 +283,6 @@ The response includes each connector's `config_schema`, which the
 frontend uses to render dynamic forms. It is also useful for building
 integrations programmatically.
 
----
-
 ## Updating a Source
 
 You can update any subset of fields on an existing source with `PATCH`:
@@ -314,8 +302,6 @@ Updatable fields: `name`, `config`, `sync_mode`, `schedule_minutes`,
 `is_active`, `collection_name`.
 
 Set `is_active` to `false` to pause a source without deleting it.
-
----
 
 ## Monitoring Sync Operations
 
@@ -343,8 +329,6 @@ curl http://localhost:8000/api/v1/rag/sync/logs?collection_name=legal&limit=5 \
   -H "Authorization: Bearer $TOKEN"
 ```
 
----
-
 ## Adding Custom Connectors
 
 To add a new connector type (e.g. Notion, Confluence, Dropbox), see
@@ -363,8 +347,6 @@ The short version:
 
 Once registered, the connector appears automatically in the CLI, API,
 and UI.
-
----
 
 ## Troubleshooting
 

--- a/docs/howto/customize-agent-prompt.md
+++ b/docs/howto/customize-agent-prompt.md
@@ -1,95 +1,89 @@
-# How to: Customize the Agent Prompt
+# How to: Write an Agent's Instructions
 
-## Where to Edit
+!!! danger "Instructions are data, not code"
 
-All agent prompts are centralized in:
+    There is no `prompts.py` to edit, and no `DEFAULT_SYSTEM_PROMPT` constant to
+    override. An agent's behaviour is the `instructions` field of its
+    [spec](../reference/spec.md) — edited in the Builder, versioned on publish,
+    and exported as YAML into a client's own repository. Editing Python to change
+    what an agent says is the single most common wrong assumption about this
+    codebase.
 
-```
-app/agents/prompts.py
-```
+## Where the text lives
 
-## Default Prompt
+| | Where | Who edits it |
+|---|---|---|
+| One agent's instructions | `AgentSpec.instructions`, edited in the Builder | Whoever may edit the agent |
+| An inline specialist's instructions | `InlineSpecialistSpec.instructions`, in the same spec | Same |
+| The starting text a new agent gets | `backend/app/agents/default_instructions.py` | A deploy — it is this deployment's idea of an assistant |
+| A procedure many agents share | A [skill](../skills.md), a row in the database | A support lead, on a Tuesday afternoon, with no deploy |
 
-```python
-DEFAULT_SYSTEM_PROMPT = """You are a helpful assistant."""
-```
+The last row is the one worth reaching for. Twenty procedures in one
+`instructions` field means every run pays for all twenty; twenty skills cost
+almost nothing, because the model sees the names and loads only what it needs.
 
-## Best Practices
+## What belongs in instructions
 
-### 1. Be specific about the agent's role
+Read `default_instructions.py` before writing your own — it is the worked example,
+and it explains its own choices. Two of them decide most of the quality:
 
-```python
-DEFAULT_SYSTEM_PROMPT = """You are a customer support agent for agenticos.
+- **Write for the refusals.** The paragraphs that earn their place are the ones
+  about not inventing facts, saying which source an answer came from, and stopping
+  to ask rather than guessing at something destructive. "Be helpful" is
+  decoration: the model is already trying to be helpful, and what it needs is
+  where the edges are.
+- **Put what is specific to *this* agent at the top.** Whoever opens it next will
+  rewrite the first paragraph and keep the rest.
 
-Your responsibilities:
-- Answer questions about our products and services
-- Help users troubleshoot issues
-- Escalate complex problems to human support
+```text
+You are a customer support agent for Acme.
 
-Tone: Professional but friendly. Use simple language."""
-```
+Answer questions about our products, help people troubleshoot, and escalate
+anything involving a refund over £500 — the refund-policy skill has the rule.
 
-### 2. Define output format
-
-```python
-DEFAULT_SYSTEM_PROMPT = """You are a data analyst assistant.
-
-When presenting data:
-- Use tables for comparisons
-- Include specific numbers and percentages
-- Cite your data sources
-
-When you don't know something, say so clearly."""
-```
-
-### 3. RAG-aware prompt
-
-The RAG prompt is in `get_system_prompt_with_rag()`. It instructs the agent to:
-- Search the knowledge base before answering
-- Cite sources using [1], [2] references
-- List sources at the end of the response
-
-To customize:
-
-```python
-def get_system_prompt_with_rag() -> str:
-    return f"""{DEFAULT_SYSTEM_PROMPT}
-
-You have access to a knowledge base. Always search before answering.
-
-Rules:
-- ALWAYS cite sources: [1], [2], etc.
-- If no results found, say so
-- Never make up information
-- Prefer recent documents over older ones
-
-Sources format:
-[1] filename.pdf, page 3
-[2] report.docx, page 1"""
+Never quote a price you have not read from the knowledge base. If a question
+needs an account change, say what you would do and ask them to confirm.
 ```
 
-### 4. Multi-persona agents
+!!! warning "Do not list the agent's tools in its instructions"
 
-Create different prompts for different use cases:
+    An agent gets its capabilities from its spec and the tools carry their own
+    descriptions from the library. A prompt that enumerates them is wrong the
+    moment somebody toggles one — and the failure is an agent confidently
+    refusing to do something it can now do.
 
-```python
-SUPPORT_PROMPT = """You are a customer support agent..."""
-ANALYST_PROMPT = """You are a data analyst..."""
-WRITER_PROMPT = """You are a content writer..."""
+!!! tip "Do not restate a capability's own rules either"
 
-def get_prompt(persona: str = "default") -> str:
-    prompts = {
-        "default": DEFAULT_SYSTEM_PROMPT,
-        "support": SUPPORT_PROMPT,
-        "analyst": ANALYST_PROMPT,
-        "writer": WRITER_PROMPT,
-    }
-    return prompts.get(persona, DEFAULT_SYSTEM_PROMPT)
-```
+    A capability that needs the model to behave a certain way contributes that
+    itself. Citation format for retrieval, how to use the sandbox, when to ask a
+    person — those arrive with the capability, in every agent that enables it.
 
-## Tips
+## Knowledge, skills and context files
 
-- Keep prompts concise — shorter prompts = faster, cheaper responses
-- Test with real user queries, not just ideal cases
-- Include example outputs in the prompt for consistent formatting
-- Use the temperature setting (`AI_TEMPERATURE` in `.env`) to control creativity
+Three ways to give an agent text it did not have, and they are not
+interchangeable:
+
+| | For | Retrieved by |
+|---|---|---|
+| `collection_ids` — [knowledge](../file-processing.md) | Thousands of documents: what we know | Semantic search, cited |
+| `skill_ids` — [skills](../skills.md) | Tens of procedures: how we do this | The model picking a name, then loading the body |
+| `context_ids` — context files | A handful of files small enough to always be present | Injected into the instructions, no search involved |
+
+All three are checked against the **publisher's** access at publish time, not at
+run time. See [Permissions](../permissions.md).
+
+## Iterating on it
+
+- **A draft cannot run.** An agent runs its published version, so trying a new
+  prompt means publishing one — which is cheap by design, and why a rollback is a
+  promote rather than a restore. Iterate on a `dev`
+  [environment](../concepts.md#version) that follows every publish, and leave
+  `production` waiting to be promoted onto.
+- **Test with real queries, not ideal ones.**
+- **Keep it as short as the behaviour needs.** A longer prompt is paid for on
+  every turn of every run, and pushes the conversation out of the window sooner.
+- **Publish when it is right.** Publishing freezes the version, so "what did this
+  agent do last Tuesday" stays answerable after a dozen edits — and a rollback
+  publishes a *new* version copied from the old one rather than deleting history.
+- **Temperature and the rest are `model_settings`**, per agent and per
+  specialist, on top of the model profile. Not an environment variable.

--- a/docs/howto/use-ratings.md
+++ b/docs/howto/use-ratings.md
@@ -1,7 +1,7 @@
 # Using Message Ratings
 
-Users can rate AI assistant responses to provide feedback on answer quality.
-This feedback helps improve the AI and gives administrators insight into response quality.
+People can rate an agent's answers, and the ratings are readable two ways: on the
+turn itself, and in aggregate for whoever administers the deployment.
 
 ## Rating Messages
 
@@ -55,9 +55,11 @@ Navigate to **Admin → Response Ratings** (or `/admin/ratings`) to access the a
 A bar chart shows ratings over the last 30 days. Green bars represent likes,
 red bars represent dislikes.
 
-This page's window is fixed. To read the same numbers over a period you choose,
-use the dashboard's **Answer quality, deployment-wide** card, which follows the
-period filter at the top of the page.
+!!! note "This page's window is fixed at 30 days"
+
+    To read the same numbers over a period you choose, use the dashboard's
+    **Answer quality, deployment-wide** card, which follows the period filter at
+    the top of the page.
 
 ### Filtering Ratings
 
@@ -86,7 +88,10 @@ Export ratings for external analysis:
 - **JSON** — Full structured data, suitable for scripts and analysis tools
 - **CSV** — Spreadsheet-compatible format for Excel or Google Sheets
 
-Exports respect the current filters (e.g., export only dislikes with comments).
+!!! tip "Exports respect the current filters"
+
+    Narrow to dislikes with comments, then export, and that is what you get -
+    the filters are part of the query, not of the view.
 
 ### Viewing Conversations
 
@@ -131,7 +136,9 @@ For programmatic access to ratings data, use the admin API endpoints:
 | `/admin/ratings/export` | GET | Export ratings (JSON/CSV) |
 | `/admin/conversations` | GET | List all conversations |
 
-Every `/admin` endpoint is gated on `CurrentAppAdmin` — a signed-in user whose
-`users.is_app_admin` is true. That is the **deployment** superadmin, not a role inside
-an organization: there is no `users.role` column and no organization role reaches
-these routes. See [permissions](../permissions.md#layer-1-usersis_app_admin-the-deployment-superadmin).
+!!! warning "Every `/admin` endpoint is the deployment superadmin, not an org role"
+
+    The gate is `CurrentAppAdmin` — a signed-in user whose `users.is_app_admin` is
+    true. There is no `users.role` column, and no organization role reaches these
+    routes. See
+    [permissions](../permissions.md#layer-1-usersis_app_admin-the-deployment-superadmin).

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,7 +97,8 @@ database row cannot be decrypted for another, and no API response ever returns o
 
 - :material-lightbulb:{ .lg .middle } **[Concepts](concepts.md)**
 
-    Spec, version, exposure, run. The four nouns everything else is built from.
+    Spec, version, exposure, trigger, run. The five nouns everything else is
+    built from.
 
 - :material-book-open-variant:{ .lg .middle } **[Reference](configuration.md)**
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -30,9 +30,7 @@ git clone https://github.com/vstorm-co/agenticos && cd agenticos
     Every variable in `docker-compose.yml` carries a default, deliberately, so
     the stack starts on a clean checkout.
 
-Every variable in `docker-compose.yml`
-carries a default, deliberately, so the stack starts on a clean checkout. One
-value is generated rather than defaulted: `make dev` runs `make sandbox-token`
+One value is generated rather than defaulted: `make dev` runs `make sandbox-token`
 first, which appends a fresh `SANDBOXD_TOKEN` to `backend/.env` if there is not
 one there already. The sandbox service refuses to start without it - it can run
 commands on this host, so an empty default would be a shared secret of `""`.

--- a/docs/install.md
+++ b/docs/install.md
@@ -25,7 +25,12 @@ idempotent - re-run any of them whenever you are not sure it worked.
 git clone https://github.com/vstorm-co/agenticos && cd agenticos
 ```
 
-**There is no `.env` to write first.** Every variable in `docker-compose.yml`
+!!! success "There is no `.env` to write first"
+
+    Every variable in `docker-compose.yml` carries a default, deliberately, so
+    the stack starts on a clean checkout.
+
+Every variable in `docker-compose.yml`
 carries a default, deliberately, so the stack starts on a clean checkout. One
 value is generated rather than defaulted: `make dev` runs `make sandbox-token`
 first, which appends a fresh `SANDBOXD_TOKEN` to `backend/.env` if there is not
@@ -44,6 +49,17 @@ appended to whatever is there.
 
 ```bash
 make dev
+```
+
+```mermaid
+flowchart LR
+    F["frontend<br/>:3000"] --> A["api<br/>:8000"]
+    A --> PG[("postgres<br/>pgvector, :5432")]
+    A --> RD[("redis<br/>:6379")]
+    A --> SD["sandboxd<br/><i>holds the Docker socket</i>"]
+    A --> PF["prefect server<br/>:4200"]
+    PF --> WK["prefect runner"]
+    WK --> PG
 ```
 
 Builds the backend image, starts **Postgres (pgvector), Redis, the API, the
@@ -127,13 +143,16 @@ part is missing rather than that something failed.
 
 ## The database must be pgvector
 
-Not stock Postgres. The retrieval store issues
+!!! danger "Not stock Postgres"
+
+    If document ingestion 500s on a fresh environment, check the image first.
+
+The retrieval store issues
 `CREATE EXTENSION IF NOT EXISTS vector` the first time a collection is written
 to, and stock Postgres answers `extension "vector" is not available` - a 500
 before any row is committed.
 
-Every compose file in this repository pins `pgvector/pgvector:pg16`. If document
-ingestion 500s on a fresh environment, check the image first.
+Every compose file in this repository pins `pgvector/pgvector:pg16`.
 
 ## Day to day
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -82,6 +82,23 @@ token setup fails. `PATCH` with `auth_token: ""` clears it.
 `401` with a `WWW-Authenticate` header pointing at RFC 9728 protected-resource
 metadata, and the flow runs from there:
 
+```mermaid
+sequenceDiagram
+    participant O as An operator
+    participant P as AgenticOS
+    participant S as The MCP server
+    participant A as Its authorization server
+    P->>S: connect
+    S-->>P: 401 + WWW-Authenticate (RFC 9728)
+    P->>S: fetch protected-resource metadata
+    P->>A: fetch RFC 8414 metadata, then register (RFC 7591)
+    P-->>O: a PKCE consent URL
+    O->>A: consents in a browser
+    A-->>P: callback with the code
+    P->>A: exchange for tokens, refresh later
+    P-->>O: back to the MCP servers page, with the outcome
+```
+
 1. **Discover** — probe the server, resolve its authorization server, fetch RFC
    8414 metadata.
 2. **Register** — RFC 7591 dynamic client registration.
@@ -92,6 +109,14 @@ metadata, and the flow runs from there:
    the only place the outcome can be told: the person is looking at a page they
    did not navigate to themselves.
 5. **Refresh** — when the access token expires.
+
+!!! danger "Every URL reached in that flow is SSRF-checked, not just the one somebody typed"
+
+    Discovery means the *remote server* chooses most of the addresses we call,
+    and connecting a single hostile server used to be enough: a name could answer
+    a public address to the check and a private one to the request that followed
+    ([#860](https://github.com/vstorm-co/agenticos/issues/860)). The address that
+    passed the check is now the address connected to.
 
 Every URL reached in that flow is SSRF-checked, not just the one somebody typed:
 discovery means the *remote server* chooses most of the addresses we call, and
@@ -196,28 +221,29 @@ keeps working until the new consent lands.
 Each server is probed with a short `tools/list` round-trip — 3 seconds — before
 the turn starts, and the probes run concurrently.
 
-**An unreachable server is skipped with a warning, not raised.** Pydantic AI
-enters every toolset when a run starts, so a dead server would otherwise abort the
-whole turn: one expired token on one connection would take down every agent that
-names it, including the ones that never needed it.
+!!! warning "An unreachable server is skipped with a warning, not raised"
 
-That is a deliberate trade. A skipped server means the model answers without those
-tools rather than not answering, which is right for a chat turn and wrong if you
-assumed a tool was always there. The `/test` endpoint and `last_status` are how you
+    Pydantic AI enters every toolset when a run starts, so a dead server would
+    otherwise abort the whole turn: one expired token on one connection would
+    take down every agent that names it, including the ones that never needed it.
+    The model then answers **without** those tools - right for a chat turn, wrong
+    if you assumed a tool was always there.
+
+That is a deliberate trade. The `/test` endpoint and `last_status` are how you
 find out; the [audit trail](governance.md#audit) records what actually ran.
 
 ### Name collisions
 
-Tools are prefixed with the connection name — `github-work` becomes
-`github_work_*` — because two servers exposing the same tool name make Pydantic AI
-raise on duplicate names, which aborts the turn.
+!!! note "Tools are prefixed with the connection name"
+
+    `github-work` becomes `github_work_*`, because two servers exposing the same
+    tool name make Pydantic AI raise on duplicates, which aborts the turn. An
+    allowlist filters *before* prefixing, so it compares against the unprefixed
+    names picked in the UI.
 
 Two connections whose names reduce to the same prefix are deduplicated, first one
 wins, with a warning naming the loser. Deployment-managed servers are ordered
 first, so they win over a user connection that happens to pick the same name.
-
-An allowlist filters *before* prefixing, so it compares against the unprefixed
-names picked in the UI.
 
 ## The catalog
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -118,12 +118,9 @@ sequenceDiagram
     ([#860](https://github.com/vstorm-co/agenticos/issues/860)). The address that
     passed the check is now the address connected to.
 
-Every URL reached in that flow is SSRF-checked, not just the one somebody typed:
-discovery means the *remote server* chooses most of the addresses we call, and
-those deserve the same policy as the one it typed. **And the address that passed the
-check is the address connected to** — the request goes to the resolved IP with
-the original host in the `Host` header and in TLS SNI, so the certificate is
-still verified against the name and nothing resolves it a second time.
+The request goes to the resolved IP with the original host in the `Host` header
+and in TLS SNI, so the certificate is still verified against the name and nothing
+resolves it a second time.
 
 That second half is what [#860](https://github.com/vstorm-co/agenticos/issues/860)
 closed, and it matters here more than anywhere else in the product. The address

--- a/docs/models.md
+++ b/docs/models.md
@@ -175,14 +175,9 @@ they are all derived from is the first:
     failing build instead, and it requires every provider to appear on **this
     page**.
 
-Everything below the first row is **derived** from it, and a derived copy that
-drifts fails nothing at run time — it shows a picker for a provider that does not
-exist, or leaves out one that does.
-`tests/test_model_catalog.py::TestOneAnswerPerQuestion` is what makes that a
-failing build instead: every key in either catalog file has to name a provider
-`PROVIDERS` has, so does every entry in the image catalog, and every provider has
-to appear on this page. Adding the twenty-eighth is one edit plus whatever that
-test then asks for.
+Every key in either catalog file has to name a provider `PROVIDERS` has, so does
+every entry in the image catalog, and every provider has to appear on this page.
+Adding the twenty-eighth is one edit plus whatever that test then asks for.
 
 Two crossings are worth knowing about because they are lookups that can answer
 nothing. The price snapshot spells three providers differently — `xai` is `x-ai`,
@@ -310,10 +305,8 @@ snapshot. Nothing phones home for them, which means two things worth knowing:
     Spend is attributed to the [vault secret](secrets.md) the run resolved to,
     and a keyless provider has none to attribute it to.
 
-Spend is attributed to the [vault secret](secrets.md) the run resolved to — which
-is why a keyless provider records none: there is no key to attribute it to. Cost
-is checked *before* each model request and recorded even when the run fails. See
-[Budgets](governance.md#budgets).
+Cost is checked *before* each model request and recorded even when the run fails.
+See [Budgets](governance.md#budgets).
 
 ### A delegation resolves its own profile
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -167,6 +167,14 @@ they are all derived from is the first:
 | What does this model cost, and how much context does it take? | the `genai-prices` snapshot, through `model_catalog.priced_model` |
 | Which models draw images? | `backend/app/core/catalog/image_models.json`, plus the SDK's own answer about which providers can draw at all |
 
+!!! info "Everything below the first row is derived from it"
+
+    A derived copy that drifts fails nothing at run time - it shows a picker for
+    a provider that does not exist, or leaves out one that does.
+    `tests/test_model_catalog.py::TestOneAnswerPerQuestion` is what makes that a
+    failing build instead, and it requires every provider to appear on **this
+    page**.
+
 Everything below the first row is **derived** from it, and a derived copy that
 drifts fails nothing at run time — it shows a picker for a provider that does not
 exist, or leaves out one that does.
@@ -296,6 +304,11 @@ snapshot. Nothing phones home for them, which means two things worth knowing:
   recorded as partially priced rather than as costing nothing. A budget that
   silently treated an unknown model as free would be a budget with a hole in it.
 - Updating prices is a dependency bump.
+
+!!! warning "A keyless provider records no spend"
+
+    Spend is attributed to the [vault secret](secrets.md) the run resolved to,
+    and a keyless provider has none to attribute it to.
 
 Spend is attributed to the [vault secret](secrets.md) the run resolved to — which
 is why a keyless provider records none: there is no key to attribute it to. Cost

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -114,18 +114,21 @@ async def get_conversations_by_user(
     skip: int = 0,
     limit: int = 50,
 ) -> list[Conversation]:
-    result = await db.execute(
-        select(Conversation)
-        .where(Conversation.organization_id == organization_id)
-        .offset(skip)
-        .limit(limit)
-    )
+    query = select(Conversation).where(Conversation.organization_id == organization_id)
+    if user_id:
+        query = query.where(Conversation.user_id == user_id)
+    result = await db.execute(query.offset(skip).limit(limit))
     return list(result.scalars().all())
 ```
 
-`organization_id` has no default anywhere in that module, on purpose: every
-conversation belongs to a tenant, and a caller that cannot name one has a bug
-rather than a default.
+Two things about that signature. `organization_id` has no default anywhere in
+that module, on purpose: every conversation belongs to a tenant, and a caller
+that cannot name one has a bug rather than a default. And a narrowing argument
+that is accepted has to be **applied** — a query that takes `user_id` and filters
+only on the tenant answers with every member's conversations. (The real module
+widens the user predicate to confirmed channel participants through
+`_reachable_by`, over ids the caller has already vetted against the platform;
+what matters here is that the argument reaches the `WHERE` clause at all.)
 
 !!! danger "`flush()`, never `commit()`"
 

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -167,14 +167,10 @@ stringified by the code that raises.
     upstream client's exception text, or a setting describing the deployment. The
     diagnosis is not deleted; it moves to the log line beside the raise.
 
-Everything in `details` is
-read by whoever was refused, so it names the field, the id or the resource they
-can act on - never a filesystem path, an upstream client's exception text, or a
-setting whose value describes the deployment rather than a limit the caller is
-being held to (`max_mb` and `seats_limit` are exactly what a caller can act on;
-where the container keeps its templates is not). The diagnosis is not deleted, it
-moves: the path the loader searched and the vendor SDK's message go in the log
-line beside the raise, where an operator reads them and a caller does not.
+`max_mb` and `seats_limit` are exactly what a caller can act on; where the
+container keeps its templates is not. The path the loader searched and the vendor
+SDK's message go in the log line beside the raise, where an operator reads them
+and a caller does not.
 
 ```python
 except Exception as exc:

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -2,54 +2,79 @@
 
 ## Dependency Injection
 
-Use FastAPI's `Depends()` for injecting dependencies:
+Everything a route needs arrives as an `Annotated` alias from `app/api/deps.py` -
+never a bare `Depends()` in the signature:
 
 ```python
-from app.api.deps import get_db, get_current_user
+from app.api.deps import ConversationSvc, CurrentUser
 
-@router.get("/conversations")
-async def list_conversations(
-    db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-):
-    service = ConversationService(db)
-    return await service.get_by_user(current_user.id)
+
+@router.get("", response_model=ConversationList)
+async def list_conversations(service: ConversationSvc, user: CurrentUser) -> Any:
+    items, total = await service.list(user_id=user.id)
+    return ConversationList(items=items, total=total)
 ```
 
-> **Important:** Routes never contain direct database calls. All data access
-> goes through a service, which in turn delegates to a repository.
+!!! important "Routes never contain direct database calls"
 
-Available dependencies in `app/api/deps.py`:
-- `get_db` - Database session
-- `get_current_user` - Authenticated user (raises 401 if not authenticated)
-- `get_current_user_optional` - User or None
-- `get_redis` - Redis connection
+    All data access goes through a service, which in turn delegates to a
+    repository. A route validates, delegates and returns.
+
+The aliases worth knowing, all in `app/api/deps.py`:
+
+| Alias | |
+|---|---|
+| `DBSession` | The request's session. `scope="function"`, which is what commits before the response is written |
+| `StreamingDBSession` | The same session with `scope="request"`, for a route that streams its body |
+| `CurrentUser` | An authenticated user; 401 without one |
+| `CurrentAppAdmin` | The deployment's superadmin |
+| `Auth` | The `AuthContext`: the caller, the organization, the permission set |
+| `Redis` | The Redis client |
+| `<Domain>Svc` | One per service, built from `DBSession` |
 
 ## Service Layer Pattern
 
-Every feature uses the same pattern: a service class receives a DB session,
-instantiates its repository, and provides business-level methods. Services
-are the **only** layer that raises domain exceptions.
+Every feature uses the same pattern: a service class receives a DB session and
+provides business-level methods. Services are the **only** layer that raises
+domain exceptions.
 
 ```python
+from app.repositories import conversation_repo
+
+
 class ConversationService:
     def __init__(self, db: AsyncSession):
         self.db = db
-        self.repo = ConversationRepository()
 
-    async def create(self, data: ConversationCreate, user_id: UUID) -> Conversation:
-        # Business validation
-        return await self.repo.create(self.db, user_id=user_id, **data.model_dump())
+    async def create(self, data: ConversationCreate, ctx: AuthContext) -> Conversation:
+        return await conversation_repo.create_conversation(
+            self.db,
+            organization_id=ctx.organization_id,
+            user_id=ctx.user_id,
+            title=data.title,
+        )
 
-    async def get_or_raise(self, id: UUID) -> Conversation:
-        conv = await self.repo.get_by_id(self.db, id)
-        if not conv:
-            raise NotFoundError(message="Conversation not found", details={"id": id})
-        return conv
+    async def get_conversation(self, conversation_id: UUID, *, organization_id: UUID) -> Conversation:
+        conversation = await conversation_repo.get_conversation_by_id(self.db, conversation_id)
+        missing = NotFoundError(
+            message="Conversation not found",
+            details={"conversation_id": conversation_id},
+        )
+        if not conversation:
+            raise missing
+        if conversation.organization_id != organization_id:
+            raise missing
+        return conversation
 ```
 
-All current services follow this pattern: `UserService`, `ConversationService`,
-`FileUploadService`, `FileStorageService`, `RagDocumentService`, `RagSyncService`, `SyncSourceService`.
+The tenant check raises **the same refusal** as a missing row: "you may not read
+this" tells somebody in another organization that the id exists.
+
+A service holds the session and nothing else - repositories are imported as
+modules rather than instantiated, so there is no per-request object graph to keep
+consistent. Where a domain owns infrastructure of its own (clients, adapters,
+parsers) the service becomes a subpackage exporting one facade:
+`services/rag/`, `services/channels/`, `services/email/`.
 
 ## Repository Layer Pattern
 
@@ -59,28 +84,54 @@ the transaction and commits it once — after the route returns and *before* the
 response is written, which is what makes a 2xx mean the write is readable. See
 [the request's transaction](architecture.md#the-requests-transaction).
 
+A repository is a **module of stateless functions**, not a class - `db` first,
+everything after it keyword-only:
+
 ```python
-class ConversationRepository:
-    async def get_by_id(self, db: AsyncSession, id: UUID) -> Conversation | None:
-        return await db.get(Conversation, id)
+# app/repositories/conversation.py
 
-    async def create(self, db: AsyncSession, **kwargs) -> Conversation:
-        conv = Conversation(**kwargs)
-        db.add(conv)
-        await db.flush()  # Not commit! Let dependency manage transaction
-        await db.refresh(conv)
-        return conv
+async def create_conversation(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    user_id: UUID | None = None,
+    title: str | None = None,
+) -> Conversation:
+    conversation = Conversation(
+        user_id=user_id, organization_id=organization_id, title=title
+    )
+    db.add(conversation)
+    await db.flush()
+    await db.refresh(conversation)
+    return conversation
 
-    async def get_by_user(
-        self, db: AsyncSession, user_id: UUID, skip: int = 0, limit: int = 100
-    ) -> list[Conversation]:
-        result = await db.execute(
-            select(Conversation)
-            .where(Conversation.user_id == user_id)
-            .offset(skip).limit(limit)
-        )
-        return list(result.scalars().all())
+
+async def get_conversations_by_user(
+    db: AsyncSession,
+    user_id: UUID | None = None,
+    *,
+    organization_id: UUID,
+    skip: int = 0,
+    limit: int = 50,
+) -> list[Conversation]:
+    result = await db.execute(
+        select(Conversation)
+        .where(Conversation.organization_id == organization_id)
+        .offset(skip)
+        .limit(limit)
+    )
+    return list(result.scalars().all())
 ```
+
+`organization_id` has no default anywhere in that module, on purpose: every
+conversation belongs to a tenant, and a caller that cannot name one has a bug
+rather than a default.
+
+!!! danger "`flush()`, never `commit()`"
+
+    The request's session commits once. The one sanctioned exception is the agent
+    run path, which commits before the model call and again in its terminal
+    `finally`.
 
 ## Exception Handling
 
@@ -96,7 +147,7 @@ if not conversation:
         details={"id": id}
     )
 
-if await self.repo.exists_by_email(self.db, email):
+if await user_repo.get_by_email(self.db, email):
     raise AlreadyExistsError(
         message="User with this email already exists"
     )
@@ -109,7 +160,14 @@ string form, a `datetime` in ISO 8601, an `Enum` as its value. Money is the
 exception worth knowing: a `Decimal` encodes to a float, so a cost or a cap is
 stringified by the code that raises.
 
-**A refusal describes the refusal, not the server.** Everything in `details` is
+!!! warning "A refusal describes the refusal, not the server"
+
+    Everything in `details` is read by whoever was refused, so it names the
+    field, the id or the resource they can act on - never a filesystem path, an
+    upstream client's exception text, or a setting describing the deployment. The
+    diagnosis is not deleted; it moves to the log line beside the raise.
+
+Everything in `details` is
 read by whoever was refused, so it names the field, the id or the resource they
 can act on - never a filesystem path, an upstream client's exception text, or a
 setting whose value describes the deployment rather than a limit the caller is

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -27,6 +27,22 @@ single source of truth; this page explains it.
     favour of Activity, and `/admin/conversations?user_id=` lists one account's
     threads without opening any of them.
 
+```mermaid
+flowchart TD
+    subgraph L1["Layer 1 · the deployment"]
+        A["<code>users.is_app_admin</code><br/>a boolean outside every organization"]
+    end
+    subgraph L2["Layer 2 · the organization"]
+        B["a row in <code>organization_members</code><br/>carrying a name from <code>OrgRoleName</code>"]
+    end
+    subgraph L3["Layer 3 · one row"]
+        C["<code>resource_grants</code><br/>and a resource's own visibility"]
+    end
+    A -.->|"bypasses, and the audit log is what holds it"| B
+    B -->|"role scope"| E{{"effective access<br/><code>max(role scope, grant)</code>"}}
+    C -->|"grant on that row"| E
+```
+
 ## Layer 1: `users.is_app_admin` - the deployment superadmin
 
 A boolean on the user, entirely outside organizations. Two effects:
@@ -147,7 +163,13 @@ Derived from the catalog rather than from a role name, so a custom role (Phase
 against the literal `"admin"` and could not see one at all - on the invitation
 paths as well as on `change_role`, which is what #696 closed.
 
-**A page's organization is the one in its URL.** `X-Organization-Id` travels on
+!!! warning "A page's organization is the one in its URL"
+
+    `X-Organization-Id` travels on every request from the *active* selection, so
+    a page acting on the organization in its path while reading permissions for
+    the active one decides Acme's members by the caller's role in Globex.
+
+`X-Organization-Id` travels on
 every request from the console and names the *active* organization, so a page
 that acts on an org from its path - `/orgs/{id}/members` - has two notions of
 "which tenant" and the organizations list opens that page without switching. They
@@ -196,18 +218,27 @@ One formula, in `app/services/access.py`:
 effective access to one row = max(role scope, grant on that row)
 ```
 
-**A grant widens what a role allows; it never narrows it.** Sharing one agent
-with a Viewer works without promoting them, and a Builder's org-wide view is not
-taken away by the absence of a grant.
+!!! danger "A grant widens what a role allows; it never narrows it"
+
+    Sharing one agent with a Viewer works without promoting them, and a
+    Builder's org-wide view is not taken away by the absence of a grant.
 
 `resolve_access` in order:
 
-1. No subject in the context → refused. Always, whatever the role says.
-2. `resource.organization_id != ctx.organization_id` → refused. **Tenancy is
-   checked before anything else.**
-3. Does the role's scope alone reach this row? If yes, done - no query.
-4. Only now is `resource_grants` consulted, and the level compared against the
-   minimum the permission requires.
+```mermaid
+flowchart TD
+    S{"a subject in the context?"} -->|no| R1([refused])
+    S -->|yes| T{"same organization<br/>as the row?"}
+    T -->|no| R2([refused])
+    T -->|yes| Sc{"does the role's scope<br/>reach this row?"}
+    Sc -->|yes| Y([allowed — no query])
+    Sc -->|no| G{"a grant on the row,<br/>at or above the level<br/>the permission needs?"}
+    G -->|yes| Y2([allowed])
+    G -->|no| R3([refused])
+```
+
+Tenancy is checked before anything else, and a context with no subject is refused
+whatever its role says.
 
 ### A surface with nobody in front of it
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -169,11 +169,8 @@ paths as well as on `change_role`, which is what #696 closed.
     a page acting on the organization in its path while reading permissions for
     the active one decides Acme's members by the caller's role in Globex.
 
-`X-Organization-Id` travels on
-every request from the console and names the *active* organization, so a page
-that acts on an org from its path - `/orgs/{id}/members` - has two notions of
-"which tenant" and the organizations list opens that page without switching. They
-are one now: the dashboard's `ActiveOrgGuard` adopts the organization a path
+The organizations list opens `/orgs/{id}/members` without switching, so that page
+used to hold two notions of "which tenant". They are one now: the dashboard's `ActiveOrgGuard` adopts the organization a path
 names, before the page asks anything, so what a caller may do there is what they
 may do *there* (#1032).
 

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -290,9 +290,10 @@ memory are the only limits worth setting.
 | `timeout_secs` | 10 | > 0, ≤ 120 |
 | `max_memory_mb` | 256 | 16–4096 |
 
-Capped rather than open-ended, and per agent rather than per deployment: an author
-raising a limit for one data-heavy agent should not need an operator or a
-redeploy.
+!!! info "Per agent, not per deployment"
+
+    An author raising a limit for one data-heavy agent should not need an
+    operator or a redeploy — and the ceilings are capped rather than open-ended.
 
 ## Files & shell
 
@@ -1165,16 +1166,18 @@ files" and "may it read them" are two decisions even though one capability answe
 both, so enabling stays per capability while approving happens per tool. `default`
 follows the capability's own `side_effecting` flag.
 
-`tool_overrides` exists because a tool's description is the highest-leverage
-prompt in the product — it is what the model reads before deciding to call —
-and its name steers just as hard: `search_refund_policy` is not
-`search_documents`. An agent that needs different behaviour from the same tool
-usually needs these reworded, not a second capability written.
+!!! tip "A tool's description is the highest-leverage prompt in the product"
 
-Both are keyed on the tool's **stable id**, never on the name the model sees. That
-is what keeps an approval gate attached to a renamed tool; keying it on the
-visible name would mean a rename silently removes the gate and a side-effecting
-call goes unattended with nothing reporting it. An id no such capability exposes
+    It is what the model reads before deciding to call, and its name steers just
+    as hard: `search_refund_policy` is not `search_documents`. An agent that
+    needs different behaviour from the same tool usually needs these reworded,
+    not a second capability written.
+
+!!! danger "Keyed on the tool's stable id, never on the name the model sees"
+
+    That is what keeps an approval gate attached to a renamed tool. Keying it on
+    the visible name would mean a rename silently removes the gate, and a
+    side-effecting call then goes unattended with nothing reporting it. An id no such capability exposes
 is refused at publish, and so is a name no model could call.
 
 ## Scopes
@@ -1192,18 +1195,21 @@ the agent is assembled:
 | `sandbox:execute` | `sandbox` |
 | `agents:delegate` | `subagents` |
 
-All seven are granted by default today (`DEFAULT_GRANTED_SCOPES` in
-`app/services/agent_registry.py`). Per-organization scope management is
-[roadmap](../ROADMAP.md) work; the check is live and honest in the meantime rather
-than disabled and forgotten.
+!!! note "All seven are granted by default today"
 
-`agents:delegate` is the one worth understanding, because it is *not* the gate on
-who may be delegated to — that is `agents:run`, checked on the publisher against
-each delegate's row. This scope answers a question no permission can: whether this
-**deployment** allows agents to call agents at all. Removing it from that set turns
-delegation off everywhere in one edit, which is what an operator who does not want
-nested runs or fan-out billing needs, and every spec that delegates then says so at
-publish rather than at 3am.
+    `DEFAULT_GRANTED_SCOPES` in `app/services/agent_registry.py`.
+    Per-organization scope management is [roadmap](../ROADMAP.md) work; the check
+    is live and honest in the meantime rather than disabled and forgotten.
+
+!!! warning "`agents:delegate` is not the gate on *who* may be delegated to"
+
+    That is `agents:run`, checked on the publisher against each delegate's row.
+    This scope answers a question no permission can: whether this **deployment**
+    allows agents to call agents at all. Remove it from that set and delegation
+    is off everywhere in one edit.
+
+An operator who does not want nested runs or fan-out billing removes it, and
+every spec that delegates then says so at publish rather than at 3am.
 
 ## What a tool tells the model
 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -14,12 +14,11 @@ organization from another, and how long any of it survives.
 
 Three processes, and the arrangement is the security model:
 
-```
-agenticos_backend  (container)  ──HTTP──▶  agenticos_sandboxd  (container)
-   no docker.sock                             /var/run/docker.sock  ──▶  the host's Docker daemon
-                                                                              │
-                                              a session's container  ◀────────┘
-                                              (a sibling, not a child)
+```mermaid
+flowchart LR
+    B["agenticos_backend<br/><i>no docker.sock</i>"] -->|HTTP + SANDBOXD_TOKEN| S["agenticos_sandboxd<br/><i>holds /var/run/docker.sock</i>"]
+    S -->|start a container| D[["the host's Docker daemon"]]
+    D --> C["a session's container<br/><i>a sibling of sandboxd, not a child</i>"]
 ```
 
 - **The API container holds no Docker socket.** That is the whole reason
@@ -40,16 +39,24 @@ the token in `SANDBOXD_TOKEN`. The other two sandbox backends a spec can name �
 `daytona` and `state` — are a hosted service and a document in Postgres, and
 neither involves any of the above.
 
-**The token is root-equivalent.** Whoever holds it can start containers on that
-host. `make sandbox-token` generates one into `backend/.env` once and leaves it
+!!! danger "The token is root-equivalent"
+
+    Whoever holds it can start containers on that host. Treat it as the Docker
+    socket it sits in front of.
+
+`make sandbox-token` generates one into `backend/.env` once and leaves it
 alone afterwards, because regenerating it orphans every workspace the service is
-currently holding. Treat it as the Docker socket it sits in front of — which is
-also why the service's own dashboard is off (`SANDBOXD_UI_ENABLED: 0`): that page
+currently holding. That is also why the service's own dashboard is off (`SANDBOXD_UI_ENABLED: 0`): that page
 asks a human to paste the token into a browser.
 
 ## A session, and what shares one
 
-**One container per session, never one for everybody.** A session is identified
+!!! abstract "One container per session, never one for everybody"
+
+    What a session's key folds in — scope, organization, backend kind and host —
+    is exactly what decides which runs share a container and a directory.
+
+A session is identified
 by a key the backend derives, and the key is what decides what is shared:
 
 ```
@@ -374,10 +381,13 @@ What remains, stated rather than implied:
    wants that trade.
 3. **A runtime with a network can reach ports published on the host.**
    `docker-compose.yml` publishes Postgres and Redis for local development, with
-   `postgres/postgres`; `docker-compose-prod.yml` publishes neither. So this is a
-   laptop caveat rather than a production one — but it is the cost of giving
-   `workbench` a network, and worth knowing before copying the local file to a
-   shared host.
+   `postgres/postgres`; `docker-compose-prod.yml` publishes neither.
+
+!!! warning "A laptop caveat, but check it before copying the local compose file"
+
+    `docker-compose.yml` publishes Postgres and Redis with `postgres/postgres`,
+    and `workbench` is the one runtime with a network. On a shared host that is
+    reachable from inside a sandbox; `docker-compose-prod.yml` publishes neither.
 
 ## What the file browser shows, and what it leaves out
 
@@ -432,11 +442,15 @@ product's Files panel possible: reading a workspace never starts a container.
 | The record of what was done | `OPERATION_RETENTION_DAYS` 30 | The daily `sandbox-log-sweep` deletes the rows. The files are untouched |
 
 The last row is the library's default and it is deliberate — the notes and scripts
-are the work, and an agent's user expects them next week. The consequence is that
-disk use only grows: nothing sweeps a workspace whose conversation nobody will
-open again. `/tmp` is cleared by a reboot on a laptop; `/var/lib` is not. A
-deployment with a retention policy sets `SANDBOXD_WORKSPACE_TTL` to the number
-that policy says, and the files older than it go.
+are the work, and an agent's user expects them next week.
+
+!!! info "Disk use only grows"
+
+    Nothing sweeps a workspace whose conversation nobody will open again. Set
+    `SANDBOXD_WORKSPACE_TTL` to whatever your retention policy says and the files
+    older than it go.
+
+`/tmp` is cleared by a reboot on a laptop; `/var/lib` is not.
 
 Deleting a conversation purges its workspace through the product, so this is about
 what nobody deletes rather than about what they do.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -222,9 +222,8 @@ uv run agenticos cmd vault-rotate
     - dropping version 1 on a partial rotation makes those rows unreadable.
 
 `vault-rotate` walks every table holding envelopes and moves each row's
-ciphertexts together with its version column, or not at all: a row that fails is
-named and left as it was, and the command exits non-zero so the old key is not
-dropped on a partial rotation. A row holding no envelope but naming a version — a
+ciphertexts together with its version column, or not at all. A row holding no
+envelope but naming a version — a
 connection whose credentials were cleared — has that claim moved to the current
 version too, so the next secret sealed into it lands on a key that still exists. Only the wrapped data key is re-sealed — payloads
 are untouched, which is what makes rotation cheap.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,8 +1,10 @@
 # Secrets and the vault
 
-Every provider key, channel bot token, MCP credential and third-party API key in
-this platform passes through one module, and there is deliberately no second
-mechanism.
+!!! abstract "One module, and deliberately no second mechanism"
+
+    Every provider key, channel bot token, MCP credential and third-party API key
+    in this platform passes through `app/core/vault.py`. Adding a second way to
+    hold a credential at rest is the defect two migrations removed.
 
 That is a decision with history, and it took two rounds to become true. Three
 mechanisms used to hold secrets at rest and only one of them bound a ciphertext to
@@ -38,11 +40,21 @@ Each secret is sealed with its own random data key. That data key is sealed with
 key derived from the master key **and the scope that owns the secret** — an
 organization, or the member a personal connection belongs to.
 
+```mermaid
+flowchart LR
+    M["VAULT_MASTER_KEY<br/><i>version n</i>"] --> K
+    S["the owning scope<br/><i>org id, or member id</i>"] --> K
+    K["derived key"] -->|wraps| D["a random data key<br/><i>one per secret</i>"]
+    D -->|seals| C["the ciphertext<br/><i>+ key_version</i>"]
+```
+
 Two properties follow, and both are the reason for the shape:
 
-**A ciphertext cannot be moved between owners.** Even with full database access, a
-row copied from organization A into organization B fails to unwrap. Tenant
-isolation here is cryptographic, not a `WHERE` clause somebody might forget.
+!!! success "A ciphertext cannot be moved between owners"
+
+    Even with full database access, a row copied from organization A into
+    organization B fails to unwrap. Tenant isolation here is cryptographic, not a
+    `WHERE` clause somebody might forget.
 
 **The master key is rotatable.** It never encrypts a payload directly, only data
 keys, so rotating it re-wraps one small blob per secret instead of re-encrypting
@@ -139,6 +151,11 @@ own key for:
 
 ## What never happens
 
+!!! success "Four guarantees, pinned by tests rather than by convention"
+
+    No plaintext in a response, in a log line, in an audit entry, or in an
+    exported spec - and a capability never learns where its credential came from.
+
 - **No API response returns a plaintext.** There is no endpoint for it. The service
   that owns organization secrets has two readers that yield one, and neither hands it
   to a caller: the runner's, while it builds an agent, and the model catalog's, which
@@ -176,8 +193,12 @@ checkout runs with no extra setup, and the config refuses an unset key anywhere
 except `local`/`development` — staging is a first-class deployment and routinely
 holds real provider keys, so it gets the same refusal production does.
 
-Losing every configured key means every stored credential is unrecoverable and has
-to be re-entered. Rotating is a staged operation, and `VAULT_MASTER_KEYS` is the
+!!! danger "Losing every configured key means every stored credential is gone"
+
+    There is no recovery path and no escrow copy: every secret has to be
+    re-entered by hand. Back the key up somewhere the database backup is not.
+
+Rotating is a staged operation, and `VAULT_MASTER_KEYS` is the
 staged form: a JSON map of every version still in use. The highest version seals
 new secrets; the older ones keep existing rows readable until they are re-wrapped.
 `key_version` on each sealed row records which version wrapped it, and asking for a
@@ -194,6 +215,11 @@ uv run agenticos cmd vault-rotate --dry-run
 uv run agenticos cmd vault-rotate
 # 4. Once it reports zero failures, drop version 1 from VAULT_MASTER_KEYS.
 ```
+
+!!! warning "Do not drop the old key until `vault-rotate` reports zero failures"
+
+    A row that fails is named and left as it was, and the command exits non-zero
+    - dropping version 1 on a partial rotation makes those rows unreadable.
 
 `vault-rotate` walks every table holding envelopes and moves each row's
 ciphertexts together with its version column, or not at all: a row that fails is

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -115,9 +115,7 @@ for anyone holding `skills:edit`:
     Applying twice would bump a version against a body already stored, and
     discarding something applied would tell a reader it never landed.
 
-Applying twice would bump a version against a body already
-stored, and discarding something applied would tell a reader it never landed. The
-proposal carries the whole body rather than a diff, so a reviewer weeks later is
+The proposal carries the whole body rather than a diff, so a reviewer weeks later is
 comparing two complete versions instead of applying a patch somewhere it was never
 meant to go. A directory the agent created with no `SKILL.md` in it, and one whose
 frontmatter it mangled, are both refused rather than guessed at — and a *deleted*

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -11,7 +11,7 @@ conversation out of the window. Skills invert that:
 ```mermaid
 flowchart LR
     A["the agent's context<br/><i>names + one-line descriptions only</i>"] -->|list_skills| B{is one relevant?}
-    B -->|no| Z["nothing loaded, nothing paid for"]
+    B -->|no| Z["no body loaded"]
     B -->|yes| C["load_skill - the body"]
     C --> D{does the body<br/>point at a file?}
     D -->|no| Z2[answer]
@@ -19,7 +19,15 @@ flowchart LR
     E --> Z2
 ```
 
-Twenty skills cost almost nothing; the twenty-first costs nothing either.
+Twenty skills cost roughly twenty descriptions instead of twenty procedures.
+
+!!! note "Discovery is cheap, not free"
+
+    `list_skills` answers with every attached skill's name and description, and
+    that result goes into the next model request — so each skill an agent is
+    bound to does cost tokens on a turn where discovery runs. It is a line per
+    skill against a body per skill, which is why the numbers work; it is not
+    grounds for binding an unbounded catalogue.
 
 The other half of the point is who writes them. A skill is a row in the database,
 editable in the UI, so a support lead can fix the refund policy on a Tuesday

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -6,8 +6,19 @@ out.
 
 The thing it replaces is an instructions field that grows. Twenty procedures in
 one prompt means every run pays for all twenty, and the twenty-first pushes the
-conversation out of the window. Skills invert that: the agent sees only names and
-one-line descriptions until it decides one is relevant, then loads the body.
+conversation out of the window. Skills invert that:
+
+```mermaid
+flowchart LR
+    A["the agent's context<br/><i>names + one-line descriptions only</i>"] -->|list_skills| B{is one relevant?}
+    B -->|no| Z["nothing loaded, nothing paid for"]
+    B -->|yes| C["load_skill - the body"]
+    C --> D{does the body<br/>point at a file?}
+    D -->|no| Z2[answer]
+    D -->|yes| E["read_skill_resource - one file beside it"]
+    E --> Z2
+```
+
 Twenty skills cost almost nothing; the twenty-first costs nothing either.
 
 The other half of the point is who writes them. A skill is a row in the database,
@@ -32,9 +43,10 @@ those before escalating anything.
 ...
 ```
 
-The frontmatter `description` is the only part the model sees for free, so it is
-the field that decides whether the skill is ever loaded. Write it as *when to
-reach for this*, not as a title.
+!!! tip "`description` is the field that decides whether the skill is ever loaded"
+
+    It is the only part the model sees for free. Write it as *when to reach for
+    this*, not as a title.
 
 A skill may carry **resources** — further files beside it, loaded on demand.
 `refund-policy` ships an `exceptions.md`; the body says when to consult it. That is
@@ -98,7 +110,12 @@ for anyone holding `skills:edit`:
   telling somebody something about the skill, and a deleted row makes that
   invisible.
 
-A decision is final: applying twice would bump a version against a body already
+!!! warning "A decision on a proposal is final"
+
+    Applying twice would bump a version against a body already stored, and
+    discarding something applied would tell a reader it never landed.
+
+Applying twice would bump a version against a body already
 stored, and discarding something applied would tell a reader it never landed. The
 proposal carries the whole body rather than a diff, so a reviewer weeks later is
 comparing two complete versions instead of applying a patch somewhere it was never
@@ -127,9 +144,12 @@ matches the shipped library.
 tops itself up: a bundled skill the organization does not have yet is copied in
 the next time anyone opens the page, matched by name so an edited copy is left
 exactly as it is. An organization created before a deployment gained a new
-bundled skill sees it on its next visit rather than never. The consequence to
-know about: deleting a built-in brings it back on the next listing — **disable**
-one to retire it.
+bundled skill sees it on its next visit rather than never.
+
+!!! warning "Deleting a built-in brings it back on the next listing"
+
+    The top-up treats an absent bundled name as a gap to close. **Disable** one
+    to retire it.
 
 The seed command does the same from a terminal, for scripted setups:
 
@@ -179,9 +199,13 @@ wrong one.
 | Cites | Nothing; it *is* the instruction | The passage and its source |
 | Scale | Tens | Thousands of documents |
 
-"Refunds over £500 need a manager" is a skill. The signed contract that says so is
-knowledge. An agent handling refunds usually wants both, and the two capabilities
-compose — `skills` for the procedure, `knowledge` for the evidence.
+!!! example "Which is which"
+
+    "Refunds over £500 need a manager" is a **skill**. The signed contract that
+    says so is **knowledge**. An agent handling refunds usually wants both.
+
+The two capabilities compose — `skills` for the procedure, `knowledge` for the
+evidence.
 
 ## Access
 
@@ -189,9 +213,12 @@ Skills are organization-scoped resources, governed like agents and collections:
 visibility plus per-row grants on top of the role. See
 [Permissions](permissions.md#layer-3-visibility-and-grants).
 
-**Binding a skill lends it.** Every run of the agent reads the body and the files,
-whoever ran it, so publishing an agent whose `skill_ids` name a skill requires the
-*publisher* to hold `skills:view` on that row — through `resolve_access`, so a grant
+!!! important "Binding a skill lends it"
+
+    Every run of the agent reads the body and the files, whoever ran it - so
+    publishing requires the *publisher* to hold `skills:view` on that row.
+
+That check goes through `resolve_access`, so a grant
 counts and a member who was shared one skill can bind it without being promoted.
 A skill they cannot reach is refused as `Skill not found: <id>`, worded identically
 to an id that does not exist: skills are bound by UUID from the API and from a

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,6 +2,11 @@
 
 ## Running Tests
 
+!!! tip "While writing, run what covers the change; the suite is the pre-push gate"
+
+    A file answers in about a second where the suite takes a minute and a half,
+    and says the same thing about the change.
+
 While writing, run what covers the change — a file answers in about a second where
 the suite takes a minute and a half, and says the same thing:
 
@@ -23,8 +28,13 @@ suite is import-bound — every worker imports the app once — and gains nothin
 that, while an uncapped `auto` on a many-core laptop is *slower* than serial, all of
 it worker startup (#520).
 
-**Every run is shuffled**, by `pytest-randomly`, and the header says with what:
-`Using --randomly-seed=1697040112`. An order-dependent test — one that passes only
+!!! warning "Every run is shuffled, and a test that passed yesterday may have been depending on the order"
+
+    `pytest-randomly` prints the seed in the header
+    (`Using --randomly-seed=1697040112`). Replay that seed **serially** to get
+    the same order back - `-n auto` does not fix which worker runs what.
+
+An order-dependent test — one that passes only
 because something before it left state behind — is the classic "green on my laptop,
 red in CI", and a suite that always runs in collection order never asks the question.
 CI asks it in a fresh order every run.
@@ -64,17 +74,23 @@ repeating their commands, and `tests/test_ci_parity.py` fails if a gating job
 grows a step `make check` does not run. It has drifted four times — see
 [Commands](commands.md#before-a-pull-request) for what `check` leaves out and why.
 
-**CI may run fewer jobs than `check` does, and that is not drift.** `test`,
-`test-frontend` and `e2e` are skipped on a pull request whose changed paths cannot
-affect them — a docs-only change runs none of the three, a backend-only change runs
-no frontend suite. What decides is `scripts/ci_changed_scope.py`, it errs towards
-running, and [Branches](branching.md#a-required-check-may-legitimately-report-skipped)
-has the rule and why a `skipped` required check still lets a merge through. Locally
-there is no equivalent: `check` runs everything.
+!!! info "CI may run fewer jobs than `check` does, and that is not drift"
 
-`make test-fast` skips coverage, which makes it the wrong last word before a push:
-the gate is most of what these commands are for. `pytest` without `uv run` picks up
-whatever interpreter is on the path rather than the pinned 3.12.
+    `test`, `test-frontend` and `e2e` are skipped on a pull request whose changed
+    paths cannot affect them, and a `skipped` required check still lets a merge
+    through. Locally there is no equivalent: `check` runs everything.
+
+A docs-only change runs none of the three; a backend-only change runs no frontend
+suite. What decides is `scripts/ci_changed_scope.py`, it errs towards running, and
+[Branches](branching.md#a-required-check-may-legitimately-report-skipped) has the
+rule.
+
+!!! danger "Two ways to push something that has not been verified"
+
+    `make test-fast` skips coverage, which makes it the wrong last word before a
+    push - the gate is most of what these commands are for. And `pytest` without
+    `uv run` picks up whatever interpreter is on the path rather than the pinned
+    3.12.
 
 ## Test Structure
 
@@ -128,6 +144,12 @@ pytestmark = pytest.mark.anyio   # at the top of the module
 or `@pytest.mark.anyio` on the test, which `tests/api/test_users.py` does where
 only some of a file is async. Either works; the module-level form is the habit
 here because most files are async throughout.
+
+!!! warning "`@pytest.mark.asyncio` does not work here, and there is no `asyncio_mode` to make it"
+
+    The suite runs on **anyio**. An unmarked `async def` fails at collection with
+    a message about the framework rather than about the test, so it reads as a
+    broken environment on the way in.
 
 `@pytest.mark.asyncio` does not, and there is no `asyncio_mode` setting to make
 it work: the suite runs on **anyio**. An unmarked `async def` is not a silent
@@ -267,11 +289,17 @@ schema that had no tiebreak at all.
 
 ### What is worth a test here
 
-Most of this platform's value is in what it refuses, so the refusal is the case
-that has to exist: a cross-tenant read (including one where the caller owns the
-row), an ungranted scope, a budget checked *before* the model request and
-recorded even when the run fails, a spec refused at publish rather than at run
-time, and no plaintext secret in any response, log line or audit entry.
+!!! important "Cover the refusal"
+
+    Most of this platform's value is in what it refuses, so the refusal is the
+    case that has to exist:
+
+    - a cross-tenant read — **including one where the caller owns the row**;
+    - an ungranted scope;
+    - a budget checked *before* the model request, and recorded even when the run
+      fails;
+    - a spec refused at publish rather than at run time;
+    - no plaintext secret in any response, log line or audit entry.
 
 `.claude/rules/testing.md` and the `backend-tests` skill carry the rest - the
 traps, the worked examples and the history behind each. This page is the shape of

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,9 +7,6 @@
     A file answers in about a second where the suite takes a minute and a half,
     and says the same thing about the change.
 
-While writing, run what covers the change — a file answers in about a second where
-the suite takes a minute and a half, and says the same thing:
-
 ```bash
 cd backend
 
@@ -151,13 +148,10 @@ here because most files are async throughout.
     a message about the framework rather than about the test, so it reads as a
     broken environment on the way in.
 
-`@pytest.mark.asyncio` does not, and there is no `asyncio_mode` setting to make
-it work: the suite runs on **anyio**. An unmarked `async def` is not a silent
-pass - pytest 9 fails it at collection with *"async def functions are not
-natively supported"* and lists the plugins that would fix it - but it is a
-failure whose message is about the framework rather than about the test, so it
-reads as a broken environment on the way in. The `anyio_backend` fixture pins
-`asyncio`, because that is what uvicorn runs.
+An unmarked `async def` is not a silent pass: pytest 9 fails it at collection
+with *"async def functions are not natively supported"* and lists the plugins
+that would fix it. The `anyio_backend` fixture pins `asyncio`, because that is
+what uvicorn runs.
 
 ## Key Fixtures (`tests/conftest.py`)
 

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -281,10 +281,8 @@ For the `github` source the algorithm is identical; only the header name changes
     every delivery arrives unsigned and is refused `403`. Budget an hour with a
     code step, not five minutes of clicking.
 
-It is tempting to reach for a no-code webhook action in Zapier or Make. Neither has an
-HMAC action: their standard "POST to a webhook" steps send the body but cannot sign it,
-so every delivery arrives unsigned and is refused `403`. You have to add their **code
-step** (Zapier's *Code by Zapier*, Make's *Custom JS / functions* module), compute the
+It is tempting to reach for a no-code webhook action in Zapier or Make. You have
+to add their **code step** (Zapier's *Code by Zapier*, Make's *Custom JS / functions* module), compute the
 `sha256=<hex>` HMAC over the exact body you are about to send, and set the
 `X-Signature-256` header from it.
 

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -60,8 +60,9 @@ flowchart TD
     J -->|no| R400["400"]
     J -->|yes| F{trigger active,<br/>filter matches?}
     F -->|no| R202["202 - nothing to do"]
-    F -->|yes| RUN[the agent runs, spending the org's budget]
-    RUN --> R202b["202"]
+    F -->|yes| SUB["submit a capped Prefect flow"]
+    SUB --> R202b["202 - accepted, not finished"]
+    SUB -.->|later, in the worker| RUN[the agent runs, spending the org's budget]
 ```
 
 - **The URL** is built on the deployment's one public address (`PUBLIC_BASE_URL`), not
@@ -103,6 +104,13 @@ flowchart TD
 A request whose signature does not verify is refused with a `403` before the runner
 is ever reached; the secret is sealed in the [vault](secrets.md) and never appears
 in a read, a listing, or the URL.
+
+!!! info "The `202` means accepted, not finished"
+
+    A matched delivery is submitted as its own `run-scheduled-trigger` flow and
+    the agent runs in the worker, so the provider gets its answer in one fast
+    Prefect call rather than waiting out a model. Do not read a `202` as
+    "the agent has replied" - read the run in Activity for that.
 
 A verified delivery that has nothing to do - an inactive trigger, or a payload the
 filter does not match - answers `202` exactly as a fired one does, so holding the secret

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -51,6 +51,19 @@ An event trigger hands you two things: a **webhook URL** and a **signing secret*
 provider POSTs its payload to the URL and signs the request; the platform recomputes
 the signature and fires the agent only if the two match.
 
+```mermaid
+flowchart TD
+    P[A provider, or your own script] -->|POST + signature header| W["/api/v1/webhooks/triggers/{source}/{id}"]
+    W --> V{signature verifies?}
+    V -->|no| R403["403 - refused before the runner"]
+    V -->|yes| J{a JSON object?}
+    J -->|no| R400["400"]
+    J -->|yes| F{trigger active,<br/>filter matches?}
+    F -->|no| R202["202 - nothing to do"]
+    F -->|yes| RUN[the agent runs, spending the org's budget]
+    RUN --> R202b["202"]
+```
+
 - **The URL** is built on the deployment's one public address (`PUBLIC_BASE_URL`), not
   on the dashboard's origin - the webhook is served by the API host, which is usually a
   different origin from the UI. Its shape is:
@@ -79,13 +92,17 @@ the signature and fires the agent only if the two match.
   A **polled** source signs nothing and holds no secret: it was not addressed, it was
   read, and the account's own OAuth grant is what authorized reading it.
 
-The signature is not decoration. Without it, the URL is the only thing between a stranger
-and your organization's model budget - and URLs leak: into logs, into a provider's
-delivery history, into a screenshot in a support ticket. Anyone who has the URL could
-fire the agent at will and spend against your caps. The secret is what makes a delivery
-*authentic* rather than merely *addressed correctly*. A request whose signature does not
-verify is refused with a `403` before the runner is ever reached; the secret is sealed
-in the [vault](secrets.md) and never appears in a read, a listing, or the URL.
+!!! danger "The signature is not decoration"
+
+    Without it, the URL is the only thing between a stranger and your
+    organization's model budget - and URLs leak: into logs, into a provider's
+    delivery history, into a screenshot in a support ticket. Anyone who has the
+    URL could fire the agent at will and spend against your caps. The secret is
+    what makes a delivery *authentic* rather than merely *addressed correctly*.
+
+A request whose signature does not verify is refused with a `403` before the runner
+is ever reached; the secret is sealed in the [vault](secrets.md) and never appears
+in a read, a listing, or the URL.
 
 A verified delivery that has nothing to do - an inactive trigger, or a payload the
 filter does not match - answers `202` exactly as a fired one does, so holding the secret
@@ -216,47 +233,53 @@ bytes:
   produces different bytes (reordered keys, different spacing). Sign a string and send
   that *same* string.
 
-**curl:**
+=== "curl"
 
-```bash
-SECRET='your-signing-secret'
-URL='https://api.example.com/api/v1/webhooks/triggers/webhook/<trigger_id>'
-BODY='{"hello":"world"}'
+    ```bash
+    SECRET='your-signing-secret'
+    URL='https://api.example.com/api/v1/webhooks/triggers/webhook/<trigger_id>'
+    BODY='{"hello":"world"}'
 
-SIG="sha256=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | sed 's/^.* //')"
+    SIG="sha256=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | sed 's/^.* //')"
 
-curl -sS -X POST "$URL" \
-  -H 'Content-Type: application/json' \
-  -H "X-Signature-256: $SIG" \
-  --data-raw "$BODY"
-```
+    curl -sS -X POST "$URL" \
+      -H 'Content-Type: application/json' \
+      -H "X-Signature-256: $SIG" \
+      --data-raw "$BODY"
+    ```
 
-**Python** (httpx):
+=== "Python (httpx)"
 
-```python
-import hashlib
-import hmac
+    ```python
+    import hashlib
+    import hmac
 
-import httpx
+    import httpx
 
-secret = b"your-signing-secret"
-url = "https://api.example.com/api/v1/webhooks/triggers/webhook/<trigger_id>"
-body = b'{"hello":"world"}'
+    secret = b"your-signing-secret"
+    url = "https://api.example.com/api/v1/webhooks/triggers/webhook/<trigger_id>"
+    body = b'{"hello":"world"}'
 
-signature = "sha256=" + hmac.new(secret, body, hashlib.sha256).hexdigest()
+    signature = "sha256=" + hmac.new(secret, body, hashlib.sha256).hexdigest()
 
-# content=body sends these exact bytes. json=... would re-serialize and sign nothing.
-httpx.post(
-    url,
-    content=body,
-    headers={"Content-Type": "application/json", "X-Signature-256": signature},
-)
-```
+    # content=body sends these exact bytes. json=... would re-serialize and sign nothing.
+    httpx.post(
+        url,
+        content=body,
+        headers={"Content-Type": "application/json", "X-Signature-256": signature},
+    )
+    ```
 
 For the `github` source the algorithm is identical; only the header name changes to
 `X-Hub-Signature-256`.
 
 ## Zapier and Make cannot do this without a code step
+
+!!! warning "Neither has an HMAC action"
+
+    Their standard "POST to a webhook" steps send the body but cannot sign it, so
+    every delivery arrives unsigned and is refused `403`. Budget an hour with a
+    code step, not five minutes of clicking.
 
 It is tempting to reach for a no-code webhook action in Zapier or Make. Neither has an
 HMAC action: their standard "POST to a webhook" steps send the body but cannot sign it,
@@ -270,6 +293,12 @@ five minutes of clicking. If you are only proving the trigger end to end, sign a
 by hand with the snippet above first.
 
 ## Testing locally
+
+!!! tip "Try *Run now* before setting up a provider"
+
+    It fires either kind of trigger once, on demand, with no signature and no
+    webhook involved - the fastest way to confirm the agent, its prompt and its
+    budget behave.
 
 On a laptop `PUBLIC_BASE_URL` defaults to `http://localhost:8000`, so the URL the dialog
 hands you is unreachable from GitHub or any hosted relay - they cannot see your machine.


### PR DESCRIPTION
## What changed

A presentation and correctness pass over **every page of the site** — 25 concept
and reference pages, the 8 Guides, and the 3 reference stubs.

The site was accurate and almost unreadable: 27 pages of unbroken prose, **one**
mermaid diagram between them, **no** content tabs anywhere, ~20 pages with no
callouts at all, and three flows drawn in ASCII that only line up in a monospace
font. The words are mostly unchanged. What changes is what a reader sees before
they start reading.

### Presentation

- **17 mermaid diagrams** where prose or ASCII described a flow: the request path
  and the transaction's ordering, both ingestion pipelines, the three permission
  layers and `resolve_access` as a decision tree, park → decide → resume, the
  sandbox's three processes, a webhook delivery's refusals, the embed handshake,
  choosing a surface, envelope encryption, progressive disclosure, MCP's OAuth
  2.1 handshake, `ai-review`'s three jobs, a sync's six stages, the local dev
  stack.
- **~130 callouts**, each promoting a rule the page already stated in bold prose
  — the ones whose violation costs something: a 2xx means the write is readable,
  a budget is checked before the request, an empty origin list allows nothing,
  the sandbox token is root-equivalent, a signature is the only thing between a
  stranger and your budget, losing every vault key is unrecoverable.
- **Content tabs** where alternatives were stacked vertically: the four platform
  quickstarts in `deploy.md`, curl vs Python in `triggers.md`.
- Prose restructured where it was a table or a list in disguise: the five run
  statuses (`concepts.md`), the production checklist (`configuration.md`), the
  rollback options (`deploy.md`), `first-agent.md`'s six-paragraph "guided way".
- Nine `---` rules that separated nothing, and `deploy.md`'s generator flag list.

### Correctness — what the pass turned up

Four pages were teaching things that are not true here:

- **`patterns.md`** — all three worked examples had drifted off the code. The DI
  example injected `Depends(get_db)` and `Depends(get_current_user)` (neither
  exists; the aliases do, and `DBSession`'s `scope="function"` is load-bearing,
  #353); the repository example was a `ConversationRepository` class, which is
  the one shape `.claude/rules/architecture.md` rules out; the service example
  held `self.repo`, which no service in the codebase does. Replaced with real
  signatures.
- **`howto/customize-agent-prompt.md`** — taught editing `app/agents/prompts.py`
  and overriding `DEFAULT_SYSTEM_PROMPT`, with `get_system_prompt_with_rag()` to
  customise and `AI_TEMPERATURE` in `.env` to tune. None of those exist, and the
  page contradicted the sentence CLAUDE.md calls the whole design. Rewritten
  around the spec and `default_instructions.py`.
- **`howto/add-background-task.md`** — step 2 was
  `asyncio.create_task(send_notification_flow(...))`, which is the shape #417
  was: the task starts before the request commits, so a flow reading its own row
  finds nothing — and it drops the exception too. Now `spawn_after_commit` /
  `spawn`.
- **`howto/add-api-endpoint.md`** was a second, already-diverging copy of
  `adding_features.md`'s walkthrough, and both taught the `self.repo` shape. It
  is now the single copy (`BaseSchema`, `TimestampMixin`, `__repr__`, `-> Any`,
  the `require`/`resolve_access` split); `adding_features.md` points at it.

Plus:

- `configure-sync-sources.md` named `app/rag/connectors/` twice (the package is
  `app/services/rag/connectors/`) and had a dangling "Scheduled syncs require a
  running background task system:" with nothing after the colon.
- `ROADMAP.md` was dated 2026-07-27 and contradicted itself — R12 said the 100%
  gate was not enforced while the Testing section said CI enforces it, and R8/R9
  described features that have shipped. Re-verified each (`fail_under = 100`,
  `org_mcp_connections.py` gated on `connections:manage`, `/e/{publicKey}`), all
  three moved to "Closed since that revision". R10 and R11 re-checked and still
  open.
- `index.md` promised "four nouns" where `concepts.md` has five.
- A dead anchor in `configuration.md` — mkdocs reports those at INFO, so
  `--strict` never caught it.

### The self-inflicted one

Promoting a bold sentence into a callout and leaving the sentence below it makes
a page say everything twice. A detector over every `!!!` block and the four lines
under it found **25** such repeats in my own diff; all are gone — the callout
keeps the claim, the prose keeps only what the callout does not carry, and where
it carried nothing else the prose is deleted.

## How it was verified

`make docs-build` (mkdocs `--strict`) after **every page**, and again at the end:
exit 0, and the one INFO-level dead anchor now fixed. Every symbol, signature,
flag and file path I asserted was checked against `backend/app/` — which is how
the four wrong pages were found in the first place.

Docs-only, so CI runs `lint`, `docs`, `changes` and the security jobs; `test`,
`test-frontend` and `e2e` skip by path scope, which is a pass.

Closes #784
