### PR TITLE
chore: cut 0.0.359

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.359] - 2026-09-05
+
+### Changed
+
+- **Impersonation is a session an administrator can end, not a token on the
+  clipboard.** It was a bare one-hour bearer token, copied to the operating
+  system clipboard, that nothing could revoke. It is started from the console
+  with no token exposed, shown in a banner while it lasts, and ended by the
+  administrator, by the person's own sign-out-everywhere or password reset, by
+  the hour, or by the administrator's account being deleted - whichever comes
+  first. `sessions.impersonator_user_id` marks the row and the token carries
+  `sid` beside `act`, so every request binds the token to its row and refuses it
+  once the row is gone, deactivated, expired, held by another administrator or
+  for another account. A deployment can tell the impersonated person it
+  happened (`notify_impersonated_users`).
+
 ## [0.0.358] - 2026-09-05
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.358"
+version = "0.0.359"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.358"
+version = "0.0.359"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.358",
+  "version": "0.0.359",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for **0.0.359**. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json`, and adds the CHANGELOG entry.

The release is #1044, merged as #1435. Impersonation was a bare one-hour bearer token, copied to the operating system clipboard, that nothing could revoke; it is a session now — started from the console with no token exposed, shown in a banner, and ended by the administrator, by the person's own sign-out-everywhere or password reset, by the hour, or by the administrator's account being deleted.

Its migration was renumbered to `0072_impersonation_sessions` on the way in: `0071_mcp_connection_catalog_key` reached `main` first, and two revisions sharing one parent is a chain with two heads rather than a migration that fails to apply.

CI on `main` was green after the merge (`test`, `test-frontend`, `e2e`, `lint`, `docs`).