### PR TITLE
fix(mcp): refuse an org OAuth start under an impersonation

### DIFF
--- a/backend/app/services/mcp_connection.py
+++ b/backend/app/services/mcp_connection.py
@@ -667,7 +667,14 @@ class McpConnectionService:
         connection stops working, and the fix is for somebody to authorize it
         again. An organization that wants this should consent with an account it
         controls, not with a member's personal one.
+
+        Raises:
+            AuthorizationError: When the request runs under an impersonation. The
+                grant that comes back is the administrator's own, and the org
+                connection would record it as the member's - the org half of the
+                refusal #1438 made for personal connections (#1490).
         """
+        refuse_binding_while_impersonating("Connecting an integration")
         return await self._oauth_start(
             name=name,
             url=url,
@@ -866,7 +873,10 @@ class McpConnectionService:
                 connect through GitHub (no `mcp_catalog_key`).
             NotFoundError: If the organization has stored no `github_oauth_app`
                 secret - a 4xx the connect UI shows, never a 500.
+            AuthorizationError: When the request runs under an impersonation - the
+                administrator's own grant would be bound as the member's (#1490).
         """
+        refuse_binding_while_impersonating("Connecting an integration")
         portal = portal_catalog.get_portal(portal_key)
         if portal is None or portal.mcp_catalog_key is None:
             raise BadRequestError(
@@ -1059,7 +1069,10 @@ class McpConnectionService:
                 the same way a missing GitHub OAuth App is, never a 500.
             BadRequestError: If more than one is stored, or `portal_key` names no
                 polled portal.
+            AuthorizationError: When the request runs under an impersonation - the
+                administrator's own grant would be bound as the member's (#1490).
         """
+        refuse_binding_while_impersonating("Connecting an integration")
         portal = portal_catalog.get_portal(portal_key)
         if portal is None or portal.delivery is not portal_catalog.DeliveryMode.POLLING:
             raise BadRequestError(

--- a/backend/tests/test_mcp_connections.py
+++ b/backend/tests/test_mcp_connections.py
@@ -1747,6 +1747,33 @@ class TestMcpConnectionService:
         repo.create.assert_not_called()
 
     @pytest.mark.anyio
+    async def test_org_oauth_start_is_refused_under_an_impersonation(self, service, repo):
+        """The organization start binds a grant the same way, so it takes the same
+        refusal - before any discovery or row - the org half of #1438 (#1490)."""
+        ctx = AuthContext(user_id=uuid4(), organization_id=uuid4(), role=OrgRoleName.OWNER.value)
+        with _impersonating(), pytest.raises(AuthorizationError):
+            await service.oauth_start_for_org(ctx, name="shared", url="https://srv/mcp")
+        repo.create_org_scoped.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_org_github_oauth_start_is_refused_under_an_impersonation(self, service, repo):
+        """The GitHub org start skips `_oauth_start`, so it carries its own guard -
+        refused before the org's OAuth-app credentials are even read (#1490)."""
+        ctx = AuthContext(user_id=uuid4(), organization_id=uuid4(), role=OrgRoleName.OWNER.value)
+        with _impersonating(), pytest.raises(AuthorizationError):
+            await service.oauth_start_for_org_github(ctx, portal_key="any-portal")
+        repo.create_org_scoped.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_polled_portal_oauth_start_is_refused_under_an_impersonation(self, service, repo):
+        """The polled-portal start skips `_oauth_start` too, so it carries its own
+        guard - the third org route #1438's single guard would have missed (#1490)."""
+        ctx = AuthContext(user_id=uuid4(), organization_id=uuid4(), role=OrgRoleName.OWNER.value)
+        with _impersonating(), pytest.raises(AuthorizationError):
+            await service.oauth_start_for_polled_portal(ctx, portal_key="any-portal")
+        repo.create_org_scoped.assert_not_called()
+
+    @pytest.mark.anyio
     async def test_oauth_start_registers_and_persists_pending(self, service, repo, monkeypatch):
         _allow_any_url(monkeypatch)
         discovered = mcp_oauth.DiscoveredServer(


### PR DESCRIPTION
> **Stacked on #1491 (#1438).** The base is
> `fix/1438-refuse-identity-binding-while-impersonating`, whose
> `refuse_binding_while_impersonating` this uses; it retargets to `main` once
> #1491 merges.

#1438 refuses the two *personal* identity-binding routes under an impersonation.
The **organization-scoped** OAuth starts take the same class of action and were
not guarded:

- `POST /organizations/{id}/mcp-connections/oauth/start` → `oauth_start_for_org`
- `.../oauth/start/github` → `oauth_start_for_org_github`
- `.../oauth/start/portal` → `oauth_start_for_polled_portal`

While an app admin acts as B, they could start an org OAuth flow, consent with
the **administrator's own** provider account, and the org connection was created
with `created_by_user_id = ctx.subject_id` — the administrator's grant recorded
as B's, and it stops working when the administrator's provider access is revoked,
with nothing saying why.

## Fix

The consistent half of #1438's decision: **refuse**. Each org start now calls
`refuse_binding_while_impersonating` at its entry — the personal `oauth_start`
already guards there, and the github/portal starts skip `_oauth_start`, so a
single chokepoint guard would have missed two of the three (the issue's own
note). Guarding each entry refuses before any discovery, credential read or row,
and keeps the tests trivial.

## Verified

A test that each of the three org starts raises `AuthorizationError` under an
impersonation and creates no org-scoped row. `make check` green.

Closes #1490
