### PR TITLE
perf(agents): resolve a spec's references in one query, not one each

### DIFF
--- a/backend/app/repositories/agent.py
+++ b/backend/app/repositories/agent.py
@@ -438,6 +438,26 @@ async def get_version(
     return result.scalar_one_or_none()
 
 
+async def get_versions_by_ids(
+    db: AsyncSession, version_ids: Sequence[UUID], *, organization_id: UUID
+) -> dict[UUID, AgentVersion]:
+    """Several versions at once, by id, inside one organization.
+
+    One statement rather than a lookup per id, for a listing that needs the
+    number behind each of a page of pins. A missing id is absent from the map,
+    the same answer the per-id read gave.
+    """
+    if not version_ids:
+        return {}
+    result = await db.execute(
+        select(AgentVersion).where(
+            AgentVersion.id.in_(list(version_ids)),
+            AgentVersion.organization_id == organization_id,
+        )
+    )
+    return {version.id: version for version in result.scalars().all()}
+
+
 async def list_versions(
     db: AsyncSession, *, agent_id: UUID, organization_id: UUID, skip: int = 0, limit: int = 25
 ) -> list[AgentVersion]:

--- a/backend/app/repositories/mcp_connection.py
+++ b/backend/app/repositories/mcp_connection.py
@@ -9,6 +9,7 @@ put somebody's private token inside a published agent.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
@@ -75,6 +76,31 @@ async def get_org_scoped_by_id(
         )
     result = await db.execute(stmt)
     return result.scalar_one_or_none()
+
+
+async def get_org_scoped_by_ids(
+    db: AsyncSession, *, connection_ids: Sequence[UUID], organization_id: UUID
+) -> dict[UUID, McpConnection]:
+    """Several organization-scoped connections at once, keyed by id.
+
+    The batch form of :func:`get_org_scoped_by_id`, for a caller resolving a
+    whole spec's bindings: one statement rather than a lookup per id. Carries the
+    same two filters - `organization_id` and `scope == "org"` - so a member's
+    personal connection or another tenant's row is absent from the map exactly as
+    it is absent from the single read. A missing or unreachable id is simply not a
+    key, and the caller validates each id against the map as it did per row.
+    """
+    if not connection_ids:
+        return {}
+    result = await db.execute(
+        select(McpConnection).where(
+            McpConnection.purpose == "mcp",
+            McpConnection.id.in_(list(connection_ids)),
+            McpConnection.organization_id == organization_id,
+            McpConnection.scope == "org",
+        )
+    )
+    return {connection.id: connection for connection in result.scalars().all()}
 
 
 async def list_org_scoped(

--- a/backend/app/services/agent_environment.py
+++ b/backend/app/services/agent_environment.py
@@ -319,10 +319,11 @@ class AgentEnvironmentService:
         the environments and reading the versions; 0 names that window rather
         than crashing the whole listing on it.
         """
-        numbers: dict[UUID, int] = {}
-        for version_id in {environment.version_id for environment in environments}:
-            version = await agent_repo.get_version(
-                self.db, version_id, organization_id=ctx.organization_id
-            )
-            numbers[version_id] = version.version if version else 0
-        return numbers
+        version_ids = {environment.version_id for environment in environments}
+        found = await agent_repo.get_versions_by_ids(
+            self.db, list(version_ids), organization_id=ctx.organization_id
+        )
+        return {
+            version_id: (found[version_id].version if version_id in found else 0)
+            for version_id in version_ids
+        }

--- a/backend/app/services/agent_registry.py
+++ b/backend/app/services/agent_registry.py
@@ -1266,9 +1266,12 @@ class AgentRegistryService:
         a refusal that reads differently would map the organization's private
         collections one guess at a time.
         """
+        if not collection_ids:
+            return []
+        found = await knowledge_base_repo.get_by_ids(self.db, collection_ids)
         problems: list[str] = []
         for collection_id in collection_ids:
-            collection = await knowledge_base_repo.get_by_id(self.db, collection_id)
+            collection = found.get(collection_id)
             reachable = collection is not None and await resolve_access(
                 self.db, ctx, collection, Perm.COLLECTIONS_VIEW, resource_type=COLLECTION
             )
@@ -1328,6 +1331,13 @@ class AgentRegistryService:
         # it - `notion-` and `notion` are one prefix - so a collision is caught
         # here rather than by `_dedupe_by_prefix` dropping a server at run time.
         claimed: dict[str, list[str]] = {}
+        found = await mcp_connection_repo.get_org_scoped_by_ids(
+            self.db,
+            connection_ids=[
+                ref.connection_id for ref in refs if not isinstance(ref, PersonalMcpServerRef)
+            ],
+            organization_id=ctx.organization_id,
+        )
         for ref in refs:
             if isinstance(ref, PersonalMcpServerRef):
                 if mcp_catalog.get_entry(ref.catalog_key) is None:
@@ -1341,9 +1351,7 @@ class AgentRegistryService:
                     f"each person's own {ref.catalog_key}"
                 )
                 continue
-            connection = await mcp_connection_repo.get_org_scoped_by_id(
-                self.db, connection_id=ref.connection_id, organization_id=ctx.organization_id
-            )
+            connection = found.get(ref.connection_id)
             if connection is None:
                 # Says which of the two ways it can fail applies, because the
                 # likely one - a personal connection picked in the Builder - is
@@ -1580,10 +1588,11 @@ class AgentRegistryService:
         delegates: list[_PinnedDelegate] = []
         handles: list[str] = []
         problems: list[str] = []
+        found = await agent_repo.get_many(
+            self.db, [ref.agent_id for ref in refs], organization_id=ctx.organization_id
+        )
         for ref in refs:
-            delegate = await agent_repo.get(
-                self.db, ref.agent_id, organization_id=ctx.organization_id
-            )
+            delegate = found.get(ref.agent_id)
             if delegate is None or not await resolve_access(
                 self.db, ctx, delegate, Perm.AGENTS_RUN, resource_type=AGENT
             ):

--- a/backend/app/services/mcp_connection.py
+++ b/backend/app/services/mcp_connection.py
@@ -1557,6 +1557,13 @@ async def build_toolsets_for_agent(
     """
     specs: list[McpServerSpec] = []
     unavailable: list[UnavailablePersonalService] = []
+    found = await mcp_connection_repo.get_org_scoped_by_ids(
+        db,
+        connection_ids=[
+            ref.connection_id for ref in refs if not isinstance(ref, PersonalMcpServerRef)
+        ],
+        organization_id=organization_id,
+    )
     for ref in refs:
         if isinstance(ref, PersonalMcpServerRef):
             spec, gap = await _personal_spec(db, ref, sender_user_id=sender_user_id)
@@ -1565,9 +1572,7 @@ async def build_toolsets_for_agent(
             if gap is not None:
                 unavailable.append(UnavailablePersonalService(ref.catalog_key, gap))
             continue
-        connection = await mcp_connection_repo.get_org_scoped_by_id(
-            db, connection_id=ref.connection_id, organization_id=organization_id
-        )
+        connection = found.get(ref.connection_id)
         if connection is None or not connection.is_enabled:
             # Deleted, disabled or moved out of the organization since publish.
             # A binding that was already broken is refused at publish, where

--- a/backend/tests/test_agent_environments.py
+++ b/backend/tests/test_agent_environments.py
@@ -84,7 +84,10 @@ class TestListing:
 
         with (
             patch(_REPO) as environments,
-            patch(f"{_AGENTS}.get_version", new=AsyncMock(return_value=version)),
+            patch(
+                f"{_AGENTS}.get_versions_by_ids",
+                new=AsyncMock(return_value={version.id: version}),
+            ),
             patch(f"{_AGENTS}.count_versions", new=AsyncMock(return_value=9)),
         ):
             environments.list_for_agent = AsyncMock(return_value=[environment])
@@ -106,7 +109,7 @@ class TestListing:
 
         with (
             patch(_REPO) as environments,
-            patch(f"{_AGENTS}.get_version", new=AsyncMock(return_value=None)),
+            patch(f"{_AGENTS}.get_versions_by_ids", new=AsyncMock(return_value={})),
             patch(f"{_AGENTS}.count_versions", new=AsyncMock(return_value=0)),
         ):
             environments.list_for_agent = AsyncMock(return_value=[environment])

--- a/backend/tests/test_agent_registry.py
+++ b/backend/tests/test_agent_registry.py
@@ -96,6 +96,27 @@ def _db():
     return db
 
 
+class _AnyIdMap(dict):
+    """A batch-lookup result that answers `value` for any id it is asked for.
+
+    The reference resolvers now read a `get_by_ids` map rather than one row at a
+    time (#954); a test that used to stub the per-id read with one return value
+    keeps that shape without having to know which id the spec names.
+    """
+
+    def __init__(self, value):
+        super().__init__()
+        self._value = value
+
+    def get(self, _key, _default=None):
+        return self._value
+
+
+def _batch(value):
+    """An `AsyncMock` standing in for a `get_by_ids`, returning `value` for any id."""
+    return AsyncMock(return_value=_AnyIdMap(value))
+
+
 def _spec(name: str = "Support", **overrides) -> AgentSpec:
     return AgentSpec(name=name, **overrides)
 
@@ -1123,9 +1144,7 @@ class TestValidateSpec:
 
         with (
             patch(f"{REGISTRY_PATH}.credential_repo.get_profile", new=AsyncMock(return_value=None)),
-            patch(
-                f"{REGISTRY_PATH}.knowledge_base_repo.get_by_id", new=AsyncMock(return_value=None)
-            ),
+            patch(f"{REGISTRY_PATH}.knowledge_base_repo.get_by_ids", new=_batch(None)),
             pytest.raises(BadRequestError) as refused,
         ):
             await AgentRegistryService(_db()).validate_spec(ctx, spec)
@@ -1243,8 +1262,8 @@ class TestValidateSpec:
                 new=AsyncMock(return_value=MagicMock()),
             ),
             patch(
-                f"{REGISTRY_PATH}.knowledge_base_repo.get_by_id",
-                new=AsyncMock(return_value=foreign),
+                f"{REGISTRY_PATH}.knowledge_base_repo.get_by_ids",
+                new=_batch(foreign),
             ),
             pytest.raises(BadRequestError) as refused,
         ):
@@ -1275,8 +1294,8 @@ class TestValidateSpec:
                 new=AsyncMock(return_value=MagicMock()),
             ),
             patch(
-                f"{REGISTRY_PATH}.knowledge_base_repo.get_by_id",
-                new=AsyncMock(return_value=private),
+                f"{REGISTRY_PATH}.knowledge_base_repo.get_by_ids",
+                new=_batch(private),
             ),
             patch(
                 "app.services.access.resource_grant_repo.get_level",
@@ -1309,8 +1328,8 @@ class TestValidateSpec:
                 new=AsyncMock(return_value=MagicMock()),
             ),
             patch(
-                f"{REGISTRY_PATH}.mcp_connection_repo.get_org_scoped_by_id",
-                new=AsyncMock(return_value=None),
+                f"{REGISTRY_PATH}.mcp_connection_repo.get_org_scoped_by_ids",
+                new=_batch(None),
             ) as lookup,
             pytest.raises(BadRequestError) as refused,
         ):
@@ -1326,7 +1345,7 @@ class TestValidateSpec:
         assert str(connection_id) in problem
         assert "personal" in problem
         assert lookup.await_args.kwargs == {
-            "connection_id": connection_id,
+            "connection_ids": [connection_id],
             "organization_id": ctx.organization_id,
         }
 
@@ -1402,8 +1421,8 @@ class TestValidateSpec:
                 new=AsyncMock(return_value=MagicMock()),
             ),
             patch(
-                f"{REGISTRY_PATH}.mcp_connection_repo.get_org_scoped_by_id",
-                new=AsyncMock(return_value=connection),
+                f"{REGISTRY_PATH}.mcp_connection_repo.get_org_scoped_by_ids",
+                new=_batch(connection),
             ),
             pytest.raises(BadRequestError) as refused,
         ):
@@ -1435,8 +1454,8 @@ class TestValidateSpec:
                 new=AsyncMock(return_value=MagicMock()),
             ),
             patch(
-                f"{REGISTRY_PATH}.mcp_connection_repo.get_org_scoped_by_id",
-                new=AsyncMock(return_value=connection),
+                f"{REGISTRY_PATH}.mcp_connection_repo.get_org_scoped_by_ids",
+                new=_batch(connection),
             ),
         ):
             await AgentRegistryService(_db()).validate_spec(
@@ -1462,12 +1481,12 @@ class TestValidateSpec:
                 new=AsyncMock(return_value=MagicMock()),
             ),
             patch(
-                f"{REGISTRY_PATH}.knowledge_base_repo.get_by_id",
-                new=AsyncMock(return_value=MagicMock(organization_id=ctx.organization_id)),
+                f"{REGISTRY_PATH}.knowledge_base_repo.get_by_ids",
+                new=_batch(MagicMock(organization_id=ctx.organization_id)),
             ),
             patch(
-                f"{REGISTRY_PATH}.mcp_connection_repo.get_org_scoped_by_id",
-                new=AsyncMock(return_value=_named_connection("linear")),
+                f"{REGISTRY_PATH}.mcp_connection_repo.get_org_scoped_by_ids",
+                new=_batch(_named_connection("linear")),
             ),
             patch(
                 f"{REGISTRY_PATH}.skill_repo.get_many",
@@ -2032,9 +2051,7 @@ class TestRollback:
                 f"{REGISTRY_PATH}.credential_repo.get_profile",
                 new=AsyncMock(return_value=MagicMock()),
             ),
-            patch(
-                f"{REGISTRY_PATH}.knowledge_base_repo.get_by_id", new=AsyncMock(return_value=None)
-            ),
+            patch(f"{REGISTRY_PATH}.knowledge_base_repo.get_by_ids", new=_batch(None)),
             patch(f"{REGISTRY_PATH}.agent_repo.create_version", new=AsyncMock()) as create_version,
             pytest.raises(BadRequestError),
         ):
@@ -3399,15 +3416,15 @@ class TestOneToolPrefixPerBinding:
     async def _problems(self, refs, *, connections: dict) -> list[str]:
         ctx = _ctx()
 
-        async def lookup(_db, *, connection_id, organization_id):
-            return connections.get(connection_id)
+        async def lookup(_db, *, connection_ids, organization_id):
+            return {cid: connections[cid] for cid in connection_ids if cid in connections}
 
         with (
             patch(
                 f"{REGISTRY_PATH}.credential_repo.get_profile",
                 new=AsyncMock(return_value=MagicMock()),
             ),
-            patch(f"{REGISTRY_PATH}.mcp_connection_repo.get_org_scoped_by_id", new=lookup),
+            patch(f"{REGISTRY_PATH}.mcp_connection_repo.get_org_scoped_by_ids", new=lookup),
         ):
             try:
                 await AgentRegistryService(_db()).validate_spec(

--- a/backend/tests/test_agent_registry_subagents.py
+++ b/backend/tests/test_agent_registry_subagents.py
@@ -41,7 +41,7 @@ from app.services.agent_registry import (
     AgentRegistryService,
     slugify,
 )
-from tests.test_agent_registry import _agent, _ctx, _db, _skill, _spec, _version
+from tests.test_agent_registry import _agent, _batch, _ctx, _db, _skill, _spec, _version
 
 pytestmark = pytest.mark.anyio
 
@@ -104,13 +104,20 @@ def _published(ctx: AuthContext, name: str, *, slug: str | None = None) -> Any:
 
 
 def _agents(*agents: Any) -> AsyncMock:
-    """`agent_repo.get`, answering from a fixed set."""
+    """`agent_repo.get`, answering one row at a time from a fixed set.
+
+    The delegation *tree* walk still reads a node at a time, so this stays the
+    single read; `_repos` derives the batched `get_many` the publish-time
+    validation now uses from the same set (#954).
+    """
     rows = {agent.id: agent for agent in agents}
 
     async def get(_db_session, agent_id, *, organization_id):
         return rows.get(agent_id)
 
-    return AsyncMock(side_effect=get)
+    mock = AsyncMock(side_effect=get)
+    mock._rows = rows  # so `_repos` can build the matching `get_many`
+    return mock
 
 
 def _versions(*versions: Any) -> AsyncMock:
@@ -124,7 +131,14 @@ def _versions(*versions: Any) -> AsyncMock:
 
 
 def _repos(monkeypatch, *, agents: AsyncMock | None = None, versions: AsyncMock | None = None):
-    monkeypatch.setattr(agent_registry.agent_repo, "get", agents or _agents())
+    single = agents or _agents()
+    rows = getattr(single, "_rows", {})
+
+    async def get_many(_db_session, agent_ids, *, organization_id):
+        return {agent_id: rows[agent_id] for agent_id in agent_ids if agent_id in rows}
+
+    monkeypatch.setattr(agent_registry.agent_repo, "get", single)
+    monkeypatch.setattr(agent_registry.agent_repo, "get_many", AsyncMock(side_effect=get_many))
     monkeypatch.setattr(agent_registry.agent_repo, "get_version", versions or _versions())
 
 
@@ -207,9 +221,9 @@ class TestInlineSpecialists:
         collection_id = uuid4()
         monkeypatch.setattr(
             agent_registry.knowledge_base_repo,
-            "get_by_id",
-            AsyncMock(
-                return_value=MagicMock(
+            "get_by_ids",
+            _batch(
+                MagicMock(
                     organization_id=ctx.organization_id,
                     owner_user_id=uuid4(),
                     visibility=Visibility.PRIVATE.value,
@@ -838,7 +852,7 @@ class TestAnAgentThatDoesNotDelegate:
             _ctx(), _spec(model_profile_id=uuid4(), capabilities=[{"id": "clock"}])
         )
 
-        assert agent_registry.agent_repo.get.await_count == 0
+        assert agent_registry.agent_repo.get_many.await_count == 0
         assert agent_registry.agent_repo.get_version.await_count == 0
 
     async def test_a_delegating_agent_whose_every_reference_resolves_publishes(self, monkeypatch):
@@ -851,8 +865,8 @@ class TestAnAgentThatDoesNotDelegate:
         _repos(monkeypatch, agents=_agents(delegate), versions=_versions(version))
         monkeypatch.setattr(
             agent_registry.knowledge_base_repo,
-            "get_by_id",
-            AsyncMock(return_value=MagicMock(organization_id=ctx.organization_id)),
+            "get_by_ids",
+            _batch(MagicMock(organization_id=ctx.organization_id)),
         )
 
         await AgentRegistryService(_db()).validate_spec(

--- a/backend/tests/test_agent_runner.py
+++ b/backend/tests/test_agent_runner.py
@@ -253,6 +253,49 @@ class TestPrepare:
         assert build.call_args.kwargs["resources"]["kb_collection_names"] == ["kb_live"]
 
     @pytest.mark.anyio
+    async def test_preparing_a_run_resolves_every_collection_in_one_query(self):
+        """`_collection_names` runs on every turn, so five bound collections cost
+        one round trip rather than five serial reads at the front of it (#954)."""
+        ctx = _ctx()
+        service = AgentRunnerService(_db())
+        ids = [uuid.uuid4() for _ in range(5)]
+        collections = {
+            cid: MagicMock(organization_id=ctx.organization_id, collection_name=f"kb{n}")
+            for n, cid in enumerate(ids)
+        }
+        agent = MagicMock(id=uuid.uuid4(), current_version_id=uuid.uuid4())
+        spec = AgentSpec(name="Support", collection_ids=ids)
+
+        async def get_collections(_db, given):
+            return {cid: collections[cid] for cid in given}
+
+        kb_read = AsyncMock(side_effect=get_collections)
+        with (
+            patch.object(
+                service.registry,
+                "get_runnable_spec",
+                new=AsyncMock(return_value=(agent, spec, agent.current_version_id)),
+            ),
+            patch.object(
+                service.models, "resolve", new=AsyncMock(return_value=MagicMock(label="gpt-4.1"))
+            ),
+            patch.object(service.skills, "resolve_for_agent", new=AsyncMock(return_value=[])),
+            patch("app.services.agent_runner.knowledge_base_repo.get_by_ids", new=kb_read),
+            patch(
+                "app.services.agent_runner.agent_run_repo.create_run",
+                new=AsyncMock(return_value=MagicMock(id=uuid.uuid4())),
+            ),
+            patch("app.services.agent_runner.build_agent") as build,
+        ):
+            await service.prepare(ctx, agent.id)
+
+        kb_read.assert_awaited_once()
+        assert list(kb_read.await_args.args[1]) == ids
+        assert build.call_args.kwargs["resources"]["kb_collection_names"] == [
+            f"kb{n}" for n in range(5)
+        ]
+
+    @pytest.mark.anyio
     async def test_the_mcp_servers_the_spec_binds_reach_the_agent_that_is_built(self):
         """`mcp_servers` is part of the published contract, so it has to act.
 

--- a/backend/tests/test_mcp_connection_repo.py
+++ b/backend/tests/test_mcp_connection_repo.py
@@ -198,6 +198,38 @@ class TestGetOrgScopedById:
         assert session.statements[-1].get_execution_options()["populate_existing"] is True
 
 
+class TestGetOrgScopedByIds:
+    async def test_it_keys_the_rows_by_id_under_the_same_two_filters(self):
+        """The batch form of the single read, so a spec resolves its bindings in
+        one query - and carries the same organization and org-scope filters, so a
+        member's personal row or another tenant's is absent from the map (#954)."""
+        organization_id = uuid.uuid4()
+        first, second = _connection(), _connection()
+        session = _RecordingSession(_Result(rows=[first, second]))
+
+        found = await mcp_connection_repo.get_org_scoped_by_ids(
+            session, connection_ids=[first.id, second.id], organization_id=organization_id
+        )
+
+        assert found == {first.id: first, second.id: second}
+        params = list(_filters(session).values())
+        assert organization_id in params
+        assert "org" in params
+        assert "mcp" in params
+        sql = _sql(session).lower()
+        assert "mcp_connections.id in" in sql
+
+    async def test_an_empty_list_asks_the_database_nothing(self):
+        session = _RecordingSession()
+
+        found = await mcp_connection_repo.get_org_scoped_by_ids(
+            session, connection_ids=[], organization_id=uuid.uuid4()
+        )
+
+        assert found == {}
+        assert session.statements == []
+
+
 class TestGetByCatalogKey:
     async def test_the_lookup_is_scoped_and_prefers_the_oldest_row(self):
         """The catalog key is the identity the frontend joins a portal to its

--- a/backend/tests/test_mcp_connections.py
+++ b/backend/tests/test_mcp_connections.py
@@ -69,6 +69,22 @@ def _allow_any_url(monkeypatch) -> None:
     monkeypatch.setattr(mcp_connection_service, "validate_mcp_url", _passthrough)
 
 
+class _AnyIdMap(dict):
+    """A `get_org_scoped_by_ids` result that answers `value` for any id (#954)."""
+
+    def __init__(self, value):
+        super().__init__()
+        self._value = value
+
+    def get(self, _key, _default=None):
+        return self._value
+
+
+def _batch(value):
+    """An `AsyncMock` for `get_org_scoped_by_ids`, returning `value` for any id."""
+    return AsyncMock(return_value=_AnyIdMap(value))
+
+
 def _connection(**overrides) -> McpConnection:
     defaults: dict = {
         "id": uuid4(),
@@ -329,8 +345,8 @@ class TestToolsetsForAgent:
         bound = _connection(name="linear", url="https://mcp.linear.app/sse")
         monkeypatch.setattr(
             mcp_connection_service.mcp_connection_repo,
-            "get_org_scoped_by_id",
-            AsyncMock(return_value=bound),
+            "get_org_scoped_by_ids",
+            _batch(bound),
         )
 
         toolsets = await mcp_connection_service.build_toolsets_for_agent(
@@ -347,9 +363,9 @@ class TestToolsetsForAgent:
         self._capture(monkeypatch)
         organization_id = uuid4()
         connection_id = uuid4()
-        lookup = AsyncMock(return_value=_connection(id=connection_id))
+        lookup = _batch(_connection(id=connection_id))
         monkeypatch.setattr(
-            mcp_connection_service.mcp_connection_repo, "get_org_scoped_by_id", lookup
+            mcp_connection_service.mcp_connection_repo, "get_org_scoped_by_ids", lookup
         )
 
         await mcp_connection_service.build_toolsets_for_agent(
@@ -359,7 +375,7 @@ class TestToolsetsForAgent:
         )
 
         assert lookup.await_args.kwargs == {
-            "connection_id": connection_id,
+            "connection_ids": [connection_id],
             "organization_id": organization_id,
         }
 
@@ -370,8 +386,8 @@ class TestToolsetsForAgent:
         bound = _connection(name="github", allowed_tools=["search_issues"])
         monkeypatch.setattr(
             mcp_connection_service.mcp_connection_repo,
-            "get_org_scoped_by_id",
-            AsyncMock(return_value=bound),
+            "get_org_scoped_by_ids",
+            _batch(bound),
         )
 
         await mcp_connection_service.build_toolsets_for_agent(
@@ -397,8 +413,8 @@ class TestToolsetsForAgent:
         seen = self._capture(monkeypatch)
         monkeypatch.setattr(
             mcp_connection_service.mcp_connection_repo,
-            "get_org_scoped_by_id",
-            AsyncMock(return_value=connection),
+            "get_org_scoped_by_ids",
+            _batch(connection),
         )
 
         toolsets = await mcp_connection_service.build_toolsets_for_agent(
@@ -419,8 +435,8 @@ class TestToolsetsForAgent:
         healthy = _connection(name="github")
         monkeypatch.setattr(
             mcp_connection_service.mcp_connection_repo,
-            "get_org_scoped_by_id",
-            AsyncMock(side_effect=[broken, healthy]),
+            "get_org_scoped_by_ids",
+            AsyncMock(return_value={broken.id: broken, healthy.id: healthy}),
         )
 
         await mcp_connection_service.build_toolsets_for_agent(
@@ -461,8 +477,8 @@ class TestWhichToolsABindingMayCall:
         bound = _connection(name="notion", allowed_tools=on_connection)
         monkeypatch.setattr(
             mcp_connection_service.mcp_connection_repo,
-            "get_org_scoped_by_id",
-            AsyncMock(return_value=bound),
+            "get_org_scoped_by_ids",
+            _batch(bound),
         )
 
         await mcp_connection_service.build_toolsets_for_agent(
@@ -722,8 +738,8 @@ class TestEachPersonsOwnAccount:
         org = _connection(name="linear", url="https://mcp.linear.app/sse", scope="org")
         monkeypatch.setattr(
             mcp_connection_service.mcp_connection_repo,
-            "get_org_scoped_by_id",
-            AsyncMock(return_value=org),
+            "get_org_scoped_by_ids",
+            _batch(org),
         )
         self._owns(monkeypatch, [])
 

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -407,7 +407,7 @@ Python quality queries the suite runs, which is the wrong trade for a repository
 whose argument is that its value is in what it refuses. #220 holds the exclusion
 to apply on the day there is somewhere to apply it.
 
-### Seven findings already adjudicated
+### Eight findings already adjudicated
 
 These have been read. The query is wrong about this codebase, and the reason does
 not change per occurrence — so **resolve the thread and point at this section.**
@@ -423,6 +423,7 @@ justification each time.
 | `py/unnecessary-lambda` | `lambda: service` in a `dependency_overrides` entry | The override has to be a *callable returning the value*. Passing the object directly is the bug the query is recommending: a `MagicMock` is itself callable, so FastAPI would call it and inject its return value instead of the mock |
 | `py/unused-global-variable` | a module global only ever written through `global` | The query reads assignment without a *read* in the same scope as dead. `model_catalog._listing_loop` is written in one function and compared in another, three lines apart, which is the whole mechanism for noticing the loop changed |
 | Wrong name for an argument | a call in a test that deliberately passes an unsupported keyword | The assertion *is* the `TypeError`. `test_channel_tools.py` calls `history(thread_id=...)` inside `pytest.raises(TypeError)` with a `# type: ignore[call-arg]` beside it, because a bound directory refusing to be re-pointed is the behaviour under test |
+| `__eq__` not overridden when adding attributes | a test double subclassing `dict` that stores state (`_AnyIdMap._value`) but keeps the inherited `__eq__` | The double is a stub return value read only through `.get()`; no two instances are ever compared, so the `__eq__` the query wants would be dead code about an equality this object never takes part in. It answers one value for any id because the batched `get_by_ids` reads it that way (#954) |
 
 The first is not a test-file quirk. Fifteen statements under `backend/` are that
 shape, and the five in production code — `agent_session.py` and the Slack, Telegram


### PR DESCRIPTION
## What this fixes

Six loops resolved a list of ids by fetching one row at a time (AUD-008, #954). The **hot** one — `AgentRunnerService._collection_names`, run inside `prepare` on **every turn** — was already batched on `main`; the remaining five are publish-time and admin-path, where N is small but the habit is the same.

## The fix

Each loop now reads its whole list in one query and validates over the returned map. **The tenant check and the "reference deleted after publish degrades the agent's reach rather than failing the run" branches are unchanged** — they just read from a dict.

| Loop | Reads through |
|---|---|
| `AgentRegistryService._collection_problems` (publish) | `knowledge_base_repo.get_by_ids` (existing) |
| `AgentRegistryService._mcp_problems` (publish) | `mcp_connection_repo.get_org_scoped_by_ids` (new) |
| `AgentRegistryService._resolve_delegates` (publish) | `agent_repo.get_many` (existing) |
| `mcp_connection._org_or_personal_specs` (toolset build) | `mcp_connection_repo.get_org_scoped_by_ids` (new) |
| `AgentEnvironmentService` listing | `agent_repo.get_versions_by_ids` (new) |

The two new repo reads are each the plural of an existing single read and carry the **same filters** (`organization_id`, `scope == "org"` for the MCP one), so a member's personal connection or another tenant's row is absent from the map exactly as it was absent from the single read. `agent_repo.get` and `get_many` already filter identically, so the delegate swap is behaviour-preserving.

## Verification

- The existing publish-validation, toolset-building and environment-listing tests pass **unchanged** against the batched reads (their per-id repo stubs became `get_by_ids`/`get_many` stubs returning the same rows) — the refusal and degradation behaviour is what those tests assert.
- New repo tests cover `get_org_scoped_by_ids` empty and populated, with the org/scope/purpose filters.
- **New run-path regression test** (`test_preparing_a_run_resolves_every_collection_in_one_query`): preparing a run with five bound collections awaits the collection read exactly **once**.
- `make check` green.

## Deliberately not batched

Two per-item reads on delegate paths are left as they are, out of #954's six flat loops: the **delegation tree** walk (`delegation_tree`) reads a node at a time because it is a recursive traversal, not a flat list; and `_resolve_pins` still reads one *version* per resolved delegate. Both are publish-time or tree-view, small N. Noted rather than folded in to keep this change a faithful batching of the six loops the audit named.

Closes #954
