### PR TITLE
chore: cut 0.0.362

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.362] - 2026-09-05
+
+### Fixed
+
+- **A collection teardown and a claim could deadlock each other.** Every path
+  that drops a collection takes its teardown lock before any row lock now, so a
+  claim - which takes the teardown lock and then the organization FK - cannot
+  cross a teardown into an ABBA deadlock.
+- **A purge could drop a collection without reserving its name, and another
+  organization could then inherit its vectors.** The purge locks the names its
+  snapshot saw, taken before the organization row is; one created between that
+  snapshot and the row lock is found only by the authoritative scan, and was
+  dropped unreserved - so a claim in the commit-to-drop window adopted the name,
+  and the deferred cleanup, finding the table newly referenced, preserved it with
+  the deleted organization's rows still in it. That lock is taken without waiting
+  now: free, and the name reserves like any other; held by a claim already in
+  flight, and the purge refuses rather than dropping unreserved.
+
 ## [0.0.361] - 2026-09-05
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.361"
+version = "0.0.362"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.361"
+version = "0.0.362"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.361",
+  "version": "0.0.362",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for **0.0.362**. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json`, and adds the CHANGELOG entry.

The release is #1387, merged as #1390. Two things: every path that drops a collection takes its teardown lock before any row lock, so a claim and a teardown cannot cross into an ABBA deadlock — and the one collection a purge could drop *without* reserving its name is reserved too.

That second half was a cross-tenant read, found in review of the PR rather than by the PR: a collection created between the purge's snapshot and its `FOR UPDATE` is seen only by the authoritative scan, was dropped unreserved, and another organization could then claim the name and inherit a vector table the deferred cleanup preserves on finding it newly referenced — with the deleted organization's rows still in it. `try_hold_name` takes that lock without waiting; where a claim already holds it, the purge refuses instead of dropping unreserved.