### PR TITLE
fix(deploy): stop the migration eating the rest of the deploy script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,6 +109,13 @@ jobs:
           printf '%s\n' "$DEPLOY_KNOWN_HOSTS" > ~/.ssh/known_hosts
           chmod 600 ~/.ssh/deploy_key ~/.ssh/known_hosts
 
+      # **Copied, then run - not piped into `bash -s`.** Under `bash -s` the
+      # script is the shell's own standard input, so the first command in it
+      # that reads stdin eats the rest: `docker compose exec` forwards stdin
+      # even with `-T`, so the migration consumed everything after itself, bash
+      # hit EOF, and the deploy reported success having never built the frontend
+      # nor waited for a single container. Two connections is the price of the
+      # script not being able to truncate itself (#1488).
       - name: Deploy
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
@@ -116,9 +123,10 @@ jobs:
           APP_DIR: ${{ vars.APP_DIR || '/opt/agenticos' }}
           SHA: ${{ needs.resolve.outputs.sha }}
         run: |
-          ssh -i ~/.ssh/deploy_key -o BatchMode=yes \
-            "$DEPLOY_USER@$DEPLOY_HOST" \
-            "APP_DIR='$APP_DIR' bash -s -- '$SHA'" < scripts/deploy.sh
+          set -euo pipefail
+          ssh() { command ssh -i ~/.ssh/deploy_key -o BatchMode=yes "$DEPLOY_USER@$DEPLOY_HOST" "$@"; }
+          ssh 'cat > ~/.agenticos-deploy.sh' < scripts/deploy.sh
+          ssh "APP_DIR='$APP_DIR' bash ~/.agenticos-deploy.sh '$SHA'"
 
       # The deploy script already waits for both containers to report healthy on
       # the host. This asks the same question from outside, which is the half it

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,8 +125,15 @@ jobs:
         run: |
           set -euo pipefail
           ssh() { command ssh -i ~/.ssh/deploy_key -o BatchMode=yes "$DEPLOY_USER@$DEPLOY_HOST" "$@"; }
-          ssh 'cat > ~/.agenticos-deploy.sh' < scripts/deploy.sh
-          ssh "APP_DIR='$APP_DIR' bash ~/.agenticos-deploy.sh '$SHA'"
+          # Named for this run, and removed by a trap in the remote shell so the
+          # exit status is the deploy's. A fixed name is a file two callers share:
+          # `concurrency` above serializes workflow runs and says nothing about
+          # the by-hand form in `docs/deploy.md`, so an operator's upload could
+          # land between this job's copy and its run - and the deploy would then
+          # execute somebody else's procedure against this job's approved sha.
+          REMOTE=".agenticos-deploy.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}.sh"
+          ssh "cat > '$REMOTE'" < scripts/deploy.sh
+          ssh "trap 'rm -f \"\$HOME/$REMOTE\"' EXIT; APP_DIR='$APP_DIR' bash \"\$HOME/$REMOTE\" '$SHA'"
 
       # The deploy script already waits for both containers to report healthy on
       # the host. This asks the same question from outside, which is the half it

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -252,8 +252,9 @@ exercises a path nothing else here checks.
 ### By hand
 
 ```bash
-ssh you@your-host 'cat > ~/.agenticos-deploy.sh' < scripts/deploy.sh
-ssh you@your-host 'bash ~/.agenticos-deploy.sh <commit-sha>'
+remote=$(ssh you@your-host 'mktemp -t agenticos-deploy.XXXXXX')
+ssh you@your-host "cat > $remote" < scripts/deploy.sh
+ssh you@your-host "trap 'rm -f $remote' EXIT; bash $remote <commit-sha>"
 ```
 
 `scripts/deploy.sh` fetches that commit, rebuilds, migrates, restarts and waits

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -252,13 +252,26 @@ exercises a path nothing else here checks.
 ### By hand
 
 ```bash
-ssh you@your-host 'bash -s -- <commit-sha>' < scripts/deploy.sh
+ssh you@your-host 'cat > ~/.agenticos-deploy.sh' < scripts/deploy.sh
+ssh you@your-host 'bash ~/.agenticos-deploy.sh <commit-sha>'
 ```
 
 `scripts/deploy.sh` fetches that commit, rebuilds, migrates, restarts and waits
 for both containers to report healthy before it returns non-zero or not. It takes
 a **commit** rather than a branch, so what is deployed is what was reviewed, not
 whatever `main` has moved to since.
+
+!!! warning "Copy it to the host, then run it — do not pipe it into `bash -s`"
+
+    Under `bash -s` the script is the shell's own standard input, and the first
+    command in it that reads stdin consumes the rest. `docker compose exec`
+    forwards stdin to the container even with `-T`, so the migration ate
+    everything below itself, bash reached EOF, and the deploy exited **0**
+    having never built the frontend or waited for any container. The site was
+    down and the deploy was green ([#1488](https://github.com/vstorm-co/agenticos/issues/1488)).
+
+    Two connections instead of one is what stops the procedure being able to
+    truncate itself.
 
 It is not zero-downtime. Compose recreates the containers it rebuilt, so the site
 is unavailable for the few seconds that takes.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,8 +2,9 @@
 #
 # Deploy one commit onto a server that already runs this stack.
 #
-#   ssh <host> 'cat > ~/.agenticos-deploy.sh' < scripts/deploy.sh
-#   ssh <host> 'bash ~/.agenticos-deploy.sh <sha>'
+#   remote=$(ssh <host> 'mktemp -t agenticos-deploy.XXXXXX')
+#   ssh <host> "cat > $remote" < scripts/deploy.sh
+#   ssh <host> "trap 'rm -f $remote' EXIT; bash $remote <sha>"
 #
 # Copied to the server rather than run from its checkout: the checkout there is
 # only the build context, and the procedure travels with whoever is running it.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,13 +2,21 @@
 #
 # Deploy one commit onto a server that already runs this stack.
 #
-#   ssh <host> 'bash -s -- <sha>' < scripts/deploy.sh
+#   ssh <host> 'cat > ~/.agenticos-deploy.sh' < scripts/deploy.sh
+#   ssh <host> 'bash ~/.agenticos-deploy.sh <sha>'
 #
-# Piped over stdin rather than run from the server's checkout: the checkout there
-# is only the build context, and the procedure travels with whoever is running
-# it. Deliberately **not** taken from the commit being deployed - a rollback to a
+# Copied to the server rather than run from its checkout: the checkout there is
+# only the build context, and the procedure travels with whoever is running it.
+# Deliberately **not** taken from the commit being deployed - a rollback to a
 # commit older than this file would then have no script to run, which is the one
 # moment it is needed most.
+#
+# Copied and *then* run, rather than piped into `bash -s`, and that is not a
+# style preference. Under `bash -s` the script is its own standard input, so the
+# first command that reads stdin consumes the rest of it: `docker compose exec`
+# forwards stdin to the container even with `-T`, so the migration swallowed
+# everything below it, bash reached EOF, and the script exited 0 having never
+# built the frontend or waited for anything (#1488).
 #
 # It takes a **commit**, not a branch. Two pushes can land while an approval is
 # pending, and `git pull` on the server would then deploy whichever one won the
@@ -63,7 +71,10 @@ git fetch --prune --quiet origin
 git checkout --quiet --detach "$SHA"
 git --no-pager log --oneline -1
 
-compose() { docker compose --env-file "$COMPOSE_ENV" "$@"; }
+# `< /dev/null` on every compose call, so this stays correct even when somebody
+# pipes the script into `bash -s` anyway: nothing in here has any business
+# reading standard input, and one that does silently truncates the deploy (#1488).
+compose() { docker compose --env-file "$COMPOSE_ENV" "$@" < /dev/null; }
 
 # The API first, and its migrations before the frontend: a frontend serving a
 # schema the backend has not migrated to yet is the window this ordering closes.


### PR DESCRIPTION
The workflow piped `scripts/deploy.sh` into `bash -s` over ssh, so the script was the shell's own standard input — and `docker compose exec` forwards stdin to the container even with `-T`. The migration consumed every line below itself, bash reached EOF, and the deploy exited **0** having never built the frontend, never waited for a container and never pruned an image.

`agenticos.testapp.ovh` then answered Traefik's own `404 page not found` — no frontend container existed for any router to match — while the deployment history said the deploy had succeeded.

Run [34119792526](https://github.com/vstorm-co/agenticos/actions/runs/34119792526) is the whole bug in two lines: the script's progress markers stop at `▶ Migrating`, and the step is green.

Two changes, either of which would have been enough; both, because the failure was silent:

- the workflow copies the script to the host and runs it from a file, so the procedure cannot truncate itself;
- every `docker compose` call in the script reads from `/dev/null`, so the script stays correct for anyone who pipes it anyway.

`docs/deploy.md` shows the two-connection form with an admonition saying why — the one-liner it replaces is the defect.

Found by the one step that could find it: `Reach it from the internet` curls `SITE_URL` from outside, which is the half the on-host health wait cannot answer.

Closes #1488