### PR TITLE
chore: cut 0.0.361

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.361] - 2026-09-05
+
+### Fixed
+
+- **A new chart type would have been drawn as a line chart, silently.** The
+  `charts` capability's `ChartType` and the channel renderer's dispatch are two
+  lists in two packages that have to agree, and nothing checked them against each
+  other: the renderer named three types and sent everything else to the line
+  drawer. There is one renderer per member now, and a test that fails when the
+  two lists drift.
+
 ## [0.0.360] - 2026-09-05
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.360"
+version = "0.0.361"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.360"
+version = "0.0.361"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.360",
+  "version": "0.0.361",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for **0.0.361**. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json`, and adds the CHANGELOG entry.

The release is #1432, merged as #1453. The `charts` capability's `ChartType` and the channel renderer's dispatch are two lists in two packages that have to agree, and nothing checked them: the renderer named `pie`, `bar` and `scatter` and drew everything else as lines — right for `line` and `area` today, and silently wrong the day a sixth member arrives. One renderer per member now, with a test that fails when the two drift.

CI on `main` was green after the merge.