### PR TITLE
chore: cut 0.0.374

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.374] - 2026-09-07
+
+### Fixed
+
+- **A deploy reported success having never built the frontend.** The workflow
+  piped `scripts/deploy.sh` into `bash -s` over ssh, so the script was the
+  shell's own standard input - and `docker compose exec` forwards stdin to the
+  container even with `-T`. The migration consumed every line below itself, bash
+  reached EOF, and the run exited 0 without building the frontend, waiting for a
+  container or pruning an image; the site answered the proxy's own 404 because no
+  frontend container existed, while the deployment history said the deploy had
+  worked. The script is now copied to the host under a name unique to the run and
+  executed from a file, and every `docker compose` call in it reads from
+  `/dev/null` - so it stays correct for anyone who pipes it anyway. Caught by the
+  one step that could catch it: the external `curl` at the URL a person visits.
+
 ## [0.0.373] - 2026-09-07
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.373"
+version = "0.0.374"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.373"
+version = "0.0.374"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.373",
+  "version": "0.0.374",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.374.

Ships #1488 — the deploy script was piped into `bash -s`, so the migration ate the rest of it and the run reported success having never built the frontend. Copied to the host under a per-run name and executed from a file now.

Version, lock and changelog only.