### PR TITLE
chore: cut 0.0.367

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,28 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.367] - 2026-09-05
+
+### Fixed
+
+- **A collection name shared by two organizations resolved the wrong tenant's
+  embedding configuration.** `knowledge_bases.collection_name` is indexed but not
+  unique, and resolution by name alone answered with whichever row the database
+  ordered first - so an embedding call for one organization could read another's
+  model and unseal *their* vault key, billing them and running this
+  organization's text through their credential. Resolution is now scoped to the
+  organization the embedding is for, falling back to an app-scoped collection
+  but never to a third tenant's.
+- **One collection name is one embedding space, and nothing used to enforce it.**
+  A name is one physical vector table, so several knowledge bases can index into
+  the same vectors - at different widths, where pgvector then refuses the
+  comparison outright, or at the same width with different models, where it ranks
+  one embedding space against another and answers with plausible nonsense. The
+  credential had the same shape of problem: whichever sibling was read is the key
+  that got billed. A row created against a name that already exists now adopts
+  that collection's model, width, provider and vault key, and a caller who named
+  a different one is refused rather than silently overridden.
+
 ## [0.0.366] - 2026-09-05
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.366"
+version = "0.0.367"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.366"
+version = "0.0.367"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.366",
+  "version": "0.0.367",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.367.

Ships #1425 — per-collection embedding resolution scoped to the organization, and the invariant that makes it correct: one collection name is one embedding space.