### PR TITLE
feat(deploy): a deployment somebody else can repeat

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,8 +34,45 @@ permissions:
   contents: read
 
 jobs:
+  # Resolves the ref and proves it is already on `main`. Deliberately *before*
+  # the environment gate and holding no secrets: a `workflow_dispatch` takes a
+  # ref, a ref can be a branch or a tag, and both move - so approving "deploy
+  # this tag" and then moving the tag would put unreviewed code on the server
+  # with one approval spent on something else. What is approved below is a
+  # digest this job has already checked.
+  resolve:
+    name: Resolve the commit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      sha: ${{ steps.pin.outputs.sha }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The whole history, or `merge-base` cannot answer.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Pin it
+        id: pin
+        env:
+          REF: ${{ inputs.ref || github.sha }}
+        run: |
+          set -euo pipefail
+          sha=$(git rev-parse --verify "$REF^{commit}")
+          # `main` rather than the default branch by name from the API: this
+          # workflow only ever deploys what merged, and a repository that renamed
+          # its branch would rather fail here than deploy something else.
+          if ! git merge-base --is-ancestor "$sha" origin/main; then
+            echo "::error::$REF ($sha) is not an ancestor of main - only merged commits are deployable" >&2
+            exit 1
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "Deploying $(git --no-pager log --oneline -1 "$sha")"
+
   deploy:
     name: Deploy to production
+    needs: resolve
     runs-on: ubuntu-latest
     # What makes the approval possible. `url` is what GitHub links to from the
     # run and from the repository's environment list, so the deployment history
@@ -46,20 +83,16 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      # **This workflow's own ref, not the commit being deployed.** The script is
+      # the deploy *procedure*, and taking it from the deployed commit means a
+      # rollback to anything older than it has no script to run - which is the
+      # one moment a rollback is being attempted.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # The commit being deployed, so `scripts/deploy.sh` is the version that
-          # ships with it. A `workflow_dispatch` with no ref deploys the branch it
-          # was started from, which is `main`.
-          ref: ${{ inputs.ref || github.sha }}
           # Nothing here pushes, and this job holds a key to a production host -
           # so the token that checkout would otherwise leave in `.git/config` is
           # one more credential in the same process for no reason.
           persist-credentials: false
-
-      - name: Resolve the commit
-        id: commit
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       # Written out rather than reached through a third-party action: this is the
       # one workflow holding a key that opens a production host, and the fewer
@@ -81,7 +114,7 @@ jobs:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           APP_DIR: ${{ vars.APP_DIR || '/opt/agenticos' }}
-          SHA: ${{ steps.commit.outputs.sha }}
+          SHA: ${{ needs.resolve.outputs.sha }}
         run: |
           ssh -i ~/.ssh/deploy_key -o BatchMode=yes \
             "$DEPLOY_USER@$DEPLOY_HOST" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,102 @@
+name: Deploy
+
+# Every merge to `main` offers itself for deployment; **somebody has to approve
+# it before anything reaches the server.** The gate is not in this file and
+# cannot be - it is the `production` environment's *required reviewers* rule,
+# configured in the repository's settings. Without that rule this workflow
+# deploys every merge unattended, which is the one failure mode worth knowing
+# about here: the safety is a setting, not a step.
+#
+# `workflow_dispatch` is the same job with a ref you pick - a rollback, or a
+# redeploy after changing something on the host - and it passes through the same
+# approval.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Commit or tag to deploy (default: the branch this is run from)"
+        required: false
+        type: string
+
+# One deploy at a time, and **never cancel one in flight**. Half a deploy is a
+# stack whose API has been rebuilt and whose migrations have not - so a second
+# merge landing mid-deploy queues behind the first rather than replacing it.
+#
+# This is the opposite of `ci.yml`'s rule, and for the opposite reason: there a
+# superseded answer is waste, here a superseded run has already changed a server.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy to production
+    runs-on: ubuntu-latest
+    # What makes the approval possible. `url` is what GitHub links to from the
+    # run and from the repository's environment list, so the deployment history
+    # says where it went as well as when.
+    environment:
+      name: production
+      url: ${{ vars.SITE_URL }}
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The commit being deployed, so `scripts/deploy.sh` is the version that
+          # ships with it. A `workflow_dispatch` with no ref deploys the branch it
+          # was started from, which is `main`.
+          ref: ${{ inputs.ref || github.sha }}
+          # Nothing here pushes, and this job holds a key to a production host -
+          # so the token that checkout would otherwise leave in `.git/config` is
+          # one more credential in the same process for no reason.
+          persist-credentials: false
+
+      - name: Resolve the commit
+        id: commit
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      # Written out rather than reached through a third-party action: this is the
+      # one workflow holding a key that opens a production host, and the fewer
+      # things that see it, the better. `known_hosts` is a secret rather than an
+      # `ssh-keyscan` at run time - scanning trusts whatever answers, which is the
+      # thing a host key exists to stop.
+      - name: Authorize
+        env:
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
+          printf '%s\n' "$DEPLOY_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/deploy_key ~/.ssh/known_hosts
+
+      - name: Deploy
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          APP_DIR: ${{ vars.APP_DIR || '/opt/agenticos' }}
+          SHA: ${{ steps.commit.outputs.sha }}
+        run: |
+          ssh -i ~/.ssh/deploy_key -o BatchMode=yes \
+            "$DEPLOY_USER@$DEPLOY_HOST" \
+            "APP_DIR='$APP_DIR' bash -s -- '$SHA'" < scripts/deploy.sh
+
+      # The deploy script already waits for both containers to report healthy on
+      # the host. This asks the same question from outside, which is the half it
+      # cannot answer: that DNS, the proxy and the certificate are all still
+      # doing their job. A green deploy and an unreachable site is exactly the
+      # combination nobody goes looking for.
+      - name: Reach it from the internet
+        env:
+          API_URL: ${{ vars.API_URL }}
+          SITE_URL: ${{ vars.SITE_URL }}
+        run: |
+          set -e
+          curl -fsS --max-time 20 "$API_URL/api/v1/health" | tee /dev/stderr | grep -q '"status"'
+          curl -fsS --max-time 20 -o /dev/null -w 'site: %{http_code}\n' "$SITE_URL"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,6 +313,7 @@ Trigger map — what changed → which page:
 | `app/services/sandbox_*.py`, `app/agents/capabilities/sandbox/**`, `app/core/catalog/sandbox_runtimes.json` | `docs/sandbox.md` |
 | `app/services/deployment_settings.py`, `signup_policy.py`, `invitation_admission.py`, `app/core/maintenance.py`, `otel_compat.py`, `app/api/exception_handlers.py` | `docs/deployment.md` |
 | `app/core/config.py` | `docs/configuration.md` |
+| `docker-compose-prod*.yml`, `docker-compose-traefik.yml`, `traefik/`, `scripts/deploy.sh`, `scripts/server-init.sh`, `.github/workflows/deploy.yml` | `docs/deploy.md` |
 | `app/commands/**`, a new `make` target | `docs/commands.md` |
 | A new route, service or layering change | `docs/architecture.md` |
 | The one-line pitch, what the product is *not*, or a page a reader should meet first | `llms.txt` at the repository root - copied into the site by `scripts/mkdocs_hooks.py`, so there is one copy and it is the one models read |
@@ -404,6 +405,7 @@ say so and move on. Run it yourself any time with
 | The automated pull request reviewer | `docs/code-review.md` |
 | Branches, rulesets and what protects `main` | `docs/branching.md` |
 | Recurring patterns | `docs/patterns.md` |
+| Getting it onto a host: sizing, TLS, the approved deploy | `docs/deploy.md` |
 | The deployment's identity, sign-up policy, notices | `docs/deployment.md` |
 | Settings and the production checklist | `docs/configuration.md` |
 | What the platform does, on one page | `docs/features.md` |

--- a/Makefile
+++ b/Makefile
@@ -158,26 +158,36 @@ dev-server-logs:
 stage: dev-server
 stage-down: dev-server-down
 
-# === Production: external Nginx, real secrets in backend/.env ===
+# === Production ===
+#
+# Two ways in, and `PROXY=traefik` is the difference. Without it the stack
+# publishes both ports on the loopback and a reverse proxy on the host reaches
+# them - `nginx/nginx.conf` is that template. With it, the containers join an
+# existing Traefik's network and carry the labels it discovers them by, which is
+# the shorter path where Traefik is already running. See docs/deploy.md.
+PROD_FILES := -f docker-compose-prod.yml $(if $(filter traefik,$(PROXY)),-f docker-compose-prod.traefik.yml)
+PROD_FRONTEND_FILES := -f docker-compose-prod.frontend.yml $(if $(filter traefik,$(PROXY)),-f docker-compose-prod.frontend.traefik.yml)
+PROD_PROXY_NOTE := $(if $(filter traefik,$(PROXY)),Traefik routes it once the certificate is issued,configure your nginx host with nginx/nginx.conf)
+
 prod:
 	@test -f backend/.env || (echo "❌ backend/.env missing — run 'cp backend/.env.example backend/.env' and fill in real secrets" && exit 1)
-	docker compose --env-file backend/.env -f docker-compose-prod.yml up -d --build
+	docker compose --env-file backend/.env $(PROD_FILES) up -d --build
 	@echo "▶ Waiting for DB then running migrations…"
 	@sleep 5
-	docker compose --env-file backend/.env -f docker-compose-prod.yml exec -T app agenticos db upgrade
-	@echo "✅ Production stack up. Configure your nginx host with nginx/nginx.conf"
+	docker compose --env-file backend/.env $(PROD_FILES) exec -T app agenticos db upgrade
+	@echo "✅ Production stack up — $(PROD_PROXY_NOTE)"
 
 prod-frontend:
 	@test -f backend/.env || (echo "❌ backend/.env missing" && exit 1)
-	docker compose --env-file backend/.env -f docker-compose-prod.frontend.yml up -d --build
-	@echo "✅ Production frontend on :3000"
+	docker compose --env-file backend/.env $(PROD_FRONTEND_FILES) up -d --build
+	@echo "✅ Production frontend up"
 
 prod-down:
-	docker compose --env-file backend/.env -f docker-compose-prod.frontend.yml down 2>/dev/null || true
-	docker compose --env-file backend/.env -f docker-compose-prod.yml down
+	docker compose --env-file backend/.env $(PROD_FRONTEND_FILES) down 2>/dev/null || true
+	docker compose --env-file backend/.env $(PROD_FILES) down
 
 prod-logs:
-	docker compose --env-file backend/.env -f docker-compose-prod.yml logs -f
+	docker compose --env-file backend/.env $(PROD_FILES) logs -f
 
 # Legacy alias
 quickstart: dev

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -183,6 +183,11 @@ CORS_ORIGINS=["http://localhost:3000","http://localhost:8080"]
 # SITE_DOMAIN=app.example.com
 # API_DOMAIN=api.example.com
 
+# Which reverse proxy this host was set up with: `traefik` or `nginx`. Read by
+# `scripts/deploy.sh`, so a deploy uses the proxy the host actually has rather
+# than the one the script was written against.
+# PROXY=traefik
+
 # Where the Traefik overlays put the containers, and how the certificate is
 # issued. Defaults suit a Traefik started from `docker-compose-traefik.yml`;
 # point them at an existing one by name if you already run it.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -50,6 +50,16 @@ ALGORITHM=HS256
 FRONTEND_URL=http://localhost:3000
 PUBLIC_BASE_URL=http://localhost:8000
 
+# The same three addresses again, for the *browser* rather than for the server.
+# Read by `docker-compose-prod.frontend.yml` as **build arguments**: Next inlines
+# them into the bundle, so changing one is a rebuild rather than a restart, and a
+# deployed frontend refuses to build without them. They are separate from the two
+# above because the two above are read by the application at run time - the same
+# values, at a different moment, which is the whole reason both exist.
+PUBLIC_SITE_URL=http://localhost:3000
+PUBLIC_API_URL=http://localhost:8000
+PUBLIC_WS_URL=ws://localhost:8000
+
 # === Secret vault ===
 # Master key for every credential stored at rest — provider keys, channel bot
 # tokens, MCP credentials and organization secrets. Empty falls back to
@@ -162,15 +172,43 @@ SMTP_TLS=true
 # Note: "*" is blocked in production - specify explicit origins
 CORS_ORIGINS=["http://localhost:3000","http://localhost:8080"]
 
-# === Docker Production (Traefik) ===
-# Domain for production deployment
-DOMAIN=example.com
+# === Deploying to a server ===
+# Read only by the compose files, not by the application - which is why they are
+# here rather than in `app/core/config.py`. See docs/deploy.md.
+#
+# The two hostnames this deployment answers on. `SITE_DOMAIN` has to agree with
+# PUBLIC_SITE_URL above, and `API_DOMAIN` with PUBLIC_API_URL: one routes the
+# request and the other is inlined into the browser bundle, so a mismatch is a
+# site that loads and then talks to the wrong host.
+# SITE_DOMAIN=app.example.com
+# API_DOMAIN=api.example.com
 
-# Let's Encrypt email for SSL certificates
-ACME_EMAIL=admin@example.com
+# Where the Traefik overlays put the containers, and how the certificate is
+# issued. Defaults suit a Traefik started from `docker-compose-traefik.yml`;
+# point them at an existing one by name if you already run it.
+# TRAEFIK_NETWORK=traefik_webgateway
+# TRAEFIK_ENTRYPOINT=websecure
+# TRAEFIK_CERT_RESOLVER=letsencrypt
+# ACME_EMAIL=ops@example.com
 
-# Traefik dashboard auth (generate with: htpasswd -nb admin password)
-# TRAEFIK_DASHBOARD_AUTH=admin:$$apr1$$...
+# How many uvicorn workers the API runs. Each is a separate process that imports
+# the application on its own - about 460 MiB - so this is the setting that
+# decides what the API costs at rest. Four for a busy deployment, two for a team.
+# Lower `app`'s memory limit with it: roughly 600M per worker.
+# UVICORN_WORKERS=4
+
+# Count a login attempt against the caller rather than against the proxy. On by
+# default in a deployment written by `scripts/server-init.sh`, and it has to be
+# behind a reverse proxy: without it every request carries the proxy's own
+# address, so a handful of failed logins locks the whole deployment out. Only
+# safe while nothing can reach the API past the proxy - see BIND_HOST below.
+# RATE_LIMIT_TRUST_FORWARDED_FOR=true
+
+# Publish the API and the site on something other than the loopback. Leave it
+# alone unless the reverse proxy runs on a different machine: anything that can
+# reach past the proxy chooses the address its login attempts are counted
+# against. See RATE_LIMIT_TRUST_FORWARDED_FOR.
+# BIND_HOST=0.0.0.0
 
 # A deployed stack needs REDIS_PASSWORD - fill in the one under Redis above.
 # It is defined once, and commented out, in both directions on purpose. This

--- a/docker-compose-prod.frontend.traefik.yml
+++ b/docker-compose-prod.frontend.traefik.yml
@@ -1,0 +1,35 @@
+# Puts the production frontend behind an existing Traefik. An overlay:
+#
+#   docker compose --env-file backend/.env \
+#     -f docker-compose-prod.frontend.yml -f docker-compose-prod.frontend.traefik.yml \
+#     up -d --build
+#
+# The API's half is `docker-compose-prod.traefik.yml`, and the reasoning for
+# every label is there. This file exists separately only because the frontend is
+# a separate compose file: passing one overlay naming both services to either
+# invocation would declare a service the other file has no image or build for.
+#
+# `SITE_DOMAIN` is the browser-facing hostname, and it has to agree with the
+# `PUBLIC_SITE_URL` the image was built with. They are two different mechanisms -
+# one routes the request, the other is inlined into the bundle - so a mismatch is
+# a site that loads and then talks to the wrong host from the browser, which is
+# the failure `docker-compose-prod.frontend.yml` warns about at the top.
+
+services:
+  frontend:
+    networks:
+      # Only the addition: compose merges a service's `networks` mapping across
+      # `-f` files, so `edge` and its alias come from the base file.
+      proxy:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=${TRAEFIK_NETWORK:-traefik_webgateway}"
+      - "traefik.http.routers.agenticos-web.rule=Host(`${SITE_DOMAIN:?SITE_DOMAIN is required, e.g. app.example.com}`)"
+      - "traefik.http.routers.agenticos-web.entrypoints=${TRAEFIK_ENTRYPOINT:-websecure}"
+      - "traefik.http.routers.agenticos-web.tls.certresolver=${TRAEFIK_CERT_RESOLVER:-letsencrypt}"
+      - "traefik.http.services.agenticos-web.loadbalancer.server.port=3000"
+
+networks:
+  proxy:
+    name: ${TRAEFIK_NETWORK:-traefik_webgateway}
+    external: true

--- a/docker-compose-prod.traefik.yml
+++ b/docker-compose-prod.traefik.yml
@@ -1,0 +1,52 @@
+# Puts the production API behind an existing Traefik. An overlay, never alone:
+#
+#   docker compose --env-file backend/.env \
+#     -f docker-compose-prod.yml -f docker-compose-prod.traefik.yml up -d --build
+#
+# The alternative this replaces is `nginx/nginx.conf`, which is a reverse proxy
+# on the *host* reaching the loopback ports. Use one or the other. Traefik is
+# worth the labels where it is already running: it discovers the container, asks
+# Let's Encrypt for the certificate and renews it, with nothing to reload.
+#
+# What it needs from the deployment, in `backend/.env`:
+#
+#   API_DOMAIN=api.example.com        # required, refuses to start without it
+#   TRAEFIK_NETWORK=traefik_webgateway
+#   TRAEFIK_ENTRYPOINT=websecure
+#   TRAEFIK_CERT_RESOLVER=letsencrypt
+#
+# and from Traefik itself: `providers.docker` watching a network this joins.
+# Where `exposedByDefault` is false - which it should be - `traefik.enable=true`
+# below is what opts this one service in, and every other service in the stack
+# stays unreachable because nothing labels them.
+#
+# `traefik.docker.network` is not optional here and the failure is confusing
+# without it. This container sits on three networks, and Traefik picks one of
+# its addresses to route to; picking `data` (which is `internal: true`) or the
+# wrong end of `edge` gives a gateway timeout on a container that is up and
+# healthy.
+#
+# The loopback publish from the base file stays. It is how you `curl` the API
+# from the host while diagnosing something, and nothing off the host can reach
+# it.
+
+services:
+  app:
+    networks:
+      # Only the addition. A service's `networks` is a mapping, and compose merges
+      # mappings across `-f` files by key - so `data` and `edge` come from the base
+      # file with their aliases intact, and repeating them here would be a second
+      # copy to keep in step.
+      proxy:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=${TRAEFIK_NETWORK:-traefik_webgateway}"
+      - "traefik.http.routers.agenticos-api.rule=Host(`${API_DOMAIN:?API_DOMAIN is required, e.g. api.example.com}`)"
+      - "traefik.http.routers.agenticos-api.entrypoints=${TRAEFIK_ENTRYPOINT:-websecure}"
+      - "traefik.http.routers.agenticos-api.tls.certresolver=${TRAEFIK_CERT_RESOLVER:-letsencrypt}"
+      - "traefik.http.services.agenticos-api.loadbalancer.server.port=8000"
+
+networks:
+  proxy:
+    name: ${TRAEFIK_NETWORK:-traefik_webgateway}
+    external: true

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -63,9 +63,17 @@ services:
     # this supervisor already replaces twice a second. Subclassing it instead
     # would have meant owning four upstream call sites in the one process whose
     # job is to survive whatever killed the worker.
+    #
+    # How many workers is a deployment's decision, not a constant: each one is a
+    # *spawned* process that imports the application on its own - 460 MiB
+    # measured, with no copy-on-write to share - so four of them are 1.9 GB
+    # before a request arrives. Four suits a busy deployment; a team of ten is
+    # better served by two, which still leaves one serving while the watchdog
+    # replaces a wedged sibling. The memory limit below is sized for the
+    # default; lower both together.
     command: >-
       uvicorn app.main:app --host 0.0.0.0 --port 8000
-      --workers 4 --ws websockets-sansio
+      --workers ${UVICORN_WORKERS:-4} --ws websockets-sansio
     networks:
       data:
       edge:
@@ -95,8 +103,13 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "2"
-          memory: 1G
+          cpus: "3"
+          # Four workers at the 460 MiB each one measures, plus the supervisor
+          # and room for a request holding a large transcript. It was 1G, which
+          # is under what the default `--workers 4` needs to *start* - so the
+          # shipped limit OOM-killed the container the first time all four were
+          # warm. Lower it with `UVICORN_WORKERS`: about 600M per worker.
+          memory: 2560M
         reservations:
           cpus: "0.5"
           memory: 512M
@@ -108,6 +121,28 @@ services:
     # `extension "vector" is not available`.
     image: pgvector/pgvector:pg16
     container_name: agenticos_db
+    # Postgres ships defaults sized for a machine from 2005 - `shared_buffers`
+    # is 128 MB whatever the host has. These are the standard ratios against the
+    # 2G limit below, so the two move together: a quarter of it resident, and
+    # `effective_cache_size` describing what the host's page cache is likely to
+    # be holding on top. `random_page_cost` and `effective_io_concurrency` say
+    # the storage is an SSD, which every deployment of this now is.
+    command: >-
+      postgres
+      -c shared_buffers=512MB
+      -c effective_cache_size=1536MB
+      -c maintenance_work_mem=128MB
+      -c work_mem=8MB
+      -c wal_buffers=16MB
+      -c random_page_cost=1.1
+      -c effective_io_concurrency=200
+      -c max_parallel_workers_per_gather=2
+    # Parallel query workers pass tuples through POSIX shared memory, which is
+    # `/dev/shm` - and Docker gives a container 64 MB of it. A parallel scan over
+    # a collection's vectors then fails with "could not resize shared memory
+    # segment", which reads as a corrupt index rather than as a container
+    # setting.
+    shm_size: 512mb
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
@@ -132,7 +167,14 @@ services:
   redis:
     image: redis:7-alpine
     container_name: agenticos_redis
-    command: redis-server --requirepass ${REDIS_PASSWORD:?REDIS_PASSWORD is required}
+    # A cache with no ceiling is a cache that grows until the container is
+    # killed, and this one holds rate-limit buckets, channel dedupe claims and
+    # membership answers - all of which are rebuildable, none of which is worth
+    # an OOM. `allkeys-lru` because everything here has a TTL anyway; the policy
+    # only decides what goes first if one is ever forgotten.
+    command: >-
+      redis-server --requirepass ${REDIS_PASSWORD:?REDIS_PASSWORD is required}
+      --maxmemory 384mb --maxmemory-policy allkeys-lru
     volumes:
       - redis_data:/data
     networks:
@@ -175,6 +217,14 @@ services:
       retries: 10
       start_period: 30s
     restart: unless-stopped
+    # It had none, which on a host without swap makes it the service that takes
+    # the others down: its SQLite state and its API are small, but nothing was
+    # stopping it from growing into whatever the machine had.
+    deploy:
+      resources:
+        limits:
+          cpus: "1"
+          memory: 768M
 
   prefect-runner:
     image: agenticos_backend:prod
@@ -223,7 +273,9 @@ services:
       resources:
         limits:
           cpus: "2"
-          memory: 2G
+          # 241 MiB measured at rest; the headroom is for a parse of a large
+          # document, which is the one thing here that allocates in bursts.
+          memory: 1536M
 
   # The only service holding the Docker socket. See docker-compose.yml for the
   # reasoning; the differences here are that it is not on by default (mounting

--- a/docker-compose-traefik.yml
+++ b/docker-compose-traefik.yml
@@ -1,0 +1,51 @@
+# Traefik for a host that does not already have one:
+#
+#   docker network create traefik_webgateway
+#   docker compose --env-file backend/.env -f docker-compose-traefik.yml up -d
+#
+# Skip it where Traefik is already running - point `TRAEFIK_NETWORK` at the
+# network it watches instead, and the overlays find it. See `docs/deploy.md`.
+#
+# The network is created by hand rather than by this file, and declared external
+# here, because the application stack joins it too: a network owned by whichever
+# compose project happened to start first is a network that disappears when that
+# project is brought down.
+
+networks:
+  traefik_webgateway:
+    external: true
+
+services:
+  traefik:
+    image: traefik:v3.7
+    container_name: traefik_proxy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      # Read by the `${ACME_EMAIL}` in traefik.yml. Where the expiry notices go,
+      # and the only address Let's Encrypt has for whoever runs this.
+      - ACME_EMAIL=${ACME_EMAIL:?ACME_EMAIL is required, e.g. ops@example.com}
+    volumes:
+      # Read-only, and this is the security boundary of the whole arrangement:
+      # the socket is what lets Traefik discover containers, and write access to
+      # it is root on the host.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro
+      # The issued certificates and the account key. A named volume rather than a
+      # bind mount because Traefik requires the file be readable by nobody else,
+      # and a bind-mounted file inherits whatever the host gave it.
+      - traefik_certificates:/certificates
+    networks:
+      - traefik_webgateway
+    security_opt:
+      - no-new-privileges:true
+    healthcheck:
+      test: ["CMD", "traefik", "healthcheck", "--ping"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+volumes:
+  traefik_certificates:

--- a/docker-compose-traefik.yml
+++ b/docker-compose-traefik.yml
@@ -24,15 +24,19 @@ services:
       - "80:80"
       - "443:443"
     environment:
-      # Read by the `${ACME_EMAIL}` in traefik.yml. Where the expiry notices go,
-      # and the only address Let's Encrypt has for whoever runs this.
-      - ACME_EMAIL=${ACME_EMAIL:?ACME_EMAIL is required, e.g. ops@example.com}
+      # Every static setting has an environment form, and this one has to use it:
+      # `traefik.yml` is bind-mounted rather than templated, so a `${...}` written
+      # in it would reach Let's Encrypt as those eight characters. The name is
+      # mechanical - the path through the config in capitals, joined by
+      # underscores.
+      - TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_EMAIL=${ACME_EMAIL:?ACME_EMAIL is required, e.g. ops@example.com}
     volumes:
       # Read-only, and this is the security boundary of the whole arrangement:
       # the socket is what lets Traefik discover containers, and write access to
       # it is root on the host.
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro
+      - ./traefik/dynamic.yml:/etc/traefik/dynamic.yml:ro
       # The issued certificates and the account key. A named volume rather than a
       # bind mount because Traefik requires the file be readable by nobody else,
       # and a bind-mounted file inherits whatever the host gave it.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,140 +1,332 @@
-# Deploy
+# Deploy to a server
 
-This is what the repository ships for getting the platform onto a host: Docker and
-`docker-compose.yml`, an Nginx config, and GitHub Actions.
+One host, Docker Compose, a reverse proxy in front. That is the whole shipped
+path, and it is what runs the deployments this project is used in.
 
-There are no Kubernetes manifests.
+There are no Kubernetes manifests, and no one-click quickstarts for the
+platform-as-a-service providers. That is not modesty about scale. The stack is
+six containers, two of which hold state, one of which can start containers of
+its own, and one of which is a Postgres that must have pgvector - which is
+already more than a `git push` deploy target models, and a guide that pretended
+otherwise would be describing a deployment nobody has run.
 
-!!! tip "Read [configuration](configuration.md#production-checklist) first"
+!!! tip "Read the [production checklist](configuration.md#production-checklist) first"
 
-    The production checklist is the list of settings whose generated defaults are
-    fine on a laptop and are not fine on a host somebody else can reach.
+    Nine settings ship with defaults that are fine on a laptop and wrong on a host
+    somebody else can reach. `scripts/server-init.sh` below generates all nine, so
+    the checklist is what you check afterwards rather than what you type.
 
-## Docker Compose (single host)
+## What you need
 
-For staging or small production:
+| | |
+|---|---|
+| **A host** | 4 vCPU and 8 GB of RAM runs it. See [sizing](#sizing-the-host) |
+| **Docker** | Engine 24+ with the Compose plugin, and your user in the `docker` group |
+| **Two hostnames** | one for the site, one for the API — see [why two](#why-two-hostnames) |
+| **A reverse proxy** | [Traefik](#option-a-traefik) or [Nginx](#option-b-nginx). It terminates TLS |
+| **An OpenRouter key** | every collection embeds through it. Chat models are configured per organization, in the product |
 
-```bash
-# 1. Configure
-cp backend/.env.example backend/.env
-# Edit backend/.env with production values (see configuration.md)
+The host also needs ports 80 and 443 open, and nothing else. Postgres, Redis and
+the Prefect API are published on no interface at all.
 
-# 2. Build + start
-docker compose up -d --build
+### Why two hostnames
 
-# 3. Apply migrations
-docker compose exec app uv run alembic upgrade head
+The browser talks to both. Most calls go through the frontend's own server-side
+routes, but the chat WebSocket connects to the API directly, so the API needs a
+name a browser can resolve and a certificate of its own.
 
-# 4. Verify
-curl http://localhost:8000/api/v1/health
-# Frontend: http://localhost:3000
+`app.example.com` and `api.example.com` is the shape. They can be any two names;
+what they must not be is one name with a path prefix, because the API's cookies
+and the site's are scoped to the host.
+
+## Sizing the host
+
+Measured on an idle deployment, not estimated:
+
+| | at rest | ceiling |
+|---|---|---|
+| `app` (2 uvicorn workers) | ~1.0 GB | 2.5 GB at the default 4 workers |
+| `db` | ~1.3 GB with the tuning below | 2 GB |
+| `prefect-runner` | 241 MiB | 1.5 GB |
+| `prefect-server` | 245 MiB | 768 MB |
+| `frontend` | ~300 MB | 1 GB |
+| `redis` | 9 MiB | 512 MB |
+
+The number that decides the host is **`UVICORN_WORKERS`**. Each worker is a
+separate process that imports the whole application — 460 MiB, spawned rather
+than forked, so nothing is shared. Four of them are 1.9 GB before a request
+arrives.
+
+Two workers suit a team of ten and still leave one serving while
+[the watchdog](configuration.md#a-worker-whose-event-loop-has-stopped-turning)
+replaces a wedged sibling. One worker is the setting to avoid: a blocked event
+loop is then the whole deployment, until it kills itself.
+
+!!! note "The database is tuned against its own limit"
+
+    `docker-compose-prod.yml` runs Postgres with `shared_buffers=512MB` against a
+    2 GB limit, and gives it 512 MB of `/dev/shm` — Docker's default is 64 MB,
+    which a parallel scan over a collection's vectors exhausts, reporting
+    `could not resize shared memory segment`. Move the limit and move the tuning
+    with it; they are written next to each other for that reason.
+
+## Point the names at the host
+
+Two A records, before anything else. Let's Encrypt proves you control a name by
+fetching a file over HTTP from wherever it resolves, so a certificate is not
+issued until this is true and propagated.
+
+```
+app.example.com   A   203.0.113.10
+api.example.com   A   203.0.113.10
 ```
 
-### Reverse proxy
+!!! warning "A wildcard does not do this for you"
 
-The Nginx config in `nginx/` proxies `/` → frontend, `/api` → backend, `/ws` →
-backend WebSocket. Update `server_name` and the TLS certificate paths in
-`nginx/conf.d/app.conf`.
+    Where `*.example.com` already points somewhere — a marketing site, usually —
+    both names resolve to it. A record for the specific name beats a wildcard, so
+    the fix is to add the two above rather than to remove the wildcard.
 
-!!! info "The security headers come from the backend, not from the proxy"
+Check from somewhere that is not the host, because the host may have its own
+answer:
+
+```bash
+dig +short app.example.com api.example.com
+```
+
+## Get it onto the host
+
+```bash
+sudo install -d -o "$USER" -g "$USER" /opt/agenticos
+git clone https://github.com/vstorm-co/agenticos.git /opt/agenticos
+cd /opt/agenticos
+bash scripts/server-init.sh
+```
+
+`server-init.sh` writes `backend/.env`: it generates the five secrets, asks for
+the two hostnames, an address for Let's Encrypt and the OpenRouter key, and
+derives the public URLs and the CORS origin from what you gave it. It refuses to
+overwrite an existing file.
+
+!!! danger "`backend/.env` holds the key that unwraps every stored credential"
+
+    `VAULT_MASTER_KEY` is what makes an organization's provider keys, bot tokens
+    and MCP credentials readable. Losing it does not lock you out of the product;
+    it makes every secret in it unrecoverable. Back the file up somewhere a lost
+    disk cannot take with it, and rotate with
+    [`agenticos cmd vault-rotate`](secrets.md#operations) rather than by editing.
+
+Two optional things it does not ask about, both in that file: `SMTP_*`, without
+which invitations and password resets cannot be sent, and `LOGFIRE_TOKEN`, which
+is where traces of agent runs go.
+
+## Choose a reverse proxy
+
+Something has to terminate TLS and route the two names. Both options below reach
+the same containers; pick on whether you already run one.
+
+### Option A: Traefik
+
+The shorter path, and the one to pick on a host that already has Traefik: the
+containers carry labels, Traefik discovers them, asks for the certificate and
+renews it. Nothing to reload and no second config file to keep in step.
+
+If Traefik is not there yet, the repository ships one: `traefik/traefik.yml` and
+`docker-compose-traefik.yml`, which is an entrypoint on 443 with a Let's Encrypt
+resolver and 80 redirecting to it.
+
+```bash
+docker network create traefik_webgateway
+docker compose --env-file backend/.env -f docker-compose-traefik.yml up -d
+```
+
+Where Traefik is **already** running, leave those alone and point
+`TRAEFIK_NETWORK` at the network it watches. The overlays read that name, so
+nothing about the existing proxy has to change.
+
+Then bring the stack up with `PROXY=traefik`, which adds the two overlay files
+that carry the labels:
+
+```bash
+make prod PROXY=traefik
+make prod-frontend PROXY=traefik
+```
+
+!!! info "`exposedByDefault: false` is doing real work"
+
+    It is the one setting in `traefik/traefik.yml` worth reading before you run
+    it. Only `app` and `frontend` carry `traefik.enable=true`, so Postgres, Redis,
+    the Prefect server and the sandbox daemon are reachable from nothing outside
+    the host — and that is a property of *not being labelled*, so it survives
+    somebody adding a service without thinking about the proxy.
+
+### Option B: Nginx
+
+For a host where Nginx already terminates TLS, or where the proxy is not in
+Docker at all. The stack publishes both ports on `127.0.0.1` and Nginx reaches
+them there:
+
+```bash
+make prod
+make prod-frontend
+```
+
+`nginx/nginx.conf` is the template: `/` to `127.0.0.1:3000`, everything the API
+answers to `127.0.0.1:8000`. Certificates are yours to obtain and renew.
+
+!!! warning "`BIND_HOST` is a security setting, not a convenience"
+
+    The loopback default is what makes the auth rate limit mean anything.
+    `RATE_LIMIT_TRUST_FORWARDED_FOR` tells the API to count an attempt against
+    the address the proxy forwards, so whatever can reach the API *past* the
+    proxy chooses the address its attempts are counted against. Set
+    `BIND_HOST=0.0.0.0` only for a proxy on a different machine, and firewall the
+    port to it.
+
+## Start it, and create the first account
+
+`make prod` builds the images, starts the stack and runs the migrations. The
+first build takes a few minutes; afterwards Docker's layer cache makes it about
+a minute.
+
+Then create an organization, an owner and a working agent:
+
+```bash
+docker compose --env-file backend/.env -f docker-compose-prod.yml \
+  exec -T app agenticos cmd bootstrap \
+  --email you@example.com --password 'a real password' \
+  --org 'Your Company' --provider anthropic --api-key sk-ant-...
+```
+
+The provider key here is what the demo agent runs on. Without it the agent is
+created and cannot answer; every other provider is added in the product, per
+organization, from the vault.
+
+!!! tip "Check it from outside, not from the host"
+
+    ```bash
+    curl -fsS https://api.example.com/api/v1/health
+    curl -fsSo /dev/null -w '%{http_code}\n' https://app.example.com
+    ```
+
+    A stack that is healthy on the host and unreachable from the internet is DNS,
+    the firewall or the certificate — three things a health check inside the host
+    cannot see.
+
+Then, once, by hand: sign in, invite somebody (which proves `SMTP_*`), and send
+the demo agent a message (which proves the provider key and the WebSocket). Each
+exercises a path nothing else here checks.
+
+!!! info "The security headers come from the backend, so any proxy is covered"
 
     A Content-Security-Policy, `X-Frame-Options: DENY`,
     `X-Content-Type-Options: nosniff`, `Referrer-Policy` and `Permissions-Policy`
-    are set on every response, so a deployment behind *any* proxy is covered.
-    Two edges: a 500 for an unhandled exception is built outside the middleware
-    stack and stamps the same headers itself; and the interactive API docs
-    (`/docs`, `/redoc`, `/api/v1/openapi.json`) drop the **CSP** only, because
-    Swagger and ReDoc load assets a strict policy forbids — their framing and
-    MIME protections stay.
+    are set on every response — including the 500 for an unhandled exception,
+    which is built outside the middleware stack and stamps them itself. The
+    interactive API docs drop the CSP only, because Swagger loads assets a strict
+    policy forbids.
 
     **HSTS is deliberately left to the proxy**, which is where TLS terminates. A
-    front proxy setting its own CSP should be at least as strict as this one.
+    proxy that sets its own CSP should be at least as strict as this one.
 
-## Platform-specific quickstarts
+## Deploying a change
 
-=== "Fly.io"
-
-    ```bash
-    fly launch --name agenticos-backend --region waw
-    fly postgres create --name agenticos-db
-    fly postgres attach agenticos-db
-    # Redis: use Upstash (`fly redis create`) or Fly's Tigris
-    fly secrets set $(cat backend/.env | grep -v '^#' | xargs)
-    fly deploy
-    ```
-
-=== "Railway"
-
-    1. Connect the repo, pick Dockerfile-based deploy.
-    2. Add env vars from `backend/.env` to the Railway service.
-    3. Provision the PostgreSQL plugin → `DATABASE_URL` auto-injected.
-    4. Provision the Redis plugin → `REDIS_URL` auto-injected.
-    5. Deploy.
-
-=== "Render"
-
-    1. Create a Web Service → docker, pointed at `backend/Dockerfile`.
-    2. Create a Static Site for the frontend (build command
-       `bun install && bun run build`, output directory `.next`).
-    3. Create PostgreSQL → copy `DATABASE_URL`.
-    4. Add env vars; deploy.
-
-=== "Vercel (frontend only)"
-
-    The frontend is a Next.js app and works on Vercel out of the box.
-
-    ```bash
-    cd frontend
-    vercel
-    ```
-
-    Set `BACKEND_URL` and `NEXT_PUBLIC_API_URL` in the Vercel dashboard, pointing
-    at your backend host.
-
-!!! warning "Whatever the platform, the database must be pgvector"
-
-    The RAG store issues `CREATE EXTENSION IF NOT EXISTS vector` the first time a
-    collection is written to, and stock Postgres answers
-    `extension "vector" is not available`. A managed Postgres that cannot enable
-    the extension cannot hold knowledge collections. See
-    [install](install.md#the-database-must-be-pgvector).
-
-## Environment validation in production
-
-Before promoting to prod, run:
+### By hand
 
 ```bash
-docker compose exec app uv run python -c "from app.core.config import settings; print('OK')"
+ssh you@your-host 'bash -s -- <commit-sha>' < scripts/deploy.sh
 ```
 
-That catches missing required env vars early. See [Configuration](configuration.md)
-for the full list.
+`scripts/deploy.sh` fetches that commit, rebuilds, migrates, restarts and waits
+for both containers to report healthy before it returns non-zero or not. It takes
+a **commit** rather than a branch, so what is deployed is what was reviewed, not
+whatever `main` has moved to since.
 
-## Post-deploy checks
+It is not zero-downtime. Compose recreates the containers it rebuilt, so the site
+is unavailable for the few seconds that takes.
 
-- [ ] `/api/v1/health` returns `{"status": "ok"}`
-- [ ] `alembic current` matches the expected revision
-- [ ] The frontend renders, and the login flow works end to end
-- [ ] A test email sends (trigger the password-reset flow)
-- [ ] Logs are flowing to your aggregator, and Logfire is receiving traces
-- [ ] The reverse proxy enforces HTTPS
+### From GitHub, with an approval
 
-## Rollback
+`.github/workflows/deploy.yml` offers every merge to `main` for deployment and
+waits for somebody to approve it. That gate is **a repository setting, not a step
+in the file** — without it, the workflow deploys every merge unattended.
+
+Set it up once:
+
+1. **Settings → Environments → New environment**, named `production`.
+2. Tick **Required reviewers** and add whoever may approve. This is the gate.
+3. Add the environment's variables: `SITE_URL`, `API_URL`, and `APP_DIR` if the
+   checkout is not at `/opt/agenticos`.
+4. Add the secrets below.
+
+| Secret | What |
+|---|---|
+| `DEPLOY_HOST` | The host's address |
+| `DEPLOY_USER` | The account the checkout belongs to |
+| `DEPLOY_SSH_KEY` | A private key whose public half is in that account's `authorized_keys` |
+| `DEPLOY_KNOWN_HOSTS` | `ssh-keyscan your-host`, run from somewhere you trust |
+
+Generate the key for this and nothing else:
+
+```bash
+ssh-keygen -t ed25519 -N '' -C 'github-actions-deploy' -f deploy_key
+ssh-copy-id -f -i deploy_key.pub you@your-host
+ssh-keyscan your-host                    # → DEPLOY_KNOWN_HOSTS
+cat deploy_key                           # → DEPLOY_SSH_KEY, then delete it locally
+```
+
+!!! note "The host key is a secret rather than a `ssh-keyscan` at deploy time"
+
+    Scanning at deploy time trusts whatever answers on that address, which is the
+    thing a host key exists to prevent. Scan once, from somewhere you trust, and
+    store the answer.
+
+A run then appears with **Review deployments**; approving it starts the job.
+`workflow_dispatch` runs the same job against a ref you name, which is how a
+rollback is done, and it passes through the same approval.
+
+## Backups
+
+One volume matters, and it is not obvious which:
+
+| Volume | Holds | Backup |
+|---|---|---|
+| `postgres_data` | everything — agents, conversations, sealed credentials | **yes** |
+| `media_data` | uploaded files, before ingestion | yes |
+| `redis_data` | rate-limit buckets and caches | no, all rebuildable |
+| `prefect_data` | the flow-run history | no |
+
+```bash
+docker compose --env-file backend/.env -f docker-compose-prod.yml exec -T db \
+  pg_dump -U postgres -Fc agenticos > "agenticos-$(date +%F).dump"
+```
+
+!!! danger "A database backup without `backend/.env` is not a backup"
+
+    The credentials in it are sealed with `VAULT_MASTER_KEY`. Restored next to a
+    different key, every provider key, bot token and MCP credential in the dump is
+    unreadable — and the product will tell you so one refusal at a time.
+
+## Rolling back
 
 | | How |
 |---|---|
-| **Schema** | `alembic downgrade -1` rolls back one migration. Test on staging first |
-| **Code** | Redeploy the previous image tag |
-| **Data** | Restore from your most recent backup, then check `alembic current` matches the data's version |
+| **Code** | Deploy the previous commit: `workflow_dispatch` with its sha, or `scripts/deploy.sh` |
+| **Schema** | `agenticos db downgrade -1`, then deploy the code that matches |
+| **Data** | `pg_restore` the dump, then check the migration the code expects |
 
-!!! danger "Pin image tags; never deploy `latest` to production"
-
-    A rollback is only a rollback if there is a specific tag to go back to.
+Rolling code back **across a migration is a decision, not a command**. The old
+code meets a schema it has never seen; whether that works depends on the
+migration. Read it before assuming.
 
 ## Recap
 
-- **Compose on one host** is the shipped path. Configure, build, migrate, verify.
-- The security headers come from the **backend**, so any proxy is covered — but
-  HSTS is the proxy's, because that is where TLS terminates.
-- Whatever the platform, the database must be **pgvector**.
-- **Pin image tags.** A rollback is only a rollback if there is a tag to go back to.
+- **One host, Compose, a proxy in front.** Six containers, two of them stateful.
+- **`UVICORN_WORKERS` decides what the host costs.** 460 MiB per worker, nothing
+  shared. Two for a team, four for real traffic.
+- **DNS before everything.** No certificate is issued until the names resolve to
+  the host.
+- **The approval is a repository setting**, not a line in the workflow. Without
+  required reviewers on the `production` environment, every merge deploys itself.
+- **Back up `postgres_data` and `backend/.env` together.** Either without the
+  other is not a restore.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -152,6 +152,10 @@ make prod PROXY=traefik
 make prod-frontend PROXY=traefik
 ```
 
+`server-init.sh` has already written `PROXY=traefik` into `backend/.env`, which is
+where `scripts/deploy.sh` reads it from — so later deploys keep the proxy this
+host was set up with rather than the one a script assumed.
+
 !!! info "`exposedByDefault: false` is doing real work"
 
     It is the one setting in `traefik/traefik.yml` worth reading before you run
@@ -171,8 +175,11 @@ make prod
 make prod-frontend
 ```
 
-`nginx/nginx.conf` is the template: `/` to `127.0.0.1:3000`, everything the API
-answers to `127.0.0.1:8000`. Certificates are yours to obtain and renew.
+`nginx/nginx.conf` is the template. Two substitutions before it serves anything:
+the `server_name` in each block is `${DOMAIN:-localhost}`, and Nginx does not
+expand that — put the two hostnames in by hand. Certificates are yours to obtain
+and renew, and so is the `Strict-Transport-Security` header, which the backend
+deliberately leaves to whatever terminates TLS.
 
 !!! warning "`BIND_HOST` is a security setting, not a convenience"
 
@@ -298,8 +305,12 @@ One volume matters, and it is not obvious which:
 
 ```bash
 docker compose --env-file backend/.env -f docker-compose-prod.yml exec -T db \
-  pg_dump -U postgres -Fc agenticos > "agenticos-$(date +%F).dump"
+  sh -c 'pg_dump -U "$POSTGRES_USER" -Fc "$POSTGRES_DB"' > "agenticos-$(date +%F).dump"
 ```
+
+The identifiers come from the container's own environment rather than being
+written out, because both are settings: a deployment that changed either would
+otherwise get an empty file and an error nobody reads on the way past.
 
 !!! danger "A database backup without `backend/.env` is not a backup"
 
@@ -312,7 +323,7 @@ docker compose --env-file backend/.env -f docker-compose-prod.yml exec -T db \
 | | How |
 |---|---|
 | **Code** | Deploy the previous commit: `workflow_dispatch` with its sha, or `scripts/deploy.sh` |
-| **Schema** | `agenticos db downgrade -1`, then deploy the code that matches |
+| **Schema** | `agenticos db downgrade --revision=-1`, then deploy the code that matches |
 | **Data** | `pg_restore` the dump, then check the migration the code expects |
 
 Rolling code back **across a migration is a decision, not a command**. The old

--- a/docs/install.md
+++ b/docs/install.md
@@ -263,14 +263,18 @@ Three, one compose file each, with a matching frontend file beside it.
 |---|---|---|
 | `make dev` | `docker-compose.yml`<br>`docker-compose.frontend.yml` | Local. Hot reload, bind-mounted source, Postgres and Redis published to the host |
 | `make dev-server` | `docker-compose-dev.yml`<br>`docker-compose-dev.frontend.yml` | A deployed dev environment. Built images, no bind mounts, no database port, verbose logging |
-| `make prod` | `docker-compose-prod.yml`<br>`docker-compose-prod.frontend.yml` | Production. Resource limits, internal data network, 4 workers |
+| `make prod` | `docker-compose-prod.yml`<br>`docker-compose-prod.frontend.yml` | Production. Resource limits, internal data network, tuned Postgres |
 
 Each has matching `-down`, `-logs` and `-frontend` siblings. `make stage` is kept
 as an alias for `make dev-server`, which is what it used to be.
 
-Both deployed environments want a reverse proxy in front of them.
-`nginx/nginx.conf` is the template, and it resolves `backend:8000` and
-`frontend:3000` as network aliases.
+Both deployed environments want a reverse proxy in front of them, and there are
+two ways to give them one. By default the stack publishes both ports on the
+loopback and a proxy on the host reaches them - `nginx/nginx.conf` is that
+template, and it resolves `backend:8000` and `frontend:3000` as network aliases.
+`make prod PROXY=traefik` instead adds two overlay files that put the containers
+on an existing Traefik's network with the labels it discovers them by.
+[Deploy](deploy.md) walks through both.
 
 The proxy reaches them by those aliases, so production publishes both ports on
 `127.0.0.1` and nothing off the host can reach either directly. That is a

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -22,14 +22,18 @@
 # certbot certonly --webroot -w /var/www/certbot -d api.yourdomain.com -d yourdomain.com
 # =============================================================================
 
-# Upstream definitions
+# Where the stack is. `docker-compose-prod.yml` publishes both on the loopback
+# (`BIND_HOST`, 127.0.0.1 by default), which is what an Nginx running on the host
+# reaches. An Nginx running *as a container on the `edge` network* uses the
+# service aliases instead - `backend:8000` and `frontend:3000` - and those names
+# resolve nowhere else, which is why they are not the default here.
 upstream backend {
-    server backend:8000;
+    server 127.0.0.1:8000;
 }
 
 
 upstream frontend {
-    server frontend:3000;
+    server 127.0.0.1:3000;
 }
 
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# Deploy one commit onto a server that already runs this stack.
+#
+#   ssh <host> 'bash -s -- <sha>' < scripts/deploy.sh
+#
+# Piped over stdin rather than run from the server's checkout, deliberately: the
+# script that runs is then the one from the commit being deployed, so a change to
+# the deploy procedure ships with the change that needs it. The checkout on the
+# server is only where the build context lives.
+#
+# It takes a **commit**, not a branch. Two pushes can land while an approval is
+# pending, and `git pull` on the server would then deploy whichever one won the
+# race rather than the one somebody approved.
+#
+# To roll back, run it again with the previous sha. There is nothing else to
+# undo: the images are rebuilt from the tree, and a migration that has run stays
+# run - which is why a rollback across one is a decision rather than a command.
+#
+# Not zero-downtime. Compose recreates the containers it rebuilt, so the API and
+# the site are unavailable for the few seconds that takes. Worth knowing before
+# scheduling a deploy in the middle of somebody's conversation; not worth a blue
+# environment for a deployment this size.
+set -euo pipefail
+
+SHA="${1:?usage: deploy.sh <commit-sha>}"
+APP_DIR="${APP_DIR:-/opt/agenticos}"
+COMPOSE_ENV="${APP_DIR}/backend/.env"
+
+BACKEND=(-f docker-compose-prod.yml -f docker-compose-prod.traefik.yml)
+FRONTEND=(-f docker-compose-prod.frontend.yml -f docker-compose-prod.frontend.traefik.yml)
+
+say() { printf '\n\033[1m▶ %s\033[0m\n' "$*"; }
+
+cd "$APP_DIR"
+test -f "$COMPOSE_ENV" || { echo "missing $COMPOSE_ENV" >&2; exit 1; }
+
+say "Fetching $SHA"
+git fetch --prune --quiet origin
+git checkout --quiet --detach "$SHA"
+git --no-pager log --oneline -1
+
+compose() { docker compose --env-file "$COMPOSE_ENV" "$@"; }
+
+# The API first, and its migrations before the frontend: a frontend serving a
+# schema the backend has not migrated to yet is the window this ordering closes.
+say "Building and starting the API"
+compose "${BACKEND[@]}" up -d --build
+
+say "Migrating"
+compose "${BACKEND[@]}" exec -T app agenticos db upgrade
+
+say "Building and starting the frontend"
+compose "${FRONTEND[@]}" up -d --build
+
+# A deploy that finished is not a deploy that works. Compose returns as soon as
+# the containers are started, so without this a broken build is discovered by
+# whoever opens the site next.
+say "Waiting for health"
+for name in agenticos_backend agenticos_frontend; do
+  for attempt in $(seq 1 60); do
+    status=$(docker inspect -f '{{.State.Health.Status}}' "$name" 2>/dev/null || echo missing)
+    case "$status" in
+      healthy) echo "  $name: healthy"; break ;;
+      unhealthy) echo "  $name: unhealthy" >&2; docker logs --tail 50 "$name" >&2; exit 1 ;;
+    esac
+    if [ "$attempt" -eq 60 ]; then
+      echo "  $name: still $status after 120s" >&2
+      docker logs --tail 50 "$name" >&2
+      exit 1
+    fi
+    sleep 2
+  done
+done
+
+# Only the layers nothing references. `image prune -a` would take the base images
+# every build starts from, and turn a two-minute deploy into a ten-minute one.
+say "Reclaiming space"
+docker image prune -f >/dev/null
+df -h / | tail -1
+
+say "Deployed $(git rev-parse --short HEAD)"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,10 +4,11 @@
 #
 #   ssh <host> 'bash -s -- <sha>' < scripts/deploy.sh
 #
-# Piped over stdin rather than run from the server's checkout, deliberately: the
-# script that runs is then the one from the commit being deployed, so a change to
-# the deploy procedure ships with the change that needs it. The checkout on the
-# server is only where the build context lives.
+# Piped over stdin rather than run from the server's checkout: the checkout there
+# is only the build context, and the procedure travels with whoever is running
+# it. Deliberately **not** taken from the commit being deployed - a rollback to a
+# commit older than this file would then have no script to run, which is the one
+# moment it is needed most.
 #
 # It takes a **commit**, not a branch. Two pushes can land while an approval is
 # pending, and `git pull` on the server would then deploy whichever one won the
@@ -27,13 +28,31 @@ SHA="${1:?usage: deploy.sh <commit-sha>}"
 APP_DIR="${APP_DIR:-/opt/agenticos}"
 COMPOSE_ENV="${APP_DIR}/backend/.env"
 
-BACKEND=(-f docker-compose-prod.yml -f docker-compose-prod.traefik.yml)
-FRONTEND=(-f docker-compose-prod.frontend.yml -f docker-compose-prod.frontend.traefik.yml)
-
 say() { printf '\n\033[1m▶ %s\033[0m\n' "$*"; }
 
 cd "$APP_DIR"
 test -f "$COMPOSE_ENV" || { echo "missing $COMPOSE_ENV" >&2; exit 1; }
+
+# Which reverse proxy this host was set up with, read from the host rather than
+# assumed. Hard-coding the Traefik overlays meant an Nginx host was silently
+# converted on its next deploy - and since the overlay declares
+# `traefik_webgateway` external, on a host that never created it compose fails
+# outright, which is the better of the two outcomes.
+PROXY="$(sed -n 's/^PROXY=//p' "$COMPOSE_ENV" | tail -1)"
+case "${PROXY:-nginx}" in
+  traefik)
+    BACKEND=(-f docker-compose-prod.yml -f docker-compose-prod.traefik.yml)
+    FRONTEND=(-f docker-compose-prod.frontend.yml -f docker-compose-prod.frontend.traefik.yml)
+    ;;
+  nginx|"")
+    BACKEND=(-f docker-compose-prod.yml)
+    FRONTEND=(-f docker-compose-prod.frontend.yml)
+    ;;
+  *)
+    echo "PROXY=$PROXY in $COMPOSE_ENV is not one of: traefik, nginx" >&2
+    exit 1
+    ;;
+esac
 
 say "Fetching $SHA"
 git fetch --prune --quiet origin

--- a/scripts/docs_drift.py
+++ b/scripts/docs_drift.py
@@ -64,6 +64,17 @@ TRIGGERS: tuple[tuple[str, str], ...] = (
     ("backend/app/services/file_upload.py", "docs/file-processing.md"),
     ("backend/app/services/ingestion_config.py", "docs/file-processing.md"),
     ("backend/app/core/config.py", "docs/configuration.md"),
+    # How this gets onto a host: the stack's shape, its sizing, and the two
+    # scripts a deployment is actually performed with.
+    ("docker-compose-prod.yml", "docs/deploy.md"),
+    ("docker-compose-prod.frontend.yml", "docs/deploy.md"),
+    ("docker-compose-prod.traefik.yml", "docs/deploy.md"),
+    ("docker-compose-prod.frontend.traefik.yml", "docs/deploy.md"),
+    ("docker-compose-traefik.yml", "docs/deploy.md"),
+    ("traefik/traefik.yml", "docs/deploy.md"),
+    ("scripts/deploy.sh", "docs/deploy.md"),
+    ("scripts/server-init.sh", "docs/deploy.md"),
+    (".github/workflows/deploy.yml", "docs/deploy.md"),
     ("backend/app/services/deployment_settings.py", "docs/deployment.md"),
     ("backend/app/services/signup_policy.py", "docs/deployment.md"),
     ("backend/app/services/invitation_admission.py", "docs/deployment.md"),

--- a/scripts/server-init.sh
+++ b/scripts/server-init.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# Prepare a fresh host to run this stack, once.
+#
+#   sudo -u "$USER" bash scripts/server-init.sh
+#
+# It writes `backend/.env` from `backend/.env.example`, generating every secret
+# the production checklist demands and asking for the four facts it cannot
+# invent: the two hostnames, an address for Let's Encrypt, and the embedding key.
+#
+# **Why a script rather than a page of instructions.** The checklist in
+# `docs/configuration.md` is nine settings whose defaults are wrong in
+# production, and a deployment that gets one of them wrong is not obviously
+# broken - it runs, and its vault is sealed under a key published in an example
+# file. Generating them is the one part of a deployment where a human adds no
+# value and a typo costs everything.
+#
+# It refuses to overwrite an existing `backend/.env`. Rotating a key that already
+# seals stored credentials is `agenticos cmd vault-rotate`, not a new file: see
+# `docs/secrets.md#operations`.
+#
+# Nothing here needs root. It does not install Docker, open ports or touch
+# systemd - `docs/deploy.md` says what to do about those, because on a managed
+# host they are usually already done and doing them twice is how a firewall ends
+# up with a rule nobody remembers adding.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+ENV_FILE="backend/.env"
+EXAMPLE="backend/.env.example"
+
+die() { printf '\033[31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
+say() { printf '\n\033[1m▶ %s\033[0m\n' "$*"; }
+ask() {
+  local prompt="$1" default="${2:-}" answer
+  if [ -n "$default" ]; then
+    read -rp "  $prompt [$default]: " answer
+    printf '%s' "${answer:-$default}"
+  else
+    while :; do
+      read -rp "  $prompt: " answer
+      [ -n "$answer" ] && break
+      echo "    (required)" >&2
+    done
+    printf '%s' "$answer"
+  fi
+}
+
+command -v docker >/dev/null || die "docker is not installed - see docs/deploy.md"
+docker compose version >/dev/null 2>&1 || die "the docker compose plugin is missing"
+command -v openssl >/dev/null || die "openssl is not installed"
+test -f "$EXAMPLE" || die "run this from a checkout: $EXAMPLE is missing"
+test -e "$ENV_FILE" && die "$ENV_FILE already exists - move it aside first, or edit it by hand"
+
+say "Where this deployment answers"
+SITE_DOMAIN=$(ask "Site hostname" "")
+API_DOMAIN=$(ask "API hostname" "")
+ACME_EMAIL=$(ask "Address for Let's Encrypt expiry notices" "")
+
+say "The one key the deployment itself needs"
+echo "  Every collection embeds through OpenRouter. Chat models are not set here -"
+echo "  each organization stores its own provider keys in the vault."
+OPENROUTER_API_KEY=$(ask "OPENROUTER_API_KEY" "")
+
+say "Sizing"
+echo "  Each uvicorn worker is a separate process holding about 460 MiB. Two suits"
+echo "  a team; four suits a deployment with real traffic."
+UVICORN_WORKERS=$(ask "Workers" "2")
+
+say "Generating secrets"
+gen() { openssl rand -hex 32; }
+SECRET_KEY=$(gen)
+API_KEY=$(gen)
+VAULT_MASTER_KEY=$(gen)
+POSTGRES_PASSWORD=$(gen)
+REDIS_PASSWORD=$(gen)
+echo "  SECRET_KEY, API_KEY, VAULT_MASTER_KEY, POSTGRES_PASSWORD, REDIS_PASSWORD"
+
+# Written with python rather than sed: several of these are hex, but a generated
+# password reaching a `sed` replacement is one `&` away from being silently
+# mangled, and a corrupted VAULT_MASTER_KEY is a vault nobody can open.
+say "Writing $ENV_FILE"
+SITE_DOMAIN="$SITE_DOMAIN" API_DOMAIN="$API_DOMAIN" ACME_EMAIL="$ACME_EMAIL" \
+OPENROUTER_API_KEY="$OPENROUTER_API_KEY" UVICORN_WORKERS="$UVICORN_WORKERS" \
+SECRET_KEY="$SECRET_KEY" API_KEY="$API_KEY" VAULT_MASTER_KEY="$VAULT_MASTER_KEY" \
+POSTGRES_PASSWORD="$POSTGRES_PASSWORD" REDIS_PASSWORD="$REDIS_PASSWORD" \
+python3 - "$EXAMPLE" "$ENV_FILE" <<'PY'
+import os
+import sys
+
+source, target = sys.argv[1], sys.argv[2]
+site, api = os.environ["SITE_DOMAIN"], os.environ["API_DOMAIN"]
+
+settings = {
+    "ENVIRONMENT": "production",
+    "DEBUG": "false",
+    "SECRET_KEY": os.environ["SECRET_KEY"],
+    "API_KEY": os.environ["API_KEY"],
+    "VAULT_MASTER_KEY": os.environ["VAULT_MASTER_KEY"],
+    "POSTGRES_PASSWORD": os.environ["POSTGRES_PASSWORD"],
+    "REDIS_PASSWORD": os.environ["REDIS_PASSWORD"],
+    "OPENROUTER_API_KEY": os.environ["OPENROUTER_API_KEY"],
+    "FRONTEND_URL": f"https://{site}",
+    "PUBLIC_BASE_URL": f"https://{api}",
+    "PUBLIC_SITE_URL": f"https://{site}",
+    "PUBLIC_API_URL": f"https://{api}",
+    "PUBLIC_WS_URL": f"wss://{api}",
+    # Only the site's own origin. A browser calls the API directly for the
+    # WebSocket and for a few reads, and anything wider here is an origin
+    # somebody else controls being allowed to make credentialed calls.
+    "CORS_ORIGINS": f'["https://{site}"]',
+    "SITE_DOMAIN": site,
+    "API_DOMAIN": api,
+    "ACME_EMAIL": os.environ["ACME_EMAIL"],
+    "UVICORN_WORKERS": os.environ["UVICORN_WORKERS"],
+    # Behind a proxy the caller's address arrives in a header, and without this
+    # every login attempt is counted against the proxy's own address - so a
+    # handful of failures locks the whole deployment out (0.0.368).
+    "RATE_LIMIT_TRUST_FORWARDED_FOR": "true",
+}
+
+written = set()
+out = []
+for line in open(source):
+    stripped = line.lstrip("# ").rstrip("\n")
+    key = stripped.split("=", 1)[0] if "=" in stripped else ""
+    if key in settings and key not in written:
+        out.append(f"{key}={settings[key]}\n")
+        written.add(key)
+    else:
+        out.append(line)
+
+missing = [f"{k}={v}\n" for k, v in settings.items() if k not in written]
+if missing:
+    out.append("\n# Set by scripts/server-init.sh; absent from .env.example.\n")
+    out.extend(missing)
+
+with open(target, "w") as handle:
+    handle.writelines(out)
+PY
+chmod 600 "$ENV_FILE"
+
+say "Done"
+cat <<EOF
+  $ENV_FILE is written and readable only by you. It holds the key that unwraps
+  every credential this deployment stores; back it up somewhere a lost disk
+  cannot take with it.
+
+  Two things it does not know about, both optional and both in that file:
+
+    SMTP_*             invitations and password resets are emailed
+    LOGFIRE_TOKEN      traces of every agent run
+
+  Next: docs/deploy.md, from "Point the names at the host".
+EOF

--- a/scripts/server-init.sh
+++ b/scripts/server-init.sh
@@ -62,6 +62,14 @@ echo "  Every collection embeds through OpenRouter. Chat models are not set here
 echo "  each organization stores its own provider keys in the vault."
 OPENROUTER_API_KEY=$(ask "OPENROUTER_API_KEY" "")
 
+say "Reverse proxy"
+echo "  traefik - the containers carry labels an existing Traefik discovers."
+echo "  nginx   - both ports on the loopback, and a proxy on the host reaches them."
+while :; do
+  PROXY=$(ask "Proxy" "traefik")
+  case "$PROXY" in traefik|nginx) break ;; *) echo "    (traefik or nginx)" >&2 ;; esac
+done
+
 say "Sizing"
 echo "  Each uvicorn worker is a separate process holding about 460 MiB. Two suits"
 echo "  a team; four suits a deployment with real traffic."
@@ -80,7 +88,7 @@ echo "  SECRET_KEY, API_KEY, VAULT_MASTER_KEY, POSTGRES_PASSWORD, REDIS_PASSWORD
 # password reaching a `sed` replacement is one `&` away from being silently
 # mangled, and a corrupted VAULT_MASTER_KEY is a vault nobody can open.
 say "Writing $ENV_FILE"
-SITE_DOMAIN="$SITE_DOMAIN" API_DOMAIN="$API_DOMAIN" ACME_EMAIL="$ACME_EMAIL" \
+SITE_DOMAIN="$SITE_DOMAIN" API_DOMAIN="$API_DOMAIN" ACME_EMAIL="$ACME_EMAIL" PROXY="$PROXY" \
 OPENROUTER_API_KEY="$OPENROUTER_API_KEY" UVICORN_WORKERS="$UVICORN_WORKERS" \
 SECRET_KEY="$SECRET_KEY" API_KEY="$API_KEY" VAULT_MASTER_KEY="$VAULT_MASTER_KEY" \
 POSTGRES_PASSWORD="$POSTGRES_PASSWORD" REDIS_PASSWORD="$REDIS_PASSWORD" \
@@ -113,6 +121,13 @@ settings = {
     "API_DOMAIN": api,
     "ACME_EMAIL": os.environ["ACME_EMAIL"],
     "UVICORN_WORKERS": os.environ["UVICORN_WORKERS"],
+    # Read by `scripts/deploy.sh` so a later deploy uses the proxy this host was
+    # set up with, rather than whichever one the script happened to hard-code.
+    "PROXY": os.environ["PROXY"],
+    # Sent to Logfire verbatim, so without it every production trace arrives
+    # labelled `development` and is filtered out of the view somebody built to
+    # watch production.
+    "LOGFIRE_ENVIRONMENT": "production",
     # Behind a proxy the caller's address arrives in a header, and without this
     # every login attempt is counted against the proxy's own address - so a
     # handful of failures locks the whole deployment out (0.0.368).
@@ -135,10 +150,14 @@ if missing:
     out.append("\n# Set by scripts/server-init.sh; absent from .env.example.\n")
     out.extend(missing)
 
-with open(target, "w") as handle:
+# `os.open` with the mode, rather than `open()` then `chmod`: under the usual
+# 022 umask the second leaves the file world-readable for as long as it takes to
+# write five secrets into it, which on a shared host is long enough. `O_EXCL`
+# also makes the "already exists" check above race-free.
+fd = os.open(target, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+with os.fdopen(fd, "w") as handle:
     handle.writelines(out)
 PY
-chmod 600 "$ENV_FILE"
 
 say "Done"
 cat <<EOF

--- a/traefik/dynamic.yml
+++ b/traefik/dynamic.yml
@@ -1,0 +1,23 @@
+# Traefik's dynamic configuration: the parts that can change without a restart.
+# One middleware, applied to the `websecure` entrypoint in `traefik.yml`, so it
+# covers every service behind this proxy.
+
+http:
+  middlewares:
+    security-headers:
+      headers:
+        # The one header the application deliberately does not set. Everything
+        # else - CSP, `X-Frame-Options`, `X-Content-Type-Options`,
+        # `Referrer-Policy`, `Permissions-Policy` - is stamped on every response
+        # by the backend, so it holds behind any proxy. HSTS cannot be: it is a
+        # promise about TLS, and TLS terminates here.
+        #
+        # A year, subdomains included. Long enough to matter and short enough to
+        # undo; `preload` is deliberately absent, because getting a domain off
+        # the preload list takes months.
+        stsSeconds: 31536000
+        stsIncludeSubdomains: true
+        stsPreload: false
+        # Only over HTTPS, which is the whole point - and this entrypoint is the
+        # only one that serves anything else.
+        forceSTSHeader: true

--- a/traefik/traefik.yml
+++ b/traefik/traefik.yml
@@ -19,6 +19,13 @@ api:
 ping: {}
 
 providers:
+  # The middlewares below. Traefik's *static* file is read once and holds no
+  # middlewares, so anything that applies to every route needs a dynamic
+  # provider - which for a fixed rule is a second file rather than a service.
+  file:
+    filename: /etc/traefik/dynamic.yml
+    watch: true
+
   docker:
     endpoint: "unix:///var/run/docker.sock"
     watch: true
@@ -49,6 +56,11 @@ entryPoints:
   websecure:
     address: :443
     http:
+      # Applied to everything behind this proxy rather than to our two routers,
+      # because a header that depends on remembering a label is a header the next
+      # service will not have.
+      middlewares:
+        - security-headers@file
       tls:
         # Set here rather than per router, so a router that forgets to name a
         # resolver still gets a certificate instead of Traefik's self-signed one.
@@ -57,7 +69,11 @@ entryPoints:
 certificatesResolvers:
   letsencrypt:
     acme:
-      email: "${ACME_EMAIL}"
+      # **Not set here.** Traefik does not expand shell placeholders in its static
+      # file, and compose does not interpolate a file it only bind-mounts - so
+      # `${ACME_EMAIL}` written here would be registered with Let's Encrypt
+      # literally. It arrives as `TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_EMAIL`
+      # instead, which is the supported second source for any static setting.
       storage: "/certificates/acme.json"
       # HTTP-01: Let's Encrypt fetches a file from whatever the name resolves to,
       # which is why the DNS records come first. The alternative is DNS-01, which

--- a/traefik/traefik.yml
+++ b/traefik/traefik.yml
@@ -1,0 +1,67 @@
+# Traefik for a host that does not already have one. `docs/deploy.md` has the
+# whole picture; this file is the static configuration, which Traefik reads once
+# at start-up. Everything dynamic - which host routes where - comes from labels
+# on the containers themselves, which is the point of the docker provider.
+
+global:
+  sendAnonymousUsage: false
+
+api:
+  # The dashboard is served but nothing routes to it, so it is reachable only by
+  # publishing a port or adding a router with authentication. Off by default
+  # because a dashboard that lists every route and service is a map of the host.
+  dashboard: true
+  insecure: false
+
+# What the compose healthcheck asks. `traefik healthcheck --ping` has nothing to
+# ask without this, so the container would report unhealthy for ever while
+# serving every request correctly.
+ping: {}
+
+providers:
+  docker:
+    endpoint: "unix:///var/run/docker.sock"
+    watch: true
+    # The setting that decides what is public. Nothing is routed unless it says
+    # `traefik.enable=true`, so a service added to the stack later is unreachable
+    # until somebody decides otherwise - rather than exposed until somebody
+    # notices.
+    exposedByDefault: false
+    network: "traefik_webgateway"
+
+log:
+  level: INFO
+  format: common
+
+accessLog:
+  format: common
+
+entryPoints:
+  web:
+    address: :80
+    # Nothing is served over plain HTTP except the ACME challenge, which Traefik
+    # answers before this redirect applies.
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
+  websecure:
+    address: :443
+    http:
+      tls:
+        # Set here rather than per router, so a router that forgets to name a
+        # resolver still gets a certificate instead of Traefik's self-signed one.
+        certResolver: letsencrypt
+
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      email: "${ACME_EMAIL}"
+      storage: "/certificates/acme.json"
+      # HTTP-01: Let's Encrypt fetches a file from whatever the name resolves to,
+      # which is why the DNS records come first. The alternative is DNS-01, which
+      # needs an API token for the zone and is what a wildcard certificate would
+      # require.
+      httpChallenge:
+        entryPoint: web


### PR DESCRIPTION
`docs/deploy.md` described a stack this repository does not have. It ran
`docker compose up -d --build` with no `-f docker-compose-prod.yml` and no
`--env-file`, migrated with `alembic upgrade head` where the image has
`agenticos db upgrade`, pointed at an `nginx/conf.d/app.conf` that does not
exist, and offered one-click quickstarts for Fly, Railway, Render and Vercel -
none of which models six containers, a Prefect server and a Postgres that must
carry pgvector. It also promised GitHub Actions, and there was no deploy
workflow. Following it end to end produced nothing that runs.

So the page is rewritten around the path that works, and the pieces it needs
now exist.

**Traefik, as two overlays.** `docker-compose-prod.traefik.yml` and its frontend
sibling put `app` and `frontend` on an existing Traefik's network with the labels
it discovers them by; `make prod PROXY=traefik` adds them. Nothing else in the
stack is labelled, so under `exposedByDefault: false` Postgres, Redis, Prefect
and the sandbox daemon are unreachable by construction rather than by omission.
For a host with no proxy at all, `docker-compose-traefik.yml` and
`traefik/traefik.yml` are a working one. The nginx path is untouched and still
the default.

**`scripts/server-init.sh`** writes `backend/.env` once: five generated secrets,
four answers it cannot invent, and the public URLs and CORS origin derived from
them. The production checklist is nine settings whose defaults are wrong on a
reachable host, and generating them is the one part of a deployment where a
human adds no value and a typo costs the vault.

**`scripts/deploy.sh`** takes a commit rather than a branch - two merges can land
while an approval is pending - rebuilds, migrates, restarts, and fails on a
container that does not report healthy rather than returning success and leaving
the discovery to whoever opens the site next.

**`.github/workflows/deploy.yml`** offers every merge to `main` for deployment
and waits. The gate is the `production` environment's required-reviewers rule,
which is a repository setting rather than a line in the file - stated in both
places, because without it the workflow deploys every merge unattended. It never
cancels a run in flight: half a deploy is an API rebuilt against migrations that
have not run.

**The stack was sized wrong, and one of them would have killed it.** `app` had a
1 GB limit for four uvicorn workers, and a worker measures 460 MiB RSS - spawned,
not forked, so nothing is shared. Four of them are 1.9 GB before a request
arrives, so the shipped ceiling OOM-killed the container as soon as all four were
warm. Worker count is now `UVICORN_WORKERS`, the limit is sized for the default,
and the page says the number decides what the host costs.

Three more, in the same measurement pass: `prefect-server` had no limit at all,
which on a host without swap makes it the service that takes the others down;
Postgres ran on the 128 MB `shared_buffers` it ships with, and with 64 MB of
`/dev/shm`, which a parallel scan over a collection's vectors exhausts reporting
`could not resize shared memory segment`; and Redis had no `maxmemory`.

**A gap that stopped the shipped path outright**: `docker-compose-prod.frontend.yml`
requires `PUBLIC_API_URL`, `PUBLIC_WS_URL` and `PUBLIC_SITE_URL` with `:?`, and
none of the three was in `.env.example`. Anyone copying the example hit a refusal
with no hint where the name came from.

Verified: `make lint` and `make docs-build --strict` clean; every compose
combination resolves through `docker compose config`, including the merge that
lets an overlay add one network without restating the base file's two;
`server-init.sh` run against a copy of `.env.example` writes all seventeen
settings in place, with nothing appended.

Not done, and worth saying: the deploy builds on the host rather than pulling an
image CI built. It is the simpler half of the trade and the right one at this
size - one artefact, no registry - but it means a deploy costs the host a Next.js
build, and moving to GHCR is the change to make when that starts to hurt.

---

Follows from putting this on a real host. The page it replaces could not be followed to a running deployment.

Closes nothing — no issue existed for it.