### PR TITLE
fix(rag): stop the vector-store probe predicting a failure it never checked

### DIFF
--- a/backend/app/services/health.py
+++ b/backend/app/services/health.py
@@ -60,6 +60,15 @@ truth in thirty seconds.
 
 _PGVECTOR_VERSION = text("SELECT extversion FROM pg_extension WHERE extname = 'vector'")
 
+# Whether the *image* ships pgvector, which is a different question from whether
+# this database has created it - and the one that decides what the first
+# ingestion does. `pg_extension` alone cannot tell a fresh deployment apart from
+# a stock-postgres one, and reporting the second's consequence for the first is
+# how a working deployment read as broken (#1504).
+_PGVECTOR_AVAILABLE = text(
+    "SELECT default_version FROM pg_available_extensions WHERE name = 'vector'"
+)
+
 # Tables carrying an embedding column, which is what the RAG store creates per
 # collection. Counted, never named: the count answers "is anything ingested
 # here", the names are the organizations' business.
@@ -185,22 +194,43 @@ async def probe_vector_store(db: AsyncSession) -> SystemCheck:
     installed and how many collection tables exist. Both are catalog reads,
     which is what makes this cheap enough for a page that refreshes itself.
 
-    A missing extension is `unconfigured`, not `unhealthy`: a deployment
-    that never ingests a document is working exactly as installed. The detail
-    says what happens if it does, which is the part worth knowing before the
-    first upload rather than after.
+    A missing extension is usually `unconfigured`, not `unhealthy`: the RAG store
+    runs `CREATE EXTENSION IF NOT EXISTS vector` the first time a collection is
+    written to, so a deployment that never ingests a document is working exactly
+    as installed.
+
+    Usually, because there are two ways for it to be absent and they have opposite
+    consequences. On the `pgvector/pgvector` image every compose file here pins,
+    it is merely not created yet and the first upload creates it. On stock
+    Postgres it cannot be created at all, and the first upload 500s after the
+    bytes have been accepted - the environment gotcha CLAUDE.md opens with. So
+    `pg_available_extensions` is read before any consequence is claimed: saying
+    the first ingestion will fail, on a deployment where it will succeed, is what
+    made a healthy production read as broken (#1504).
     """
     start = perf_counter()
     try:
         async with asyncio.timeout(PROBE_TIMEOUT_SECONDS):
             version = (await db.execute(_PGVECTOR_VERSION)).scalar_one_or_none()
             if version is None:
+                available = (await db.execute(_PGVECTOR_AVAILABLE)).scalar_one_or_none()
+                if available is None:
+                    return SystemCheck(
+                        key="vector_store",
+                        status="unhealthy",
+                        detail=(
+                            "this Postgres image does not ship pgvector, so the first "
+                            "document ingestion will fail after accepting the upload; "
+                            "the database must be pgvector/pgvector:pg16"
+                        ),
+                        latency_ms=_elapsed_ms(start),
+                    )
                 return SystemCheck(
                     key="vector_store",
                     status="unconfigured",
                     detail=(
-                        "the pgvector extension is not installed in this database; the "
-                        "first document ingestion will fail trying to create it"
+                        f"pgvector {available} is available but not yet created in this "
+                        "database; the first document ingestion creates it"
                     ),
                     latency_ms=_elapsed_ms(start),
                 )

--- a/backend/app/services/health.py
+++ b/backend/app/services/health.py
@@ -60,13 +60,24 @@ truth in thirty seconds.
 
 _PGVECTOR_VERSION = text("SELECT extversion FROM pg_extension WHERE extname = 'vector'")
 
-# Whether the *image* ships pgvector, which is a different question from whether
-# this database has created it - and the one that decides what the first
-# ingestion does. `pg_extension` alone cannot tell a fresh deployment apart from
-# a stock-postgres one, and reporting the second's consequence for the first is
-# how a working deployment read as broken (#1504).
-_PGVECTOR_AVAILABLE = text(
-    "SELECT default_version FROM pg_available_extensions WHERE name = 'vector'"
+# What the *image* ships and what this *role* may do with it - both different
+# questions from whether the extension has been created here, and between them
+# the ones that decide what the first ingestion does. `pg_extension` alone
+# cannot tell a fresh deployment apart from a stock-postgres one, and reporting
+# the second's consequence for the first is how a working deployment read as
+# broken (#1504).
+#
+# `CREATE EXTENSION` is a superuser action unless the extension is trusted, in
+# which case CREATE on the database is enough. Asked rather than assumed: an
+# application connecting as a restricted role sees `vector` listed here and
+# still cannot create it, so availability alone is one more consequence claimed
+# without evidence.
+_PGVECTOR_CAPABILITY = text(
+    "SELECT "
+    "(SELECT default_version FROM pg_available_extensions WHERE name = 'vector'), "
+    "(SELECT bool_or(trusted) FROM pg_available_extension_versions WHERE name = 'vector'), "
+    "current_setting('is_superuser') = 'on', "
+    "has_database_privilege(current_database(), 'CREATE')"
 )
 
 # Tables carrying an embedding column, which is what the RAG store creates per
@@ -197,31 +208,60 @@ async def probe_vector_store(db: AsyncSession) -> SystemCheck:
     A missing extension is usually `unconfigured`, not `unhealthy`: the RAG store
     runs `CREATE EXTENSION IF NOT EXISTS vector` the first time a collection is
     written to, so a deployment that never ingests a document is working exactly
-    as installed.
+    as installed - and it will keep working when somebody uploads one.
 
-    Usually, because there are two ways for it to be absent and they have opposite
-    consequences. On the `pgvector/pgvector` image every compose file here pins,
-    it is merely not created yet and the first upload creates it. On stock
-    Postgres it cannot be created at all, and the first upload 500s after the
-    bytes have been accepted - the environment gotcha CLAUDE.md opens with. So
-    `pg_available_extensions` is read before any consequence is claimed: saying
-    the first ingestion will fail, on a deployment where it will succeed, is what
-    made a healthy production read as broken (#1504).
+    Usually, because "absent" covers four situations with two different outcomes,
+    and the row in `pg_extension` distinguishes none of them. What decides is
+    whether the image ships pgvector and whether this role may create it, so both
+    are asked before any consequence is claimed - the whole defect here was
+    claiming one (#1504):
+
+    | Ships it | Created | This role may create it | |
+    |---|---|---|---|
+    | yes | yes | - | `healthy` |
+    | yes | no | yes | `unconfigured`, and the first ingestion creates it |
+    | yes | no | no | `unhealthy` - a restricted role, and it fails at the upload |
+    | no | no | - | `unhealthy` - stock Postgres, the gotcha CLAUDE.md opens with |
+    | no | yes | - | `unhealthy` - a volume that outlived its image |
+
+    That last row is why availability is read whether or not the extension exists.
+    A data directory carrying the `pg_extension` row, started on an image without
+    the library, keeps the row and loses `$libdir/vector`: the catalog says
+    installed, the collection tables are still countable, and every vector
+    operation fails.
     """
     start = perf_counter()
     try:
         async with asyncio.timeout(PROBE_TIMEOUT_SECONDS):
+            available, trusted, superuser, may_create = (
+                await db.execute(_PGVECTOR_CAPABILITY)
+            ).one()
             version = (await db.execute(_PGVECTOR_VERSION)).scalar_one_or_none()
+            if available is None:
+                return SystemCheck(
+                    key="vector_store",
+                    status="unhealthy",
+                    detail=(
+                        "this Postgres image does not ship pgvector, so vector "
+                        "operations fail loading $libdir/vector; the database must be "
+                        "pgvector/pgvector:pg16"
+                        if version is not None
+                        else "this Postgres image does not ship pgvector, so the first "
+                        "document ingestion will fail after accepting the upload; "
+                        "the database must be pgvector/pgvector:pg16"
+                    ),
+                    latency_ms=_elapsed_ms(start),
+                )
             if version is None:
-                available = (await db.execute(_PGVECTOR_AVAILABLE)).scalar_one_or_none()
-                if available is None:
+                if not (superuser or (trusted and may_create)):
                     return SystemCheck(
                         key="vector_store",
                         status="unhealthy",
                         detail=(
-                            "this Postgres image does not ship pgvector, so the first "
-                            "document ingestion will fail after accepting the upload; "
-                            "the database must be pgvector/pgvector:pg16"
+                            f"pgvector {available} is available but this database role "
+                            "cannot create it, so the first document ingestion will fail "
+                            "after accepting the upload; create the extension as a "
+                            "superuser, once"
                         ),
                         latency_ms=_elapsed_ms(start),
                     )
@@ -229,8 +269,8 @@ async def probe_vector_store(db: AsyncSession) -> SystemCheck:
                     key="vector_store",
                     status="unconfigured",
                     detail=(
-                        f"pgvector {available} is available but not yet created in this "
-                        "database; the first document ingestion creates it"
+                        f"pgvector {available} is available and this role may create it; "
+                        "the first document ingestion does"
                     ),
                     latency_ms=_elapsed_ms(start),
                 )

--- a/backend/tests/api/test_admin_system.py
+++ b/backend/tests/api/test_admin_system.py
@@ -62,9 +62,12 @@ class _User:
 def _client(user: _User, mock_redis: Any) -> AsyncGenerator[AsyncClient, None]:
     app.dependency_overrides[get_current_user] = lambda: user
     app.dependency_overrides[get_redis] = lambda: mock_redis
-    # SELECT 1, the pgvector version, the embedding table count, then the
+    # SELECT 1, the pgvector capability row (what the image ships, what this role
+    # may do with it), the pgvector version, the embedding table count, then the
     # (profiles, organizations) pair.
-    app.dependency_overrides[get_db_session] = lambda: _Session(1, "0.8.0", 2, (3, 2))
+    app.dependency_overrides[get_db_session] = lambda: _Session(
+        1, ("0.8.0", True, True, True), "0.8.0", 2, (3, 2)
+    )
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
 
 

--- a/backend/tests/test_health_probes.py
+++ b/backend/tests/test_health_probes.py
@@ -220,19 +220,39 @@ class TestVectorStoreProbe:
         assert "pgvector 0.8.0" in check.detail
         assert "3 collection table(s)" in check.detail
 
-    async def test_a_missing_extension_is_unconfigured_not_broken(self) -> None:
+    async def test_an_extension_not_created_yet_is_unconfigured_not_broken(self) -> None:
         """A deployment that never ingests a document is not having an incident.
 
-        It does need to know before the first upload that the upload will fail,
-        which is what the detail is for.
+        The RAG store creates the extension the first time a collection is
+        written to, so on the image every compose file here pins this is a state
+        that resolves itself - and the detail says so rather than predicting a
+        failure that will not happen (#1504).
         """
-        session = _Session(None)
+        session = _Session(None, "0.8.0")
         check = await health.probe_vector_store(session)  # type: ignore[arg-type]
 
         assert check.status == "unconfigured"
-        assert "not installed" in check.detail
-        # No point counting embedding tables when the type they use is absent.
-        assert session.queries == 1
+        assert "available but not yet created" in check.detail
+        assert "0.8.0" in check.detail
+        # Two catalog reads, and no point counting embedding tables when the type
+        # they use does not exist yet.
+        assert session.queries == 2
+
+    async def test_an_image_without_pgvector_is_unhealthy_and_says_which_image(self) -> None:
+        """The other half, and the opposite consequence.
+
+        On stock Postgres the extension cannot be created at all, so the first
+        upload 500s *after* the bytes have been accepted. Reported as unhealthy,
+        because nothing about it resolves itself, and naming the image because
+        that is the fix.
+        """
+        session = _Session(None, None)
+        check = await health.probe_vector_store(session)  # type: ignore[arg-type]
+
+        assert check.status == "unhealthy"
+        assert "does not ship pgvector" in check.detail
+        assert "pgvector/pgvector:pg16" in check.detail
+        assert session.queries == 2
 
     async def test_a_catalog_read_that_fails_is_unhealthy(self) -> None:
         check = await health.probe_vector_store(

--- a/backend/tests/test_health_probes.py
+++ b/backend/tests/test_health_probes.py
@@ -212,9 +212,22 @@ class TestRedisProbe:
         assert "did not answer within" in check.detail
 
 
+def _capable(
+    *,
+    available: str = "0.8.0",
+    trusted: bool = True,
+    superuser: bool = True,
+    may_create: bool = True,
+) -> tuple[str | None, bool | None, bool, bool]:
+    """One row of `_PGVECTOR_CAPABILITY`: what the image ships, what the role may do."""
+    return (available, trusted, superuser, may_create)
+
+
 class TestVectorStoreProbe:
     async def test_it_reports_the_extension_version_and_how_many_collections(self) -> None:
-        check = await health.probe_vector_store(_Session("0.8.0", 3))  # type: ignore[arg-type]
+        check = await health.probe_vector_store(
+            _Session(_capable(), "0.8.0", 3)  # type: ignore[arg-type]
+        )
 
         assert check.status == "healthy"
         assert "pgvector 0.8.0" in check.detail
@@ -224,19 +237,51 @@ class TestVectorStoreProbe:
         """A deployment that never ingests a document is not having an incident.
 
         The RAG store creates the extension the first time a collection is
-        written to, so on the image every compose file here pins this is a state
-        that resolves itself - and the detail says so rather than predicting a
-        failure that will not happen (#1504).
+        written to, so on the image every compose file here pins, and as a role
+        that may create it, this is a state that resolves itself - and the detail
+        says so rather than predicting a failure that will not happen (#1504).
         """
-        session = _Session(None, "0.8.0")
+        session = _Session(_capable(), None)
         check = await health.probe_vector_store(session)  # type: ignore[arg-type]
 
         assert check.status == "unconfigured"
-        assert "available but not yet created" in check.detail
+        assert "may create it" in check.detail
         assert "0.8.0" in check.detail
-        # Two catalog reads, and no point counting embedding tables when the type
-        # they use does not exist yet.
+        # No point counting embedding tables when the type they use does not
+        # exist yet.
         assert session.queries == 2
+
+    async def test_a_trusted_extension_is_creatable_without_being_superuser(self) -> None:
+        """`CREATE EXTENSION` needs superuser *unless* the extension is trusted,
+        which pgvector is - then CREATE on the database is enough."""
+        check = await health.probe_vector_store(
+            _Session(_capable(superuser=False), None)  # type: ignore[arg-type]
+        )
+
+        assert check.status == "unconfigured"
+
+    async def test_a_role_that_cannot_create_it_is_unhealthy_however_available(self) -> None:
+        """Availability is the image's answer, not the role's.
+
+        An application connecting as a restricted role sees `vector` in
+        `pg_available_extensions` and still cannot run `CREATE EXTENSION`, so
+        promising that the first ingestion creates it is the same unverified
+        claim this probe exists to stop making.
+        """
+        check = await health.probe_vector_store(
+            _Session(_capable(superuser=False, may_create=False), None)  # type: ignore[arg-type]
+        )
+
+        assert check.status == "unhealthy"
+        assert "cannot create it" in check.detail
+
+    async def test_an_untrusted_extension_needs_superuser(self) -> None:
+        check = await health.probe_vector_store(
+            _Session(_capable(superuser=False, trusted=False), None)  # type: ignore[arg-type]
+        )
+
+        assert check.status == "unhealthy"
+        assert "cannot create it" in check.detail
 
     async def test_an_image_without_pgvector_is_unhealthy_and_says_which_image(self) -> None:
         """The other half, and the opposite consequence.
@@ -246,13 +291,29 @@ class TestVectorStoreProbe:
         because nothing about it resolves itself, and naming the image because
         that is the fix.
         """
-        session = _Session(None, None)
+        session = _Session((None, None, False, True), None)
         check = await health.probe_vector_store(session)  # type: ignore[arg-type]
 
         assert check.status == "unhealthy"
         assert "does not ship pgvector" in check.detail
         assert "pgvector/pgvector:pg16" in check.detail
         assert session.queries == 2
+
+    async def test_a_volume_that_outlived_its_image_is_unhealthy(self) -> None:
+        """The row survives; the shared library does not.
+
+        A data directory carrying `pg_extension` started on an image without
+        pgvector keeps the catalog row and loses `$libdir/vector`, so the
+        extension reads as installed, the collection tables are still countable,
+        and every vector operation fails. Availability is therefore read whether
+        or not the extension exists (#1504).
+        """
+        check = await health.probe_vector_store(
+            _Session((None, None, False, True), "0.8.0")  # type: ignore[arg-type]
+        )
+
+        assert check.status == "unhealthy"
+        assert "$libdir/vector" in check.detail
 
     async def test_a_catalog_read_that_fails_is_unhealthy(self) -> None:
         check = await health.probe_vector_store(
@@ -336,7 +397,7 @@ class TestReadiness:
 class TestSystemHealth:
     async def test_it_reports_every_check_an_operator_can_act_on(self) -> None:
         report = await health.system_health(
-            db=_Session(1, "0.8.0", 2, (1, 1)),  # type: ignore[arg-type]
+            db=_Session(1, _capable(), "0.8.0", 2, (1, 1)),  # type: ignore[arg-type]
             redis=_Redis(),  # type: ignore[arg-type]
         )
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -255,7 +255,19 @@ see RAG below.
 ### Vector database
 
 pgvector uses the existing PostgreSQL connection. No additional configuration
-is needed.
+is needed — but the **image** must be `pgvector/pgvector:pg16`, which every
+compose file here pins.
+
+!!! note "\"Vector store: unconfigured\" on a fresh deployment is not a fault"
+
+    The extension is created the first time a collection is written to, so
+    before the first document it is genuinely absent and the admin System page
+    and `agenticos cmd doctor` both say so. It resolves itself on the first
+    ingestion.
+
+    What is a fault is `unhealthy` there — the image does not ship pgvector at
+    all, and an upload will 500 after the bytes have been accepted. The two used
+    to read the same ([#1504](https://github.com/vstorm-co/agenticos/issues/1504)).
 
 ### Embeddings
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -265,9 +265,12 @@ compose file here pins.
     and `agenticos cmd doctor` both say so. It resolves itself on the first
     ingestion.
 
-    What is a fault is `unhealthy` there — the image does not ship pgvector at
-    all, and an upload will 500 after the bytes have been accepted. The two used
-    to read the same ([#1504](https://github.com/vstorm-co/agenticos/issues/1504)).
+    What is a fault is `unhealthy` there, and it names which of three: the image
+    does not ship pgvector; the connecting role may not create it; or the data
+    directory carries the extension row while the image it now runs on has lost
+    the library. All three fail an upload after the bytes have been accepted, and
+    all three used to read the same as a healthy first day
+    ([#1504](https://github.com/vstorm-co/agenticos/issues/1504)).
 
 ### Embeddings
 


### PR DESCRIPTION
The probe read `pg_extension` — whether the extension has been *created* in this database — and then reported a consequence of that answer it had never established:

> the pgvector extension is not installed in this database; the first document ingestion will fail trying to create it

**Two situations produce that absence, with opposite consequences.** On the `pgvector/pgvector` image every compose file here pins, nothing has been ingested yet and the first ingestion creates the extension and succeeds — every deployment on its first day. On stock Postgres it cannot be created at all and the first upload 500s *after* the bytes have been accepted, the environment gotcha CLAUDE.md opens with.

So the probe printed the second one's consequence for the first: a healthy production reporting that ingestion will fail, on a database where it will not. **And the reverse matters more** — the one state somebody must fix before their first upload read exactly like the one that fixes itself.

`pg_available_extensions` separates them, at the same cost as the read already there:

| Image ships pgvector | Created here | Status |
|---|---|---|
| yes | yes | `healthy`, with the version and the collection count |
| yes | not yet | `unconfigured` — the first ingestion creates it |
| no | — | `unhealthy`, naming `pgvector/pgvector:pg16` |

Found on `agenticos.testapp.ovh` at 0.0.375, where the message was the only thing wrong: the database is on the right image and the status (`unconfigured`) was correct — the sentence beneath it, which is what an operator acts on, was not.

`docs/configuration.md` says which of the two an operator is looking at, since "no additional configuration is needed" was true and silent about the one thing that matters.

Closes #1504