### PR TITLE
chore: cut 0.0.329

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.329] - 2026-08-28
+
+### Fixed
+
+- **Dropping a collection orphaned every file it held.**
+  `DELETE /rag/collections/{name}` dropped the vector table and deleted the
+  `rag_documents` rows, but `delete_by_collection` was a bulk delete returning only a
+  rowcount - so nothing unlinked the uploads and each one stayed on disk. The
+  repository deletes `RETURNING storage_path` now and answers with the non-null paths,
+  the shape `delete_by_knowledge_base` already used, and the service unlinks each one
+  best-effort: a file already gone is not a reason to fail the drop. Keyed on
+  `collection_name`, so it clears the files for every knowledge base backing that
+  physical collection - which is what the drop route means. (#1265)
+
 ## [0.0.328] - 2026-08-28
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.328"
+version = "0.0.329"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.328"
+version = "0.0.329"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.328",
+  "version": "0.0.329",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.329. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.329 and adds the CHANGELOG entry.

Releases #1265, one of two file leaks found while tracing #1131. The route's only
caller ignored the old `int` return, so widening it to the path list is
contained.

Verified on #1284: unit tests for the service unlinking each returned path and
for a failed unlink not failing the drop; the repository's `RETURNING` mirrors
`delete_by_knowledge_base`, which the integration suite already exercises.
`make lint` and `ty` clean.

`scripts/check_backticks.py` and `make lint-spelling` clean.
