### PR TITLE
chore: cut 0.0.331

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.331] - 2026-08-28
+
+### Fixed
+
+- **`DELETE /kb/{id}` deleted only the `knowledge_bases` row.** Its `rag_documents`
+  rows, whose FK is `SET NULL`, survived detached and readable by a later same-named
+  collection; the uploaded files stayed on disk; and the physical `rag_<collection>`
+  table was left behind with the collection name still blocking reuse. The full
+  teardown existed only on the org purge path. `KnowledgeBaseService.delete` now takes
+  the vector store - **required, not optional**, the shape #992 used so a delete route
+  cannot silently skip the teardown again - and runs it: the base's document rows and
+  their stored files, then the row, then the `rag_<collection>` table, dropped only
+  when no other base still references the name, which is not tenant-unique (#913). The
+  route wires in the `VectorStoreSvc` it did not have. (#1266, #1290)
+
 ## [0.0.330] - 2026-08-28
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.330"
+version = "0.0.331"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.330"
+version = "0.0.331"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.330",
+  "version": "0.0.331",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.331. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.331 and adds the CHANGELOG entry.

Releases #1266 and #1290: the third of the teardown paths that knew only how to
delete a row. Only the route called `service.delete`, so requiring the store is
contained.

Verified on #1286: the personal-KB delete test asserts the vector table is
dropped with the row, and the four refusal tests - default base, another org's
default, a non-owner's personal base, a non-admin on an app base - still refuse
before any teardown runs, so a refused delete tears nothing down. `make lint` and
`ty` clean; `test_kb_scoping` and `test_reserved_collection_names` green.

`scripts/check_backticks.py` and `make lint-spelling` clean.
