### PR TITLE
fix(onboarding): keep the Agents "?" walk offering create-agent

### DIFF
--- a/frontend/src/components/onboarding/creation-offer.integration.test.tsx
+++ b/frontend/src/components/onboarding/creation-offer.integration.test.tsx
@@ -34,7 +34,14 @@ function renderOffer(
 
 beforeEach(() => {
   rig.can = () => true;
-  useOnboardingStore.setState({ isOpen: false, index: 0, mode: "tour", flowId: null, offer: null });
+  useOnboardingStore.setState({
+    isOpen: false,
+    index: 0,
+    mode: "tour",
+    flowId: null,
+    offer: null,
+    offerFromTour: false,
+  });
 });
 
 describe("CreationOffer", () => {
@@ -90,27 +97,49 @@ describe("CreationOffer", () => {
   });
 
   it("does not offer a first agent to an organization that already has one", () => {
-    // This is what the first-run tour (`mode: "tour"`) ends with, having just
-    // walked the reader through an existing agent's builder in detail — so to an
-    // organization with six agents it answers a question nobody asked.
-    useOnboardingStore.setState({ offer: "create-agent", mode: "tour" });
+    // This is what the first-run tour ends with (`offerFromTour: true`), having
+    // just walked the reader through an existing agent's builder in detail — so to
+    // an organization with six agents it answers a question nobody asked.
+    useOnboardingStore.setState({ offer: "create-agent", offerFromTour: true });
     renderOffer(<CreationOffer />, { agents: 6 });
     expect(screen.queryByText("Create your first agent?")).toBeNull();
   });
 
   it("offers it where the organization has none", () => {
-    useOnboardingStore.setState({ offer: "create-agent", mode: "tour" });
+    useOnboardingStore.setState({ offer: "create-agent", offerFromTour: true });
     renderOffer(<CreationOffer />, { agents: 0 });
     expect(screen.getByText("Create your first agent?")).toBeInTheDocument();
   });
 
   it("still offers create-agent from the Agents ? walk when the org has agents", () => {
-    // The explicit help walk (`mode: "page"`) ends on the same offer, and asking
-    // to build one is the whole point of it — so unlike the first-run tour
+    // The explicit help walk ends on the same offer (`offerFromTour: false`), and
+    // asking to build one is the whole point of it — so unlike the first-run tour
     // ending, it is not gated on the agent count (#910).
-    useOnboardingStore.setState({ offer: "create-agent", mode: "page" });
+    useOnboardingStore.setState({ offer: "create-agent", offerFromTour: false });
     renderOffer(<CreationOffer />, { agents: 6 });
     expect(screen.getByText("Create your first agent?")).toBeInTheDocument();
+  });
+
+  it("keeps a suppressed tour offer suppressed once a later walk flips the mode", () => {
+    // A tour offer suppressed for an org with agents lingers in the store; opening
+    // a "?" walk sets `mode: "page"` without clearing it. Reading live `mode`
+    // would resurface the stale dialog over the new walk, so the origin is
+    // snapshotted at offer time and the suppression holds regardless of `mode`.
+    useOnboardingStore.setState({ offer: "create-agent", offerFromTour: true, mode: "page" });
+    renderOffer(<CreationOffer />, { agents: 6 });
+    expect(screen.queryByText("Create your first agent?")).toBeNull();
+  });
+
+  it("snapshots the tour as the offer's origin when the walk ends there", () => {
+    useOnboardingStore.getState().openTour();
+    useOnboardingStore.getState().openOffer("create-agent");
+    expect(useOnboardingStore.getState().offerFromTour).toBe(true);
+  });
+
+  it("snapshots a page walk as the offer's origin", () => {
+    useOnboardingStore.getState().openPage();
+    useOnboardingStore.getState().openOffer("create-agent");
+    expect(useOnboardingStore.getState().offerFromTour).toBe(false);
   });
 
   it("renders nothing when there is no offer", () => {

--- a/frontend/src/components/onboarding/creation-offer.integration.test.tsx
+++ b/frontend/src/components/onboarding/creation-offer.integration.test.tsx
@@ -90,17 +90,26 @@ describe("CreationOffer", () => {
   });
 
   it("does not offer a first agent to an organization that already has one", () => {
-    // This is what the first-run tour ends with, having just walked the reader
-    // through an existing agent's builder in detail — so to an organization with
-    // six agents it answers a question nobody asked.
-    useOnboardingStore.setState({ offer: "create-agent" });
+    // This is what the first-run tour (`mode: "tour"`) ends with, having just
+    // walked the reader through an existing agent's builder in detail — so to an
+    // organization with six agents it answers a question nobody asked.
+    useOnboardingStore.setState({ offer: "create-agent", mode: "tour" });
     renderOffer(<CreationOffer />, { agents: 6 });
     expect(screen.queryByText("Create your first agent?")).toBeNull();
   });
 
   it("offers it where the organization has none", () => {
-    useOnboardingStore.setState({ offer: "create-agent" });
+    useOnboardingStore.setState({ offer: "create-agent", mode: "tour" });
     renderOffer(<CreationOffer />, { agents: 0 });
+    expect(screen.getByText("Create your first agent?")).toBeInTheDocument();
+  });
+
+  it("still offers create-agent from the Agents ? walk when the org has agents", () => {
+    // The explicit help walk (`mode: "page"`) ends on the same offer, and asking
+    // to build one is the whole point of it — so unlike the first-run tour
+    // ending, it is not gated on the agent count (#910).
+    useOnboardingStore.setState({ offer: "create-agent", mode: "page" });
+    renderOffer(<CreationOffer />, { agents: 6 });
     expect(screen.getByText("Create your first agent?")).toBeInTheDocument();
   });
 

--- a/frontend/src/components/onboarding/creation-offer.tsx
+++ b/frontend/src/components/onboarding/creation-offer.tsx
@@ -32,6 +32,7 @@ import { useOnboardingStore } from "@/stores/onboarding-store";
 export function CreationOffer() {
   const t = useTranslations("onboarding");
   const offer = useOnboardingStore((state) => state.offer);
+  const mode = useOnboardingStore((state) => state.mode);
   const openFlow = useOnboardingStore((state) => state.openFlow);
   const dismissOffer = useOnboardingStore((state) => state.dismissOffer);
   const { can } = usePermissions();
@@ -61,12 +62,14 @@ export function CreationOffer() {
   // "Shall we build your first agent?" to an organization that has six of them is
   // the offer answering a question nobody asked — and it is what the first-run
   // tour ends with, having just walked the reader through an existing agent's
-  // builder in detail. So the agent offer is for an organization with no agent
-  // yet; anyone else reaches the same flow from the Agents "?" walk, where asking
-  // for it is the whole point. Read from the cache the walk itself filled, not a
-  // fetch of this always-mounted component's own.
+  // builder in detail. So the *tour's* agent offer is for an organization with no
+  // agent yet. The Agents "?" walk ends on the same offer, but there asking to
+  // build one is the whole point of the walk, so it is not gated on the count —
+  // only `mode === "tour"` is (#910). Read from the cache the walk itself filled,
+  // not a fetch of this always-mounted component's own.
   if (
     offer === "create-agent" &&
+    mode === "tour" &&
     (queryClient.getQueryData<AgentList>(qk.agents.list())?.total ?? 0) > 0
   ) {
     return null;

--- a/frontend/src/components/onboarding/creation-offer.tsx
+++ b/frontend/src/components/onboarding/creation-offer.tsx
@@ -32,7 +32,7 @@ import { useOnboardingStore } from "@/stores/onboarding-store";
 export function CreationOffer() {
   const t = useTranslations("onboarding");
   const offer = useOnboardingStore((state) => state.offer);
-  const mode = useOnboardingStore((state) => state.mode);
+  const offerFromTour = useOnboardingStore((state) => state.offerFromTour);
   const openFlow = useOnboardingStore((state) => state.openFlow);
   const dismissOffer = useOnboardingStore((state) => state.dismissOffer);
   const { can } = usePermissions();
@@ -65,11 +65,13 @@ export function CreationOffer() {
   // builder in detail. So the *tour's* agent offer is for an organization with no
   // agent yet. The Agents "?" walk ends on the same offer, but there asking to
   // build one is the whole point of the walk, so it is not gated on the count —
-  // only `mode === "tour"` is (#910). Read from the cache the walk itself filled,
-  // not a fetch of this always-mounted component's own.
+  // only the tour's is (#910). Read the origin the offer was made with rather than
+  // live `mode`, which a later walk mutates: a suppressed tour offer must stay
+  // suppressed, not resurface when the next "?" walk flips the mode. Read the
+  // count from the cache the walk itself filled, not a fetch of our own.
   if (
     offer === "create-agent" &&
-    mode === "tour" &&
+    offerFromTour &&
     (queryClient.getQueryData<AgentList>(qk.agents.list())?.total ?? 0) > 0
   ) {
     return null;

--- a/frontend/src/stores/onboarding-store.ts
+++ b/frontend/src/stores/onboarding-store.ts
@@ -47,6 +47,15 @@ interface OnboardingState {
    */
   offer: FlowId | null;
   /**
+   * Whether the current `offer` was produced by the first-run tour rather than a
+   * section's "?" walk — snapshotted when the offer is made, because `mode` is
+   * mutable and a later `openPage()` would otherwise flip a tour offer's origin
+   * mid-flight. Only the tour's `create-agent` offer is gated on the agent count;
+   * the "?" walk's is not, and reading live `mode` at render let a suppressed
+   * tour offer resurface over the next walk. `false` when there is no offer.
+   */
+  offerFromTour: boolean;
+  /**
    * The forks the reader has answered in the running flow, keyed by the
    * question step's id. A detour step runs only when its `requires` question is
    * answered `"yes"` here, so recording an answer is what widens the step list
@@ -109,6 +118,7 @@ export const useOnboardingStore = create<OnboardingState>((set) => ({
   mode: "tour",
   flowId: null,
   offer: null,
+  offerFromTour: false,
   choices: {},
   flowAgentId: null,
   openTour: () => set({ isOpen: true, index: 0, mode: "tour", flowId: null }),
@@ -120,11 +130,15 @@ export const useOnboardingStore = create<OnboardingState>((set) => ({
       mode: "flow",
       flowId,
       offer: null,
+      offerFromTour: false,
       choices: {},
       flowAgentId: null,
     }),
-  openOffer: (flowId) => set({ offer: flowId }),
-  dismissOffer: () => set({ offer: null }),
+  // Snapshots the origin here, not at render: `mode` is mutable, and a walk the
+  // reader opens after a suppressed tour offer would otherwise flip that offer's
+  // origin and pop it over the new walk.
+  openOffer: (flowId) => set((state) => ({ offer: flowId, offerFromTour: state.mode === "tour" })),
+  dismissOffer: () => set({ offer: null, offerFromTour: false }),
   // One update, because the recorded answer is what widens the step list and the
   // index has to land inside the widened one. Where it lands is the caller's to
   // decide: this store cannot see the step list, and the answer's destination
@@ -138,7 +152,16 @@ export const useOnboardingStore = create<OnboardingState>((set) => ({
     })),
   setFlowAgentId: (agentId) => set({ flowAgentId: agentId }),
   resume: ({ flowId, index, choices, flowAgentId }) =>
-    set({ isOpen: true, mode: "flow", flowId, index, choices, flowAgentId, offer: null }),
+    set({
+      isOpen: true,
+      mode: "flow",
+      flowId,
+      index,
+      choices,
+      flowAgentId,
+      offer: null,
+      offerFromTour: false,
+    }),
   close: () => set({ isOpen: false }),
   setIndex: (index) => set({ index }),
 }));


### PR DESCRIPTION
After the first-run tour, the "Shall we build an agent together?" offer is
suppressed for an organization that already has an agent (#624) — right for the
tour, which has just walked the reader through an existing agent's builder.

But the suppression was blind to where the offer came from, so it also swallowed
the offer at the end of the **Agents "?" walk**, the explicit help walk where
asking to build one is the whole point. In an org with any agent, clicking "?"
in Agents and walking to the end showed no create-agent offer; the same walk in
Skills and KB still did.

## Fix

`creation-offer.tsx` gated `create-agent` purely on the agent count. The store
already records how the walk was opened — `mode === "tour"` for the first-run
walkthrough, `mode === "page"` for a section's "?" replay — and `close`/`openOffer`
preserve it, so at offer time it still says which walk produced the offer. The
count gate now applies only when `mode === "tour"`; the "?" walk (`mode === "page"`)
offers regardless, matching the flow's own docstring ("an Agents '?' that walked
into the builder still offers create-agent").

## Verified

- New test: the Agents "?" walk (`mode: "page"`) offers create-agent even in an
  org with six agents.
- Existing tests, now explicit about mode: the first-run tour ending
  (`mode: "tour"`) stays suppressed for an org with agents and still offers for an
  org with none.
- `make lint-frontend`, `make test-frontend-cov`, `make build-frontend` green.

## Noted, not changed

The offer's copy is "Create your first agent?", the tour's framing. Shown from the
"?" walk in an org that already has agents, "first" reads slightly off. Left as-is
— the issue scopes the fix to distinguishing the source, not the copy — and worth a
follow-up if the wording matters.

Closes #910
