### PR TITLE
chore: cut 0.0.337

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,50 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.337] - 2026-08-28
+
+### Added
+
+- **A per-conversation approval mode in the chat.** The spec decides which tools are
+  gated, at publish time, per tool - which is right for a statement about what the
+  agent *is*, and says nothing about the mood of one session. Somebody working through
+  twenty turns with an agent that gates three tools answered the same three questions
+  every turn, and their only way out was to republish the agent, changing it for
+  everybody, permanently, to fix an afternoon. Three modes ride the send frame beside
+  the model override: **Follow the agent** (the default, and exactly what existed
+  before), **Approve everything** (standing consent for this conversation - every gated
+  call granted without parking, each one still writing its row), and **Ask about
+  everything** (gate every tool the agent can reach, including the ones the spec left
+  ungated and the ones no capability owns). (#925)
+- Four things make it a session setting rather than a hole in the model. A caller who
+  may not waive is **refused, never downgraded** - quietly following the spec would
+  leave somebody believing they had turned the questions off, and the next parked run
+  says the opposite; the check is in `AgentRunnerService.prepare`, the one funnel a
+  fresh run and a resumed one share. Waiving needs `approvals:decide` **and** the
+  organization's leave: a standing consent *is* the decision the queue exists to
+  record, so `organizations.chat_may_waive_approvals` is the ceiling - **off by
+  default**, changed by somebody holding `approvals:decide` - and without it a
+  Builder's deliberate gate on `send_email` would be one click from nothing in every
+  conversation. **No channel still means no**: only the web chat may waive, because
+  `ApprovalGate` already refuses a run with nobody to ask. And **every waived call is
+  recorded** - the row is written `approved`, names the consenting account and carries
+  `decided_via = "standing"`, its own column rather than a sentence in `note`, because
+  a waived run indistinguishable from an agent that was never gated is
+  `docs/governance.md`'s trail quietly ceasing to be one. (#925)
+- "Ask about everything" gates **MCP tools too**. The spec-driven gate leaves them
+  alone because their approval is a property of the connection; a person who does not
+  trust an agent yet is asking about everything it can do. It only tightens, so it
+  takes no permission, no ceiling and no surface check -
+  `ApprovalRequest.capability_id` is nullable for exactly this case. (#925)
+- `docs/governance.md` gains **How much one conversation wants to be asked**; the tour
+  gains `chat-approval-mode`.
+
+### Changed
+
+- New column `organizations.chat_may_waive_approvals`, default off, with its own switch
+  beside the spending limit - so an upgrade changes nobody's behaviour and the waive
+  option does not render until an owner turns it on.
+
 ## [0.0.336] - 2026-08-28
 
 ### Added

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.336"
+version = "0.0.337"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.336"
+version = "0.0.337"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.336",
+  "version": "0.0.337",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.337. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.337 and adds the CHANGELOG entry.

Releases #925: the spec's per-tool gate is a statement about the agent, and there
was nothing between it and a person answering the same three questions for
twenty turns. Three modes per conversation, the loosening one gated on a
permission and an organization ceiling that is off by default.

Verified on #1295, refusals first: a member refused; an organization with waiving
off refusing an *operator*; four unattended surfaces refused; tightening allowed
to a viewer without the organization being read at all; the row written approved
and named beside a parked row on the same run that names nobody; the gate asking
about an ungated tool, an MCP tool, and still refusing where nobody can be asked.
On the client: the control's default, waiving disabled with a reason for somebody
who may not, the ceiling switch hiding itself from a caller without
`approvals:decide`, and the approvals record distinguishing a standing consent
from a click. `make test` at 100% on the platform layer; `make lint`,
`make test-frontend-cov`, `make build-frontend` and `make docs-build` green.

Two things about the merge into `main`. The migration is `0062`, and its
`down_revision` was repointed from `0060` to `0061_session_last_used_index`,
which #1256 added on the way past - left alone that is two alembic heads. And
**#1326 is filed against this feature**: `ASK_ALL` is not restored when a parked
run resumes, so a tool gated only by the mode and then *rejected* can reach its
handler on the continuation. Severity high, and not fixed here.

Not in this change: the per-tool-call line in the chat transcript. It needs the
persisted tool-call row linked to its approval row, and everything it needs is
now in place.

`scripts/check_backticks.py` and `make lint-spelling` clean.
