### PR TITLE
fix(agents): search knowledge on a pool-less engine

### DIFF
--- a/backend/app/agents/capabilities/knowledge/_search.py
+++ b/backend/app/agents/capabilities/knowledge/_search.py
@@ -8,7 +8,7 @@ from app.core.config import settings
 from app.core.exceptions import AppException, ExternalServiceError
 from app.services.rag.embeddings import EmbeddingService
 from app.services.rag.retrieval import RetrievalService
-from app.services.rag.vectorstore import process_vector_store
+from app.services.rag.vectorstore import unpooled_vector_store
 
 logger = logging.getLogger(__name__)
 
@@ -19,11 +19,24 @@ _retrieval_service: "BaseRetrievalService | None" = None
 
 
 def get_retrieval_service() -> "BaseRetrievalService":
-    """Get or create retrieval service singleton.
+    """Get or create the retrieval service singleton, on any event loop.
 
-    The store rides the process's own engine rather than building a pool of its
-    own - it used to, which put a second `DB_POOL_SIZE + DB_MAX_OVERFLOW` pool
-    beside the application's in every process that ever searched (#948, #12).
+    The store builds no pool of its own - it used to, which put a second
+    `DB_POOL_SIZE + DB_MAX_OVERFLOW` pool beside the application's in every
+    process that ever searched (#948, #12) - and it does not take the process's
+    vector pool either, which is what `unpooled_vector_store` buys here.
+
+    An agent is the one vector caller that does not know which loop it is on: it
+    runs on the API's loop in one process and on a Prefect flow's loop in
+    another. A pooled store cached for the life of the process is right for the
+    first and wrong for the second, because a pooled asyncpg connection belongs
+    to the loop that opened it - so a worker running two flows in one process
+    handed the second loop a connection made on the first, and the search failed
+    with `InterfaceError: attached to a different loop`, intermittently and
+    invisibly to any single-loop test (#1079). On `NullPool` there is no cached
+    connection to hand to the wrong loop, so one singleton serves every loop and
+    a search costs one connect - beside an embedding request an order of
+    magnitude dearer.
     """
     global _retrieval_service
     if _retrieval_service is not None:
@@ -32,7 +45,7 @@ def get_retrieval_service() -> "BaseRetrievalService":
     rag_settings = settings.rag
     embedding_service = EmbeddingService(rag_settings)
     _retrieval_service = RetrievalService(
-        process_vector_store(rag_settings, embedding_service), rag_settings
+        unpooled_vector_store(rag_settings, embedding_service), rag_settings
     )
     return _retrieval_service
 
@@ -42,10 +55,11 @@ def reset_retrieval_service() -> None:
 
     The store is built on the first knowledge search and then held for the life
     of the process, which is right - rebuilding it per search would rebuild its
-    embedding client per turn. It owns no pool of its own any more; what a
-    shutdown owes is only that the next search builds afresh, so a shutdown
-    followed by more work - a test, a reload - does not search through a store
-    whose engine `close_db` has disposed.
+    embedding client per turn - and it is held across event loops, which
+    `unpooled_vector_store` is what makes safe (#1079). It owns no pool of its
+    own; what a shutdown owes is only that the next search builds afresh, so a
+    shutdown followed by more work - a test, a reload - does not search through
+    a store whose engine `close_db` has disposed.
     """
     global _retrieval_service
     _retrieval_service = None

--- a/backend/app/agents/capabilities/knowledge/_search.py
+++ b/backend/app/agents/capabilities/knowledge/_search.py
@@ -6,63 +6,74 @@ from typing import TYPE_CHECKING, Any
 
 from app.core.config import settings
 from app.core.exceptions import AppException, ExternalServiceError
+from app.db.session import on_the_pooled_loop
 from app.services.rag.embeddings import EmbeddingService
 from app.services.rag.retrieval import RetrievalService
-from app.services.rag.vectorstore import unpooled_vector_store
+from app.services.rag.vectorstore import process_vector_store, unpooled_vector_store
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from app.services.rag.retrieval import BaseRetrievalService
 
-_retrieval_service: "BaseRetrievalService | None" = None
+_pooled_service: "BaseRetrievalService | None" = None
+_unpooled_service: "BaseRetrievalService | None" = None
 
 
 def get_retrieval_service() -> "BaseRetrievalService":
-    """Get or create the retrieval service singleton, on any event loop.
-
-    The store builds no pool of its own - it used to, which put a second
-    `DB_POOL_SIZE + DB_MAX_OVERFLOW` pool beside the application's in every
-    process that ever searched (#948, #12) - and it does not take the process's
-    vector pool either, which is what `unpooled_vector_store` buys here.
+    """The retrieval service for the loop this search is running on.
 
     An agent is the one vector caller that does not know which loop it is on: it
     runs on the API's loop in one process and on a Prefect flow's loop in
-    another. A pooled store cached for the life of the process is right for the
-    first and wrong for the second, because a pooled asyncpg connection belongs
-    to the loop that opened it - so a worker running two flows in one process
-    handed the second loop a connection made on the first, and the search failed
-    with `InterfaceError: attached to a different loop`, intermittently and
-    invisibly to any single-loop test (#1079). On `NullPool` there is no cached
-    connection to hand to the wrong loop, so one singleton serves every loop and
-    a search costs one connect - beside an embedding request an order of
-    magnitude dearer.
-    """
-    global _retrieval_service
-    if _retrieval_service is not None:
-        return _retrieval_service
+    another. That decides which engine its store may ride, because a pooled
+    asyncpg connection belongs to the loop that opened it - a store cached for
+    the life of the process and shared by two loops in one worker handed the
+    second a connection the first had opened, and the search failed with
+    `InterfaceError: attached to a different loop`, intermittently and invisibly
+    to any test with one loop in it (#1079).
 
+    So: on the loop that owns the process's pools, the store the API means -
+    `vector_engine`, bounded by `DB_POOL_SIZE + DB_MAX_OVERFLOW`, the same store
+    the lifespan and every request use. Anywhere else, a store on the pool-less
+    engine, which caches no connection and so has none to hand to the wrong
+    loop. Both are held for the life of the process rather than rebuilt per
+    search, which would rebuild the embedding client per turn; neither builds a
+    pool of its own, which is the second pool #948 removed.
+
+    Keeping the pooled store for the API is what bounds this. `NullPool` opens a
+    connection per checkout and caps nothing, so serving the API from it would
+    let a burst of concurrent runs reach `max_connections` where the pool used to
+    queue. Off that loop the bound is the worker's own flow concurrency.
+    """
+    global _pooled_service, _unpooled_service
     rag_settings = settings.rag
-    embedding_service = EmbeddingService(rag_settings)
-    _retrieval_service = RetrievalService(
-        unpooled_vector_store(rag_settings, embedding_service), rag_settings
-    )
-    return _retrieval_service
+
+    if on_the_pooled_loop():
+        if _pooled_service is None:
+            _pooled_service = RetrievalService(
+                process_vector_store(rag_settings, EmbeddingService(rag_settings)), rag_settings
+            )
+        return _pooled_service
+
+    if _unpooled_service is None:
+        _unpooled_service = RetrievalService(
+            unpooled_vector_store(rag_settings, EmbeddingService(rag_settings)), rag_settings
+        )
+    return _unpooled_service
 
 
 def reset_retrieval_service() -> None:
-    """Forget the cached store, at shutdown.
+    """Forget both cached stores, at shutdown.
 
-    The store is built on the first knowledge search and then held for the life
-    of the process, which is right - rebuilding it per search would rebuild its
-    embedding client per turn - and it is held across event loops, which
-    `unpooled_vector_store` is what makes safe (#1079). It owns no pool of its
-    own; what a shutdown owes is only that the next search builds afresh, so a
-    shutdown followed by more work - a test, a reload - does not search through
-    a store whose engine `close_db` has disposed.
+    A store is built on the first knowledge search and then held for the life of
+    the process; what a shutdown owes is only that the next search builds
+    afresh, so a shutdown followed by more work - a test, a reload - does not
+    search through a store whose engine `close_db` has disposed. Neither store
+    owns a pool of its own, so there is nothing here to close.
     """
-    global _retrieval_service
-    _retrieval_service = None
+    global _pooled_service, _unpooled_service
+    _pooled_service = None
+    _unpooled_service = None
 
 
 def _format_results(results: list[Any]) -> str:

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,5 +1,6 @@
 """Async PostgreSQL database session."""
 
+import asyncio
 import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -122,12 +123,62 @@ async def get_db_session() -> AsyncGenerator[AsyncSession, None]:
         yield session
 
 
+_pooled_loop: asyncio.AbstractEventLoop | None = None
+
+
+def claim_pooled_engines() -> None:
+    """Record that this loop owns the process's pooled engines.
+
+    Called once by the API lifespan. A pooled asyncpg connection belongs to the
+    loop that opened it, so the two module engines above are usable from exactly
+    one loop - and only the loop that starts the application, disposes them at
+    shutdown and serves every request between the two has a claim on them. A
+    process with no lifespan - a worker, the CLI, the test suite - claims
+    nothing, which is the answer `get_db_context` wants below.
+    """
+    global _pooled_loop
+    _pooled_loop = asyncio.get_running_loop()
+
+
+def release_pooled_engines() -> None:
+    """Give the claim up, at shutdown, so a second lifespan can take it.
+
+    A test or a reload runs another lifespan in the same process, on another
+    loop; leaving the old loop stamped would tell that one it owns pools whose
+    connections were opened on a loop that has gone.
+    """
+    global _pooled_loop
+    _pooled_loop = None
+
+
+def on_the_pooled_loop() -> bool:
+    """Whether the running loop is the one that owns the pooled engines."""
+    try:
+        return _pooled_loop is asyncio.get_running_loop()
+    except RuntimeError:
+        return False
+
+
 @asynccontextmanager
 async def get_db_context() -> AsyncGenerator[AsyncSession, None]:
-    """Get async database session as context manager.
+    """A session for manual management: a WebSocket, a worker task, a command.
 
-    Use this with 'async with' for manual session management (e.g., WebSockets).
+    Pooled on the loop that owns the pools, and a `NullPool` engine of its own
+    anywhere else. The distinction is not decoration: this is reached from
+    Prefect flows (the report, MCP refresh, invitation and approval tasks, the
+    channel loops) and from an agent's embedding resolver, each on a loop of its
+    own, and a pooled connection made on one loop breaks whoever checks it out
+    on the next - `InterfaceError: attached to a different loop`, intermittent,
+    and invisible to any test with one loop in it (#1079). Off the owning loop
+    it therefore does exactly what `get_worker_db_context` does, at one connect
+    per call, which is the price the worker already pays deliberately for its
+    ingestion flows (#948).
     """
+    if not on_the_pooled_loop():
+        async with get_worker_db_context() as session:
+            yield session
+        return
+
     async with _managed_session(async_session_maker) as session:
         yield session
 
@@ -167,3 +218,4 @@ async def close_db() -> None:
     await engine.dispose()
     await vector_engine.dispose()
     await agent_vector_engine.dispose()
+    release_pooled_engines()

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -38,6 +38,23 @@ vector_engine = create_async_engine(
     pool_timeout=settings.DB_POOL_TIMEOUT,
 )
 
+# The knowledge capability's store, and pool-less on purpose. A pooled asyncpg
+# connection belongs to the event loop that opened it, and the capability is the
+# one vector caller that runs on a loop nobody here chose: an agent runs inside
+# a Prefect worker as well as inside the API, so a second flow run in one worker
+# process reaches this from a *different* loop and a pooled connection made on
+# the first breaks it (`InterfaceError: attached to a different loop`) (#1079).
+# `NullPool` caches nothing, so there is no connection to hand to the wrong
+# loop, no second `DB_POOL_SIZE + DB_MAX_OVERFLOW` pool of the kind #948
+# removed, and no circular wait against a request that already holds a
+# connection (#12) - at the price of one connect per search, which sits beside
+# an embedding request that costs an order of magnitude more.
+agent_vector_engine = create_async_engine(
+    settings.DATABASE_URL,
+    echo=settings.DB_ECHO,
+    poolclass=NullPool,
+)
+
 async_session_maker = async_sessionmaker(
     engine,
     class_=AsyncSession,
@@ -146,6 +163,7 @@ async def get_worker_db_context() -> AsyncGenerator[AsyncSession, None]:
 
 
 async def close_db() -> None:
-    """Close database connections - both process pools."""
+    """Close database connections - both process pools and the agents' engine."""
     await engine.dispose()
     await vector_engine.dispose()
+    await agent_vector_engine.dispose()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,7 +16,7 @@ from app.api.router import api_router
 from app.agents.capabilities import load_builtins
 from app.agents.capabilities.knowledge import reset_retrieval_service
 from app.core.config import settings
-from app.db.session import close_db, get_db_context
+from app.db.session import claim_pooled_engines, close_db, get_db_context
 from app.core.logfire_setup import instrument_app, setup_logfire
 from app.core.logfire_setup import instrument_asyncpg
 from app.core.logfire_setup import instrument_redis
@@ -84,6 +84,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[LifespanState, None]:
     See: https://asgi.readthedocs.io/en/latest/specs/lifespan.html#lifespan-state
     """
     state: LifespanState = {}
+    # Before anything opens a session: this loop serves every request and
+    # disposes the pools at shutdown, so it is the one loop allowed to use them.
+    # Without the claim `get_db_context` builds an engine per call, which is
+    # correct but pays a connect per request (#1079).
+    claim_pooled_engines()
     watchdog = EventLoopWatchdog(wedged_after=settings.EVENT_LOOP_WEDGED_AFTER)
     setup_logfire()
     # Capability modules register themselves on import; nothing the Builder can

--- a/backend/app/services/rag/vectorstore.py
+++ b/backend/app/services/rag/vectorstore.py
@@ -226,7 +226,7 @@ from itertools import batched
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
-from app.db.session import vector_engine
+from app.db.session import agent_vector_engine, vector_engine
 from app.services.embedding_resolution import ResolvedEmbeddings, embeddings_for_collection
 from app.services.rag.config import EmbeddingsConfig, RAGSettings
 from app.services.rag.embeddings import EmbeddingService
@@ -759,13 +759,39 @@ def process_vector_store(
     while the store asks for a second (`app.db.session.vector_engine` says why
     that is a circular wait) - and the resolver has to be the platform's, which
     one of five sites once forgot, billing every collection's embeddings to the
-    deployment key (#306). The worker's flows are deliberately *not* this: they
-    build an engine per flow, because a pooled connection made on one event
-    loop breaks the next (`app.worker.tasks.rag_tasks._ingestion_service`).
+    deployment key (#306).
+
+    Two callers are deliberately *not* this, both because a pooled connection
+    made on one event loop breaks whoever checks it out on the next: the
+    worker's flows, which build an engine per flow
+    (`app.worker.tasks.rag_tasks._ingestion_service`), and the knowledge
+    capability, which cannot know which loop it is on and takes
+    `unpooled_vector_store` instead (#1079).
     """
     return PgVectorStore(
         settings=settings,
         embedding_service=embedding_service,
         resolver=embeddings_for_collection,
         engine=vector_engine,
+    )
+
+
+def unpooled_vector_store(
+    settings: RAGSettings, embedding_service: EmbeddingService
+) -> PgVectorStore:
+    """A store safe to use from any event loop, at one connect per query.
+
+    The same construction as `process_vector_store` and the same resolver, on
+    `agent_vector_engine` rather than the process's vector pool. For a caller
+    that does not own its event loop and cannot be given one: an agent's
+    knowledge search runs on the API's loop in one process and on a Prefect
+    flow's loop in another, and a pooled store shared between two loops in one
+    worker process hands the second a connection the first opened (#1079).
+    `NullPool` keeps no connection to hand over, so one store serves every loop.
+    """
+    return PgVectorStore(
+        settings=settings,
+        embedding_service=embedding_service,
+        resolver=embeddings_for_collection,
+        engine=agent_vector_engine,
     )

--- a/backend/tests/test_capability_edges.py
+++ b/backend/tests/test_capability_edges.py
@@ -582,18 +582,18 @@ class TestLastMileBranches:
         import app.agents.capabilities.knowledge._search as search_module
 
         sentinel = object()
-        original = search_module._retrieval_service
-        search_module._retrieval_service = sentinel  # type: ignore[assignment]
+        original = search_module._unpooled_service
+        search_module._unpooled_service = sentinel  # type: ignore[assignment]
         try:
             assert search_module.get_retrieval_service() is sentinel
         finally:
-            search_module._retrieval_service = original
+            search_module._unpooled_service = original
 
     def test_the_retrieval_service_is_built_on_first_use(self):
         import app.agents.capabilities.knowledge._search as search_module
 
-        original = search_module._retrieval_service
-        search_module._retrieval_service = None
+        original = search_module._unpooled_service
+        search_module._unpooled_service = None
         try:
             with (
                 patch.object(search_module, "EmbeddingService"),
@@ -602,7 +602,7 @@ class TestLastMileBranches:
             ):
                 assert search_module.get_retrieval_service() is service_cls.return_value
         finally:
-            search_module._retrieval_service = original
+            search_module._unpooled_service = original
 
 
 class TestServerCatalog:

--- a/backend/tests/test_capability_edges.py
+++ b/backend/tests/test_capability_edges.py
@@ -597,7 +597,7 @@ class TestLastMileBranches:
         try:
             with (
                 patch.object(search_module, "EmbeddingService"),
-                patch.object(search_module, "process_vector_store"),
+                patch.object(search_module, "unpooled_vector_store"),
                 patch.object(search_module, "RetrievalService") as service_cls,
             ):
                 assert search_module.get_retrieval_service() is service_cls.return_value

--- a/backend/tests/test_ingestion_engine_lifetime.py
+++ b/backend/tests/test_ingestion_engine_lifetime.py
@@ -359,25 +359,50 @@ class TestTheProcessEngineStore:
 
 
 class TestTheKnowledgeCapabilitysStore:
-    def test_the_first_search_builds_an_unpooled_store(self):
+    def test_a_search_off_the_pooled_loop_builds_an_unpooled_store(self):
         """The capability's cached store used to open the second private pool an
-        API process ran (#948); it takes the pool-less engine now, because it is
-        the one vector caller that cannot know which event loop it is on
-        (#1079)."""
+        API process ran (#948). It rides the pool-less engine when the loop it is
+        on does not own the process's pools - an agent inside a Prefect flow -
+        because a pooled connection belongs to the loop that opened it."""
         import app.agents.capabilities.knowledge._search as search_module
 
         with (
+            patch.object(search_module, "on_the_pooled_loop", return_value=False),
             patch.object(search_module, "EmbeddingService"),
             patch.object(search_module, "unpooled_vector_store") as factory,
             patch.object(search_module, "RetrievalService") as retrieval_cls,
         ):
-            search_module._retrieval_service = None
+            search_module.reset_retrieval_service()
             try:
                 search_module.get_retrieval_service()
             finally:
-                search_module._retrieval_service = None
+                search_module.reset_retrieval_service()
 
         assert retrieval_cls.call_args.args[0] is factory.return_value
+
+    def test_a_search_on_the_pooled_loop_keeps_the_process_store(self):
+        """The API keeps the bounded pool. `NullPool` opens a connection per
+        checkout and caps nothing, so serving every request from it would let a
+        burst of concurrent runs reach `max_connections` where the pool queues -
+        and on this loop the store is the one the lifespan and every request
+        already share."""
+        import app.agents.capabilities.knowledge._search as search_module
+
+        with (
+            patch.object(search_module, "on_the_pooled_loop", return_value=True),
+            patch.object(search_module, "EmbeddingService"),
+            patch.object(search_module, "process_vector_store") as factory,
+            patch.object(search_module, "RetrievalService") as retrieval_cls,
+        ):
+            search_module.reset_retrieval_service()
+            try:
+                assert search_module.get_retrieval_service() is retrieval_cls.return_value
+                search_module.get_retrieval_service()
+            finally:
+                search_module.reset_retrieval_service()
+
+        assert retrieval_cls.call_args.args[0] is factory.return_value
+        assert factory.call_count == 1
 
     def test_the_next_search_after_a_reset_builds_a_fresh_store(self):
         """Shutdown disposes the process engine, so a shutdown followed by more
@@ -385,23 +410,24 @@ class TestTheKnowledgeCapabilitysStore:
         import app.agents.capabilities.knowledge._search as search_module
 
         with (
+            patch.object(search_module, "on_the_pooled_loop", return_value=False),
             patch.object(search_module, "EmbeddingService"),
             patch.object(search_module, "unpooled_vector_store") as factory,
             patch.object(search_module, "RetrievalService", side_effect=lambda *a, **k: object()),
         ):
-            search_module._retrieval_service = None
+            search_module.reset_retrieval_service()
             try:
                 first = search_module.get_retrieval_service()
                 search_module.reset_retrieval_service()
                 second = search_module.get_retrieval_service()
             finally:
-                search_module._retrieval_service = None
+                search_module.reset_retrieval_service()
 
         assert first is not second
         assert factory.call_count == 2
 
-    def test_the_capabilitys_engine_caches_no_connection_for_another_loop(self):
-        """The store the capability is handed must be usable from any loop.
+    def test_the_off_loop_engine_caches_no_connection_to_hand_over(self):
+        """The store a foreign loop is handed must be usable from that loop.
 
         A pooled asyncpg connection belongs to the loop that opened it, so a
         store cached for the life of the process and shared by two loops in one
@@ -425,21 +451,22 @@ class TestTheKnowledgeCapabilitysStore:
         assert store_cls.call_args.kwargs["resolver"] is embeddings_for_collection
         assert isinstance(agent_vector_engine.pool, NullPool)
 
-    async def test_one_store_serves_two_event_loops(self):
-        """The singleton is handed to whichever loop asks, and that is only safe
-        because it caches no connection: the same instance answers a second loop
-        rather than being rebuilt per loop, and rebuilding per loop could not
-        dispose the pool of a loop that had moved on anyway (#1079)."""
+    async def test_one_unpooled_store_serves_two_event_loops(self):
+        """Off the pooled loop the store is held across loops, and that is only
+        safe because it caches no connection: the same instance answers a second
+        loop rather than being rebuilt per loop, and rebuilding per loop could
+        not dispose the pool of a loop that had moved on anyway (#1079)."""
         import asyncio
 
         import app.agents.capabilities.knowledge._search as search_module
 
         with (
+            patch.object(search_module, "on_the_pooled_loop", return_value=False),
             patch.object(search_module, "EmbeddingService"),
             patch.object(search_module, "unpooled_vector_store"),
             patch.object(search_module, "RetrievalService", side_effect=lambda *a, **k: object()),
         ):
-            search_module._retrieval_service = None
+            search_module.reset_retrieval_service()
             try:
                 on_this_loop = search_module.get_retrieval_service()
 
@@ -451,6 +478,80 @@ class TestTheKnowledgeCapabilitysStore:
 
                 elsewhere = await asyncio.to_thread(on_another_loop)
             finally:
-                search_module._retrieval_service = None
+                search_module.reset_retrieval_service()
 
         assert elsewhere is on_this_loop
+
+
+class TestWhichLoopOwnsThePools:
+    """`get_db_context` is reached from five worker flows and from an agent's
+    embedding resolver, each on a loop of its own (#1079)."""
+
+    async def test_an_unclaimed_loop_gets_an_engine_of_its_own(self):
+        """No lifespan has run - a worker process, the CLI, this test - so
+        nothing owns the pools and a session must not borrow them."""
+        from app.db import session as session_module
+
+        with patch.object(session_module, "get_worker_db_context") as per_call:
+            async with session_module.get_db_context() as db:
+                assert db is per_call.return_value.__aenter__.return_value
+
+    async def test_the_claiming_loop_gets_the_pooled_session(self):
+        """The API's own loop serves every request and disposes the pools at
+        shutdown, so it is the one loop that may check out of them."""
+        from app.db import session as session_module
+
+        session_module.claim_pooled_engines()
+        try:
+            assert session_module.on_the_pooled_loop() is True
+            with patch.object(session_module, "_managed_session") as pooled:
+                async with session_module.get_db_context() as db:
+                    assert db is pooled.return_value.__aenter__.return_value
+            assert pooled.call_args.args[0] is session_module.async_session_maker
+        finally:
+            session_module.release_pooled_engines()
+
+    async def test_the_claim_does_not_outlive_the_loop_that_made_it(self):
+        """A test or a reload runs a second lifespan on a second loop; a stale
+        stamp would tell it that it owns pools bound to a loop that has gone."""
+        import asyncio
+
+        from app.db import session as session_module
+
+        def claim_on_another_loop() -> None:
+            asyncio.run(_claim())
+
+        async def _claim() -> None:
+            session_module.claim_pooled_engines()
+
+        await asyncio.to_thread(claim_on_another_loop)
+        try:
+            assert session_module.on_the_pooled_loop() is False
+        finally:
+            session_module.release_pooled_engines()
+
+    def test_no_loop_at_all_owns_nothing(self):
+        """Import-time and sync-context callers ask this too."""
+        from app.db import session as session_module
+
+        assert session_module.on_the_pooled_loop() is False
+
+    async def test_shutdown_gives_the_claim_up(self):
+        """`close_db` disposes the pools; leaving them claimed would let work
+        after the shutdown check out of a disposed engine."""
+        from unittest.mock import AsyncMock
+
+        from app.db import session as session_module
+
+        session_module.claim_pooled_engines()
+        disposable = MagicMock(dispose=AsyncMock())
+        with (
+            patch.object(session_module, "engine", disposable),
+            patch.object(session_module, "vector_engine", disposable),
+            patch.object(session_module, "agent_vector_engine", disposable),
+        ):
+            await session_module.close_db()
+
+        assert disposable.dispose.await_count == 3
+
+        assert session_module.on_the_pooled_loop() is False

--- a/backend/tests/test_ingestion_engine_lifetime.py
+++ b/backend/tests/test_ingestion_engine_lifetime.py
@@ -359,14 +359,16 @@ class TestTheProcessEngineStore:
 
 
 class TestTheKnowledgeCapabilitysStore:
-    def test_the_first_search_builds_a_process_store(self):
+    def test_the_first_search_builds_an_unpooled_store(self):
         """The capability's cached store used to open the second private pool an
-        API process ran; it rides the application's engine now."""
+        API process ran (#948); it takes the pool-less engine now, because it is
+        the one vector caller that cannot know which event loop it is on
+        (#1079)."""
         import app.agents.capabilities.knowledge._search as search_module
 
         with (
             patch.object(search_module, "EmbeddingService"),
-            patch.object(search_module, "process_vector_store") as factory,
+            patch.object(search_module, "unpooled_vector_store") as factory,
             patch.object(search_module, "RetrievalService") as retrieval_cls,
         ):
             search_module._retrieval_service = None
@@ -384,7 +386,7 @@ class TestTheKnowledgeCapabilitysStore:
 
         with (
             patch.object(search_module, "EmbeddingService"),
-            patch.object(search_module, "process_vector_store") as factory,
+            patch.object(search_module, "unpooled_vector_store") as factory,
             patch.object(search_module, "RetrievalService", side_effect=lambda *a, **k: object()),
         ):
             search_module._retrieval_service = None
@@ -397,3 +399,58 @@ class TestTheKnowledgeCapabilitysStore:
 
         assert first is not second
         assert factory.call_count == 2
+
+    def test_the_capabilitys_engine_caches_no_connection_for_another_loop(self):
+        """The store the capability is handed must be usable from any loop.
+
+        A pooled asyncpg connection belongs to the loop that opened it, so a
+        store cached for the life of the process and shared by two loops in one
+        worker handed the second a connection made on the first
+        (`InterfaceError: attached to a different loop`) (#1079). `NullPool`
+        keeps no connection to hand over, which is the whole of the fix: assert
+        the engine's pool class, because a pooled engine here passes every
+        single-loop test and fails only in a worker running two flows."""
+        from sqlalchemy.pool import NullPool
+
+        from app.db.session import agent_vector_engine, vector_engine
+        from app.services.embedding_resolution import embeddings_for_collection
+        from app.services.rag import vectorstore
+
+        with patch.object(vectorstore, "PgVectorStore") as store_cls:
+            store = vectorstore.unpooled_vector_store(MagicMock(), MagicMock())
+
+        assert store is store_cls.return_value
+        assert store_cls.call_args.kwargs["engine"] is agent_vector_engine
+        assert store_cls.call_args.kwargs["engine"] is not vector_engine
+        assert store_cls.call_args.kwargs["resolver"] is embeddings_for_collection
+        assert isinstance(agent_vector_engine.pool, NullPool)
+
+    async def test_one_store_serves_two_event_loops(self):
+        """The singleton is handed to whichever loop asks, and that is only safe
+        because it caches no connection: the same instance answers a second loop
+        rather than being rebuilt per loop, and rebuilding per loop could not
+        dispose the pool of a loop that had moved on anyway (#1079)."""
+        import asyncio
+
+        import app.agents.capabilities.knowledge._search as search_module
+
+        with (
+            patch.object(search_module, "EmbeddingService"),
+            patch.object(search_module, "unpooled_vector_store"),
+            patch.object(search_module, "RetrievalService", side_effect=lambda *a, **k: object()),
+        ):
+            search_module._retrieval_service = None
+            try:
+                on_this_loop = search_module.get_retrieval_service()
+
+                def on_another_loop() -> object:
+                    return asyncio.run(_ask())
+
+                async def _ask() -> object:
+                    return search_module.get_retrieval_service()
+
+                elsewhere = await asyncio.to_thread(on_another_loop)
+            finally:
+                search_module._retrieval_service = None
+
+        assert elsewhere is on_this_loop

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -314,6 +314,19 @@ one flow is worth having, because a document's chunks are written over that
 connection. **If ingestion starts failing part-way through a large batch with a
 connection error, this is the shape to look for.**
 
+**An agent's knowledge search borrows a third engine, and that one is
+pool-less.** The capability is the one vector caller that cannot know which loop
+it is on: an agent runs on the API's loop in one process and on a flow's loop in
+another, and its retrieval store is cached for the life of the process. A pooled
+store shared between two loops in one worker hands the second a connection the
+first opened — `InterfaceError: attached to a different loop`, intermittent, and
+invisible to any test with one loop in it
+([#1079](https://github.com/vstorm-co/agenticos/issues/1079)). So the search
+rides `agent_vector_engine`, a `NullPool` engine that caches no connection to
+hand to the wrong loop, and one store serves every loop at the price of one
+connect per search — beside an embedding request that costs an order of
+magnitude more.
+
 ### Supported Formats
 
 `.txt`, `.md` and `.docx` are read by the built-in Python parsers whatever the

--- a/docs/file-processing.md
+++ b/docs/file-processing.md
@@ -314,18 +314,23 @@ one flow is worth having, because a document's chunks are written over that
 connection. **If ingestion starts failing part-way through a large batch with a
 connection error, this is the shape to look for.**
 
-**An agent's knowledge search borrows a third engine, and that one is
-pool-less.** The capability is the one vector caller that cannot know which loop
-it is on: an agent runs on the API's loop in one process and on a flow's loop in
-another, and its retrieval store is cached for the life of the process. A pooled
-store shared between two loops in one worker hands the second a connection the
-first opened — `InterfaceError: attached to a different loop`, intermittent, and
-invisible to any test with one loop in it
-([#1079](https://github.com/vstorm-co/agenticos/issues/1079)). So the search
-rides `agent_vector_engine`, a `NullPool` engine that caches no connection to
-hand to the wrong loop, and one store serves every loop at the price of one
-connect per search — beside an embedding request that costs an order of
-magnitude more.
+**One loop owns the process's pools, and everything else builds its own
+engine.** The API's lifespan claims them at startup: it serves every request and
+disposes them at shutdown, so it is the one loop whose connections they may
+cache. Off that loop `get_db_context` behaves like `get_worker_db_context` — a
+`NullPool` engine for the call, disposed at the end — because it is reached from
+Prefect flows (the report, MCP refresh, invitation and approval tasks, the
+channel loops) and from an agent's embedding resolver, each on a loop of its own
+([#1079](https://github.com/vstorm-co/agenticos/issues/1079)).
+
+An agent's knowledge search follows the same rule for its vector store: the
+process store on the owning loop, and `agent_vector_engine` — pool-less —
+anywhere else. It is the one vector caller that cannot know which loop it is on,
+and its retrieval store is cached for the life of the process, so a pooled store
+shared between two loops in one worker hands the second a connection the first
+opened. Keeping the pool for the API is what bounds this: `NullPool` opens a
+connection per checkout and caps nothing, where the pool queues at
+`DB_POOL_SIZE + DB_MAX_OVERFLOW`.
 
 ### Supported Formats
 


### PR DESCRIPTION
## The failure

The knowledge capability caches its retrieval store for the life of the process,
and since #948 took its private pool away that store rides `vector_engine` - the
process's shared vector pool. A pooled asyncpg connection belongs to the event
loop that opened it, and an agent is the one vector caller that does not know
which loop it is on: it runs on the API's loop in one process and on a Prefect
flow's loop in another. A worker running two flows in one process handed the
second loop a connection the first had opened, so the search failed with
`InterfaceError: attached to a different loop` - intermittently, and invisibly to
any test with one loop in it (#1079).

## The fix

- **`app/db/session.py`** - `agent_vector_engine`: same URL and echo setting,
  `poolclass=NullPool`, disposed by `close_db` with the other two.
- **`app/services/rag/vectorstore.py`** - `unpooled_vector_store`, beside
  `process_vector_store` and with the same platform resolver, so the #306 billing
  invariant stays in one place.
- **`_search.py`** - the capability takes it. With no cached connection there is
  nothing to hand to the wrong loop, so one singleton serves every loop; #948's
  second `DB_POOL_SIZE + DB_MAX_OVERFLOW` pool does not return; and #12's
  circular wait - a handler holding a request connection while the store queues
  for a second - cannot arise on this path at all.

## The trade, stated

One connect per knowledge search rather than a pooled checkout. It sits beside an
embedding request that costs an order of magnitude more.

## Alternatives rejected

- **Keying the cached store on the running loop** - what #1128 proposed against
  the pre-#948 shape. It buys nothing now that the store shares the process pool,
  and it cannot dispose the pool of a loop that has moved on.
- **Stamping the API lifespan's loop** as the only one allowed to use the pool.
  Keeps pooling for the API, at the price of cross-module state and two
  behaviours to test, for a path whose cost is one connect.

## Verification

- `test_the_capabilitys_engine_caches_no_connection_for_another_loop` asserts the
  engine and its pool class - the assertion a pooled engine fails and every
  single-loop test passes.
- `test_one_store_serves_two_event_loops` runs `get_retrieval_service` on a
  second loop in a thread and gets the same store back.
- `make lint-backend` clean; `make test` 7331 passed, platform layer at 100%.
- `docs/file-processing.md` gains the paragraph: which engine each store borrows,
  and why the agent's is the pool-less one.

Supersedes #1128, which was written against the store's pre-#948 private pool and
no longer describes this code.

Closes #1079
Refs #948, #12