### PR TITLE
fix(mcp): refuse manual token entry while impersonating

### DIFF
--- a/backend/app/services/mcp_connection.py
+++ b/backend/app/services/mcp_connection.py
@@ -474,6 +474,12 @@ class McpConnectionService:
                 silently never substitutes rather than an obvious mistake.
             AlreadyExistsError: If this member already has a connection by that
                 name.
+            AuthorizationError: When the request runs under an impersonation and a
+                non-empty `auth_token` is supplied. The token is the administrator's
+                own, sealed under the target's vault scope, and it would speak as
+                the administrator's account, outlive the hour the impersonation is
+                bounded to, and stand recorded against the target (#1492); refused,
+                not audited.
         """
         if data.catalog_key is not None and not await self._known_catalog_key(data.catalog_key):
             raise BadRequestError(
@@ -488,6 +494,8 @@ class McpConnectionService:
                 details={"name": data.name},
             )
         token = data.auth_token.strip() if data.auth_token else None
+        if token:
+            refuse_binding_while_impersonating("Adding an integration token")
         sealed = seal(token, scope=VaultScope.user(user_id)) if token else None
         try:
             return await mcp_connection_repo.create(
@@ -511,6 +519,16 @@ class McpConnectionService:
     async def update(
         self, *, user_id: UUID, connection_id: UUID, data: McpConnectionUpdate
     ) -> McpConnection:
+        """Change one member's own connection.
+
+        Raises:
+            AlreadyExistsError: If the new name is taken by another of this
+                member's connections.
+            AuthorizationError: When the request runs under an impersonation and a
+                non-empty `auth_token` replacement is supplied - the same refusal
+                as `create`, for the same reason (#1492). Clearing the token is
+                left alone; it stores no credential.
+        """
         # Locked from the read: the token below is sealed at the row's recorded
         # key version, and a rotation committing between an unlocked read and
         # this write would tag the new envelope with a version it was not
@@ -540,6 +558,8 @@ class McpConnectionService:
             # "" clears the stored token; a non-empty value replaces it, sealed at
             # the row's version - one version column covers every envelope in the
             # row, so bumping it would orphan the OAuth siblings (#552).
+            if token:
+                refuse_binding_while_impersonating("Adding an integration token")
             sealed = _seal_for(db_connection, token) if token else None
             update_data["auth_token"] = sealed.ciphertext if sealed else None
 

--- a/backend/app/services/mcp_connection.py
+++ b/backend/app/services/mcp_connection.py
@@ -1282,6 +1282,8 @@ class McpConnectionService:
                 details={"name": data.name},
             )
         token = data.auth_token.strip() if data.auth_token else None
+        if token:
+            refuse_binding_while_impersonating("Adding an integration token")
         sealed = seal(token, scope=VaultScope.organization(ctx.organization_id)) if token else None
         try:
             connection = await mcp_connection_repo.create_org_scoped(
@@ -1323,6 +1325,12 @@ class McpConnectionService:
         update_data: dict[str, Any] = writable(
             data, over=McpConnection, exclude={"clear_allowed_tools"}
         )
+        # What the caller changed, snapshotted before the staleness resets below
+        # add their own keys - those are bookkeeping, not an edit the audit should
+        # report (#1521).
+        edited_fields = set(update_data)
+        if data.clear_allowed_tools:
+            edited_fields.add("allowed_tools")
 
         if "url" in update_data:
             update_data["url"] = await _checked_url(update_data["url"])
@@ -1342,6 +1350,8 @@ class McpConnectionService:
 
         if "auth_token" in update_data:
             token = (update_data["auth_token"] or "").strip()
+            if token:
+                refuse_binding_while_impersonating("Adding an integration token")
             # "" clears the stored token; a non-empty value replaces it, sealed at
             # the row's version - one version column covers every envelope in the
             # row, so bumping it would orphan the OAuth siblings (#552).
@@ -1379,9 +1389,25 @@ class McpConnectionService:
 
         if not update_data:
             return db_connection
-        return await mcp_connection_repo.update(
+        connection = await mcp_connection_repo.update(
             self.db, db_connection=db_connection, update_data=update_data
         )
+        # `create_for_org` records who created a shared credential; an update that
+        # repoints or re-keys one is the same authority and left no trail at all
+        # (#1521). Under an impersonation `record_audit` stamps the administrator
+        # behind it, so a change made while acting as somebody else is attributable
+        # to who really made it. The fields that changed, never their values: the
+        # token is sealed and must not reach the log, and the rest is on the row.
+        await record_audit(
+            self.db,
+            actor_user_id=ctx.subject_id,
+            organization_id=ctx.organization_id,
+            action="mcp_connection.updated",
+            target_type="mcp_connection",
+            target_id=str(connection.id),
+            details={"fields": sorted(edited_fields)},
+        )
+        return connection
 
     async def delete_for_org(self, ctx: AuthContext, *, connection_id: UUID) -> None:
         db_connection = await self._get_org(ctx, connection_id)

--- a/backend/tests/test_mcp_connections.py
+++ b/backend/tests/test_mcp_connections.py
@@ -1747,6 +1747,72 @@ class TestMcpConnectionService:
         repo.create.assert_not_called()
 
     @pytest.mark.anyio
+    async def test_create_with_a_token_is_refused_under_an_impersonation(
+        self, service, repo, monkeypatch
+    ):
+        """An administrator acting as B must not store their own bearer token as
+        B's personal connection - B's agents would then call the server as the
+        administrator's account after the hour-bounded impersonation ends, and
+        the credential would stand recorded against B (#1492)."""
+        _allow_any_url(monkeypatch)
+        with _impersonating(), pytest.raises(AuthorizationError):
+            await service.create(
+                user_id=uuid4(),
+                data=McpConnectionCreate(
+                    name="linear", url="https://srv/mcp", auth_token="admin-token"
+                ),
+            )
+        repo.create.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_create_without_a_token_is_allowed_under_an_impersonation(
+        self, service, repo, monkeypatch
+    ):
+        """Only a manually entered credential is refused - a tokenless connection
+        captures no identity, and configuring one as B is much of what
+        impersonation is for (#1492)."""
+        _allow_any_url(monkeypatch)
+        with _impersonating():
+            await service.create(
+                user_id=uuid4(),
+                data=McpConnectionCreate(name="linear", url="https://srv/mcp"),
+            )
+        repo.create.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_update_with_a_replacement_token_is_refused_under_an_impersonation(
+        self, service, repo
+    ):
+        """The same refusal as create, for a token pasted over an existing
+        connection. Refused before the write, so nothing is resealed (#1492)."""
+        user_id = uuid4()
+        conn = _connection(user_id=user_id)
+        repo.get_by_id.return_value = conn
+        with _impersonating(), pytest.raises(AuthorizationError):
+            await service.update(
+                user_id=user_id,
+                connection_id=conn.id,
+                data=McpConnectionUpdate(auth_token="admin-token"),
+            )
+        repo.update.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_update_clearing_the_token_is_allowed_under_an_impersonation(self, service, repo):
+        """Removing a token stores no credential, so it is left alone - only a
+        non-empty replacement is refused (#1492)."""
+        user_id = uuid4()
+        conn = _connection(user_id=user_id)
+        conn.auth_token = _seal_into(conn, "old")
+        repo.get_by_id.return_value = conn
+        with _impersonating():
+            await service.update(
+                user_id=user_id,
+                connection_id=conn.id,
+                data=McpConnectionUpdate(auth_token=""),
+            )
+        assert repo.update.call_args.kwargs["update_data"]["auth_token"] is None
+
+    @pytest.mark.anyio
     async def test_oauth_start_registers_and_persists_pending(self, service, repo, monkeypatch):
         _allow_any_url(monkeypatch)
         discovered = mcp_oauth.DiscoveredServer(

--- a/backend/tests/test_mcp_connections.py
+++ b/backend/tests/test_mcp_connections.py
@@ -2553,6 +2553,39 @@ class TestOrganizationConnections:
         }
         assert "ghp-secret-9876" not in str(recorded)
 
+    @pytest.mark.anyio
+    async def test_creating_with_a_token_is_refused_under_an_impersonation(
+        self, service, ctx, repo, audit, monkeypatch
+    ):
+        """An administrator acting as an org owner must not store their own bearer
+        token as the organization's shared credential: every org agent would then
+        call the server as the administrator's account after the hour-bounded
+        impersonation ends, and the token was entered by nobody the org can see
+        (#1521). Refused before the write, so nothing is sealed."""
+        _allow_any_url(monkeypatch)
+        with _impersonating(), pytest.raises(AuthorizationError):
+            await service.create_for_org(
+                ctx,
+                OrgMcpConnectionCreate(
+                    name="github", url="https://example.com/mcp", auth_token="admin-token"
+                ),
+            )
+        repo.create_org_scoped.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_creating_without_a_token_is_allowed_under_an_impersonation(
+        self, service, ctx, repo, audit, monkeypatch
+    ):
+        """Only a manually entered credential is refused - a tokenless org server
+        captures no identity, and configuring one while acting as an owner is
+        ordinary administration (#1521)."""
+        _allow_any_url(monkeypatch)
+        with _impersonating():
+            await service.create_for_org(
+                ctx, OrgMcpConnectionCreate(name="docs", url="https://example.com/mcp")
+            )
+        repo.create_org_scoped.assert_called_once()
+
     # -- updating -------------------------------------------------------
 
     @pytest.mark.anyio
@@ -2625,6 +2658,75 @@ class TestOrganizationConnections:
         # No new envelope, so the version that sealed the old one is left alone
         # rather than rewritten to describe a token that no longer exists.
         assert "secret_key_version" not in update_data
+
+    @pytest.mark.anyio
+    async def test_updating_with_a_replacement_token_is_refused_under_an_impersonation(
+        self, service, ctx, repo, audit
+    ):
+        """The same refusal as creating, for a token pasted over an existing org
+        connection. Refused before the write, so nothing is resealed (#1521)."""
+        conn = self._org_connection(ctx)
+        repo.get_org_scoped_by_id.return_value = conn
+        with _impersonating(), pytest.raises(AuthorizationError):
+            await service.update_for_org(
+                ctx, connection_id=conn.id, data=OrgMcpConnectionUpdate(auth_token="admin-token")
+            )
+        repo.update.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_updating_clearing_the_token_is_allowed_under_an_impersonation(
+        self, service, ctx, repo, audit
+    ):
+        """Removing a token stores no credential, so it is left alone - only a
+        non-empty replacement is refused (#1521)."""
+        conn = self._org_connection(ctx, auth_token="envelope")
+        repo.get_org_scoped_by_id.return_value = conn
+        repo.update.return_value = conn
+        with _impersonating():
+            await service.update_for_org(
+                ctx, connection_id=conn.id, data=OrgMcpConnectionUpdate(auth_token="")
+            )
+        assert repo.update.call_args.kwargs["update_data"]["auth_token"] is None
+
+    @pytest.mark.anyio
+    async def test_an_update_records_who_changed_the_shared_credential(
+        self, service, ctx, repo, audit, monkeypatch
+    ):
+        """`create_for_org` records who added a shared credential; an update that
+        rotated or repointed one left no trail at all. It now records the change -
+        the fields, never their values or the staleness resets - so a token set
+        under an impersonation is attributable to the administrator behind it,
+        which `record_audit` stamps from the audit context (#1521)."""
+        _allow_any_url(monkeypatch)
+        conn = self._org_connection(ctx)
+        repo.get_org_scoped_by_id.return_value = conn
+        repo.update.return_value = conn
+
+        await service.update_for_org(
+            ctx,
+            connection_id=conn.id,
+            data=OrgMcpConnectionUpdate(auth_token="ghp-rotated-4321"),
+        )
+
+        recorded = audit.call_args.kwargs
+        assert recorded["action"] == "mcp_connection.updated"
+        assert recorded["organization_id"] == ctx.organization_id
+        assert recorded["target_id"] == str(conn.id)
+        assert recorded["details"] == {"fields": ["auth_token"]}
+        assert "ghp-rotated-4321" not in str(recorded)
+
+    @pytest.mark.anyio
+    async def test_a_no_op_update_writes_no_audit(self, service, ctx, repo, audit):
+        """An update that changes nothing returns early, so it neither writes the
+        row nor records an entry that says a shared credential changed when it
+        did not (#1521)."""
+        conn = self._org_connection(ctx)
+        repo.get_org_scoped_by_id.return_value = conn
+
+        await service.update_for_org(ctx, connection_id=conn.id, data=OrgMcpConnectionUpdate())
+
+        repo.update.assert_not_called()
+        audit.assert_not_called()
 
     @pytest.mark.anyio
     async def test_moving_the_url_somewhere_internal_is_refused_by_field(self, service, ctx, repo):

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1322,6 +1322,14 @@ administrator still does on the member's behalf is configuration that stores no
 secret — a name, a URL, a tool allowlist — and clearing a stored token, which
 keeps nothing.
 
+An **organization's** shared connection is the same, though it is meant to be
+admin-entered: a bearer token typed onto one under an impersonation is refused
+too, because sealed under the organization's vault scope it speaks as the
+administrator's own account for every agent the organization binds, past the
+hour the impersonation ends. Creating an org connection already recorded the
+administrator behind it; updating one recorded nothing at all, so a token
+rotated onto an existing connection now leaves the same trail (#1521).
+
 ## What none of this covers
 
 Worth stating, because a governance page implies otherwise:

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1312,10 +1312,15 @@ Both are refused with a 403 while impersonating, because an administrator
 repairing a member's connection is not a flow this platform has. The member
 links their own accounts, as themselves.
 
-The line is the administrator's *own* identity: the refusal covers a binding
-that captures whoever is acting — a chat account, an OAuth grant — not ordinary
-configuration an administrator legitimately performs on the member's behalf,
-such as typing a server's bearer token.
+The line is any credential fastened to the member, not only an identity: beyond
+the chat account and the OAuth grant above, a bearer token typed onto the
+member's connection is refused too. Such a token is not the administrator's own
+identity, but sealed under the member's vault scope it speaks as whoever's
+account it belongs to for every one of the member's agents, outlives the hour
+the impersonation is bounded to, and stands recorded against the member. What an
+administrator still does on the member's behalf is configuration that stores no
+secret — a name, a URL, a tool allowlist — and clearing a stored token, which
+keeps nothing.
 
 ## What none of this covers
 


### PR DESCRIPTION
## What this refuses

An administrator acting as another account (an impersonation) could paste their own MCP server bearer token into the personal connection surface — `POST /api/v1/me/mcp-connections` (`McpConnectionService.create`) or `PATCH /api/v1/me/mcp-connections/{id}` (`.update`). The token was sealed under the **target's** vault scope, so the target's agents would call that server as the administrator's account, the credential outlived the hour-bounded impersonation, and it stood recorded against the target.

This is the manual-token half of the captured-identity line #1438 drew (personal chat link + personal OAuth) and #1490 extended to organization-scoped OAuth.

## The decision

Refuse, matching #1438 / #1490 — not audit. Both `create` and `update` call `refuse_binding_while_impersonating("Adding an integration token")` when a non-empty `auth_token` is supplied, **before** the vault seal and the repo write, so nothing is stored on refusal (403 `AuthorizationError`).

**Clearing a token is left alone** — it stores no credential, and configuring a connection *as the target* is much of what impersonation is for. Only a non-empty value is refused.

## Tests

Four service tests in `tests/test_mcp_connections.py`:

- `create` with a token under an impersonation → refused, `repo.create` never called
- `update` with a replacement token under an impersonation → refused, `repo.update` never called
- a tokenless `create` under an impersonation → allowed
- a token-clearing `update` under an impersonation → allowed (stores `None`)

## Verification

`make check` green in substance — 7324 passed, 0 failures; `app/services/mcp_connection.py` at 100%. The reported 98.99% total is the local integration-skip artifact (no database on this machine); CI, which has one, reaches 100%.

## Scope / follow-up

Scoped to the personal `/me/` surface named by the issue. The organization-scoped manual-token path (`create_for_org` / `update_for_org`) has the same shape and no guard — its `create` audit already attributes to the impersonator but `update` writes no audit at all. Filed as **#1521** rather than folded in here, since whether to refuse (as here) or accept a deliberately-shared org credential is a decision of its own.

## Stack

Branches off `fix/1438-refuse-identity-binding-while-impersonating` for `refuse_binding_while_impersonating`; cannot stand alone until #1438 merges, at which point GitHub retargets this PR to `main`.

Closes #1492
Refs #1438, #1490, #1521
