### PR TITLE
chore: cut 0.0.342

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.342] - 2026-08-28
+
+### Fixed
+
+- **`LocalFileStorage.delete` was `async def` over three blocking syscalls with no
+  yield point** - `realpath` inside `_resolve_safe_path`, `Path.exists` and
+  `Path.unlink`. The RAG teardown loops (collection drop, knowledge-base delete) call it
+  once per file with no bound, so dropping a large collection unlinked every upload in a
+  single event-loop turn and stalled every other request the worker was serving. It
+  runs through `run_blocking` now - the dedicated file pool `load` already uses - so
+  every caller yields and the teardown loops interleave. This is the `delete` case #25
+  did not reach: it offloaded `save` and `load`, and `delete` only became a hot path
+  once the bulk teardown loops started calling it per file. Behaviour is unchanged; it
+  still removes the file and tolerates a missing one. (#1294)
+
 ## [0.0.341] - 2026-08-28
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.341"
+version = "0.0.342"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.341"
+version = "0.0.342"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.341",
+  "version": "0.0.342",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.342. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.342 and adds the CHANGELOG entry.

Releases #1294. Pure latency and availability - no behaviour change.

Verified on #1300: `tests/test_blocking_io_offload.py` asserts the unlink lands on
a thread other than the loop's, which fails if the offload is removed, plus a
no-op-on-missing-file case. `make lint` and `ty` clean.

The transactional-ordering half of the same teardown review (#1293) and the
durable-cleanup gap (#1274) are tracked separately.

`scripts/check_backticks.py` and `make lint-spelling` clean.
