### PR TITLE
chore: cut 0.0.333

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,29 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.333] - 2026-08-28
+
+### Fixed
+
+- **An ingestion that had already read its file kept writing when the collection was
+  deleted underneath it.** `insert_document` reaches `_ensure_collection`, whose
+  `CREATE TABLE IF NOT EXISTS` recreated the just-dropped `rag_<collection>` table and
+  inserted the chunks - leaving an untracked table of stale vectors reachable by a
+  later same-named collection, and then failing to record completion because the
+  document row was gone. `IngestionService.ingest_file` takes an optional
+  `still_wanted` check, run **after the parse and before the write**: the upload flow
+  checks its own `rag_documents` row, which the delete removes, and the two sync flows
+  check that the collection still has a knowledge base. When it reports the collection
+  gone the write is skipped and a failure returned rather than the table resurrected.
+  (#1275)
+- Both checks are **fail-safe**: any error answers "still wanted", so the guard can
+  only ever skip a write it is certain is unwanted and never blocks a legitimate
+  ingestion. It closes the parse-duration window, which is the wide one - parsing a
+  large file is seconds where the insert is fast. Two residuals stay, both narrow and
+  pre-existing: a collection dropped in the instant between the check and the insert,
+  and the sync check being collection-level rather than tenant-precise while
+  collection names are not tenant-unique (#913). (#1275)
+
 ## [0.0.332] - 2026-08-28
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.332"
+version = "0.0.333"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.332"
+version = "0.0.333"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.332",
+  "version": "0.0.333",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.333. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.333 and adds the CHANGELOG entry.

Releases #1275, the race the #1131 review turned up: the teardown paths released
a collection while a worker still held a parsed file, and `CREATE TABLE IF NOT
EXISTS` brought it back.

Fail-safe by design so it cannot break the critical ingestion path - the guard
can only skip, never block. The full close (a durable liveness or generation
signal that removes even the micro-race and #913's imprecision) stays the
architectural thread with #913 and the durable-teardown work.

Verified on #1288: a gone collection skips the write (`insert_document` not
awaited) and returns `ERROR`, a live one still writes, and the existing
`ingest_file` and sync suites pass with the new argument defaulted off.
`make lint` and `ty` clean.

`scripts/check_backticks.py` and `make lint-spelling` clean.
