### PR TITLE
chore: cut 0.0.353

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.353] - 2026-09-01
+
+### Changed
+
+- `knip` to 6.32.2 from 5.88.1. `bun run lint:deps` - the narrowed run that gates
+  `lint-frontend` on a declared dependency nothing imports - is clean on the major
+  with the existing `knip.jsonc`. The bump arrived with `frontend/package.json`
+  changed and `bun.lock` untouched, which is not a lockfile drift the frontend jobs
+  tolerate: `bun install --frozen-lockfile` refused it, so `test-frontend` and `e2e`
+  failed before either ran a test. The lockfile is refreshed in the same change.
+  (#1358)
+
 ## [0.0.352] - 2026-09-01
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.352"
+version = "0.0.353"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.352"
+version = "0.0.353"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.352",
+  "version": "0.0.353",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.353. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.353 and adds the CHANGELOG entry.

Releases #1358: `knip` 6.32.2, a major from 5.88.1, with `frontend/bun.lock`
regenerated in the same branch.

The bump arrived with the manifest changed and the lockfile untouched, so
`bun install --frozen-lockfile` refused it and `test-frontend` and `e2e` both
failed before running a test - the failure had nothing to do with knip 6.
`bun run lint:deps`, the narrowed run that gates `lint-frontend`, is clean on
the major with the existing `knip.jsonc`; the full `knip` report that
`make dead-code` runs still exits 1 on unused exports, exactly as it did on
5.88.1.