### PR TITLE
chore: cut 0.0.322

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.322] - 2026-08-28
+
+### Added
+
+- **Azure, Bedrock and Vertex AI are inside the model-catalog drift guard.**
+  `_documented_rows` reads the two four-column tables, so the three providers with
+  the most involved credential shapes were in no assertion but the id one. Their
+  credential is prose and maps to no field - but *which of the three tables a
+  provider sits in* is itself a claim about its credential, since the heading says
+  "Credential is not an API key", and that is comparable. Two assertions follow: the
+  three tables partition `PROVIDERS`, so a provider documented twice or in none of
+  them fails; and which table a row is in matches `secret_kind`, so moving a row
+  without changing the spec, or the reverse, fails. (#1252)
+
 ## [0.0.321] - 2026-08-28
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.321"
+version = "0.0.322"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.321"
+version = "0.0.322"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.321",
+  "version": "0.0.322",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.322. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.322 and adds the CHANGELOG entry.

Releases #1252's third item - items 1, 2 and 4 landed with #923. The drift guard
covered every provider's id but only checked the credential of the ones whose
credential is a field; the three whose credential is prose are now checked
against the table they are documented in, which is the same claim in another
form.

Verified on #1277 by introducing each of the four drifts and watching the guard
fail: a provider removed from `PROVIDERS` with its docs row left behind, Ollama's
credential spelled as an API key, Cohere moved into the not-an-API-key table, and
the image catalog's `google` entry repointed. `make test` 100% (7204 passed),
`make lint-backend` clean.

`scripts/check_backticks.py` and `make lint-spelling` clean.
