### PR TITLE
fix(channels): make the jwt_linked mode require a link on its own

### DIFF
--- a/.claude/skills/channel-bot/SKILL.md
+++ b/.claude/skills/channel-bot/SKILL.md
@@ -62,7 +62,9 @@ uv run agenticos cmd channel-webhook-delete --bot-id <uuid>   # back to polling
 
 There is no `cmd channel` group — the commands are flat, hyphenated names.
 
-Access modes: `open`, `whitelist`, `jwt_linked`, `group_only`.
+Access modes: `open`, `whitelist`, `jwt_linked`, `group_only`. `jwt_linked` refuses
+an unlinked chat account everywhere on its own; `require_link` is the switch that
+makes the *other* modes refuse in a channel too (#639).
 
 ## Webhook vs polling
 

--- a/backend/app/commands/channel.py
+++ b/backend/app/commands/channel.py
@@ -140,7 +140,7 @@ def channel_list_bots(platform: str | None, org_id: str | None) -> None:
     "--mode",
     default="open",
     type=click.Choice(["open", "whitelist", "jwt_linked", "group_only"]),
-    help="Access policy mode",
+    help="Access policy mode. jwt_linked answers only chat accounts linked to a member.",
 )
 @click.option(
     "--api-base-url",

--- a/backend/app/services/channels/router.py
+++ b/backend/app/services/channels/router.py
@@ -787,7 +787,7 @@ class ChannelMessageRouter:
                         "denied_message", "This bot is only available in specific groups."
                     )
                 )
-        # "open" and "jwt_linked" pass through here; jwt_linked is enforced at identity resolution
+        # "open" and "jwt_linked" pass through here; jwt_linked is `_admits_unlinked`'s to enforce.
 
     def _admits_unlinked(self, incoming: IncomingMessage, bot: Any) -> bool:
         """Whether somebody with no linked account may be answered here.
@@ -807,10 +807,18 @@ class ChannelMessageRouter:
         it mean anything: it sat in the default policy, the schema, the CLI and
         the dashboard while the gate it was meant to control refused everybody
         regardless.
+
+        The `jwt_linked` mode refuses both on its own. An operator who picks a
+        mode named for a linked account has asked for one, and the mode used to
+        decide nothing unless `require_link` was also set - a gate that read as
+        applied and was inert, behaviourally the same as `open`.
         """
         if incoming.chat_type == "private":
             return False
-        return not bool(self._parse_policy(bot).get("require_link", False))
+        policy = self._parse_policy(bot)
+        if policy.get("mode") == "jwt_linked":
+            return False
+        return not bool(policy.get("require_link", False))
 
     @staticmethod
     def _is_overheard(incoming: IncomingMessage) -> bool:
@@ -954,11 +962,13 @@ class ChannelMessageRouter:
         return None
 
     async def _resolve_identity(self, incoming: IncomingMessage, bot: Any, db: Any) -> Any:
-        """Get or create ChannelIdentity for this platform user."""
-        policy: dict[str, Any] = self._parse_policy(bot)
-        mode: str = policy.get("mode", "open")
+        """Get or create ChannelIdentity for this platform user.
 
-        identity = await channel_identity_repo.get_or_create(
+        Whether an unlinked one may be answered is `_admits_unlinked`'s decision,
+        made after this returns, so the refusal can carry the link where it is safe
+        to send. A second refusal here answered a plain sentence and no link.
+        """
+        return await channel_identity_repo.get_or_create(
             db,
             platform=incoming.platform,
             platform_user_id=incoming.platform_user_id,
@@ -966,13 +976,6 @@ class ChannelMessageRouter:
             platform_display_name=incoming.platform_display_name,
             user_id=None,
         )
-
-        if mode == "jwt_linked" and policy.get("require_link", False) and not identity.user_id:
-            raise AuthorizationError(
-                message="Please /link your account first before using this bot."
-            )
-
-        return identity
 
     async def _resolve_session(
         self, incoming: IncomingMessage, bot: Any, identity: Any, db: Any

--- a/backend/app/services/channels/router.py
+++ b/backend/app/services/channels/router.py
@@ -257,7 +257,10 @@ class ChannelMessageRouter:
 
         admit_unlinked = self._admits_unlinked(incoming, bot)
         if identity.user_id is None and not admit_unlinked:
-            await self._send_reply(bot, incoming, await self._invite_to_link(incoming, db))
+            # Through `_refuse_if_named`, not `_send_reply`: a room message that
+            # names a colleague passes the overheard gate on its handle, and the
+            # invitation must not interrupt two people talking to each other.
+            await self._refuse_if_named(bot, incoming, await self._invite_to_link(incoming, db))
             return
 
         session = await self._resolve_session(incoming, bot, identity, db)

--- a/backend/tests/test_channel_link_requests.py
+++ b/backend/tests/test_channel_link_requests.py
@@ -356,6 +356,16 @@ class TestWhoIsAskedToLinkAtAll:
 
         assert identity.user_id is None
 
+    def test_jwt_linked_with_both_switches_is_refused_at_the_admission_gate(self):
+        """The refusal `_resolve_identity` used to carry was reachable only with
+        both switches set. Removing it must not have been the only barrier for
+        that combination: the admission gate refuses it too, in a room and in a
+        direct message, so the invite path is what answers and nothing runs."""
+        bot = self._bot(mode="jwt_linked", require_link=True)
+
+        assert ChannelMessageRouter()._admits_unlinked(_incoming("group"), bot) is False
+        assert ChannelMessageRouter()._admits_unlinked(_incoming(), bot) is False
+
 
 class TestASlashAPlatformAte:
     """Mattermost parses a leading `/` itself.

--- a/backend/tests/test_channel_link_requests.py
+++ b/backend/tests/test_channel_link_requests.py
@@ -367,6 +367,56 @@ class TestWhoIsAskedToLinkAtAll:
         assert ChannelMessageRouter()._admits_unlinked(_incoming(), bot) is False
 
 
+class TestWhereTheInvitationIsPosted:
+    """A room message that names a colleague passes the overheard gate on its
+    handle - `@ada` is a handle as far as the pattern knows - and the bot must
+    keep the link invitation to itself there. Sent unconditionally, a
+    `jwt_linked` bot interrupted two people talking to each other with "send me
+    a direct message". The invitation takes the same addressed-only rule every
+    other refusal takes."""
+
+    @staticmethod
+    def _incoming(*, addressed: bool | None) -> IncomingMessage:
+        message = _incoming("group")
+        message.text = "@ada could you look at this?"
+        message.addressed = addressed
+        return message
+
+    async def _routed(self, incoming: IncomingMessage) -> AsyncMock:
+        router = ChannelMessageRouter()
+        bot = MagicMock(is_active=True, access_policy={"mode": "jwt_linked"})
+        sent = AsyncMock()
+        with (
+            patch(
+                "app.services.channels.router.channel_bot_repo.get_for_inbound",
+                new=AsyncMock(return_value=bot),
+            ),
+            patch.object(ChannelMessageRouter, "_handle_command", new=AsyncMock(return_value=None)),
+            patch.object(
+                ChannelMessageRouter,
+                "_resolve_identity",
+                new=AsyncMock(return_value=MagicMock(user_id=None)),
+            ),
+            patch.object(
+                ChannelMessageRouter, "_invite_to_link", new=AsyncMock(return_value="link first")
+            ),
+            patch.object(ChannelMessageRouter, "_send_reply", new=sent),
+        ):
+            await router._route_inner(incoming, MagicMock())
+        return sent
+
+    async def test_a_colleague_mention_in_a_room_is_not_answered_with_the_invitation(self):
+        sent = await self._routed(self._incoming(addressed=False))
+
+        sent.assert_not_awaited()
+
+    async def test_a_message_that_names_the_bot_still_gets_it(self):
+        sent = await self._routed(self._incoming(addressed=True))
+
+        sent.assert_awaited_once()
+        assert sent.await_args.args[2] == "link first"
+
+
 class TestASlashAPlatformAte:
     """Mattermost parses a leading `/` itself.
 

--- a/backend/tests/test_channel_link_requests.py
+++ b/backend/tests/test_channel_link_requests.py
@@ -328,6 +328,34 @@ class TestWhoIsAskedToLinkAtAll:
 
         assert ChannelMessageRouter()._admits_unlinked(_incoming("group"), bot) is True
 
+    def test_jwt_linked_mode_requires_a_link_even_without_require_link(self):
+        """A mode named for a linked account is a request for one. It used to
+        decide nothing on its own - `mode="jwt_linked", require_link=False` admitted
+        a room exactly as `open` did, a gate that read as applied and was inert."""
+        bot = self._bot(mode="jwt_linked")
+
+        assert ChannelMessageRouter()._admits_unlinked(_incoming("group"), bot) is False
+        assert ChannelMessageRouter()._admits_unlinked(_incoming(), bot) is False
+
+    def test_jwt_linked_is_read_from_a_policy_stored_as_a_string(self):
+        bot = MagicMock(access_policy='{"mode":"jwt_linked","require_link":false}')
+
+        assert ChannelMessageRouter()._admits_unlinked(_incoming("group"), bot) is False
+
+    async def test_identity_resolution_no_longer_refuses_on_its_own(self):
+        """The refusal belonged in one place. A second one here, reached only when
+        both switches were set, answered a bare sentence where the invite path
+        answers with the link in a direct message."""
+        with patch(
+            "app.services.channels.router.channel_identity_repo.get_or_create",
+            new=AsyncMock(return_value=MagicMock(user_id=None)),
+        ):
+            identity = await ChannelMessageRouter()._resolve_identity(
+                _incoming(), self._bot(mode="jwt_linked", require_link=True), MagicMock()
+            )
+
+        assert identity.user_id is None
+
 
 class TestASlashAPlatformAte:
     """Mattermost parses a leading `/` itself.

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -1097,7 +1097,9 @@ it is about to wait.
     failure — no credential, a recording over the endpoint's limit, a refusal, a
     timeout — is reported on the reply and the turn goes ahead without it.
 
-- **Access policy per bot** — open, whitelist, or "must be linked to a member".
+- **Access policy per bot** — open, whitelist, group-only, or `jwt_linked`: "must
+  be linked to a member", in a channel as much as in a direct message, with no
+  second setting to flip.
 - **A credential can be added or replaced after registration.** The pencil on a
   bot's row opens it: rename it, paste a rotated token, or supply the credential
   that was not in hand when it was registered — which is the ordinary case on
@@ -1130,7 +1132,9 @@ it is about to wait.
     chat account, the access policy, and the organization's monthly cap.
 
     Set **`require_link`** on the bot's access policy to refuse in channels too,
-    which is the old behaviour.
+    which is the old behaviour. The **`jwt_linked`** mode refuses on its own: a
+    mode named for a linked account asks for one, and it used to decide nothing
+    unless `require_link` was also set.
 
     Linking still matters in a channel, and it is worth doing: a linked sender
     runs as *themselves* rather than under the binding, and linking later makes

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -433,9 +433,11 @@ uv run agenticos cmd channel-webhook-delete --bot-id <uuid>
 Registering a bot from the CLI is the only way on a deployment with no browser
 pointed at it, which is what a Mattermost server behind a VPN usually is.
 
-Access modes are `open`, `whitelist`, `jwt_linked` and `group_only`. A mention runs
-as the *sender*, never as the bot, and an unlinked identity is refused rather than
-run with no role — see [Channels](channels.md#what-every-channel-shares).
+Access modes are `open`, `whitelist`, `jwt_linked` and `group_only`; `jwt_linked`
+answers only chat accounts linked to a member, in a channel as much as in a direct
+message. A mention runs as the *sender*, never as the bot, and an unlinked identity
+is refused rather than run with no role — see
+[Channels](channels.md#what-every-channel-shares).
 
 ### RAG commands
 


### PR DESCRIPTION
## What changed

The access mode **`jwt_linked` decided nothing on its own**: with `require_link=False` (the default) a bot saved as `jwt_linked` admitted an unlinked room sender under the binding creator exactly as `open` did. `_check_access` enforced only `whitelist`/`group_only`, `_admits_unlinked` keyed off `require_link` alone, and the one place that read the mode (`_resolve_identity`) required *both* switches. An operator who picks a mode named for a linked account has asked for one - the gate read as applied and was inert (the #718 class; adjacent to #639, which deliberately made `require_link` the switch).

Of the three options the issue lists, this takes the middle one - **the mode itself requires a link** - rather than a schema validator or retiring the value:

- `_admits_unlinked` returns `False` for `mode == "jwt_linked"` regardless of `require_link`. `require_link` keeps its #639 meaning for the other modes.
- `_resolve_identity` no longer carries a second refusal. It was reachable only when both switches were set, and it answered a bare sentence where the invite path (`_invite_to_link`) answers with the link in a direct message and the safe instruction in a room. One refusal, in the place that can carry the link.
- Copy: the CLI `--mode` help, `docs/channels.md` (the access-policy bullet and the `require_link` paragraph), `docs/commands.md`, and the `channel-bot` skill say what `jwt_linked` does now.

Retiring the mode value was the alternative, and it is the bigger change for the same outcome: the value is in the schema `Literal`, the CLI `Choice`, the docs, and every stored `access_policy` JSON that names it - a migration for a word.

## How it was verified

`tests/test_channel_link_requests.py::TestWhoIsAskedToLinkAtAll`:

- `test_jwt_linked_mode_requires_a_link_even_without_require_link` - room and DM both refused. **Fails against the previous router** (checked by swapping the file back).
- `test_jwt_linked_is_read_from_a_policy_stored_as_a_string` - the SQLite JSON-text shape.
- `test_identity_resolution_no_longer_refuses_on_its_own` - the removed branch stays removed.

- 194 router/mention/command tests pass locally
- `make lint-backend` clean (`ty` warnings pre-existing, none here)
- `make check` - see the CI checks on this PR

## Notes

- **Behaviour change for existing `jwt_linked` bots with `require_link=False`:** unlinked room senders are now refused (with the "send me a direct message" instruction) instead of running under the binding. That is what the mode's name promised; a deployment that wants the old behaviour sets the mode to `open`.
- **From review (Codex):** the invitation an unlinked sender gets now goes through `_refuse_if_named` - a room message naming a colleague (`@ada …`) passes the overheard gate on its handle, and the bot must not answer it with "send me a direct message". Two route-level tests pin both sides. A further test pins that `jwt_linked` with **both** switches is refused at the admission gate, so removing the duplicate refusal opened nothing.
- **Pre-existing gaps the review surfaced, filed rather than widened into this PR:** #1455 (`/new`, `/project`, `/unlink` run before the link gate - since #639), #1456 (a deactivated linked sender is refused at the run, after attachments and transcription were paid for - the #1436 refusal, moved earlier), #1457 (thread backfill quotes unlinked authors under `jwt_linked` / `require_link`).
- Rebased on `main` after #1392 merged; no conflicts.

Closes #1433
