### PR TITLE
fix(channels): bound the router's chat-lock and rate-bucket maps

### DIFF
--- a/backend/app/services/channels/dedupe.py
+++ b/backend/app/services/channels/dedupe.py
@@ -12,10 +12,10 @@ answer in the thread (#167).
 
 The claim is one atomic `SET NX` against the deployment's shared Redis, so
 it holds across API workers and covers the pollers as well as the webhook
-routes - the router's module-level `_chat_locks` and `_rate_buckets` are
-per-process and deliberately no model to follow here. The router takes the
-claim at the top of `route`, the one point all six inbound paths cross, and
-gives it back if the run under it does not finish.
+routes - the router's chat lock is per-process on purpose, serialising the
+turns one worker runs in one chat, and is no model to follow here. The router
+takes the claim at the top of `route`, the one point all six inbound paths
+cross, and gives it back if the run under it does not finish.
 """
 
 from __future__ import annotations

--- a/backend/app/services/channels/router.py
+++ b/backend/app/services/channels/router.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import re
+import time
 from collections.abc import AsyncIterator, Callable, Sequence
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
@@ -92,6 +93,44 @@ class _ChatLocks:
 
 
 _chat_locks = _ChatLocks()
+
+
+class _LocalWindows:
+    """A per-process fixed window, for the turns the shared limiter could not count.
+
+    `rate_limit.consume` is the limit that holds across workers, and it fails
+    open when Redis is down or nobody configured one. For a public widget that
+    is the documented trade; for a channel bot the per-sender `rate_limit_rpm`
+    is a production control (`SECURITY.md`), and a limiter that vanishes for
+    the length of a Redis outage lets a permitted participant run the model as
+    fast as they can type until it recovers. So this stands in for exactly that
+    stretch: wrong by the worker count, which is the defect the shared limiter
+    exists to fix, and still a floor where there would have been none.
+
+    Bounded: every write drops the windows that have expired, so the map is the
+    size of the callers seen in the last minute, not of every caller since the
+    process started - which is what the dict this replaces did.
+    """
+
+    def __init__(self, clock: Callable[[], float] = time.monotonic) -> None:
+        self._windows: dict[str, tuple[int, float]] = {}
+        self._clock = clock
+
+    def __len__(self) -> int:
+        return len(self._windows)
+
+    def consume(self, caller: str, *, attempts: int, window_seconds: int) -> bool:
+        now = self._clock()
+        for key in [
+            k for k, (_n, opened) in self._windows.items() if now - opened >= window_seconds
+        ]:
+            del self._windows[key]
+        count, opened = self._windows.get(caller, (0, now))
+        self._windows[caller] = (count + 1, opened)
+        return count < attempts
+
+
+_fallback_windows = _LocalWindows()
 
 
 _SLASHLESS = re.compile(r"^link$", re.IGNORECASE)
@@ -1051,17 +1090,25 @@ class ChannelMessageRouter:
         expiry is also what bounds the keyspace - a per-process dict kept an
         entry for every chat account the process had ever heard from.
 
+        When that limiter could not count - Redis down, or none configured - the
+        turn is counted in `_fallback_windows` instead, so a permitted sender is
+        still held to the allowance on this worker for as long as the outage
+        lasts. Fail-open here would remove a production control for the length
+        of a cache blip.
+
         Raises:
             BadRequestError: If the rate limit is exceeded.
         """
         policy: dict[str, Any] = self._parse_policy(bot)
-        rpm: int = int(policy.get("rate_limit_rpm", _DEFAULT_RPM))
-        decision = await rate_limit.consume(
-            surface="channel",
-            caller=f"bot:{bot.id}:identity:{identity_id}",
-            limit=Limit(attempts=rpm),
-        )
-        if not decision.allowed:
+        limit = Limit(attempts=int(policy.get("rate_limit_rpm", _DEFAULT_RPM)))
+        caller = f"bot:{bot.id}:identity:{identity_id}"
+        decision = await rate_limit.consume(surface="channel", caller=caller, limit=limit)
+        allowed = decision.allowed
+        if not decision.metered:
+            allowed = _fallback_windows.consume(
+                caller, attempts=limit.attempts, window_seconds=limit.window_seconds
+            )
+        if not allowed:
             raise BadRequestError(message="Rate limit exceeded. Please slow down.")
 
     async def _open_reply(

--- a/backend/app/services/channels/router.py
+++ b/backend/app/services/channels/router.py
@@ -4,8 +4,8 @@ import asyncio
 import json
 import logging
 import re
-import time
-from collections.abc import Callable, Sequence
+from collections.abc import AsyncIterator, Callable, Sequence
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from typing import Any
 
@@ -20,6 +20,7 @@ from app.repositories import (
     channel_session_repo,
     conversation_repo,
 )
+from app.services import rate_limit
 from app.services.channel_bot import unseal_bot_token
 from app.services.channel_link import ChannelLinkService
 from app.services.channels import get_adapter
@@ -42,20 +43,55 @@ from app.services.channels.mentions import (
     parse_mention,
 )
 from app.services.conversation import ConversationService
+from app.services.rate_limit import Limit
 from app.services.transcription import MAX_BYTES as TRANSCRIPTION_MAX_BYTES
 from app.services.transcription import Recording, TranscriptionService
 
 logger = logging.getLogger(__name__)
 
-# key format: "{bot_id}:{identity_id}", value = (count, window_start_ts)
-_rate_buckets: dict[str, tuple[int, float]] = {}
-
 _DEFAULT_RPM = 10
 
-# In group chats multiple users can message simultaneously. Without a lock the router
-# would race: duplicate ChannelSession creation, interleaved agent calls, rate-limit races.
-# Key = (bot_id, platform_chat_id); 1-on-1 chats also acquire it but contention is negligible.
-_chat_locks: dict[str, asyncio.Lock] = {}
+
+class _ChatLocks:
+    """One lock per chat with a message in flight, and none for the rest.
+
+    In a group chat several people message at once, and without the lock the
+    router races: a duplicate `ChannelSession`, interleaved agent calls. The lock
+    is keyed on the bot and the chat the message arrived in - on Slack that is
+    the thread, and a top-level message opens a thread of its own, so a busy
+    workspace mints a new key with nearly every message. An entry lives only
+    while somebody holds or waits for it and is dropped by the last one out, so
+    the map is the size of the chats in flight rather than of every chat this
+    process has ever heard from.
+
+    Per process on purpose: what it serialises is the turns *this* worker runs
+    in one chat. Once-only delivery across workers is the dedupe claim's job,
+    and the rate limit counts in the shared Redis - neither is a job for a lock.
+    """
+
+    def __init__(self) -> None:
+        self._held: dict[str, tuple[asyncio.Lock, int]] = {}
+
+    def __len__(self) -> int:
+        return len(self._held)
+
+    @asynccontextmanager
+    async def hold(self, bot_id: str, chat_id: str) -> AsyncIterator[None]:
+        key = f"{bot_id}:{chat_id}"
+        lock, waiting = self._held.get(key) or (asyncio.Lock(), 0)
+        self._held[key] = (lock, waiting + 1)
+        try:
+            async with lock:
+                yield
+        finally:
+            lock, waiting = self._held[key]
+            if waiting == 1:
+                del self._held[key]
+            else:
+                self._held[key] = (lock, waiting - 1)
+
+
+_chat_locks = _ChatLocks()
 
 
 _SLASHLESS = re.compile(r"^link$", re.IGNORECASE)
@@ -112,14 +148,6 @@ turns we already hold, paid for once; this is an HTTP round trip to somebody's
 chat platform before an answer can start. Fifty is a thread worth joining and a
 transcript still short enough to be a prompt.
 """
-
-
-def _get_chat_lock(bot_id: str, chat_id: str) -> asyncio.Lock:
-    """Return (or create) the asyncio.Lock for a bot + chat pair."""
-    key = f"{bot_id}:{chat_id}"
-    if key not in _chat_locks:
-        _chat_locks[key] = asyncio.Lock()
-    return _chat_locks[key]
 
 
 def _needs_approval(run_id: Any) -> str:
@@ -196,9 +224,8 @@ class ChannelMessageRouter:
                 incoming.message_id,
             )
             return
-        lock = _get_chat_lock(incoming.bot_id, incoming.platform_chat_id)
         try:
-            async with lock:
+            async with _chat_locks.hold(incoming.bot_id, incoming.platform_chat_id):
                 await self._route_inner(incoming, db)
         except BaseException:
             await release_delivery(incoming)
@@ -263,7 +290,7 @@ class ChannelMessageRouter:
         session = await self._resolve_session(incoming, bot, identity, db)
 
         try:
-            self._check_rate_limit(bot, str(identity.id))
+            await self._check_rate_limit(bot, str(identity.id))
         except BadRequestError as exc:
             await self._send_reply(bot, incoming, exc.message)
             return
@@ -1013,32 +1040,29 @@ class ChannelMessageRouter:
         # drift quietly against the messages people actually sent.
         return await channel_session_repo.touch(db, session)
 
-    def _check_rate_limit(self, bot: Any, identity_id: str) -> None:
-        """In-memory token-bucket rate limiter.
+    async def _check_rate_limit(self, bot: Any, identity_id: str) -> None:
+        """Count this message against the chat account's allowance on this bot.
 
-        Uses a module-level dict. Default: 10 req/minute from
-        `bot.access_policy.rate_limit_rpm`.
+        Ten a minute unless `bot.access_policy.rate_limit_rpm` says otherwise.
+        Counted in the deployment's shared Redis through `rate_limit.consume`,
+        for the reason that module gives: production runs several API workers,
+        and a count kept in this process lets through the allowance once per
+        worker while reading as the number that was configured. The window's
+        expiry is also what bounds the keyspace - a per-process dict kept an
+        entry for every chat account the process had ever heard from.
 
         Raises:
             BadRequestError: If the rate limit is exceeded.
         """
         policy: dict[str, Any] = self._parse_policy(bot)
         rpm: int = int(policy.get("rate_limit_rpm", _DEFAULT_RPM))
-        window: float = 60.0
-
-        key = f"{bot.id}:{identity_id}"
-        now = time.monotonic()
-
-        if key in _rate_buckets:
-            count, window_start = _rate_buckets[key]
-            if now - window_start < window:
-                if count >= rpm:
-                    raise BadRequestError(message="Rate limit exceeded. Please slow down.")
-                _rate_buckets[key] = (count + 1, window_start)
-            else:
-                _rate_buckets[key] = (1, now)
-        else:
-            _rate_buckets[key] = (1, now)
+        decision = await rate_limit.consume(
+            surface="channel",
+            caller=f"bot:{bot.id}:identity:{identity_id}",
+            limit=Limit(attempts=rpm),
+        )
+        if not decision.allowed:
+            raise BadRequestError(message="Rate limit exceeded. Please slow down.")
 
     async def _open_reply(
         self, bot: Any, incoming: IncomingMessage

--- a/backend/app/services/rate_limit.py
+++ b/backend/app/services/rate_limit.py
@@ -33,7 +33,10 @@ somebody's money, not a traffic shaper.
 *It fails open, loudly.* A Redis nobody can reach means the limit is not
 applied and a warning is logged. Refusing a visitor their answer because a
 cache blipped is the worse failure of the two, and it is the same trade-off,
-for the same reason, as the deduplication claim.
+for the same reason, as the deduplication claim. The `Decision` says when that
+happened (`metered=False`), so a surface whose per-caller limit is a production
+control - a channel bot's `rate_limit_rpm` - can keep a per-process floor under
+the caller for as long as the outage lasts rather than none at all.
 """
 
 from __future__ import annotations
@@ -82,10 +85,18 @@ class Limit:
 
 @dataclass(frozen=True)
 class Decision:
-    """Whether this attempt is allowed, and when to try again if not."""
+    """Whether this attempt is allowed, and when to try again if not.
+
+    `metered` says whether the answer came from a count at all. It is `False`
+    on the two fail-open paths - no limiter configured, a Redis that could not
+    be reached - where `allowed` is a default rather than a decision, so a
+    surface that must keep a floor under a caller while Redis is down can tell
+    the two apart and count locally instead of reading "allowed" as "inside".
+    """
 
     allowed: bool
     retry_after_seconds: int
+    metered: bool = True
 
 
 def caller_ip(connection: HTTPConnection) -> str:
@@ -138,14 +149,14 @@ async def consume(*, surface: str, caller: str, limit: Limit) -> Decision:
     """
     if _redis is None:
         logger.warning("Rate limiting not configured - %s reached unmetered by %s", surface, caller)
-        return Decision(allowed=True, retry_after_seconds=0)
+        return Decision(allowed=True, retry_after_seconds=0, metered=False)
 
     key = f"ratelimit:{surface}:{_bounded(caller)}"
     try:
         used = await _redis.count_in_window(key, ttl=limit.window_seconds)
     except Exception:
         logger.warning("rate_limit_redis_unavailable", exc_info=True)
-        return Decision(allowed=True, retry_after_seconds=0)
+        return Decision(allowed=True, retry_after_seconds=0, metered=False)
 
     if used > limit.attempts:
         return Decision(allowed=False, retry_after_seconds=limit.window_seconds)

--- a/backend/app/services/rate_limit.py
+++ b/backend/app/services/rate_limit.py
@@ -20,8 +20,8 @@ What replaced both is this module, and the shape is deliberately
 Production runs `uvicorn --workers 4`, so a per-process counter lets through
 four times what it says it does - and a limit that is wrong by the worker count
 is worse than no limit, because it reads as one that holds. The channel
-router's own `_rate_buckets` is per-process and is not a model to follow here,
-which that module already says.
+router's per-account allowance counts through here too, for the same reason:
+its own per-process dict was off by the worker count and never forgot a caller.
 
 *A fixed window, not a rolling one.* `INCR` plus an `EXPIRE … NX`, two
 commands, and a caller who arrives at the end of one window and again at the

--- a/backend/tests/test_channel_router_limits.py
+++ b/backend/tests/test_channel_router_limits.py
@@ -199,9 +199,49 @@ class TestTheAllowanceAChatAccountGets:
         with pytest.raises(BadRequestError):
             await ChannelMessageRouter()._check_rate_limit(_bot('{"rate_limit_rpm": 2}'), "id")
 
-    async def test_a_deployment_with_no_limiter_answers_rather_than_refusing(self, caplog):
-        """The same fail-open the limiter applies everywhere: a cache that is
-        down is logged, a message that is dropped is silence in front of a user."""
-        await ChannelMessageRouter()._check_rate_limit(_bot(), "identity-1")
+    async def test_a_redis_that_cannot_count_still_bounds_the_sender_on_this_worker(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The shared limiter fails open, and for a widget that is the documented
+        trade. A channel bot's per-sender allowance is a production control, and
+        the in-process dict this branch removed used to hold it through a Redis
+        outage - so the outage is counted locally instead of not at all."""
+        redis = MagicMock()
+        redis.count_in_window = AsyncMock(side_effect=ConnectionError("redis is down"))
+        rate_limit.configure(redis)
+        monkeypatch.setattr(router_module, "_fallback_windows", router_module._LocalWindows())
+        router = ChannelMessageRouter()
+        bot = _bot({"rate_limit_rpm": 3})
+
+        for _ in range(3):
+            await router._check_rate_limit(bot, "identity-1")
+        with pytest.raises(BadRequestError):
+            await router._check_rate_limit(bot, "identity-1")
+        await router._check_rate_limit(bot, "identity-2")
+
+    async def test_a_deployment_with_no_limiter_is_bounded_locally_and_says_so(
+        self, monkeypatch: pytest.MonkeyPatch, caplog
+    ):
+        monkeypatch.setattr(router_module, "_fallback_windows", router_module._LocalWindows())
+        router = ChannelMessageRouter()
+        bot = _bot({"rate_limit_rpm": 1})
+
+        await router._check_rate_limit(bot, "identity-1")
+        with pytest.raises(BadRequestError):
+            await router._check_rate_limit(bot, "identity-1")
 
         assert "Rate limiting not configured" in caplog.text
+
+    async def test_the_local_fallback_forgets_expired_windows(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Bounded the way the shared window is bounded by its TTL: an entry
+        lives one window, so the map is the callers of the last minute."""
+        clock = iter([0.0, 1.0, 61.0, 62.0])
+        windows = router_module._LocalWindows(clock=lambda: next(clock))
+
+        assert windows.consume("a", attempts=1, window_seconds=60) is True
+        assert windows.consume("a", attempts=1, window_seconds=60) is False
+        assert windows.consume("b", attempts=1, window_seconds=60) is True
+        assert windows.consume("a", attempts=1, window_seconds=60) is True, "a new window"
+        assert len(windows) == 2

--- a/backend/tests/test_channel_router_limits.py
+++ b/backend/tests/test_channel_router_limits.py
@@ -1,0 +1,207 @@
+"""What the channel router keeps per chat, and for how long.
+
+Two maps in the router used to grow for the life of the process. The per-chat
+lock was keyed on the thread, which on Slack is a fresh key for every top-level
+message, and nothing ever removed an entry - one `asyncio.Lock` retained per
+message a busy workspace ever sent. The rate-limit bucket kept one entry per chat
+account for ever, and counted in this process alone, so four API workers let
+through four times the allowance a bot's policy named.
+
+So the assertions here are about size and about where the count lives: N
+messages leave no lock behind, two messages in one chat still take turns, and
+the allowance is consumed from the Redis every worker shares.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.exceptions import BadRequestError
+from app.services import rate_limit
+from app.services.channels import router as router_module
+from app.services.channels.base import IncomingMessage, thread_key
+from app.services.channels.router import ChannelMessageRouter, _ChatLocks
+
+pytestmark = pytest.mark.anyio
+
+
+def _message(**overrides: Any) -> IncomingMessage:
+    defaults: dict[str, Any] = {
+        "platform": "slack",
+        "bot_id": "bot-1",
+        "platform_user_id": "U1",
+        "platform_chat_id": "C1",
+        "chat_type": "channel",
+        "text": "hello",
+        "message_id": "1723300000.000100",
+    }
+    defaults.update(overrides)
+    return IncomingMessage(**defaults)
+
+
+def _top_level_slack_message(n: int) -> IncomingMessage:
+    """What the Slack adapter hands the router for the n-th message in a channel:
+    a thread of its own, keyed on the message's own `ts`."""
+    ts = f"1723300000.{n:06d}"
+    return _message(platform_chat_id=thread_key("C1", thread_id="", message_id=ts), message_id=ts)
+
+
+@pytest.fixture
+def locks(monkeypatch: pytest.MonkeyPatch) -> _ChatLocks:
+    """A lock map of this test's own, so a count means what it says."""
+    fresh = _ChatLocks()
+    monkeypatch.setattr(router_module, "_chat_locks", fresh)
+    monkeypatch.setattr(router_module, "claim_delivery", AsyncMock(return_value=True))
+    monkeypatch.setattr(router_module, "release_delivery", AsyncMock())
+    return fresh
+
+
+class TestTheLockAChatIsProcessedUnder:
+    async def test_the_chat_lock_map_does_not_grow_per_message(self, locks: _ChatLocks):
+        router = ChannelMessageRouter()
+        with patch.object(ChannelMessageRouter, "_route_inner", new=AsyncMock()):
+            for n in range(50):
+                await router.route(_top_level_slack_message(n), MagicMock())
+
+        assert len(locks) == 0
+
+    async def test_two_messages_in_one_chat_take_turns_and_leave_nothing_behind(
+        self, locks: _ChatLocks
+    ):
+        """The lock still serialises a chat - that is what it is for - and a
+        waiter keeps the entry alive exactly until it has had its turn."""
+        router = ChannelMessageRouter()
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+        order: list[str] = []
+
+        async def slow_turn(incoming: IncomingMessage, db: Any) -> None:
+            order.append(f"start {incoming.message_id}")
+            if incoming.message_id == "one":
+                first_started.set()
+                await release_first.wait()
+            order.append(f"end {incoming.message_id}")
+
+        with patch.object(
+            ChannelMessageRouter, "_route_inner", new=AsyncMock(side_effect=slow_turn)
+        ):
+            first = asyncio.create_task(router.route(_message(message_id="one"), MagicMock()))
+            await first_started.wait()
+            second = asyncio.create_task(router.route(_message(message_id="two"), MagicMock()))
+            await asyncio.sleep(0)
+
+            assert len(locks) == 1, "one chat in flight, one entry - however many wait on it"
+            assert order == ["start one"]
+
+            release_first.set()
+            await asyncio.gather(first, second)
+
+        assert order == ["start one", "end one", "start two", "end two"]
+        assert len(locks) == 0
+
+    async def test_messages_in_different_chats_do_not_wait_on_each_other(self, locks: _ChatLocks):
+        router = ChannelMessageRouter()
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+        seen: list[str] = []
+
+        async def turn(incoming: IncomingMessage, db: Any) -> None:
+            seen.append(incoming.platform_chat_id)
+            if incoming.platform_chat_id == "C1":
+                first_started.set()
+                await release_first.wait()
+
+        with patch.object(ChannelMessageRouter, "_route_inner", new=AsyncMock(side_effect=turn)):
+            blocked = asyncio.create_task(
+                router.route(_message(platform_chat_id="C1"), MagicMock())
+            )
+            await first_started.wait()
+            await router.route(_message(platform_chat_id="C2"), MagicMock())
+
+            assert seen == ["C1", "C2"]
+            assert len(locks) == 1
+
+            release_first.set()
+            await blocked
+
+        assert len(locks) == 0
+
+    async def test_a_turn_that_raises_still_drops_its_lock(self, locks: _ChatLocks):
+        router = ChannelMessageRouter()
+        with (
+            patch.object(
+                ChannelMessageRouter, "_route_inner", new=AsyncMock(side_effect=RuntimeError("no"))
+            ),
+            pytest.raises(RuntimeError),
+        ):
+            await router.route(_message(), MagicMock())
+
+        assert len(locks) == 0
+
+
+@pytest.fixture
+def _unmetered():
+    rate_limit.configure(None)
+    yield
+    rate_limit.configure(None)
+
+
+def _counting(counts: list[int]) -> MagicMock:
+    client = MagicMock()
+    client.count_in_window = AsyncMock(side_effect=counts)
+    return client
+
+
+def _bot(policy: dict[str, Any] | None = None) -> MagicMock:
+    return MagicMock(id=uuid.uuid4(), access_policy=policy or {})
+
+
+@pytest.mark.usefixtures("_unmetered")
+class TestTheAllowanceAChatAccountGets:
+    async def test_the_allowance_is_counted_in_the_shared_redis(self):
+        """Not in this process: four workers counting separately let through four
+        times the number the policy names, and read as though they did not."""
+        redis = _counting([1])
+        rate_limit.configure(redis)
+        bot = _bot()
+
+        await ChannelMessageRouter()._check_rate_limit(bot, "identity-1")
+
+        key = redis.count_in_window.await_args.args[0]
+        assert key == f"ratelimit:channel:bot:{bot.id}:identity:identity-1"
+        assert redis.count_in_window.await_args.kwargs["ttl"] == 60
+
+    async def test_the_message_past_the_allowance_is_refused(self):
+        rate_limit.configure(_counting([10, 11]))
+        bot = _bot()
+        router = ChannelMessageRouter()
+
+        await router._check_rate_limit(bot, "identity-1")
+        with pytest.raises(BadRequestError) as refused:
+            await router._check_rate_limit(bot, "identity-1")
+
+        assert "slow down" in refused.value.message
+
+    async def test_the_bots_policy_sets_the_allowance(self):
+        rate_limit.configure(_counting([3]))
+
+        with pytest.raises(BadRequestError):
+            await ChannelMessageRouter()._check_rate_limit(_bot({"rate_limit_rpm": 2}), "id")
+
+    async def test_a_policy_stored_as_json_is_read_the_same_way(self):
+        rate_limit.configure(_counting([3]))
+
+        with pytest.raises(BadRequestError):
+            await ChannelMessageRouter()._check_rate_limit(_bot('{"rate_limit_rpm": 2}'), "id")
+
+    async def test_a_deployment_with_no_limiter_answers_rather_than_refusing(self, caplog):
+        """The same fail-open the limiter applies everywhere: a cache that is
+        down is logged, a message that is dropped is silence in front of a user."""
+        await ChannelMessageRouter()._check_rate_limit(_bot(), "identity-1")
+
+        assert "Rate limiting not configured" in caplog.text

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -56,6 +56,7 @@ class TestTheAllowanceItself:
         )
 
         assert decision.allowed is True
+        assert decision.metered is True
 
     async def test_the_attempt_after_the_allowance_is_refused(self):
         """Four attempts against a limit of three: the fourth is the one the
@@ -127,10 +128,13 @@ class TestDegradingRatherThanRefusing:
         decision = await rate_limit.consume(surface="s", caller="c", limit=Limit(attempts=1))
 
         assert decision.allowed is True
+        assert decision.metered is False, "allowed by default, not by a count"
 
     async def test_an_unreachable_redis_lets_the_caller_through(self):
         """The same trade-off, and the same reasoning, as the channel dedupe
-        claim: losing the guarantee beats losing the visitor's answer."""
+        claim: losing the guarantee beats losing the visitor's answer. The
+        decision says it was not counted, so a surface that must keep a floor
+        under the caller - the channel router - can count locally meanwhile."""
         client = MagicMock()
         client.count_in_window = AsyncMock(side_effect=ConnectionError("redis is down"))
         rate_limit.configure(client)
@@ -138,6 +142,7 @@ class TestDegradingRatherThanRefusing:
         decision = await rate_limit.consume(surface="s", caller="c", limit=Limit(attempts=1))
 
         assert decision.allowed is True
+        assert decision.metered is False
 
     async def test_degrading_is_logged_rather_than_silent(self, caplog):
         """ "Under the limit" and "not limited at all" are the same response, so

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -1127,7 +1127,10 @@ it is about to wait.
     real and worth saying: anyone who can speak in the channel can spend the
     organization's budget and reach what the binding's creator can reach, which
     is the same trade a public widget makes. The ceilings are the rate limit per
-    chat account, the access policy, and the organization's monthly cap.
+    chat account, the access policy, and the organization's monthly cap. The
+    rate limit (`rate_limit_rpm` on the bot's access policy, ten a minute by
+    default) is counted in the deployment's shared Redis, so it holds across
+    API workers rather than once per worker.
 
     Set **`require_link`** on the bot's access policy to refuse in channels too,
     which is the old behaviour.


### PR DESCRIPTION
## What changed

Two module-level dicts in `app/services/channels/router.py` grew for the life of the process:

- **`_chat_locks`** was keyed on the chat the message arrived in. On Slack that is the *thread*, and a top-level message opens a thread of its own (`thread_key(channel, "", message_ts)`), so a busy workspace retained one `asyncio.Lock` per message it had ever received. Nothing ever removed an entry.
- **`_rate_buckets`** kept one entry per chat account for ever, and counted in this process alone - so a deployment on four API workers let through four times the allowance a bot's policy named, while reading as though it enforced it.

Now:

- The lock map is a small holder (`_ChatLocks`) that keeps an entry only while somebody holds or waits for it and drops it on the last release. Its size is the number of chats **in flight**, not the number of chats the process has heard from. Serialisation per chat is unchanged.
- `_check_rate_limit` goes through `rate_limit.consume` - the shared-Redis fixed window every other public surface already counts in. Cross-worker, and the window's TTL bounds the keyspace. Key: `ratelimit:channel:bot:{bot_id}:identity:{identity_id}`, 60s window, `rate_limit_rpm` from the bot's policy (default 10). The refusal message is unchanged.
- `dedupe.py` and `rate_limit.py` no longer describe the router's buckets as the per-process counter not to copy, because it is gone. `docs/channels.md` says the per-account limit is counted in the shared Redis.

## How it was verified

`tests/test_channel_router_limits.py` (new):

- `test_the_chat_lock_map_does_not_grow_per_message` - fifty top-level Slack messages leave **0** locks. On the previous router the same sequence leaves **50** (checked by swapping the file back).
- two messages in one chat still take turns, and the entry lives exactly as long as the waiter; different chats do not wait on each other; a raising turn drops its lock.
- the allowance is consumed from Redis under the key above with `ttl=60`; the message past the allowance is refused; the bot's `rate_limit_rpm` (dict or JSON string) sets it; a limiter nobody configured, or a Redis that raises, still bounds the sender on this worker and logs that it is unmetered; the local fallback forgets a window once it has passed.

- 299 channel + limiter tests pass locally; after the fallback, 172 limiter + router tests and `rate_limit.py` at 100%
- `make lint-backend` clean (the 60 `ty` warnings are pre-existing, none in these files)
- `make check` - see the CI checks on this PR

## Notes

- **The lock stays per process on purpose.** It serialises the turns *one worker* runs in one chat; once-only delivery across workers is the dedupe claim's job (`claim_delivery`), and the rate limit now counts in Redis. A distributed lock would add a Redis round trip to every turn for a race the claim already closes.
- **Fixed window, not rolling** - the same trade `rate_limit.consume` makes everywhere; a caller straddling a window boundary gets up to twice the allowance once.
- **When Redis cannot count, the sender is still bounded on this worker** (added in review). `rate_limit.consume` fails open, and for a public widget that is the documented trade - but a channel bot's `rate_limit_rpm` is a production control (SECURITY.md), and the per-process dict this PR removed used to hold through a Redis outage. `Decision.metered` now says whether the answer came from a count; when it did not, the router consults `_LocalWindows`, a per-process fixed window that drops expired entries on every write, so the map is the callers of the last minute rather than every caller ever. The shared limiter still decides whenever it can count.
- Rebased on `main` after #1392 merged; no conflicts.
- #17 named both leaks and was closed by #1114 without touching either dict.

Closes #1428
