### PR TITLE
chore: cut 0.0.351

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.351] - 2026-09-01
+
+### Changed
+
+- Backend dependencies: `pydantic[email]` 2.13.5, `prefect` 3.8.4,
+  `pydantic-ai-harness` 0.27.0, `llama-cloud` 2.15.0, `liteparse` 2.14.2,
+  `google-auth` 2.57.0, `boto3` 1.43.83, `click` 8.5.0, `tavily-python` 0.8.0,
+  `cryptography` 50.0.1, `aiogram` 3.31.0, `slack-sdk` 3.44.0, and the dev pins
+  `ruff` 0.16.5 and `ty` 0.0.75. (#1367)
+
 ## [0.0.350] - 2026-09-01
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.350"
+version = "0.0.351"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.350"
+version = "0.0.351"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.350",
+  "version": "0.0.351",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.351. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.351 and adds the CHANGELOG entry.

Releases the backend dependency group - fourteen updates, `cryptography`
50.0.1 and `aiogram` 3.31.0 among them.

This landed as #1367, not #1346: dependabot closed #1346 and reopened the group
against a moved `main` while the teardown arc was merging, adding
`pydantic[email]` 2.13.5 and taking `boto3` to 1.43.83. #1346 is closed with no
content of its own left.

Verified on #1367 - `lint`, `test`, `docs` and `e2e` green.