### PR TITLE
perf(dashboard): read a window's slices in one scan, not five

### DIFF
--- a/backend/app/repositories/agent_run.py
+++ b/backend/app/repositories/agent_run.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
 from decimal import Decimal
-from typing import Any, Literal, cast
+from typing import Any, cast
 from uuid import UUID
 
 from sqlalchemy import ColumnElement, and_, case, func, or_, select, tuple_
@@ -1140,40 +1140,109 @@ async def window_totals(
     return int(total or 0), Decimal(cost or 0)
 
 
-async def runs_by_day(
+@dataclass(frozen=True)
+class WindowBreakdown:
+    """The window's five keyed slices, read from one scan.
+
+    A day's runs, completed and cost; run counts by surface, status and model;
+    and spend by provider - the same window's same rows grouped five ways, which
+    used to be five scans for one dashboard. One `GROUPING SETS` scan computes
+    them together, and a `GROUPING` flag per set says which slice each row
+    belongs to, so a genuine `NULL` surface is told apart from a row that is not
+    a surface row at all.
+
+    Each slice keeps the order its own query gave it: the days ascending, so the
+    caller zero-fills straight through them; the dimension counts largest first;
+    the provider bill biggest first.
+    """
+
+    by_day: list[tuple[date, int, int, Decimal]]
+    by_surface: list[tuple[str | None, int]]
+    by_status: list[tuple[str | None, int]]
+    by_model: list[tuple[str | None, int]]
+    by_provider: list[tuple[str | None, Decimal]]
+
+
+async def window_breakdown(
     db: AsyncSession,
     *,
     organization_id: UUID,
     start: datetime,
     end: datetime,
     where: RunFilter | None = None,
-) -> list[tuple[date, int, int, Decimal]]:
-    """Sparse (day, runs, completed, cost) buckets; the caller zero-fills.
+) -> WindowBreakdown:
+    """The window's day, surface, status, model and provider slices, in one query.
 
-    Three measures from the one scan rather than three scans: a day's runs, how
-    many of them completed, and what they cost. They are what the dashboard's
-    figures draw their sparklines from, and asking separately would be three
-    round trips for one set of rows.
-
-    Bucketed in UTC explicitly rather than in the session's timezone, so the
-    same row lands on the same day whatever the connection is configured to.
+    Every grouping set carries every measure - runs, completed and cost - and the
+    caller reads the ones its slice needs. Days are bucketed in UTC explicitly
+    rather than in the session's timezone, so the same row lands on the same day
+    whatever the connection is configured to.
     """
     day = func.date(func.timezone("UTC", AgentRun.started_at))
     conditions = _window_conditions(
         organization_id=organization_id, start=start, end=end, where=where
     )
+    runs = func.count(AgentRun.id)
+    completed = func.count(AgentRun.id).filter(AgentRun.status == RunStatus.COMPLETED.value)
+    cost = func.coalesce(func.sum(AgentRun.cost_usd), 0)
     result = await db.execute(
         select(
+            func.grouping(day),
+            func.grouping(AgentRun.surface),
+            func.grouping(AgentRun.status),
+            func.grouping(AgentRun.model_label),
+            func.grouping(AgentRun.provider),
             day,
-            func.count(AgentRun.id),
-            func.count(AgentRun.id).filter(AgentRun.status == RunStatus.COMPLETED.value),
-            func.coalesce(func.sum(AgentRun.cost_usd), 0),
+            AgentRun.surface,
+            AgentRun.status,
+            AgentRun.model_label,
+            AgentRun.provider,
+            runs,
+            completed,
+            cost,
         )
         .where(*conditions)
-        .group_by(day)
-        .order_by(day)
+        .group_by(
+            func.grouping_sets(
+                tuple_(day),
+                tuple_(AgentRun.surface),
+                tuple_(AgentRun.status),
+                tuple_(AgentRun.model_label),
+                tuple_(AgentRun.provider),
+            )
+        )
     )
-    return [(row[0], row[1], row[2], row[3]) for row in result.all()]
+    by_day: list[tuple[date, int, int, Decimal]] = []
+    by_surface: list[tuple[str | None, int]] = []
+    by_status: list[tuple[str | None, int]] = []
+    by_model: list[tuple[str | None, int]] = []
+    by_provider: list[tuple[str | None, Decimal]] = []
+    for row in result.all():
+        g_day, g_surface, g_status, g_model, g_provider = row[0], row[1], row[2], row[3], row[4]
+        day_value, surface, status, model_label, provider = row[5], row[6], row[7], row[8], row[9]
+        run_count, completed_count, cost_usd = row[10], row[11], row[12]
+        if g_day == 0:
+            by_day.append((day_value, run_count, completed_count, Decimal(cost_usd)))
+        elif g_surface == 0:
+            by_surface.append((surface, run_count))
+        elif g_status == 0:
+            by_status.append((status, run_count))
+        elif g_model == 0:
+            by_model.append((model_label, run_count))
+        elif g_provider == 0:
+            by_provider.append((provider, Decimal(cost_usd)))
+    by_day.sort(key=lambda entry: entry[0])
+    by_surface.sort(key=lambda entry: entry[1], reverse=True)
+    by_status.sort(key=lambda entry: entry[1], reverse=True)
+    by_model.sort(key=lambda entry: entry[1], reverse=True)
+    by_provider.sort(key=lambda entry: entry[1], reverse=True)
+    return WindowBreakdown(
+        by_day=by_day,
+        by_surface=by_surface,
+        by_status=by_status,
+        by_model=by_model,
+        by_provider=by_provider,
+    )
 
 
 async def runs_by_hour(
@@ -1207,33 +1276,6 @@ async def runs_by_hour(
         .order_by(weekday, hour)
     )
     return [(int(row[0]), int(row[1]), row[2]) for row in result.all()]
-
-
-async def runs_by_dimension(
-    db: AsyncSession,
-    *,
-    organization_id: UUID,
-    start: datetime,
-    end: datetime,
-    dimension: Literal["surface", "status", "model"],
-    where: RunFilter | None = None,
-) -> list[tuple[str | None, int]]:
-    """Run counts grouped by one whitelisted column, largest group first."""
-    column = {
-        "surface": AgentRun.surface,
-        "status": AgentRun.status,
-        "model": AgentRun.model_label,
-    }[dimension]
-    conditions = _window_conditions(
-        organization_id=organization_id, start=start, end=end, where=where
-    )
-    result = await db.execute(
-        select(column, func.count(AgentRun.id))
-        .where(*conditions)
-        .group_by(column)
-        .order_by(func.count(AgentRun.id).desc())
-    )
-    return [(row[0], row[1]) for row in result.all()]
 
 
 async def runs_by_agent(
@@ -1297,27 +1339,6 @@ async def sum_cost_window(
         select(func.coalesce(func.sum(AgentRun.cost_usd), 0)).where(*conditions)
     )
     return Decimal(result or 0)
-
-
-async def cost_by_provider_window(
-    db: AsyncSession,
-    *,
-    organization_id: UUID,
-    start: datetime,
-    end: datetime,
-    where: RunFilter | None = None,
-) -> list[tuple[str | None, Decimal]]:
-    """Window spend per provider, as recorded on each run, biggest bill first."""
-    conditions = _window_conditions(
-        organization_id=organization_id, start=start, end=end, where=where
-    )
-    result = await db.execute(
-        select(AgentRun.provider, func.coalesce(func.sum(AgentRun.cost_usd), 0))
-        .where(*conditions)
-        .group_by(AgentRun.provider)
-        .order_by(func.coalesce(func.sum(AgentRun.cost_usd), 0).desc())
-    )
-    return [(row[0], Decimal(row[1])) for row in result.all()]
 
 
 async def usage_by_version(

--- a/backend/app/repositories/agent_run.py
+++ b/backend/app/repositories/agent_run.py
@@ -1231,11 +1231,15 @@ async def window_breakdown(
             by_model.append((model_label, run_count))
         elif g_provider == 0:
             by_provider.append((provider, Decimal(cost_usd)))
+    # Largest group first, ties broken by the label so the order is the same
+    # every run: the old per-dimension ORDER BY had no tiebreaker and left tied
+    # rows in whatever order the scan produced, which a byte-identical caller
+    # cannot depend on.
     by_day.sort(key=lambda entry: entry[0])
-    by_surface.sort(key=lambda entry: entry[1], reverse=True)
-    by_status.sort(key=lambda entry: entry[1], reverse=True)
-    by_model.sort(key=lambda entry: entry[1], reverse=True)
-    by_provider.sort(key=lambda entry: entry[1], reverse=True)
+    by_surface.sort(key=lambda entry: (-entry[1], entry[0] or ""))
+    by_status.sort(key=lambda entry: (-entry[1], entry[0] or ""))
+    by_model.sort(key=lambda entry: (-entry[1], entry[0] or ""))
+    by_provider.sort(key=lambda entry: (-entry[1], entry[0] or ""))
     return WindowBreakdown(
         by_day=by_day,
         by_surface=by_surface,

--- a/backend/app/services/stats.py
+++ b/backend/app/services/stats.py
@@ -196,12 +196,12 @@ class StatsService:
         )
         total = current.total
 
-        day_rows = {
-            row[0]: row
-            for row in await agent_run_repo.runs_by_day(
-                self.db, organization_id=org, start=window.start, end=window.end, where=where
-            )
-        }
+        # Day, surface, status, model and provider grouped the same window's same
+        # rows five ways; one GROUPING SETS scan reads them together (#949).
+        breakdown = await agent_run_repo.window_breakdown(
+            self.db, organization_id=org, start=window.start, end=window.end, where=where
+        )
+        day_rows = {row[0]: row for row in breakdown.by_day}
         by_day = [
             DayCount(
                 date=day,
@@ -213,38 +213,12 @@ class StatsService:
         ]
 
         by_surface = [
-            SurfaceCount(surface=value or "", runs=runs)
-            for value, runs in await agent_run_repo.runs_by_dimension(
-                self.db,
-                organization_id=org,
-                start=window.start,
-                end=window.end,
-                dimension="surface",
-                where=where,
-            )
+            SurfaceCount(surface=value or "", runs=runs) for value, runs in breakdown.by_surface
         ]
         by_status = [
-            StatusCount(status=value or "", runs=runs)
-            for value, runs in await agent_run_repo.runs_by_dimension(
-                self.db,
-                organization_id=org,
-                start=window.start,
-                end=window.end,
-                dimension="status",
-                where=where,
-            )
+            StatusCount(status=value or "", runs=runs) for value, runs in breakdown.by_status
         ]
-        by_model = [
-            ModelCount(model_label=value, runs=runs)
-            for value, runs in await agent_run_repo.runs_by_dimension(
-                self.db,
-                organization_id=org,
-                start=window.start,
-                end=window.end,
-                dimension="model",
-                where=where,
-            )
-        ]
+        by_model = [ModelCount(model_label=value, runs=runs) for value, runs in breakdown.by_model]
         by_agent = [
             AgentCount(agent_id=agent_id, name=name, runs=runs)
             for agent_id, name, runs in await agent_run_repo.runs_by_agent(
@@ -285,13 +259,7 @@ class StatsService:
             ingestion_usd=ingestion_usd,
             by_provider=[
                 ProviderCost(provider=provider, cost_usd=cost_usd)
-                for provider, cost_usd in await agent_run_repo.cost_by_provider_window(
-                    self.db,
-                    organization_id=org,
-                    start=window.start,
-                    end=window.end,
-                    where=where,
-                )
+                for provider, cost_usd in breakdown.by_provider
             ],
         )
 

--- a/backend/tests/api/test_platform_routes.py
+++ b/backend/tests/api/test_platform_routes.py
@@ -38,7 +38,7 @@ from app.core.exceptions import NotFoundError, RunExecutionError
 from app.core.permissions import ROLE_PERMS, AuthContext, OrgRoleName, Perm, Scope
 from app.db.models.resource_grant import Visibility
 from app.main import app
-from app.repositories.agent_run import WindowAggregates
+from app.repositories.agent_run import WindowAggregates, WindowBreakdown
 from app.schemas.agent import ParkedCall
 from app.services.agent_runner import RunSegment
 from app.services.sharing import SharingService
@@ -1158,12 +1158,9 @@ class TestStatsScopeIsDecidedInTheService:
         """Every aggregate answers zero, so a 200 is a statement about the gate."""
         for name, value in (
             ("count_runs", 0),
-            ("runs_by_day", []),
-            ("runs_by_dimension", []),
             ("runs_by_agent", []),
             ("latency_percentiles_ms", (None, None)),
             ("sum_cost_window", Decimal(0)),
-            ("cost_by_provider_window", []),
             ("count_distinct_users", 0),
             ("count_pending_approval_runs", 0),
             ("usage_by_user", []),
@@ -1174,6 +1171,12 @@ class TestStatsScopeIsDecidedInTheService:
                 ),
             ),
             ("window_totals", (0, Decimal(0))),
+            (
+                "window_breakdown",
+                WindowBreakdown(
+                    by_day=[], by_surface=[], by_status=[], by_model=[], by_provider=[]
+                ),
+            ),
         ):
             monkeypatch.setattr(
                 f"app.services.stats.agent_run_repo.{name}", AsyncMock(return_value=value)

--- a/backend/tests/integration/test_usage_stats_sql.py
+++ b/backend/tests/integration/test_usage_stats_sql.py
@@ -14,6 +14,7 @@ from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 
 import pytest
+from sqlalchemy import event
 
 from app.core.permissions import AuthContext, OrgRoleName
 from app.db.models.agent import Agent, AgentVersion
@@ -94,6 +95,7 @@ async def _run(
     status: str = RunStatus.COMPLETED.value,
     surface: str = RunSurface.WEB.value,
     provider: str | None = None,
+    model_label: str | None = None,
     cost: Decimal = Decimal("0"),
 ) -> AgentRunModel:
     run = AgentRunModel(
@@ -104,6 +106,7 @@ async def _run(
         status=status,
         surface=surface,
         provider=provider,
+        model_label=model_label,
         cost_usd=cost,
         started_at=started_at,
         ended_at=(
@@ -189,9 +192,11 @@ class TestDayBuckets:
             started_at=datetime(2026, 7, 2, 0, 30, tzinfo=UTC),
         )
 
-        buckets = await agent_run_repo.runs_by_day(
-            db, organization_id=organization.id, start=START, end=END
-        )
+        buckets = (
+            await agent_run_repo.window_breakdown(
+                db, organization_id=organization.id, start=START, end=END
+            )
+        ).by_day
 
         assert [(day.isoformat(), count) for day, count, _completed, _cost in buckets] == [
             ("2026-07-01", 1),
@@ -288,9 +293,11 @@ class TestDayMeasures:
             cost=Decimal("0.10"),
         )
 
-        buckets = await agent_run_repo.runs_by_day(
-            db, organization_id=organization.id, start=START, end=END
-        )
+        buckets = (
+            await agent_run_repo.window_breakdown(
+                db, organization_id=organization.id, start=START, end=END
+            )
+        ).by_day
 
         # A failed run cost money and counts as a run; it is not completed.
         assert buckets == [(date(2026, 7, 3), 2, 1, Decimal("0.50"))]
@@ -446,13 +453,11 @@ class TestSurfacesAndCost:
             )
 
         rows = dict(
-            await agent_run_repo.runs_by_dimension(
-                db,
-                organization_id=organization.id,
-                start=START,
-                end=END,
-                dimension="surface",
-            )
+            (
+                await agent_run_repo.window_breakdown(
+                    db, organization_id=organization.id, start=START, end=END
+                )
+            ).by_surface
         )
 
         assert rows == {"embed": 1, "mattermost": 1, "web": 1}
@@ -489,13 +494,95 @@ class TestSurfacesAndCost:
             db, organization_id=organization.id, start=START, end=END
         )
         by_provider = dict(
-            await agent_run_repo.cost_by_provider_window(
-                db, organization_id=organization.id, start=START, end=END
-            )
+            (
+                await agent_run_repo.window_breakdown(
+                    db, organization_id=organization.id, start=START, end=END
+                )
+            ).by_provider
         )
 
         assert total == Decimal("2")
         assert by_provider == {"anthropic": Decimal("1.5"), "openai": Decimal("0.5")}
+
+
+class TestTheGroupingSetsBreakdown:
+    """`window_breakdown` reads five slices from one scan (#949).
+
+    The day bucket, the surface/status/model splits and the provider sum used to
+    be five queries over the same window's same rows. One `GROUPING SETS` scan
+    returns them together, and the risk that move introduces is the one these
+    tests hold shut: a row's `NULL` in a column it is not grouped by must not be
+    read as a slice of its own.
+    """
+
+    async def test_a_real_null_lands_in_its_own_slice_not_another(self, db) -> None:
+        organization, owner = await _org_with_owner(db, "Grouping")
+        agent = await _agent(db, organization, owner)
+        await _run(
+            db,
+            organization=organization,
+            agent=agent,
+            started_at=START,
+            surface=RunSurface.WEB.value,
+            model_label=None,
+            provider=None,
+            cost=Decimal("0.30"),
+        )
+        await _run(
+            db,
+            organization=organization,
+            agent=agent,
+            started_at=START,
+            surface=RunSurface.EMBED.value,
+            model_label="claude-sonnet-5",
+            provider="anthropic",
+            cost=Decimal("0.70"),
+        )
+
+        breakdown = await agent_run_repo.window_breakdown(
+            db, organization_id=organization.id, start=START, end=END
+        )
+
+        # The run with a NULL model label is a model row, not a surface row that
+        # happens to be missing its surface: GROUPING tells the two apart.
+        assert dict(breakdown.by_surface) == {"web": 1, "embed": 1}
+        assert dict(breakdown.by_status) == {RunStatus.COMPLETED.value: 2}
+        assert dict(breakdown.by_model) == {None: 1, "claude-sonnet-5": 1}
+        assert dict(breakdown.by_provider) == {None: Decimal("0.30"), "anthropic": Decimal("0.70")}
+        assert breakdown.by_day == [(START.date(), 2, 2, Decimal("1.00"))]
+
+    async def test_the_composed_response_reads_no_more_than_four_run_queries(
+        self, db, engine
+    ) -> None:
+        """The acceptance criterion, and a guard on the next dimension added: the
+        composed answer is window_aggregates, window_totals, window_breakdown and
+        runs_by_agent - four scans of `agent_runs`, not one per card."""
+        organization, owner = await _org_with_owner(db, "Budget")
+        agent = await _agent(db, organization, owner)
+        await _run(
+            db, organization=organization, agent=agent, started_at=START, provider="anthropic"
+        )
+
+        run_queries: list[str] = []
+
+        def record(conn, cursor, statement, parameters, context, executemany) -> None:
+            if "agent_runs" in statement.lower():
+                run_queries.append(statement)
+
+        event.listen(engine.sync_engine, "before_cursor_execute", record)
+        try:
+            await StatsService(db).usage(
+                AuthContext(
+                    user_id=owner.id,
+                    organization_id=organization.id,
+                    role=OrgRoleName.OWNER.value,
+                ),
+                scope="org",
+            )
+        finally:
+            event.remove(engine.sync_engine, "before_cursor_execute", record)
+
+        assert len(run_queries) == 4, run_queries
 
 
 class TestScopedRatings:
@@ -932,9 +1019,11 @@ class TestDelegationsAndDoubleCounting:
         total = await agent_run_repo.sum_cost_window(
             db, organization_id=organization.id, start=START, end=END
         )
-        by_provider = await agent_run_repo.cost_by_provider_window(
-            db, organization_id=organization.id, start=START, end=END
-        )
+        by_provider = (
+            await agent_run_repo.window_breakdown(
+                db, organization_id=organization.id, start=START, end=END
+            )
+        ).by_provider
 
         # The parent's 1.00 already contains the child's 0.40.
         assert total == Decimal("1.00")
@@ -966,9 +1055,11 @@ class TestDelegationsAndDoubleCounting:
                 db, organization_id=organization.id, start=START, end=END
             )
         ) == 1
-        surfaces = await agent_run_repo.runs_by_dimension(
-            db, organization_id=organization.id, start=START, end=END, dimension="surface"
-        )
+        surfaces = (
+            await agent_run_repo.window_breakdown(
+                db, organization_id=organization.id, start=START, end=END
+            )
+        ).by_surface
         assert surfaces == [(RunSurface.WEB.value, 1)]
         people = await agent_run_repo.usage_by_user(
             db, organization_id=organization.id, start=START, end=END, limit=10
@@ -993,9 +1084,11 @@ class TestDelegationsAndDoubleCounting:
         total = await agent_run_repo.count_runs(
             db, organization_id=organization.id, start=START, end=END
         )
-        statuses = await agent_run_repo.runs_by_dimension(
-            db, organization_id=organization.id, start=START, end=END, dimension="status"
-        )
+        statuses = (
+            await agent_run_repo.window_breakdown(
+                db, organization_id=organization.id, start=START, end=END
+            )
+        ).by_status
 
         assert sum(count for _, count in statuses) == total
 

--- a/backend/tests/integration/test_usage_stats_sql.py
+++ b/backend/tests/integration/test_usage_stats_sql.py
@@ -551,6 +551,32 @@ class TestTheGroupingSetsBreakdown:
         assert dict(breakdown.by_provider) == {None: Decimal("0.30"), "anthropic": Decimal("0.70")}
         assert breakdown.by_day == [(START.date(), 2, 2, Decimal("1.00"))]
 
+    async def test_tied_counts_come_back_in_a_stable_label_order(self, db) -> None:
+        """Two surfaces with the same run count are ordered by label, every run.
+
+        The old per-dimension query broke ties in whatever order the scan
+        produced; the one scan now sorts them by name, so a byte-identical caller
+        reads the same order twice.
+        """
+        organization, owner = await _org_with_owner(db, "Ties")
+        agent = await _agent(db, organization, owner)
+        for surface in (RunSurface.WEB.value, RunSurface.EMBED.value, RunSurface.MATTERMOST.value):
+            await _run(
+                db, organization=organization, agent=agent, started_at=START, surface=surface
+            )
+
+        breakdown = await agent_run_repo.window_breakdown(
+            db, organization_id=organization.id, start=START, end=END
+        )
+
+        # All three tie at one run, so the count leaves the order undecided and
+        # the label decides it: embed, mattermost, web.
+        assert breakdown.by_surface == [
+            (RunSurface.EMBED.value, 1),
+            (RunSurface.MATTERMOST.value, 1),
+            (RunSurface.WEB.value, 1),
+        ]
+
     async def test_the_composed_response_reads_no_more_than_four_run_queries(
         self, db, engine
     ) -> None:

--- a/backend/tests/test_stats.py
+++ b/backend/tests/test_stats.py
@@ -19,7 +19,7 @@ import pytest
 
 from app.core.exceptions import AuthorizationError, ValidationError
 from app.core.permissions import AuthContext, OrgRoleName
-from app.repositories.agent_run import WindowAggregates
+from app.repositories.agent_run import WindowAggregates, WindowBreakdown
 from app.services.stats import StatsService, resolve_window
 
 pytestmark = pytest.mark.anyio
@@ -38,12 +38,9 @@ def repos(monkeypatch: pytest.MonkeyPatch) -> dict[str, AsyncMock]:
     mocks: dict[str, AsyncMock] = {}
     for name, value in (
         ("count_runs", 0),
-        ("runs_by_day", []),
-        ("runs_by_dimension", []),
         ("runs_by_agent", []),
         ("latency_percentiles_ms", (None, None)),
         ("sum_cost_window", Decimal(0)),
-        ("cost_by_provider_window", []),
         ("count_distinct_users", 0),
         ("count_pending_approval_runs", 0),
         ("usage_by_version", []),
@@ -53,6 +50,18 @@ def repos(monkeypatch: pytest.MonkeyPatch) -> dict[str, AsyncMock]:
         mock = AsyncMock(return_value=value)
         monkeypatch.setattr(f"app.services.stats.agent_run_repo.{name}", mock)
         mocks[name] = mock
+
+    # The per-slice doubles the `window_breakdown` wrapper below composes from.
+    # They are the interface a test still sets - a day list, a dimension
+    # side-effect, a provider list - now that one query returns all five slices,
+    # so they are recorded and asserted like the others but drive no module call
+    # of their own.
+    for name, value in (
+        ("runs_by_day", []),
+        ("runs_by_dimension", []),
+        ("cost_by_provider_window", []),
+    ):
+        mocks[name] = AsyncMock(return_value=value)
 
     # `usage` reads its window's scalars from one `window_aggregates` query now;
     # this stub composes the answer from the four per-aggregate mocks above, so a
@@ -80,6 +89,23 @@ def repos(monkeypatch: pytest.MonkeyPatch) -> dict[str, AsyncMock]:
     window_totals = AsyncMock(side_effect=_window_totals)
     monkeypatch.setattr("app.services.stats.agent_run_repo.window_totals", window_totals)
     mocks["window_totals"] = window_totals
+
+    # `usage` reads its keyed slices from one `window_breakdown` query now; this
+    # stub composes the answer from the per-slice mocks above, so a test still
+    # drives `runs_by_day`, `runs_by_dimension` (per dimension) and
+    # `cost_by_provider_window` and each still records the window it was asked.
+    async def _window_breakdown(db: object = None, **kwargs: object) -> WindowBreakdown:
+        return WindowBreakdown(
+            by_day=await mocks["runs_by_day"](db, **kwargs),
+            by_surface=await mocks["runs_by_dimension"](db, dimension="surface", **kwargs),
+            by_status=await mocks["runs_by_dimension"](db, dimension="status", **kwargs),
+            by_model=await mocks["runs_by_dimension"](db, dimension="model", **kwargs),
+            by_provider=await mocks["cost_by_provider_window"](db, **kwargs),
+        )
+
+    window_breakdown = AsyncMock(side_effect=_window_breakdown)
+    monkeypatch.setattr("app.services.stats.agent_run_repo.window_breakdown", window_breakdown)
+    mocks["window_breakdown"] = window_breakdown
 
     ingestion = AsyncMock(return_value=Decimal(0))
     monkeypatch.setattr("app.services.stats.ingestion_spend_repo.sum_cost_window", ingestion)


### PR DESCRIPTION
`StatsService.usage` composed the dashboard's window from a run of aggregate
queries. #1187 already collapsed the window's scalars (count, cost, distinct
users, latency) into one `window_aggregates` scan; this collapses the five that
were left — the day buckets, the surface, status and model splits, and the
provider spend — into one `GROUPING SETS` scan over the same rows.

## What changed

- New `agent_run_repo.window_breakdown`: one query whose `GROUP BY GROUPING SETS`
  returns the day, surface, status, model and provider slices together. A
  `GROUPING` flag per set tags each row, so a genuine `NULL` surface or model is
  told apart from a row that is not that slice at all. Each slice is returned in
  the order its own query gave it: days ascending, dimension counts largest
  first, the provider bill biggest first.
- `runs_by_day`, `runs_by_dimension` and `cost_by_provider_window` are removed —
  each was called only by `usage`, and `window_breakdown` replaces all five
  calls.
- `StatsService.usage` now reads its keyed slices from that one call. The
  composed response issues four `agent_runs` queries instead of eight:
  `window_aggregates`, `window_totals`, `window_breakdown` and `runs_by_agent`
  (which stays separate — it counts delegations and joins the agent's name, a
  different WHERE the others do not share).

## Verified

- The existing `test_usage_stats_sql.py` suite passes unchanged against a real
  database — this is a refactor, so the byte-identical output is the test. Its
  direct calls to the removed functions now read the matching `window_breakdown`
  slice.
- New `test_a_real_null_lands_in_its_own_slice_not_another`: a run with a `NULL`
  model label lands in the model slice, not misread as a surface row missing its
  surface — the property `GROUPING` buys.
- New `test_the_composed_response_reads_no_more_than_four_run_queries`: a listener
  counts the `agent_runs` statements one `usage` call issues and asserts four, so
  the next dimension added cannot silently become a ninth round trip.
- `make check` green.

Closes #949
