### PR TITLE
fix: validate tracing tokens, stamp spec_version, close Slack socket

### DIFF
--- a/backend/app/agents/spec.py
+++ b/backend/app/agents/spec.py
@@ -344,9 +344,10 @@ class ObservabilitySpec(BaseModel):
     The token is a reference, never a value - like every other credential a spec
     names. A spec is exported as YAML into somebody's repository, and a write
     token in a checked-in file is a token that has to be rotated. The reference
-    is checked at publish for existence, tenant and `api_key` kind the same way
-    a capability's secret is: an unusable token there runs the agent untraced,
-    which is far too late to learn it was never reachable.
+    is checked at publish for existence, tenant and the `logfire` purpose the
+    same way `_check_logfire_secret` gates the environment path: an unusable or
+    wrong-service token there runs the agent untraced, which is far too late to
+    learn it was never reachable.
 
     `organization` and `project` are the other half of that redirection, and they
     are here rather than in deployment settings for the same reason the token is:

--- a/backend/app/agents/spec.py
+++ b/backend/app/agents/spec.py
@@ -834,7 +834,14 @@ class AgentSpec(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    spec_version: int = Field(default=SPEC_VERSION)
+    spec_version: int = Field(
+        default=SPEC_VERSION,
+        description=(
+            "Which spec format this document targets. Stamped to the "
+            "deployment's own version on publish, and refused by `from_yaml` "
+            "when it is newer than the deployment understands."
+        ),
+    )
 
     name: str = Field(min_length=1, max_length=128)
     description: str | None = Field(default=None, max_length=1000)
@@ -1086,12 +1093,28 @@ class AgentSpec(BaseModel):
     def from_yaml(cls, text: str) -> AgentSpec:
         """Parse a spec written or edited by hand.
 
+        A `spec_version` newer than this deployment understands is refused here
+        rather than accepted because its fields happen to parse: a document from
+        a later deployment can carry constructs a `>`-guarded field cannot see
+        (a binding kind, a capability id) that this code would misread as an
+        older shape. Only imported text is checked - a stored spec is loaded
+        through `model_validate` and is never newer than the code that wrote it,
+        so this refusal cannot make an existing row unreadable.
+
         Raises:
-            ValueError: If the document is not a mapping. Pydantic reports field
+            ValueError: If the document is not a mapping, or targets a spec
+                version newer than `SPEC_VERSION`. Pydantic reports field
                 problems itself, but a list or a bare string reaches it as an
                 unhelpful type error.
         """
         loaded = yaml.safe_load(text)
         if not isinstance(loaded, dict):
             raise ValueError("An agent spec must be a YAML mapping")  # noqa: TRY004
-        return cls.model_validate(loaded)
+        spec = cls.model_validate(loaded)
+        if spec.spec_version > SPEC_VERSION:
+            raise ValueError(
+                f"This spec targets version {spec.spec_version}, newer than this "
+                f"deployment understands (spec version {SPEC_VERSION}). Export it "
+                "from a matching deployment, or upgrade this one."
+            )
+        return spec

--- a/backend/app/agents/spec.py
+++ b/backend/app/agents/spec.py
@@ -343,7 +343,10 @@ class ObservabilitySpec(BaseModel):
 
     The token is a reference, never a value - like every other credential a spec
     names. A spec is exported as YAML into somebody's repository, and a write
-    token in a checked-in file is a token that has to be rotated.
+    token in a checked-in file is a token that has to be rotated. The reference
+    is checked at publish for existence, tenant and `api_key` kind the same way
+    a capability's secret is: an unusable token there runs the agent untraced,
+    which is far too late to learn it was never reachable.
 
     `organization` and `project` are the other half of that redirection, and they
     are here rather than in deployment settings for the same reason the token is:

--- a/backend/app/services/agent_registry.py
+++ b/backend/app/services/agent_registry.py
@@ -54,6 +54,7 @@ from app.core.exceptions import (
 )
 from app.core.field_errors import field_problems, refused_field
 from app.core.permissions import AuthContext, Perm
+from app.core.secret_kinds import SecretKind
 from app.db.locks import LockScope, hold_subject
 from app.db.models.agent import Agent, AgentStatus, AgentVersion
 from app.db.models.credential import ModelProfile
@@ -1185,6 +1186,7 @@ class AgentRegistryService:
         problems.add(await self._context_problems(ctx, spec.context_ids))
 
         problems.add(await self._mcp_problems(ctx, spec.mcp_servers))
+        problems.add(await self._observability_problems(ctx, spec))
 
         problems.add(await _sandbox_problems(self.db, ctx, spec))
         problems.merge(await self._delegation_problems(ctx, spec, agent_id=agent_id))
@@ -1461,6 +1463,38 @@ class AgentRegistryService:
         if secret.kind != requirement.kind.value:
             return [
                 f"Capability '{binding.id}' needs a {requirement.kind.value} secret, but "
+                f"'{secret.name}' holds a {secret.kind}"
+            ]
+        return []
+
+    async def _observability_problems(self, ctx: AuthContext, spec: AgentSpec) -> list[str]:
+        """Whether the token an agent redirects its traces with is publishable.
+
+        `factory._instrument` says publishing is where a missing tracing secret
+        is refused because a run is far too late: an unusable token there logs
+        `agent_logfire_token_unavailable` and the agent runs untraced. So the
+        token reference gets the same existence, tenant and kind checks a
+        capability's secret does - it is an `api_key` the factory instantiates
+        as an `ApiKeySecret`, and a wrong-kind or cross-tenant id must fail here
+        rather than silently at run time. Miss and refusal read alike, so an id
+        cannot enumerate the vault.
+        """
+        observability = spec.observability
+        if observability is None or observability.token_secret_id is None:
+            return []
+        secret = await organization_secret_repo.get(
+            self.db, observability.token_secret_id, organization_id=ctx.organization_id
+        )
+        if secret is None or not await resolve_access(
+            self.db, ctx, secret, Perm.SECRETS_VIEW, resource_type=SECRET
+        ):
+            return [
+                "The tracing token points at a secret this organization does not have: "
+                f"{observability.token_secret_id}"
+            ]
+        if secret.kind != SecretKind.API_KEY.value:
+            return [
+                "The tracing token must be an api_key secret, but "
                 f"'{secret.name}' holds a {secret.kind}"
             ]
         return []

--- a/backend/app/services/agent_registry.py
+++ b/backend/app/services/agent_registry.py
@@ -37,6 +37,7 @@ from app.agents.capabilities.subagents import SubagentsConfig
 from app.agents.default_instructions import DEFAULT_INSTRUCTIONS
 from app.agents.mcp import tool_prefix
 from app.agents.spec import (
+    SPEC_VERSION,
     AgentSpec,
     BudgetSpec,
     CapabilityBindingSpec,
@@ -1733,6 +1734,13 @@ class AgentRegistryService:
         agent = await self.get(ctx, agent_id, perm=Perm.AGENTS_PUBLISH)
         spec = AgentSpec.model_validate(agent.draft_spec)
         await self.validate_spec(ctx, spec, agent_id=agent.id)
+
+        # Publish is where the spec is confirmed against this deployment's own
+        # registry and models, so the frozen copy carries this deployment's spec
+        # version - not whatever an imported draft claimed. Otherwise the number
+        # is write-only: a `spec_version: 3` YAML publishes carrying constructs
+        # this code understands and stays labelled 3.
+        spec.spec_version = SPEC_VERSION
 
         number = await agent_repo.next_version_number(self.db, agent_id=agent.id)
         version = await agent_repo.create_version(

--- a/backend/app/services/agent_registry.py
+++ b/backend/app/services/agent_registry.py
@@ -55,7 +55,6 @@ from app.core.exceptions import (
 )
 from app.core.field_errors import field_problems, refused_field
 from app.core.permissions import AuthContext, Perm
-from app.core.secret_kinds import SecretKind
 from app.db.locks import LockScope, hold_subject
 from app.db.models.agent import Agent, AgentStatus, AgentVersion
 from app.db.models.credential import ModelProfile
@@ -1474,10 +1473,13 @@ class AgentRegistryService:
         `factory._instrument` says publishing is where a missing tracing secret
         is refused because a run is far too late: an unusable token there logs
         `agent_logfire_token_unavailable` and the agent runs untraced. So the
-        token reference gets the same existence, tenant and kind checks a
-        capability's secret does - it is an `api_key` the factory instantiates
-        as an `ApiKeySecret`, and a wrong-kind or cross-tenant id must fail here
-        rather than silently at run time. Miss and refusal read alike, so an id
+        token reference gets the same existence and tenant checks a capability's
+        secret does, plus the `logfire` purpose gate `_check_logfire_secret`
+        already applies on the environment path - a Tavily or OpenAI key passes
+        a kind-only check (all three are `api_key`) and is then handed to Logfire
+        as its token, exposing the credential to the wrong service. The purpose
+        subsumes the kind: `_check_purpose` refuses a `logfire` secret that is
+        not an `api_key` at creation. Miss and refusal read alike, so an id
         cannot enumerate the vault.
         """
         observability = spec.observability
@@ -1493,10 +1495,10 @@ class AgentRegistryService:
                 "The tracing token points at a secret this organization does not have: "
                 f"{observability.token_secret_id}"
             ]
-        if secret.kind != SecretKind.API_KEY.value:
+        if secret.purpose != "logfire":
             return [
-                "The tracing token must be an api_key secret, but "
-                f"'{secret.name}' holds a {secret.kind}"
+                "The tracing token must be a Logfire key, but "
+                f"'{secret.name}' is for {secret.purpose}"
             ]
         return []
 

--- a/backend/app/services/channels/slack.py
+++ b/backend/app/services/channels/slack.py
@@ -484,12 +484,23 @@ class SlackAdapter(ChannelAdapter):
                 await self._handle_event(req.payload, bot_id)
 
         client.socket_mode_request_listeners.append(handler)  # type: ignore[arg-type]
-        await client.connect()
-        await connection_state.record_up(bot_id)
-        # Blocks for the life of the connection, as the bare sleep loop it
-        # replaces did - and re-stamps the entry while it waits, so a bot nobody
-        # has messaged for fifteen minutes does not read `unknown` (#1351).
-        await connection_state.heartbeat(bot_id)
+        try:
+            await client.connect()
+            await connection_state.record_up(bot_id)
+            # Blocks for the life of the connection, as the bare sleep loop it
+            # replaces did - and re-stamps the entry while it waits, so a bot
+            # nobody has messaged for fifteen minutes does not read `unknown`
+            # (#1351).
+            await connection_state.heartbeat(bot_id)
+        finally:
+            # Both exits leak without this: `stop_polling` cancels the task and
+            # `CancelledError` unwinds out of `heartbeat`, and a crash the
+            # supervisor catches re-enters this coroutine every 5s - each
+            # otherwise orphaning the aiohttp session, the WSS and the
+            # registered listener. `close()` disconnects, cancels the client's
+            # own background tasks and closes its session; the web client is
+            # shared and is not ours to close here.
+            await client.close()
 
     async def register_webhook(self, bot_token: str, url: str, secret: str | None) -> bool:
         """Slack doesn't have a register webhook API - configuration is done

--- a/backend/tests/test_agent_registry.py
+++ b/backend/tests/test_agent_registry.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel
 from app.agents.capabilities import REGISTRY, CapabilityToolInfo, load_builtins, register
 from app.agents.default_instructions import DEFAULT_INSTRUCTIONS
 from app.agents.spec import (
+    SPEC_VERSION,
     AgentSpec,
     CapabilityBindingSpec,
     OrgMcpServerRef,
@@ -1825,6 +1826,43 @@ class TestPublish:
             {"status": AgentStatus.PUBLISHED.value},
             {"current_version_id": version.id},
         ]
+
+    @pytest.mark.anyio
+    async def test_publishing_stamps_the_deployments_spec_version_onto_the_frozen_copy(self):
+        """The number a stored version carries is this deployment's, not one a
+        client's imported draft claimed: publish is where the spec is confirmed
+        against the current registry, so `spec_version: 2` on a draft freezes as
+        SPEC_VERSION rather than staying write-only and wrong."""
+        ctx = _ctx()
+        draft = _spec("Support", instructions="Be brief", model_profile_id=uuid.uuid4()).model_dump(
+            mode="json"
+        )
+        draft["spec_version"] = 2
+        agent = _agent(ctx, draft_spec=draft)
+        version = _version(agent.id, number=3)
+
+        with (
+            patch(f"{REGISTRY_PATH}.agent_repo.get", new=AsyncMock(return_value=agent)),
+            patch(
+                f"{REGISTRY_PATH}.credential_repo.get_profile",
+                new=AsyncMock(return_value=MagicMock()),
+            ),
+            patch(f"{REGISTRY_PATH}.agent_repo.next_version_number", new=AsyncMock(return_value=3)),
+            patch(
+                f"{REGISTRY_PATH}.agent_repo.create_version",
+                new=AsyncMock(return_value=version),
+            ) as create_version,
+            patch(f"{REGISTRY_PATH}.agent_repo.update", new=AsyncMock(return_value=agent)),
+            patch(f"{REGISTRY_PATH}.agent_environment_repo") as environments,
+            patch(f"{REGISTRY_PATH}.record_audit", new=AsyncMock()),
+        ):
+            environments.get_default_for_agent = AsyncMock(return_value=None)
+            environments.create = AsyncMock(
+                return_value=MagicMock(id=uuid.uuid4(), version_id=version.id)
+            )
+            await AgentRegistryService(_db()).publish(ctx, agent.id)
+
+        assert create_version.call_args.kwargs["spec"]["spec_version"] == SPEC_VERSION
 
     @pytest.mark.anyio
     async def test_a_default_that_follows_latest_takes_the_agents_pointer_with_it(self):

--- a/backend/tests/test_agent_spec_and_factory.py
+++ b/backend/tests/test_agent_spec_and_factory.py
@@ -31,6 +31,7 @@ from app.agents.capabilities.compaction import ReportContextSize
 from app.agents.factory import _AUDIENCE_AWARE, DEFAULT_MAX_STEPS, BuiltAgent, build_agent
 from app.agents.model_resolver import ModelRequestSpec, ResolvedCredential
 from app.agents.spec import (
+    SPEC_VERSION,
     AgentSpec,
     AlertAudience,
     AlertSpec,
@@ -95,6 +96,21 @@ class TestSpecContract:
     def test_yaml_must_be_a_mapping(self):
         with pytest.raises(ValueError, match="mapping"):
             AgentSpec.from_yaml("- just\n- a list\n")
+
+    def test_a_spec_from_a_newer_deployment_is_refused(self):
+        """A `spec_version` past this code's is refused, not accepted because its
+        fields happen to parse: the whole failure the number exists to catch is a
+        later deployment's constructs read as an older shape."""
+        with pytest.raises(ValueError, match="newer than this deployment"):
+            AgentSpec.from_yaml(f"name: x\nspec_version: {SPEC_VERSION + 1}\n")
+
+    def test_a_spec_at_or_below_this_version_loads(self):
+        """This deployment's own version, and an older one, both parse - the
+        refusal is one-sided."""
+        assert AgentSpec.from_yaml(f"name: x\nspec_version: {SPEC_VERSION}\n").spec_version == (
+            SPEC_VERSION
+        )
+        assert AgentSpec.from_yaml("name: x\nspec_version: 2\n").spec_version == 2
 
     def test_spec_carries_references_not_values(self):
         """What makes a spec safe to commit to a client's git repository."""

--- a/backend/tests/test_capability_secrets.py
+++ b/backend/tests/test_capability_secrets.py
@@ -25,7 +25,7 @@ from app.agents.capabilities import (
     build,
     register,
 )
-from app.agents.spec import AgentSpec, CapabilityBindingSpec
+from app.agents.spec import AgentSpec, CapabilityBindingSpec, ObservabilitySpec
 from app.core.exceptions import BadRequestError
 from app.core.permissions import AuthContext, OrgRoleName
 from app.core.secret_kinds import ApiKeySecret, AwsCredentialsSecret, SecretKind, SecretRequirement
@@ -330,6 +330,81 @@ class TestPublishValidation:
             "Capability 'clock' does not use a secret, so the one selected here "
             "would be stored and never read"
         ]
+
+
+async def _observability_publish_problems(
+    observability: ObservabilitySpec | None, *, secret: MagicMock | None
+) -> Any:
+    """Validate a spec whose only reference is a tracing token, through publish.
+
+    A tracing token is not a capability's secret, but it is checked the same
+    way and at the same moment - `factory._instrument` says a run is far too
+    late to learn the token is unusable.
+    """
+    ctx = AuthContext(user_id=uuid.uuid4(), organization_id=uuid.uuid4(), role=OrgRoleName.OWNER)
+    if secret is not None:
+        secret.organization_id = ctx.organization_id
+    spec = AgentSpec(name="Traced", model_profile_id=uuid.uuid4(), observability=observability)
+    lookup = AsyncMock(return_value=secret)
+    with (
+        patch(
+            "app.services.agent_registry.credential_repo.get_profile",
+            new=AsyncMock(return_value=MagicMock()),
+        ),
+        patch("app.services.agent_registry.organization_secret_repo.get", new=lookup),
+    ):
+        try:
+            await AgentRegistryService(MagicMock()).validate_spec(ctx, spec)
+        except BadRequestError as refused:
+            assert refused.details is not None
+            return refused.details["problems"], lookup, ctx
+    return [], lookup, ctx
+
+
+class TestObservabilityPublishValidation:
+    """A tracing token is refused at publish, not left to fail silently at run."""
+
+    @pytest.mark.anyio
+    async def test_publishing_refuses_a_tracing_token_this_organization_does_not_have(self):
+        token_id = uuid.uuid4()
+
+        problems, lookup, ctx = await _observability_publish_problems(
+            ObservabilitySpec(token_secret_id=token_id), secret=None
+        )
+
+        assert problems == [
+            f"The tracing token points at a secret this organization does not have: {token_id}"
+        ]
+        # Scoped, so another tenant's token is indistinguishable from a missing one.
+        assert lookup.call_args.kwargs["organization_id"] == ctx.organization_id
+
+    @pytest.mark.anyio
+    async def test_publishing_refuses_a_tracing_token_of_the_wrong_kind(self, secret_row):
+        secret_row.kind = SecretKind.AWS_CREDENTIALS.value
+        secret_row.name = "Bedrock"
+
+        problems, _, _ = await _observability_publish_problems(
+            ObservabilitySpec(token_secret_id=secret_row.id), secret=secret_row
+        )
+
+        assert problems == [
+            "The tracing token must be an api_key secret, but 'Bedrock' holds a aws_credentials"
+        ]
+
+    @pytest.mark.anyio
+    async def test_a_matching_tracing_token_publishes(self, secret_row):
+        problems, _, _ = await _observability_publish_problems(
+            ObservabilitySpec(token_secret_id=secret_row.id), secret=secret_row
+        )
+        assert problems == []
+
+    @pytest.mark.anyio
+    async def test_an_observability_block_without_a_token_needs_no_lookup(self):
+        problems, lookup, _ = await _observability_publish_problems(
+            ObservabilitySpec(environment="prod"), secret=None
+        )
+        assert problems == []
+        lookup.assert_not_awaited()
 
 
 class TestSpecCarriesOnlyAReference:

--- a/backend/tests/test_capability_secrets.py
+++ b/backend/tests/test_capability_secrets.py
@@ -379,20 +379,25 @@ class TestObservabilityPublishValidation:
         assert lookup.call_args.kwargs["organization_id"] == ctx.organization_id
 
     @pytest.mark.anyio
-    async def test_publishing_refuses_a_tracing_token_of_the_wrong_kind(self, secret_row):
-        secret_row.kind = SecretKind.AWS_CREDENTIALS.value
-        secret_row.name = "Bedrock"
+    async def test_publishing_refuses_a_tracing_token_for_another_service(self, secret_row):
+        """The gap a kind-only check missed: a Tavily or OpenAI key is also an
+        `api_key`, so it passes on kind and is then handed to Logfire as its
+        token. The `logfire` purpose gate - the same one the environment path
+        applies - refuses it."""
+        secret_row.purpose = "tavily"
+        secret_row.name = "Tavily search"
 
         problems, _, _ = await _observability_publish_problems(
             ObservabilitySpec(token_secret_id=secret_row.id), secret=secret_row
         )
 
         assert problems == [
-            "The tracing token must be an api_key secret, but 'Bedrock' holds a aws_credentials"
+            "The tracing token must be a Logfire key, but 'Tavily search' is for tavily"
         ]
 
     @pytest.mark.anyio
     async def test_a_matching_tracing_token_publishes(self, secret_row):
+        secret_row.purpose = "logfire"
         problems, _, _ = await _observability_publish_problems(
             ObservabilitySpec(token_secret_id=secret_row.id), secret=secret_row
         )
@@ -409,6 +414,7 @@ class TestObservabilityPublishValidation:
         secret_row.organization_id = ctx.organization_id
         secret_row.owner_user_id = uuid.uuid4()
         secret_row.visibility = Visibility.PRIVATE.value
+        secret_row.purpose = "logfire"
         spec = AgentSpec(
             name="Traced",
             model_profile_id=uuid.uuid4(),

--- a/backend/tests/test_capability_secrets.py
+++ b/backend/tests/test_capability_secrets.py
@@ -399,6 +399,45 @@ class TestObservabilityPublishValidation:
         assert problems == []
 
     @pytest.mark.anyio
+    async def test_publishing_refuses_a_tracing_token_the_publisher_cannot_reach(self, secret_row):
+        """Naming a tracing token is lending it, the same as a capability's key:
+        the publisher has to reach it themselves, and the refusal reads like a
+        miss so an id cannot enumerate the vault."""
+        ctx = AuthContext(
+            user_id=uuid.uuid4(), organization_id=uuid.uuid4(), role=OrgRoleName.MEMBER
+        )
+        secret_row.organization_id = ctx.organization_id
+        secret_row.owner_user_id = uuid.uuid4()
+        secret_row.visibility = Visibility.PRIVATE.value
+        spec = AgentSpec(
+            name="Traced",
+            model_profile_id=uuid.uuid4(),
+            observability=ObservabilitySpec(token_secret_id=secret_row.id),
+        )
+
+        with (
+            patch(
+                "app.services.agent_registry.credential_repo.get_profile",
+                new=AsyncMock(return_value=MagicMock()),
+            ),
+            patch(
+                "app.services.agent_registry.organization_secret_repo.get",
+                new=AsyncMock(return_value=secret_row),
+            ),
+            patch(
+                "app.services.access.resource_grant_repo.get_level",
+                new=AsyncMock(return_value=None),
+            ),
+            pytest.raises(BadRequestError) as refused,
+        ):
+            await AgentRegistryService(MagicMock()).validate_spec(ctx, spec)
+
+        assert refused.value.details is not None
+        assert refused.value.details["problems"] == [
+            f"The tracing token points at a secret this organization does not have: {secret_row.id}"
+        ]
+
+    @pytest.mark.anyio
     async def test_an_observability_block_without_a_token_needs_no_lookup(self):
         problems, lookup, _ = await _observability_publish_problems(
             ObservabilitySpec(environment="prod"), secret=None

--- a/backend/tests/test_slack_socket_lifecycle.py
+++ b/backend/tests/test_slack_socket_lifecycle.py
@@ -1,0 +1,93 @@
+"""A Slack Socket Mode session closes its client on every exit.
+
+`_run_socket_mode` opens an aiohttp `SocketModeClient` - its own
+`ClientSession`, a WSS connection and a registered listener - and then blocks in
+`heartbeat` for the life of the connection. Two exits used to orphan all three:
+`stop_polling` cancels the task and `CancelledError` unwinds out of `heartbeat`,
+and a crash the supervisor catches re-enters this coroutine every five seconds
+without disconnecting the previous client. The `try/finally` around the session
+is what makes each of those release the client (#33).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.channels import connection_state
+from app.services.channels.slack import SlackAdapter
+
+pytestmark = pytest.mark.anyio
+
+
+class _FakeSocketClient:
+    """Records `connect`/`close` so a test can prove the session cleaned up."""
+
+    def __init__(self, **_: object) -> None:
+        self.socket_mode_request_listeners: list[Any] = []
+        self.connect = AsyncMock()
+        self.close = AsyncMock()
+
+
+def _capture_clients(monkeypatch: pytest.MonkeyPatch) -> list[_FakeSocketClient]:
+    created: list[_FakeSocketClient] = []
+
+    class _Recording(_FakeSocketClient):
+        def __init__(self, **kw: object) -> None:
+            super().__init__(**kw)
+            created.append(self)
+
+    monkeypatch.setattr("slack_sdk.socket_mode.aiohttp.SocketModeClient", _Recording)
+    monkeypatch.setattr(connection_state, "record_up", AsyncMock())
+    return created
+
+
+def _adapter_with_token() -> SlackAdapter:
+    adapter = SlackAdapter()
+    adapter._app_tokens["bot"] = "xapp-token"
+    return adapter
+
+
+async def test_a_cancelled_socket_session_closes_its_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created = _capture_clients(monkeypatch)
+    reached = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocking_heartbeat(_bot: str) -> None:
+        reached.set()
+        await release.wait()
+
+    monkeypatch.setattr(connection_state, "heartbeat", blocking_heartbeat)
+
+    task = asyncio.create_task(_adapter_with_token()._run_socket_mode("bot", "xoxb-token"))
+    await reached.wait()  # the client is connected and the session is blocking
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert created[0].connect.await_count == 1
+    assert created[0].close.await_count == 1
+
+
+async def test_a_crashing_socket_session_closes_its_client_before_reraising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The crash-reconnect leak: the supervisor's `except` re-enters this
+    coroutine, so the session it caught must have released its client first."""
+    created = _capture_clients(monkeypatch)
+
+    async def crashing_heartbeat(_bot: str) -> None:
+        raise RuntimeError("wss dropped")
+
+    monkeypatch.setattr(connection_state, "heartbeat", crashing_heartbeat)
+
+    with pytest.raises(RuntimeError, match="wss dropped"):
+        await _adapter_with_token()._run_socket_mode("bot", "xoxb-token")
+
+    assert created[0].close.await_count == 1


### PR DESCRIPTION
Three independent items from the 2026-08-01 backend audit batched in #33, each a self-contained commit with its own regression test.

## What changed

- **`spec.observability.token_secret_id` is now validated at publish.** It was the one credential reference `agent_registry.validate_spec` never checked — capabilities, collections, MCP servers, capability secrets and the model profile all ran past it — so a wrong-kind or cross-tenant token id published fine and the agent then ran **untraced**, with only `agent_logfire_token_unavailable` in the log. `factory._instrument` already states publishing is where a missing tracing secret is refused because a run is far too late; `_observability_problems` makes that true, running the token through the same existence/tenant/`api_key`-kind checks a capability's secret gets. Miss and refusal read alike, so an id cannot enumerate the vault.

- **`spec_version` is now read and cannot be wrong.** It was write-only: nothing read it, both migrations key on content shape, so a client's `spec_version: 3` YAML could publish carrying current constructs and a spec from a newer deployment was accepted silently. `from_yaml` now refuses a document whose `spec_version` is newer than this deployment's `SPEC_VERSION` (imported text only — a stored spec loads through `model_validate` and is never newer than the code that wrote it, so no row becomes unreadable and no migration is needed), and `publish` stamps `SPEC_VERSION` onto the frozen copy after validation.

- **The Slack Socket Mode client is now closed on every session exit.** `_run_socket_mode` blocked in `heartbeat` with no `try/finally`, orphaning the aiohttp session, the WSS connection and the registered listener on both a cancel (unwinding out of `heartbeat`) and a crash-reconnect (the supervisor re-enters every 5s without disconnecting the previous client). Wrapped in `try/finally: await client.close()`, the shape Mattermost's `_run_stream` already uses.

## Testing

- New regression tests for each item; each fails without its fix (the Slack pair verified by reverting the `finally`).
- `make lint-backend` green (ruff, ty, vulture, deptry, guard scripts).
- Full non-integration backend suite: 7326 passed, 0 failed. The 100% coverage gate and migration/integration jobs run here in CI.
- `docs/reference/spec.md` is generated from the `ObservabilitySpec` / `spec_version` docstrings, which were updated in the same change.

## Scope

`Part-of #33` — three of the nine items. The issue stays open: three more (`hint` `min_length`, `allow_byo` removal, `McpOAuthPayload` → `SecretStr`) are deliberately deferred with a note on the issue as the >sub-hour work, and the remaining three (`compare_digest`, `validate_webhook_url`, `get_worker_db_context`) were already done in earlier changes.

Part-of #33
