### PR TITLE
chore: cut 0.0.347

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,30 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.347] - 2026-09-01
+
+### Fixed
+
+- **A collection's name could be claimed while its vector table was being
+  dropped.** The teardown re-reads `list_by_collection_name` before dropping a
+  `rag_<name>` table (#913), but the re-check and the drop are two statements and
+  the claim path is two more: under READ COMMITTED a claim reading "this name is
+  free" and a drop reading "no base holds this name" both act, and the drop then
+  removes the table the claim just created and committed a row against. `POST
+  /rag/collections/{name}` creates the table before committing its row, so the
+  window was reachable. Both ends now take a transaction-scoped advisory lock keyed
+  on the collection name - `hold_name`, the string-subject sibling of
+  `hold_subject`, under a new `COLLECTION_TEARDOWN` scope in `app/db/locks.py`.
+  `CollectionAccessService.claim` takes it after the identifier rule and before the
+  taken-check, holding it past `create_collection` until the request commits;
+  `cleanup_external_state` takes it before each collection's re-check and holds it
+  through the drop. Either the claim commits first and the drop's re-check skips,
+  or the drop commits first and the claim recreates the table its row points at.
+  (#1355)
+- Two pre-existing in-request drops still bypass that teardown - `DELETE
+  /rag/collections/{name}` and `_purge_personal_collections` - so the invariant
+  stays reachable through them until #1359. (#1355)
+
 ## [0.0.346] - 2026-09-01
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.346"
+version = "0.0.347"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.346"
+version = "0.0.347"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.346",
+  "version": "0.0.347",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.347. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.347 and adds the CHANGELOG entry.

Releases #1355: a claim on a collection name and the drop of that name's vector
table now serialize on a transaction-scoped advisory lock, so a claim that read
"free" and a drop that read "unreferenced" can no longer both act and leave a
committed knowledge-base row pointing at a dropped table.

Verified on #1360 - an integration test proves two holders of one name
serialize and two holders of different names do not, and unit tests assert both
paths take the `COLLECTION_TEARDOWN` lock.

Two in-request drops still bypass the durable teardown and its lock; #1359 is
the next release in this chain.