### PR TITLE
docs(deploy): say that an unapproved deploy holds the lane

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,11 @@ on:
 #
 # This is the opposite of `ci.yml`'s rule, and for the opposite reason: there a
 # superseded answer is waste, here a superseded run has already changed a server.
+#
+# The sharp edge is a run that has not started: one sitting at the approval gate
+# holds this group too, and holds it until somebody approves or cancels it. So a
+# deploy decided against is cancelled rather than left - `docs/deploy.md` says so
+# where an operator will read it.
 concurrency:
   group: deploy-production
   cancel-in-progress: false

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -291,6 +291,18 @@ Set it up once:
    checkout is not at `/opt/agenticos`.
 4. Add the secrets below.
 
+!!! warning "Cancel a deploy you do not intend to approve"
+
+    Every run shares the `deploy-production` concurrency group, and a run sitting
+    at the approval gate holds it. It does not expire on its own — GitHub cancels
+    an unactioned one after 30 days — so until somebody approves or cancels it,
+    later merges queue behind a decision nobody is going to make, and the server
+    keeps running whatever was deployed last.
+
+    So a deploy you have decided against is cancelled, not left. One left waiting
+    on a superseded commit blocked three later runs here before anybody noticed
+    the queue rather than the runs.
+
 | Secret | What |
 |---|---|
 | `DEPLOY_HOST` | The host's address |


### PR DESCRIPTION
A deploy sitting at the approval gate holds the \`deploy-production\` concurrency group, and holds it until somebody approves or cancels — GitHub only cancels an unactioned run after 30 days. So later merges queue behind a decision nobody is going to make, while the server keeps running whatever was deployed last.

That happened here: run #10 waited on a superseded commit and three later runs died around it before anybody looked at the queue rather than at the runs. Nothing in the page or the workflow said to cancel one.

Documentation only.