### PR TITLE
chore: cut 0.0.348

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,30 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.348] - 2026-09-01
+
+### Fixed
+
+- **The last two collection drops that ran in the request now go through the
+  durable teardown.** `DELETE /rag/collections/{name}` dropped the table directly,
+  with no #913 reference re-check and no lock, so it could drop a table a second
+  knowledge base still referenced and could race a concurrent claim of the name;
+  `UserService._purge_personal_collections` (#1131) re-checked and then dropped with
+  nothing held in between. Both now delete their document and knowledge-base rows
+  in the request and hand the files and the table drop to
+  `dispatch_external_state_cleanup`, which takes the `COLLECTION_TEARDOWN` lock,
+  re-reads the reference check on its own session, and drops only what no base
+  still claims. `drop_collection`'s drop moves into
+  `KnowledgeBaseService.delete_for_rag_collection`, so the route loses its
+  `vector_store` dependency the way `delete_knowledge_base` did. (#1359)
+- The reserved-name refusal that gated `drop_collection` in-request is now the
+  store's, inside the flow: the route answers 204 and removes the records, and a
+  pre-rule collection whose name folds onto a model table keeps that table. The
+  same deferral tradeoff `delete_knowledge_base` already makes. (#1359)
+- The window every deferred drop leaves - a populated table with no row naming it,
+  which a concurrent claim can adopt - is closed by 0.0.349 (#1362), the tip of
+  this arc. (#1359)
+
 ## [0.0.347] - 2026-09-01
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.347"
+version = "0.0.348"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.347"
+version = "0.0.348"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.347",
+  "version": "0.0.348",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.348. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.348 and adds the CHANGELOG entry.

Releases #1359: `DELETE /rag/collections/{name}` and
`_purge_personal_collections` were the last two paths dropping a vector table
inside the request, the first with neither the #913 reference re-check nor the
#1355 lock. Both now hand the files and the drop to the durable, locked,
re-checked cleanup.

Verified on #1361 - service tests cover `delete_for_rag_collection`'s default,
sibling and drop branches at 100%, and the route test asserts the deferred
teardown.

Stated plainly: this release still carries the window every deferred drop
leaves - a populated table with no row naming it, which a concurrent claim can
adopt (#1362). It closes in 0.0.349, the next release in this chain.