### PR TITLE
fix(channels): render a channel chart off the event loop

### DIFF
--- a/backend/app/services/channels/mentions.py
+++ b/backend/app/services/channels/mentions.py
@@ -38,6 +38,7 @@ handle typed into a public channel is a name, not a key.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 from dataclasses import dataclass, field
@@ -97,6 +98,10 @@ def drawn_chart(called: list[RecordedToolCall]) -> bytes | None:
     a reply carries one image. A result that no longer parses is skipped rather
     than raised on: the payload is whatever the tool returned, and a chart that
     cannot be drawn must not cost somebody the answer it came with.
+
+    Blocking: Pillow rasterises and PNG-encodes here, and a channel turn runs on
+    the loop the pollers and the other webhook tasks share - so the callers reach
+    it through `asyncio.to_thread`, never inline.
     """
     for call in reversed(called):
         if call.tool_name != _CHART_TOOL or call.result is None:
@@ -370,7 +375,7 @@ class ChannelAgentRouter:
             ),
             attachments=produced,
             refused=refused,
-            image_png=drawn_chart(called),
+            image_png=await asyncio.to_thread(drawn_chart, called),
             awaiting_approval_run_id=(
                 run.id if run.status == RunStatus.AWAITING_APPROVAL else None
             ),
@@ -468,7 +473,7 @@ class ChannelAgentRouter:
             ),
             attachments=produced,
             refused=refused,
-            image_png=drawn_chart(called),
+            image_png=await asyncio.to_thread(drawn_chart, called),
             awaiting_approval_run_id=(
                 run.id if run.status == RunStatus.AWAITING_APPROVAL else None
             ),

--- a/backend/tests/test_channel_charts.py
+++ b/backend/tests/test_channel_charts.py
@@ -9,6 +9,7 @@ for a chart on a channel answered "here is the chart" with no chart, which is th
 worst shape a bug can take: the sentence is confident and the evidence is absent.
 """
 
+import threading
 import uuid
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -272,3 +273,49 @@ class TestTheReplyAChannelTurnBuilds:
         assert answered.image_png.startswith(b"\x89PNG")
         assert [a.filename for a in answered.attachments] == ["revenue.csv"]
         assert answered.refused == ["/too-big.csv"]
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("path", ["answer", "answer_default"])
+    async def test_a_channel_chart_is_rendered_off_the_event_loop(
+        self, path: str, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Pillow rasterises and PNG-encodes the picture, and a channel turn runs
+        on the loop every poller and webhook task on the worker shares - so a
+        chart drawn inline stalled every other channel turn for its duration.
+        Asserted the way the upload offload is: the render lands on a thread
+        other than the loop's, which fails if the `to_thread` is removed."""
+        loop_thread = threading.get_ident()
+        ran_on: list[int] = []
+
+        def recording(spec: ChartSpec) -> bytes:
+            ran_on.append(threading.get_ident())
+            return render_chart_png(spec)
+
+        monkeypatch.setattr("app.services.channels.mentions.render_chart_png", recording)
+        membership = AsyncMock(return_value=MagicMock(role=OrgRoleName.MEMBER))
+
+        with (
+            patch("app.services.channels.mentions.member_repo") as members,
+            patch("app.services.channels.mentions.agent_repo") as agents,
+            patch("app.services.channels.mentions.agent_exposure_repo") as exposures,
+            patch("app.services.channels.mentions.AgentRunnerService") as runner_cls,
+        ):
+            members.get = membership
+            members.get_active = membership
+            agents.get_by_slug = AsyncMock(return_value=MagicMock(id=uuid.uuid4()))
+            exposures.get_for_bot = AsyncMock(return_value=MagicMock(is_active=True))
+            exposures.list_active_for_bot = AsyncMock(
+                return_value=[(MagicMock(), MagicMock(id=uuid.uuid4(), slug="support"))]
+            )
+            runner_cls.return_value.execute = _runner_that_draws()
+
+            answered = await getattr(ChannelAgentRouter(MagicMock()), path)(
+                "@support chart my revenue" if path == "answer" else "chart my revenue",
+                platform="slack",
+                organization_id=uuid.uuid4(),
+                bot_id=uuid.uuid4(),
+                user_id=uuid.uuid4(),
+            )
+
+        assert answered.image_png is not None
+        assert ran_on and ran_on[0] != loop_thread


### PR DESCRIPTION
## What changed

The PNG a channel reply carries was rasterised and PNG-encoded by Pillow **synchronously on the event loop**: `AnsweredTurn(..., image_png=drawn_chart(called))` inside the `async def` turn methods in `app/services/channels/mentions.py`, right after `await self.runner.execute`. A channel turn runs on the loop every poller and webhook task on the worker shares, so each chart stalled every other channel turn for its duration - the same class as the upload parse (#25) and the worker's file hash (#1100), both already moved off the loop.

Both call sites (`answer` and `answer_default`) now read `image_png=await asyncio.to_thread(drawn_chart, called)`. `drawn_chart`'s docstring says it blocks and that callers reach it through a thread.

**Default executor, not the bounded file pool** (`app/core/blocking.run_blocking`): a chart is a fixed-size canvas, tens of milliseconds, and nothing about it queues large buffers the way an upload storm does - which is what that pool's admission gate exists for.

## How it was verified

`tests/test_channel_charts.py::TestTheReplyAChannelTurnBuilds::test_a_channel_chart_is_rendered_off_the_event_loop`, parametrised over both paths: the render is wrapped to record `threading.get_ident()` and the test asserts it is not the loop's thread - the shape `tests/test_blocking_io_offload.py` uses for the upload offload. **Fails with the `to_thread` removed.**

- `uv run pytest tests/test_channel_charts.py tests/test_channel_mentions.py tests/test_surface_transcripts.py` - 105 passed
- `ruff` / `ty` clean on the changed files; `mentions.py` stays in the 100% gate (no new branch)
- `make check` - see the CI checks on this PR

## Notes

- No page describes where the render runs, so `docs/channels.md` owes nothing here (the drift hook names it because `mentions.py` moved).
- The test stubs both `member_repo.get` and `member_repo.get_active` for the sender, so it passes before and after #1436 (#1427) lands.
- #1392 rewrites `mentions.py`; this is two one-line hunks, trivial to carry across in either order.

Closes #1429
