### PR TITLE
chore: cut 0.0.327

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.327] - 2026-08-28
+
+### Changed
+
+- **One HTTP client per module for web search and model listings**, rather than one per
+  call. These are the two per-call `httpx.AsyncClient` sites the #952 audit left
+  outside its channel-adapter scope: the HTTP-based search providers (Brave, Exa) and
+  the model-catalog listing fetch. Each opened a fresh client per call, so a search
+  tool invoked several times in one run - or a catalog refresh asking provider after
+  provider - paid a new TCP and TLS handshake against a host it had just talked to.
+  Both are module-level functions with no adapter lifecycle to hang a client on, so
+  #1262's shape does not fit: the client is built lazily, rebuilt if it was closed,
+  and carries the timeout per request so one client serves every provider. The app
+  lifespan closes both at shutdown, after background work has drained, where it
+  already closes the channel adapters' clients. `ddgs` and Tavily go through their own
+  SDKs rather than httpx and are untouched. (#1263)
+
 ## [0.0.326] - 2026-08-28
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.326"
+version = "0.0.327"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.326"
+version = "0.0.327"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.326",
+  "version": "0.0.327",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.327. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.327 and adds the CHANGELOG entry.

Releases #1263, the remaining half of the #952 audit: the two HTTP clients that
had no adapter lifecycle to be reused on. Perf-internal - no behaviour a page
describes changes, so `docs/models.md` and `docs/reference/capabilities.md` are
unchanged.

Verified on #1282: `_search.py` is in the platform layer, so its getter and close
are covered both ways - built once and reused, rebuilt after close, closing a
live client, skipping a closed or absent one. The provider suites reset the
module client between tests so each test's `httpx.AsyncClient` patch is what the
next call builds. `make lint` and `ty` clean; `test_web_search` and
`test_model_catalog` green.

`scripts/check_backticks.py` and `make lint-spelling` clean.
