### PR TITLE
chore: cut 0.0.345

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,25 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.345] - 2026-09-01
+
+### Fixed
+
+- **The RAG delete paths did their vector-store work inside the request
+  transaction.** #1293 deferred the file unlinks; the store side effects stayed
+  where they were, so the same rollback left the vectors gone.
+  `RAGDocumentService.delete_document`'s `remove_document` and
+  `KnowledgeBaseService.delete`'s `delete_collection` `DROP TABLE` now go over with
+  `spawn_after_commit` too. The collection drop is the sharper of the two: a
+  rollback used to restore the knowledge-base and `rag_documents` rows pointing at
+  a table that no longer existed, which is a correctness fault rather than a
+  recoverable leak. The deferred drop re-reads its `list_by_collection_name`
+  reference check on a session of its own, because the name is not tenant-unique
+  and a second organization can reclaim it in the window between the commit and
+  the drop (#913) - the same re-check the org purge's durable cleanup makes. (#1347)
+- Still deferred in-process, so a crash between the commit and the dispatch loses
+  the cleanup; that durability gap is #1349. (#1347)
+
 ## [0.0.344] - 2026-09-01
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.344"
+version = "0.0.345"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.344"
+version = "0.0.345"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.344",
+  "version": "0.0.345",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.345. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.345 and adds the CHANGELOG entry.

Releases #1347: the vector-store half of the RAG delete paths now runs after
the request commits, so a rollback no longer restores a `rag_documents` row
whose vectors are gone or a knowledge base whose table has been dropped.

Verified on #1354 - the delete tests assert the deferred pattern, a rolled-back
delete keeps the vectors and the table, and a name reclaimed in the
commit-to-drop window skips the drop (#913).

The cleanup is still in-process, so a crash between the commit and the dispatch
loses it; #1349 is the next release in this chain.