### PR TITLE
feat(auth): self-service password change that revokes sessions and versions credentials

### DIFF
--- a/backend/alembic/versions/0075_user_credential_version.py
+++ b/backend/alembic/versions/0075_user_credential_version.py
@@ -1,0 +1,41 @@
+"""A credential version on the user, bumped when a password changes.
+
+A password change revokes the account's other sessions (#1439), but a refresh
+racing that revocation could read its old session as still valid and mint a
+replacement the bulk deactivate never saw - so the stolen refresh token outlived
+the change (#1517). This column is the version a refresh token is minted with,
+and the refresh path refuses a token whose version is behind the user's: a change
+that bumps it invalidates every token issued before it, whatever the race did to
+the session rows.
+
+`0` for every existing row, and a token minted before this carries no version and
+reads as `0` - so nothing is logged out on deploy, until the first password change
+moves that user to `1` and its earlier tokens stop refreshing.
+
+Revision ID: 0075_user_credential_version
+Revises: 0074_message_search_vector
+Create Date: 2026-09-08
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0075_user_credential_version"
+down_revision: str | None = "0074_message_search_vector"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("credential_version", sa.Integer(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "credential_version")

--- a/backend/app/api/routes/v1/auth.py
+++ b/backend/app/api/routes/v1/auth.py
@@ -20,6 +20,7 @@ from app.core.exceptions import AuthenticationError
 from app.core.security import (
     create_access_token,
     create_refresh_token,
+    verify_token,
 )
 from app.schemas.password_reset import (
     MagicLinkRequest,
@@ -49,7 +50,9 @@ async def login(
     """OAuth2 password login, returns access and refresh tokens."""
     await enforce_auth_limit(request, surface="auth_login", identifier=form_data.username)
     user = await user_service.authenticate(form_data.username, form_data.password)
-    refresh_token = create_refresh_token(subject=str(user.id))
+    refresh_token = create_refresh_token(
+        subject=str(user.id), credential_version=user.credential_version
+    )
 
     # Track this login as a server-side session (enables remote logout).
     session = await session_service.create_session(
@@ -91,7 +94,18 @@ async def refresh_token(
     if not user.is_active:
         raise AuthenticationError(message="User account is disabled")
 
-    new_refresh_token = create_refresh_token(subject=str(user.id))
+    # The presented token must be at the account's current credential version. A
+    # password change bumps it, so a token minted before the change - even one
+    # whose session row a concurrent revocation had not yet closed - cannot rotate
+    # past it (#1517). A token minted before the claim existed carries no `cv` and
+    # reads as 0, which matches an account that has never changed its password.
+    payload = verify_token(body.refresh_token)
+    if payload is None or payload.get("cv", 0) != user.credential_version:
+        raise AuthenticationError(message="Invalid or expired refresh token")
+
+    new_refresh_token = create_refresh_token(
+        subject=str(user.id), credential_version=user.credential_version
+    )
 
     await session_service.logout_by_refresh_token(body.refresh_token)
     session = await session_service.create_session(
@@ -247,7 +261,9 @@ async def verify_magic_link(
     """
     await enforce_auth_limit(request, surface="auth_magic_link_verify")
     user, return_to = await user_service.consume_magic_link_token(body.token)
-    refresh_token = create_refresh_token(subject=str(user.id))
+    refresh_token = create_refresh_token(
+        subject=str(user.id), credential_version=user.credential_version
+    )
     session = await session_service.create_session(
         user_id=user.id,
         refresh_token=refresh_token,

--- a/backend/app/api/routes/v1/auth.py
+++ b/backend/app/api/routes/v1/auth.py
@@ -148,7 +148,12 @@ async def change_password(
     the new version and returned, keeping the one who made the change signed in
     while every other device, an impersonation among them, is logged out (#1439).
     """
-    await enforce_auth_limit(request, surface="auth_password_change")
+    # Identified by the account, not only the caller's address: a stolen access
+    # token spread across source IPs would otherwise get a fresh guess budget per
+    # address against the same account's current password (#1517).
+    await enforce_auth_limit(
+        request, surface="auth_password_change", identifier=str(current_user.id)
+    )
     updated = await user_service.change_password(
         current_user,
         current_password=body.current_password,

--- a/backend/app/api/routes/v1/auth.py
+++ b/backend/app/api/routes/v1/auth.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, Request, status
 from fastapi.security import OAuth2PasswordRequestForm
 
 from app.api.deps import (
+    CurrentSessionId,
     CurrentUser,
     DeploymentSettingsSvc,
     ImpersonationSvc,
@@ -23,6 +24,7 @@ from app.core.security import (
 from app.schemas.password_reset import (
     MagicLinkRequest,
     MagicLinkVerifyRequest,
+    PasswordChangeRequest,
     PasswordResetConfirm,
     PasswordResetConfirmResponse,
     PasswordResetRequest,
@@ -114,6 +116,29 @@ async def logout(
     """
     await enforce_auth_limit(request, surface="auth_logout")
     await session_service.logout_by_refresh_token(body.refresh_token)
+
+
+@router.post("/password/change", status_code=status.HTTP_204_NO_CONTENT, response_model=None)
+async def change_password(
+    request: Request,
+    body: PasswordChangeRequest,
+    current_user: CurrentUser,
+    user_service: UserSvc,
+    current_session_id: CurrentSessionId,
+) -> None:
+    """Change the signed-in user's password and revoke the account's other sessions.
+
+    The current password is proved here, which `PATCH /users/me` cannot ask for -
+    the flow the Settings form posts to (#1517). The session that made the change
+    is spared; every other one, an impersonation among them, is revoked (#1439).
+    """
+    await enforce_auth_limit(request, surface="auth_password_change")
+    await user_service.change_password(
+        current_user,
+        current_password=body.current_password,
+        new_password=body.new_password,
+        current_session_id=current_session_id,
+    )
 
 
 @router.get("/me", response_model=MeRead)

--- a/backend/app/api/routes/v1/auth.py
+++ b/backend/app/api/routes/v1/auth.py
@@ -7,7 +7,6 @@ from fastapi import APIRouter, Depends, Request, status
 from fastapi.security import OAuth2PasswordRequestForm
 
 from app.api.deps import (
-    CurrentSessionId,
     CurrentUser,
     DeploymentSettingsSvc,
     ImpersonationSvc,
@@ -132,27 +131,40 @@ async def logout(
     await session_service.logout_by_refresh_token(body.refresh_token)
 
 
-@router.post("/password/change", status_code=status.HTTP_204_NO_CONTENT, response_model=None)
+@router.post("/password/change", response_model=Token)
 async def change_password(
     request: Request,
     body: PasswordChangeRequest,
     current_user: CurrentUser,
     user_service: UserSvc,
-    current_session_id: CurrentSessionId,
-) -> None:
-    """Change the signed-in user's password and revoke the account's other sessions.
+    session_service: SessionSvc,
+) -> Any:
+    """Change the signed-in user's password and open this device a fresh session.
 
     The current password is proved here, which `PATCH /users/me` cannot ask for -
-    the flow the Settings form posts to (#1517). The session that made the change
-    is spared; every other one, an impersonation among them, is revoked (#1439).
+    the flow the Settings form posts to (#1517). The change bumps the credential
+    version and revokes every session, the caller's own included - so its stale
+    refresh token cannot rotate past the change - and a fresh session is minted at
+    the new version and returned, keeping the one who made the change signed in
+    while every other device, an impersonation among them, is logged out (#1439).
     """
     await enforce_auth_limit(request, surface="auth_password_change")
-    await user_service.change_password(
+    updated = await user_service.change_password(
         current_user,
         current_password=body.current_password,
         new_password=body.new_password,
-        current_session_id=current_session_id,
     )
+    refresh_token = create_refresh_token(
+        subject=str(updated.id), credential_version=updated.credential_version
+    )
+    session = await session_service.create_session(
+        user_id=updated.id,
+        refresh_token=refresh_token,
+        ip_address=request.client.host if request.client else None,
+        user_agent=request.headers.get("User-Agent"),
+    )
+    access_token = create_access_token(subject=str(updated.id), sid=str(session.id))
+    return Token(access_token=access_token, refresh_token=refresh_token)
 
 
 @router.get("/me", response_model=MeRead)

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -56,14 +56,26 @@ def create_access_token(
 def create_refresh_token(
     subject: str | Any,
     expires_delta: timedelta | None = None,
+    *,
+    credential_version: int = 0,
 ) -> str:
-    """Create a JWT refresh token."""
+    """Create a JWT refresh token.
+
+    Carries the account's `credential_version` as `cv`: a password change bumps
+    the user's version, and the refresh path refuses a token whose `cv` is behind
+    it, so a token minted before the change cannot be rotated past it (#1517).
+    """
     if expires_delta:
         expire = datetime.now(UTC) + expires_delta
     else:
         expire = datetime.now(UTC) + timedelta(minutes=settings.REFRESH_TOKEN_EXPIRE_MINUTES)
 
-    to_encode = {"exp": expire, "sub": str(subject), "type": "refresh"}
+    to_encode = {
+        "exp": expire,
+        "sub": str(subject),
+        "type": "refresh",
+        "cv": credential_version,
+    }
     return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
 
 

--- a/backend/app/db/models/user.py
+++ b/backend/app/db/models/user.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, Literal
 
-from sqlalchemy import Boolean, DateTime, SmallInteger, String, text
+from sqlalchemy import Boolean, DateTime, Integer, SmallInteger, String, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -31,6 +31,12 @@ class User(Base, TimestampMixin):
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     email: Mapped[str] = mapped_column(String(255), unique=True, index=True, nullable=False)
     hashed_password: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    # Bumped on every password change; a refresh token carries the version it was
+    # minted with, and the refresh path refuses one that is behind. That is what
+    # invalidates a token racing the change's session revocation (#1517).
+    credential_version: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
     full_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     # The one global privilege. Authorization inside an organization is a

--- a/backend/app/schemas/password_reset.py
+++ b/backend/app/schemas/password_reset.py
@@ -30,6 +30,18 @@ class PasswordResetConfirm(BaseSchema):
     new_password: str = Field(..., min_length=8, max_length=128)
 
 
+class PasswordChangeRequest(BaseSchema):
+    """A signed-in user changing their own password, proving the current one.
+
+    `current_password` only has to be present; whether it is right is decided
+    against the stored hash, not by its length. `new_password` takes the same
+    bounds every other password field does.
+    """
+
+    current_password: str = Field(..., min_length=1)
+    new_password: str = Field(..., min_length=8, max_length=128)
+
+
 class PasswordResetResponse(BaseSchema):
     """Symmetric response for both request + confirm to avoid email enumeration."""
 

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -384,21 +384,21 @@ class UserService:
         return await self.update(user.id, user_in, current_session_id=current_session_id)
 
     async def change_password(
-        self,
-        user: User,
-        *,
-        current_password: str,
-        new_password: str,
-        current_session_id: UUID | None = None,
+        self, user: User, *, current_password: str, new_password: str
     ) -> User:
         """Change a signed-in user's own password, proving they know the current one.
 
         The proof is what `PATCH /users/me` cannot ask for, and the reason
         self-service password change is its own endpoint rather than that route: a
         stolen access token must not be able to change a password without the old
-        one (#1517). The change runs through `update`, so it revokes the account's
-        other sessions - sparing the one that made it - exactly as an admin reset
-        does (#1439).
+        one (#1517). The change bumps the credential version and revokes *every*
+        session - the caller's own included, because the `cv` gate would refuse a
+        spared session's stale-version token at its next refresh anyway. The caller
+        keeps their access through the fresh session the route opens at the new
+        version, while every other device is logged out (#1439).
+
+        Returns the updated user so the route can mint that session at the new
+        `credential_version`.
 
         Raises:
             AuthenticationError: the current password is wrong, or the account
@@ -410,11 +410,7 @@ class UserService:
         )
         if not ok:
             raise AuthenticationError(message="Current password is incorrect")
-        return await self.update(
-            user.id,
-            UserUpdate(password=new_password),
-            current_session_id=current_session_id,
-        )
+        return await self.update(user.id, UserUpdate(password=new_password))
 
     async def update_avatar(self, user_id: UUID, file_data: bytes, content_type: str) -> User:
         ALLOWED_AVATAR_TYPES = {"image/jpeg", "image/png", "image/webp", "image/gif"}

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -376,7 +376,16 @@ class UserService:
         terminal). A non-admin deactivating their own account only affects
         themselves and an admin can restore it, so the guard is the app admin's
         alone.
+
+        A password is refused here rather than applied: this route proves nothing
+        about the current one, and honouring it would be the bypass the dedicated
+        `/auth/password/change` endpoint exists to close - a stolen access token
+        changing a password without the old one (#1517).
         """
+        if user_in.password is not None:
+            raise BadRequestError(
+                message="Change your password through /auth/password/change, which proves the current one."
+            )
         if user.is_app_admin and user_in.is_active is False:
             raise AuthorizationError(
                 message="You cannot suspend your own account; ask another app admin to."
@@ -400,17 +409,26 @@ class UserService:
         Returns the updated user so the route can mint that session at the new
         `credential_version`.
 
+        The user row is locked for the whole change, so two overlapping requests
+        cannot both prove the same old hash and then have the later one overwrite
+        the first, nor both read the same version and lose one of the two bumps -
+        either would leave a session refreshable past a password change (#1517).
+
         Raises:
             AuthenticationError: the current password is wrong, or the account
                 signs in through OAuth alone and has no password to change.
+            NotFoundError: the account no longer exists.
         """
-        stored = user.hashed_password
+        locked = await user_repo.get_by_id_for_update(self.db, user.id)
+        if locked is None:
+            raise NotFoundError(message="User not found", details={"user_id": user.id})
+        stored = locked.hashed_password
         ok = stored is not None and await asyncio.to_thread(
             verify_password, current_password, stored
         )
         if not ok:
             raise AuthenticationError(message="Current password is incorrect")
-        return await self.update(user.id, UserUpdate(password=new_password))
+        return await self.update(locked.id, UserUpdate(password=new_password))
 
     async def update_avatar(self, user_id: UUID, file_data: bytes, content_type: str) -> User:
         ALLOWED_AVATAR_TYPES = {"image/jpeg", "image/png", "image/webp", "image/gif"}

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -347,6 +347,10 @@ class UserService:
             update_data["hashed_password"] = await asyncio.to_thread(
                 get_password_hash, update_data.pop("password")
             )
+            # Bump the credential version alongside the hash, so a refresh token
+            # minted before this change is refused even if it raced the session
+            # revocation below and its session row survived (#1517).
+            update_data["credential_version"] = user.credential_version + 1
 
         updated = await user_repo.update(self.db, db_user=user, update_data=update_data)
         if password_changed:
@@ -717,7 +721,11 @@ class UserService:
             self.db,
             db_user=user,
             update_data={
-                "hashed_password": await asyncio.to_thread(get_password_hash, new_password)
+                "hashed_password": await asyncio.to_thread(get_password_hash, new_password),
+                # Bumped for the same reason the self-service change bumps it: a
+                # refresh racing the revocation below must not rotate a token
+                # minted before the reset (#1517).
+                "credential_version": user.credential_version + 1,
             },
         )
         # Revoke any active sessions so a previously-issued refresh token cannot

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -379,6 +379,39 @@ class UserService:
             )
         return await self.update(user.id, user_in, current_session_id=current_session_id)
 
+    async def change_password(
+        self,
+        user: User,
+        *,
+        current_password: str,
+        new_password: str,
+        current_session_id: UUID | None = None,
+    ) -> User:
+        """Change a signed-in user's own password, proving they know the current one.
+
+        The proof is what `PATCH /users/me` cannot ask for, and the reason
+        self-service password change is its own endpoint rather than that route: a
+        stolen access token must not be able to change a password without the old
+        one (#1517). The change runs through `update`, so it revokes the account's
+        other sessions - sparing the one that made it - exactly as an admin reset
+        does (#1439).
+
+        Raises:
+            AuthenticationError: the current password is wrong, or the account
+                signs in through OAuth alone and has no password to change.
+        """
+        stored = user.hashed_password
+        ok = stored is not None and await asyncio.to_thread(
+            verify_password, current_password, stored
+        )
+        if not ok:
+            raise AuthenticationError(message="Current password is incorrect")
+        return await self.update(
+            user.id,
+            UserUpdate(password=new_password),
+            current_session_id=current_session_id,
+        )
+
     async def update_avatar(self, user_id: UUID, file_data: bytes, content_type: str) -> User:
         ALLOWED_AVATAR_TYPES = {"image/jpeg", "image/png", "image/webp", "image/gif"}
         if content_type not in ALLOWED_AVATAR_TYPES:

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -342,10 +342,14 @@ class UserService:
         user = await self.get_by_id(user_id)
 
         update_data = writable(user_in, over=User)
-        password_changed = "password" in update_data
+        # `password` has no column (the row stores `hashed_password`), so writable
+        # keeps an explicit null rather than dropping it. Popped unconditionally so
+        # a null is a no-op, not a hash of None that reaches bcrypt as a 500 (#1497).
+        new_password = update_data.pop("password", None)
+        password_changed = new_password is not None
         if password_changed:
             update_data["hashed_password"] = await asyncio.to_thread(
-                get_password_hash, update_data.pop("password")
+                get_password_hash, new_password
             )
             # Bump the credential version alongside the hash, so a refresh token
             # minted before this change is refused even if it raced the session

--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -156,6 +156,78 @@ async def test_get_current_session_id_is_none_for_an_unverifiable_token() -> Non
 
 
 @pytest.mark.anyio
+async def test_a_password_change_needs_a_signed_in_caller(
+    mock_user_service: MagicMock, mock_redis: MagicMock, mock_db_session
+) -> None:
+    """The endpoint is authenticated: no token, no change (#1517)."""
+    app.dependency_overrides[get_user_service] = lambda: mock_user_service
+    app.dependency_overrides[get_redis] = lambda: mock_redis
+    app.dependency_overrides[get_db_session] = lambda: mock_db_session
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                f"{settings.API_V1_STR}/auth/password/change",
+                json={"current_password": "old", "new_password": "newpassword123"},
+            )
+    finally:
+        app.dependency_overrides.clear()
+    assert resp.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_a_password_change_hands_the_service_the_session_to_spare(
+    mock_user: MockUser, mock_user_service: MagicMock, mock_redis: MagicMock, mock_db_session
+) -> None:
+    """The route proves nothing itself; it hands the service the caller, the two
+    passwords and the session to keep, and answers 204 (#1517)."""
+    session_id = uuid4()
+    mock_user_service.change_password = AsyncMock(return_value=mock_user)
+    app.dependency_overrides[get_user_service] = lambda: mock_user_service
+    app.dependency_overrides[get_redis] = lambda: mock_redis
+    app.dependency_overrides[get_db_session] = lambda: mock_db_session
+    app.dependency_overrides[get_current_user] = lambda: mock_user
+    app.dependency_overrides[get_current_session_id] = lambda: session_id
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                f"{settings.API_V1_STR}/auth/password/change",
+                json={"current_password": "old-password", "new_password": "newpassword123"},
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code == 204
+    kwargs = mock_user_service.change_password.await_args.kwargs
+    assert kwargs["current_password"] == "old-password"
+    assert kwargs["new_password"] == "newpassword123"
+    assert kwargs["current_session_id"] == session_id
+
+
+@pytest.mark.anyio
+async def test_a_wrong_current_password_is_refused_with_a_401(
+    mock_user: MockUser, mock_user_service: MagicMock, mock_redis: MagicMock, mock_db_session
+) -> None:
+    """The service's refusal reaches the caller as a 401, not a 500 (#1517)."""
+    mock_user_service.change_password = AsyncMock(
+        side_effect=AuthenticationError(message="Current password is incorrect")
+    )
+    app.dependency_overrides[get_user_service] = lambda: mock_user_service
+    app.dependency_overrides[get_redis] = lambda: mock_redis
+    app.dependency_overrides[get_db_session] = lambda: mock_db_session
+    app.dependency_overrides[get_current_user] = lambda: mock_user
+    app.dependency_overrides[get_current_session_id] = lambda: None
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                f"{settings.API_V1_STR}/auth/password/change",
+                json={"current_password": "wrong", "new_password": "newpassword123"},
+            )
+    finally:
+        app.dependency_overrides.clear()
+    assert resp.status_code == 401
+
+
+@pytest.mark.anyio
 async def test_login_invalid_credentials(
     client_with_mock_service: AsyncClient,
     mock_user_service: MagicMock,

--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -14,7 +14,7 @@ from httpx import ASGITransport, AsyncClient
 from app.api.deps import get_current_session_id, get_current_user, get_user_service
 from app.core.config import settings
 from app.core.exceptions import AlreadyExistsError, AuthenticationError
-from app.core.security import create_access_token, verify_token
+from app.core.security import create_access_token, create_refresh_token, verify_token
 from app.main import app
 from app.api.deps import get_redis
 from app.api.deps import get_db_session
@@ -38,6 +38,7 @@ class MockUser:
         self.is_active = is_active
         self.role = role
         self.hashed_password = "hashed"
+        self.credential_version = 0
         self.avatar_url = None
         self.oauth_provider = None
         self.created_at = datetime.now(UTC)
@@ -153,6 +154,76 @@ async def test_get_current_session_id_is_none_for_an_unverifiable_token() -> Non
     """A garbled or expired token is no session to spare, not a refusal - the
     route it serves already authenticated through `CurrentUser`."""
     assert await get_current_session_id("not-a-real-jwt") is None
+
+
+@pytest.mark.anyio
+async def test_refresh_refuses_a_token_behind_the_credential_version(
+    mock_redis: MagicMock, mock_db_session
+) -> None:
+    """A refresh token minted before a password change carries the old credential
+    version, so it cannot rotate past the change even if its session row is still
+    active - the close on the revocation race (#1517)."""
+    user = MockUser()
+    user.credential_version = 5
+    user_service = MagicMock()
+    user_service.get_by_id = AsyncMock(return_value=user)
+    session_service = MagicMock()
+    session_service.validate_refresh_token = AsyncMock(
+        return_value=SimpleNamespace(id=uuid4(), user_id=user.id)
+    )
+    session_service.create_session = AsyncMock()
+    stale = create_refresh_token(subject=str(user.id), credential_version=4)
+
+    app.dependency_overrides[get_user_service] = lambda: user_service
+    app.dependency_overrides[get_session_service] = lambda: session_service
+    app.dependency_overrides[get_redis] = lambda: mock_redis
+    app.dependency_overrides[get_db_session] = lambda: mock_db_session
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                f"{settings.API_V1_STR}/auth/refresh", json={"refresh_token": stale}
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code == 401
+    session_service.create_session.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_refresh_at_the_current_version_mints_a_token_carrying_it(
+    mock_redis: MagicMock, mock_db_session
+) -> None:
+    """A token at the account's current version rotates, and the token it mints
+    carries that version so the chain stays valid until the next change (#1517)."""
+    user = MockUser()
+    user.credential_version = 5
+    user_service = MagicMock()
+    user_service.get_by_id = AsyncMock(return_value=user)
+    session_service = MagicMock()
+    session_service.validate_refresh_token = AsyncMock(
+        return_value=SimpleNamespace(id=uuid4(), user_id=user.id)
+    )
+    session_service.logout_by_refresh_token = AsyncMock()
+    session_service.create_session = AsyncMock(return_value=SimpleNamespace(id=uuid4()))
+    current = create_refresh_token(subject=str(user.id), credential_version=5)
+
+    app.dependency_overrides[get_user_service] = lambda: user_service
+    app.dependency_overrides[get_session_service] = lambda: session_service
+    app.dependency_overrides[get_redis] = lambda: mock_redis
+    app.dependency_overrides[get_db_session] = lambda: mock_db_session
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                f"{settings.API_V1_STR}/auth/refresh", json={"refresh_token": current}
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code == 200
+    minted = verify_token(resp.json()["refresh_token"])
+    assert minted is not None
+    assert minted["cv"] == 5
 
 
 @pytest.mark.anyio

--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -246,18 +246,21 @@ async def test_a_password_change_needs_a_signed_in_caller(
 
 
 @pytest.mark.anyio
-async def test_a_password_change_hands_the_service_the_session_to_spare(
+async def test_a_password_change_returns_a_fresh_session_at_the_new_version(
     mock_user: MockUser, mock_user_service: MagicMock, mock_redis: MagicMock, mock_db_session
 ) -> None:
-    """The route proves nothing itself; it hands the service the caller, the two
-    passwords and the session to keep, and answers 204 (#1517)."""
-    session_id = uuid4()
+    """The change revokes every session, the caller's own included, so the route
+    opens a fresh one and hands back its tokens - keeping the one who made the
+    change signed in, on a refresh token carrying the new version (#1517)."""
+    mock_user.credential_version = 3
     mock_user_service.change_password = AsyncMock(return_value=mock_user)
+    session_service = MagicMock()
+    session_service.create_session = AsyncMock(return_value=SimpleNamespace(id=uuid4()))
     app.dependency_overrides[get_user_service] = lambda: mock_user_service
+    app.dependency_overrides[get_session_service] = lambda: session_service
     app.dependency_overrides[get_redis] = lambda: mock_redis
     app.dependency_overrides[get_db_session] = lambda: mock_db_session
     app.dependency_overrides[get_current_user] = lambda: mock_user
-    app.dependency_overrides[get_current_session_id] = lambda: session_id
     try:
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             resp = await client.post(
@@ -267,26 +270,34 @@ async def test_a_password_change_hands_the_service_the_session_to_spare(
     finally:
         app.dependency_overrides.clear()
 
-    assert resp.status_code == 204
+    assert resp.status_code == 200
+    body = resp.json()
+    minted = verify_token(body["refresh_token"])
+    assert minted is not None
+    assert minted["cv"] == 3
+    session_service.create_session.assert_awaited_once()
     kwargs = mock_user_service.change_password.await_args.kwargs
     assert kwargs["current_password"] == "old-password"
     assert kwargs["new_password"] == "newpassword123"
-    assert kwargs["current_session_id"] == session_id
+    assert "current_session_id" not in kwargs
 
 
 @pytest.mark.anyio
 async def test_a_wrong_current_password_is_refused_with_a_401(
     mock_user: MockUser, mock_user_service: MagicMock, mock_redis: MagicMock, mock_db_session
 ) -> None:
-    """The service's refusal reaches the caller as a 401, not a 500 (#1517)."""
+    """The service's refusal reaches the caller as a 401, not a 500, and mints no
+    session (#1517)."""
     mock_user_service.change_password = AsyncMock(
         side_effect=AuthenticationError(message="Current password is incorrect")
     )
+    session_service = MagicMock()
+    session_service.create_session = AsyncMock()
     app.dependency_overrides[get_user_service] = lambda: mock_user_service
+    app.dependency_overrides[get_session_service] = lambda: session_service
     app.dependency_overrides[get_redis] = lambda: mock_redis
     app.dependency_overrides[get_db_session] = lambda: mock_db_session
     app.dependency_overrides[get_current_user] = lambda: mock_user
-    app.dependency_overrides[get_current_session_id] = lambda: None
     try:
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             resp = await client.post(
@@ -296,6 +307,7 @@ async def test_a_wrong_current_password_is_refused_with_a_401(
     finally:
         app.dependency_overrides.clear()
     assert resp.status_code == 401
+    session_service.create_session.assert_not_called()
 
 
 @pytest.mark.anyio

--- a/backend/tests/api/test_magic_link_return_to.py
+++ b/backend/tests/api/test_magic_link_return_to.py
@@ -42,6 +42,7 @@ class _User:
         self.email = "kacper@example.com"
         self.full_name = "Kacper"
         self.is_active = True
+        self.credential_version = 0
 
 
 @pytest.fixture

--- a/backend/tests/integration/test_password_change_sessions.py
+++ b/backend/tests/integration/test_password_change_sessions.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.exceptions import AuthenticationError
+from app.core.security import get_password_hash, verify_password
 from app.repositories import session_repo, user_repo
 from app.schemas.user import UserUpdate
 from app.services.session import SessionService
@@ -53,6 +55,50 @@ async def test_a_password_change_with_no_current_session_revokes_every_one(
     for session_id in (first.id, second.id):
         row = await session_repo.get_by_id(db, session_id)
         assert row is not None and row.is_active is False
+
+
+async def test_change_password_proves_the_old_bumps_the_version_and_revokes_all(
+    db: AsyncSession,
+) -> None:
+    """The self-service change against a real row: the current password is proved
+    under the lock, the hash and credential version move, and every session is
+    revoked so the route can open a fresh one (#1517)."""
+    user = await user_repo.create(
+        db, email="selfchange@example.com", hashed_password=get_password_hash("old-password")
+    )
+    sessions = SessionService(db)
+    one = await sessions.create_session(user_id=user.id, refresh_token="rt-1")
+    two = await sessions.create_session(user_id=user.id, refresh_token="rt-2")
+
+    updated = await UserService(db).change_password(
+        user, current_password="old-password", new_password="a-brand-new-password"
+    )
+
+    assert verify_password("a-brand-new-password", updated.hashed_password) is True
+    assert updated.credential_version == 1
+    for session_id in (one.id, two.id):
+        row = await session_repo.get_by_id(db, session_id)
+        assert row is not None and row.is_active is False
+
+
+async def test_change_password_refuses_a_wrong_current_password_and_changes_nothing(
+    db: AsyncSession,
+) -> None:
+    user = await user_repo.create(
+        db, email="wrongpw@example.com", hashed_password=get_password_hash("real-password")
+    )
+    sessions = SessionService(db)
+    live = await sessions.create_session(user_id=user.id, refresh_token="rt-live")
+
+    with pytest.raises(AuthenticationError):
+        await UserService(db).change_password(
+            user, current_password="not-the-password", new_password="a-brand-new-password"
+        )
+
+    assert verify_password("real-password", user.hashed_password) is True
+    assert user.credential_version == 0
+    row = await session_repo.get_by_id(db, live.id)
+    assert row is not None and row.is_active is True
 
 
 async def test_another_accounts_sessions_are_untouched(db: AsyncSession) -> None:

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -11,6 +11,7 @@ from app.core.exceptions import (
     AlreadyExistsError,
     AuthenticationError,
     AuthorizationError,
+    BadRequestError,
     NotFoundError,
 )
 from app.schemas.user import UserCreate, UserUpdate
@@ -395,6 +396,7 @@ class TestUserServicePostgresql:
             patch("app.services.user.session_repo") as mock_sessions,
             patch("app.services.user.verify_password", return_value=True),
         ):
+            mock_repo.get_by_id_for_update = AsyncMock(return_value=mock_user)
             mock_repo.get_by_id = AsyncMock(return_value=mock_user)
             mock_repo.update = AsyncMock(return_value=mock_user)
             mock_sessions.deactivate_all_user_sessions = AsyncMock(return_value=2)
@@ -403,9 +405,35 @@ class TestUserServicePostgresql:
                 mock_user, current_password="old-password", new_password="newpassword123"
             )
 
+            mock_repo.get_by_id_for_update.assert_awaited_once()
             mock_sessions.deactivate_all_user_sessions.assert_awaited_once_with(
                 user_service.db, mock_user.id, except_session_id=None
             )
+
+    @pytest.mark.anyio
+    async def test_change_password_verifies_the_locked_row_not_the_passed_user(
+        self, user_service: UserService, mock_user: MockUser
+    ):
+        """The proof is checked against the row locked for the change, not the
+        request's own user object - so an overlapping change cannot slip a stale
+        hash past it (#1517)."""
+        locked = MockUser()
+        locked.hashed_password = "the-locked-hash"
+        with (
+            patch("app.services.user.user_repo") as mock_repo,
+            patch("app.services.user.session_repo") as mock_sessions,
+            patch("app.services.user.verify_password", return_value=True) as verify,
+        ):
+            mock_repo.get_by_id_for_update = AsyncMock(return_value=locked)
+            mock_repo.get_by_id = AsyncMock(return_value=locked)
+            mock_repo.update = AsyncMock(return_value=locked)
+            mock_sessions.deactivate_all_user_sessions = AsyncMock()
+
+            await user_service.change_password(
+                mock_user, current_password="old", new_password="newpassword123"
+            )
+
+            assert verify.call_args.args == ("old", "the-locked-hash")
 
     @pytest.mark.anyio
     async def test_change_password_refuses_a_wrong_current_password(
@@ -414,9 +442,11 @@ class TestUserServicePostgresql:
         """The proof is the whole point: a wrong current password changes nothing
         and revokes no session (#1517)."""
         with (
+            patch("app.services.user.user_repo") as mock_repo,
             patch("app.services.user.session_repo") as mock_sessions,
             patch("app.services.user.verify_password", return_value=False),
         ):
+            mock_repo.get_by_id_for_update = AsyncMock(return_value=mock_user)
             mock_sessions.deactivate_all_user_sessions = AsyncMock()
             with pytest.raises(AuthenticationError):
                 await user_service.change_password(
@@ -426,20 +456,22 @@ class TestUserServicePostgresql:
 
     @pytest.mark.anyio
     async def test_change_password_refuses_an_account_with_no_password(
-        self, user_service: UserService
+        self, user_service: UserService, mock_user: MockUser
     ):
         """An OAuth-only account has no password to prove, so there is nothing to
         change here - and bcrypt is never run against a null hash (#1517)."""
         oauth_user = MockUser()
         oauth_user.hashed_password = None
         with (
+            patch("app.services.user.user_repo") as mock_repo,
             patch("app.services.user.session_repo") as mock_sessions,
             patch("app.services.user.verify_password") as verify,
         ):
+            mock_repo.get_by_id_for_update = AsyncMock(return_value=oauth_user)
             mock_sessions.deactivate_all_user_sessions = AsyncMock()
             with pytest.raises(AuthenticationError):
                 await user_service.change_password(
-                    oauth_user, current_password="anything", new_password="newpassword123"
+                    mock_user, current_password="anything", new_password="newpassword123"
                 )
             verify.assert_not_called()
             mock_sessions.deactivate_all_user_sessions.assert_not_awaited()
@@ -516,6 +548,19 @@ class TestUserServicePostgresql:
             await user_service.update_current(mock_user, UserUpdate(is_active=False))
 
             mock_repo.update.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_self_update_refuses_a_password(
+        self, user_service: UserService, mock_user: MockUser
+    ):
+        """`/users/me` proves no current password, so honouring one would be the
+        bypass `/auth/password/change` exists to close - it is refused, and the
+        hash is never touched (#1517)."""
+        with patch("app.services.user.user_repo") as mock_repo:
+            mock_repo.update = AsyncMock()
+            with pytest.raises(BadRequestError):
+                await user_service.update_current(mock_user, UserUpdate(password="newpassword123"))
+            mock_repo.update.assert_not_awaited()
 
     @pytest.mark.anyio
     async def test_an_admin_may_suspend_another_user(

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -384,12 +384,12 @@ class TestUserServicePostgresql:
             )
 
     @pytest.mark.anyio
-    async def test_change_password_proves_the_current_one_then_revokes_others(
+    async def test_change_password_proves_the_current_one_then_revokes_every_session(
         self, user_service: UserService, mock_user: MockUser
     ):
-        """A signed-in change proves the old password, then revokes the account's
-        other sessions and spares the one that made it (#1517)."""
-        current = uuid4()
+        """A signed-in change proves the old password, then revokes every session -
+        the caller's own included, since the cv gate would refuse its stale token
+        anyway; the route re-establishes this device at the new version (#1517)."""
         with (
             patch("app.services.user.user_repo") as mock_repo,
             patch("app.services.user.session_repo") as mock_sessions,
@@ -397,17 +397,14 @@ class TestUserServicePostgresql:
         ):
             mock_repo.get_by_id = AsyncMock(return_value=mock_user)
             mock_repo.update = AsyncMock(return_value=mock_user)
-            mock_sessions.deactivate_all_user_sessions = AsyncMock(return_value=1)
+            mock_sessions.deactivate_all_user_sessions = AsyncMock(return_value=2)
 
             await user_service.change_password(
-                mock_user,
-                current_password="old-password",
-                new_password="newpassword123",
-                current_session_id=current,
+                mock_user, current_password="old-password", new_password="newpassword123"
             )
 
             mock_sessions.deactivate_all_user_sessions.assert_awaited_once_with(
-                user_service.db, mock_user.id, except_session_id=current
+                user_service.db, mock_user.id, except_session_id=None
             )
 
     @pytest.mark.anyio

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -345,6 +345,70 @@ class TestUserServicePostgresql:
             )
 
     @pytest.mark.anyio
+    async def test_change_password_proves_the_current_one_then_revokes_others(
+        self, user_service: UserService, mock_user: MockUser
+    ):
+        """A signed-in change proves the old password, then revokes the account's
+        other sessions and spares the one that made it (#1517)."""
+        current = uuid4()
+        with (
+            patch("app.services.user.user_repo") as mock_repo,
+            patch("app.services.user.session_repo") as mock_sessions,
+            patch("app.services.user.verify_password", return_value=True),
+        ):
+            mock_repo.get_by_id = AsyncMock(return_value=mock_user)
+            mock_repo.update = AsyncMock(return_value=mock_user)
+            mock_sessions.deactivate_all_user_sessions = AsyncMock(return_value=1)
+
+            await user_service.change_password(
+                mock_user,
+                current_password="old-password",
+                new_password="newpassword123",
+                current_session_id=current,
+            )
+
+            mock_sessions.deactivate_all_user_sessions.assert_awaited_once_with(
+                user_service.db, mock_user.id, except_session_id=current
+            )
+
+    @pytest.mark.anyio
+    async def test_change_password_refuses_a_wrong_current_password(
+        self, user_service: UserService, mock_user: MockUser
+    ):
+        """The proof is the whole point: a wrong current password changes nothing
+        and revokes no session (#1517)."""
+        with (
+            patch("app.services.user.session_repo") as mock_sessions,
+            patch("app.services.user.verify_password", return_value=False),
+        ):
+            mock_sessions.deactivate_all_user_sessions = AsyncMock()
+            with pytest.raises(AuthenticationError):
+                await user_service.change_password(
+                    mock_user, current_password="wrong", new_password="newpassword123"
+                )
+            mock_sessions.deactivate_all_user_sessions.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_change_password_refuses_an_account_with_no_password(
+        self, user_service: UserService
+    ):
+        """An OAuth-only account has no password to prove, so there is nothing to
+        change here - and bcrypt is never run against a null hash (#1517)."""
+        oauth_user = MockUser()
+        oauth_user.hashed_password = None
+        with (
+            patch("app.services.user.session_repo") as mock_sessions,
+            patch("app.services.user.verify_password") as verify,
+        ):
+            mock_sessions.deactivate_all_user_sessions = AsyncMock()
+            with pytest.raises(AuthenticationError):
+                await user_service.change_password(
+                    oauth_user, current_password="anything", new_password="newpassword123"
+                )
+            verify.assert_not_called()
+            mock_sessions.deactivate_all_user_sessions.assert_not_awaited()
+
+    @pytest.mark.anyio
     async def test_delete_success(self, user_service: UserService, mock_user: MockUser):
         """Test deleting user."""
         with (

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -28,6 +28,7 @@ class MockUser:
         hashed_password="$2b$12$hashedpassword",
         is_active=True,
         role="user",
+        credential_version=0,
     ):
         self.id = id or uuid4()
         self.email = email
@@ -35,6 +36,7 @@ class MockUser:
         self.hashed_password = hashed_password
         self.is_active = is_active
         self.role = role
+        self.credential_version = credential_version
 
 
 class TestUserServicePostgresql:
@@ -305,6 +307,43 @@ class TestUserServicePostgresql:
             mock_sessions.deactivate_all_user_sessions.assert_awaited_once_with(
                 user_service.db, mock_user.id, except_session_id=current
             )
+
+    @pytest.mark.anyio
+    async def test_a_password_change_bumps_the_credential_version(
+        self, user_service: UserService, mock_user: MockUser
+    ):
+        """The bump is what a refresh racing the revocation is caught by: the token
+        it would rotate carries the version from before the change (#1517)."""
+        mock_user.credential_version = 3
+        with (
+            patch("app.services.user.user_repo") as mock_repo,
+            patch("app.services.user.session_repo") as mock_sessions,
+        ):
+            mock_repo.get_by_id = AsyncMock(return_value=mock_user)
+            mock_repo.update = AsyncMock(return_value=mock_user)
+            mock_sessions.deactivate_all_user_sessions = AsyncMock()
+
+            await user_service.update(mock_user.id, UserUpdate(password="newpassword123"))
+
+            assert mock_repo.update.call_args.kwargs["update_data"]["credential_version"] == 4
+
+    @pytest.mark.anyio
+    async def test_a_profile_update_without_a_password_leaves_the_version_alone(
+        self, user_service: UserService, mock_user: MockUser
+    ):
+        """Only a password change moves the version; renaming yourself does not."""
+        mock_user.credential_version = 3
+        with (
+            patch("app.services.user.user_repo") as mock_repo,
+            patch("app.services.user.session_repo") as mock_sessions,
+        ):
+            mock_repo.get_by_id = AsyncMock(return_value=mock_user)
+            mock_repo.update = AsyncMock(return_value=mock_user)
+            mock_sessions.deactivate_all_user_sessions = AsyncMock()
+
+            await user_service.update(mock_user.id, UserUpdate(full_name="Renamed"))
+
+            assert "credential_version" not in mock_repo.update.call_args.kwargs["update_data"]
 
     @pytest.mark.anyio
     async def test_a_profile_update_without_a_password_leaves_sessions_alone(

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -385,6 +385,32 @@ class TestUserServicePostgresql:
             )
 
     @pytest.mark.anyio
+    async def test_an_explicit_null_password_is_a_no_op_not_a_crash(
+        self, user_service: UserService, mock_user: MockUser
+    ):
+        """`PATCH /users/{id}` (and /users/me) with `{"password": null}` reaches
+        here as an explicit None that `writable` keeps - there is no `password`
+        column. It must be a no-op: nothing hashed, no version bump, no session
+        revoked - not `get_password_hash(None)` reaching bcrypt as a 500 (#1497)."""
+        mock_user.credential_version = 3
+        with (
+            patch("app.services.user.user_repo") as mock_repo,
+            patch("app.services.user.session_repo") as mock_sessions,
+        ):
+            mock_repo.get_by_id = AsyncMock(return_value=mock_user)
+            mock_repo.update = AsyncMock(return_value=mock_user)
+            mock_sessions.deactivate_all_user_sessions = AsyncMock()
+
+            await user_service.update(mock_user.id, UserUpdate(password=None, full_name="Renamed"))
+
+            update_data = mock_repo.update.call_args.kwargs["update_data"]
+            assert "password" not in update_data
+            assert "hashed_password" not in update_data
+            assert "credential_version" not in update_data
+            assert update_data["full_name"] == "Renamed"
+            mock_sessions.deactivate_all_user_sessions.assert_not_awaited()
+
+    @pytest.mark.anyio
     async def test_change_password_proves_the_current_one_then_revokes_every_session(
         self, user_service: UserService, mock_user: MockUser
     ):

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -4000,7 +4000,6 @@
       "optionalUsage": "Usage reports",
       "optionalUsageAudience": "The organization's report goes to owners and admins. An agent can also ask for a report of its own. A period with zero runs sends nothing.",
       "optionalUsageTrigger": "Weekly and monthly, when your organization's agents ran anything at all.",
-      "passwordChangeRequiresBackend": "Password change requires backend wiring (POST /auth/password/change).",
       "passwordUpdated": "Password updated",
       "passwordsDoNotMatch": "Passwords do not match",
       "permanentlyRemoveYourAccount": "Permanently remove your account, conversations, and uploaded data. This can't be undone.",

--- a/frontend/src/app/[locale]/(dashboard)/settings/account/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/settings/account/page.tsx
@@ -55,14 +55,9 @@ export default function AccountSettingsPage() {
       setNewPassword("");
       setConfirmPassword("");
     } catch (err) {
-      // Backend may not have this endpoint yet - surface a helpful message.
-      if (err instanceof ApiError && err.status === 404) {
-        toast.error(t("passwordChangeRequiresBackend"));
-      } else {
-        toast.error(
-          err instanceof ApiError ? getErrorMessage(err, tErrors) : t("failedUpdatePassword"),
-        );
-      }
+      toast.error(
+        err instanceof ApiError ? getErrorMessage(err, tErrors) : t("failedUpdatePassword"),
+      );
     } finally {
       setSaving(false);
     }

--- a/frontend/src/app/api/auth/password/change/route.test.ts
+++ b/frontend/src/app/api/auth/password/change/route.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @vitest-environment node
+ *
+ * A server route: it reads the access-token cookie and forwards the change to
+ * the backend. The token lives in an HttpOnly cookie, so what this proves is that
+ * the proxy carries it as a bearer and passes the backend's answer straight back.
+ */
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { POST as changePassword } from "./route";
+import { BackendApiError, backendFetch } from "@/lib/server-api";
+
+vi.mock("@/lib/server-api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/server-api")>("@/lib/server-api");
+  return { ...actual, backendFetch: vi.fn() };
+});
+
+function request(cookies: Record<string, string> = {}, body: unknown = {}): NextRequest {
+  const header = Object.entries(cookies)
+    .map(([name, value]) => `${name}=${value}`)
+    .join("; ");
+  return new NextRequest("http://localhost:3000/api/auth/password/change", {
+    method: "POST",
+    headers: { ...(header ? { cookie: header } : {}), "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("changing a password", () => {
+  it("forwards the access-token cookie as a bearer and answers 204", async () => {
+    vi.mocked(backendFetch).mockResolvedValue(null);
+
+    const response = await changePassword(
+      request({ access_token: "tok-123" }, { current_password: "old", new_password: "newpass12" }),
+    );
+
+    expect(response.status).toBe(204);
+    const [endpoint, options] = vi.mocked(backendFetch).mock.calls[0]!;
+    expect(endpoint).toBe("/api/v1/auth/password/change");
+    expect((options?.headers as Record<string, string>).Authorization).toBe("Bearer tok-123");
+  });
+
+  it("sends no bearer when the browser carries no token, so the backend refuses it", async () => {
+    vi.mocked(backendFetch).mockResolvedValue(null);
+
+    await changePassword(request({}, { current_password: "old", new_password: "newpass12" }));
+
+    const [, options] = vi.mocked(backendFetch).mock.calls[0]!;
+    expect((options?.headers as Record<string, string>).Authorization).toBeUndefined();
+  });
+
+  it("passes the backend's refusal body and status straight through", async () => {
+    const body = {
+      error: { code: "AUTHENTICATION_ERROR", message: "Current password is incorrect" },
+    };
+    vi.mocked(backendFetch).mockRejectedValue(new BackendApiError(401, "Unauthorized", body));
+
+    const response = await changePassword(request({ access_token: "t" }));
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual(body);
+  });
+
+  it("forwards a rate limit as a rate limit", async () => {
+    vi.mocked(backendFetch).mockRejectedValue(new BackendApiError(429, "Too Many Requests", null));
+
+    const response = await changePassword(request({ access_token: "t" }));
+
+    expect(response.status).toBe(429);
+  });
+
+  it("answers a non-backend failure as a 500 refusal", async () => {
+    vi.mocked(backendFetch).mockRejectedValue(new Error("socket hang up"));
+
+    const response = await changePassword(request({ access_token: "t" }));
+
+    expect(response.status).toBe(500);
+  });
+});

--- a/frontend/src/app/api/auth/password/change/route.test.ts
+++ b/frontend/src/app/api/auth/password/change/route.test.ts
@@ -1,9 +1,9 @@
 /**
  * @vitest-environment node
  *
- * A server route: it reads the access-token cookie and forwards the change to
- * the backend. The token lives in an HttpOnly cookie, so what this proves is that
- * the proxy carries it as a bearer and passes the backend's answer straight back.
+ * A server route: it reads the access-token cookie, forwards the change as a
+ * bearer, and swaps the token cookies to the fresh pair the change returns - the
+ * old ones are on a credential version the backend has just moved past.
  */
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -30,21 +30,23 @@ function request(cookies: Record<string, string> = {}, body: unknown = {}): Next
 beforeEach(() => vi.clearAllMocks());
 
 describe("changing a password", () => {
-  it("forwards the access-token cookie as a bearer and answers 204", async () => {
-    vi.mocked(backendFetch).mockResolvedValue(null);
+  it("forwards the cookie as a bearer and swaps in the fresh token pair", async () => {
+    vi.mocked(backendFetch).mockResolvedValue({ access_token: "new-a", refresh_token: "new-r" });
 
     const response = await changePassword(
       request({ access_token: "tok-123" }, { current_password: "old", new_password: "newpass12" }),
     );
 
-    expect(response.status).toBe(204);
+    expect(response.status).toBe(200);
     const [endpoint, options] = vi.mocked(backendFetch).mock.calls[0]!;
     expect(endpoint).toBe("/api/v1/auth/password/change");
     expect((options?.headers as Record<string, string>).Authorization).toBe("Bearer tok-123");
+    expect(response.cookies.get("access_token")?.value).toBe("new-a");
+    expect(response.cookies.get("refresh_token")?.value).toBe("new-r");
   });
 
   it("sends no bearer when the browser carries no token, so the backend refuses it", async () => {
-    vi.mocked(backendFetch).mockResolvedValue(null);
+    vi.mocked(backendFetch).mockResolvedValue({ access_token: "a", refresh_token: "r" });
 
     await changePassword(request({}, { current_password: "old", new_password: "newpass12" }));
 

--- a/frontend/src/app/api/auth/password/change/route.ts
+++ b/frontend/src/app/api/auth/password/change/route.ts
@@ -18,12 +18,33 @@ export async function POST(request: NextRequest) {
     : {};
   try {
     const body = (await request.json()) as Record<string, unknown>;
-    await backendFetch<unknown>("/api/v1/auth/password/change", {
-      method: "POST",
-      headers: { ...authHeaders, ...forwardedFor(request) },
-      body: JSON.stringify(body),
+    const data = await backendFetch<{ access_token: string; refresh_token: string }>(
+      "/api/v1/auth/password/change",
+      {
+        method: "POST",
+        headers: { ...authHeaders, ...forwardedFor(request) },
+        body: JSON.stringify(body),
+      },
+    );
+    // The change revoked every session including this device's, so the backend
+    // returns a fresh pair at the new credential version; the cookies are swapped
+    // to it, or the next refresh - now on the old version - would 401 (#1517).
+    const response = bffJson({ access_token: data.access_token });
+    response.cookies.set("access_token", data.access_token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      maxAge: 60 * 15,
+      path: "/",
     });
-    return new Response(null, { status: 204 });
+    response.cookies.set("refresh_token", data.refresh_token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      maxAge: 60 * 60 * 24 * 7,
+      path: "/",
+    });
+    return response;
   } catch (error) {
     if (error instanceof BackendApiError) {
       if (error.status === 429) return forwardRateLimit(error);

--- a/frontend/src/app/api/auth/password/change/route.ts
+++ b/frontend/src/app/api/auth/password/change/route.ts
@@ -1,0 +1,36 @@
+import { type NextRequest } from "next/server";
+
+import {
+  BackendApiError,
+  backendFetch,
+  bffJson,
+  bffRefusal,
+  forwardedFor,
+  forwardRateLimit,
+} from "@/lib/server-api";
+
+export async function POST(request: NextRequest) {
+  // The change is authenticated, so the access-token cookie is forwarded as a
+  // bearer; with none, the backend refuses it as any signed-in route does.
+  const accessToken = request.cookies.get("access_token")?.value;
+  const authHeaders: Record<string, string> = accessToken
+    ? { Authorization: `Bearer ${accessToken}` }
+    : {};
+  try {
+    const body = (await request.json()) as Record<string, unknown>;
+    await backendFetch<unknown>("/api/v1/auth/password/change", {
+      method: "POST",
+      headers: { ...authHeaders, ...forwardedFor(request) },
+      body: JSON.stringify(body),
+    });
+    return new Response(null, { status: 204 });
+  } catch (error) {
+    if (error instanceof BackendApiError) {
+      if (error.status === 429) return forwardRateLimit(error);
+      // The backend's own error body, so "Current password is incorrect" reaches
+      // the form rather than a generic message the field cannot act on.
+      return bffJson(error.data, { status: error.status });
+    }
+    return bffRefusal("INTERNAL_SERVER_ERROR", 500);
+  }
+}

--- a/frontend/src/lib/api-client.test.ts
+++ b/frontend/src/lib/api-client.test.ts
@@ -165,6 +165,20 @@ describe("recovering from an expired token", () => {
     ]);
   });
 
+  it("does not refresh and retry a password-change 401", async () => {
+    fetchMock.mockResolvedValueOnce(
+      refused(401, { error: { message: "Current password is incorrect" } }),
+    );
+
+    await expect(
+      apiClient.post("/auth/password/change", { current_password: "x", new_password: "y" }),
+    ).rejects.toBeInstanceOf(ApiError);
+
+    // A wrong current password is the answer, not an expired token: the client
+    // must not refresh and resubmit the wrong password (#1517).
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual(["/api/auth/password/change"]);
+  });
+
   it("keeps the fresh token in memory, which is what the websocket authenticates with", async () => {
     fetchMock
       .mockResolvedValueOnce(refused(401, {}))

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -21,6 +21,12 @@ interface RequestOptions extends Omit<RequestInit, "body"> {
 // The proxy route that mints a fresh access token from the refresh cookie.
 const REFRESH_ENDPOINT = "/auth/refresh";
 
+// Endpoints where a 401 is the answer, not an expired access token, so a refresh
+// and retry would be wrong: the refresh route itself (would loop), and a
+// password change, whose 401 means the current password was wrong - retrying
+// resubmits it and burns the rate limit twice (#1517).
+const NO_REFRESH_RETRY: ReadonlySet<string> = new Set([REFRESH_ENDPOINT, "/auth/password/change"]);
+
 // Shared in-flight refresh promise so a burst of concurrent 401s triggers only
 // ONE refresh round-trip. Reset once the refresh settles.
 let refreshPromise: Promise<boolean> | null = null;
@@ -116,9 +122,9 @@ class ApiClient {
     let response = await doFetch();
 
     // Transparent 401 recovery: refresh once, then retry the request once.
-    // Never recurse into the refresh endpoint itself (would loop), and only
-    // attempt this a single time per call.
-    if (response.status === 401 && endpoint !== REFRESH_ENDPOINT) {
+    // Never on an endpoint whose 401 is the answer rather than an expired token,
+    // and only a single time per call.
+    if (response.status === 401 && !NO_REFRESH_RETRY.has(endpoint)) {
       const refreshed = await refreshAccessToken();
       if (refreshed) {
         response = await doFetch();

--- a/frontend/src/lib/platform-proxy.test.ts
+++ b/frontend/src/lib/platform-proxy.test.ts
@@ -694,11 +694,7 @@ function calledPaths(): Set<string> {
  * ignored because "the client calls something that does not exist" is
  * otherwise exactly the thing this sweep is for.
  */
-const CALLED_WITHOUT_AN_ENDPOINT: ReadonlySet<string> = new Set([
-  // Settings → Account. The form is built; the backend endpoint is not, and the
-  // page says so in the toast it shows on the 404.
-  "/api/auth/password/change",
-]);
+const CALLED_WITHOUT_AN_ENDPOINT: ReadonlySet<string> = new Set([]);
 
 describe("every endpoint the client calls is proxied", () => {
   it("finds the calls it is supposed to be checking", () => {


### PR DESCRIPTION
> **Stacked on #1498 (#1439).** The base is `fix/1439-revoke-sessions-on-password-change`,
> so this diff is only #1517's commits; it retargets to `main` once #1498 merges.
> #1517's revocation lives in `UserService.update`, which #1498 adds, so this
> cannot stand alone.

#1439 revokes the account's other sessions on a password change, but two gaps
meant it protected nothing in practice. This closes both, and the review's
findings on top.

## 1. A working password-change endpoint

The Settings account form has always posted to `/auth/password/change`, and no
handler existed — it 404'd behind a "requires backend" toast, so the one action a
person takes when they think they are compromised did nothing, and #1439's
revocation was never reached.

`POST /auth/password/change` proves the current password — which `PATCH /users/me`
cannot ask for — under a lock on the user row, then changes it. It revokes **every**
session (the caller's own included, since the version gate below would refuse a
spared session's stale token anyway) and opens a fresh session at the new version,
returning its tokens; the BFF swaps the cookies to them. The caller stays signed
in while every other device is logged out, and `PATCH /users/me` now **refuses** a
password so it cannot be used as a bypass.

## 2. Closing the revocation-vs-rotation race

A refresh rotating a stolen token could read its session as active before the
deactivate and insert its replacement after. A `credential_version` on the user,
bumped on every password change under the row lock and stamped into each refresh
token as `cv`, closes it: the refresh path refuses a token whose `cv` is behind
the account's. A token minted before the claim reads as 0, so nothing is logged
out on deploy until the first change.

## Verified

- Service: refuses a wrong current password and an OAuth-only account with none,
  proves against the *locked* row, revokes every session, and bumps the version;
  a profile edit does neither and `/users/me` refuses a password.
- Route: answers 200 with a fresh refresh token carrying the new version, mints
  no session on a wrong password, and rate-limits by account as well as address.
- Refresh: refuses a token below the version; one at it rotates and carries the
  version forward.
- Frontend: the BFF swaps both cookies; a password-change 401 does not refresh and
  retry; the proxy-coverage list has no stale entry.
- Migration verified against a real Postgres — applies over the chain, `alembic
  check` sees no model drift, and it reverses. `make check` green.

Closes #1517
