### PR TITLE
fix(rag): defer teardown file unlinks until the request commits

### DIFF
--- a/backend/app/services/file_storage.py
+++ b/backend/app/services/file_storage.py
@@ -4,7 +4,6 @@ Supports local filesystem storage.
 Files are organized per-user: {storage_root}/{user_id}/{uuid}_{filename}
 """
 
-import contextlib
 import logging
 import os
 import re
@@ -19,19 +18,24 @@ logger = logging.getLogger(__name__)
 
 
 async def delete_files_best_effort(storage_paths: list[str]) -> None:
-    """Unlink stored uploads, suppressing any failure - a file already gone is not
-    an error.
+    """Unlink stored uploads best-effort, logging - not raising on - a failure.
 
     Handed to `spawn_after_commit` by the teardown paths, so the unlinks run only
     once the transaction that removed the rows has committed: an unlink before the
     commit is undone by a rollback as a file already gone, leaving the restored row
     pointing at nothing (#1293). Takes ids, holds nothing of the request session,
     and resolves the storage backend when it runs.
+
+    A failure is logged rather than swallowed: the row that named the file is gone
+    by now, so a silent failure leaves an orphan nothing else can find - the warning
+    is the only remaining trace of which path it was.
     """
     storage = get_file_storage()
     for storage_path in storage_paths:
-        with contextlib.suppress(Exception):
+        try:
             await storage.delete(storage_path)
+        except Exception as exc:
+            logger.warning("Failed to unlink stored file %s: %s", storage_path, exc)
 
 
 ALLOWED_MIME_TYPES = {

--- a/backend/app/services/file_storage.py
+++ b/backend/app/services/file_storage.py
@@ -4,6 +4,7 @@ Supports local filesystem storage.
 Files are organized per-user: {storage_root}/{user_id}/{uuid}_{filename}
 """
 
+import contextlib
 import logging
 import os
 import re
@@ -15,6 +16,23 @@ from app.core.blocking import delete_cancel_safe, run_blocking, write_bytes_canc
 from app.core.config import settings
 
 logger = logging.getLogger(__name__)
+
+
+async def delete_files_best_effort(storage_paths: list[str]) -> None:
+    """Unlink stored uploads, suppressing any failure - a file already gone is not
+    an error.
+
+    Handed to `spawn_after_commit` by the teardown paths, so the unlinks run only
+    once the transaction that removed the rows has committed: an unlink before the
+    commit is undone by a rollback as a file already gone, leaving the restored row
+    pointing at nothing (#1293). Takes ids, holds nothing of the request session,
+    and resolves the storage backend when it runs.
+    """
+    storage = get_file_storage()
+    for storage_path in storage_paths:
+        with contextlib.suppress(Exception):
+            await storage.delete(storage_path)
+
 
 ALLOWED_MIME_TYPES = {
     "image/jpeg",

--- a/backend/app/services/knowledge_base.py
+++ b/backend/app/services/knowledge_base.py
@@ -30,7 +30,6 @@ from app.schemas.knowledge_base import (
 )
 from app.services.access import COLLECTION, SECRET, resolve_access, visible_resource_ids
 from app.services.collection_access import CollectionAccessService, readable_kb, writable_kb
-from app.services.file_storage import get_file_storage
 from app.services.ingestion_config import (
     IngestionConfig,
     IngestionConfigService,
@@ -481,11 +480,14 @@ class KnowledgeBaseService:
         left the `rag_documents` rows (their FK is `SET NULL`, so they survived
         detached and readable by a later same-named collection), the uploaded
         files, and the physical `rag_<collection>` vector table all behind, with
-        the collection name still blocking reuse (#1266). So the documents and
-        their files go, then the row, then the table - dropped only when no other
-        base still references the name, which is not tenant-unique (#913). The
-        store is required, not optional, so a delete route cannot silently skip
-        the teardown again.
+        the collection name still blocking reuse (#1266). So the documents go, then
+        the row, then the table - dropped only when no other base still references
+        the name, which is not tenant-unique (#913). The store is required, not
+        optional, so a delete route cannot silently skip the teardown again.
+
+        The stored files are unlinked after the commit (`spawn_after_commit`), so a
+        rollback keeps them beside the rows it restores rather than stranding those
+        rows on missing files (#1293).
         """
         # Access first, then the rule about default bases: "cannot delete the
         # default knowledge base" is a statement about a row, so answering it for
@@ -501,10 +503,13 @@ class KnowledgeBaseService:
         await knowledge_base_repo.lock(self.db, kb.id)
         storage_paths = await rag_document_repo.delete_by_knowledge_base(self.db, kb.id)
         await knowledge_base_repo.delete(self.db, kb.id)
-        storage = get_file_storage()
-        for storage_path in storage_paths:
-            with contextlib.suppress(Exception):
-                await storage.delete(storage_path)
+        if storage_paths:
+            from app.core.background import spawn_after_commit
+            from app.services.file_storage import delete_files_best_effort
+
+            spawn_after_commit(
+                self.db, delete_files_best_effort(storage_paths), name="delete-kb-files"
+            )
         if not await knowledge_base_repo.list_by_collection_name(self.db, collection):
             # No base references the name any more, so any sync source still
             # pointing at it is dangling: `get_due_for_sync` would re-select it

--- a/backend/app/services/rag_document.py
+++ b/backend/app/services/rag_document.py
@@ -2,7 +2,6 @@
 """RAG document service."""
 
 import anyio
-import contextlib
 import logging
 from datetime import UTC, datetime
 from pathlib import Path
@@ -361,9 +360,10 @@ class RAGDocumentService:
         gone, and a directory synced nightly accumulates one dead row per file
         per run.
 
-        The stored file goes with it, on the same best-effort terms as
-        `delete_document`: a storage backend that refuses must not leave the
-        database describing vectors nobody holds.
+        The stored files are unlinked after the commit (`spawn_after_commit`), so
+        a rollback leaves them beside the rows it restores rather than gone; an
+        unlink before the commit would strand a restored row on a missing file
+        (#1293). Best-effort on the same terms as `delete_document`.
         """
         superseded = await rag_document_repo.get_superseded(
             self.db,
@@ -371,13 +371,16 @@ class RAGDocumentService:
             vector_document_id=vector_document_id,
             keep_id=keep_id,
         )
+        storage_paths = [stale.storage_path for stale in superseded if stale.storage_path]
         for stale in superseded:
-            if stale.storage_path:
-                try:
-                    await get_file_storage().delete(stale.storage_path)
-                except Exception as exc:
-                    logger.warning("Failed to delete superseded file: %s", exc)
             await rag_document_repo.delete(self.db, stale.id)
+        if storage_paths:
+            from app.core.background import spawn_after_commit
+            from app.services.file_storage import delete_files_best_effort
+
+            spawn_after_commit(
+                self.db, delete_files_best_effort(storage_paths), name="retire-superseded-files"
+            )
 
     async def fail_ingestion(self, doc_id: str, error_message: str) -> None:
         """Mark a document ingestion as failed."""
@@ -447,9 +450,10 @@ class RAGDocumentService:
     ) -> None:
         """Delete a document with cascading cleanup.
 
-        Removes the record from the database and attempts to clean up the vector
-        store entry and stored file. Failures in cleanup are logged but do not
-        prevent the DB deletion.
+        Removes the record and the vector store entry; the stored file is unlinked
+        after the commit (`spawn_after_commit`), so a rollback keeps it beside the
+        row it restores rather than stranding it on a missing file (#1293). Cleanup
+        failures are logged, not raised.
 
         **`ingestion_service` has no default, and that is the whole of it.** It
         was `Any = None`, and the vector cleanup ran only when a caller happened
@@ -468,31 +472,36 @@ class RAGDocumentService:
             except Exception as e:
                 logger.warning("Failed to delete from vector store: %s", e)
 
-        if doc.storage_path:
-            try:
-                storage = get_file_storage()
-                await storage.delete(doc.storage_path)
-            except Exception as e:
-                logger.warning("Failed to delete file: %s", e)
-
+        storage_path = doc.storage_path
         await rag_document_repo.delete(self.db, doc.id)
+
+        if storage_path:
+            from app.core.background import spawn_after_commit
+            from app.services.file_storage import delete_files_best_effort
+
+            spawn_after_commit(
+                self.db, delete_files_best_effort([storage_path]), name="delete-document-file"
+            )
 
     async def delete_by_collection(self, collection_name: str) -> None:
         """Delete a collection's document rows and unlink their stored uploads.
 
         The bulk row delete used to return only a count, so nothing removed the
         uploaded files and every one was orphaned on disk when a collection was
-        dropped (#1265). The unlink is best-effort - a file already gone is not a
-        reason to fail the drop - and mirrors the org purge's teardown.
-
-        `get_file_storage()` is resolved inside the suppression, and only when
-        there is a path to unlink: it `mkdir`s `MEDIA_DIR` on construction, so a
-        misconfigured storage backend would otherwise raise here and 500 a drop
-        whose vector table the route has already removed.
+        dropped (#1265). The unlink runs after the commit (`spawn_after_commit`),
+        so a rollback keeps the files beside the rows it restores rather than
+        stranding them on missing files (#1293). It is best-effort, and
+        `delete_files_best_effort` resolves the storage backend only when it runs -
+        a misconfigured backend fails the background unlink, not the drop.
         """
-        for storage_path in await rag_document_repo.delete_by_collection(self.db, collection_name):
-            with contextlib.suppress(Exception):
-                await get_file_storage().delete(storage_path)
+        storage_paths = await rag_document_repo.delete_by_collection(self.db, collection_name)
+        if storage_paths:
+            from app.core.background import spawn_after_commit
+            from app.services.file_storage import delete_files_best_effort
+
+            spawn_after_commit(
+                self.db, delete_files_best_effort(storage_paths), name="delete-collection-files"
+            )
 
     async def get_parsed_content(
         self, doc_id: str, vector_store: BaseVectorStore

--- a/backend/tests/test_kb_scoping.py
+++ b/backend/tests/test_kb_scoping.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.core import background
 from app.core.exceptions import AuthorizationError, BadRequestError, NotFoundError
 from app.core.permissions import AuthContext, OrgRoleName
 from app.db.models.knowledge_base import KBScope, KnowledgeBase
@@ -14,6 +15,14 @@ from app.repositories.rag_document import CollectionCounts
 from app.schemas.knowledge_base import KnowledgeBaseCreate, KnowledgeBaseUpdate
 from app.services.ingestion_config import deployment_defaults
 from app.services.knowledge_base import KnowledgeBaseService, _with_counts
+
+
+@pytest.fixture(autouse=True)
+def _no_leftover_tasks():
+    """A deferred unlink one test starts must not be drained by the next."""
+    background._running.clear()
+    yield
+    background._running.clear()
 
 
 def _ctx(
@@ -285,6 +294,39 @@ class TestKBAccessControl:
         # The row is not the whole teardown: with nothing else on the collection,
         # its vector table is dropped too, not left orphaned (#1266).
         store.delete_collection.assert_awaited_once_with(kb.collection_name)
+
+    @pytest.mark.anyio
+    async def test_deleting_a_kb_defers_the_file_unlinks_past_the_commit(self, monkeypatch):
+        """The stored files are unlinked after the commit, so a rollback keeps them
+        beside the rows it restores rather than stranding them (#1293)."""
+        user_id = uuid.uuid4()
+        kb = _kb("personal", owner_user_id=user_id)
+        storage = MagicMock(delete=AsyncMock())
+        monkeypatch.setattr("app.services.file_storage.get_file_storage", lambda: storage)
+        db = MagicMock()
+        db.info = {}
+
+        with (
+            patch("app.repositories.knowledge_base_repo.get_by_id", new=AsyncMock(return_value=kb)),
+            patch("app.repositories.knowledge_base_repo.lock", new=AsyncMock(return_value=kb)),
+            patch("app.repositories.knowledge_base_repo.delete", new=AsyncMock(return_value=True)),
+            patch(
+                "app.repositories.rag_document_repo.delete_by_knowledge_base",
+                new=AsyncMock(return_value=["rag/docs/a.pdf", "rag/docs/b.md"]),
+            ),
+            patch(
+                "app.repositories.knowledge_base_repo.list_by_collection_name",
+                new=AsyncMock(return_value=[MagicMock()]),
+            ),
+        ):
+            svc = KnowledgeBaseService(db)
+            await svc.delete(kb.id, ctx=_ctx(user_id=user_id), vector_store=MagicMock())
+            storage.delete.assert_not_awaited()
+
+            background.start_deferred(db)
+            await background.drain(timeout=5.0)
+
+        assert storage.delete.await_count == 2
 
     @pytest.mark.anyio
     async def test_deleting_the_last_kb_locks_it_and_deactivates_its_sources(self, mock_db):

--- a/backend/tests/test_rag_chunk_count.py
+++ b/backend/tests/test_rag_chunk_count.py
@@ -22,6 +22,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.core import background
 from app.repositories import rag_document_repo
 from app.services.rag.ingestion import IngestionService
 from app.services.rag.models import (
@@ -36,6 +37,28 @@ from app.services.rag_document import RAGDocumentService
 from app.worker.tasks.rag_tasks import _run_ingestion
 
 pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture(autouse=True)
+def _no_leftover_tasks():
+    """A deferred unlink one test starts must not be drained by the next."""
+    background._running.clear()
+    yield
+    background._running.clear()
+
+
+def _deferring_db() -> MagicMock:
+    """A session stand-in whose `info` is a real dict, so `spawn_after_commit`
+    queues on it the way a live session's does."""
+    db = MagicMock()
+    db.info = {}
+    return db
+
+
+async def _run_deferred(db: MagicMock) -> None:
+    """What `_managed_session` does the instant its commit returns."""
+    background.start_deferred(db)
+    await background.drain(timeout=5.0)
 
 
 def _document(*, chunks: int) -> Document:
@@ -231,9 +254,10 @@ class TestRetiringWhatAReplacementDeleted:
             "delete",
             AsyncMock(side_effect=lambda _db, doc_id: deleted.append(doc_id)),
         )
-        monkeypatch.setattr("app.services.rag_document.get_file_storage", lambda: storage)
+        monkeypatch.setattr("app.services.file_storage.get_file_storage", lambda: storage)
 
-        service = RAGDocumentService(MagicMock())
+        db = _deferring_db()
+        service = RAGDocumentService(db)
         monkeypatch.setattr(service, "get_document", AsyncMock(return_value=current))
         await service.complete_ingestion(
             str(current.id),
@@ -242,12 +266,15 @@ class TestRetiringWhatAReplacementDeleted:
             replaced_document_id="old-vector-doc",
         )
 
+        # The row goes in the transaction; the file is unlinked only once it commits.
         assert deleted == [stale_id]
+        storage.delete.assert_not_awaited()
+        await _run_deferred(db)
         storage.delete.assert_awaited_once_with("rag/docs/handbook.md")
 
     async def test_a_storage_backend_that_refuses_still_loses_the_row(self, monkeypatch):
         """The database must not go on describing vectors nobody holds because a
-        file could not be unlinked - the same terms `delete_document` takes.
+        file could not be unlinked - the deferred unlink swallows its failure.
         """
         stale = MagicMock(id=uuid.uuid4(), storage_path="rag/docs/handbook.md")
         deleted: list[uuid.UUID] = []
@@ -260,11 +287,12 @@ class TestRetiringWhatAReplacementDeleted:
             AsyncMock(side_effect=lambda _db, doc_id: deleted.append(doc_id)),
         )
         monkeypatch.setattr(
-            "app.services.rag_document.get_file_storage",
+            "app.services.file_storage.get_file_storage",
             lambda: MagicMock(delete=AsyncMock(side_effect=OSError("read-only volume"))),
         )
 
-        service = RAGDocumentService(MagicMock())
+        db = _deferring_db()
+        service = RAGDocumentService(db)
         monkeypatch.setattr(
             service,
             "get_document",
@@ -276,6 +304,7 @@ class TestRetiringWhatAReplacementDeleted:
             chunk_count=9,
             replaced_document_id="old-vector-doc",
         )
+        await _run_deferred(db)
 
         assert deleted == [stale.id]
 
@@ -294,9 +323,10 @@ class TestRetiringWhatAReplacementDeleted:
             "delete",
             AsyncMock(side_effect=lambda _db, doc_id: deleted.append(doc_id)),
         )
-        monkeypatch.setattr("app.services.rag_document.get_file_storage", lambda: storage)
+        monkeypatch.setattr("app.services.file_storage.get_file_storage", lambda: storage)
 
-        service = RAGDocumentService(MagicMock())
+        db = _deferring_db()
+        service = RAGDocumentService(db)
         monkeypatch.setattr(
             service,
             "get_document",
@@ -308,6 +338,7 @@ class TestRetiringWhatAReplacementDeleted:
             chunk_count=9,
             replaced_document_id="old-vector-doc",
         )
+        await _run_deferred(db)
 
         assert deleted == [stale.id]
         storage.delete.assert_not_awaited()

--- a/backend/tests/test_synced_document_delete.py
+++ b/backend/tests/test_synced_document_delete.py
@@ -23,10 +23,33 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from app.core import background
 from app.repositories import rag_document_repo
 from app.services.rag_document import RAGDocumentService
 
 pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture(autouse=True)
+def _no_leftover_tasks():
+    """A deferred unlink one test starts must not be drained by the next."""
+    background._running.clear()
+    yield
+    background._running.clear()
+
+
+def _deferring_db() -> MagicMock:
+    """A session stand-in whose `info` is a real dict, so `spawn_after_commit`
+    queues on it the way a live session's does."""
+    db = MagicMock()
+    db.info = {}
+    return db
+
+
+async def _run_deferred(db: MagicMock) -> None:
+    """What `_managed_session` does the instant its commit returns."""
+    background.start_deferred(db)
+    await background.drain(timeout=5.0)
 
 
 def _row(*, vector_document_id: str | None, storage_path: str = "") -> MagicMock:
@@ -60,6 +83,23 @@ class TestDeletingATrackedDocument:
         await RAGDocumentService(MagicMock()).delete_document(str(row.id), ingestion)
 
         ingestion.remove_document.assert_not_awaited()
+
+    async def test_the_stored_file_is_unlinked_after_the_commit(self, monkeypatch):
+        """The row and its vectors go in the transaction; the file is unlinked only
+        once it commits, so a rollback keeps it beside the restored row (#1293)."""
+        row = _row(vector_document_id="vector-doc-1", storage_path="rag/docs/report.pdf")
+        monkeypatch.setattr(rag_document_repo, "get_by_id", AsyncMock(return_value=row))
+        monkeypatch.setattr(rag_document_repo, "delete", AsyncMock(return_value=True))
+        storage = MagicMock(delete=AsyncMock())
+        monkeypatch.setattr("app.services.file_storage.get_file_storage", lambda: storage)
+        ingestion = MagicMock(remove_document=AsyncMock(return_value=True))
+        db = _deferring_db()
+
+        await RAGDocumentService(db).delete_document(str(row.id), ingestion)
+        storage.delete.assert_not_awaited()
+
+        await _run_deferred(db)
+        storage.delete.assert_awaited_once_with("rag/docs/report.pdf")
 
     async def test_a_store_that_refuses_still_removes_the_row(self, monkeypatch):
         """The cleanup is best-effort by design: a row kept because the store was
@@ -275,33 +315,56 @@ class TestTheCLISync:
 
 
 class TestDroppingACollection:
-    async def test_it_unlinks_the_stored_uploads(self, monkeypatch):
-        """The bulk row delete returns the storage paths now, so each upload is
-        unlinked rather than orphaned on disk when a collection is dropped (#1265)."""
+    async def test_it_unlinks_the_stored_uploads_after_the_commit(self, monkeypatch):
+        """The bulk row delete returns the storage paths, and the unlink is deferred
+        past the commit so a rollback keeps the files (#1265, #1293)."""
         monkeypatch.setattr(
             rag_document_repo,
             "delete_by_collection",
             AsyncMock(return_value=["rag/docs/a.pdf", "rag/docs/b.md"]),
         )
         storage = MagicMock(delete=AsyncMock())
-        monkeypatch.setattr("app.services.rag_document.get_file_storage", lambda: storage)
+        monkeypatch.setattr("app.services.file_storage.get_file_storage", lambda: storage)
+        db = _deferring_db()
 
-        await RAGDocumentService(MagicMock()).delete_by_collection("docs")
+        await RAGDocumentService(db).delete_by_collection("docs")
+        storage.delete.assert_not_awaited()
 
+        await _run_deferred(db)
         assert storage.delete.await_count == 2
         storage.delete.assert_any_await("rag/docs/a.pdf")
         storage.delete.assert_any_await("rag/docs/b.md")
 
-    async def test_a_failed_unlink_does_not_fail_the_drop(self, monkeypatch):
-        """A file already gone is not a reason to leave the collection half-dropped."""
+    async def test_a_rolled_back_drop_keeps_the_files(self, monkeypatch):
+        """The unlink is discarded when the transaction that removed the rows did
+        not commit, so the restored rows still point at their files (#1293)."""
+        monkeypatch.setattr(
+            rag_document_repo,
+            "delete_by_collection",
+            AsyncMock(return_value=["rag/docs/a.pdf"]),
+        )
+        storage = MagicMock(delete=AsyncMock())
+        monkeypatch.setattr("app.services.file_storage.get_file_storage", lambda: storage)
+        db = _deferring_db()
+
+        await RAGDocumentService(db).delete_by_collection("docs")
+        background.discard_deferred(db)
+        await background.drain(timeout=5.0)
+
+        storage.delete.assert_not_awaited()
+
+    async def test_a_failed_unlink_does_not_raise(self, monkeypatch):
+        """A file already gone is not a reason for the deferred unlink to fail."""
         monkeypatch.setattr(
             rag_document_repo,
             "delete_by_collection",
             AsyncMock(return_value=["rag/docs/gone.pdf"]),
         )
         storage = MagicMock(delete=AsyncMock(side_effect=FileNotFoundError()))
-        monkeypatch.setattr("app.services.rag_document.get_file_storage", lambda: storage)
+        monkeypatch.setattr("app.services.file_storage.get_file_storage", lambda: storage)
+        db = _deferring_db()
 
-        await RAGDocumentService(MagicMock()).delete_by_collection("docs")
+        await RAGDocumentService(db).delete_by_collection("docs")
+        await _run_deferred(db)
 
         storage.delete.assert_awaited_once()


### PR DESCRIPTION
## Summary

The RAG delete paths unlinked stored uploads inside the request transaction,
before it committed. A commit that then failed rolled the `rag_documents` rows
back but left the files gone, so a restored row pointed at a missing upload — its
download and re-ingestion broken, and the original that could rebuild the vectors
lost (#1293).

Now on main after #1284 and #1286 merged, all four sites are in one place to fix.

## Changed

- **`app/services/file_storage.py`** — one shared `delete_files_best_effort(paths)`,
  the deferred coroutine: it holds only ids, resolves the storage backend when it
  runs, and suppresses a file already gone.
- **`app/services/rag_document.py`** — `delete_by_collection`, `delete_document` and
  `complete_ingestion`'s `_retire_superseded` now hand the unlink to
  `spawn_after_commit` after deleting the rows.
- **`app/services/knowledge_base.py`** — `delete` does the same; the table drop and
  sync-source deactivation stay in the transaction.

## Testing

- The four sites' unit tests (`test_synced_document_delete`, `test_rag_chunk_count`,
  `test_kb_scoping`) now assert the unlink is **queued on the session and not run**,
  **runs on `start_deferred`**, and is **discarded on `discard_deferred`** — a
  rolled-back drop keeps the files. `make lint` clean, `ty` clean.

## Notes for reviewers

- **Scope.** This defers the *file* unlinks, per the issue. The same paths still do
  their *vector-store* ops before the commit — `delete_document`'s `remove_document`
  and `knowledge_base.delete`'s `delete_collection` (a `DROP TABLE`) — which is the
  same rollback class on the store's own engine, but needs the store held across the
  commit and the #913 reference re-check moved with it. Filed as **#1347** rather than
  widened into here.
- Sibling of **#1274** (org-teardown durability); the org purge path (`purge`) is not
  touched here.

Closes #1293
