### PR TITLE
chore: cut 0.0.350

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.350] - 2026-09-01
+
+### Changed
+
+- `pydantic-ai-slim` to 2.35.3, both extras sets - the runtime one
+  (`anthropic`, `cohere`, `duckduckgo`, `google`, `groq`, `huggingface`,
+  `mistral`, `openrouter`, `web-fetch`, `xai`) and `mcp` - from 2.33.0. The agent
+  runtime is the one dependency where a lag is felt in every run, so the group
+  moves on its own. (#1345)
+
 ## [0.0.349] - 2026-09-01
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.349"
+version = "0.0.350"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.349"
+version = "0.0.350"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.349",
+  "version": "0.0.350",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.350. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.350 and adds the CHANGELOG entry.

Releases #1345: `pydantic-ai-slim` to 2.35.3 from 2.33.0, both the runtime
extras set and `mcp`.

Verified on #1345 - `lint`, `test`, `docs` and `e2e` green on the bump; the
agent runtime is exercised end to end by the seeded e2e run, which is what a
version jump on this dependency is worth checking against.