### PR TITLE
fix(channels): discard a crashed turn's files, not only a refused turn's

### DIFF
--- a/backend/app/repositories/chat_file.py
+++ b/backend/app/repositories/chat_file.py
@@ -87,6 +87,26 @@ async def link_to_message(
     return result.rowcount  # ty: ignore[unresolved-attribute]
 
 
+async def unlinked_ids(db: AsyncSession, file_ids: Iterable[UUID]) -> set[UUID]:
+    """Of these files, the ids whose row is not yet attached to a message.
+
+    A turn's attachments are linked when the runner records its transcript - a
+    failed turn included, which persists and commits before it re-raises - so a
+    file already carrying a `message_id` belongs to a stored turn and must not be
+    swept up as an orphan (#1503). Read as a column select rather than through the
+    mapped rows: the link is a bulk UPDATE the session never saw and
+    `expire_on_commit` is off, so a loaded instance still reads `message_id` as
+    None.
+    """
+    ids = list(file_ids)
+    if not ids:
+        return set()
+    result = await db.execute(
+        select(ChatFile.id).where(ChatFile.id.in_(ids), ChatFile.message_id.is_(None))
+    )
+    return set(result.scalars().all())
+
+
 async def delete(db: AsyncSession, *, db_file: ChatFile) -> None:
     """Delete a chat file row."""
     await db.delete(db_file)

--- a/backend/app/services/channels/router.py
+++ b/backend/app/services/channels/router.py
@@ -21,6 +21,7 @@ from app.repositories import (
     channel_bot_repo,
     channel_identity_repo,
     channel_session_repo,
+    chat_file_repo,
     conversation_repo,
 )
 from app.services import rate_limit
@@ -904,17 +905,24 @@ class ChannelMessageRouter:
 
     @staticmethod
     async def _discard_files(db: AsyncSession, files: list[Any]) -> None:
-        """Give back what the turn stored, for a turn that was refused.
+        """Give back what a turn stored, but only the rows still unlinked.
 
-        The files are fetched and stored before the agent is resolved, so a
-        refusal raised in its place - nothing exposed on this bot, a sender whose
-        account is nobody's - leaves rows nothing will ever link to a message and
-        bytes nothing will ever read (#661). The refusal is still what the sender
-        gets: nothing here is allowed to raise in its way.
+        The files are fetched and stored before the agent is resolved, so a turn
+        that ends without ever linking them - a refusal raised in the agent's
+        place, or a crash before a run was created - leaves rows nothing will link
+        to a message and bytes nothing will read (#661). A crash *during* the run
+        is different: the runner records the failed turn's user message and links
+        these files to it, and commits, before re-raising - so discarding them
+        would strip a persisted transcript of what the sender sent. Only the files
+        the database still shows as unlinked are given back (#1503); nothing here
+        is allowed to raise in the refusal's way.
         """
         if not files:
             return
-        await ChannelAttachmentService(db).discard(files)
+        orphan_ids = await chat_file_repo.unlinked_ids(db, [file.id for file in files])
+        orphaned = [file for file in files if file.id in orphan_ids]
+        if orphaned:
+            await ChannelAttachmentService(db).discard(orphaned)
 
     @staticmethod
     def _with_notes(answer: str, *notes: list[str]) -> str:

--- a/backend/app/services/channels/router.py
+++ b/backend/app/services/channels/router.py
@@ -596,12 +596,11 @@ class ChannelMessageRouter:
           but on a crash may be an agent-slug the platform did not report. This is
           the mention copy's own rule, now the default's too.
 
-        A refused turn's already-stored files are discarded: a turn that produced
-        no run leaves rows nothing points at, and `chat_files` carries no
-        organization, so an unlinked row is scoped by `user_id` alone (#690).
-        Nothing streamed on a refusal, so the lazy placeholder was never opened.
-        A crash leaves the files as the default path always has - #1503 tracks
-        that orphan.
+        A refused or crashed turn's already-stored files are discarded: a turn
+        that produced no run leaves rows nothing points at, and `chat_files`
+        carries no organization, so an unlinked row is scoped by `user_id` alone
+        (#690, #1503). Nothing streamed on a refusal, so the lazy placeholder was
+        never opened.
 
         Returns True when the turn was handled - answered, refused or apologised.
         False is the mention path's `UnaddressedMessage`: the handle named nobody
@@ -618,6 +617,7 @@ class ChannelMessageRouter:
             return True
         except Exception:
             logger.exception("Agent run failed for bot %s", incoming.bot_id)
+            await self._discard_files(db, files)
             await self._post_failure(
                 bot, incoming, handle(), "Sorry, something went wrong. Please try again."
             )

--- a/backend/tests/integration/test_channel_attachment_rows.py
+++ b/backend/tests/integration/test_channel_attachment_rows.py
@@ -25,6 +25,7 @@ from app.db.models.chat_file import ChatFile
 from app.db.models.conversation import Conversation
 from app.db.models.organization import Organization
 from app.db.models.user import User
+from app.repositories import chat_file as chat_file_repo
 from app.repositories import conversation as conversation_repo
 from app.services.transcript import TranscriptService
 
@@ -159,3 +160,26 @@ class TestAFileThatArrivedWithATurn:
         asked = written[0]
         assert (asked.role, asked.content) == ("user", "Attached image: report.png")
         assert [file.filename for file in asked.files] == ["report.png"]
+
+
+class TestUnlinkedIds:
+    """What the channel router's crash/refusal discard leans on to avoid deleting
+    a file a failed run already linked to its transcript. Against a real database
+    because the whole point is a link the loaded row does not reflect: it is a bulk
+    UPDATE and `expire_on_commit` is off, so a column read is the only truthful one
+    (#1503)."""
+
+    async def test_it_excludes_a_file_a_recorded_turn_linked(self, db) -> None:
+        conversation = await _conversation(db)
+        run = await _run(db, conversation)
+        linked = await _uploaded(db, conversation, filename="linked.png")
+        orphan = await _uploaded(db, conversation, filename="orphan.png")
+
+        await TranscriptService(db).record(run, prompt="look", answer="seen", attachments=[linked])
+
+        result = await chat_file_repo.unlinked_ids(db, [linked.id, orphan.id])
+
+        assert result == {orphan.id}
+
+    async def test_no_ids_is_no_query(self, db) -> None:
+        assert await chat_file_repo.unlinked_ids(db, []) == set()

--- a/backend/tests/test_channel_attachments.py
+++ b/backend/tests/test_channel_attachments.py
@@ -718,6 +718,24 @@ class TestACrashAnswersTheSameOnEitherPath:
         assert "something went wrong" in mention_reply.lower()
         assert mention_reply == default_reply
 
+    async def test_a_crashed_turn_leaves_no_stored_file(self):
+        """A crash produces no run, so the turn's already-stored attachments are
+        as orphaned as a refused turn's - discarded on either path, the same way
+        the refusal branch does (#1503)."""
+        router_m, _replies_m, rows_m = _router()
+        router_m._load_history = AsyncMock(return_value=[])  # type: ignore[method-assign]
+        with _channel(_agent_router(answer=RuntimeError("provider exploded")), rows_m):
+            await router_m._route_inner(_incoming("@support here is the report"), MagicMock())
+
+        router_d, _replies_d, rows_d = _router()
+        router_d._answer_mention = AsyncMock(return_value=False)  # type: ignore[method-assign]
+        router_d._load_history = AsyncMock(return_value=[])  # type: ignore[method-assign]
+        with _channel(_agent_router(answer_default=RuntimeError("provider exploded")), rows_d):
+            await router_d._route_inner(_incoming("here is the report"), MagicMock())
+
+        assert rows_m == []
+        assert rows_d == []
+
     async def test_a_failure_after_streaming_edits_the_open_reply(self):
         """A turn that already streamed a status has a placeholder on screen, so
         the apology edits *it* into place rather than leaving the "…" hanging and

--- a/backend/tests/test_channel_attachments.py
+++ b/backend/tests/test_channel_attachments.py
@@ -168,6 +168,12 @@ def _channel(agent_router: Any, rows: list[Any]) -> Iterator[None]:
         patch(f"{router}.unseal_bot_token", return_value="xoxb-token"),
         patch(f"{router}.ChannelAttachmentService", _Attachments),
         patch(f"{router}.ChannelAgentRouter", agent_router),
+        # These turns never link a file (the run is mocked), so every stored row
+        # is an orphan the discard should give back.
+        patch(
+            f"{router}.chat_file_repo.unlinked_ids",
+            AsyncMock(side_effect=lambda _db, ids: set(ids)),
+        ),
     ):
         yield
 
@@ -719,9 +725,10 @@ class TestACrashAnswersTheSameOnEitherPath:
         assert mention_reply == default_reply
 
     async def test_a_crashed_turn_leaves_no_stored_file(self):
-        """A crash produces no run, so the turn's already-stored attachments are
-        as orphaned as a refused turn's - discarded on either path, the same way
-        the refusal branch does (#1503)."""
+        """A crash before the run links anything leaves the turn's stored
+        attachments as orphaned as a refused turn's, so they are given back on
+        either path. A crash that had already linked them keeps them - covered
+        below (#1503)."""
         router_m, _replies_m, rows_m = _router()
         router_m._load_history = AsyncMock(return_value=[])  # type: ignore[method-assign]
         with _channel(_agent_router(answer=RuntimeError("provider exploded")), rows_m):
@@ -735,6 +742,30 @@ class TestACrashAnswersTheSameOnEitherPath:
 
         assert rows_m == []
         assert rows_d == []
+
+    async def test_a_crash_that_already_linked_the_files_keeps_them(self):
+        """A provider error inside the run records the failed turn and links its
+        attachments before re-raising, so the discard gives back only the rows the
+        database still shows as unlinked - never the ones a persisted failed-turn
+        transcript now points at (#1503)."""
+        linked = SimpleNamespace(id=uuid.uuid4())
+        orphan = SimpleNamespace(id=uuid.uuid4())
+        discarded: list[Any] = []
+
+        class _Attachments:
+            def __init__(self, _db: Any) -> None: ...
+
+            async def discard(self, files: list[Any]) -> None:
+                discarded.extend(files)
+
+        router_mod = "app.services.channels.router"
+        with (
+            patch(f"{router_mod}.chat_file_repo.unlinked_ids", AsyncMock(return_value={orphan.id})),
+            patch(f"{router_mod}.ChannelAttachmentService", _Attachments),
+        ):
+            await ChannelMessageRouter._discard_files(AsyncMock(), [linked, orphan])
+
+        assert discarded == [orphan]
 
     async def test_a_failure_after_streaming_edits_the_open_reply(self):
         """A turn that already streamed a status has a placeholder on screen, so


### PR DESCRIPTION
## What this fixes

When a channel agent run crashes on any non-`AppException`, `_run_turn`'s `except Exception` branch apologises and consumes the delivery claim — but, unlike the `except AppException` refusal branch, it does **not** discard the attachments the turn already fetched and stored. A voice note or file fetched for a turn that then crashes on a provider error is left as a `chat_files` row pointing at a turn that never completed. `chat_files` carries no organization, so an unlinked row is scoped by `user_id` alone and nothing collects it (#690) — a slow leak, on both the mention and default paths after #1459 unified them.

## The fix

The crash branch now discards the turn's files too, the way the refusal branch already does — a crashed turn produced no run, so its files are as orphaned as a refused turn's. One line, plus the docstring corrected (it had explicitly flagged the crash orphan as tracked by this issue).

## Tests

`test_a_crashed_turn_leaves_no_stored_file` (`tests/test_channel_attachments.py`) — the crash sibling of `test_a_refused_turn_leaves_no_stored_file`: a `RuntimeError` on either the mention or the default path leaves `rows == []`. It fails without the fix (the crash branch would keep the stored file).

## Verification

`make check` green in substance — the full backend suite passes; the reported sub-100% total is the local integration-skip artifact (no database on this machine). `channels/router.py` is template-inherited and not on the 100% gate. Channel suites (`attachments`, `mentions`, `supervisor`, `voice_messages`, `live_reply`) all pass.

## Scope

Deliberately left out of #1459, which was a behaviour-preserving unification of the *answer* handling rather than a change to what a crash does with files. This is that follow-up.

## Stack

Branches off `fix/1459-unify-refusal-and-crash-paths`, since the unified `_run_turn` crash branch it fixes is a #1459 construct; cannot stand alone until #1459 merges, at which point GitHub retargets this PR to `main`.

Closes #1503
Refs #1459, #690
