### PR TITLE
chore: cut 0.0.344

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,26 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.344] - 2026-09-01
+
+### Fixed
+
+- **The RAG delete paths unlinked stored uploads inside the request transaction.**
+  `rag_document.delete_by_collection`, `delete_document`, `complete_ingestion`'s
+  `_retire_superseded` and `knowledge_base.delete` all removed the file before the
+  commit, so a commit that then failed rolled the `rag_documents` rows back and left
+  the files gone - a restored row pointing at a missing upload, its download and
+  re-ingestion broken, and the original that could have rebuilt the vectors lost. All
+  four now hand the unlink to `spawn_after_commit` after deleting the rows, through
+  one shared `delete_files_best_effort(paths)` in `app/services/file_storage.py`
+  which holds only ids, resolves the storage backend when it runs, and suppresses a
+  file already gone. The table drop and the sync-source deactivation stay in the
+  transaction. (#1293)
+- The vector-store half of those same paths - `delete_document`'s `remove_document`
+  and `knowledge_base.delete`'s `DROP TABLE` - still runs before the commit, which is
+  the same rollback class on the store's own engine and needs the #913 reference
+  re-check moved with it. Filed as #1347 rather than widened into this change. (#1293)
+
 ## [0.0.343] - 2026-08-28
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.343"
+version = "0.0.344"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.343"
+version = "0.0.344"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.343",
+  "version": "0.0.344",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.344. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.344 and adds the CHANGELOG entry.

Releases #1293: the four RAG delete paths now defer their file unlinks to
`spawn_after_commit`, so a failed commit no longer leaves a restored
`rag_documents` row pointing at a file that is gone.

Verified on #1348 - `test_synced_document_delete`, `test_rag_chunk_count` and
`test_kb_scoping` assert the unlink is queued on the session and not run, runs
on `start_deferred`, and is discarded on `discard_deferred`.

The vector-store half of the same paths is still in the transaction and is
tracked by #1347, the next release in this chain.