### PR TITLE
feat(memory): promote a fact from agent to operator

### DIFF
--- a/backend/app/api/routes/v1/memory.py
+++ b/backend/app/api/routes/v1/memory.py
@@ -124,6 +124,13 @@ async def get_memory_fact(fact_id: UUID, service: MemorySvc, ctx: Auth) -> Any:
     return await service.get_fact(ctx, fact_id)
 
 
+@router.post("/facts/{fact_id}/promote", response_model=AgentMemoryFactRead)
+async def promote_memory_fact(fact_id: UUID, service: MemorySvc, ctx: Auth) -> Any:
+    """Mark an agent-authored fact operator-trusted, so it may enter the standing
+    brief. Deliberate, like a file's promote; native-only."""
+    return await service.promote_fact(ctx, fact_id)
+
+
 @router.delete("/facts/{fact_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None)
 async def delete_memory_fact(fact_id: UUID, service: MemorySvc, ctx: Auth) -> None:
     """Forget a fact. Operators do not create or edit facts - only the agent does,

--- a/backend/app/repositories/memory.py
+++ b/backend/app/repositories/memory.py
@@ -471,6 +471,23 @@ async def list_facts(
     return list(items.scalars().all()), total or 0
 
 
+async def set_fact_origin(
+    db: AsyncSession, *, fact: AgentMemoryFact, origin: str
+) -> AgentMemoryFact:
+    """Change a fact's trust tier - the promote write - and return the refreshed row.
+
+    A fact's only mutation: its content is never amended, only replaced, so unlike a
+    file's `update` this takes just the one field. `embedding` is not a mapped column
+    (see `AgentMemoryFact`), so a plain attribute set, flush and refresh leaves the
+    stored vector untouched.
+    """
+    fact.origin = origin
+    db.add(fact)
+    await db.flush()
+    await db.refresh(fact)
+    return fact
+
+
 async def delete_fact(db: AsyncSession, fact: AgentMemoryFact) -> None:
     await db.delete(fact)
     await db.flush()

--- a/backend/app/schemas/memory.py
+++ b/backend/app/schemas/memory.py
@@ -102,8 +102,9 @@ class AgentMemoryFactCreate(BaseSchema):
 
     The one exception to "operators never author facts": seeding standing semantic
     knowledge - a company fact the agent should recall - is a deliberate management
-    act. The embedding is unmetered, since there is no run to book it against, so it
-    is a deployment cost rather than a budget charge (see `embed_operator_fact`).
+    act. The embedding is metered to the organization's ingestion spend - a seed is
+    off any run, so it books to the org budget the way a RAG document does - and the
+    monthly cap is checked before it embeds.
     """
 
     agent_id: UUID = Field(description="The agent whose memory this fact belongs to")

--- a/backend/app/services/memory/facade.py
+++ b/backend/app/services/memory/facade.py
@@ -504,6 +504,46 @@ class MemoryService:
     async def get_fact(self, ctx: AuthContext, fact_id: UUID) -> AgentMemoryFact:
         return await self._fact_or_404(ctx, fact_id, perm=Perm.AGENTS_VIEW)
 
+    async def promote_fact(self, ctx: AuthContext, fact_id: UUID) -> AgentMemoryFactRead:
+        """Mark an agent-authored fact operator-authored (trusted).
+
+        The fact analogue of :meth:`promote`, and the one deliberate path from
+        `agent` to `operator` for a fact: a person vouches that an agent-learned
+        fact is safe to treat as the operator's own. That is what lets it enter the
+        standing brief - `list_brief_facts` injects operator-authored *shared* facts
+        and never an agent-authored one, so without a promote an operator's only way
+        to trust one was to delete and reseed it. A listing never launders origin;
+        promotion is the separate act, exactly as for a file. Native-only: a
+        mem0-backed agent has no origin tier to promote within, so it is refused
+        like the other fact-management paths. Requires edit on the parent agent -
+        promoting reaches the shared brief every end-user reads, never just one
+        person's own.
+        """
+        fact = await memory_repo.get_fact(self.db, fact_id, organization_id=ctx.organization_id)
+        if fact is None:
+            raise NotFoundError(message="Memory fact not found", details={"fact_id": str(fact_id)})
+        agent = await self._agent_or_404(ctx, fact.agent_id, perm=Perm.AGENTS_EDIT)
+        self._refuse_if_mem0(agent)
+        updated = await memory_repo.set_fact_origin(
+            self.db, fact=fact, origin=MemoryOrigin.OPERATOR.value
+        )
+        await record_audit(
+            self.db,
+            actor_user_id=ctx.subject_id,
+            organization_id=ctx.organization_id,
+            action="memory.fact.promoted",
+            target_type="memory",
+            target_id=str(fact.id),
+        )
+        return AgentMemoryFactRead(
+            id=updated.id,
+            agent_id=updated.agent_id,
+            content=updated.content,
+            origin=cast(MemoryOriginLiteral, updated.origin),
+            end_user_scope_key=updated.end_user_scope_key,
+            created_at=updated.created_at,
+        )
+
     async def delete_fact(self, ctx: AuthContext, fact_id: UUID) -> None:
         """Forget a fact. There is no operator create or edit - facts are the
         agent's own runtime writes - but clearing one is a management action."""

--- a/backend/tests/api/test_memory_routes.py
+++ b/backend/tests/api/test_memory_routes.py
@@ -281,6 +281,23 @@ class TestFacts:
         assert response.status_code == 200
         assert response.json()["content"] == fact.content
 
+    async def test_promoting_a_fact_answers_200_with_the_trusted_row(self, client: OpenClient):
+        fact = _fact_row()
+        promoted = _fact_row()
+        promoted.origin = MemoryOrigin.OPERATOR.value
+        get_agent, allow = _reachable()
+        with (
+            patch(f"{FACADE}.memory_repo.get_fact", new=AsyncMock(return_value=fact)),
+            get_agent,
+            allow,
+            patch(f"{FACADE}.memory_repo.set_fact_origin", new=AsyncMock(return_value=promoted)),
+            patch(f"{FACADE}.record_audit", new=AsyncMock()),
+        ):
+            async with client() as http:
+                response = await http.post(_url(f"/facts/{fact.id}/promote"))
+        assert response.status_code == 200
+        assert response.json()["origin"] == "operator"
+
     async def test_deleting_a_fact_answers_204(self, client: OpenClient):
         fact = _fact_row()
         get_agent, allow = _reachable()

--- a/backend/tests/integration/test_memory_repo.py
+++ b/backend/tests/integration/test_memory_repo.py
@@ -320,7 +320,7 @@ def test_fact_repr_names_the_agent() -> None:
 
 @pytest.fixture
 async def facts_table(db) -> int:
-    """The `embedding` column and extension migration 0064 adds in raw SQL.
+    """The `embedding` column and extension migration 0072 adds in raw SQL.
 
     The integration schema is built with `create_all` from the models, and
     `AgentMemoryFact` deliberately omits the vector column, so a fact test adds
@@ -539,6 +539,40 @@ class TestFacts:
         assert (
             await memory_repo.get_fact(db, fact.id, organization_id=agent.organization_id) is None
         )
+
+    async def test_set_fact_origin_promotes_a_fact_into_the_brief(self, db, facts_table) -> None:
+        # The whole point of promote: an agent-authored shared fact is recall-only
+        # until an operator vouches for it, after which it joins the standing brief.
+        agent = await _agent(db, org=await _org(db, owner=await _user(db)))
+        await _add_fact(db, agent, content="learned", at=0, dim=facts_table)
+        listed, _ = await memory_repo.list_facts(
+            db, organization_id=agent.organization_id, agent_id=agent.id, all_partitions=True
+        )
+        fact = listed[0]
+        assert fact.origin == MemoryOrigin.AGENT.value
+
+        before = await memory_repo.list_brief_facts(
+            db,
+            organization_id=agent.organization_id,
+            agent_id=agent.id,
+            personal_key=None,
+            limit=30,
+        )
+        assert before == []
+
+        promoted = await memory_repo.set_fact_origin(
+            db, fact=fact, origin=MemoryOrigin.OPERATOR.value
+        )
+        assert promoted.origin == MemoryOrigin.OPERATOR.value
+
+        after = await memory_repo.list_brief_facts(
+            db,
+            organization_id=agent.organization_id,
+            agent_id=agent.id,
+            personal_key=None,
+            limit=30,
+        )
+        assert {f.content for f in after} == {"learned"}
 
     async def test_deleting_the_agent_takes_its_facts(self, db, facts_table) -> None:
         agent = await _agent(db, org=await _org(db, owner=await _user(db)))

--- a/backend/tests/test_memory_service.py
+++ b/backend/tests/test_memory_service.py
@@ -729,9 +729,9 @@ class TestMem0FactManagement:
 
 
 class TestCreateFact:
-    """The operator seeds a fact directly: it is embedded server-side (unmetered),
-    stored, and audited, and the tier decides the permission the same way a file
-    create does."""
+    """The operator seeds a fact directly: it is embedded server-side (metered to the
+    org's ingestion spend, checked against the cap first), stored, and audited, and
+    the tier decides the permission the same way a file create does."""
 
     async def test_it_embeds_the_fact_stores_it_and_audits(self):
         service = _service()
@@ -912,3 +912,70 @@ class TestOperatorEmbeddingSpend:
                 MagicMock(), SpendLedger(organization_id=uuid.uuid4()), organization_id=uuid.uuid4()
             )
         record.assert_not_awaited()
+
+
+class TestPromoteFact:
+    """The fact analogue of promote: an agent-authored fact becomes operator-trusted
+    so it may enter the standing brief, a deliberate act rather than a side effect of
+    a listing - and, like the other fact-management paths, refused for a mem0 agent."""
+
+    async def test_promotion_sets_origin_operator_and_is_audited(self):
+        service = _service()
+        fact = _fact()
+        promoted = _fact()
+        promoted.origin = MemoryOrigin.OPERATOR.value
+        get_agent, allow = _reachable_agent()
+        with (
+            patch(f"{MEMORY_PATH}.memory_repo.get_fact", new=AsyncMock(return_value=fact)),
+            get_agent,
+            allow,
+            patch(
+                f"{MEMORY_PATH}.memory_repo.set_fact_origin",
+                new=AsyncMock(return_value=promoted),
+            ) as promote,
+            patch(f"{MEMORY_PATH}.record_audit", new=AsyncMock()) as audit,
+        ):
+            result = await service.promote_fact(_ctx(), fact.id)
+        assert promote.call_args.kwargs["origin"] == MemoryOrigin.OPERATOR.value
+        assert result.origin == "operator"
+        assert audit.call_args.kwargs["action"] == "memory.fact.promoted"
+
+    async def test_a_missing_fact_is_not_found(self):
+        service = _service()
+        with (
+            patch(f"{MEMORY_PATH}.memory_repo.get_fact", new=AsyncMock(return_value=None)),
+            pytest.raises(NotFoundError),
+        ):
+            await service.promote_fact(_ctx(), uuid.uuid4())
+
+    async def test_promoting_needs_edit_on_the_agent(self):
+        # Promotion reaches the shared brief every end-user reads, so view-only is a
+        # 404 here even though a viewer may forget their own personal fact.
+        service = _service()
+        fact = _fact()
+
+        async def _view_only(_db, _ctx, _agent, perm, **_kw) -> bool:
+            return perm == Perm.AGENTS_VIEW
+
+        with (
+            patch(f"{MEMORY_PATH}.memory_repo.get_fact", new=AsyncMock(return_value=fact)),
+            patch(f"{MEMORY_PATH}.agent_repo.get", new=AsyncMock(return_value=MagicMock())),
+            patch(f"{MEMORY_PATH}.resolve_access", new=AsyncMock(side_effect=_view_only)),
+            patch(f"{MEMORY_PATH}.memory_repo.set_fact_origin", new=AsyncMock()) as promote,
+            pytest.raises(NotFoundError),
+        ):
+            await service.promote_fact(_ctx(), fact.id)
+        promote.assert_not_awaited()
+
+    async def test_promotion_is_refused_for_a_mem0_agent(self):
+        service = _service()
+        fact = _fact()
+        with (
+            patch(f"{MEMORY_PATH}.memory_repo.get_fact", new=AsyncMock(return_value=fact)),
+            patch(f"{MEMORY_PATH}.agent_repo.get", new=AsyncMock(return_value=_mem0_agent())),
+            patch(f"{MEMORY_PATH}.resolve_access", new=AsyncMock(return_value=True)),
+            patch(f"{MEMORY_PATH}.memory_repo.set_fact_origin", new=AsyncMock()) as promote,
+            pytest.raises(BadRequestError),
+        ):
+            await service.promote_fact(_ctx(), fact.id)
+        promote.assert_not_awaited()

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -201,7 +201,10 @@ person vouched for; turning an agent note into an operator one is a deliberate
 A fact carries an `origin` for the same reason: the runtime `remember` writes an
 `agent` fact, an operator seed writes an `operator` one, and only the injectable
 set — a person's own facts and operator-authored shared ones — is placed in the
-standing brief, while an agent-authored shared fact stays `recall`-only.
+standing brief, while an agent-authored shared fact stays `recall`-only. As with a
+file, an agent fact an operator vouches for is **promoted** to `operator` in place —
+a deliberate act, never a side effect of a listing — after which it joins the
+injectable set rather than being deleted and reseeded.
 
 Access to the management API rides on the parent agent — whoever may view the
 agent may read its memory, whoever may edit the agent may

--- a/frontend/src/components/memory/memory-facts-pane.integration.test.tsx
+++ b/frontend/src/components/memory/memory-facts-pane.integration.test.tsx
@@ -149,11 +149,29 @@ describe("MemoryFactsPane", () => {
     expect(await screen.findByText("Something went wrong")).toBeInTheDocument();
   });
 
-  it("gives a viewer nothing to delete with", async () => {
+  it("offers promote only on an agent-authored fact, and promotes it", async () => {
+    // The operator-seeded fact (x1) is already trusted, so only the agent-written
+    // one (x2) carries a promote control; clicking it marks that fact trusted.
+    vi.mocked(apiClient.post).mockResolvedValue({ ...FACT_USER, origin: "operator" });
+    mount();
+    await screen.findByText("Prefers weekly summaries on Fridays.");
+
+    const promoteButtons = screen.getAllByRole("button", { name: "Promote to trusted" });
+    expect(promoteButtons).toHaveLength(1);
+
+    await userEvent.click(promoteButtons[0]!);
+
+    await waitFor(() =>
+      expect(apiClient.post).toHaveBeenCalledWith("/memory/facts/x2/promote", {}),
+    );
+  });
+
+  it("gives a viewer no control to change a fact", async () => {
     mount({ canEdit: false });
     await screen.findByText("Acme's fiscal year starts in April.");
 
     expect(screen.queryByRole("button", { name: "Forget fact" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Promote to trusted" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Clear all facts" })).not.toBeInTheDocument();
   });
 

--- a/frontend/src/components/memory/memory-facts-pane.tsx
+++ b/frontend/src/components/memory/memory-facts-pane.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Info, Plus, Sparkles, Trash2 } from "lucide-react";
+import { Info, Plus, ShieldCheck, Sparkles, Trash2 } from "lucide-react";
 import { useFormatter, useTranslations } from "next-intl";
 
 import {
@@ -50,7 +50,7 @@ export function MemoryFactsPane({ agentId, canEdit, scope }: MemoryFactsPaneProp
   const search = useDebounced(query);
 
   const { clearFacts } = useMemoryDangerZone(agentId);
-  const { facts, total, isLoading, error, refetch, remove } = useMemoryFacts({
+  const { facts, total, isLoading, error, refetch, promote, remove } = useMemoryFacts({
     agentId,
     scope,
     search,
@@ -136,15 +136,29 @@ export function MemoryFactsPane({ agentId, canEdit, scope }: MemoryFactsPaneProp
                     </div>
                   </div>
                   {canEdit && (
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="text-muted-foreground hover:text-destructive h-8 w-8 shrink-0"
-                      aria-label={t("forgetFact")}
-                      onClick={() => setPendingDelete(fact)}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
+                    <div className="flex shrink-0 items-center gap-1">
+                      {fact.origin === "agent" && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="text-muted-foreground hover:text-foreground h-8 w-8"
+                          aria-label={t("promote")}
+                          disabled={promote.isPending}
+                          onClick={() => promote.mutate(fact.id)}
+                        >
+                          <ShieldCheck className="h-4 w-4" />
+                        </Button>
+                      )}
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="text-muted-foreground hover:text-destructive h-8 w-8"
+                        aria-label={t("forgetFact")}
+                        onClick={() => setPendingDelete(fact)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
                   )}
                 </li>
               ))}

--- a/frontend/src/hooks/use-memory.test.tsx
+++ b/frontend/src/hooks/use-memory.test.tsx
@@ -266,6 +266,24 @@ describe("useMemoryFacts", () => {
     await expect(result.current.remove.mutateAsync("x1")).rejects.toThrow();
     expect(toastError).toHaveBeenCalled();
   });
+
+  it("promotes an agent fact to trusted and reports it", async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({ id: "x1", origin: "operator" });
+    const { result } = renderHook(() => useMemoryFacts({ agentId: "a1" }), { wrapper });
+
+    await result.current.promote.mutateAsync("x1");
+
+    expect(apiClient.post).toHaveBeenCalledWith("/memory/facts/x1/promote", {});
+    expect(toastSuccess).toHaveBeenCalled();
+  });
+
+  it("toasts when promoting a fact fails", async () => {
+    vi.mocked(apiClient.post).mockRejectedValue(new Error("boom"));
+    const { result } = renderHook(() => useMemoryFacts({ agentId: "a1" }), { wrapper });
+
+    await expect(result.current.promote.mutateAsync("x1")).rejects.toThrow();
+    expect(toastError).toHaveBeenCalled();
+  });
 });
 
 describe("useMemoryDangerZone", () => {

--- a/frontend/src/hooks/use-memory.ts
+++ b/frontend/src/hooks/use-memory.ts
@@ -228,6 +228,20 @@ export function useMemoryFacts({
     onError: (error) => toast.error(getErrorMessage(error, tErrors)),
   });
 
+  // Promoting an agent-authored fact makes it operator-trusted, which is what lets
+  // it enter the standing brief — the fact counterpart of a file's promote. There
+  // is no open detail to reconcile as there is for a file, so a plain list
+  // invalidation is enough: the row re-renders operator, and its promote control
+  // disappears with the origin it was gated on.
+  const promote = useMutation({
+    mutationFn: (id: string) => apiClient.post<MemoryFact>(`/memory/facts/${id}/promote`, {}),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: qk.memory.factsRoot(agentId) });
+      toast.success(t("promoted"));
+    },
+    onError: (error) => toast.error(getErrorMessage(error, tErrors)),
+  });
+
   const remove = useMutation({
     mutationFn: (id: string) => apiClient.delete<void>(`/memory/facts/${id}`),
     onSuccess: async () => {
@@ -244,6 +258,7 @@ export function useMemoryFacts({
     error,
     refetch,
     create,
+    promote,
     remove,
   };
 }


### PR DESCRIPTION
## What

Files could be **promoted** from agent-authored to operator-trusted; facts could
not. So an operator who wanted an agent-learned fact in the standing brief had no
one-click path — the only route was to delete the fact and reseed it as an operator
one. This adds the fact counterpart, mirroring the file promote (#1384).

## Changes

- **`set_fact_origin`** (repository) writes the one field a fact can change — its
  content is replaced, never amended — and leaves the stored embedding untouched.
- **`MemoryService.promote_fact`** sets `origin=operator`, audits it
  (`memory.fact.promoted`), and refuses a mem0-backed agent like the other
  fact-management paths. It requires **edit** on the parent agent, not view:
  promotion reaches the shared brief every end-user reads, never just one person's
  own store.
- **`POST /memory/facts/{id}/promote`** exposes it, mirroring the file route.
- **Console**: an inline promote control next to each agent-authored fact (gated on
  edit), and a `promote` mutation on `useMemoryFacts`. No open detail to reconcile
  as there is for a file, so a plain list invalidation is enough. Reuses the file
  promote's copy, so no new strings.
- **Docs**: `capabilities.md` now notes a fact can be promoted, like a file.

Also corrects two stale notes left where they can no longer be amended: the
fact-seed schema docstring still said the embedding was "unmetered" (the metering
landed in #1383, approved and pending merge), and the repo test fixture named
migration `0064`, renumbered to `0072` on this branch.

## Verification

- **Backend**: `test_memory_service.py` (promote sets origin + audits; 404;
  view-only refused; mem0 refused), `test_memory_routes.py` (200 + trusted row),
  and an integration test proving the consequence end to end — an agent-authored
  shared fact is **absent** from `list_brief_facts` before the promote and
  **present** after.
- **Frontend**: `use-memory.test.tsx` (promote + failure) and the facts-pane
  integration test (promote offered only on an agent-authored fact; a viewer sees
  none).
- `make lint` (ruff / ty / guards), both type checks, and the full frontend
  coverage gate (404 files, 6159 tests, exit 0) pass locally.

## Stacking

Stacked on `feat/agent-memory` (#1383) so it need not wait for that merge —
**retarget to `main` once #1383 lands**. Do not merge before #1383.

Closes #1384
