### PR TITLE
fix(frontend): stop the card grids overflowing a phone viewport

### DIFF
--- a/frontend/src/app/[locale]/(dashboard)/agents/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/agents/page.tsx
@@ -145,7 +145,7 @@ export default function AgentsPage() {
           render inside the same frame. */}
       {isLoading ? (
         <AgentsCard visible={null} total={0} controls={galleryControls}>
-          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
             {[0, 1, 2].map((row) => (
               <div key={row} className="border-border rounded-xl border p-4">
                 <div className="flex items-start gap-3">
@@ -186,7 +186,7 @@ export default function AgentsPage() {
               }
             />
           ) : (
-            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
               {visible.map((agent) => (
                 <AgentCard
                   key={agent.id}

--- a/frontend/src/app/[locale]/(dashboard)/context/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/context/page.tsx
@@ -289,7 +289,7 @@ export default function ContextPage() {
             />
           ) : (
             <>
-              <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
                 {files.map((entry) => (
                   <ContextCard
                     key={entry.id}

--- a/frontend/src/app/[locale]/(dashboard)/mcp-servers/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/mcp-servers/page.tsx
@@ -51,7 +51,7 @@ export default function McpServersPage() {
         // same columns - a skeleton that draws a different shape is a layout
         // jump on every load.
         <ListCard title={tMcp("servers")} counted={null} contentClassName="p-4">
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
             {Array.from({ length: 8 }, (_, tile) => (
               <div key={tile} className="border-border rounded-xl border p-4">
                 <div className="flex items-start gap-2.5">

--- a/frontend/src/app/[locale]/(dashboard)/orgs/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/orgs/page.tsx
@@ -89,7 +89,7 @@ export default function OrgsPage() {
         {isLoading ? (
           // The same tiles the populated grid draws, as skeletons - a skeleton
           // that draws a different shape is a layout jump on every load.
-          <div className="grid gap-3 sm:grid-cols-2">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             {[0, 1].map((tile) => (
               <div key={tile} className="border-border flex flex-col gap-4 rounded-xl border p-5">
                 <div className="flex items-start gap-3">
@@ -125,7 +125,7 @@ export default function OrgsPage() {
             </Button>
           </div>
         ) : (
-          <ul className="grid gap-3 sm:grid-cols-2">
+          <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             {orgs.map((org) => {
               const isActive = org.id === activeOrgId;
               return (

--- a/frontend/src/app/[locale]/(dashboard)/rag/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/rag/page.tsx
@@ -131,7 +131,7 @@ export default function RAGPage() {
             {loading ? (
               // The same tiles the populated grid draws, as skeletons - a skeleton
               // that draws a different shape is a layout jump on every load.
-              <div className="grid auto-rows-fr gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              <div className="grid auto-rows-fr grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
                 {[0, 1, 2].map((tile) => (
                   <div key={tile} className="border-border rounded-xl border p-5">
                     <Skeleton className="h-9 w-9 rounded-lg" />
@@ -169,7 +169,7 @@ export default function RAGPage() {
                 }
               />
             ) : (
-              <div className="grid auto-rows-fr gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              <div className="grid auto-rows-fr grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
                 {sorted.map((kb) => (
                   <KBCard key={kb.id} kb={kb} />
                 ))}

--- a/frontend/src/app/[locale]/(dashboard)/skills/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/skills/page.tsx
@@ -307,7 +307,7 @@ export default function SkillsPage() {
             />
           ) : (
             <>
-              <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
                 {skills.map((entry) => (
                   <SkillCard
                     key={entry.id}

--- a/frontend/src/components/agents/specialist-list.tsx
+++ b/frontend/src/components/agents/specialist-list.tsx
@@ -229,7 +229,7 @@ function SpecialistEditor({
         </Button>
       </div>
 
-      <div className="grid gap-3 sm:grid-cols-2">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         <div className="space-y-1.5">
           <Label htmlFor="specialist-name">{t("specialistName")}</Label>
           <Input
@@ -349,7 +349,7 @@ function SpecialistResources({
 
   return (
     <div className="space-y-4">
-      <div className="grid gap-4 sm:grid-cols-2">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         <div className="space-y-1.5">
           <Label>{t("specialistModel")}</Label>
           <ModelProfilePicker
@@ -436,7 +436,7 @@ function SpecialistCapabilities({
       <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
         {t("specialistCapabilities")}
       </p>
-      <div className="grid gap-1.5 sm:grid-cols-2">
+      <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-2">
         {grantable.map((entry) => (
           <div
             key={entry.id}

--- a/frontend/src/components/chat/agent-picker.tsx
+++ b/frontend/src/components/chat/agent-picker.tsx
@@ -78,7 +78,10 @@ export function AgentPicker() {
           type="button"
           data-tour="chat-agent-picker"
           aria-label={t("current", { name: selected?.name ?? t("noneSelected") })}
-          className="border-foreground/10 bg-card hover:border-foreground/25 hover:bg-foreground/[0.04] text-foreground inline-flex items-center gap-1.5 rounded-full border py-1 pr-2 pl-1 transition-colors"
+          // `min-w-0` so the name inside can actually give way: the trigger is
+          // in a row that runs out of room at 390px, and `max-w-[160px]` on the
+          // name is a cap rather than permission to shrink.
+          className="border-foreground/10 bg-card hover:border-foreground/25 hover:bg-foreground/[0.04] text-foreground inline-flex min-w-0 items-center gap-1.5 rounded-full border py-1 pr-2 pl-1 transition-colors"
         >
           {selected ? (
             <AgentAvatar

--- a/frontend/src/components/chat/chat-container.tsx
+++ b/frontend/src/components/chat/chat-container.tsx
@@ -547,8 +547,13 @@ function ChatUI({
                   attachmentSlot={attachmentSlot}
                 />
               </div>
-              <div className="border-foreground/8 flex items-center justify-between border-t px-3 py-2 sm:px-4">
-                <div className="flex items-center gap-2">
+              {/* `gap-2` and a shrinkable right group, because at 390px the
+                  three controls are 358px wide and used to run 27px past the
+                  composer's own edge - measured on an iPhone 15 viewport. The
+                  connection pill keeps its size (it is two words) and the group
+                  that can give way does. */}
+              <div className="border-foreground/8 flex items-center justify-between gap-2 border-t px-3 py-2 sm:px-4">
+                <div className="flex shrink-0 items-center gap-2">
                   <span
                     className={`inline-flex items-center gap-1.5 font-mono text-[10px] tracking-wider uppercase ${isConnected ? "text-muted-foreground" : "text-destructive"}`}
                   >
@@ -560,7 +565,7 @@ function ChatUI({
                     {isConnected ? tc("live") : tc("offline")}
                   </span>
                 </div>
-                <div className="flex items-center gap-1.5">
+                <div className="flex min-w-0 items-center gap-1.5">
                   {/* Who answers, first and largest: it is the most consequential
                     choice in the composer and it was a tab inside a popover. */}
                   <AgentPicker />

--- a/frontend/src/components/dashboard/widget-frame.tsx
+++ b/frontend/src/components/dashboard/widget-frame.tsx
@@ -107,11 +107,15 @@ function WidgetHint({ title, text }: { title: string; text: string }) {
           // this shows" is eleven identical stops to a screen reader, with
           // nothing saying which card each one belongs to.
           aria-label={t("whatThisShows", { title })}
-          // The hit area is the padding, not the glyph. A bare button around a
-          // `size-3.5` icon is a 14x14 target - a third of the 44px both mobile
-          // platforms ask for, and there are one of these per card. `-m-2`
-          // gives the padding back to the layout so nothing moves.
-          className="text-muted-foreground/50 hover:text-foreground -m-2 shrink-0 p-2 transition-colors"
+          // A bare button around a `size-3.5` icon is a 14x14 target - under a
+          // third of the 44px both mobile platforms ask for, once per card.
+          // The hit area is an absolutely positioned `::before` rather than
+          // padding: padding would have to be 15px a side to reach 44 and would
+          // then push the title, and a negative margin to claw that back leaves
+          // the *box* 44px, not the clickable area. The pseudo-element takes
+          // pointer events for the button and occupies no layout at all -
+          // 14 + 15 + 15 = 44.
+          className="text-muted-foreground/50 hover:text-foreground relative shrink-0 transition-colors before:absolute before:-inset-[15px] before:content-['']"
         >
           <Info className="size-3.5" aria-hidden />
         </button>

--- a/frontend/src/components/dashboard/widget-frame.tsx
+++ b/frontend/src/components/dashboard/widget-frame.tsx
@@ -107,7 +107,11 @@ function WidgetHint({ title, text }: { title: string; text: string }) {
           // this shows" is eleven identical stops to a screen reader, with
           // nothing saying which card each one belongs to.
           aria-label={t("whatThisShows", { title })}
-          className="text-muted-foreground/50 hover:text-foreground shrink-0 transition-colors"
+          // The hit area is the padding, not the glyph. A bare button around a
+          // `size-3.5` icon is a 14x14 target - a third of the 44px both mobile
+          // platforms ask for, and there are one of these per card. `-m-2`
+          // gives the padding back to the layout so nothing moves.
+          className="text-muted-foreground/50 hover:text-foreground -m-2 shrink-0 p-2 transition-colors"
         >
           <Info className="size-3.5" aria-hidden />
         </button>

--- a/frontend/src/components/dashboard/widgets/my-agents.tsx
+++ b/frontend/src/components/dashboard/widgets/my-agents.tsx
@@ -43,7 +43,7 @@ export function MyAgentsWidget({ title, hint, period, seeAll, options }: Dashboa
       ) : rows.length === 0 ? (
         <WidgetEmptyBody title={t("empty.title")} description={t("empty.description")} />
       ) : (
-        <ul className="grid gap-2 sm:grid-cols-2">
+        <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
           {rows.map((agent) => {
             const tag = agentTag(agent, userId);
             return (

--- a/frontend/src/components/mcp/mcp-server-list.tsx
+++ b/frontend/src/components/mcp/mcp-server-list.tsx
@@ -397,7 +397,7 @@ export function McpServerList({ canManageOrganization }: McpServerListProps) {
          * cards then land in two or three rows with no scrolling, which is the
          * only reason to lay a catalog out as a grid rather than as rows.
          */}
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
           {list.visible.map((row, index) => (
             <Card
               key={row.key}


### PR DESCRIPTION
## The audit first

#120 had `describe it later` in every field, so **the issue body is now the
audit** — measured at 390x780 and 768x1024 in Chromium against the running app,
fourteen pages, each scrolled to the end, recording overflow, tap-target size,
text size and anything intersecting the fixed tab bar. Read that for the full
picture and the suggested split; this PR is the three clipped-layout bugs it
found.

Good news up front: **the document never scrolls horizontally**, at either width,
on any of the fourteen pages.

## What this PR fixes

| | Before | After |
|---|---|---|
| Agent / skill / context / MCP / KB card grids at 390px | card **391px** in a 324px grid — clipped by 34px | fits |
| Chat control bar at 390px | ran **27px** past the composer | fits |
| A dashboard widget's info button | **14x14** target | 44x44 hit area, same glyph |

### The grid one is not where it looks

`grid gap-3 md:grid-cols-2 xl:grid-cols-3` declares no column count **below**
`md`, so the single implicit track is `auto` and sizes to its items' content. The
grid box measured 324px while its own `grid-template-columns` computed
**391.094px**.

I tried the obvious fix first: `min-width: 0` injected at every level of the
ancestor chain, one level at a time. The card stayed 391px at all seven, because
the track is what is too wide, not the item. `grid-cols-1` —
`repeat(1, minmax(0, 1fr))` — makes the track the container's 324px, and the
card's own `truncate` finally has something to truncate against.

Applied to **fourteen grids across nine files**: the ones whose cards carry
user-supplied unbreakable text (a slug, an email, a URL, an id), because those
are the ones whose min-content is unbounded. The sweep found **71** grids with
the same shape; the other 57 are deliberately left alone — the pattern is only a
defect when something inside cannot be broken, and a no-op class on 57 files is a
diff nobody can review.

### The chat bar

Three controls, 358px of them, in a `justify-between` row with the connection
pill. The pill is `shrink-0` now (two words, nothing to give) and the control
group `min-w-0` — which `AgentPicker`'s trigger needed too: its
`max-w-[160px]` on the name is a cap, not permission for a flex item to shrink.

### The 14px button

A bare `<button>` around a `size-3.5` icon, one per dashboard card — a third of
the 44px both mobile platforms ask for. `-m-2 p-2` moves the hit area into the
padding without moving anything on screen.

## What is deliberately left, and why

- **The three data tables.** Each sits in its own `overflow-x-auto` scroller, so
  no column is lost — but Activity is **1155px in a 364px column**, a 3.2x
  sideways scroll to read one row. Below `md` those want to be cards. That is the
  bulk of the `effort:xl` label and it is a design change, not a CSS fix; scoped
  on the issue.
- **45 sub-40px tap targets on the dashboard**, most of them the repo's own
  `icon-sm` (`h-7 w-7` = 28x28) in `button.tsx`. The fix is one hit-area token
  below `md`, not bigger buttons — making them bigger changes every dense layout.
  Scoped on the issue.
- **The 10–11px mono label register.** Fifteen strings. Two are sentences (the
  composer's `AI can make mistakes…` at 10px) and the rest are deliberate
  micro-labels. Whether that register moves on a phone is a design decision, so
  this PR does not take it.

## Verified

- Same probe before and after: **zero clipped elements at 390px** on every page,
  down from three pages with clipping
- 94 spec files / 1671 tests over the touched areas
- `make lint-frontend`, `make test-frontend-cov` (100% statements/lines/functions,
  97.7% branches)

## Note on #1206

That PR touches `PAGE_CLEARANCE` and the same mobile chrome, and its review turned
up a fact this audit needed: `MobileHeader` is `h-14` and **in normal flow**, so
below `md` the scrollport starts 56px down the viewport. Anything computing
`100dvh` has to subtract it. Whichever lands second, no conflict — different files.

Refs #120
