### PR TITLE
chore: cut 0.0.366

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,26 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.366] - 2026-09-05
+
+### Fixed
+
+- **The channel router's two module-level dicts grew without bound.** One held
+  an asyncio lock per chat, the other a rate-limit window per sender, and
+  neither ever dropped an entry - a long-running API worker kept one of each for
+  every chat and every chat account it had ever heard from. The lock map is now
+  reference-counted and drops a lock when the last waiter leaves it; the window
+  map drops what has expired on every write, so it is the size of the callers
+  seen in the last minute.
+- **The per-sender channel limit survives a Redis outage.** `rate_limit.consume`
+  fails open when Redis is unreachable, which is the documented trade for a
+  public widget - but for a channel bot `rate_limit_rpm` is a production
+  control, and a limiter that vanishes for the length of an outage lets a
+  permitted participant run the model as fast as they can type. `Decision` now
+  says whether it counted at all, and a turn it could not count is counted in a
+  bounded per-process window instead: wrong by the worker count, and still a
+  floor where there had been none.
+
 ## [0.0.365] - 2026-09-05
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.365"
+version = "0.0.366"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.365"
+version = "0.0.366"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.365",
+  "version": "0.0.366",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.366.

Ships #1440 — the channel router's two unbounded module-level maps, and the per-sender channel limit surviving a Redis outage.