### PR TITLE
chore: cut 0.0.360

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.360] - 2026-09-05
+
+### Fixed
+
+- **A chart in a channel reply stalled every other channel turn while it drew.**
+  The PNG was rasterised and encoded by Pillow synchronously on the event loop
+  the worker's pollers and webhooks all share. It is handed to a thread now, like
+  the upload parse and the worker's file hash before it.
+
 ## [0.0.359] - 2026-09-05
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.359"
+version = "0.0.360"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.359"
+version = "0.0.360"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.359",
+  "version": "0.0.360",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for **0.0.360**. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json`, and adds the CHANGELOG entry.

The release is #1429, merged as #1447. The PNG a channel reply carries was rasterised and encoded by Pillow synchronously on the event loop that every poller and webhook task on the worker shares, so drawing one chart stalled all of them for its duration — the same class as the upload parse (#25) and the worker's file hash (#1100). Both call sites hand it to a thread now.