### PR TITLE
chore: cut 0.0.334

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,45 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.334] - 2026-08-28
+
+### Fixed
+
+- **Every notification link was organization-agnostic, and the page it opens acts on
+  whichever organization the reader last used.** `apiClient` stamps
+  `X-Organization-Id` from a selection persisted per browser, so somebody in two
+  organizations who was last working in Globex opened the approval alert for a run in
+  Acme and read **Globex's** queue: very likely empty, and reading as *nothing is
+  waiting* about a run that is parked and ageing towards
+  `ApprovalService.expire_stale`. The agent links were wrong more quietly -
+  `/agents/{id}` under the wrong organization is a refusal for an agent the reader can
+  genuinely see, one switch away. `run.organization_id` and `agent.organization_id`
+  were in scope at all four call sites and discarded. Every link now carries
+  `org=<id>`, built in one place - `NotificationService._link`, which picks the
+  separator from the path because the approvals link already carries
+  `?tab=approvals`. (#1204)
+- **The console adopts it the way it adopts `/orgs/{id}`.** `organizationInQuery`
+  reads it under the same two rules as the path's reader and for the same reasons
+  #1032 gives: a UUID only, so a future `?org=new` is not adopted as a tenant id and
+  refused on every request, and lower-cased, because the value is stored and found by
+  `===` against ids the server serialises in canonical lower case. The adoption is the
+  existing layout effect in the recovery hook, before the tenant cache reset and
+  before the page's own queries, so the first request the page makes already carries
+  the right tenant. Two rules follow from what the parameter is: **the path outranks
+  it**, since `/orgs/{id}` *is* that organization while `?org=` only says which one an
+  alert was about; and adoption is keyed on the path and the adopted id together,
+  because two alerts about two organizations arrive at the same path and keying on the
+  path alone would read the first one's tenant. (#1204)
+- A reader who has since left that organization is told the link is the reason, rather
+  than being moved in silence and reading another organization's page as the answer to
+  the alert. It cannot name the organization: they are not a member, so it is not in
+  their list. (#1204)
+
+### Added
+
+- `docs/governance.md` gains **Every link says which organization it is about** under
+  Alerts.
+
 ## [0.0.333] - 2026-08-28
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.333"
+version = "0.0.334"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.333"
+version = "0.0.334"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.333",
+  "version": "0.0.334",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.334. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.334 and adds the CHANGELOG entry.

Releases #1204: four alert links that named an agent, a run or a dashboard but
never the tenant any of them belong to, opening whichever organization the
browser last remembered.

Verified on #1289: one backend case per email kind asserting the id is in the
URL, plus one that the parameter is built in a single place; three client cases
on `organizationInQuery` and four on the hook - adoption from a link, the path
winning over one, a second link to the same page, and the refusal naming the
link. `make test` at 100% on the platform layer; `make lint`,
`make test-frontend-cov` and `make docs-build` green.

Merged with `main` here: #935's `/runs?tab=approvals` landed first, so `_link`
picks `&` when the path already carries a query - appending a second `?` would
have named no organization at all, since the console would read the whole tail as
the tab. Three tests pin that.

`scripts/check_backticks.py` and `make lint-spelling` clean.
