### PR TITLE
fix(mcp): refuse a manual org token while impersonating

### DIFF
--- a/backend/app/services/mcp_connection.py
+++ b/backend/app/services/mcp_connection.py
@@ -1282,6 +1282,8 @@ class McpConnectionService:
                 details={"name": data.name},
             )
         token = data.auth_token.strip() if data.auth_token else None
+        if token:
+            refuse_binding_while_impersonating("Adding an integration token")
         sealed = seal(token, scope=VaultScope.organization(ctx.organization_id)) if token else None
         try:
             connection = await mcp_connection_repo.create_org_scoped(
@@ -1323,6 +1325,12 @@ class McpConnectionService:
         update_data: dict[str, Any] = writable(
             data, over=McpConnection, exclude={"clear_allowed_tools"}
         )
+        # What the caller changed, snapshotted before the staleness resets below
+        # add their own keys - those are bookkeeping, not an edit the audit should
+        # report (#1521).
+        edited_fields = set(update_data)
+        if data.clear_allowed_tools:
+            edited_fields.add("allowed_tools")
 
         if "url" in update_data:
             update_data["url"] = await _checked_url(update_data["url"])
@@ -1342,6 +1350,8 @@ class McpConnectionService:
 
         if "auth_token" in update_data:
             token = (update_data["auth_token"] or "").strip()
+            if token:
+                refuse_binding_while_impersonating("Adding an integration token")
             # "" clears the stored token; a non-empty value replaces it, sealed at
             # the row's version - one version column covers every envelope in the
             # row, so bumping it would orphan the OAuth siblings (#552).
@@ -1379,9 +1389,25 @@ class McpConnectionService:
 
         if not update_data:
             return db_connection
-        return await mcp_connection_repo.update(
+        connection = await mcp_connection_repo.update(
             self.db, db_connection=db_connection, update_data=update_data
         )
+        # `create_for_org` records who created a shared credential; an update that
+        # repoints or re-keys one is the same authority and left no trail at all
+        # (#1521). Under an impersonation `record_audit` stamps the administrator
+        # behind it, so a change made while acting as somebody else is attributable
+        # to who really made it. The fields that changed, never their values: the
+        # token is sealed and must not reach the log, and the rest is on the row.
+        await record_audit(
+            self.db,
+            actor_user_id=ctx.subject_id,
+            organization_id=ctx.organization_id,
+            action="mcp_connection.updated",
+            target_type="mcp_connection",
+            target_id=str(connection.id),
+            details={"fields": sorted(edited_fields)},
+        )
+        return connection
 
     async def delete_for_org(self, ctx: AuthContext, *, connection_id: UUID) -> None:
         db_connection = await self._get_org(ctx, connection_id)

--- a/backend/tests/test_mcp_connections.py
+++ b/backend/tests/test_mcp_connections.py
@@ -2553,6 +2553,39 @@ class TestOrganizationConnections:
         }
         assert "ghp-secret-9876" not in str(recorded)
 
+    @pytest.mark.anyio
+    async def test_creating_with_a_token_is_refused_under_an_impersonation(
+        self, service, ctx, repo, audit, monkeypatch
+    ):
+        """An administrator acting as an org owner must not store their own bearer
+        token as the organization's shared credential: every org agent would then
+        call the server as the administrator's account after the hour-bounded
+        impersonation ends, and the token was entered by nobody the org can see
+        (#1521). Refused before the write, so nothing is sealed."""
+        _allow_any_url(monkeypatch)
+        with _impersonating(), pytest.raises(AuthorizationError):
+            await service.create_for_org(
+                ctx,
+                OrgMcpConnectionCreate(
+                    name="github", url="https://example.com/mcp", auth_token="admin-token"
+                ),
+            )
+        repo.create_org_scoped.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_creating_without_a_token_is_allowed_under_an_impersonation(
+        self, service, ctx, repo, audit, monkeypatch
+    ):
+        """Only a manually entered credential is refused - a tokenless org server
+        captures no identity, and configuring one while acting as an owner is
+        ordinary administration (#1521)."""
+        _allow_any_url(monkeypatch)
+        with _impersonating():
+            await service.create_for_org(
+                ctx, OrgMcpConnectionCreate(name="docs", url="https://example.com/mcp")
+            )
+        repo.create_org_scoped.assert_called_once()
+
     # -- updating -------------------------------------------------------
 
     @pytest.mark.anyio
@@ -2625,6 +2658,75 @@ class TestOrganizationConnections:
         # No new envelope, so the version that sealed the old one is left alone
         # rather than rewritten to describe a token that no longer exists.
         assert "secret_key_version" not in update_data
+
+    @pytest.mark.anyio
+    async def test_updating_with_a_replacement_token_is_refused_under_an_impersonation(
+        self, service, ctx, repo, audit
+    ):
+        """The same refusal as creating, for a token pasted over an existing org
+        connection. Refused before the write, so nothing is resealed (#1521)."""
+        conn = self._org_connection(ctx)
+        repo.get_org_scoped_by_id.return_value = conn
+        with _impersonating(), pytest.raises(AuthorizationError):
+            await service.update_for_org(
+                ctx, connection_id=conn.id, data=OrgMcpConnectionUpdate(auth_token="admin-token")
+            )
+        repo.update.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_updating_clearing_the_token_is_allowed_under_an_impersonation(
+        self, service, ctx, repo, audit
+    ):
+        """Removing a token stores no credential, so it is left alone - only a
+        non-empty replacement is refused (#1521)."""
+        conn = self._org_connection(ctx, auth_token="envelope")
+        repo.get_org_scoped_by_id.return_value = conn
+        repo.update.return_value = conn
+        with _impersonating():
+            await service.update_for_org(
+                ctx, connection_id=conn.id, data=OrgMcpConnectionUpdate(auth_token="")
+            )
+        assert repo.update.call_args.kwargs["update_data"]["auth_token"] is None
+
+    @pytest.mark.anyio
+    async def test_an_update_records_who_changed_the_shared_credential(
+        self, service, ctx, repo, audit, monkeypatch
+    ):
+        """`create_for_org` records who added a shared credential; an update that
+        rotated or repointed one left no trail at all. It now records the change -
+        the fields, never their values or the staleness resets - so a token set
+        under an impersonation is attributable to the administrator behind it,
+        which `record_audit` stamps from the audit context (#1521)."""
+        _allow_any_url(monkeypatch)
+        conn = self._org_connection(ctx)
+        repo.get_org_scoped_by_id.return_value = conn
+        repo.update.return_value = conn
+
+        await service.update_for_org(
+            ctx,
+            connection_id=conn.id,
+            data=OrgMcpConnectionUpdate(auth_token="ghp-rotated-4321"),
+        )
+
+        recorded = audit.call_args.kwargs
+        assert recorded["action"] == "mcp_connection.updated"
+        assert recorded["organization_id"] == ctx.organization_id
+        assert recorded["target_id"] == str(conn.id)
+        assert recorded["details"] == {"fields": ["auth_token"]}
+        assert "ghp-rotated-4321" not in str(recorded)
+
+    @pytest.mark.anyio
+    async def test_a_no_op_update_writes_no_audit(self, service, ctx, repo, audit):
+        """An update that changes nothing returns early, so it neither writes the
+        row nor records an entry that says a shared credential changed when it
+        did not (#1521)."""
+        conn = self._org_connection(ctx)
+        repo.get_org_scoped_by_id.return_value = conn
+
+        await service.update_for_org(ctx, connection_id=conn.id, data=OrgMcpConnectionUpdate())
+
+        repo.update.assert_not_called()
+        audit.assert_not_called()
 
     @pytest.mark.anyio
     async def test_moving_the_url_somewhere_internal_is_refused_by_field(self, service, ctx, repo):

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1322,6 +1322,14 @@ administrator still does on the member's behalf is configuration that stores no
 secret — a name, a URL, a tool allowlist — and clearing a stored token, which
 keeps nothing.
 
+An **organization's** shared connection is the same, though it is meant to be
+admin-entered: a bearer token typed onto one under an impersonation is refused
+too, because sealed under the organization's vault scope it speaks as the
+administrator's own account for every agent the organization binds, past the
+hour the impersonation ends. Creating an org connection already recorded the
+administrator behind it; updating one recorded nothing at all, so a token
+rotated onto an existing connection now leaves the same trail (#1521).
+
 ## What none of this covers
 
 Worth stating, because a governance page implies otherwise:


### PR DESCRIPTION
## Summary

The organization MCP surface had the same shape as the personal one #1492 guarded, and no guard. `create_for_org` / `update_for_org` seal a caller-supplied `auth_token` under the org's vault scope, so while acting as an org owner an app admin could paste their own MCP server's bearer token and store it as the **organization's shared credential** — every org agent then calls that server as the administrator's account, long after the hour-bounded impersonation ends (#1521).

This is the org-scoped manual-token corner of the same matrix as #1438 (personal OAuth / identity), #1490 (org OAuth) and #1492 (personal manual token).

## Stacking

Based on **`fix/1492-refuse-manual-token-while-impersonating`** (PR #1522), not `main`: it needs the `refuse_binding_while_impersonating` helper (added by #1438, carried through #1492) and extends #1492's governance paragraph to cover the org connection. Retarget to `main` once #1492 (and #1438 beneath it) merge.

## Related issue

Closes #1521. Refs #1492.

## Changed

- `app/services/mcp_connection.py`
  - **Refuse** a typed org token under an impersonation in `create_for_org` and `update_for_org`, via `refuse_binding_while_impersonating("Adding an integration token")` — mirroring #1492's personal-surface guard. A tokenless connection and clearing a token stay allowed (they store no credential).
  - **Audit** `update_for_org`, which wrote no entry at all: an `mcp_connection.updated` record naming the changed fields (never their values, never the staleness resets), so a token rotated onto an existing org connection is attributable — matching `create_for_org`, which already was. `record_audit` stamps the impersonator from the audit context.
- `docs/governance.md`: extend the impersonation binding-refusal paragraph to state the org connection is refused the same way, and that updates now leave a trail.

## Testing

- Regression tests (org surface): a manual token is refused on **create** and **update** under an impersonation — both fail without the guard (verified by reverting it); a tokenless create and a token clear stay allowed; a no-op update writes nothing; and an update records who changed the shared credential.
- `test_mcp_connections.py` + impersonation/audit suites green (254 passed).
- Backend 100% coverage gate green (8106 passed) against a real database.
- `make lint-backend` and `make docs-build` (--strict) green.
- No migration — the flag lives in the audit context; nothing changed on a table.

## Notes for reviewers

- The refusal fires only on a **non-empty** token (`if token:`), matching #1492: clearing a token under an impersonation is allowed, since it stores no credential.
- The update audit lists the caller's fields snapshotted before the internal staleness/OAuth resets add their own keys, so the trail names what was actually edited.
