### PR TITLE
chore: cut 0.0.377

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.377] - 2026-09-07
+
+### Fixed
+
+- **Connecting an MCP server through OAuth authorized, then sent the browser
+  nowhere.** The provider returned somebody to
+  `http://0.0.0.0:3000/mcp-servers?mcp_oauth=success` — the connection made, the
+  person on a page nothing can reach. `NextResponse.redirect` requires an
+  absolute URL, and the only origin a standalone Next process knows is the
+  address it binds to, so behind any reverse proxy the `Location` header carried
+  it. The callback emits a relative one now, which the browser resolves against
+  the URL it actually asked for. Local development never showed it, because there
+  the bind address is the address the browser used.
+
 ## [0.0.376] - 2026-09-07
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.376"
+version = "0.0.377"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.376"
+version = "0.0.377"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.376",
+  "version": "0.0.377",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.377.

Ships #1528 — an MCP OAuth consent authorized and then returned the browser to `http://0.0.0.0:3000`, the address the frontend process binds to rather than the one the person came from.

Version, lock and changelog only.