### PR TITLE
chore: cut 0.0.364

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.364] - 2026-09-05
+
+### Fixed
+
+- **A quiet Telegram bot read `unknown` on the channels listing while polling
+  fine.** `record_up` fires once when the poll opens and the connection entry
+  expires on a fifteen-minute TTL, with nothing re-stamping it - the defect
+  #1351 fixed for Slack Socket Mode and the Mattermost event stream, whose own
+  body named Telegram polling as the same shape. It gets the same heartbeat.
+
 ## [0.0.363] - 2026-09-05
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.363"
+version = "0.0.364"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.363"
+version = "0.0.364"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.363",
+  "version": "0.0.364",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for **0.0.364**. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json`, and adds the CHANGELOG entry.

The release is #1431, merged as #1451. `record_up` fires once when a Telegram poll opens and the connection entry expires on a fifteen-minute TTL with nothing re-stamping it, so a bot nobody had messaged for fifteen minutes read `unknown` on `/channels` while polling fine — the defect #1351 fixed for Slack Socket Mode and the Mattermost event stream, whose own body named Telegram polling as the same shape. It gets the same heartbeat.

Cut after #1451 merged and with nothing else in flight, so this tree is exactly what the entry describes.