### PR TITLE
chore: cut 0.0.328

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.328] - 2026-08-28
+
+### Fixed
+
+- **`make test-frontend-cov` intermittently failed the 100% statement gate at 99.98%
+  on a clean tree.** The one miss was `markdown-content.impl.tsx:37`, the `pl-8`
+  return in `orderedIndent` - the indent band for a 10-99 item ordered list. Nothing
+  in the markdown-content suite renders a list that size, so the statement was covered
+  only when some *other* suite happened to render one, and under parallel scheduling
+  that render is not guaranteed. The indent test already pinned the 1-9, 100+ and
+  1000+ bands; the two-digit case is pinned now too, deterministically rather than by
+  accident. The branch is live - a 10-99 item list is reachable - so it is covered,
+  not removed. (#1264)
+
 ## [0.0.327] - 2026-08-28
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.327"
+version = "0.0.328"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.327"
+version = "0.0.328"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.327",
+  "version": "0.0.328",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.328. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.328 and adds the CHANGELOG entry.

Releases #1264: a coverage gate that went red on a clean tree, because one
statement was covered by another suite's incidental render and pytest-style
parallel scheduling does not guarantee it.

Verified on #1283: `bunx vitest run markdown-content.impl.test.tsx` green (23
tests) and `bun run test:coverage` green at 100% statements/lines/functions,
97.83% branches. Test-only.

`scripts/check_backticks.py` and `make lint-spelling` clean.
