### PR TITLE
chore: cut 0.0.358

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.358] - 2026-09-05
+
+### Fixed
+
+- **A member deactivated in the console kept answering through a channel.**
+  Their chat account is still linked and the bot still routes to it, so the turn
+  ran under a person the organization had switched off, with their role, their
+  grants and their budget. The channel path now asks for a membership that can
+  sign in - the same question `access.publisher_context` already asks of a
+  binding's creator, so the two answers cannot drift.
+
 ## [0.0.357] - 2026-09-05
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.357"
+version = "0.0.358"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.357"
+version = "0.0.358"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.357",
+  "version": "0.0.358",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for **0.0.358**. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json`, and adds the CHANGELOG entry.

The release is #1427, merged as #1436. A member deactivated in the console kept answering through a channel: their chat account is still linked and the bot still routes to it, so the turn ran under a person the organization had switched off — with their role, their grants and their budget. The channel path now asks for a membership that can sign in, the same question `access.publisher_context` already asks of a binding's creator.

CI on `main` was green after the merge.