### PR TITLE
fix(users): treat an explicit null password as a no-op, not a 500

### DIFF
--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -342,10 +342,14 @@ class UserService:
         user = await self.get_by_id(user_id)
 
         update_data = writable(user_in, over=User)
-        password_changed = "password" in update_data
+        # `password` has no column (the row stores `hashed_password`), so writable
+        # keeps an explicit null rather than dropping it. Popped unconditionally so
+        # a null is a no-op, not a hash of None that reaches bcrypt as a 500 (#1497).
+        new_password = update_data.pop("password", None)
+        password_changed = new_password is not None
         if password_changed:
             update_data["hashed_password"] = await asyncio.to_thread(
-                get_password_hash, update_data.pop("password")
+                get_password_hash, new_password
             )
             # Bump the credential version alongside the hash, so a refresh token
             # minted before this change is refused even if it raced the session

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -385,6 +385,32 @@ class TestUserServicePostgresql:
             )
 
     @pytest.mark.anyio
+    async def test_an_explicit_null_password_is_a_no_op_not_a_crash(
+        self, user_service: UserService, mock_user: MockUser
+    ):
+        """`PATCH /users/{id}` (and /users/me) with `{"password": null}` reaches
+        here as an explicit None that `writable` keeps - there is no `password`
+        column. It must be a no-op: nothing hashed, no version bump, no session
+        revoked - not `get_password_hash(None)` reaching bcrypt as a 500 (#1497)."""
+        mock_user.credential_version = 3
+        with (
+            patch("app.services.user.user_repo") as mock_repo,
+            patch("app.services.user.session_repo") as mock_sessions,
+        ):
+            mock_repo.get_by_id = AsyncMock(return_value=mock_user)
+            mock_repo.update = AsyncMock(return_value=mock_user)
+            mock_sessions.deactivate_all_user_sessions = AsyncMock()
+
+            await user_service.update(mock_user.id, UserUpdate(password=None, full_name="Renamed"))
+
+            update_data = mock_repo.update.call_args.kwargs["update_data"]
+            assert "password" not in update_data
+            assert "hashed_password" not in update_data
+            assert "credential_version" not in update_data
+            assert update_data["full_name"] == "Renamed"
+            mock_sessions.deactivate_all_user_sessions.assert_not_awaited()
+
+    @pytest.mark.anyio
     async def test_change_password_proves_the_current_one_then_revokes_every_session(
         self, user_service: UserService, mock_user: MockUser
     ):


### PR DESCRIPTION
## What this fixes

`PATCH /users/me` and the admin `PATCH /users/{id}` with a body of `{"password": null}` returned a **500**, not a 4xx or a no-op. `writable()` keeps the explicit `None` — the row stores `hashed_password`, so there is no `password` column for its null-drop rule to key on — and `UserService.update` branched on `"password" in update_data`, which is true for an explicit null, so `get_password_hash(None)` reached bcrypt and raised. It raised before any write (the transaction rolled back — nothing persisted, no sessions revoked), so it was a malformed-input 500 rather than a data hazard.

## The fix

`update()` pops `password` unconditionally and only hashes it, bumps the credential version and revokes sessions when a real value was sent. An explicit null falls through untouched — a no-op.

## Tests

`test_an_explicit_null_password_is_a_no_op_not_a_crash` (`tests/test_services.py`): `update` with `{"password": null}` hashes nothing, bumps no version, revokes no session, and keeps the other fields. It raised without the fix.

## Verification

`make check` green in substance — 7339 passed, 0 failures; lint clean. The reported 98.99% total is the local integration-skip artifact (no database on this machine); `services/user.py` is not on the 100% platform gate.

## Stack

Branches off `fix/1517-password-change-endpoint`, which evolved this same `UserService.update` password branch (the `credential_version` bump on top of #1439's session revocation); basing here keeps the null-guard composing with that shape rather than conflicting. Cannot stand alone until #1517 merges, at which point GitHub retargets this PR to `main`.

Closes #1497
Refs #1517, #1439
