### PR TITLE
chore: cut 0.0.332

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,31 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.332] - 2026-08-28
+
+### Fixed
+
+- **A new turn no longer starts from a checklist that is already finished.**
+  `keep_plan` records whatever the store held when the run ended, completed steps
+  included, and the next turn seeded from it - so a thread whose three steps were all
+  ticked off in August opened in November with the tail reminder calling them "your
+  current plan" and `read_plan` answering with them, and the agent worked to a
+  checklist about a task nobody is doing. The filter is at the **seed** rather than at
+  the moment the last step is ticked: within the turn that finishes a plan the store
+  still holds it, so `read_plan`, the reminder and the transcript agree and the agent
+  can summarise what it just did - and it is the *next* question that starts clean,
+  with the ticked checklist still in the messages above it where it reads as what was
+  done. Nothing is deleted; the row keeps the finished plan and `still_open` decides
+  only what a fresh turn is seeded with. **Finished** means at least one step and every
+  step `completed` or `cancelled` - `blocked` is work outstanding and keeps the plan.
+  (#1221)
+
+### Changed
+
+- The rule is written down in both places: the seeding rule's docstring in
+  `planning/_capability.py`, and `docs/reference/capabilities.md`, whose paragraph said
+  the opposite ("A finished checklist is kept rather than cleared").
+
 ## [0.0.331] - 2026-08-28
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.331"
+version = "0.0.332"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.331"
+version = "0.0.332"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.331",
+  "version": "0.0.332",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.332. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.332 and adds the CHANGELOG entry.

Releases #1221, the half of #1077 its implementation left open. The issue offered
three shapes and expected the third; this is the first, moved to the seed, which
answers the objection to clearing - nothing on screen is denied, because the
ticked steps stay in the transcript where they read as history.

The third shape (seed it and label it finished) needs the library's tail reminder
to say so: `_reminder_text` in `pydantic_ai_harness.planning` opens with "Your
current plan" unconditionally, so that is a change in that package rather than
here.

Verified on #1287: six cases on the helper - every step ticked, a cancelled step
counting as finished, one step left seeding the whole plan, a `blocked` step
keeping it, and `None` and `[]` surviving as themselves because they mean
different things to `keep_plan` - plus one on the runner that fails without the
change. `make test` at 100% on the platform layer, `make lint` and
`make docs-build` green.

`scripts/check_backticks.py` and `make lint-spelling` clean.
