### PR TITLE
fix(channels): one supervised reconnect loop for the three adapters

### DIFF
--- a/.claude/skills/channel-bot/SKILL.md
+++ b/.claude/skills/channel-bot/SKILL.md
@@ -78,7 +78,11 @@ Access modes: `open`, `whitelist`, `jwt_linked`, `group_only`.
 2. Wire it into `router.py` so inbound reaches the agent and replies stream back.
    **Do not fork the agent pipeline** — one runner behind every surface is the whole
    design.
-3. Add a signature-verified webhook route and/or a polling entrypoint.
+3. Add a signature-verified webhook route and/or a polling entrypoint. A polling
+   entrypoint runs its session under `supervise_stream` from `base.py` — the one
+   reconnect loop — and raises `ChannelNotConfigured` for anything a retry cannot
+   fix (a missing token or URL, a token the platform rejects); do not hand-roll a
+   `while True` with its own sleep.
 4. Reuse the existing conversation/session model.
 5. Respect the per-group/per-thread concurrency controls already in the adapters.
 

--- a/backend/app/services/channels/base.py
+++ b/backend/app/services/channels/base.py
@@ -1,4 +1,7 @@
+import asyncio
+import logging
 from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -9,6 +12,10 @@ from app.agents.capabilities.channel_tools import (
     ChannelPost,
     ChannelSummary,
 )
+from app.services.channels import connection_state
+from app.services.channels.exceptions import ChannelNotConfigured
+
+logger = logging.getLogger(__name__)
 
 # Handles every chat platform reserves for addressing the room, rather than one
 # member of it. They match the shape of an agent slug, so `@channel deploying at
@@ -459,3 +466,59 @@ class ChannelAdapter(ABC):
     @abstractmethod
     def parse_incoming(self, raw_payload: dict[str, Any], bot_id: str) -> IncomingMessage | None:
         """Parse raw platform payload into IncomingMessage. Return None to ignore."""
+
+
+RECONNECT_FLOOR_SECONDS = 5.0
+RECONNECT_CEILING_SECONDS = 60.0
+
+
+async def supervise_stream(
+    bot_id: str,
+    *,
+    platform: str,
+    session: Callable[[], Awaitable[None]],
+    failing: str,
+) -> None:
+    """Run one bot's inbound stream, session after session, until cancelled.
+
+    The one reconnect loop for Telegram long-polling, Slack Socket Mode and the
+    Mattermost event stream. Each adapter used to carry its own, and the three
+    disagreed: one backed off, two retried every five seconds flat; two knew a
+    configuration error from a crash, one retried a rejected bot token for ever,
+    a traceback every five seconds. A reconnect fix had to find three loops.
+
+    `session` opens one connection and returns when it ends or raises when it
+    fails. A session that ends is reopened after `RECONNECT_FLOOR_SECONDS`; one
+    that raises is reopened after a wait that doubles up to
+    `RECONNECT_CEILING_SECONDS`, so a server down for an hour is not hammered 720
+    times by every bot on it. A clean session resets the wait.
+
+    `ChannelNotConfigured` is not a crash and not something a retry fixes - an
+    operator has to add the token or the server URL - so it is recorded once
+    and the loop stops. `failing` is what the connection row says while a
+    session keeps crashing.
+
+    The wait is outside the `except` on purpose: a session may return without
+    ever awaiting (a row not filled in yet), and awaiting a coroutine that never
+    suspends does not yield to the event loop. Without the wait this loop spun
+    at 100% CPU and nothing else on the process - the health check included -
+    was scheduled again. The line logged before each wait names the delay it is
+    about to wait, so the doubling happens after it.
+    """
+    delay = RECONNECT_FLOOR_SECONDS
+    while True:
+        try:
+            await session()
+        except asyncio.CancelledError:
+            raise
+        except ChannelNotConfigured as exc:
+            logger.warning("%s not started for bot %s: %s", platform, bot_id, exc.message)
+            await connection_state.record_down(bot_id, exc.message)
+            return
+        except Exception:
+            logger.exception("%s failed for bot %s, retrying in %.0fs", platform, bot_id, delay)
+            await connection_state.record_down(bot_id, failing)
+            wait, delay = delay, min(delay * 2, RECONNECT_CEILING_SECONDS)
+        else:
+            wait = delay = RECONNECT_FLOOR_SECONDS
+        await asyncio.sleep(wait)

--- a/backend/app/services/channels/mattermost.py
+++ b/backend/app/services/channels/mattermost.py
@@ -680,7 +680,10 @@ class MattermostAdapter(ChannelAdapter):
         base_url = self._base_urls.get(bot_id)
         if not base_url:
             raise ChannelNotConfigured(
-                message="Mattermost bot has no server URL; cannot open a stream",
+                message=(
+                    "Mattermost bot has no server URL; cannot open a stream. Set the "
+                    "bot's server URL, or switch it to webhook mode."
+                ),
                 details={"bot_id": bot_id},
             )
 

--- a/backend/app/services/channels/mattermost.py
+++ b/backend/app/services/channels/mattermost.py
@@ -54,6 +54,7 @@ from app.services.channels.base import (
     IncomingMessage,
     OutgoingMessage,
     split_thread,
+    supervise_stream,
     thread_key,
 )
 from app.services.channels.exceptions import ChannelNotConfigured
@@ -601,44 +602,16 @@ class MattermostAdapter(ChannelAdapter):
         logger.info("Stopped Mattermost event stream for bot %s", bot_id)
 
     async def _supervise(self, bot_id: str, bot_token: str) -> None:
-        """Reconnect on failure. A dropped socket is a bot that stopped
-        answering with nothing in the logs to say so."""
-        delay = 5.0
-        while True:
-            try:
-                await self._run_stream(bot_id, bot_token)
-                delay = 5.0
-            except asyncio.CancelledError:
-                raise
-            except ChannelNotConfigured:
-                # An operator has to set the server URL; looping cannot. And
-                # `_run_stream` returns without awaiting on that branch, so a
-                # retry here spun the event loop at 100% CPU and starved every
-                # other task on the process.
-                logger.warning("Mattermost stream not started for bot %s", bot_id)
-                await connection_state.record_down(
-                    bot_id,
-                    "The Mattermost event stream cannot start. Check the bot's "
-                    "server URL, or switch it to webhook mode.",
-                )
-                return
-            except Exception:
-                logger.exception(
-                    "Mattermost stream failed for bot %s, retrying in %.0fs", bot_id, delay
-                )
-                await connection_state.record_down(
-                    bot_id,
-                    "The Mattermost event stream keeps dropping. Check that the "
-                    "server is reachable and the bot token is still valid.",
-                )
-            # Outside the `except`: a session that ends by returning has to
-            # yield before the next attempt, or this loop never suspends.
-            await asyncio.sleep(delay)
-            # Doubled after the wait, not before it: the line logged above names
-            # `delay`, and backing off first made it sleep twice what it said.
-            # Backs off to a minute so a server that is down for an hour is not
-            # hammered 720 times by every bot on it.
-            delay = min(delay * 2, 60.0)
+        """Event-stream sessions, reopened under the shared reconnect loop."""
+        await supervise_stream(
+            bot_id,
+            platform="Mattermost event stream",
+            session=lambda: self._run_stream(bot_id, bot_token),
+            failing=(
+                "The Mattermost event stream keeps dropping. Check that the "
+                "server is reachable and the bot token is still valid."
+            ),
+        )
 
     async def _own_user_id(self, bot_id: str, bot_token: str) -> str | None:
         """Which Mattermost account this bot *is*, so a mention of it is legible.

--- a/backend/app/services/channels/slack.py
+++ b/backend/app/services/channels/slack.py
@@ -34,6 +34,7 @@ from app.services.channels.base import (
     IncomingMessage,
     OutgoingMessage,
     split_thread,
+    supervise_stream,
     thread_key,
 )
 from app.services.channels.exceptions import ChannelNotConfigured
@@ -406,38 +407,16 @@ class SlackAdapter(ChannelAdapter):
         logger.info("Stopped Slack Socket Mode for bot %s", bot_id)
 
     async def _socket_supervisor(self, bot_id: str, bot_token: str) -> None:
-        """Supervised loop: restart Socket Mode on crash.
-
-        The sleep is outside the `except` on purpose. `_run_socket_mode` has
-        branches that return without ever awaiting, and awaiting a coroutine
-        that never suspends does not yield to the event loop - so this looped at
-        100% CPU and no other task on the process was scheduled again. The API
-        stayed up and answered nothing, health check included, on one WARNING
-        line.
-        """
-        while True:
-            try:
-                await self._run_socket_mode(bot_id, bot_token)
-            except asyncio.CancelledError:
-                break
-            except ChannelNotConfigured as exc:
-                # Not a crash and not something a retry fixes: an operator has
-                # to add the token. Retrying would be the spin all over again.
-                logger.warning("Slack Socket Mode not started for bot %s", bot_id)
-                # Its own message, because this one is written here rather than by
-                # a vendor: it names the credential to add. Recorded so the row
-                # says so - a WARNING in a container was the only evidence, and
-                # `/channels` showed the bot as healthy (#1351).
-                await connection_state.record_down(bot_id, str(exc))
-                return
-            except Exception:
-                logger.exception("Slack Socket Mode crashed for bot %s, restarting in 5s", bot_id)
-                await connection_state.record_down(
-                    bot_id,
-                    "The Slack connection keeps failing. Check the app-level token "
-                    "and that Socket Mode is enabled in the Slack app.",
-                )
-            await asyncio.sleep(5)
+        """Socket Mode sessions, reopened under the shared reconnect loop."""
+        await supervise_stream(
+            bot_id,
+            platform="Slack Socket Mode",
+            session=lambda: self._run_socket_mode(bot_id, bot_token),
+            failing=(
+                "The Slack connection keeps failing. Check the app-level token "
+                "and that Socket Mode is enabled in the Slack app."
+            ),
+        )
 
     async def _run_socket_mode(self, bot_id: str, bot_token: str) -> None:
         """Run one Socket Mode session."""

--- a/backend/app/services/channels/telegram.py
+++ b/backend/app/services/channels/telegram.py
@@ -10,7 +10,7 @@ from typing import Any
 from aiogram import Bot, Dispatcher
 from aiogram.client.default import DefaultBotProperties
 from aiogram.enums import ParseMode
-from aiogram.exceptions import TelegramBadRequest
+from aiogram.exceptions import TelegramBadRequest, TelegramUnauthorizedError
 from aiogram.types import Message as AiogramMessage
 
 from app.agents.capabilities.channel_tools import ChannelDetails, ChannelMember
@@ -21,7 +21,9 @@ from app.services.channels.base import (
     IncomingAttachment,
     IncomingMessage,
     OutgoingMessage,
+    supervise_stream,
 )
+from app.services.channels.exceptions import ChannelNotConfigured
 from app.services.channels.router import ChannelMessageRouter
 
 logger = logging.getLogger(__name__)
@@ -264,23 +266,25 @@ class TelegramAdapter(ChannelAdapter):
         logger.info("Stopped Telegram polling for bot %s", bot_id)
 
     async def _polling_supervisor(self, bot_id: str, bot_token: str) -> None:
-        """Supervised loop: restart polling on crash, stop on CancelledError."""
-        while True:
-            try:
-                await self._run_polling_once(bot_id, bot_token)
-            except asyncio.CancelledError:
-                break
-            except Exception:
-                logger.exception("Telegram polling crashed for bot %s, restarting in 5s", bot_id)
-                await connection_state.record_down(
-                    bot_id,
-                    "Telegram polling keeps failing. Check the bot token, and "
-                    "whether a webhook is registered - Telegram will not do both.",
-                )
-                await asyncio.sleep(5)
+        """Polling sessions, reopened under the shared reconnect loop."""
+        await supervise_stream(
+            bot_id,
+            platform="Telegram polling",
+            session=lambda: self._run_polling_once(bot_id, bot_token),
+            failing=(
+                "Telegram polling keeps failing. Check the bot token, and "
+                "whether a webhook is registered - Telegram will not do both."
+            ),
+        )
 
     async def _run_polling_once(self, bot_id: str, bot_token: str) -> None:
-        """Run one polling session using aiogram Dispatcher."""
+        """Run one polling session using aiogram Dispatcher.
+
+        A token Telegram rejects is raised as `ChannelNotConfigured` rather than
+        left as the vendor's 401: nothing a retry does will make the token valid,
+        and the supervisor retried it for ever, a traceback every five seconds,
+        where the other two platforms record `down` once and stop.
+        """
         async with self._bot(
             bot_token, default=DefaultBotProperties(parse_mode=ParseMode.MARKDOWN)
         ) as bot:
@@ -291,7 +295,16 @@ class TelegramAdapter(ChannelAdapter):
                 await self._handle_update(message, bot_id)
 
             await connection_state.record_up(bot_id)
-            await dp.start_polling(bot, handle_signals=False)
+            try:
+                await dp.start_polling(bot, handle_signals=False)
+            except TelegramUnauthorizedError as exc:
+                raise ChannelNotConfigured(
+                    message=(
+                        "Telegram rejected the bot token - polling not started. "
+                        "Check the token in the bot's settings."
+                    ),
+                    details={"bot_id": bot_id},
+                ) from exc
 
     async def register_webhook(self, bot_token: str, url: str, secret: str | None) -> bool:
         """Register a webhook URL with Telegram."""

--- a/backend/tests/test_channel_supervisor_yields.py
+++ b/backend/tests/test_channel_supervisor_yields.py
@@ -176,10 +176,14 @@ class TestMattermost:
         recorded.assert_awaited_once()
 
     async def test_the_missing_server_url_raises_rather_than_returning(self) -> None:
+        """And the refusal is what the connection row will show, so it names the
+        way out: the server URL, or webhook mode, which needs no stream."""
         adapter = MattermostAdapter()
 
-        with pytest.raises(ChannelNotConfigured):
+        with pytest.raises(ChannelNotConfigured) as refused:
             await adapter._run_stream("bot-without-a-url", "token")
+
+        assert "webhook mode" in refused.value.message
 
 
 class TestTelegram:

--- a/backend/tests/test_channel_supervisor_yields.py
+++ b/backend/tests/test_channel_supervisor_yields.py
@@ -1,15 +1,19 @@
-"""A channel supervisor must suspend between attempts, whatever its session does.
+"""One reconnect loop for every inbound stream, and what it must do.
 
-Both supervisors were `while True: await self._run_x(...)` with the only sleep
-inside `except Exception`. Both inner coroutines have branches that return
+Each adapter used to carry a loop of its own, and the three disagreed. Two put
+the sleep inside `except Exception`, so a session that ended by returning
 without ever awaiting - a Slack bot with no `xapp-` token, a Mattermost bot with
-no server URL, either package missing - and awaiting a coroutine that never
-suspends does not yield to the event loop.
+no server URL, either package missing - was retried without yielding: the loop
+ran at 100% CPU and **nothing else on the process was scheduled again**, the
+health check included. Two knew a configuration error from a crash and stopped;
+Telegram did not, so a bot with a rejected token was retried for ever, a
+traceback every five seconds. One backed off; two retried every five seconds
+flat.
 
-So the loop ran at 100% CPU and **nothing else on the process was scheduled
-again**: not a request, not the health check, not a WebSocket stream. The API
-was up and answered nothing, and the only clue was one WARNING line. Both
-trigger states are ordinary rows an operator has simply not filled in yet.
+`supervise_stream` in `base.py` is the one loop now, and these tests hold it to
+one contract through all three adapters: it suspends between sessions whatever
+the session does, it stops on `ChannelNotConfigured` after recording `down`
+once, and it backs off on a crash and resets after a clean session.
 
 Asserted by counting sleeps rather than by racing another task. A starved event
 loop cannot run a timer either, so a timeout-based test does not fail - it
@@ -25,14 +29,20 @@ import asyncio
 import contextlib
 from collections.abc import Awaitable, Callable
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from aiogram.exceptions import TelegramUnauthorizedError
 
+from app.services.channels import base as base_module
 from app.services.channels import mattermost as mattermost_module
 from app.services.channels import slack as slack_module
+from app.services.channels import telegram as telegram_module
+from app.services.channels.base import supervise_stream
 from app.services.channels.exceptions import ChannelNotConfigured
 from app.services.channels.mattermost import MattermostAdapter
 from app.services.channels.slack import SlackAdapter
+from app.services.channels.telegram import TelegramAdapter
 
 pytestmark = pytest.mark.anyio
 
@@ -70,6 +80,28 @@ async def _sleeps_between_sessions(
     return sleeps
 
 
+async def _stops_after_one_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+    adapter: Any,
+    session_attr: str,
+    supervisor: Callable[[], Awaitable[None]],
+) -> tuple[int, AsyncMock]:
+    """Run the supervisor over a session that cannot be configured; count attempts
+    and hand back what the connection row was told."""
+    attempts = 0
+
+    async def session(*_: object, **__: object) -> None:
+        nonlocal attempts
+        attempts += 1
+        raise ChannelNotConfigured(message="the operator has not filled this in")
+
+    recorded = AsyncMock()
+    monkeypatch.setattr(adapter, session_attr, session)
+    monkeypatch.setattr(base_module.connection_state, "record_down", recorded)
+    await supervisor()
+    return attempts, recorded
+
+
 class TestSlack:
     async def test_a_session_that_returns_immediately_still_sleeps(
         self, monkeypatch: pytest.MonkeyPatch
@@ -92,17 +124,16 @@ class TestSlack:
         """Nothing a retry can fix - an operator has to paste the xapp- token.
         Retrying is what the spin was."""
         adapter = SlackAdapter()
-        attempts = 0
 
-        async def session(*_: object, **__: object) -> None:
-            nonlocal attempts
-            attempts += 1
-            raise ChannelNotConfigured(message="no app token")
-
-        monkeypatch.setattr(adapter, "_run_socket_mode", session)
-        await adapter._socket_supervisor("bot", "xoxb-token")
+        attempts, recorded = await _stops_after_one_attempt(
+            monkeypatch,
+            adapter,
+            "_run_socket_mode",
+            lambda: adapter._socket_supervisor("bot", "xoxb-token"),
+        )
 
         assert attempts == 1
+        recorded.assert_awaited_once_with("bot", "the operator has not filled this in")
 
     async def test_the_missing_app_token_raises_rather_than_returning(self) -> None:
         """Where the distinction is made. Returning here is indistinguishable
@@ -133,17 +164,16 @@ class TestMattermost:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         adapter = MattermostAdapter()
-        attempts = 0
 
-        async def session(*_: object, **__: object) -> None:
-            nonlocal attempts
-            attempts += 1
-            raise ChannelNotConfigured(message="no server url")
-
-        monkeypatch.setattr(adapter, "_run_stream", session)
-        await adapter._supervise("bot", "token")
+        attempts, recorded = await _stops_after_one_attempt(
+            monkeypatch,
+            adapter,
+            "_run_stream",
+            lambda: adapter._supervise("bot", "token"),
+        )
 
         assert attempts == 1
+        recorded.assert_awaited_once()
 
     async def test_the_missing_server_url_raises_rather_than_returning(self) -> None:
         adapter = MattermostAdapter()
@@ -152,34 +182,152 @@ class TestMattermost:
             await adapter._run_stream("bot-without-a-url", "token")
 
 
-class TestMattermostBackoff:
-    async def test_the_first_retry_waits_what_the_log_says(
+class TestTelegram:
+    async def test_a_session_that_returns_immediately_still_sleeps(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The log names `delay`, so `delay` has to be what is then slept.
+        adapter = TelegramAdapter()
 
-        Moving the sleep out of the `except` left the doubling in front of it:
-        the line said "retrying in 5s" and the loop waited ten. Doubling after
-        the wait keeps the two agreeing, and keeps the first retry prompt.
-        """
-        adapter = MattermostAdapter()
-        sessions = 0
+        sleeps = await _sleeps_between_sessions(
+            monkeypatch,
+            telegram_module,
+            adapter,
+            "_run_polling_once",
+            lambda: adapter._polling_supervisor("bot", "123:token"),
+        )
+
+        assert sleeps == 2
+
+    async def test_a_telegram_config_error_records_down_and_stops_rather_than_looping(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The one adapter whose loop had no such branch: a bot with a bad token
+        was retried every five seconds for the life of the process, re-recording
+        `down` each time, where the other two record it once and stop."""
+        adapter = TelegramAdapter()
+
+        attempts, recorded = await _stops_after_one_attempt(
+            monkeypatch,
+            adapter,
+            "_run_polling_once",
+            lambda: adapter._polling_supervisor("bot", "123:token"),
+        )
+
+        assert attempts == 1
+        recorded.assert_awaited_once_with("bot", "the operator has not filled this in")
+
+    async def test_a_rejected_token_is_a_configuration_error_not_a_crash(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Where the distinction is made for Telegram: aiogram answers a bad token
+        with its 401, and left as that it is a crash the loop retries. Nothing a
+        retry does will make the token valid."""
+        adapter = TelegramAdapter()
+        dispatcher = MagicMock()
+        dispatcher.start_polling = AsyncMock(
+            side_effect=TelegramUnauthorizedError(method=MagicMock(), message="Unauthorized")
+        )
+
+        @contextlib.asynccontextmanager
+        async def fake_bot(*_: object, **__: object):
+            yield MagicMock()
+
+        monkeypatch.setattr(TelegramAdapter, "_bot", staticmethod(fake_bot))
+        monkeypatch.setattr(telegram_module, "Dispatcher", MagicMock(return_value=dispatcher))
+        monkeypatch.setattr(telegram_module.connection_state, "record_up", AsyncMock())
+
+        with pytest.raises(ChannelNotConfigured) as refused:
+            await adapter._run_polling_once("bot", "123:bad-token")
+
+        assert "token" in refused.value.message
+
+
+class TestTheOneLoop:
+    async def test_all_three_adapters_run_the_same_loop(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A reconnect fix that lands in one place lands in all three."""
+        shared = AsyncMock()
+        for module in (slack_module, telegram_module, mattermost_module):
+            monkeypatch.setattr(module, "supervise_stream", shared)
+
+        await SlackAdapter()._socket_supervisor("bot", "xoxb")
+        await TelegramAdapter()._polling_supervisor("bot", "123:t")
+        await MattermostAdapter()._supervise("bot", "t")
+
+        assert shared.await_count == 3
+        platforms = {call.kwargs["platform"] for call in shared.await_args_list}
+        assert platforms == {"Slack Socket Mode", "Telegram polling", "Mattermost event stream"}
+
+    async def test_a_crash_backs_off_and_a_clean_session_resets_it(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The log names `delay`, so `delay` has to be what is then slept -
+        doubling after the wait keeps the two agreeing and the first retry
+        prompt. A session that ended cleanly starts the ladder over."""
+        outcomes: list[BaseException | None] = [
+            RuntimeError("dropped"),
+            RuntimeError("dropped"),
+            RuntimeError("dropped"),
+            None,
+            RuntimeError("dropped"),
+            asyncio.CancelledError(),
+        ]
         waited: list[float] = []
+        recorded = AsyncMock()
 
-        async def session(*_: object, **__: object) -> None:
-            nonlocal sessions
-            sessions += 1
-            if sessions >= 4:
-                raise asyncio.CancelledError
-            raise RuntimeError("the server dropped the socket")
+        async def session() -> None:
+            outcome = outcomes.pop(0)
+            if outcome is not None:
+                raise outcome
 
         async def counting_sleep(delay: float) -> None:
             waited.append(delay)
 
-        monkeypatch.setattr(adapter, "_run_stream", session)
-        monkeypatch.setattr(mattermost_module.asyncio, "sleep", counting_sleep)
+        monkeypatch.setattr(base_module.asyncio, "sleep", counting_sleep)
+        monkeypatch.setattr(base_module.connection_state, "record_down", recorded)
 
         with contextlib.suppress(asyncio.CancelledError):
-            await adapter._supervise("bot", "token")
+            await supervise_stream(
+                "bot", platform="Test stream", session=session, failing="keeps dropping"
+            )
 
-        assert waited == [5.0, 10.0, 20.0]
+        assert waited == [5.0, 10.0, 20.0, 5.0, 5.0]
+        assert recorded.await_count == 4
+        recorded.assert_awaited_with("bot", "keeps dropping")
+
+    async def test_the_wait_is_capped_at_a_minute(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        crashes = 8
+        waited: list[float] = []
+
+        async def session() -> None:
+            nonlocal crashes
+            crashes -= 1
+            if crashes < 0:
+                raise asyncio.CancelledError
+            raise RuntimeError("dropped")
+
+        async def counting_sleep(delay: float) -> None:
+            waited.append(delay)
+
+        monkeypatch.setattr(base_module.asyncio, "sleep", counting_sleep)
+        monkeypatch.setattr(base_module.connection_state, "record_down", AsyncMock())
+
+        with contextlib.suppress(asyncio.CancelledError):
+            await supervise_stream("bot", platform="Test stream", session=session, failing="x")
+
+        assert waited == [5.0, 10.0, 20.0, 40.0, 60.0, 60.0, 60.0, 60.0]
+
+    async def test_a_cancelled_session_ends_the_loop_cancelled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`stop_polling` cancels the task and awaits it; swallowing the
+        cancellation would report a stream as stopped while its loop went on."""
+
+        async def session() -> None:
+            raise asyncio.CancelledError
+
+        monkeypatch.setattr(base_module.connection_state, "record_down", AsyncMock())
+
+        with pytest.raises(asyncio.CancelledError):
+            await supervise_stream("bot", platform="Test stream", session=session, failing="x")

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -972,11 +972,12 @@ check.
 
 ## A bot that cannot start stops, rather than retrying
 
-Slack Socket Mode and the Mattermost event stream both run under a supervisor
-that reconnects a dropped session. A missing configuration value is not a
-dropped session, and the supervisor treats it differently: it logs once and
-stops. Nothing it does would change the row — an operator has to add the Slack
-`xapp-` token or the Mattermost server URL.
+Telegram polling, Slack Socket Mode and the Mattermost event stream all run
+under one supervisor that reconnects a dropped session. A missing or rejected
+configuration value is not a dropped session, and the supervisor treats it
+differently: it records the bot as down with the reason, logs once and stops.
+Nothing it does would change the row — an operator has to add the Slack `xapp-`
+token or the Mattermost server URL, or replace a bot token Telegram rejects.
 
 This matters more than it sounds. Retrying a start that fails immediately never
 suspends, so the supervisor spins without yielding and every other task on the
@@ -988,9 +989,10 @@ If a bot is silent, check the log for `not started` before assuming a network
 problem.
 
 A dropped session is different: that one is retried, waiting five seconds and
-doubling to a minute, so a Mattermost server down for an hour is not hammered
-720 times by every bot on it. The line logged before each wait names the delay
-it is about to wait.
+doubling to a minute, so a server down for an hour is not hammered 720 times by
+every bot on it. A session that ended cleanly starts the ladder over. The line
+logged before each wait names the delay it is about to wait, and the same loop
+serves all three platforms, so the policy cannot drift between them.
 
 ---
 


### PR DESCRIPTION
## What changed

Each adapter carried its own "restart the inbound stream on failure" loop, and the three disagreed:

| | Slack | Telegram | Mattermost |
|---|---|---|---|
| Backoff | fixed 5s | fixed 5s | 5s → 60s |
| `sleep` vs `except` | outside | **inside** | outside |
| `ChannelNotConfigured` branch | records `down`, stops | **absent** | records `down`, stops |

So a Telegram bot whose token Telegram rejects was retried **for ever**, a traceback and a fresh `down` record every five seconds, where the other two stop after one. And any reconnect fix had to find and edit three places (#565 lifted the transport boilerplate into `base.py`; the loop was never lifted).

**`supervise_stream` in `app/services/channels/base.py` is the one loop now.** The three supervisor methods (`_socket_supervisor`, `_polling_supervisor`, `_supervise`) keep their names and call it with their session and their failing-row message. One policy:

- wait 5s, doubling to 60s, on a crash; a clean session resets the wait to 5s
- the wait is **outside** the `except` (a session that returns without awaiting must still yield - the 100% CPU spin)
- `ChannelNotConfigured` → `record_down(bot_id, exc.message)` once, log once, stop
- `CancelledError` propagates (`stop_polling` cancels and awaits the task)
- the log line before each wait names the delay it is about to wait

**Telegram's session** (`_run_polling_once`) raises `ChannelNotConfigured` for the `TelegramUnauthorizedError` a rejected token produces - that is what gives it the branch the other two had.

Docs: `docs/channels.md` "A bot that cannot start stops, rather than retrying" now names Telegram and the shared policy; the `channel-bot` skill tells a new adapter to run under `supervise_stream` rather than hand-roll a loop.

## How it was verified

`tests/test_channel_supervisor_yields.py` now holds all three adapters to the one contract:

- each adapter suspends between sessions that return immediately (the existing sleep-count tests, extended to Telegram)
- each adapter records `down` **once** and stops on `ChannelNotConfigured` - including `test_a_telegram_config_error_records_down_and_stops_rather_than_looping`
- `test_a_rejected_token_is_a_configuration_error_not_a_crash` - Telegram's 401 becomes `ChannelNotConfigured`
- `test_all_three_adapters_run_the_same_loop` - a fix in one place lands in all three
- backoff `[5, 10, 20]`, reset to 5 after a clean session, cap at 60; a cancelled session ends the loop cancelled

Against the **previous** Telegram supervisor (checked by loading `origin/main`'s `telegram.py`), the same configuration error gives 3 attempts and 3 `down` records in 3 sleeps - i.e. it never stops.

- 197 adapter/channel tests pass locally
- `make lint-backend` clean (`ty` warnings are pre-existing, none in these files)
- `make check` - see the CI checks on this PR

## Notes

- **One behaviour change beyond Telegram:** Slack now backs off 5→60s on repeated crashes instead of a flat 5s. That is the Mattermost policy applied to all three, and it is what the issue asks for.
- Mattermost's "not configured" row message is now the exception's own text rather than a second fixed sentence - one message, written where the refusal is decided, as Slack already did. Review caught that the fixed sentence had carried a hint the exception did not ("or switch it to webhook mode"); the refusal names it now, and the test asserts it.
- Rebased on `main` after #1392 merged; no conflicts.

Closes #1430
