### PR TITLE
chore: cut 0.0.343

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,29 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.343] - 2026-08-28
+
+### Changed
+
+- **The org teardown's external cleanup is a durable Prefect deployment.** It was
+  deferred to an in-process `spawn_after_commit` task (#1137), which closed the
+  commit-ordering window but left a durability gap: `spawn_after_commit` is not
+  durable, so a process that died after the commit but before or during the cleanup
+  lost it - orphaning a `rag_<collection>` table and its files with no record of what
+  to drop. `OrganizationService.purge` still hands the work over after the commit, but
+  hands over a `run_deployment` submission rather than the work: the run and its
+  parameters - the paths and collection names, all that is left of the deleted rows -
+  are recorded on the Prefect server, executed by a worker, and re-run by the flow's
+  `retries` if that worker dies. New `app/worker/tasks/teardown_tasks.py` holds the
+  idempotent cleanup, the durable flow wrapper and the submit-and-return dispatch; the
+  flow re-checks each collection name against the knowledge-base table before dropping
+  it, because the name is not tenant-unique (#913), so a name a second organization
+  claimed between the commit and the drop keeps its table. The inline
+  `_purge_external_state` and `_collection_still_referenced` go with it. (#1274)
+- The gap that remains is commit-to-dispatch: a crash before `spawn_after_commit`
+  fires still loses the cleanup, which only a record committed with the delete - an
+  outbox - would close. (#1274)
+
 ## [0.0.342] - 2026-08-28
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.342"
+version = "0.0.343"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.342"
+version = "0.0.343"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.342",
+  "version": "0.0.343",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.343. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.343 and adds the CHANGELOG entry.

Releases #1274, the durability half of the org-teardown work #1137 started.

Verified on the reopened pull request (#1333, the same head as #1301, which
GitHub closed when its parent branch merged): `tests/test_org_purge_cleanup.py`
covers the dispatch submitting the right run, the cleanup unlinking files and
dropping only unreferenced tables, a failed unlink and a failed drop being
tolerated, no engine being built when there are no collections, and the flow
wrapper delegating.

The merge with `main` removed main's in-process `_purge_external_state` and the
module-level `spawn_after_commit` import it needed: the reference re-check moved
into the flow, so keeping both would have left a dead second cleanup path.

`scripts/check_backticks.py` and `make lint-spelling` clean.
