### PR TITLE
chore: cut 0.0.340

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,41 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.340] - 2026-08-28
+
+### Added
+
+- **A README front page: hero, pitch, badges, nav, then the spec sample and what the
+  product looks like.** The content was already strong; what it lacked was the visual
+  first impression. The graphics are authored in this repository - no icon package, no
+  external asset host, no hand-copied path data:
+  `.github/assets/hero-{light,dark}.svg`, one per theme and served through a
+  `<picture>`, drawing the sentence the README opens with rather than decorating it -
+  one spec, one runner, the surfaces that reach it and the four refusals underneath,
+  in the app's own palette read out of `globals.css` and converted rather than
+  eyeballed; and `docs/assets/mark.svg`, the same mark alone, which is now the docs
+  site's logo and favicon, which the site did not have. One file, not two: an earlier
+  draft had a copy in `.github/assets/`, which is the second-source defect this
+  repository keeps citing. (#783)
+- **Release and stars badges** - the two the header lacked - plus a star-history image
+  before the footer. Image paths are relative, so they render in a pull request as
+  well as on `main`; absolute `raw.githubusercontent` URLs would show broken images to
+  whoever reviews a change about graphics. (#783)
+- Three screenshots - the builder, the catalog, the chat surface - at 1600px,
+  palette-reduced to 220 colours, 392KB for all three. Taken from a `make dev` run
+  against a **throwaway database** rather than a developer's own, which held eleven E2E
+  fixtures and four scratch agents; the fresh one was dropped afterwards and the
+  developer's eleven agents verified still there. No shot shows a live model answer,
+  deliberately: the alternatives were to spend somebody's tokens or to fake a
+  transcript, so the chat shot is the composer with a real question typed and the agent
+  picker showing which agent will answer. (#783)
+
+### Fixed
+
+- The docs table promised "Spec, version, exposure, run - the four nouns" where
+  `concepts.md` has five: the trigger was added and one of the two pages updated.
+  (#783)
+
 ## [0.0.339] - 2026-08-28
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.339"
+version = "0.0.340"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.339"
+version = "0.0.340"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.339",
+  "version": "0.0.340",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.340. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.340 and adds the CHANGELOG entry.

Releases #783. Every SVG was parsed, rendered to PNG at 2x and looked at -
twice, because the first pass ran the surface labels past the right margin.

Verified on #1298: `make docs-build` (`--strict`) green with `assets/mark.svg` in
the build output as logo and favicon, and `python3 scripts/docs_drift.py` clean.

`scripts/check_backticks.py` and `make lint-spelling` clean.
