### PR TITLE
chore: cut 0.0.365

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,29 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.365] - 2026-09-05
+
+### Fixed
+
+- **Slack's attachment download sent the bot token to whatever host the event
+  named.** The payload is signed, so this is the second lock rather than the
+  first - but a token posted to a host somebody else chose is a token gone. The
+  host is checked against `slack.com` and `slack-files.com` over TLS before
+  anything is sent, and anything else is refused with the client untouched.
+- **Telegram's webhook secret is compared through `encode_untrusted`**, as Slack
+  and Mattermost already did. Safe today, because Starlette decodes headers as
+  latin-1; the same defence in depth regardless.
+
+### Changed
+
+- **`router.py` names its domain objects.** `db`, `bot`, `identity` and `session`
+  were `Any` forty-three times. The first thing the type checker found was a
+  `/start` branch reading a `welcome_message` field no model, schema, page or
+  test has ever had; `list_platforms()` went the same way, defined and exported
+  and called by nothing. The HTTP-client decision is written once on
+  `ChannelAdapter`, and a `prepare_connection` hook replaces `getattr`
+  duck-typing in the supervisor.
+
 ## [0.0.364] - 2026-09-05
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.364"
+version = "0.0.365"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.364"
+version = "0.0.365"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.364",
+  "version": "0.0.365",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release commit for **0.0.365**. Bumps `backend/pyproject.toml`, `backend/uv.lock` and `frontend/package.json`, and adds the CHANGELOG entry.

The release is #1434, merged as #1458: seven hygiene items from the 2026-09-03 channels audit. Two are worth a reader's attention — Slack's `download_attachment` sent the bot token to whatever host the (signed) event payload named, and the typing sweep over `router.py` found, as its first result, a `/start` branch reading a `welcome_message` field no model, schema, page or test has ever had.

Cut after #1458 merged, with `main` green and nothing else in flight.