### PR TITLE
chore: cut 0.0.326

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,33 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.326] - 2026-08-28
+
+### Fixed
+
+- **Two app admins deleting each other could leave the deployment with none.** The
+  not-self refusal in `admin_delete` states a lockout invariant - a deployment keeps
+  at least one administrator - and it held only against one request at a time. #1115's
+  `SELECT ... FOR UPDATE` covers the *target* row, so admin A deleting B and admin B
+  deleting A locked different rows, touched different personal organizations and never
+  contended: both committed, and `count(*) FROM users WHERE is_app_admin` was 0, with
+  a direct database write as the only recovery. New
+  `user_repo.app_admin_ids_for_update` locks the set the decision was always about,
+  and `admin_delete` takes it before deciding, so the later of two mutual deletes
+  waits, re-reads a set of one once the first commits, and is refused. (#1208)
+- Two choices worth naming. **`ORDER BY id` is load-bearing**: rows are locked in the
+  order they are returned, so two requests taking the same set take it in the same
+  order and one waits, where an unordered pair each holding half of it is #1134 in a
+  new place. And the lock is taken on **every** admin deletion, not only when the
+  target is an admin - reading the target's flag first to decide whether to lock puts
+  a window between the read and the lock, and deleting a user is an administrator's
+  action rather than a hot path. (#1208)
+
+### Changed
+
+- `docs/deployment.md` already argued this invariant from the set; it now says what
+  makes it true across two requests.
+
 ## [0.0.325] - 2026-08-28
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.325"
+version = "0.0.326"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.325"
+version = "0.0.326"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.325",
+  "version": "0.0.326",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.326. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.326 and adds the CHANGELOG entry.

Releases #1208: the lockout invariant was enforced per request, so two mutual
admin deletions both passed the not-self check and committed. The decision now
runs against a locked, ordered read of the app-admin set.

Verified on #1281 with the interleaving held open rather than raced through
`gather`: B is observed still blocked 400ms into A's open transaction, and once A
commits B raises `AuthorizationError` with one admin left. That fails without the
fix. Plus one of three admins still being deletable, so the refusal is about
emptying the set rather than touching it. `make test` at 100% on the platform
layer, `make lint` and `make docs-build` green.

`scripts/check_backticks.py` and `make lint-spelling` clean.
