### PR TITLE
chore: cut 0.0.372

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.372] - 2026-09-07
+
+### Fixed
+
+- **Inviting a teammate said "sent" on a deployment that emails nobody.** With no
+  `SMTP_*` configured - which is every deployment on its first day - the dialog
+  reported the invitation as sent and closed, and the accept link went with it:
+  the token comes back exactly once, is in no cache and is not refetchable, so
+  the invitation existed, pending, reachable by nobody. The backend had been
+  returning that link all along, and the hook discarded it on the way past.
+  Delivery is now reported rather than logged - `email_delivered` on the wire,
+  read beside a new `EmailProvider.delivers` so the development log provider
+  accepting a message is not mistaken for a message that left the deployment -
+  and the dialog stays open holding the link with a copy control, saying plainly
+  which of the two happened. Found on the first real deployment.
+
 ## [0.0.371] - 2026-09-07
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.371"
+version = "0.0.372"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.371"
+version = "0.0.372"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.371",
+  "version": "0.0.372",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.372.

Ships #1484 — inviting a teammate on a deployment with no mail service said "sent" and threw away the accept link, which is the only other way in and comes back exactly once. The link is now on screen with a copy control, and the dialog says which of the two actually happened.

Found on the first real deployment.

Version, lock and changelog only.