### PR TITLE
chore: cut 0.0.349

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,37 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.349] - 2026-09-01
+
+### Fixed
+
+- **A name freed by a deferred drop could adopt the table it was about to drop.**
+  The teardown removes a collection's `rag_<name>` table only after the request that
+  deleted its knowledge-base rows commits, so between the commit and the drop the
+  name is free of any row while the populated table lingers - and a concurrent `POST
+  /rag/collections/{name}` had `_ensure_collection`'s `CREATE TABLE IF NOT EXISTS`
+  adopt it and read another tenant's chunks. The #1355 advisory lock serializes
+  claim against drop; it does not stop the claim winning the race. A tombstone
+  committed with the delete does: the new `collection_teardowns` table (the name is
+  the key, deployment-global) with an idempotent `reserve` / `is_reserved` /
+  `release`, reserved in the delete's own transaction by every path that schedules a
+  drop - `KnowledgeBaseService.delete`, `delete_for_rag_collection`,
+  `OrganizationService.purge`, `UserService._purge_personal_collections`. `claim`
+  refuses a reserved name, and `cleanup_external_state` drops the table and then
+  releases the reservation, so the name is never free while the populated table
+  exists and a failed drop keeps it for the retry. The flow drops unconditionally
+  now, and the "is another base still on this name?" check runs inline in each
+  delete path instead of once in the flow. (#1362)
+- **Dropping a default collection clears its table** rather than leaving the deleted
+  chunks searchable; the default row is kept, so the table recreates empty on the
+  next write. The inline reference check excludes the base being torn down, which is
+  what the flow's own check could not do. (#1362)
+
+### Added
+
+- `collection_teardowns` - the drop reservation, one row per name, released by the
+  cleanup that finishes the drop. (#1362)
+
 ## [0.0.348] - 2026-09-01
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.348"
+version = "0.0.349"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.348"
+version = "0.0.349"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.348",
+  "version": "0.0.349",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.349. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.349 and adds the CHANGELOG entry.

Releases #1362, the tip of the teardown arc #1293 opened - and the release that
makes the arc safe: a name freed by a deferred drop can no longer adopt the
populated table the drop has not reached yet, because the delete commits a
tombstone in `collection_teardowns` and `claim` refuses a reserved name until
the cleanup drops the table and releases it.

Also closes #1361's P1: dropping a default collection clears its table instead
of leaving the deleted chunks searchable.

Verified on #1363 - the repo, the claim refusal, the default-clear and the
cleanup's drop-then-release / keep-on-failure in unit tests, plus a
real-database integration test that a reserved name is refused until released.
New migration `0063_collection_teardowns`; `db-check` and the chain ran in CI.