### PR TITLE
chore: cut 0.0.363

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.363] - 2026-09-05
+
+### Fixed
+
+- **A bot saved as `jwt_linked` admitted senders with no linked account.** The
+  mode decided nothing on its own: with `require_link` off, which is the default,
+  it admitted an unlinked room sender under the binding's creator exactly as
+  `open` did - the access check enforced only `whitelist` and `group_only`, and
+  the one place that read the mode required both switches. An operator who picks
+  a mode named for a linked account has asked for one, so the mode requires it.
+
 ## [0.0.362] - 2026-09-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,17 +21,25 @@ Two things are versioned separately from this file and worth knowing about:
 
 ### Fixed
 
+- **A Telegram bot with a token Telegram rejects was retried for ever.** Each
+  adapter carried its own reconnect loop and the three disagreed - a fixed five
+  seconds against a 5s-to-60s backoff, the sleep inside the `except` in one and
+  outside it in the others, and a stop-on-misconfiguration branch in two of the
+  three. So that bot logged a traceback and wrote a fresh `down` record every
+  five seconds, where the same bot on Slack or Mattermost recorded `down` once
+  and stopped. One supervised loop serves all three, with the backoff, the stop
+  condition and the accounting written once.
+
+## [0.0.362] - 2026-09-05
+
+### Fixed
+
 - **A bot saved as `jwt_linked` admitted senders with no linked account.** The
   mode decided nothing on its own: with `require_link` off, which is the default,
   it admitted an unlinked room sender under the binding's creator exactly as
   `open` did - the access check enforced only `whitelist` and `group_only`, and
   the one place that read the mode required both switches. An operator who picks
   a mode named for a linked account has asked for one, so the mode requires it.
-
-## [0.0.362] - 2026-09-05
-
-### Fixed
-
 - **A collection teardown and a claim could deadlock each other.** Every path
   that drops a collection takes its teardown lock before any row lock now, so a
   claim - which takes the teardown lock and then the organization FK - cannot

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.362"
+version = "0.0.363"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.362"
+version = "0.0.363"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.362",
+  "version": "0.0.363",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for **0.0.363**. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json`, and adds the CHANGELOG entry.

The release is #1430, merged as #1450. Each adapter carried its own reconnect loop and the three disagreed — a fixed five seconds against a 5s-to-60s backoff, the sleep inside the `except` in one and outside it in the others, and a stop-on-misconfiguration branch in two of the three. A Telegram bot whose token Telegram rejects was therefore retried for ever, logging a traceback and writing a fresh `down` record every five seconds, where the same bot on Slack or Mattermost recorded `down` once and stopped. One supervised loop serves all three now.

**It also corrects the previous release's notes.** The 0.0.362 release commit was cut before #1454 merged and squashed in after it, so `v0.0.362`'s tree already carries the `jwt_linked` fix while its notes credited only #1390 — and this section originally announced that fix as new, which would have told anyone reading the notes to upgrade for something they already had. The entry moves to 0.0.362 and the published `v0.0.362` notes are amended to match. Caught by the reviewer on this PR.