### PR TITLE
fix(runs): give Activity its room without clipping the sticky panel

### DIFF
--- a/frontend/src/app/[locale]/(dashboard)/runs/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/runs/page.tsx
@@ -14,6 +14,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui";
 import { useApprovals, usePermissions, useRuns, useSpend, useUrlState } from "@/hooks";
 import { periodEnd, periodStart } from "@/lib/dashboard/period";
 import { formatPeriodParam, parsePeriodParam, type Period } from "@/lib/dashboard/period";
+import { PAGE_CLEARANCE } from "@/lib/page-clearance";
 import { parseRunFilters, writeRunFilters, type RunFilters } from "@/lib/runs/filter-params";
 import { cn, setUrlParam } from "@/lib/utils";
 import { Perm } from "@/types/permissions";
@@ -192,6 +193,15 @@ export default function RunsPage() {
                   // underneath the detail panel rather than scrolling inside its
                   // own column.
                   "min-w-0 flex-1 overflow-hidden",
+                  // The room under this page, declared here rather than by
+                  // `PageTransition` - which is where every other page gets it.
+                  // Padding on the box *around* this row shortens what the
+                  // sticky panel beside it may pin in, because a sticky box is
+                  // clamped to its containing block: 64px of it put the panel's
+                  // top at -48px at maximum scroll, cutting its own header off
+                  // by 56px. Inside the column it lands under the last row and
+                  // the row still ends at the viewport (#1206).
+                  PAGE_CLEARANCE,
                   focusedRunId !== null && "hidden lg:block",
                 )}
               >
@@ -257,7 +267,14 @@ export default function RunsPage() {
                 // pixels of nothing to the right of the panel while the table ran
                 // flush to the left edge. Sixteen of those are given back, which
                 // matches the eight above and below.
-                <div className="sticky top-[calc(0.5rem-1rem)] h-[calc(100dvh-1rem)] self-start sm:top-[calc(0.5rem-2rem)] lg:-mr-4">
+                //
+                // The height counts the mobile tab bar below `lg`, where the
+                // list column is hidden and this is the only column: the bar is
+                // `fixed bottom-0`, `min-h-[56px]` plus the safe-area inset, so
+                // a flat `100dvh-1rem` put the panel's last 56px behind it -
+                // measured at 390x780. Above `lg` the bar is `lg:hidden` and the
+                // full height is right.
+                <div className="sticky top-[calc(0.5rem-1rem)] h-[calc(100dvh-1rem-3.5rem-env(safe-area-inset-bottom))] self-start sm:top-[calc(0.5rem-2rem)] lg:-mr-4 lg:h-[calc(100dvh-1rem)]">
                   <RunDetailPanel runId={focusedRunId} onFocusRun={focusRun} />
                 </div>
               )}

--- a/frontend/src/app/[locale]/(dashboard)/runs/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/runs/page.tsx
@@ -268,13 +268,18 @@ export default function RunsPage() {
                 // flush to the left edge. Sixteen of those are given back, which
                 // matches the eight above and below.
                 //
-                // The height counts the mobile tab bar below `lg`, where the
-                // list column is hidden and this is the only column: the bar is
-                // `fixed bottom-0`, `min-h-[56px]` plus the safe-area inset, so
-                // a flat `100dvh-1rem` put the panel's last 56px behind it -
-                // measured at 390x780. Above `lg` the bar is `lg:hidden` and the
-                // full height is right.
-                <div className="sticky top-[calc(0.5rem-1rem)] h-[calc(100dvh-1rem-3.5rem-env(safe-area-inset-bottom))] self-start sm:top-[calc(0.5rem-2rem)] lg:-mr-4 lg:h-[calc(100dvh-1rem)]">
+                // The height counts what is *not* the scrollport below `lg`,
+                // where the list column is hidden and this is the only column.
+                // Two things are, and they come off at different breakpoints:
+                // the tab bar (`fixed bottom-0`, `min-h-[56px]` plus the
+                // safe-area inset, `lg:hidden`) and `MobileHeader` (`h-14`,
+                // sticky but **in normal flow** above `main`, `md:hidden`), which
+                // starts the scrollport 56px down. Measured at 390x780: a flat
+                // `100dvh-1rem` left the panel's last 56px behind the bar, and
+                // subtracting the bar alone left the same 56px, because the
+                // header had not been counted. Both off below `md`, the bar only
+                // from `md`, neither from `lg`.
+                <div className="sticky top-[calc(0.5rem-1rem)] h-[calc(100dvh-1rem-3.5rem-3.5rem-env(safe-area-inset-bottom))] self-start sm:top-[calc(0.5rem-2rem)] md:h-[calc(100dvh-1rem-3.5rem-env(safe-area-inset-bottom))] lg:-mr-4 lg:h-[calc(100dvh-1rem)]">
                   <RunDetailPanel runId={focusedRunId} onFocusRun={focusRun} />
                 </div>
               )}

--- a/frontend/src/app/[locale]/(dashboard)/runs/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/runs/page.tsx
@@ -239,47 +239,46 @@ export default function RunsPage() {
                   and an approval row are both doors to the same view. `?run=`
                   still deep-links here - the page opens with it already out. */}
               {focusedRunId !== null && (
-                // Sticky *and* bounded to the scrollport, which has to be both:
-                // sticky alone left a panel taller than the window hanging past
-                // it, so its own header - the agent, the status, the cost - was
-                // scrolled off above and the timeline had to be scrolled back up
-                // to read. A sticky element taller than the viewport pins at its
-                // top edge and no more.
+                // Sticky *and* bounded to the scrollport, from `lg` only - which
+                // is where there is a second column for it to stay beside. Below
+                // `lg` the list is `hidden` and this is the only column, so
+                // sticky buys nothing and a viewport-height box costs: what is
+                // *not* the scrollport there is the mobile tab bar (`fixed
+                // bottom-0`, 56px plus the safe-area inset) and `MobileHeader`
+                // (`h-14`, in normal flow above `main`), and subtracting both
+                // still left the panel's last 8px behind the bar - measured at
+                // 390x780. So below `lg` it is an ordinary block that scrolls
+                // with the page, carrying the page's own clearance, and there is
+                // no `dvh` arithmetic to get wrong.
                 //
-                // A definite height rather than a cap, because `RunDetailPanel`
-                // is `h-full` over `FocusedRun`'s one scrolling column: with only
-                // a `max-height` the percentage resolves against auto, the chain
-                // grows past the cap and `overflow-hidden` clips the timeline
-                // instead of scrolling it. `dvh` so mobile browser chrome is not
-                // counted twice.
+                // From `lg`: a definite height rather than a cap, because
+                // `RunDetailPanel` is `h-full` over `FocusedRun`'s one scrolling
+                // column - with only a `max-height` the percentage resolves
+                // against auto, the chain grows past the cap and
+                // `overflow-hidden` clips the timeline instead of scrolling it.
+                // `dvh` so browser chrome is not counted twice. A sticky element
+                // taller than the viewport pins at its top edge and no more,
+                // which is what keeps its own header - the agent, the status,
+                // the cost - readable at maximum scroll.
                 //
                 // The offset is negative, and the arithmetic is the point: a
                 // sticky top is measured from the scroll container's *padding*
                 // edge, and `main` carries `pt-4 sm:pt-8`. So a plain `top-4`
                 // pinned the panel 48px down the window while the table's rows
-                // scrolled past above it - the panel read as hanging in the
-                // middle of a moving column. Cancelling that padding and adding
-                // 8px back puts its top edge 8px from the window at either
-                // breakpoint, with nothing scrolling above it.
+                // scrolled past above it. Cancelling that padding and adding 8px
+                // back puts its top edge 8px from the window.
                 //
                 // `-mr-4` is the same trick sideways, and only where there are two
                 // columns: `main`'s `sm:px-6` plus its scrollbar left about forty
                 // pixels of nothing to the right of the panel while the table ran
                 // flush to the left edge. Sixteen of those are given back, which
                 // matches the eight above and below.
-                //
-                // The height counts what is *not* the scrollport below `lg`,
-                // where the list column is hidden and this is the only column.
-                // Two things are, and they come off at different breakpoints:
-                // the tab bar (`fixed bottom-0`, `min-h-[56px]` plus the
-                // safe-area inset, `lg:hidden`) and `MobileHeader` (`h-14`,
-                // sticky but **in normal flow** above `main`, `md:hidden`), which
-                // starts the scrollport 56px down. Measured at 390x780: a flat
-                // `100dvh-1rem` left the panel's last 56px behind the bar, and
-                // subtracting the bar alone left the same 56px, because the
-                // header had not been counted. Both off below `md`, the bar only
-                // from `md`, neither from `lg`.
-                <div className="sticky top-[calc(0.5rem-1rem)] h-[calc(100dvh-1rem-3.5rem-3.5rem-env(safe-area-inset-bottom))] self-start sm:top-[calc(0.5rem-2rem)] md:h-[calc(100dvh-1rem-3.5rem-env(safe-area-inset-bottom))] lg:-mr-4 lg:h-[calc(100dvh-1rem)]">
+                <div
+                  className={cn(
+                    PAGE_CLEARANCE,
+                    "lg:sticky lg:top-[calc(0.5rem-2rem)] lg:-mr-4 lg:h-[calc(100dvh-1rem)] lg:self-start lg:pb-0",
+                  )}
+                >
                   <RunDetailPanel runId={focusedRunId} onFocusRun={focusRun} />
                 </div>
               )}

--- a/frontend/src/components/layout/page-transition.test.tsx
+++ b/frontend/src/components/layout/page-transition.test.tsx
@@ -52,15 +52,26 @@ describe("the page transition wrapper", () => {
     expect(rootClasses("/en/chat")).not.toContain("pb-");
   });
 
-  it("constrains Activity too, where the list and the run detail scroll apart", () => {
-    // Two columns, each with its own scroll: the table keeps its column headers
-    // and the run detail keeps its own header, which is only true while neither
-    // of them is scrolling the page.
-    expect(rootClasses("/en/runs")).toContain("min-h-0");
+  it("does not constrain Activity, which has been an ordinary scrolling page since #914", () => {
+    // The run detail is `sticky` inside the page's own scroll, not a pane with a
+    // scrollbar of its own - the page's root says so (`flex flex-col`). This
+    // test asserted the opposite, which was true before the page was rebuilt.
+    expect(rootClasses("/en/runs")).not.toContain("min-h-0");
+  });
+
+  it("leaves Activity to place its own room, because a sticky panel is clamped to it", () => {
+    // Padding on this box shortens the containing block the run detail may pin
+    // in: 64px of it put the panel's top at -48px at maximum scroll and cut its
+    // own header off by 56px, measured at 1440x800 in Chromium. Activity
+    // declares `PAGE_CLEARANCE` on its list column instead, where it lands under
+    // the last row and the row itself still ends at the viewport (#1206).
+    expect(rootClasses("/en/runs")).not.toContain("pb-");
   });
 
   it("does not mistake a route that merely starts with a constrained one", () => {
     expect(rootClasses("/en/chatty")).not.toContain("min-h-0");
     expect(rootClasses("/en/runsomething")).not.toContain("min-h-0");
+    // And it gets the room, which the prefix match would have taken away.
+    expect(rootClasses("/en/runsomething")).toContain(PAGE_CLEARANCE);
   });
 });

--- a/frontend/src/components/layout/page-transition.tsx
+++ b/frontend/src/components/layout/page-transition.tsx
@@ -5,33 +5,52 @@ import { usePathname } from "next/navigation";
 import { PAGE_CLEARANCE } from "@/lib/page-clearance";
 import { cn } from "@/lib/utils";
 
-/** Routes that scroll inside their own panes, not in `main`. */
-const FULL_HEIGHT_ROUTES = /\/(?:chat|runs)(?:\/|$)/;
+/**
+ * Routes that scroll inside their own panes, not in `main`.
+ *
+ * `min-h-0` is what stops this box growing with its content, so the pane below
+ * it scrolls instead of the page. Chat needs the constrained chain: a flex
+ * item's `min-height: 0` is a floor, not a ceiling, so the chat page setting it
+ * on its own root does NOT stop this box's min-content from growing to the
+ * transcript's height.
+ */
+const OWN_SCROLL_PANE = /\/chat(?:\/|$)/;
+
+/**
+ * Routes that place their own room under themselves, lower down.
+ *
+ * Two routes, for two different reasons, and both are about something that has
+ * to reach the bottom edge of the viewport:
+ *
+ * - **`/chat`**, whose composer belongs on that edge. Room beneath a fixed
+ *   control is a gap under it, so the page takes none at all.
+ * - **`/runs`**, whose run detail is `sticky` beside the list. A sticky box is
+ *   clamped to its containing block, so padding *below* that block shortens the
+ *   scrollport the panel may pin in: 64px of it put the panel's top at -48px at
+ *   maximum scroll and cut its own header off by 56px (#1206). Activity declares
+ *   the same `PAGE_CLEARANCE` one level in, on the list column, where it lands
+ *   under the last row and leaves the row itself ending at the viewport.
+ */
+const OWN_BOTTOM_ROOM = /\/(?:chat|runs)(?:\/|$)/;
 
 export function PageTransition({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
-  const constrained = FULL_HEIGHT_ROUTES.test(pathname);
 
   return (
-    // `min-h-0` only on full-height routes. Chat needs the constrained chain:
-    // a flex item's `min-height: 0` is a floor, not a ceiling, so the chat
-    // page setting it on its own root does NOT stop this box's min-content
-    // from growing to the transcript's height - without `min-h-0` here the
-    // whole page scrolls instead of the message pane.
-    //
-    // Everywhere else it stays off, and that is what makes this the one place
-    // the room under a page can be declared. `main` scrolls, but `main` is not
-    // where its own bottom padding lands: `DeploymentGate` wraps this in a
-    // `min-h-0 flex-1` box, so a long page overflows that box and `main`'s
-    // padding edge stays where the shorter box ended - buried mid-content,
-    // measured at 0px below the last card at every width (#933). This box grows
-    // with its content, so padding here is painted after the last element.
-    //
-    // Not on the constrained branch: chat's composer belongs on the bottom
-    // edge, and room beneath it would be a gap under a fixed control.
+    // Everywhere else the room under a page is declared here, and this is the
+    // one place it paints: `main` scrolls, but `main` is not where its own
+    // bottom padding lands - `DeploymentGate` wraps this in a `min-h-0 flex-1`
+    // box, so a long page overflows that box and `main`'s padding edge stays
+    // where the shorter box ended, buried mid-content and measured at 0px below
+    // the last card at every width (#933). This box grows with its content, so
+    // padding here is painted after the last element.
     <div
       key={pathname}
-      className={cn("page-enter flex flex-1 flex-col", constrained ? "min-h-0" : PAGE_CLEARANCE)}
+      className={cn(
+        "page-enter flex flex-1 flex-col",
+        OWN_SCROLL_PANE.test(pathname) && "min-h-0",
+        !OWN_BOTTOM_ROOM.test(pathname) && PAGE_CLEARANCE,
+      )}
     >
       {children}
     </div>


### PR DESCRIPTION
## The defect

`/runs` had **0px** under its last run row where every other list page gets 64px,
because it was in `FULL_HEIGHT_ROUTES` — so `PageTransition` gave it `min-h-0`
and withheld `PAGE_CLEARANCE`.

It stopped being a full-height route in #914. The page's root is
`<div className="flex flex-col">`, an ordinary scrolling page, and the run detail
is `sticky` inside the page's own scroll rather than a pane with a scrollbar of
its own. One regex was answering two different questions on its behalf.

## The fix, and why it is not a one-character one

Splitting the two questions:

- **`OWN_SCROLL_PANE`** — `/chat` alone. It needs the constrained chain so the
  transcript scrolls instead of the page.
- **`OWN_BOTTOM_ROOM`** — `/chat` and `/runs`. Both have something that has to
  reach the bottom edge of the viewport.

Activity then declares the same `PAGE_CLEARANCE` one level in, on its **list
column**, and that placement is the whole point: padding on the box *around* the
two-column row shortens the containing block the sticky panel is clamped to, so
the obvious fix trades one defect for a worse one.

Measured at 1440x800 in Chromium, against a transcription of the page's own chain
(`main` / `DeploymentGate` / `PageTransition` / the `items-start` row), scrolled
to the end:

| arrangement | room below last row | panel top | panel header |
|---|---|---|---|
| today (`/runs` constrained) | **0px** | 8px | visible |
| room on the outer box | 64px | **-48px** | cut off by 56px |
| room on the list column — **this PR** | **64px** | **8px** | **visible** |

The -48px reproduces the figure in the issue exactly. Inside the column the
padding lands under the last row while the row itself still ends at the viewport,
so the panel keeps its full height and pins 8px from the window top.

## Also fixed, found while measuring

Below `lg` the list column is `hidden` and the panel is the only column, so its
flat `h-[calc(100dvh-1rem)]` put its **last 56px behind the mobile tab bar** —
`fixed bottom-0`, `min-h-[56px]` plus the safe-area inset. Measured at 390x780:
56px hidden before, 8px clear after, which matches the 8px it already keeps at
the top. The full height stays above `lg`, where the bar is `lg:hidden`.

Same element, two lines, measured — so it is here rather than in a second PR.

## The test that was asserting the old reason

`page-transition.test.tsx` said *"constrains Activity too, where the list and the
run detail scroll apart"* — true before the page was rebuilt, false since. It now
asserts both halves of what is true: no `min-h-0`, and no `pb-` either. The
prefix-match case also checks `/runsomething` still **gets** the room.

## Verified

- `bunx vitest run` over the layout and runs specs — 36 files, 309 tests
- `make lint-frontend`
- `make test-frontend-cov` — 100% statements/lines/functions, 97.7% branches
- `make build-frontend`

## Note for #120

`PAGE_CLEARANCE` and the mobile bar's geometry are both touched here. #120 works
the same shell; whichever lands second should read this diff first.

Closes #1206
