### PR TITLE
fix(mcp): send the OAuth callback back to the address the browser used

### DIFF
--- a/frontend/src/app/api/binary-routes.test.ts
+++ b/frontend/src/app/api/binary-routes.test.ts
@@ -614,7 +614,12 @@ describe("finishing an MCP OAuth flow", () => {
    * this address with the second.
    */
   function redirected(response: Response) {
-    const location = new URL(response.headers.get("location")!);
+    const raw = response.headers.get("location")!;
+    // Relative, deliberately - resolved here the way a browser resolves it,
+    // against the address the person actually asked for rather than the one this
+    // process binds to (#1528).
+    expect(raw.startsWith("/")).toBe(true);
+    const location = new URL(raw, "https://agenticos.example");
     return {
       path: location.pathname,
       status: location.searchParams.get("mcp_oauth"),
@@ -830,7 +835,9 @@ describe("coming back from an MCP OAuth consent to where it started", () => {
 
     const response = await callback(callbackWithReturn("/chat?id=conv-1"));
 
-    const location = new URL(response.headers.get("location")!);
+    const raw = response.headers.get("location")!;
+    expect(raw.startsWith("/")).toBe(true);
+    const location = new URL(raw, "https://agenticos.example");
     expect(location.pathname).toBe("/chat");
     expect(location.searchParams.get("id")).toBe("conv-1");
     expect(location.searchParams.get("mcp_oauth")).toBe("success");
@@ -838,11 +845,30 @@ describe("coming back from an MCP OAuth consent to where it started", () => {
     expect(response.headers.get("set-cookie")).toMatch(/mcp_oauth_return=;/);
   });
 
+  it("sends the browser somewhere it can actually resolve, whatever this process binds to", async () => {
+    // The whole bug. `NextResponse.redirect` needs an absolute URL, and the only
+    // origin a standalone Next process knows is `HOSTNAME`:`PORT` - `0.0.0.0:3000`
+    // in the image - so behind a proxy a successful authorization sent people to
+    // an address no browser can reach (#1528). A relative `Location` is resolved
+    // against the URL the person asked for, which is the public one by
+    // construction.
+    vi.mocked(backendFetch).mockResolvedValue({ ok: true, connection_name: "Notion", error: null });
+
+    const response = await callback(callbackWithReturn(null));
+
+    const raw = response.headers.get("location")!;
+    expect(raw).not.toMatch(/^https?:\/\//);
+    expect(raw).not.toContain("0.0.0.0");
+    expect(raw.startsWith("/mcp-servers?")).toBe(true);
+  });
+
   it("ignores a return target that is not this app's own", async () => {
     vi.mocked(backendFetch).mockResolvedValue({ ok: true, connection_name: "Notion", error: null });
 
     const response = await callback(callbackWithReturn("//evil.example/steal"));
 
-    expect(new URL(response.headers.get("location")!).pathname).toBe("/mcp-servers");
+    expect(new URL(response.headers.get("location")!, "https://agenticos.example").pathname).toBe(
+      "/mcp-servers",
+    );
   });
 });

--- a/frontend/src/app/api/me/mcp-connections/oauth/callback/route.ts
+++ b/frontend/src/app/api/me/mcp-connections/oauth/callback/route.ts
@@ -29,9 +29,18 @@ export async function GET(request: NextRequest) {
   );
   const servers = (query: string) => {
     const target = back ?? "/mcp-servers";
-    const response = NextResponse.redirect(
-      new URL(`${target}${target.includes("?") ? "&" : "?"}${query}`, request.url),
-    );
+    // **A relative `Location`, resolved by the browser against the URL it asked
+    // for.** `NextResponse.redirect` takes an absolute one, and the only origin
+    // this process knows is the address it binds to - `HOSTNAME=0.0.0.0` and
+    // `PORT=3000` in the Dockerfile - so behind a proxy every provider sent
+    // somebody back to `http://0.0.0.0:3000/mcp-servers`, having authorized
+    // successfully. Trusting `x-forwarded-host` would be the other answer and a
+    // worse one: it is a header, and this address is reachable by strangers
+    // (#1528).
+    const response = new NextResponse(null, {
+      status: 307,
+      headers: { Location: `${target}${target.includes("?") ? "&" : "?"}${query}` },
+    });
     // One consent, one return: a stale cookie must not steer the next.
     response.cookies.delete(MCP_OAUTH_RETURN_COOKIE);
     return response;


### PR DESCRIPTION
Connecting a personal MCP server through OAuth authorizes successfully and then sends the browser to **`http://0.0.0.0:3000/mcp-servers?mcp_oauth=success`**. The connection is made; the person is left on a page nothing can reach. Reproduced on the live deployment connecting Notion.

`NextResponse.redirect` requires an **absolute** URL, and the only origin a standalone Next process knows is the address it binds to — `ENV HOSTNAME="0.0.0.0"` and `ENV PORT=3000` in `frontend/Dockerfile`. So `request.url` is that behind any reverse proxy, and the `Location` header was built from it.

Local development never shows it: there the bind address *is* the address the browser used.

A relative `Location` now, which the browser resolves against the URL it actually asked for. Trusting `x-forwarded-host` is the other answer and a worse one — it is a header, and this address is deliberately reachable without a session: the `state` token authenticates the exchange, so a stranger can reach it.

Scope: this is the only `NextResponse.redirect` in a route handler. Every other redirect in the app is client-side or a `redirect()` from a server component, both of which take a path.

Verified the regression test fails without the fix — restoring the absolute form reddens ten of the sixty-six, the new one among them.

Closes #1528