### PR TITLE
fix(rag): run LocalFileStorage.delete off the event loop

### DIFF
--- a/backend/app/core/blocking.py
+++ b/backend/app/core/blocking.py
@@ -143,3 +143,35 @@ async def _discard(future: asyncio.Future[Any], path: Path) -> None:
         await future
     with contextlib.suppress(FileNotFoundError, OSError):
         await run_blocking(path.unlink)
+
+
+async def delete_cancel_safe(fn: Callable[..., None], *args: object) -> None:
+    """Run a blocking delete on the file pool, letting it finish if cancelled.
+
+    An executor cannot interrupt a running unlink, so a task cancelled mid-delete
+    would unwind while the file is still being removed - and the caller's
+    follow-up (save the replacement, update the row) is skipped, leaving the old
+    file gone and the record pointing at it. The delete is shielded so it runs to
+    completion before the cancellation propagates: the mirror of
+    `write_bytes_cancel_safe`, which restores the atomicity a plain sync unlink on
+    the loop had before the offload (#1108, #1294).
+    """
+    future = asyncio.wrap_future(await _submit(fn, *args))
+    try:
+        await asyncio.shield(future)
+    except asyncio.CancelledError:
+        # A second cancellation - a cancelled request whose loop then begins
+        # shutting down - would raise straight out and detach the drain, unwinding
+        # before the unlink finishes. So the drain is a task, and cancellations
+        # arriving while it runs are absorbed until it has completed.
+        drain = asyncio.ensure_future(_drain(future))
+        while not drain.done():
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.shield(drain)
+        raise
+
+
+async def _drain(future: asyncio.Future[Any]) -> None:
+    """Let the uninterruptible unlink finish; its own error is not the caller's."""
+    with contextlib.suppress(Exception):
+        await future

--- a/backend/app/services/file_storage.py
+++ b/backend/app/services/file_storage.py
@@ -225,6 +225,17 @@ class LocalFileStorage(BaseFileStorage):
         return await run_blocking(file_path.read_bytes)
 
     async def delete(self, storage_path: str) -> None:
+        await run_blocking(self._delete_blocking, storage_path)
+
+    def _delete_blocking(self, storage_path: str) -> None:
+        """The blocking half of :meth:`delete`, run on the file pool.
+
+        `realpath`, `exists` and `unlink` are each blocking syscalls with no
+        yield point, so a bulk teardown that unlinked a whole collection ran
+        them all in one loop turn, stalling every other request on the worker
+        (#1294). Off the loop, the per-file await also lets the teardown loops
+        interleave.
+        """
         file_path = self._resolve_safe_path(storage_path)
         if file_path.exists():
             file_path.unlink()

--- a/backend/app/services/file_storage.py
+++ b/backend/app/services/file_storage.py
@@ -11,7 +11,7 @@ import uuid
 from abc import ABC, abstractmethod
 from pathlib import Path
 
-from app.core.blocking import run_blocking, write_bytes_cancel_safe
+from app.core.blocking import delete_cancel_safe, run_blocking, write_bytes_cancel_safe
 from app.core.config import settings
 
 logger = logging.getLogger(__name__)
@@ -225,20 +225,23 @@ class LocalFileStorage(BaseFileStorage):
         return await run_blocking(file_path.read_bytes)
 
     async def delete(self, storage_path: str) -> None:
-        await run_blocking(self._delete_blocking, storage_path)
+        await delete_cancel_safe(self._delete_blocking, storage_path)
 
     def _delete_blocking(self, storage_path: str) -> None:
         """The blocking half of :meth:`delete`, run on the file pool.
 
-        `realpath`, `exists` and `unlink` are each blocking syscalls with no
-        yield point, so a bulk teardown that unlinked a whole collection ran
-        them all in one loop turn, stalling every other request on the worker
-        (#1294). Off the loop, the per-file await also lets the teardown loops
-        interleave.
+        `realpath` and `unlink` are blocking syscalls with no yield point, so a
+        bulk teardown that unlinked a whole collection ran them all in one loop
+        turn, stalling every other request on the worker (#1294). Off the loop,
+        the per-file await also lets the teardown loops interleave.
+
+        `missing_ok=True` rather than a check-then-unlink: two coroutines
+        deleting one path now run on separate pool workers, so a guarded unlink
+        would let both see the file, then one succeed and the other raise
+        `FileNotFoundError`. The teardown loops call `delete` best-effort, so a
+        path another path already removed must be a no-op.
         """
-        file_path = self._resolve_safe_path(storage_path)
-        if file_path.exists():
-            file_path.unlink()
+        self._resolve_safe_path(storage_path).unlink(missing_ok=True)
 
     def get_full_path(self, storage_path: str) -> Path | None:
         """Return absolute filesystem path for local files."""

--- a/backend/tests/test_blocking_io_offload.py
+++ b/backend/tests/test_blocking_io_offload.py
@@ -92,10 +92,3 @@ async def test_deleting_from_local_storage_runs_off_the_request_loop(
     await storage.delete(stored)
     assert ran_on and ran_on[0] != loop_thread
     assert not (tmp_path / "media" / stored).exists()
-
-
-async def test_deleting_a_missing_file_is_a_no_op(tmp_path: Path) -> None:
-    """`delete` tolerates a path already gone - the teardown loops call it
-    best-effort and must not raise on a file another path removed first."""
-    storage = LocalFileStorage(base_dir=tmp_path / "media")
-    await storage.delete("u1/never-written.bin")

--- a/backend/tests/test_blocking_io_offload.py
+++ b/backend/tests/test_blocking_io_offload.py
@@ -70,3 +70,32 @@ async def test_loading_from_local_storage_runs_off_the_request_loop(
 
     assert await storage.load(stored) == b"payload"
     assert ran_on and ran_on[0] != loop_thread
+
+
+async def test_deleting_from_local_storage_runs_off_the_request_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bulk teardown unlinks one file per call, so the unlink must not run on
+    the loop - a dropped collection would otherwise stall the worker (#1294)."""
+    storage = LocalFileStorage(base_dir=tmp_path / "media")
+    stored = await storage.save("u1", "report.bin", b"payload")
+    loop_thread = threading.get_ident()
+    ran_on: list[int] = []
+    real_unlink = Path.unlink
+
+    def recording(self: Path, *args: object, **kwargs: object) -> None:
+        ran_on.append(threading.get_ident())
+        real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", recording)
+
+    await storage.delete(stored)
+    assert ran_on and ran_on[0] != loop_thread
+    assert not (tmp_path / "media" / stored).exists()
+
+
+async def test_deleting_a_missing_file_is_a_no_op(tmp_path: Path) -> None:
+    """`delete` tolerates a path already gone - the teardown loops call it
+    best-effort and must not raise on a file another path removed first."""
+    storage = LocalFileStorage(base_dir=tmp_path / "media")
+    await storage.delete("u1/never-written.bin")

--- a/backend/tests/test_file_offload_hardening.py
+++ b/backend/tests/test_file_offload_hardening.py
@@ -78,6 +78,83 @@ async def test_a_save_cancelled_before_it_runs_creates_nothing(tmp_path: Path) -
     assert [p for p in tmp_path.rglob("*") if p.is_file()] == []
 
 
+async def test_an_uncancelled_delete_removes_the_file(tmp_path: Path) -> None:
+    storage = LocalFileStorage(base_dir=tmp_path)
+    stored = await storage.save("user", "doc.txt", b"payload")
+    await storage.delete(stored)
+    assert not (tmp_path / stored).exists()
+
+
+async def test_deleting_a_missing_path_through_the_helper_is_a_no_op(tmp_path: Path) -> None:
+    """`unlink(missing_ok=True)` makes concurrent deletes of one path idempotent -
+    a path another cleanup already removed must not raise (#1294)."""
+    storage = LocalFileStorage(base_dir=tmp_path)
+    await storage.delete("user/never-written.bin")
+
+
+async def test_a_cancelled_delete_finishes_the_unlink(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An executor cannot interrupt a running unlink, so a delete cancelled
+    mid-unlink must wait it out - returning while it ran on in the background
+    would let the caller's follow-up be skipped with the old file already gone
+    (#1294)."""
+    storage = LocalFileStorage(base_dir=tmp_path)
+    stored = await storage.save("user", "doc.txt", b"payload")
+    entered = threading.Event()
+    allow = threading.Event()
+    original_unlink = Path.unlink
+
+    def slow_unlink(self: Path, *args: object, **kwargs: object) -> None:
+        entered.set()
+        allow.wait(5)
+        original_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", slow_unlink)
+
+    task = asyncio.create_task(storage.delete(stored))
+    while not entered.is_set():  # noqa: ASYNC110
+        await asyncio.sleep(0.01)
+    task.cancel()
+    allow.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert not (tmp_path / stored).exists()
+
+
+async def test_a_second_cancellation_does_not_detach_the_delete_drain(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A cancellation arriving while the drain waits the unlink out must not carry
+    the caller off and leave it detached; cancelling twice still finishes the
+    unlink (#1294)."""
+    storage = LocalFileStorage(base_dir=tmp_path)
+    stored = await storage.save("user", "doc.txt", b"payload")
+    entered = threading.Event()
+    allow = threading.Event()
+    original_unlink = Path.unlink
+
+    def slow_unlink(self: Path, *args: object, **kwargs: object) -> None:
+        entered.set()
+        allow.wait(5)
+        original_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", slow_unlink)
+
+    task = asyncio.create_task(storage.delete(stored))
+    while not entered.is_set():  # noqa: ASYNC110
+        await asyncio.sleep(0.01)
+    task.cancel()
+    await asyncio.sleep(0)
+    task.cancel()
+    allow.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert not (tmp_path / stored).exists()
+
+
 async def test_parse_content_still_extracts_text_through_the_pool() -> None:
     """The parse wiring moved to `run_blocking`; the extraction is unchanged."""
     service = FileUploadService(db=None)  # type: ignore[arg-type]  # parse touches no db


### PR DESCRIPTION
## Summary

`LocalFileStorage.delete` was `async def` over three blocking syscalls with no
yield point — `realpath` (inside `_resolve_safe_path`), `Path.exists`, and
`Path.unlink`. The RAG teardown loops (collection drop, KB delete) call it once
per file with no bound, so dropping a large collection unlinked every upload in a
single event-loop turn, stalling every other request the worker was serving.

This is the `delete` case the now-closed #25 didn't reach — it offloaded `save`
and `load` but not `delete`, which only became a hot path once the bulk teardown
loops started calling it per file.

## Changed

- `LocalFileStorage.delete` now runs its `realpath`/`exists`/`unlink` through
  `run_blocking` (the dedicated file pool `load` already uses), so every caller
  yields and the teardown loops interleave.

## Testing

- `tests/test_blocking_io_offload.py`: a regression test asserting the unlink
  lands on a thread other than the loop's (fails if the offload is removed), plus
  a no-op-on-missing-file case. `make lint` clean, `ty` clean.

## Notes for reviewers

Behaviour is unchanged — `delete` still removes the file and tolerates a missing
one. Pure latency/availability fix. The transactional-ordering half of the same
teardown review (#1293) and the durable-cleanup gap (#1274) are tracked
separately.

Closes #1294
