### PR TITLE
chore: cut 0.0.354

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,46 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.354] - 2026-09-01
+
+### Fixed
+
+- **An agent's knowledge search could be handed a database connection made on
+  another event loop.** The capability caches its retrieval store for the life of
+  the process, and since #948 took the store's private pool away that store rode
+  `vector_engine`, the process's shared vector pool. A pooled asyncpg connection
+  belongs to the loop that opened it, and an agent is the one vector caller that
+  does not know which loop it is on - it runs on the API's loop in one process and
+  on a Prefect flow's loop in another - so a worker running two flows in one
+  process handed the second loop a connection the first had opened and the search
+  failed with `InterfaceError: attached to a different loop`, intermittently and
+  invisibly to any test with one loop in it. (#1079)
+- **The rule is now stated once, in the layer that owns the engines.** The API's
+  lifespan claims the process pools with `claim_pooled_engines`: it serves every
+  request and disposes them at shutdown, so it is the one loop whose connections
+  they may cache. `get_db_context` is pooled on that loop and behaves like
+  `get_worker_db_context` anywhere else - a `NullPool` engine for the call,
+  disposed at the end - and `close_db` gives the claim up, so a second lifespan in
+  one process (a test, a reload) does not inherit a stamp naming a loop that has
+  gone. That half was found reviewing the first fix and reaches further than the
+  agent: `get_db_context` is also reached from five worker flows - the report, MCP
+  refresh, invitation and approval tasks and the channel loops - and from
+  `embeddings_for_collection`, which every search consults before querying
+  vectors. (#1079)
+- The knowledge capability follows the same rule for its vector store: the process
+  store on the owning loop, and a store on the new pool-less `agent_vector_engine`
+  anywhere else. Keeping the pooled store for the API is what bounds this -
+  `NullPool` opens a connection per checkout and caps nothing, where the pool
+  queues at `DB_POOL_SIZE + DB_MAX_OVERFLOW` - and off that loop the bound is the
+  worker's own flow concurrency. (#1079)
+
+### Changed
+
+- #1128 is closed rather than merged. It keyed the cached store on the running
+  loop, which was right for the store's pre-#948 private pool and buys nothing
+  once the store shares the process pool - two loops keyed separately still check
+  out of one pool. Its trade-off note is what pointed at the layer below. (#1079)
+
 ## [0.0.353] - 2026-09-01
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.353"
+version = "0.0.354"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.353"
+version = "0.0.354"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.353",
+  "version": "0.0.354",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for 0.0.354. Bumps `backend/pyproject.toml`, `backend/uv.lock`
and `frontend/package.json` to 0.0.354 and adds the CHANGELOG entry.

Releases #1079: a pooled database connection can no longer reach a loop that
did not open it. The API's lifespan claims the process pools and `get_db_context`
builds a `NullPool` engine per call anywhere else, which covers the agent's
knowledge search, its embedding resolver and the five worker flows that were
reaching the request pool from a flow loop.

Verified on #1376 - `TestWhichLoopOwnsThePools` covers the claim, the release,
a claim made on a loop that has gone and no running loop at all; the capability's
tests cover both stores, the pool class of the off-loop engine, and one store
answering two loops. `make test` 7337 passed with the platform layer at 100%.

#1128 is closed rather than merged: it fixed the shape the store had before
#948, and the two review findings on #1376 - the resolver still on the pooled
engine, and `NullPool` bounding nothing - are what moved the fix down a layer.