### PR TITLE
test(e2e): stop reloading over the publish this spec is about

### DIFF
--- a/frontend/e2e/journey.spec.ts
+++ b/frontend/e2e/journey.spec.ts
@@ -266,11 +266,39 @@ test("an agent goes from a stored key to a run with a cost", async ({ page, brow
   // shortest integration this product has - send somebody a link - impossible to
   // create without inventing a site.
   await expect(availability.getByLabel("Allowed sites")).toHaveCount(0);
-  await availability.getByRole("button", { name: "Publish", exact: true }).click();
 
-  // Reloaded before the link is read. The list's refetch after a write is
-  // sometimes answered with the pre-write list (#230), and this step needs the
-  // row itself - the link is what is under test, so a toast will not do.
+  // **Armed before the click, awaited after it.** `click()` returns when the
+  // click is dispatched, not when the request it starts is answered - and the
+  // `reload()` below navigates, which aborts whatever is still in flight. So the
+  // publish that this whole section is about was sometimes cancelled before the
+  // server saw it, and the 30-second wait for a link then expired on an embed
+  // that had never been created. That is #1474, four failures in nine runs on
+  // branches that touch none of this.
+  const published = page.waitForResponse(
+    (response) =>
+      response.url().includes("/api/agents/embeds") && response.request().method() === "POST",
+  );
+  await availability.getByRole("button", { name: "Publish", exact: true }).click();
+  expect((await published).ok(), "publishing the hosted page was refused").toBe(true);
+
+  // And the row is readable before the DOM is asked about it, by polling the API
+  // rather than by reloading and hoping - the shape every fixture step takes
+  // after #335. The refetch after a write is sometimes answered with the
+  // pre-write list (#230), which a reload narrows rather than closes.
+  await expect
+    .poll(
+      async () => {
+        const response = await page.request.get(`/api/agents/${agentId}/embeds`);
+        if (!response.ok()) return [];
+        const body = (await response.json()) as { items?: { public_key?: string }[] };
+        // `public_key` is what the hosted link is built from, so this polls for
+        // exactly the thing the assertion below reads off the page.
+        return (body.items ?? []).map((embed) => embed.public_key).filter(Boolean);
+      },
+      { message: "the publish was accepted, but the agent lists no embed" },
+    )
+    .not.toHaveLength(0);
+
   await page.reload();
   await page.getByRole("tab", { name: "Availability" }).click();
   const link = page.getByText(new RegExp(`^${origin}/e/`)).first();

--- a/frontend/e2e/journey.spec.ts
+++ b/frontend/e2e/journey.spec.ts
@@ -276,7 +276,14 @@ test("an agent goes from a stored key to a run with a cost", async ({ page, brow
   // branches that touch none of this.
   const published = page.waitForResponse(
     (response) =>
-      response.url().includes("/api/agents/embeds") && response.request().method() === "POST",
+      new URL(response.url()).pathname === "/api/agents/embeds" &&
+      response.request().method() === "POST" &&
+      // A 401 on this path is not the answer, for the reason `submitDialog` gives
+      // at length: `apiClient.send` recovers from an expired access token by
+      // refreshing and re-issuing the same write, so stopping at the first
+      // response would fail a publish that succeeded on the retry - a new flake
+      // in place of the one being removed.
+      response.status() !== 401,
   );
   await availability.getByRole("button", { name: "Publish", exact: true }).click();
   expect((await published).ok(), "publishing the hosted page was refused").toBe(true);


### PR DESCRIPTION
`journey.spec.ts` has now failed four times in nine runs, on three branches,
two of which touch no application code at all - and once on `main`, where the
run is what makes the badge mean anything. Re-running made it pass every time,
which is what kept it filed rather than fixed (#1474).

The race is not the browser-side staleness the comment blamed. `click()` returns
when the click is dispatched, not when the request it starts is answered, and the
`page.reload()` on the next line navigates - which aborts whatever is still in
flight. So the publish was sometimes cancelled before the server saw it, and the
30-second wait for a hosted link then expired on an embed that had never been
created. The reload was put there to narrow a different window and widened this
one.

Three steps now, each answering a different failure: the POST is awaited and its
status asserted, so a refusal reads as a refusal rather than as a missing link;
the agent's embeds are polled until one is listed, which is the shape every
fixture step takes after #335 and covers the read-after-write staleness #230
still tracks; and only then is the page reloaded and the link read.

Closes #1474