### PR TITLE
chore: cut 0.0.371

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.371] - 2026-09-07
+
+### Fixed
+
+- **Bringing the frontend up called the backend an orphan, and offered to remove
+  it.** Docker Compose names a project after the directory it runs in, so the two
+  production stacks shared one - and starting the frontend reported the API, the
+  database, Redis and both Prefect services as orphans of it, with compose's own
+  suggestion to run the command again with `--remove-orphans`. Taking that advice
+  stops all five; the volumes survive and nothing else does. The frontend is its
+  own compose project now, in the `make` targets, in `scripts/deploy.sh` and in
+  the commands the compose files themselves advertise. Seen on the first real
+  deployment.
+
+
 ## [0.0.370] - 2026-09-06
 
 ### Added

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.370"
+version = "0.0.371"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.370"
+version = "0.0.371"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.370",
+  "version": "0.0.371",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.371.

Ships #1480 — the frontend is its own compose project, so starting it no longer reports the backend's five containers as orphans and suggest the flag that would stop them.

Found on the first real deployment of the documented path, which is the point of having deployed it.