### PR TITLE
fix(channels): refuse a deactivated member's channel turn

### DIFF
--- a/backend/app/repositories/member.py
+++ b/backend/app/repositories/member.py
@@ -45,8 +45,9 @@ async def get_active(
     Deactivating a user leaves their membership row exactly where it was, so
     anything reading a role off `get` alone answers with the authority of an account
     that is refused everywhere a person signs in. That is only a difference on the
-    paths where nobody is signed in - see `access.publisher_context`, which is the
-    one caller and the reason this exists.
+    paths where nobody is signed in: `access.publisher_context`, the reason this
+    exists, and the channel router's `_membership_context`, which reads a linked
+    sender's own role off a chat account that stays linked after the deactivation.
 
     Joined rather than a second read: it is answered on every turn a public surface
     takes, and two round trips for one decision is one of them that can be true

--- a/backend/app/services/channels/mentions.py
+++ b/backend/app/services/channels/mentions.py
@@ -554,10 +554,14 @@ class ChannelAgentRouter:
         A linked account that is no longer a member takes the same path as an
         unlinked one rather than a third: there is no membership to read a role
         from, and in a room a former member is no more entitled than the stranger
-        beside them.
+        beside them. A deactivated account is one of those, which is why this is
+        the joined read: the membership row outlives a deactivation, and the link
+        in `channel_identities` outlives it too, so the plain read ran an
+        offboarded Owner's turns at their full authority from a chat account
+        nobody had unlinked - refused everywhere they sign in, except here.
         """
         if user_id is not None:
-            membership = await member_repo.get(
+            membership = await member_repo.get_active(
                 self.db, organization_id=organization_id, user_id=user_id
             )
             if membership is not None:

--- a/backend/tests/test_channel_charts.py
+++ b/backend/tests/test_channel_charts.py
@@ -227,7 +227,7 @@ class TestTheReplyAChannelTurnBuilds:
             patch("app.services.channels.mentions.agent_exposure_repo") as exposures,
             patch("app.services.channels.mentions.AgentRunnerService") as runner_cls,
         ):
-            members.get = AsyncMock(return_value=MagicMock(role=OrgRoleName.MEMBER))
+            members.get_active = AsyncMock(return_value=MagicMock(role=OrgRoleName.MEMBER))
             agents.get_by_slug = AsyncMock(return_value=MagicMock(id=uuid.uuid4()))
             exposures.get_for_bot = AsyncMock(return_value=MagicMock(is_active=True))
             runner_cls.return_value.execute = _runner_that_draws()
@@ -254,7 +254,7 @@ class TestTheReplyAChannelTurnBuilds:
             patch("app.services.channels.mentions.agent_exposure_repo") as exposures,
             patch("app.services.channels.mentions.AgentRunnerService") as runner_cls,
         ):
-            members.get = AsyncMock(return_value=MagicMock(role=OrgRoleName.MEMBER))
+            members.get_active = AsyncMock(return_value=MagicMock(role=OrgRoleName.MEMBER))
             exposures.list_active_for_bot = AsyncMock(
                 return_value=[(MagicMock(), MagicMock(id=uuid.uuid4(), slug="support"))]
             )

--- a/backend/tests/test_channel_mentions.py
+++ b/backend/tests/test_channel_mentions.py
@@ -266,7 +266,7 @@ class TestAnswer:
             patch("app.services.access.member_repo", new=members),
             patch("app.services.access.member_repo", new=members),
         ):
-            members.get = AsyncMock(return_value=None)
+            members.get_active = AsyncMock(return_value=None)
 
             with pytest.raises(AuthorizationError) as refused:
                 await ChannelAgentRouter(MagicMock()).answer(
@@ -279,6 +279,37 @@ class TestAnswer:
 
         assert "/link" in refused.value.message
 
+    async def test_a_deactivated_linked_member_does_not_run_a_channel_turn_at_their_old_role(
+        self,
+    ):
+        """Deactivating an account revokes its sessions but leaves its membership row
+        and its chat-account link where they were. The plain read still answered
+        with that row, so an offboarded Owner kept running turns from Slack at
+        Owner - blocked everywhere they sign in, except here. The joined read is
+        what says the account is gone; a DM then asks for a link, as it does for a
+        stranger, and nothing runs."""
+        with (
+            patch("app.services.channels.mentions.member_repo") as members,
+            patch("app.services.access.member_repo", new=members),
+            patch("app.services.channels.mentions.agent_repo") as agents,
+            patch("app.services.channels.mentions.AgentRunnerService") as runner_cls,
+        ):
+            members.get = AsyncMock(return_value=MagicMock(role=OrgRoleName.OWNER))
+            members.get_active = AsyncMock(return_value=None)
+
+            with pytest.raises(AuthorizationError) as refused:
+                await ChannelAgentRouter(MagicMock()).answer(
+                    "@support delete every agent",
+                    platform="slack",
+                    organization_id=uuid.uuid4(),
+                    bot_id=_BOT_ID,
+                    user_id=uuid.uuid4(),
+                )
+
+        assert "/link" in refused.value.message
+        agents.get_by_slug.assert_not_called()
+        runner_cls.return_value.execute.assert_not_called()
+
     async def test_an_unknown_handle_is_reported_as_missing(self):
         with (
             patch("app.services.channels.mentions.member_repo") as members,
@@ -286,7 +317,7 @@ class TestAnswer:
             patch("app.services.channels.mentions.agent_repo") as agents,
             patch("app.services.channels.mentions.agent_exposure_repo") as exposures,
         ):
-            members.get = AsyncMock(return_value=MagicMock(role=OrgRoleName.MEMBER))
+            members.get_active = AsyncMock(return_value=MagicMock(role=OrgRoleName.MEMBER))
             agents.get_by_slug = AsyncMock(return_value=None)
 
             with pytest.raises(NotFoundError) as refused:
@@ -319,7 +350,7 @@ class TestAnswer:
             patch("app.services.channels.mentions.agent_exposure_repo") as exposures,
             patch("app.services.channels.mentions.AgentRunnerService") as runner_cls,
         ):
-            members.get = AsyncMock(return_value=MagicMock(role=OrgRoleName.MEMBER))
+            members.get_active = AsyncMock(return_value=MagicMock(role=OrgRoleName.MEMBER))
             agents.get_by_slug = AsyncMock(return_value=MagicMock(id=agent_id))
             exposures.get_for_bot = AsyncMock(return_value=None)
             runner_cls.return_value.execute = AsyncMock()
@@ -347,7 +378,7 @@ class TestAnswer:
             patch("app.services.channels.mentions.agent_exposure_repo") as exposures,
             patch("app.services.channels.mentions.AgentRunnerService") as runner_cls,
         ):
-            members.get = AsyncMock(return_value=MagicMock(role=OrgRoleName.MEMBER))
+            members.get_active = AsyncMock(return_value=MagicMock(role=OrgRoleName.MEMBER))
             agents.get_by_slug = AsyncMock(return_value=MagicMock(id=uuid.uuid4()))
             exposures.get_for_bot = _bound(is_active=False)
             runner_cls.return_value.execute = AsyncMock()
@@ -379,7 +410,7 @@ class TestAnswer:
             patch("app.services.channels.mentions.agent_exposure_repo") as exposures,
             patch("app.services.channels.mentions.AgentRunnerService") as runner_cls,
         ):
-            members.get = AsyncMock(return_value=MagicMock(role=OrgRoleName.MEMBER))
+            members.get_active = AsyncMock(return_value=MagicMock(role=OrgRoleName.MEMBER))
             agents.get_by_slug = AsyncMock(return_value=MagicMock(id=agent_id))
             exposures.get_for_bot = _bound()
             runner_cls.return_value.execute = AsyncMock(return_value=("hi", MagicMock()))
@@ -409,7 +440,6 @@ class TestAnswer:
             patch("app.services.channels.mentions.agent_exposure_repo") as exposures,
             patch("app.services.channels.mentions.AgentRunnerService") as runner_cls,
         ):
-            members.get = AsyncMock(return_value=MagicMock(role=OrgRoleName.MEMBER))
             members.get_active = AsyncMock(return_value=MagicMock(role=OrgRoleName.MEMBER))
             agents.get_by_slug = AsyncMock(return_value=agent)
             exposures.get_for_bot = _bound()
@@ -437,7 +467,7 @@ class TestAnswer:
             patch("app.services.channels.mentions.agent_exposure_repo") as exposures,
             patch("app.services.channels.mentions.AgentRunnerService") as runner_cls,
         ):
-            members.get = AsyncMock(return_value=MagicMock(role=OrgRoleName.VIEWER))
+            members.get_active = AsyncMock(return_value=MagicMock(role=OrgRoleName.VIEWER))
             agents.get_by_slug = AsyncMock(return_value=MagicMock(id=uuid.uuid4()))
             exposures.get_for_bot = _bound()
             execute = AsyncMock(return_value=("hi", MagicMock()))
@@ -477,7 +507,7 @@ class TestAnswer:
             patch("app.services.channels.mentions.agent_exposure_repo") as exposures,
             patch("app.services.channels.mentions.AgentRunnerService") as runner_cls,
         ):
-            members.get = AsyncMock(return_value=MagicMock(role=OrgRoleName.MEMBER))
+            members.get_active = AsyncMock(return_value=MagicMock(role=OrgRoleName.MEMBER))
             agents.get_by_slug = AsyncMock(return_value=MagicMock(id=uuid.uuid4()))
             exposures.get_for_bot = _bound()
             execute = AsyncMock(return_value=("hi", MagicMock()))
@@ -504,7 +534,7 @@ class TestAnswer:
             patch("app.services.channels.mentions.agent_exposure_repo") as exposures,
             patch("app.services.channels.mentions.AgentRunnerService") as runner_cls,
         ):
-            members.get = AsyncMock(return_value=MagicMock(role=OrgRoleName.MEMBER))
+            members.get_active = AsyncMock(return_value=MagicMock(role=OrgRoleName.MEMBER))
             agents.get_by_slug = AsyncMock(return_value=MagicMock(id=uuid.uuid4()))
             exposures.get_for_bot = _bound()
             execute = AsyncMock(return_value=("42 days", MagicMock()))
@@ -595,7 +625,7 @@ class TestAnswerDefault:
             patch("app.services.channels.mentions.agent_exposure_repo") as exposures,
             patch("app.services.channels.mentions.AgentRunnerService") as runner_cls,
         ):
-            members.get = AsyncMock(return_value=MagicMock(role=OrgRoleName.MEMBER))
+            members.get_active = AsyncMock(return_value=MagicMock(role=OrgRoleName.MEMBER))
             exposures.list_active_for_bot = AsyncMock(return_value=[(exposure, agent)])
             execute = AsyncMock(return_value=("42 days", MagicMock()))
             runner_cls.return_value.execute = execute
@@ -619,6 +649,16 @@ class TestAnswerDefault:
         assert answer.text == "42 days"
 
 
+def _standing(by_user: dict[uuid.UUID, MagicMock | None]):
+    """A `member_repo.get_active` that knows who can still sign in: anybody not
+    listed cannot - they left, or their account was deactivated."""
+
+    async def get_active(db, *, organization_id, user_id):
+        return by_user.get(user_id)
+
+    return get_active
+
+
 class TestWhatARoomRunsAs:
     """A channel admits somebody this platform cannot name (#639).
 
@@ -638,7 +678,13 @@ class TestWhatARoomRunsAs:
         `membership` is what `member_repo.get_active` answers with, so it stands for
         an account that is both still a member and still able to sign in: `None`
         covers having left *and* having been deactivated, which is the same answer
-        for the same reason (`access.publisher_context`).
+        for the same reason (`access.publisher_context`). `standing` (see
+        `_standing`) replaces it when the sender and the creator must answer
+        differently.
+
+        `stale_row` is what the plain `get` would still answer with - the membership
+        row a deactivation leaves behind. Nothing on this path may read it, so by
+        default it raises.
         """
         agent = MagicMock(id=uuid.uuid4(), slug="support")
         with (
@@ -648,8 +694,17 @@ class TestWhatARoomRunsAs:
             patch("app.services.channels.mentions.AgentRunnerService") as runner_cls,
         ):
             membership = kwargs.pop("membership", None)
-            members.get = AsyncMock(return_value=membership)
-            members.get_active = AsyncMock(return_value=membership)
+            stale_row = kwargs.pop("stale_row", None)
+            members.get = (
+                AsyncMock(return_value=stale_row)
+                if stale_row is not None
+                else AsyncMock(side_effect=AssertionError("the joined read decides this"))
+            )
+            standing = kwargs.pop("standing", None)
+            if standing is not None:
+                members.get_active = AsyncMock(side_effect=standing)
+            else:
+                members.get_active = AsyncMock(return_value=membership)
             exposures.list_active_for_bot = AsyncMock(return_value=[(exposure, agent)])
             execute = AsyncMock(return_value=("hello", MagicMock()))
             runner_cls.return_value.execute = execute
@@ -760,36 +815,46 @@ class TestWhatARoomRunsAs:
     async def test_a_former_member_in_a_room_is_no_more_entitled_than_a_stranger(self):
         """An account that exists and a standing in this workspace are not the
         same thing, and only the second one carries a role."""
-        creator = uuid.uuid4()
+        creator, departed = uuid.uuid4(), uuid.uuid4()
         exposure = self._binding(creator, uuid.uuid4())
-        agent = MagicMock(id=uuid.uuid4(), slug="support")
 
-        with (
-            patch("app.services.channels.mentions.member_repo") as members,
-            patch("app.services.access.member_repo", new=members),
-            patch("app.services.channels.mentions.agent_exposure_repo") as exposures,
-            patch("app.services.channels.mentions.AgentRunnerService") as runner_cls,
-        ):
-            # The departed sender, read by the router; the creator's own standing is
-            # the joined read, which is what decides the role.
-            members.get = AsyncMock(return_value=None)
-            members.get_active = AsyncMock(return_value=MagicMock(role=OrgRoleName.ADMIN))
-            exposures.list_active_for_bot = AsyncMock(return_value=[(exposure, agent)])
-            execute = AsyncMock(return_value=("hello", MagicMock()))
-            runner_cls.return_value.execute = execute
+        ctx = await self._ran_as(
+            exposure,
+            user_id=departed,
+            standing=_standing({creator: MagicMock(role=OrgRoleName.ADMIN)}),
+        )
 
-            await ChannelAgentRouter(MagicMock()).answer_default(
-                "hello",
-                platform="mattermost",
-                organization_id=exposure.organization_id,
-                bot_id=_BOT_ID,
-                user_id=uuid.uuid4(),
-                admit_unlinked=True,
-            )
-
-        ctx = execute.call_args.args[0]
         assert ctx.user_id == creator, "the turn runs under the binding, not under them"
         assert ctx.role == OrgRoleName.ADMIN
+
+    @pytest.mark.parametrize(
+        ("creator_standing", "expected_role"),
+        [
+            (MagicMock(role=OrgRoleName.MEMBER), OrgRoleName.MEMBER),
+            (None, OrgRoleName.VIEWER),
+        ],
+    )
+    async def test_a_deactivated_member_in_a_room_runs_under_the_binding_not_at_their_old_role(
+        self, creator_standing: MagicMock | None, expected_role: str
+    ):
+        """Offboarding leaves both the membership row and the chat account's link
+        in place, so the plain read let a deactivated Owner keep speaking to the
+        bot at Owner. `get` answering with that row is the defect; the joined read
+        is what says they can no longer sign in, and a room then admits them as
+        it admits anybody else - under whoever bound the agent."""
+        creator, deactivated = uuid.uuid4(), uuid.uuid4()
+        exposure = self._binding(creator, uuid.uuid4())
+
+        ctx = await self._ran_as(
+            exposure,
+            user_id=deactivated,
+            channel_identity_id=uuid.uuid4(),
+            standing=_standing({creator: creator_standing}),
+            stale_row=MagicMock(role=OrgRoleName.OWNER),
+        )
+
+        assert ctx.user_id == creator
+        assert ctx.role == expected_role
 
     async def test_a_room_that_asks_for_a_link_refuses_instead(self):
         """`require_link` is the opt-out, and this is the layer that honours it:
@@ -827,7 +892,6 @@ class TestWhatARoomRunsAs:
             patch("app.services.channels.mentions.agent_exposure_repo") as exposures,
             patch("app.services.channels.mentions.AgentRunnerService") as runner_cls,
         ):
-            members.get = AsyncMock(return_value=MagicMock(role=OrgRoleName.MEMBER))
             members.get_active = AsyncMock(return_value=MagicMock(role=OrgRoleName.MEMBER))
             agents.get_by_slug = AsyncMock(return_value=agent)
             exposures.get_for_bot = AsyncMock(return_value=exposure)

--- a/backend/tests/test_surface_transcripts.py
+++ b/backend/tests/test_surface_transcripts.py
@@ -416,7 +416,7 @@ class TestAMentionRecordsItsTranscript:
         with (
             _run_yielding(run) as (captured, conversations),
             patch(
-                "app.services.channels.mentions.member_repo.get",
+                "app.services.channels.mentions.member_repo.get_active",
                 new=AsyncMock(return_value=MagicMock(role="builder")),
             ),
             patch(
@@ -470,7 +470,7 @@ class TestTheDefaultAgentRecordsItsTranscript:
                 new=AsyncMock(return_value=[(exposure, agent)]),
             ),
             patch(
-                "app.services.channels.mentions.member_repo.get",
+                "app.services.channels.mentions.member_repo.get_active",
                 new=AsyncMock(return_value=MagicMock(role="builder")),
             ),
             patch.object(
@@ -518,7 +518,7 @@ class TestTheDefaultAgentRecordsItsTranscript:
                 new=AsyncMock(return_value=[(exposure, agent)]),
             ),
             patch(
-                "app.services.channels.mentions.member_repo.get",
+                "app.services.channels.mentions.member_repo.get_active",
                 new=AsyncMock(return_value=MagicMock(role="builder")),
             ),
             patch.object(
@@ -575,7 +575,7 @@ class TestTheDefaultAgentRecordsItsTranscript:
                 new=AsyncMock(return_value=[(exposure, agent)]),
             ),
             patch(
-                "app.services.channels.mentions.member_repo.get",
+                "app.services.channels.mentions.member_repo.get_active",
                 new=AsyncMock(return_value=MagicMock(role="builder")),
             ),
             patch.object(

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -809,6 +809,12 @@ Works in channels and in DMs. A message from a linked account runs as that
 person — never as the bot; one from an account nobody has linked runs under the
 binding, and only in a channel. A direct message asks for the account first.
 
+A linked account whose member has left the organization, or whose account has
+been deactivated, is treated as unlinked: refused in a direct message, run under
+the binding in a channel. Offboarding clears neither the membership row nor the
+chat account's link, so the role is read only off a membership that can still
+sign in.
+
 ### One conversation per thread
 
 **The unit is the thread, and that now includes a direct message.** Send the bot
@@ -1129,7 +1135,10 @@ it is about to wait.
     Linking still matters in a channel, and it is worth doing: a linked sender
     runs as *themselves* rather than under the binding, and linking later makes
     their earlier channel turns attributable to them — the run points at the chat
-    account, and the chat account gains a person.
+    account, and the chat account gains a person. Only while that person is a
+    member who can sign in: a linked sender who has left, or whose account was
+    deactivated, is admitted the way a stranger is — under the binding in a
+    channel, refused in a direct message.
 
     **A channel thread is one conversation with several people in it**, and it
     appears in the conversation list of everybody whose linked chat account has

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -414,6 +414,13 @@ their account has been deactivated, so neither can silently widen what a public
 surface reaches. The subject is therefore a real one, and it is not the person who
 typed the message.
 
+A channel sender who *has* linked a member account runs as that member — and the
+same joined read decides whether they still are one. Deactivation leaves both the
+membership row and the chat account's link in place, so a role read off the
+membership alone kept an offboarded Owner running turns from Slack at Owner. A
+deactivated or departed sender is treated as unlinked instead: refused in a direct
+message, run under the binding in a room.
+
 `AuthContext.channel_identity_id` is who typed it, when that is a chat account
 rather than a member. It carries no authority - no permission reads it - and
 exists so a channel turn is attributable: it is stamped on `agent_runs`, and


### PR DESCRIPTION
## What changed

`ChannelAgentRouter._membership_context` now reads a linked sender's role off `member_repo.get_active` - the joined read that answers only while the account can still sign in - instead of the plain `member_repo.get`.

A linked channel sender whose account had been **deactivated** kept running agent turns at their old role (up to Owner), on every platform and on both the `@handle` and the default path. Deactivation revokes web sessions but leaves the membership row and the `channel_identities` link in place. The sibling **binding** path (`access.publisher_context`) was already moved to `get_active` for exactly this reason; the **sender** path was not.

A deactivated or departed linked sender now falls through to the unlinked rule: refused with the link-first message in a direct message, admitted under the binding's publisher in a room - never at their own old role.

Also: `get_active`'s docstring no longer claims `publisher_context` is its one caller; `docs/channels.md` and `docs/permissions.md` say what a deactivated linked sender is now.

## How it was verified

Three regression tests in `tests/test_channel_mentions.py` that **fail against the previous `mentions.py`** (checked by swapping the file back) and pass now:

- `test_a_deactivated_linked_member_does_not_run_a_channel_turn_at_their_old_role` - a DM mention from a sender whose `get` still answers Owner and whose `get_active` answers `None` is refused before the handle is looked up; the runner is never called.
- `test_a_deactivated_member_in_a_room_runs_under_the_binding_not_at_their_old_role` (x2) - the same sender in a room runs under the binding creator at the creator's role, and at `viewer` when the creator is gone too.

The remaining mention tests stub `get_active` for the sender, and the room fixture now raises if anything on the path reads the plain row.

- `uv run pytest tests/test_channel_mentions.py tests/test_channel_charts.py tests/test_surface_transcripts.py` - 106 passed
- `make lint-backend` clean (`ty` prints 60 pre-existing warnings in unrelated modules, exit 0)
- `make check` - see the CI checks on this PR

## Notes

- **Sequencing with #1392:** it rewrites `mentions.py` (renames `ctx→sender`, removes `one_to_one`). This PR touches one production line there plus a docstring, so whichever lands second carries a one-line conflict. Not blocked on it.
- The refusal a deactivated sender sees is the same link-first message a stranger sees. It does not say "your account was deactivated" - a refusal must not tell a sender more about their standing than a stranger learns.

Closes #1427
