### PR TITLE
fix(docs): resolve the presentation's poster path

### DIFF
--- a/docs/presentation/index.html
+++ b/docs/presentation/index.html
@@ -250,7 +250,7 @@
 </section>
 
 <section class="slide t-light shot">
-  <video src="../assets/screens/chat-live-demo.mp4" poster="screens/chat-live-demo-poster.webp" autoplay muted loop playsinline></video>
+  <video src="../assets/screens/chat-live-demo.mp4" poster="../assets/screens/chat-live-demo-poster.webp" autoplay muted loop playsinline></video>
   <div class="cap">
     <div class="eyebrow">One agent, answering</div>
     <div class="t">The reasoning, the tools it reached for, and what it cost</div>


### PR DESCRIPTION
The presentation's video slide was blank.

Moving the deck into `docs/presentation/` rewrote `src="screens/…"` to
`src="../assets/screens/…"` and **left `poster="screens/…"` behind it**. The mp4
resolved and its first frame did not — which is what a browser shows before
playback starts, and what Chrome prints into the PDF `make presentation`
renders. One character class in one regex.

The check written to confirm that move had the same blind spot as the move: it
resolved `src=` paths and never looked at any other attribute, so both the edit
and its verification agreed the page was fine.

`verify.py assets` in the `deck-build` skill now resolves every attribute that
can name a file — `src`, `poster`, `href`, `srcset` — against the page's own
directory, and fails on this exact input. A rendered-output check was tried
first and deleted: the slide still carried its caption card and its page
number, so it was not a flat field and no measurement of the raster called it
out.

Verified: `verify.py assets` reports nine local references and none missing;
the re-rendered deck is 20 slides with the frame back on slide 9.