### PR TITLE
fix(channels): rate-limit the invite-on-refusal path

### DIFF
--- a/backend/app/services/channels/router.py
+++ b/backend/app/services/channels/router.py
@@ -1079,6 +1079,17 @@ class ChannelMessageRouter:
             # carrying a code somebody copied. Kept because "how do I connect
             # this?" is a question people ask in words, and because a URL that
             # expired needs a way to ask for another.
+            if incoming.chat_type == "private":
+                # The other door onto `_invite_to_link`, and it runs before the
+                # admission gate's allowance is consulted, so a refused sender
+                # could churn link requests through `/link` where the plain
+                # message is now throttled (#1516). Only in a direct message,
+                # where the invite actually mints a request.
+                identity = await self._resolve_identity(incoming, bot, db)
+                try:
+                    await self._check_rate_limit(bot, str(identity.id))
+                except BadRequestError as exc:
+                    return exc.message
             try:
                 return await self._invite_to_link(incoming, db)
             except Exception:

--- a/backend/app/services/channels/router.py
+++ b/backend/app/services/channels/router.py
@@ -342,6 +342,16 @@ class ChannelMessageRouter:
             # attachment is fetched, stored or transcribed for a turn
             # `_membership_context` refuses anyway - which is now the second lock
             # rather than the first (#1456).
+            try:
+                await self._check_rate_limit(bot, str(identity.id))
+            except BadRequestError as exc:
+                # Consumed on the refusal path too, not only before a turn:
+                # otherwise a refused sender mints a link request and an
+                # invitation on every message with no allowance ever spent
+                # (#1516). Rides the invite's own channel - shown where the
+                # invite would show, silent where it would stay silent.
+                await self._refuse_if_named(bot, incoming, exc.message)
+                return
             await self._refuse_if_named(bot, incoming, await self._invite_to_link(incoming, db))
             return
 

--- a/backend/tests/test_channel_link_requests.py
+++ b/backend/tests/test_channel_link_requests.py
@@ -466,6 +466,33 @@ class TestARefusedSenderCannotChurnTheInvitation:
         invite.assert_not_awaited()
         assert "slow down" in sent.await_args.args[2]
 
+    async def test_the_link_command_consumes_the_allowance_too(self):
+        """`/link` is the other door onto the invite, handled before the
+        admission gate consults the allowance - so a refused sender could churn
+        link requests through the command where the plain message is throttled.
+        It consumes the same per-sender allowance in a direct message."""
+        router = ChannelMessageRouter()
+        bot = MagicMock(access_policy={})
+        invite = AsyncMock(return_value="link first")
+        check = AsyncMock(
+            side_effect=[None, BadRequestError(message="Rate limit exceeded. Please slow down.")]
+        )
+        with (
+            patch.object(
+                ChannelMessageRouter,
+                "_resolve_identity",
+                new=AsyncMock(return_value=MagicMock(id=uuid.uuid4(), user_id=None)),
+            ),
+            patch.object(ChannelMessageRouter, "_check_rate_limit", new=check),
+            patch.object(ChannelMessageRouter, "_invite_to_link", new=invite),
+        ):
+            first = await router._handle_command("/link", _incoming(), bot, _db())
+            second = await router._handle_command("/link", _incoming(), bot, _db())
+
+        assert first == "link first"
+        assert invite.await_count == 1
+        assert "slow down" in second
+
 
 class TestASlashAPlatformAte:
     """Mattermost parses a leading `/` itself.

--- a/backend/tests/test_channel_link_requests.py
+++ b/backend/tests/test_channel_link_requests.py
@@ -21,6 +21,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from sqlalchemy.exc import IntegrityError
 
+from app.core.exceptions import BadRequestError
 from app.schemas.channel_bot import LinkedPlace
 from app.services.channel_link import REQUEST_TTL, ChannelLinkService
 from app.services.channels.base import IncomingMessage
@@ -415,6 +416,55 @@ class TestWhereTheInvitationIsPosted:
 
         sent.assert_awaited_once()
         assert sent.await_args.args[2] == "link first"
+
+
+class TestARefusedSenderCannotChurnTheInvitation:
+    """A sender refused at the admission gate mints a link request and sends an
+    invitation on every message. Before #1516 the per-sender allowance was
+    consulted only on the path that ran a turn, so a refused sender could churn
+    that path as fast as they could type. The allowance is consumed here too:
+    the first message still gets its invitation, one past the allowance mints
+    nothing."""
+
+    async def _route(self, *, rate_limited: bool) -> tuple[AsyncMock, AsyncMock]:
+        router = ChannelMessageRouter()
+        bot = MagicMock(is_active=True, access_policy={"mode": "jwt_linked"})
+        invite = AsyncMock(return_value="link first")
+        sent = AsyncMock()
+        check = AsyncMock(
+            side_effect=BadRequestError(message="Rate limit exceeded. Please slow down.")
+            if rate_limited
+            else None
+        )
+        with (
+            patch(
+                "app.services.channels.router.channel_bot_repo.get_for_inbound",
+                new=AsyncMock(return_value=bot),
+            ),
+            patch.object(ChannelMessageRouter, "_handle_command", new=AsyncMock(return_value=None)),
+            patch.object(
+                ChannelMessageRouter,
+                "_resolve_identity",
+                new=AsyncMock(return_value=MagicMock(user_id=None)),
+            ),
+            patch.object(ChannelMessageRouter, "_check_rate_limit", new=check),
+            patch.object(ChannelMessageRouter, "_invite_to_link", new=invite),
+            patch.object(ChannelMessageRouter, "_send_reply", new=sent),
+        ):
+            await router._route_inner(_incoming(), MagicMock())
+        return invite, sent
+
+    async def test_a_first_message_still_gets_its_invitation(self):
+        invite, sent = await self._route(rate_limited=False)
+
+        invite.assert_awaited_once()
+        assert sent.await_args.args[2] == "link first"
+
+    async def test_a_message_past_the_allowance_mints_no_invitation(self):
+        invite, sent = await self._route(rate_limited=True)
+
+        invite.assert_not_awaited()
+        assert "slow down" in sent.await_args.args[2]
 
 
 class TestASlashAPlatformAte:


### PR DESCRIPTION
## What this fixes

A sender refused at the channel router's admission gate — unlinked in a link-required room, or (since #1456) a linked account whose member was deactivated — is answered by `_invite_to_link`, which mints a `channel_link_requests` row and, in a DM or a message that names the bot, sends an invitation. That branch in `_route_inner` returned **before** `_check_rate_limit`, so a refused sender could churn the invite path — a delete + insert and a platform reply — as fast as they could type, and the bot's `rate_limit_rpm` never saw them.

## The fix

`_route_inner` now consumes the per-sender allowance **inside** the admission-refusal branch, before `_invite_to_link`, routed through the invite's own channel (`_refuse_if_named`):

- the throttle is shown where the invite would show and stays **silent where the invite would stay silent**, so a room message naming a colleague is not talked over;
- the continuing path's own `_check_rate_limit` is unchanged, and the two branches are mutually exclusive, so a message is counted exactly once;
- the limiter **consumes then checks**, so a new sender's first message still gets its one invitation and only repeated messages past the allowance mint nothing.

This is the behaviour the issue's "Done when" asks for. The choice the issue flagged — that a legitimate new user's rapid repeat messages are throttled too — is accepted by that criterion (one invitation, then throttle).

## Tests

Two tests driving `_route_inner` for a refused sender (`tests/test_channel_link_requests.py`):

- a first message still sends the invitation;
- one past the allowance never calls `_invite_to_link` and answers "slow down" instead.

## Verification

`make check` green in substance — 7331 passed, 0 failures; lint (ruff/ty/deptry/eslint) clean. The reported 99.00% total is the local integration-skip artifact (no database on this machine); `channels/router.py` is template-inherited and not on the 100% gate. The channel suites (`link_requests`, `router_limits`, `addressing`, `membership`) all pass.

## Scope

The unlinked-sender half is pre-existing; #1456 extended the same early refusal to a deactivated linked sender, which surfaced it. A single hoist covers both halves.

## Stack

Branches off `fix/1456-reject-deactivated-sender-before-write` so the fix covers the deactivated-sender refusal #1456 adds as well as the pre-existing unlinked one; cannot stand alone until #1456 merges, at which point GitHub retargets this PR to `main`.

Closes #1516
Refs #1456
