### PR TITLE
chore: cut 0.0.357

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.357] - 2026-09-05
+
+### Fixed
+
+- **A teardown reservation nobody released blocked a collection name for
+  ever.** The reservation is committed with the delete and released when the
+  durable drop runs; a drop lost to a crash in the commit-to-dispatch gap, or
+  failing past the flow's retries, left the row behind and `claim` refused that
+  name from then on, with nothing to reattempt it. An hourly
+  `teardown-reservation-sweep` retries the drop for any reservation older than
+  its window, the way the other reap-sweeps do.
+- **An upload could repopulate a collection on its way out.** `dispatch_upload`
+  refuses a name under teardown, which `claim` already did.
+- **An organization whose default collection was dropped kept pointing at it.**
+
 ## [0.0.356] - 2026-09-05
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.356"
+version = "0.0.357"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.356"
+version = "0.0.357"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.356",
+  "version": "0.0.357",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for **0.0.357**. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json`, and adds the CHANGELOG entry.

The release is #1364, merged as #1378. A teardown reservation is committed with the delete and released when the durable drop runs — and a drop lost to a crash in the commit-to-dispatch gap, or failing past the flow's retries, left the row behind, so `claim` refused that collection name from then on with nothing to reattempt it. An hourly `teardown-reservation-sweep` retries it. `dispatch_upload` now refuses a name under teardown as `claim` already did, and an organization whose default collection was dropped stops pointing at it.

CI on `main` was green after the merge (`test`, `test-frontend`, `e2e`, `lint`, `docs`).