### PR TITLE
fix(rag): make org-teardown cleanup durable via a Prefect deployment

### DIFF
--- a/backend/app/services/organization.py
+++ b/backend/app/services/organization.py
@@ -3,10 +3,8 @@ import logging
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.background import spawn_after_commit
 from app.core.config import settings
 from app.core.exceptions import (
     AlreadyExistsError,
@@ -38,47 +36,6 @@ if TYPE_CHECKING:
     from app.services.rag.vectorstore import BaseVectorStore
 
 logger = logging.getLogger(__name__)
-
-
-async def _purge_external_state(
-    storage_paths: list[str],
-    collections: list[str],
-    vector_store: "BaseVectorStore | None",
-) -> None:
-    """Unlink stored uploads and drop vector tables, after an org purge commits.
-
-    Deferred with `spawn_after_commit` (see `OrganizationService.purge`), so it
-    runs only once the relational teardown has committed: a commit that fails
-    rolls the rows back and this never runs, leaving nothing pointing at a
-    dropped table or a missing file (#1137). A module function taking primitives
-    and the process-lived store - not a method - so the queued coroutine holds
-    nothing belonging to the request session, which is gone by the time it runs.
-
-    Because it runs after the commit that frees the collection name, a second
-    org can claim that name and back a table onto it before this drop fires -
-    `CollectionAccessService.claim` checks only `knowledge_bases` rows. So each
-    table is re-checked here, in its own session, and dropped only when no base
-    references the name again; deferral would otherwise widen the #913 TOCTOU
-    from a sub-request window to the whole gap before this runs, and drop the new
-    tenant's table.
-    """
-    from app.db.session import get_db_context
-
-    storage = get_file_storage()
-    for storage_path in storage_paths:
-        with contextlib.suppress(Exception):
-            await storage.delete(storage_path)
-    if vector_store is not None and collections:
-        async with get_db_context() as db:
-            for collection in collections:
-                if await knowledge_base_repo.list_by_collection_name(db, collection):
-                    continue
-                # Best-effort, and only against the database: `delete_collection`
-                # issues `DROP TABLE IF EXISTS`, so a collection whose table was
-                # never created is not an error, and any other database failure is
-                # not a reason to abandon the rest of the cleanup.
-                with contextlib.suppress(SQLAlchemyError):
-                    await vector_store.delete_collection(collection)
 
 
 def _org_read(org: Organization, member_count: int, role: str) -> OrganizationRead:
@@ -377,17 +334,19 @@ class OrganizationService:
         without a tenant column to filter on.
 
         The external side effects - dropping each physical vector table and
-        unlinking the stored uploads - are deferred to after the request commits,
-        via `spawn_after_commit`. They run only if the relational teardown
-        committed, so a final commit that fails rolls back the org, KB and doc
-        rows and leaves none of them pointing at a table or a file already gone
-        (#1137). A table is dropped only when no other knowledge base still backs
-        onto it: `collection_name` is not tenant-unique (#913), so two
-        organizations can share one table and dropping it for one would destroy
-        the other's vectors. That reference check reads under READ COMMITTED
-        against the org lock, not the collection name, so a same-named table a
-        second org creates between the check and the drop is a TOCTOU residual
-        (#913) this does not close either.
+        unlinking the stored uploads - are handed to a durable Prefect flow after
+        the request commits, via `spawn_after_commit`. Deferral means they run
+        only if the relational teardown committed, so a final commit that fails
+        rolls back the org, KB and doc rows and leaves none of them pointing at a
+        table or a file already gone (#1137). A Prefect deployment run rather than
+        an in-process task means a process that dies after the commit no longer
+        takes the cleanup with it - the run is recorded on the server and retried
+        by a worker (#1274). The flow re-checks each collection against the KB
+        table before dropping it, because `collection_name` is not tenant-unique
+        (#913): a name a second org has claimed between this commit and the drop
+        keeps its table. The gap this does not close is commit-to-dispatch - a
+        crash before `spawn_after_commit` fires still loses the cleanup, which
+        only a record committed with the delete (an outbox) would close.
         """
         await organization_repo.get_by_id_for_update(self.db, org.id)
         collections: list[str] = []
@@ -398,28 +357,19 @@ class OrganizationService:
             await knowledge_base_repo.delete(self.db, kb.id)
         await organization_repo.delete(self.db, org)
 
-        to_drop: list[str] = []
-        if self._vector_store is not None:
-            for collection in dict.fromkeys(collections):
-                if not await self._collection_still_referenced(collection):
-                    to_drop.append(collection)
-
+        # A store is wired only on the teardown path, and it is the signal to
+        # clean up the vector tables; the flow re-checks each name and drops only
+        # the unreferenced ones. Files are unlinked whether or not one was wired.
+        to_drop = list(dict.fromkeys(collections)) if self._vector_store is not None else []
         if storage_paths or to_drop:
+            from app.core.background import spawn_after_commit
+            from app.worker.tasks.teardown_tasks import dispatch_org_purge_cleanup
+
             spawn_after_commit(
                 self.db,
-                _purge_external_state(storage_paths, to_drop, self._vector_store),
+                dispatch_org_purge_cleanup(storage_paths, to_drop),
                 name="org_purge_cleanup",
             )
-
-    async def _collection_still_referenced(self, collection_name: str) -> bool:
-        """Whether another knowledge base still backs onto this collection's table.
-
-        Read after the org's own rows are deleted (and flushed), so it counts only
-        knowledge bases outside this teardown - a table one of them shares must
-        not be dropped (#1116, #913).
-        """
-        others = await knowledge_base_repo.list_by_collection_name(self.db, collection_name)
-        return len(others) > 0
 
     async def upload_avatar(
         self,

--- a/backend/app/worker/prefect_app.py
+++ b/backend/app/worker/prefect_app.py
@@ -41,6 +41,7 @@ from app.worker.tasks.report_tasks import (
     weekly_usage_report_flow,
 )
 from app.worker.tasks.run_tasks import stale_run_sweep_flow
+from app.worker.tasks.teardown_tasks import org_purge_cleanup_flow
 from app.worker.tasks.trigger_tasks import (
     check_agent_triggers_flow,
     poll_portal_grants_flow,
@@ -71,6 +72,9 @@ async def main() -> None:
     deployments.append(
         await run_scheduled_trigger_flow.ato_deployment(name="run-scheduled-trigger")
     )
+    # On-demand: the external cleanup of a deleted org, submitted after its purge
+    # commits so it survives the request process dying mid-cleanup (#1274).
+    deployments.append(await org_purge_cleanup_flow.ato_deployment(name="org-purge-cleanup"))
     # Every minute: fire the agent triggers that have come due.
     deployments.append(
         await check_agent_triggers_flow.ato_deployment(

--- a/backend/app/worker/tasks/teardown_tasks.py
+++ b/backend/app/worker/tasks/teardown_tasks.py
@@ -1,0 +1,123 @@
+"""Durable teardown of a deleted organization's external state.
+
+`OrganizationService.purge` commits the relational teardown of an organization -
+its rows, its knowledge bases, its document records - and then hands the external
+side effects, unlinking the stored uploads and dropping the vector tables, to
+this flow. Handing them over rather than running them in the request process is
+what makes them survive: the run is recorded on the Prefect server and retried by
+a worker, where the in-process `spawn_after_commit` task it replaces was lost the
+moment the process that dispatched it died (#1274).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+
+from prefect import flow
+from prefect.deployments import run_deployment
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from app.core.config import settings
+from app.core.logging import setup_logging
+
+logger = logging.getLogger(__name__)
+
+_ORG_PURGE_DEPLOYMENT = "org-purge-cleanup/org-purge-cleanup"
+
+
+async def dispatch_org_purge_cleanup(storage_paths: list[str], collections: list[str]) -> None:
+    """Submit an org's external-state cleanup as its own durable flow run, and return.
+
+    `timeout=0` makes this submit-and-return: `run_deployment` records the run on
+    the Prefect server and does not wait for it, so the caller pays for one API
+    call rather than the cleanup it starts. Handed to `spawn_after_commit` by
+    `OrganizationService.purge`, so it runs only once the relational teardown has
+    committed - and the run it creates is then the durable record, executed by a
+    worker and retried by Prefect, so a process that dies after the commit no
+    longer takes the cleanup with it (#1274).
+
+    The window this does not close is commit-to-dispatch: a crash after the commit
+    but before this call still loses the cleanup. Closing it fully needs a record
+    committed *with* the delete (an outbox), a larger change; this narrows the loss
+    from the whole cleanup to a single API call and makes everything past it
+    durable, which is the mechanism #1274 chose.
+    """
+    # `run_deployment` is sync-compatible: its stub unions the coroutine it returns
+    # in an async context with the `FlowRun` a sync caller gets, and ty cannot tell
+    # which applies. Awaiting it is correct here.
+    await run_deployment(  # ty: ignore[invalid-await]
+        name=_ORG_PURGE_DEPLOYMENT,
+        parameters={"storage_paths": storage_paths, "collections": collections},
+        timeout=0,
+    )
+
+
+async def purge_org_external_state(
+    storage_paths: list[str], collections: list[str]
+) -> dict[str, int]:
+    """Unlink a purged org's stored uploads and drop its unreferenced vector tables.
+
+    The cleanup itself, plain async so it is testable without a Prefect runtime
+    and reusable by the flow below. Runs after the org's rows are committed-gone,
+    so the paths and collection names it is handed are all that is left of them.
+
+    Idempotent, because the flow's retries must be safe: unlinking a file already
+    gone is a no-op, `delete_collection` issues `DROP TABLE IF EXISTS`, and each
+    collection is re-checked against the knowledge-base table so a name a second
+    org has claimed since the purge keeps its table (#913). The store rides an
+    engine built for this one run and disposed on the way out, because a pooled
+    connection made on one flow's event loop breaks the next (the reason
+    `rag_tasks._ingestion_service` builds per-flow engines too, #948).
+    """
+    from app.db.session import get_worker_db_context
+    from app.repositories import knowledge_base_repo
+    from app.services.embedding_resolution import embeddings_for_collection
+    from app.services.file_storage import get_file_storage
+    from app.services.rag.embeddings import EmbeddingService
+    from app.services.rag.vectorstore import PgVectorStore
+
+    storage = get_file_storage()
+    for storage_path in storage_paths:
+        with contextlib.suppress(Exception):
+            await storage.delete(storage_path)
+
+    dropped = 0
+    if collections:
+        rag_settings = settings.rag
+        engine = create_async_engine(settings.DATABASE_URL)
+        try:
+            store = PgVectorStore(
+                settings=rag_settings,
+                embedding_service=EmbeddingService(settings=rag_settings),
+                resolver=embeddings_for_collection,
+                engine=engine,
+            )
+            async with get_worker_db_context() as db:
+                for collection in collections:
+                    if await knowledge_base_repo.list_by_collection_name(db, collection):
+                        continue
+                    with contextlib.suppress(SQLAlchemyError):
+                        await store.delete_collection(collection)
+                        dropped += 1
+        finally:
+            await engine.dispose()
+
+    logger.info("org_purge_cleanup", extra={"unlinked": len(storage_paths), "dropped": dropped})
+    return {"unlinked": len(storage_paths), "dropped": dropped}
+
+
+@flow(name="org-purge-cleanup", log_prints=True, retries=3, retry_delay_seconds=30)
+async def org_purge_cleanup_flow(
+    storage_paths: list[str], collections: list[str]
+) -> dict[str, int]:
+    """The durable wrapper: what `dispatch_org_purge_cleanup` submits.
+
+    Thin over :func:`purge_org_external_state` so the cleanup can be tested
+    without a Prefect runtime. The `@flow` is what carries the durability - the
+    run and its parameters are recorded on the Prefect server, and `retries` re-run
+    it on a worker if it or the process it was dispatched from dies (#1274).
+    """
+    setup_logging()
+    return await purge_org_external_state(storage_paths, collections)

--- a/backend/app/worker/tasks/teardown_tasks.py
+++ b/backend/app/worker/tasks/teardown_tasks.py
@@ -11,6 +11,7 @@ moment the process that dispatched it died (#1274).
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import logging
 
@@ -26,32 +27,72 @@ logger = logging.getLogger(__name__)
 
 _ORG_PURGE_DEPLOYMENT = "org-purge-cleanup/org-purge-cleanup"
 
+# One run carries at most this many storage paths. A large org can leave tens of
+# thousands of files behind, and a path can be long; the whole parameter payload
+# has to stay under Prefect's 512 KiB flow-parameter limit, or `run_deployment`
+# rejects the run after the rows that carried the paths are already gone (#1274).
+_MAX_PATHS_PER_RUN = 500
+
+# The submission is fired after the commit that removed the rows, so a run lost to
+# a transient Prefect outage - or to the deployment not being registered yet
+# during a rollout - has no row left to reconstruct it and no heartbeat to
+# re-dispatch it. So the submission itself is retried before it is given up on; the
+# run is idempotent, so a retry that duplicates one accepted-but-unacknowledged is
+# safe (#1274).
+_SUBMIT_ATTEMPTS = 3
+_SUBMIT_BACKOFF_SECONDS = 2.0
+
 
 async def dispatch_org_purge_cleanup(storage_paths: list[str], collections: list[str]) -> None:
-    """Submit an org's external-state cleanup as its own durable flow run, and return.
+    """Submit an org's external-state cleanup as durable flow runs, and return.
 
-    `timeout=0` makes this submit-and-return: `run_deployment` records the run on
-    the Prefect server and does not wait for it, so the caller pays for one API
-    call rather than the cleanup it starts. Handed to `spawn_after_commit` by
-    `OrganizationService.purge`, so it runs only once the relational teardown has
-    committed - and the run it creates is then the durable record, executed by a
-    worker and retried by Prefect, so a process that dies after the commit no
-    longer takes the cleanup with it (#1274).
+    Each run submits-and-returns (`run_deployment(timeout=0)`): the run is recorded
+    on the Prefect server and executed by a worker, so a process that dies after the
+    commit no longer takes the cleanup with it - the run and its parameters are the
+    durable record, and the flow's own retries re-run it if a worker dies (#1274).
+    Handed to `spawn_after_commit` by `OrganizationService.purge`, so it runs only
+    once the relational teardown has committed.
 
-    The window this does not close is commit-to-dispatch: a crash after the commit
-    but before this call still loses the cleanup. Closing it fully needs a record
-    committed *with* the delete (an outbox), a larger change; this narrows the loss
-    from the whole cleanup to a single API call and makes everything past it
-    durable, which is the mechanism #1274 chose.
+    The paths are chunked across runs so no run's parameters approach Prefect's
+    512 KiB limit. Collections ride the first run only - `delete_collection` is
+    idempotent, but re-checking them once is enough. The window none of this closes
+    is commit-to-dispatch: a crash after the commit but before this fires still
+    loses the cleanup, which only a record committed *with* the delete (an outbox)
+    would close - a larger change #1274 deferred.
     """
-    # `run_deployment` is sync-compatible: its stub unions the coroutine it returns
-    # in an async context with the `FlowRun` a sync caller gets, and ty cannot tell
-    # which applies. Awaiting it is correct here.
-    await run_deployment(  # ty: ignore[invalid-await]
-        name=_ORG_PURGE_DEPLOYMENT,
-        parameters={"storage_paths": storage_paths, "collections": collections},
-        timeout=0,
-    )
+    chunks = [
+        storage_paths[i : i + _MAX_PATHS_PER_RUN]
+        for i in range(0, len(storage_paths), _MAX_PATHS_PER_RUN)
+    ] or [[]]
+    for index, chunk in enumerate(chunks):
+        await _submit_cleanup_run(chunk, collections if index == 0 else [])
+
+
+async def _submit_cleanup_run(storage_paths: list[str], collections: list[str]) -> None:
+    """One `run_deployment` submission, retried before it is given up on.
+
+    A submission lost for good is a run that never existed, so its file chunk (and,
+    on the first run, the table drops) is orphaned with no row to reconstruct it.
+    Best-effort past the retries: a chunk that cannot be submitted is logged and the
+    remaining chunks still go, rather than one transient failure aborting the rest.
+    """
+    for attempt in range(_SUBMIT_ATTEMPTS):
+        try:
+            # `run_deployment` is sync-compatible: its stub unions the coroutine it
+            # returns in an async context with the `FlowRun` a sync caller gets, and
+            # ty cannot tell which applies. Awaiting it is correct here.
+            await run_deployment(  # ty: ignore[invalid-await]
+                name=_ORG_PURGE_DEPLOYMENT,
+                parameters={"storage_paths": storage_paths, "collections": collections},
+                timeout=0,
+            )
+        except Exception:
+            if attempt == _SUBMIT_ATTEMPTS - 1:
+                logger.exception("org_purge_cleanup submission failed after retries")
+                return
+            await asyncio.sleep(_SUBMIT_BACKOFF_SECONDS * (attempt + 1))
+        else:
+            return
 
 
 async def purge_org_external_state(

--- a/backend/tests/integration/test_deletion_reconciliation.py
+++ b/backend/tests/integration/test_deletion_reconciliation.py
@@ -13,7 +13,8 @@ to neighbouring rows when one is deleted, which a mock cannot show.
 from __future__ import annotations
 
 import uuid
-from unittest.mock import MagicMock
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from sqlalchemy import select, text
@@ -32,6 +33,26 @@ from app.services.rag.vectorstore import PgVectorStore
 from app.services.user import UserService
 
 pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture(autouse=True)
+def _route_purge_dispatch_to_impl(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run the org-purge cleanup in-process instead of submitting it to Prefect.
+
+    `OrganizationService.purge` now hands its external cleanup to a durable
+    Prefect deployment run (#1274); with no runner behind the test, `run_deployment`
+    would fail on an unregistered deployment. Routing that submission straight to
+    the cleanup it would have run keeps these tests exercising the real drop and
+    unlink through the commit/rollback gate that defers them - the submission fires
+    only after a committed teardown, so a rolled-back one still runs nothing.
+    """
+    from app.worker.tasks import teardown_tasks
+
+    async def _run(*, name: str, parameters: dict[str, Any], timeout: float) -> None:
+        del name, timeout
+        await teardown_tasks.purge_org_external_state(**parameters)
+
+    monkeypatch.setattr(teardown_tasks, "run_deployment", AsyncMock(side_effect=_run))
 
 
 def _user(email: str | None = None) -> User:

--- a/backend/tests/test_org_purge_cleanup.py
+++ b/backend/tests/test_org_purge_cleanup.py
@@ -41,6 +41,56 @@ class TestDispatch:
             timeout=0,
         )
 
+    async def test_a_purge_with_no_paths_still_submits_the_table_drops(self) -> None:
+        run = AsyncMock()
+        with patch.object(teardown_tasks, "run_deployment", run):
+            await dispatch_org_purge_cleanup([], ["docs"])
+
+        run.assert_awaited_once_with(
+            name="org-purge-cleanup/org-purge-cleanup",
+            parameters={"storage_paths": [], "collections": ["docs"]},
+            timeout=0,
+        )
+
+    async def test_it_chunks_a_large_path_list_across_bounded_runs(self) -> None:
+        """A payload over Prefect's 512 KiB flow-parameter limit would be rejected
+        after the rows are gone, so the paths are split across runs and each stays
+        bounded; the table drops ride the first run only (#1274)."""
+        paths = [f"u/{i}.txt" for i in range(teardown_tasks._MAX_PATHS_PER_RUN + 1)]
+        run = AsyncMock()
+        with patch.object(teardown_tasks, "run_deployment", run):
+            await dispatch_org_purge_cleanup(paths, ["docs"])
+
+        assert run.await_count == 2
+        first, second = run.await_args_list
+        assert len(first.kwargs["parameters"]["storage_paths"]) == teardown_tasks._MAX_PATHS_PER_RUN
+        assert first.kwargs["parameters"]["collections"] == ["docs"]
+        assert second.kwargs["parameters"]["storage_paths"] == [paths[-1]]
+        assert second.kwargs["parameters"]["collections"] == []
+
+    async def test_a_transient_submission_failure_is_retried(self) -> None:
+        run = AsyncMock(side_effect=[RuntimeError("prefect blip"), None])
+        with (
+            patch.object(teardown_tasks, "run_deployment", run),
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            await dispatch_org_purge_cleanup(["a/one.txt"], [])
+
+        assert run.await_count == 2
+
+    async def test_a_submission_that_keeps_failing_is_logged_not_raised(self) -> None:
+        """A run that cannot be submitted has no row to reconstruct it, but one
+        transient failure must not abort the rest, so it is logged rather than
+        raised (#1274)."""
+        run = AsyncMock(side_effect=RuntimeError("prefect down"))
+        with (
+            patch.object(teardown_tasks, "run_deployment", run),
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            await dispatch_org_purge_cleanup(["a/one.txt"], [])
+
+        assert run.await_count == teardown_tasks._SUBMIT_ATTEMPTS
+
 
 @asynccontextmanager
 async def _db_ctx() -> Any:

--- a/backend/tests/test_org_purge_cleanup.py
+++ b/backend/tests/test_org_purge_cleanup.py
@@ -1,0 +1,130 @@
+"""The org-teardown cleanup survives the process that dispatched it (#1274).
+
+`OrganizationService.purge` used to hand its external cleanup - unlinking stored
+uploads, dropping vector tables - to an in-process `spawn_after_commit` task,
+which died with the process. It now submits a durable Prefect deployment run: the
+run and its parameters are recorded on the server and retried by a worker. These
+pin the two halves - the dispatch submits the right run, and the cleanup it runs
+is idempotent and re-checks a shared collection name before dropping it.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.worker.tasks import teardown_tasks
+from app.worker.tasks.teardown_tasks import (
+    dispatch_org_purge_cleanup,
+    org_purge_cleanup_flow,
+    purge_org_external_state,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+class TestDispatch:
+    async def test_it_submits_the_cleanup_as_its_own_deployment_run(self) -> None:
+        """`run_deployment` records the run on the Prefect server; that is what
+        makes the cleanup outlive the process that dispatched it."""
+        run = AsyncMock()
+        with patch.object(teardown_tasks, "run_deployment", run):
+            await dispatch_org_purge_cleanup(["a/one.txt"], ["docs"])
+
+        run.assert_awaited_once_with(
+            name="org-purge-cleanup/org-purge-cleanup",
+            parameters={"storage_paths": ["a/one.txt"], "collections": ["docs"]},
+            timeout=0,
+        )
+
+
+@asynccontextmanager
+async def _db_ctx() -> Any:
+    yield MagicMock()
+
+
+def _patch_cleanup(*, referenced: list[str]) -> Any:
+    """Patch everything `purge_org_external_state` reaches, so the store and the
+    reference check are controllable. `referenced` names the collections a base
+    still claims - those must not be dropped."""
+    storage = MagicMock(delete=AsyncMock())
+    store = MagicMock(delete_collection=AsyncMock())
+    engine = MagicMock(dispose=AsyncMock())
+
+    async def _list(_db: object, name: str) -> list[object]:
+        return [MagicMock()] if name in referenced else []
+
+    patches = [
+        patch("app.services.file_storage.get_file_storage", return_value=storage),
+        patch.object(teardown_tasks, "create_async_engine", return_value=engine),
+        patch("app.services.rag.vectorstore.PgVectorStore", return_value=store),
+        patch("app.services.rag.embeddings.EmbeddingService", return_value=MagicMock()),
+        patch("app.db.session.get_worker_db_context", _db_ctx),
+        patch("app.repositories.knowledge_base_repo.list_by_collection_name", new=_list),
+    ]
+    return storage, store, engine, patches
+
+
+class TestTheCleanup:
+    async def test_it_unlinks_every_file_and_drops_every_unreferenced_table(self) -> None:
+        storage, store, engine, patches = _patch_cleanup(referenced=[])
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            result = await purge_org_external_state(["u/a.txt", "u/b.txt"], ["docs", "wiki"])
+
+        assert storage.delete.await_count == 2
+        assert store.delete_collection.await_count == 2
+        assert result == {"unlinked": 2, "dropped": 2}
+        engine.dispose.assert_awaited_once()
+
+    async def test_it_leaves_a_table_a_base_still_references(self) -> None:
+        """`collection_name` is not tenant-unique, so a name a second org has
+        claimed since the purge must keep its table (#913)."""
+        storage, store, _engine, patches = _patch_cleanup(referenced=["wiki"])
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            result = await purge_org_external_state([], ["docs", "wiki"])
+
+        store.delete_collection.assert_awaited_once_with("docs")
+        assert result == {"unlinked": 0, "dropped": 1}
+
+    async def test_a_failed_unlink_or_drop_does_not_abort_the_rest(self) -> None:
+        """Best-effort: a file already gone or a table that never existed is not a
+        reason to abandon the cleanup a retry would otherwise repeat."""
+        storage, store, _engine, patches = _patch_cleanup(referenced=[])
+        storage.delete = AsyncMock(side_effect=OSError("gone"))
+        store.delete_collection = AsyncMock(side_effect=SQLAlchemyError("no such table"))
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            result = await purge_org_external_state(["u/a.txt"], ["docs"])
+
+        assert result == {"unlinked": 1, "dropped": 0}
+
+    async def test_no_collections_touches_no_store(self) -> None:
+        """A purge that only left files behind builds no vector-store engine."""
+        storage, _store, _engine, patches = _patch_cleanup(referenced=[])
+        with (
+            patches[0],
+            patch.object(teardown_tasks, "create_async_engine") as make_engine,
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+        ):
+            result = await purge_org_external_state(["u/a.txt"], [])
+
+        make_engine.assert_not_called()
+        assert result == {"unlinked": 1, "dropped": 0}
+
+
+class TestTheFlow:
+    async def test_it_runs_the_cleanup(self) -> None:
+        """The `@flow` wrapper is thin: it carries the durability and delegates the
+        work to `purge_org_external_state`."""
+        impl = AsyncMock(return_value={"unlinked": 1, "dropped": 1})
+        with patch.object(teardown_tasks, "purge_org_external_state", impl):
+            result = await org_purge_cleanup_flow(["u/a.txt"], ["docs"])
+
+        impl.assert_awaited_once_with(["u/a.txt"], ["docs"])
+        assert result == {"unlinked": 1, "dropped": 1}

--- a/backend/tests/test_prefect_app.py
+++ b/backend/tests/test_prefect_app.py
@@ -79,6 +79,7 @@ async def test_every_deployment_is_registered_before_the_runner_starts(
         "sync-collection",
         "rag-sync-check",
         "run-scheduled-trigger",
+        "org-purge-cleanup",
         "agent-triggers-check",
         "portal-poll",
         "sandbox-log-sweep",


### PR DESCRIPTION
## Summary

The org purge deferred its external cleanup — unlinking stored uploads, dropping
vector tables — to an in-process `spawn_after_commit` task (#1137/#1259). That
closed the commit-ordering window but left a **durability gap**: `spawn_after_commit`
is not durable, so a process that died after the commit but before or during the
cleanup lost it, orphaning a `rag_<collection>` table and its files with no record
of what to drop (#1274).

The cleanup now runs as a **Prefect deployment**. `OrganizationService.purge` still
hands it over after the commit, but hands over a `run_deployment` submission rather
than the work: the run and its parameters (the paths and collection names — all that
is left of the deleted rows) are recorded on the Prefect server, executed by a
worker, and re-run by the flow's `retries` if the worker dies.

> **Stacked on #1259 (`fix/1137-purge-post-commit-cleanup`).** This PR's base is that
> branch, because it makes the `spawn_after_commit` cleanup #1259 introduces durable.
> Merge #1259 first; GitHub will retarget this to `main`.

## Changed

- **`app/worker/tasks/teardown_tasks.py`** (new) — `purge_org_external_state` (the
  idempotent cleanup: unlink files, drop unreferenced tables, re-checking each name
  against the KB table for #913), the `org_purge_cleanup_flow` durable wrapper, and
  `dispatch_org_purge_cleanup` (submit-and-return via `run_deployment(timeout=0)`, the
  `trigger_tasks` pattern).
- **`app/worker/prefect_app.py`** — register the `org-purge-cleanup` deployment.
- **`app/services/organization.py`** — `purge` now dispatches the durable flow after
  commit instead of running the cleanup in-process; the inline `_purge_external_state`
  and `_collection_still_referenced` (the re-check moved into the flow) are removed.

## Testing

- `tests/test_org_purge_cleanup.py` (new) — the dispatch submits the right run; the
  cleanup unlinks files, drops only unreferenced tables, tolerates a failed unlink/drop,
  and builds no engine when there are no collections; the flow wrapper delegates.
- `tests/integration/test_deletion_reconciliation.py` — still exercises the real
  drop/unlink through the commit/rollback gate, routing the submission to the in-process
  cleanup (no Prefect runner backs the test).
- `make lint` clean, `ty` clean. **Not verified locally:** the run against a real
  Prefect server + worker (no local DB/runner) — CI's integration job is the gate.

## Notes for reviewers

- **Residual window, stated plainly:** commit-to-dispatch. A crash after the commit but
  before `spawn_after_commit` fires the submission still loses the cleanup. Closing it
  fully needs a record committed *with* the delete (an outbox); this narrows the loss
  from the whole cleanup to one API call and makes everything past it durable — the
  mechanism chosen for #1274.
- The RAG delete-path ordering follow-up **#1293** is a separate change on separate
  files (`rag_document.py`, `knowledge_base.py`) and is not touched here.

Closes #1274
