### PR TITLE
refactor(channels): seven hygiene items from the 2026-09-03 audit

### DIFF
--- a/.claude/skills/channel-bot/SKILL.md
+++ b/.claude/skills/channel-bot/SKILL.md
@@ -75,6 +75,9 @@ Access modes: `open`, `whitelist`, `jwt_linked`, `group_only`.
 
 1. Implement `services/channels/<platform>.py` against `base.py`: parse inbound into
    the normalized message, send outbound.
+   Anything per bot the connection needs before it opens - a server address, an
+   app token - is registered in `prepare_connection`, the base hook the supervisor
+   calls on every adapter; do not add a differently named method for it.
 2. Wire it into `router.py` so inbound reaches the agent and replies stream back.
    **Do not fork the agent pipeline** — one runner behind every surface is the whole
    design.

--- a/backend/app/services/channels/__init__.py
+++ b/backend/app/services/channels/__init__.py
@@ -16,7 +16,6 @@ __all__ = [
     "SECRET_MINTED_BY_US",
     "get_adapter",
     "inbound_webhook_url",
-    "list_platforms",
     "register_adapter",
 ]
 
@@ -37,8 +36,3 @@ def get_adapter(platform: str) -> "ChannelAdapter":
     if platform not in _adapters:
         raise KeyError(f"No channel adapter registered for platform '{platform}'")
     return _adapters[platform]
-
-
-def list_platforms() -> list[str]:
-    """Return a list of all registered platform names."""
-    return list(_adapters.keys())

--- a/backend/app/services/channels/base.py
+++ b/backend/app/services/channels/base.py
@@ -233,9 +233,40 @@ class OutgoingMessage:
 
 
 class ChannelAdapter(ABC):
-    """Abstract base class for all messaging platform adapters."""
+    """One messaging platform, behind the interface the router speaks.
+
+    An adapter is a singleton serving every bot on its platform, so anything
+    per bot - a self-hosted server's address, a Slack app's own token - is
+    registered against the bot id through :meth:`prepare_connection` before a
+    stream opens, never read off a row at send time.
+
+    **HTTP clients, decided once here rather than three times.** REST traffic
+    the adapter makes itself goes through one `httpx.AsyncClient` per adapter,
+    built in `__init__` and closed in :meth:`aclose`: a streamed turn is dozens
+    of calls to one host, and a client per call throws the pool away before it
+    is reused, paying a TLS handshake each time (#952). A vendor SDK object is
+    the exception and is built per call inside a context manager that closes
+    it: aiogram's `Bot` opens a session it leaks unless closed, and slack-sdk's
+    `AsyncWebClient` is a thin wrapper that holds nothing worth keeping. So
+    Mattermost is one client; Slack is one client for its own downloads and an
+    SDK object per send; Telegram is an SDK object per call, closed on the way
+    out. What none of them does is build an `httpx.AsyncClient` per message.
+    """
 
     platform: str  # class-level constant e.g. "telegram"
+
+    def prepare_connection(  # noqa: B027
+        self, bot_id: str, *, api_base_url: str | None, app_token: str | None
+    ) -> None:
+        """Register what this bot's connection needs before the stream opens.
+
+        The adapter is one object serving every bot, so a per-bot fact - a
+        self-hosted server's address, a Slack app's `xapp-` token - is keyed on
+        the bot id here, and a stream opened before this ran would have nowhere
+        to connect. A platform that needs neither leaves it alone; the supervisor
+        calls it on every adapter the same way, which is what replaced reaching
+        for two differently named methods by `getattr`.
+        """
 
     @abstractmethod
     async def send_message(self, bot_token: str, msg: OutgoingMessage) -> None:

--- a/backend/app/services/channels/mattermost.py
+++ b/backend/app/services/channels/mattermost.py
@@ -135,6 +135,12 @@ class MattermostAdapter(ChannelAdapter):
         """Record which Mattermost server a bot belongs to."""
         self._base_urls[bot_id] = api_base_url.rstrip("/")
 
+    def prepare_connection(
+        self, bot_id: str, *, api_base_url: str | None, app_token: str | None
+    ) -> None:
+        if api_base_url:
+            self.remember_server(bot_id, api_base_url)
+
     def _client(self) -> contextlib.AbstractAsyncContextManager[httpx.AsyncClient]:
         """The adapter's shared HTTP client, borrowed for one request cycle.
 

--- a/backend/app/services/channels/router.py
+++ b/backend/app/services/channels/router.py
@@ -1,5 +1,7 @@
 """Channel message router - processes incoming messages end-to-end."""
 
+from __future__ import annotations
+
 import asyncio
 import json
 import logging
@@ -7,7 +9,7 @@ import re
 import time
 from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic_ai.messages import ModelMessage, ModelRequest, UserPromptPart
 
@@ -25,6 +27,7 @@ from app.services.channel_link import ChannelLinkService
 from app.services.channels import get_adapter
 from app.services.channels.attachments import ChannelAttachmentService
 from app.services.channels.base import (
+    ChannelAdapter,
     ChannelDirectoryUnsupported,
     IncomingAttachment,
     IncomingMessage,
@@ -44,6 +47,13 @@ from app.services.channels.mentions import (
 from app.services.conversation import ConversationService
 from app.services.transcription import MAX_BYTES as TRANSCRIPTION_MAX_BYTES
 from app.services.transcription import Recording, TranscriptionService
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from app.db.models.channel_bot import ChannelBot
+    from app.db.models.channel_identity import ChannelIdentity
+    from app.db.models.channel_session import ChannelSession
 
 logger = logging.getLogger(__name__)
 
@@ -172,7 +182,7 @@ def _kept_back(paths: list[str]) -> list[str]:
 class ChannelMessageRouter:
     """Process an incoming channel message end-to-end."""
 
-    async def route(self, incoming: IncomingMessage, db: Any) -> None:
+    async def route(self, incoming: IncomingMessage, db: AsyncSession) -> None:
         """Claim the delivery, acquire the per-chat lock, then process.
 
         The claim comes first, and before the lock on purpose: a redelivered
@@ -204,7 +214,7 @@ class ChannelMessageRouter:
             await release_delivery(incoming)
             raise
 
-    async def _route_inner(self, incoming: IncomingMessage, db: Any) -> None:
+    async def _route_inner(self, incoming: IncomingMessage, db: AsyncSession) -> None:
         """Process an incoming channel message end-to-end.
 
         Steps:
@@ -383,7 +393,7 @@ class ChannelMessageRouter:
 
     async def _deliver(
         self,
-        bot: Any,
+        bot: ChannelBot,
         incoming: IncomingMessage,
         answer: str,
         answered: Any,
@@ -402,13 +412,7 @@ class ChannelMessageRouter:
             adapter = get_adapter(incoming.platform)
             try:
                 await adapter.update_reply(
-                    unseal_bot_token(bot),
-                    OutgoingMessage(
-                        platform_chat_id=incoming.platform_chat_id,
-                        text=text,
-                        api_base_url=getattr(bot, "api_base_url", None),
-                    ),
-                    handle,
+                    unseal_bot_token(bot), self._message(bot, incoming, text), handle
                 )
             except Exception:
                 # The edit failed - a rate-limit on the last one, or the
@@ -435,10 +439,10 @@ class ChannelMessageRouter:
     async def _answer_mention(
         self,
         incoming: IncomingMessage,
-        bot: Any,
-        identity: Any,
-        session: Any,
-        db: Any,
+        bot: ChannelBot,
+        identity: ChannelIdentity,
+        session: ChannelSession,
+        db: AsyncSession,
         directory: BoundChannelDirectory | None,
         admit_unlinked: bool,
         *,
@@ -514,7 +518,7 @@ class ChannelMessageRouter:
         return True
 
     def _lazy_reply(
-        self, bot: Any, incoming: IncomingMessage
+        self, bot: ChannelBot, incoming: IncomingMessage
     ) -> tuple[LiveReply, Callable[[], str | None]]:
         """A live reply that posts its placeholder on the first push, not before.
 
@@ -539,35 +543,60 @@ class ChannelMessageRouter:
             nonlocal opened
             if not opened:
                 opened = True
-                placeholder = OutgoingMessage(
-                    platform_chat_id=incoming.platform_chat_id,
-                    text=text or WORKING,
-                    reply_to_message_id=incoming.message_id,
-                    api_base_url=getattr(bot, "api_base_url", None),
+                state["handle"] = await self._post_placeholder(
+                    adapter, token, bot, incoming, text or WORKING
                 )
-                try:
-                    state["handle"] = await adapter.begin_reply(token, placeholder)
-                except Exception:
-                    logger.warning(
-                        "Could not open a live reply on %s", incoming.platform, exc_info=True
-                    )
                 return
             if state["handle"] is None:
                 return
-            await adapter.update_reply(
-                token,
-                OutgoingMessage(
-                    platform_chat_id=incoming.platform_chat_id,
-                    text=text,
-                    api_base_url=getattr(bot, "api_base_url", None),
-                ),
-                state["handle"],
-            )
+            await adapter.update_reply(token, self._message(bot, incoming, text), state["handle"])
 
         return LiveReply(push), lambda: state["handle"]
 
     @staticmethod
-    def _channel_directory(bot: Any, incoming: IncomingMessage) -> BoundChannelDirectory | None:
+    def _message(
+        bot: ChannelBot, incoming: IncomingMessage, text: str, *, in_reply: bool = False
+    ) -> OutgoingMessage:
+        """One outgoing message for the chat this one arrived in.
+
+        Built in one place so the placeholder, each edit of it and the final
+        answer agree on where they go and which server they go to. Only the
+        placeholder replies to the incoming message: an edit addresses the
+        message it rewrites, and a reply marker on it would be ignored or wrong.
+        """
+        return OutgoingMessage(
+            platform_chat_id=incoming.platform_chat_id,
+            text=text,
+            reply_to_message_id=incoming.message_id if in_reply else None,
+            api_base_url=getattr(bot, "api_base_url", None),
+        )
+
+    async def _post_placeholder(
+        self,
+        adapter: ChannelAdapter,
+        token: str,
+        bot: ChannelBot,
+        incoming: IncomingMessage,
+        text: str,
+    ) -> str | None:
+        """Post the message the answer will be written into, or `None`.
+
+        `None` when the platform cannot edit what it has sent, or when posting
+        failed - logged and swallowed, because both mean the same thing to the
+        caller: answer the way we always did rather than cost somebody the answer.
+        """
+        try:
+            return await adapter.begin_reply(
+                token, self._message(bot, incoming, text, in_reply=True)
+            )
+        except Exception:
+            logger.warning("Could not open a live reply on %s", incoming.platform, exc_info=True)
+            return None
+
+    @staticmethod
+    def _channel_directory(
+        bot: ChannelBot, incoming: IncomingMessage
+    ) -> BoundChannelDirectory | None:
         """This channel, bound so an agent can ask about it - or `None`.
 
         Keyed on `channel_key`, not on `platform_chat_id`: in a thread the raw id
@@ -619,7 +648,7 @@ class ChannelMessageRouter:
         return recordings, rest
 
     async def _transcribe(
-        self, db: Any, bot: Any, recordings: list[IncomingAttachment]
+        self, db: AsyncSession, bot: ChannelBot, recordings: list[IncomingAttachment]
     ) -> tuple[list[str], list[str]]:
         """What the voice notes on this message said, and what could not be read.
 
@@ -704,7 +733,11 @@ class ChannelMessageRouter:
         return f"{text}\n\n{quoted}".strip() if text else quoted
 
     async def _receive_files(
-        self, db: Any, bot: Any, incoming: IncomingMessage, identity: Any
+        self,
+        db: AsyncSession,
+        bot: ChannelBot,
+        incoming: IncomingMessage,
+        identity: ChannelIdentity,
     ) -> tuple[list[Any], list[str]]:
         """Fetch, validate and store what arrived with the message.
 
@@ -730,7 +763,7 @@ class ChannelMessageRouter:
         )
 
     @staticmethod
-    async def _discard_files(db: Any, files: list[Any]) -> None:
+    async def _discard_files(db: AsyncSession, files: list[Any]) -> None:
         """Give back what the turn stored, for a turn that was refused.
 
         The files are fetched and stored before the agent is resolved, so a
@@ -757,7 +790,7 @@ class ChannelMessageRouter:
         return answer + "\n\n" + "\n".join(lines)
 
     @staticmethod
-    def _parse_policy(bot: Any) -> dict[str, Any]:
+    def _parse_policy(bot: ChannelBot) -> dict[str, Any]:
         """Return bot.access_policy as a dict regardless of storage format.
 
         SQLite stores access_policy as a JSON string; PostgreSQL/MongoDB store
@@ -768,7 +801,7 @@ class ChannelMessageRouter:
             return json.loads(raw) if raw else {}
         return raw
 
-    def _check_access(self, incoming: IncomingMessage, bot: Any) -> None:
+    def _check_access(self, incoming: IncomingMessage, bot: ChannelBot) -> None:
         """Enforce access policy. Raises AuthorizationError if denied."""
         policy: dict[str, Any] = self._parse_policy(bot)
         mode: str = policy.get("mode", "open")
@@ -789,7 +822,7 @@ class ChannelMessageRouter:
                 )
         # "open" and "jwt_linked" pass through here; jwt_linked is enforced at identity resolution
 
-    def _admits_unlinked(self, incoming: IncomingMessage, bot: Any) -> bool:
+    def _admits_unlinked(self, incoming: IncomingMessage, bot: ChannelBot) -> bool:
         """Whether somebody with no linked account may be answered here.
 
         In a room, yes. Somebody with the rights to invite the bot put it in a
@@ -856,7 +889,7 @@ class ChannelMessageRouter:
         """
         return incoming.chat_type == "private" or incoming.addressed is not False
 
-    async def _invite_to_link(self, incoming: IncomingMessage, db: Any) -> str:
+    async def _invite_to_link(self, incoming: IncomingMessage, db: AsyncSession) -> str:
         """What to answer somebody whose chat account is nobody's yet.
 
         A run belongs to a person - their budget, their permissions, their name
@@ -879,7 +912,7 @@ class ChannelMessageRouter:
         )
 
     async def _handle_command(
-        self, text: str, incoming: IncomingMessage, bot: Any, db: Any
+        self, text: str, incoming: IncomingMessage, bot: ChannelBot, db: AsyncSession
     ) -> str | None:
         """Handle bot commands. Returns reply text or None if not a command."""
         text = _as_command(text)
@@ -893,12 +926,8 @@ class ChannelMessageRouter:
 
         if cmd == "/start":
             return (
-                bot.welcome_message
-                if hasattr(bot, "welcome_message") and bot.welcome_message
-                else (
-                    f"Welcome! I'm {bot.name}. How can I help you today?\n\n"
-                    "Use /help to see available commands."
-                )
+                f"Welcome! I'm {bot.name}. How can I help you today?\n\n"
+                "Use /help to see available commands."
             )
 
         if cmd == "/help":
@@ -953,7 +982,9 @@ class ChannelMessageRouter:
 
         return None
 
-    async def _resolve_identity(self, incoming: IncomingMessage, bot: Any, db: Any) -> Any:
+    async def _resolve_identity(
+        self, incoming: IncomingMessage, bot: ChannelBot, db: AsyncSession
+    ) -> ChannelIdentity:
         """Get or create ChannelIdentity for this platform user."""
         policy: dict[str, Any] = self._parse_policy(bot)
         mode: str = policy.get("mode", "open")
@@ -975,8 +1006,12 @@ class ChannelMessageRouter:
         return identity
 
     async def _resolve_session(
-        self, incoming: IncomingMessage, bot: Any, identity: Any, db: Any
-    ) -> Any:
+        self,
+        incoming: IncomingMessage,
+        bot: ChannelBot,
+        identity: ChannelIdentity,
+        db: AsyncSession,
+    ) -> ChannelSession:
         """Get or create ChannelSession (+ backing Conversation) for this bot+chat.
 
         Whether the thread above this message still has to be read is *not*
@@ -1013,7 +1048,7 @@ class ChannelMessageRouter:
         # drift quietly against the messages people actually sent.
         return await channel_session_repo.touch(db, session)
 
-    def _check_rate_limit(self, bot: Any, identity_id: str) -> None:
+    def _check_rate_limit(self, bot: ChannelBot, identity_id: str) -> None:
         """In-memory token-bucket rate limiter.
 
         Uses a module-level dict. Default: 10 req/minute from
@@ -1041,7 +1076,7 @@ class ChannelMessageRouter:
             _rate_buckets[key] = (1, now)
 
     async def _open_reply(
-        self, bot: Any, incoming: IncomingMessage
+        self, bot: ChannelBot, incoming: IncomingMessage
     ) -> tuple[LiveReply | None, str | None]:
         """Put a message on screen now, and return how to keep writing it.
 
@@ -1058,36 +1093,20 @@ class ChannelMessageRouter:
         """
         adapter = get_adapter(incoming.platform)
         token = unseal_bot_token(bot)
-        placeholder = OutgoingMessage(
-            platform_chat_id=incoming.platform_chat_id,
-            text=WORKING,
-            reply_to_message_id=incoming.message_id,
-            api_base_url=getattr(bot, "api_base_url", None),
-        )
-        try:
-            handle = await adapter.begin_reply(token, placeholder)
-        except Exception:
-            logger.warning("Could not open a live reply on %s", incoming.platform, exc_info=True)
-            return None, None
+        handle = await self._post_placeholder(adapter, token, bot, incoming, WORKING)
         if handle is None:
             return None, None
 
-        await adapter.typing(str(bot.id), placeholder)
+        await adapter.typing(str(bot.id), self._message(bot, incoming, WORKING, in_reply=True))
 
         async def push(text: str) -> None:
-            await adapter.update_reply(
-                token,
-                OutgoingMessage(
-                    platform_chat_id=incoming.platform_chat_id,
-                    text=text,
-                    api_base_url=getattr(bot, "api_base_url", None),
-                ),
-                handle,
-            )
+            await adapter.update_reply(token, self._message(bot, incoming, text), handle)
 
         return LiveReply(push), handle
 
-    async def _refuse_if_named(self, bot: Any, incoming: IncomingMessage, message: str) -> None:
+    async def _refuse_if_named(
+        self, bot: ChannelBot, incoming: IncomingMessage, message: str
+    ) -> None:
         """Post a refusal only where the bot was actually addressed.
 
         In a channel the bot is one member of many, so a refusal to a message
@@ -1107,7 +1126,7 @@ class ChannelMessageRouter:
 
     async def _send_reply(
         self,
-        bot: Any,
+        bot: ChannelBot,
         incoming: IncomingMessage,
         text: str,
         attachments: list[OutgoingAttachment] | None = None,
@@ -1142,10 +1161,10 @@ class ChannelMessageRouter:
 
     async def _thread_files(
         self,
-        db: Any,
-        bot: Any,
+        db: AsyncSession,
+        bot: ChannelBot,
         incoming: IncomingMessage,
-        identity: Any,
+        identity: ChannelIdentity,
         handled: Sequence[IncomingAttachment] = (),
     ) -> tuple[list[Any], list[str], bool]:
         """The files posted in this thread before we were brought into it.
@@ -1218,7 +1237,7 @@ class ChannelMessageRouter:
         return received, refusals, True
 
     async def _thread_backfill(
-        self, incoming: IncomingMessage, directory: Any, bot: Any
+        self, incoming: IncomingMessage, directory: Any, bot: ChannelBot
     ) -> tuple[list[ModelMessage], bool]:
         """What was said in this thread before we were brought into it.
 
@@ -1319,7 +1338,7 @@ class ChannelMessageRouter:
             return str(post_id) == str(incoming.message_id)
         return bool(post.text) and post.text == incoming.text
 
-    def _backfill_admits(self, bot: Any) -> Callable[[Any], bool]:
+    def _backfill_admits(self, bot: ChannelBot) -> Callable[[Any], bool]:
         """Which earlier speakers may be quoted into the prompt.
 
         The bot's own access policy, applied to authors rather than only to the
@@ -1348,7 +1367,7 @@ class ChannelMessageRouter:
         return _admits
 
     @staticmethod
-    async def _load_history(db: Any, conversation_id: Any) -> list[ModelMessage]:
+    async def _load_history(db: AsyncSession, conversation_id: Any) -> list[ModelMessage]:
         """The most recent turns of the channel thread, oldest first.
 
         **The most recent, which took a `count` to get right** - and the count

--- a/backend/app/services/channels/slack.py
+++ b/backend/app/services/channels/slack.py
@@ -16,6 +16,7 @@ import logging
 import time
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
 
 import httpx
 
@@ -69,6 +70,20 @@ At Slack's 1000 ids per page this covers a fifty-thousand-member channel,
 which is a bound on a runaway cursor rather than on any real room.
 """
 
+_FILE_HOSTS = ("slack.com", "slack-files.com")
+"""Where Slack serves a file's `url_private`; the bot token is sent nowhere else."""
+
+
+def _slack_file_host(url: str) -> str | None:
+    """The host of a Slack file URL, or `None` if it is not one of Slack's over TLS."""
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme != "https" or not host:
+        return None
+    if any(host == root or host.endswith(f".{root}") for root in _FILE_HOSTS):
+        return host
+    return None
+
 
 class SlackAdapter(ChannelAdapter):
     """Concrete Slack adapter using slack-sdk."""
@@ -90,6 +105,12 @@ class SlackAdapter(ChannelAdapter):
     def remember_app_token(self, bot_id: str, app_token: str) -> None:
         """Register the app-level token Socket Mode will connect with."""
         self._app_tokens[bot_id] = app_token
+
+    def prepare_connection(
+        self, bot_id: str, *, api_base_url: str | None, app_token: str | None
+    ) -> None:
+        if app_token:
+            self.remember_app_token(bot_id, app_token)
 
     async def aclose(self) -> None:
         await self._http.aclose()
@@ -710,7 +731,19 @@ class SlackAdapter(ChannelAdapter):
         token would store that page as the user's spreadsheet. Hence the explicit
         content-type check - the failure mode here is silent corruption, not an
         error.
+
+        The URL comes out of the event payload, and this is the one place a
+        payload-supplied address is fetched with the bot token in the header - so
+        the host is checked against Slack's own before anything is sent. The
+        payload is signed, which makes this a second lock rather than the first;
+        a token posted to a host somebody else named is still a token gone.
         """
+        host = _slack_file_host(attachment.handle)
+        if host is None:
+            raise ValueError(
+                f"Slack named a file host this bot will not send its token to for "
+                f"{attachment.filename}."
+            )
         response = await self._http.get(
             attachment.handle, headers={"Authorization": f"Bearer {bot_token}"}
         )

--- a/backend/app/services/channels/supervisor.py
+++ b/backend/app/services/channels/supervisor.py
@@ -82,14 +82,7 @@ async def open_inbound_stream(
         return
 
     adapter = get_adapter(platform)
-
-    remember_server = getattr(adapter, "remember_server", None)
-    if remember_server is not None and api_base_url:
-        remember_server(bot_id, api_base_url)
-
-    remember_app_token = getattr(adapter, "remember_app_token", None)
-    if remember_app_token is not None and app_token:
-        remember_app_token(bot_id, app_token)
+    adapter.prepare_connection(bot_id, api_base_url=api_base_url, app_token=app_token)
 
     await adapter.stop_polling(bot_id)
     if _shutting_down:

--- a/backend/app/services/channels/telegram.py
+++ b/backend/app/services/channels/telegram.py
@@ -14,6 +14,7 @@ from aiogram.exceptions import TelegramBadRequest
 from aiogram.types import Message as AiogramMessage
 
 from app.agents.capabilities.channel_tools import ChannelDetails, ChannelMember
+from app.core.security import encode_untrusted
 from app.db.session import get_db_context
 from app.services.channels import connection_state
 from app.services.channels.base import (
@@ -322,7 +323,7 @@ class TelegramAdapter(ChannelAdapter):
         but accepted for interface compatibility with ChannelAdapter.
         """
         received = headers.get("x-telegram-bot-api-secret-token", "")
-        return hmac.compare_digest(received.encode(), secret.encode())
+        return hmac.compare_digest(encode_untrusted(received), secret.encode())
 
     def parse_incoming(self, raw_payload: dict[str, Any], bot_id: str) -> IncomingMessage | None:
         """Normalise one Telegram update, whichever transport delivered it.

--- a/backend/tests/test_channel_adapter_attachments.py
+++ b/backend/tests/test_channel_adapter_attachments.py
@@ -415,12 +415,41 @@ class TestSlackReceiving:
                     filename="report.csv",
                     mime_type="text/csv",
                     size=1,
-                    handle="https://files.slack.test/report.csv",
+                    handle="https://files.slack.com/files-pri/T1-F1/download/report.csv",
                 ),
             )
 
         assert data == b"month,total"
         assert client.get.await_args.kwargs["headers"] == {"Authorization": "Bearer xoxb-token"}
+
+    @pytest.mark.parametrize(
+        "handle",
+        [
+            "https://evil.example/report.csv",
+            "http://files.slack.com/report.csv",
+            "https://files.slack.com.evil.example/report.csv",
+            "https://notslack.com/report.csv",
+        ],
+    )
+    async def test_a_slack_download_url_off_slacks_domain_is_refused(self, handle: str):
+        """The URL is the payload's, and this is the one place a payload-supplied
+        address is fetched with the bot token in the header. The payload is
+        signed, so this is a second lock - and a token sent to a host somebody
+        else named is a token gone, so the host is Slack's or nothing is sent."""
+        client = _http_client(MagicMock())
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            pytest.raises(ValueError, match="will not send its token"),
+        ):
+            await SlackAdapter().download_attachment(
+                "xoxb-token",
+                IncomingAttachment(
+                    filename="report.csv", mime_type="text/csv", size=1, handle=handle
+                ),
+            )
+
+        client.get.assert_not_awaited()
 
     async def test_a_sign_in_page_is_refused_rather_than_stored_as_the_file(self):
         """Slack answers 200 with HTML rather than 401 when the token cannot read a
@@ -437,7 +466,10 @@ class TestSlackReceiving:
             await SlackAdapter().download_attachment(
                 "xoxb-token",
                 IncomingAttachment(
-                    filename="report.csv", mime_type="text/csv", size=1, handle="https://x/y"
+                    filename="report.csv",
+                    mime_type="text/csv",
+                    size=1,
+                    handle="https://files.slack.com/files-pri/T1-F1/download/report.csv",
                 ),
             )
 

--- a/backend/tests/test_channel_supervisor.py
+++ b/backend/tests/test_channel_supervisor.py
@@ -10,12 +10,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.services.channels.mattermost import MattermostAdapter
+from app.services.channels.slack import SlackAdapter
 from app.services.channels.supervisor import (
     allow_intake,
     begin_shutdown,
     close_inbound_stream,
     open_inbound_stream,
 )
+from app.services.channels.telegram import TelegramAdapter
 
 pytestmark = pytest.mark.anyio
 
@@ -26,16 +29,15 @@ def _adapter(**extra) -> MagicMock:
 
 
 class TestOpening:
-    async def test_the_bot_is_told_its_own_server_before_the_socket_opens(self):
-        """A Mattermost adapter is one object serving every bot, so the address
-        has to be registered against the id first - a stream opened before it
-        has nowhere to connect."""
+    async def test_the_bot_is_told_what_it_needs_before_the_socket_opens(self):
+        """An adapter is one object serving every bot, so a per-bot fact - the
+        Mattermost server address, a Slack app's token - has to be registered
+        against the id first: a stream opened before it has nowhere to connect."""
         order: list[str] = []
         adapter = _adapter(
-            remember_server=MagicMock(side_effect=lambda *_: order.append("remember")),
+            prepare_connection=MagicMock(side_effect=lambda *_, **__: order.append("prepare")),
         )
         adapter.start_polling = AsyncMock(side_effect=lambda *_: order.append("start"))
-        del adapter.remember_app_token
 
         with patch("app.services.channels.supervisor.get_adapter", return_value=adapter):
             await open_inbound_stream(
@@ -43,21 +45,13 @@ class TestOpening:
                 platform="mattermost",
                 token="tok",
                 api_base_url="https://mattermost.acme.com",
+                app_token="xapp",
             )
 
-        assert order == ["remember", "start"]
-        adapter.remember_server.assert_called_once_with("b-1", "https://mattermost.acme.com")
-
-    async def test_a_slack_app_token_is_registered_the_same_way(self):
-        adapter = _adapter(remember_app_token=MagicMock())
-        del adapter.remember_server
-
-        with patch("app.services.channels.supervisor.get_adapter", return_value=adapter):
-            await open_inbound_stream(
-                bot_id="b-1", platform="slack", token="xoxb", app_token="xapp"
-            )
-
-        adapter.remember_app_token.assert_called_once_with("b-1", "xapp")
+        assert order == ["prepare", "start"]
+        adapter.prepare_connection.assert_called_once_with(
+            "b-1", api_base_url="https://mattermost.acme.com", app_token="xapp"
+        )
 
     async def test_an_existing_stream_is_closed_first(self):
         """`start_polling` returns early when a task for that bot is running, so
@@ -67,22 +61,48 @@ class TestOpening:
         adapter = _adapter()
         adapter.stop_polling = AsyncMock(side_effect=lambda *_: order.append("stop"))
         adapter.start_polling = AsyncMock(side_effect=lambda *_: order.append("start"))
-        del adapter.remember_server
-        del adapter.remember_app_token
 
         with patch("app.services.channels.supervisor.get_adapter", return_value=adapter):
             await open_inbound_stream(bot_id="b-1", platform="telegram", token="tok")
 
         assert order == ["stop", "start"]
 
-    async def test_a_platform_with_no_address_is_not_told_one(self):
-        adapter = _adapter(remember_server=MagicMock())
-        del adapter.remember_app_token
 
-        with patch("app.services.channels.supervisor.get_adapter", return_value=adapter):
-            await open_inbound_stream(bot_id="b-1", platform="telegram", token="tok")
+class TestWhatEachAdapterPrepares:
+    """The hook is on the base, so every adapter is asked the same way; what
+    each one keeps is its own. The `getattr` reach this replaced needed the
+    supervisor to know the two method names, and a third adapter would have been
+    a third name."""
 
-        adapter.remember_server.assert_not_called()
+    def test_mattermost_keeps_the_server_and_ignores_the_app_token(self):
+        adapter = MattermostAdapter()
+
+        adapter.prepare_connection("b-1", api_base_url="https://mm.acme.com/", app_token="xapp")
+
+        assert adapter._base_urls == {"b-1": "https://mm.acme.com"}
+
+    def test_slack_keeps_the_app_token_and_ignores_the_server(self):
+        adapter = SlackAdapter()
+
+        adapter.prepare_connection("b-1", api_base_url="https://mm.acme.com", app_token="xapp")
+
+        assert adapter._app_tokens == {"b-1": "xapp"}
+
+    def test_a_platform_that_needs_neither_keeps_nothing(self):
+        adapter = TelegramAdapter()
+
+        adapter.prepare_connection("b-1", api_base_url="https://mm.acme.com", app_token="xapp")
+
+        assert not hasattr(adapter, "_base_urls")
+
+    def test_nothing_is_kept_for_a_bot_that_supplied_nothing(self):
+        mattermost, slack = MattermostAdapter(), SlackAdapter()
+
+        mattermost.prepare_connection("b-1", api_base_url=None, app_token=None)
+        slack.prepare_connection("b-1", api_base_url=None, app_token=None)
+
+        assert mattermost._base_urls == {}
+        assert slack._app_tokens == {}
 
 
 class TestClosing:

--- a/backend/tests/test_non_ascii_credential_compare.py
+++ b/backend/tests/test_non_ascii_credential_compare.py
@@ -25,6 +25,7 @@ from app.core.config import settings
 from app.core.exceptions import AuthorizationError
 from app.services.channels.mattermost import MattermostAdapter
 from app.services.channels.slack import SlackAdapter
+from app.services.channels.telegram import TelegramAdapter
 
 pytestmark = pytest.mark.anyio
 
@@ -72,6 +73,22 @@ def test_a_lone_surrogate_slack_body_is_refused_rather_than_crashing() -> None:
     assert (
         SlackAdapter().verify_webhook_signature(headers, "signing-secret", _LONE_SURROGATE) is False
     )
+
+
+def test_a_lone_surrogate_telegram_secret_is_refused_rather_than_crashing() -> None:
+    """The one header-only check of the three, and the outlier that still used a
+    bare `.encode()`. Starlette decodes headers as latin-1, so a surrogate cannot
+    arrive this way today; the encode is the same defence the other two apply,
+    so the next decoder change is not a 500 on an unauthenticated route."""
+    headers = {"x-telegram-bot-api-secret-token": _LONE_SURROGATE}
+
+    assert TelegramAdapter().verify_webhook_signature(headers, "secret") is False
+
+
+def test_the_right_telegram_secret_still_matches() -> None:
+    headers = {"x-telegram-bot-api-secret-token": "secret"}
+
+    assert TelegramAdapter().verify_webhook_signature(headers, "secret") is True
 
 
 async def test_a_non_ascii_api_key_is_refused_rather_than_crashing(


### PR DESCRIPTION
## What changed

The seven items of #1434, batched as the issue asks. Each is independent; the commit body has a paragraph per item.

- [x] **Slack sends the bot token only to Slack.** `download_attachment` fetched `url_private_download` straight from the (signed) event payload with `Authorization: Bearer` and no check on the host. The host is now checked against `slack.com` / `slack-files.com` over TLS before anything is sent; anything else is refused with the client untouched. Second lock, not the first - but a token posted to a host somebody else named is a token gone.
- [x] **`router.py` names its domain objects.** `db`/`bot`/`identity`/`session` were `Any` 43 times; now `AsyncSession`/`ChannelBot`/`ChannelIdentity`/`ChannelSession` under `TYPE_CHECKING`, and `_resolve_identity`/`_resolve_session` say what they return. First thing the checker found: `/start` read `bot.welcome_message` behind a `hasattr`, and no model, schema, page or test has ever had that field - dead branch, removed.
- [x] **`list_platforms()` deleted** - defined, exported, called by nothing.
- [x] **The HTTP-client decision is written once**, on `ChannelAdapter`: one `httpx.AsyncClient` per adapter for the adapter's own REST (#952); a vendor SDK object per call, closed on the way out (aiogram's `Bot`, slack-sdk's `AsyncWebClient`); never a client per message.
- [x] **`prepare_connection` replaces the `getattr` duck-typing** in `supervisor.py`. A no-op hook on the base, called on every adapter the same way; Mattermost keeps the server, Slack the app token, Telegram nothing. The webhook route's direct `remember_server` stays (it already narrows to `MattermostAdapter`).
- [x] **Telegram's secret compare uses `encode_untrusted`**, as Slack and Mattermost do. Safe today (Starlette decodes headers as latin-1); the same defence in depth.
- [ ] **Two duplicated router shapes - half done.** `_message` and `_post_placeholder` are now the one copy of the `OutgoingMessage` and the guarded `begin_reply` that `_lazy_reply`, `_open_reply` and `_deliver` each built. **Left as is:** the try/`AppException`/`Exception` shape `_answer_mention` and the default path share. Unifying it changes what a crash on the mention path does (today it propagates to `route` and releases the dedupe claim; the default path apologises) - a behaviour decision, so its own change: **#1459**, split out on review rather than left as a note here.

## How it was verified

- `test_a_slack_download_url_off_slacks_domain_is_refused` (4 shapes: another host, plain http, a look-alike suffix, a look-alike name) - refused, `client.get` never awaited. The two existing download tests moved to a real `files.slack.com` URL.
- `TestOpening` rewritten for the hook (order: prepare → stop → start; the exact kwargs), plus `TestWhatEachAdapterPrepares` - each adapter keeps only its own fact; Telegram keeps nothing; `None`s keep nothing.
- `test_a_lone_surrogate_telegram_secret_is_refused_rather_than_crashing` + the right secret still matches.
- Live-reply suite over the unified builders; 519 channel tests pass.
- `make lint-backend` clean; `ty` on `router.py` is down to the one pre-existing warning (`get_for_inbound` str/UUID). `make check` - see CI.

## Notes

- `docs/channels.md` owes nothing: none of this changes behaviour a page describes (the Slack host check refuses only what Slack never sends). The `channel-bot` skill's "Adding an adapter" names `prepare_connection`.
- The two observations the issue lists as "not filed" (`/new` attribution in a group; a session whose conversation was hard-deleted) are untouched here.

Part-of #1434
Refs #1459
