### PR TITLE
fix(deploy): stop the frontend stack calling the backend an orphan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,13 @@ stage-down: dev-server-down
 # existing Traefik's network and carry the labels it discovers them by, which is
 # the shorter path where Traefik is already running. See docs/deploy.md.
 PROD_FILES := -f docker-compose-prod.yml $(if $(filter traefik,$(PROXY)),-f docker-compose-prod.traefik.yml)
-PROD_FRONTEND_FILES := -f docker-compose-prod.frontend.yml $(if $(filter traefik,$(PROXY)),-f docker-compose-prod.frontend.traefik.yml)
+# A project of its own, and this one is not tidiness. Compose derives the project
+# name from the directory, so both invocations were `agenticos` - and the
+# frontend one then reported the five backend containers as **orphans**, with
+# compose's own suggestion to "run this command with the --remove-orphans flag to
+# clean it up". Following that advice takes the API, the database, Redis and both
+# Prefect services down. The volumes survive; nothing else does.
+PROD_FRONTEND_FILES := -p agenticos-frontend -f docker-compose-prod.frontend.yml $(if $(filter traefik,$(PROXY)),-f docker-compose-prod.frontend.traefik.yml)
 PROD_PROXY_NOTE := $(if $(filter traefik,$(PROXY)),Traefik routes it once the certificate is issued,configure your nginx host with nginx/nginx.conf)
 
 prod:

--- a/docker-compose-prod.frontend.traefik.yml
+++ b/docker-compose-prod.frontend.traefik.yml
@@ -1,8 +1,12 @@
 # Puts the production frontend behind an existing Traefik. An overlay:
 #
-#   docker compose --env-file backend/.env \
+#   docker compose -p agenticos-frontend --env-file backend/.env \
 #     -f docker-compose-prod.frontend.yml -f docker-compose-prod.frontend.traefik.yml \
 #     up -d --build
+#
+# `-p agenticos-frontend` for the reason the file it overlays gives: without it
+# compose calls the backend's containers orphans of this stack and offers to
+# remove them.
 #
 # The API's half is `docker-compose-prod.traefik.yml`, and the reasoning for
 # every label is there. This file exists separately only because the frontend is

--- a/docker-compose-prod.frontend.yml
+++ b/docker-compose-prod.frontend.yml
@@ -1,6 +1,13 @@
 # The frontend in production. `make prod-frontend`.
 #
-#   docker compose --env-file backend/.env -f docker-compose-prod.frontend.yml up -d --build
+#   docker compose -p agenticos-frontend --env-file backend/.env \
+#     -f docker-compose-prod.frontend.yml up -d --build
+#
+# `-p` is not optional and not tidiness. Compose names a project after the
+# directory, so without it this shares one with `docker-compose-prod.yml` - and
+# reports that stack's five containers as **orphans** of this one, suggesting the
+# `--remove-orphans` flag that would stop the API, the database, Redis and both
+# Prefect services.
 #
 # Start `docker-compose-prod.yml` first: this joins the `edge` network it creates
 # and declares it `external: true`, so bringing the frontend up without a backend

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -190,6 +190,17 @@ deliberately leaves to whatever terminates TLS.
     `BIND_HOST=0.0.0.0` only for a proxy on a different machine, and firewall the
     port to it.
 
+!!! warning "The frontend is a compose project of its own"
+
+    Compose names a project after the directory, so both stacks were
+    `agenticos` — and bringing the frontend up then reported the five backend
+    containers as **orphans**, with compose's own suggestion to run the command
+    again with `--remove-orphans`. Taking that advice stops the API, the
+    database, Redis and both Prefect services. The `make` targets and
+    `scripts/deploy.sh` pass `-p agenticos-frontend`, so the warning is gone; a
+    deployment that predates this fix needs its frontend container removed once
+    (`docker rm -f agenticos_frontend`) before the renamed project can create it.
+
 ## Start it, and create the first account
 
 `make prod` builds the images, starts the stack and runs the migrations. The

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -27,6 +27,10 @@ set -euo pipefail
 SHA="${1:?usage: deploy.sh <commit-sha>}"
 APP_DIR="${APP_DIR:-/opt/agenticos}"
 COMPOSE_ENV="${APP_DIR}/backend/.env"
+# The frontend is a project of its own, or compose - which names a project after
+# the directory - reports the backend's containers as orphans of the frontend
+# stack, and suggests the flag that would remove them. Matches the Makefile.
+FRONTEND_PROJECT="agenticos-frontend"
 
 say() { printf '\n\033[1m▶ %s\033[0m\n' "$*"; }
 
@@ -42,11 +46,11 @@ PROXY="$(sed -n 's/^PROXY=//p' "$COMPOSE_ENV" | tail -1)"
 case "${PROXY:-nginx}" in
   traefik)
     BACKEND=(-f docker-compose-prod.yml -f docker-compose-prod.traefik.yml)
-    FRONTEND=(-f docker-compose-prod.frontend.yml -f docker-compose-prod.frontend.traefik.yml)
+    FRONTEND=(-p "$FRONTEND_PROJECT" -f docker-compose-prod.frontend.yml -f docker-compose-prod.frontend.traefik.yml)
     ;;
   nginx|"")
     BACKEND=(-f docker-compose-prod.yml)
-    FRONTEND=(-f docker-compose-prod.frontend.yml)
+    FRONTEND=(-p "$FRONTEND_PROJECT" -f docker-compose-prod.frontend.yml)
     ;;
   *)
     echo "PROXY=$PROXY in $COMPOSE_ENV is not one of: traefik, nginx" >&2


### PR DESCRIPTION
Compose names a project after the directory, so `make prod` and
`make prod-frontend` were both project `agenticos` - and the frontend
invocation reported the five backend containers as orphans of its own stack:

    WARN Found orphan containers (agenticos_prefect_runner, agenticos_backend,
    agenticos_redis, agenticos_db, agenticos_prefect_server) for this project.
    If you removed or renamed this service in your compose file, you can run
    this command with the --remove-orphans flag to clean it up.

That last sentence is the problem. The flag it recommends stops the API, the
database, Redis and both Prefect services; the volumes survive and nothing else
does. A warning that names five healthy containers and suggests removing them is
a footgun with instructions, and it appeared on the very first deploy of the
documented path.

The frontend is `-p agenticos-frontend` now, in the Makefile and in
`scripts/deploy.sh`. Nothing else changes: it joins `agenticos_edge` and the
Traefik network by name, both declared external, and it owns no volumes.

Seen on the first real deployment of #1476. `docs/deploy.md` carries the one-time
step an existing deployment needs, because `container_name` is pinned and the
renamed project cannot create a container that the old one still owns.