### PR TITLE
chore: cut 0.0.356

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.356] - 2026-09-05
+
 ### Changed
 
 - **An MCP binding says whose account it speaks through, and that is its

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.355"
+version = "0.0.356"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.355"
+version = "0.0.356"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.355",
+  "version": "0.0.356",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for **0.0.356**. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json`, and dates the CHANGELOG entry.

The release is #1391, merged as #1392: **an MCP binding now says whose account it speaks through.**

`SPEC_VERSION` moves **10 → 11**, which is why the CHANGELOG's header moved too. A binding carries `account`: either the organization's connection, as before, or `personal` with a catalog key and no connection at all, where whoever talks to the agent connects their own and the agent speaks to the service as them — in the dashboard, in a direct message and in a channel alike, per message and never per thread. A stored v10 binding loads as an organization one, so nothing published before this stops loading and an exported YAML keeps working.

What a reader will notice: **the chat offers the button that connects the account**, beside the sentence saying it cannot reach it, and comes back to the conversation after the consent — where before the agent said only that it had no access.

Three defects the first real walk-through found are in it too: every connection ever made from the console held `catalog_key = NULL`, so no personal binding could have matched one (`0071_mcp_connection_catalog_key` backfills it); a draft naming a deleted collection, context file, skill or connection was refused at publish with nowhere to clear it; and the tool picker opened empty on a connection nobody had probed.

Verified: `make check` on the merged tree, `uv lock --check` clean, `make docs-build` strict.
