### PR TITLE
chore: cut 0.0.352

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.352] - 2026-09-01
+
+### Changed
+
+- GitHub Actions: `openai/codex-action` 1.12, `astral-sh/setup-uv` 10.0.1 and
+  `docker/setup-buildx-action` 4.3.0. (#1357)
+
 ## [0.0.351] - 2026-09-01
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.351"
+version = "0.0.352"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.351"
+version = "0.0.352"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.351",
+  "version": "0.0.352",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.352. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.352 and adds the CHANGELOG entry.

Releases #1357: the GitHub Actions group - `openai/codex-action` 1.12,
`astral-sh/setup-uv` 10.0.1 and `docker/setup-buildx-action` 4.3.0.

Verified on #1357, which is the honest check for a workflow bump: every job in
`ci.yml` ran on the new action versions and passed, including `test-frontend`,
which the path filter usually skips.

`setup-uv` is a major, 9 to 10. Nothing in the workflows relies on the
behaviour it changed - the pins are the version and `enable-cache`.