### PR TITLE
feat(auth): revoke an ordinary session's access token by binding it to its session row

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -291,6 +291,7 @@ async def get_current_user(
     token: Annotated[str, Depends(oauth2_scheme)],
     user_service: UserSvc,
     impersonation: ImpersonationSvc,
+    session: SessionSvc,
 ) -> User:
     """Get current authenticated user from JWT token.
 
@@ -299,9 +300,14 @@ async def get_current_user(
     is refused here rather than served for the rest of its hour (#1044). The
     check also puts who is really acting on the request's audit context (#943).
 
+    An ordinary token carrying a `sid` is bound to its login's session row the
+    same way, so signing out everywhere refuses it here rather than letting it
+    live to its `exp` (#1501); a token minted before that binding has no `sid`
+    and is left to expire.
+
     Raises:
-        AuthenticationError: If token is invalid, its impersonation has ended, or
-            the user is not found.
+        AuthenticationError: If token is invalid, its session or impersonation has
+            ended, or the user is not found.
     """
 
     payload = verify_token(token)
@@ -316,6 +322,7 @@ async def get_current_user(
         raise AuthenticationError(message="Invalid token payload")
 
     await impersonation.verify(payload=payload, token=token, subject=user_id)
+    await session.verify_access_session(payload=payload, subject=user_id)
 
     user = await user_service.get_by_id(UUID(user_id))
     if not user.is_active:

--- a/backend/app/api/routes/v1/auth.py
+++ b/backend/app/api/routes/v1/auth.py
@@ -47,16 +47,18 @@ async def login(
     """OAuth2 password login, returns access and refresh tokens."""
     await enforce_auth_limit(request, surface="auth_login", identifier=form_data.username)
     user = await user_service.authenticate(form_data.username, form_data.password)
-    access_token = create_access_token(subject=str(user.id))
     refresh_token = create_refresh_token(subject=str(user.id))
 
-    # Track this login as a server-side session (enables remote logout).
-    await session_service.create_session(
+    # The session row is created before the access token is minted, so the token
+    # can name it in `sid` - which is what lets signing out everywhere revoke the
+    # access token, not only stop the next refresh (#1501).
+    session = await session_service.create_session(
         user_id=user.id,
         refresh_token=refresh_token,
         ip_address=request.client.host if request.client else None,
         user_agent=request.headers.get("User-Agent"),
     )
+    access_token = create_access_token(subject=str(user.id), sid=str(session.id))
     return Token(access_token=access_token, refresh_token=refresh_token)
 
 
@@ -222,14 +224,14 @@ async def verify_magic_link(
     """
     await enforce_auth_limit(request, surface="auth_magic_link_verify")
     user, return_to = await user_service.consume_magic_link_token(body.token)
-    access_token = create_access_token(subject=str(user.id))
     refresh_token = create_refresh_token(subject=str(user.id))
-    await session_service.create_session(
+    session = await session_service.create_session(
         user_id=user.id,
         refresh_token=refresh_token,
         ip_address=request.client.host if request.client else None,
         user_agent=request.headers.get("User-Agent"),
     )
+    access_token = create_access_token(subject=str(user.id), sid=str(session.id))
     return MagicLinkToken(
         access_token=access_token, refresh_token=refresh_token, return_to=return_to
     )

--- a/backend/app/api/routes/v1/auth.py
+++ b/backend/app/api/routes/v1/auth.py
@@ -91,16 +91,14 @@ async def refresh_token(
     if not user.is_active:
         raise AuthenticationError(message="User account is disabled")
 
-    access_token = create_access_token(subject=str(user.id))
     new_refresh_token = create_refresh_token(subject=str(user.id))
 
-    await session_service.logout_by_refresh_token(body.refresh_token)
-    await session_service.create_session(
-        user_id=user.id,
-        refresh_token=new_refresh_token,
-        ip_address=request.client.host if request.client else None,
-        user_agent=request.headers.get("User-Agent"),
-    )
+    # Rotate the refresh token in place, keeping the row's id: the new access
+    # token names the same `sid`, so a live socket or a second tab holding the
+    # old access token is not cut off by a routine refresh (#1437, #1501). The
+    # old refresh token's hash is replaced, which is what makes it unusable.
+    await session_service.rotate_session(session, new_refresh_token)
+    access_token = create_access_token(subject=str(user.id), sid=str(session.id))
     return Token(access_token=access_token, refresh_token=new_refresh_token)
 
 

--- a/backend/app/api/routes/v1/auth.py
+++ b/backend/app/api/routes/v1/auth.py
@@ -97,7 +97,12 @@ async def refresh_token(
     # token names the same `sid`, so a live socket or a second tab holding the
     # old access token is not cut off by a routine refresh (#1437, #1501). The
     # old refresh token's hash is replaced, which is what makes it unusable.
-    await session_service.rotate_session(session, new_refresh_token)
+    await session_service.rotate_session(
+        session,
+        new_refresh_token,
+        ip_address=request.client.host if request.client else None,
+        user_agent=request.headers.get("User-Agent"),
+    )
     access_token = create_access_token(subject=str(user.id), sid=str(session.id))
     return Token(access_token=access_token, refresh_token=new_refresh_token)
 

--- a/backend/app/api/routes/v1/oauth.py
+++ b/backend/app/api/routes/v1/oauth.py
@@ -7,7 +7,7 @@ from urllib.parse import urlencode
 from fastapi import APIRouter, Request
 from fastapi.responses import RedirectResponse
 
-from app.api.deps import OAuthExchangeSvc, UserSvc
+from app.api.deps import OAuthExchangeSvc, SessionSvc, UserSvc
 from app.core.config import settings
 from app.core.exceptions import AuthenticationError
 from app.core.oauth import oauth
@@ -48,7 +48,10 @@ async def google_login(request: Request, invitation: str | None = None):
 
 @router.get("/google/callback", response_model=None)
 async def google_callback(
-    request: Request, user_service: UserSvc, exchange_service: OAuthExchangeSvc
+    request: Request,
+    user_service: UserSvc,
+    exchange_service: OAuthExchangeSvc,
+    session_service: SessionSvc,
 ):
     """Handle Google OAuth2 callback."""
     frontend = settings.FRONTEND_URL.rstrip("/")
@@ -71,8 +74,18 @@ async def google_callback(
             invitation_token=request.session.pop(_INVITATION_KEY, None),
         )
 
-        access_token = create_access_token(subject=str(user.id))
         refresh_token = create_refresh_token(subject=str(user.id))
+
+        # An OAuth sign-in is an ordinary session, so it gets its own row and the
+        # access token names it in `sid` - otherwise signing out everywhere could
+        # not revoke it, the way it could not for any login before #1501.
+        session = await session_service.create_session(
+            user_id=user.id,
+            refresh_token=refresh_token,
+            ip_address=request.client.host if request.client else None,
+            user_agent=request.headers.get("User-Agent"),
+        )
+        access_token = create_access_token(subject=str(user.id), sid=str(session.id))
 
         # A single-use code, not the tokens: a token in the redirect URL reaches
         # the address bar, the server access log, and the `Referer` of the next

--- a/backend/app/api/routes/v1/oauth.py
+++ b/backend/app/api/routes/v1/oauth.py
@@ -3,6 +3,7 @@
 import logging
 from typing import Any
 from urllib.parse import urlencode
+from uuid import uuid4
 
 from fastapi import APIRouter, Request
 from fastapi.responses import RedirectResponse
@@ -76,21 +77,25 @@ async def google_callback(
 
         refresh_token = create_refresh_token(subject=str(user.id))
 
-        # An OAuth sign-in is an ordinary session, so it gets its own row and the
-        # access token names it in `sid` - otherwise signing out everywhere could
-        # not revoke it, the way it could not for any login before #1501.
-        session = await session_service.create_session(
-            user_id=user.id,
-            refresh_token=refresh_token,
-            ip_address=request.client.host if request.client else None,
-            user_agent=request.headers.get("User-Agent"),
-        )
-        access_token = create_access_token(subject=str(user.id), sid=str(session.id))
+        # An OAuth sign-in is an ordinary session, so the access token names its
+        # session row in `sid` - otherwise signing out everywhere could not revoke
+        # it, the way it could not for any login before #1501. The id is chosen up
+        # front so the row can be written *after* the code is issued: a failure
+        # handing out the code then leaves no phantom session behind.
+        session_id = uuid4()
+        access_token = create_access_token(subject=str(user.id), sid=str(session_id))
 
         # A single-use code, not the tokens: a token in the redirect URL reaches
         # the address bar, the server access log, and the `Referer` of the next
         # same-origin request, and the refresh token is good for a week (#14).
         code = await exchange_service.issue(access_token=access_token, refresh_token=refresh_token)
+        await session_service.create_session(
+            user_id=user.id,
+            refresh_token=refresh_token,
+            ip_address=request.client.host if request.client else None,
+            user_agent=request.headers.get("User-Agent"),
+            session_id=session_id,
+        )
         params = urlencode({"code": code})
         return RedirectResponse(url=f"{frontend}/auth/callback?{params}")
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime, timedelta
 from typing import Any
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import bcrypt
 import jwt
@@ -58,13 +58,21 @@ def create_refresh_token(
     subject: str | Any,
     expires_delta: timedelta | None = None,
 ) -> str:
-    """Create a JWT refresh token."""
+    """Create a JWT refresh token.
+
+    Carries a random `jti` so two tokens minted for the same subject in the same
+    second are not byte-identical. A session row stores the SHA-256 of its refresh
+    token, and `exp` is second-resolution, so without this two sign-ins a moment
+    apart would hash to the same value - two active rows under one hash, and the
+    next refresh's `scalar_one_or_none` lookup raises rather than resolving (#1501
+    review).
+    """
     if expires_delta:
         expire = datetime.now(UTC) + expires_delta
     else:
         expire = datetime.now(UTC) + timedelta(minutes=settings.REFRESH_TOKEN_EXPIRE_MINUTES)
 
-    to_encode = {"exp": expire, "sub": str(subject), "type": "refresh"}
+    to_encode = {"exp": expire, "sub": str(subject), "type": "refresh", "jti": uuid4().hex}
     return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
 
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -2,6 +2,7 @@
 
 from datetime import UTC, datetime, timedelta
 from typing import Any
+from uuid import UUID
 
 import bcrypt
 import jwt
@@ -87,6 +88,23 @@ def verify_token(token: str, *, verify_exp: bool = True) -> dict[str, Any] | Non
             options={"verify_exp": verify_exp},
         )
     except jwt.PyJWTError:
+        return None
+
+
+def read_uuid_claim(payload: dict[str, Any], name: str) -> UUID | None:
+    """A token claim read as a uuid, or None when it is absent or not one.
+
+    A malformed claim is no claim rather than a refusal: the token is signed by
+    this deployment, so a value it cannot parse is one this code never wrote. Both
+    the impersonation `sid`/`act` (#943) and the ordinary-session `sid` (#1501)
+    read their row id through here, so the leniency is decided in one place.
+    """
+    value = payload.get(name)
+    if not value:
+        return None
+    try:
+        return UUID(str(value))
+    except ValueError:
         return None
 
 

--- a/backend/app/repositories/session.py
+++ b/backend/app/repositories/session.py
@@ -15,14 +15,24 @@ async def get_by_id(db: AsyncSession, session_id: UUID) -> Session | None:
     return await db.get(Session, session_id)
 
 
-async def get_by_refresh_token_hash(db: AsyncSession, token_hash: str) -> Session | None:
-    """Get session by refresh token hash."""
-    result = await db.execute(
-        select(Session).where(
-            Session.refresh_token_hash == token_hash,
-            Session.is_active.is_(True),
-        )
+async def get_by_refresh_token_hash(
+    db: AsyncSession, token_hash: str, *, for_update: bool = False
+) -> Session | None:
+    """Get session by refresh token hash.
+
+    `for_update` locks the row for the rest of the transaction, so a refresh
+    serializes against a concurrent one bearing the same token: the second blocks
+    until the first commits, then re-reads and finds the hash already rotated away,
+    so it refuses cleanly rather than both rotating the row and one client walking
+    off with a refresh token the row no longer holds (#1501 review).
+    """
+    query = select(Session).where(
+        Session.refresh_token_hash == token_hash,
+        Session.is_active.is_(True),
     )
+    if for_update:
+        query = query.with_for_update()
+    result = await db.execute(query)
     return result.scalar_one_or_none()
 
 
@@ -160,16 +170,25 @@ async def rotate(
     session: Session,
     refresh_token_hash: str,
     expires_at: datetime,
+    device_name: str | None = None,
+    device_type: str | None = None,
+    ip_address: str | None = None,
+    user_agent: str | None = None,
 ) -> Session:
     """Re-key a session row to a rotated refresh token, keeping its id.
 
     The id is what a live access token names in `sid`, so it has to survive a
-    refresh (#1501); only the hash and the window move, and `last_used_at` gets
-    the same touch a plain use gives it.
+    refresh (#1501); the hash and the window move, `last_used_at` gets the same
+    touch a plain use gives it, and the device and address move to where the
+    refresh came from so the sessions list shows where the credential is used now.
     """
     session.refresh_token_hash = refresh_token_hash
     session.expires_at = expires_at
     session.last_used_at = datetime.now(UTC)
+    session.device_name = device_name
+    session.device_type = device_type
+    session.ip_address = ip_address
+    session.user_agent = user_agent
     db.add(session)
     await db.flush()
     await db.refresh(session)

--- a/backend/app/repositories/session.py
+++ b/backend/app/repositories/session.py
@@ -154,6 +154,28 @@ async def update_last_used(db: AsyncSession, session_id: UUID) -> None:
     await db.flush()
 
 
+async def rotate(
+    db: AsyncSession,
+    *,
+    session: Session,
+    refresh_token_hash: str,
+    expires_at: datetime,
+) -> Session:
+    """Re-key a session row to a rotated refresh token, keeping its id.
+
+    The id is what a live access token names in `sid`, so it has to survive a
+    refresh (#1501); only the hash and the window move, and `last_used_at` gets
+    the same touch a plain use gives it.
+    """
+    session.refresh_token_hash = refresh_token_hash
+    session.expires_at = expires_at
+    session.last_used_at = datetime.now(UTC)
+    db.add(session)
+    await db.flush()
+    await db.refresh(session)
+    return session
+
+
 async def deactivate(db: AsyncSession, session_id: UUID) -> Session | None:
     """Deactivate a session (logout)."""
     session = await get_by_id(db, session_id)

--- a/backend/app/services/impersonation.py
+++ b/backend/app/services/impersonation.py
@@ -52,7 +52,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.audit import current_impersonator, record_audit, set_impersonator
 from app.core.background import spawn_after_commit
 from app.core.exceptions import AuthenticationError, BadRequestError
-from app.core.security import create_access_token
+from app.core.security import create_access_token, read_uuid_claim
 from app.db.models.user import User
 from app.repositories import session_repo, user_repo
 from app.schemas.user import ImpersonateResponse, ImpersonationRead, ImpersonatorRead
@@ -95,25 +95,9 @@ def current_impersonation() -> ActiveImpersonation | None:
     return _active.get()
 
 
-def _uuid_claim(payload: dict[str, Any], name: str) -> UUID | None:
-    """A claim read as a uuid, or None when it is absent or not one.
-
-    A malformed claim is no claim rather than a refusal: the token is signed by
-    this deployment, so a claim it cannot parse is one this code never wrote,
-    and the request stays attributable to its subject (#943).
-    """
-    value = payload.get(name)
-    if not value:
-        return None
-    try:
-        return UUID(str(value))
-    except ValueError:
-        return None
-
-
 def impersonator_from(payload: dict[str, Any]) -> UUID | None:
     """The administrator behind an impersonated token, or None for an ordinary one."""
-    return _uuid_claim(payload, "act")
+    return read_uuid_claim(payload, "act")
 
 
 class ImpersonationService:
@@ -244,7 +228,7 @@ class ImpersonationService:
             _active.set(None)
             return None
 
-        session_id = _uuid_claim(payload, "sid")
+        session_id = read_uuid_claim(payload, "sid")
         if session_id is None:
             raise AuthenticationError(message="An impersonation without a session is not accepted")
 

--- a/backend/app/services/session.py
+++ b/backend/app/services/session.py
@@ -84,7 +84,14 @@ class SessionService:
             session_id=session_id,
         )
 
-    async def rotate_session(self, session: Session, new_refresh_token: str) -> Session:
+    async def rotate_session(
+        self,
+        session: Session,
+        new_refresh_token: str,
+        *,
+        ip_address: str | None = None,
+        user_agent: str | None = None,
+    ) -> Session:
         """Rotate a login's refresh token in place, keeping the session row's id.
 
         Refresh mints a new refresh token and a new access token; the row keeps
@@ -92,13 +99,23 @@ class SessionService:
         socket, or a second tab, holding the old access token is not cut off by a
         routine rotation (#1437, #1501) - while the new token's hash replaces the
         old, which is what stops the spent refresh token being replayed.
+
+        The device and address are moved to wherever the refresh came from, the way
+        recreating the row used to: the sessions list is what a person revokes an
+        unfamiliar device from, so it has to show where the credential is being used
+        now, not only where the login began (#1501 review).
         """
         expires_at = datetime.now(UTC) + timedelta(minutes=settings.REFRESH_TOKEN_EXPIRE_MINUTES)
+        device_name, device_type = _parse_user_agent(user_agent)
         return await session_repo.rotate(
             self.db,
             session=session,
             refresh_token_hash=hash_token(new_refresh_token),
             expires_at=expires_at,
+            device_name=device_name,
+            device_type=device_type,
+            ip_address=ip_address,
+            user_agent=user_agent,
         )
 
     async def get_user_sessions(self, user_id: UUID) -> list[Session]:
@@ -161,7 +178,10 @@ class SessionService:
         it: its window is the access token's own, and nothing extends it.
         """
         token_hash = hash_token(refresh_token)
-        session = await session_repo.get_by_refresh_token_hash(self.db, token_hash)
+        # Locked: a refresh and a concurrent one bearing the same token serialize
+        # here, so the second finds the hash already rotated away and refuses,
+        # rather than both rotating the row (#1501 review).
+        session = await session_repo.get_by_refresh_token_hash(self.db, token_hash, for_update=True)
 
         if (
             session

--- a/backend/app/services/session.py
+++ b/backend/app/services/session.py
@@ -72,6 +72,23 @@ class SessionService:
             user_agent=user_agent,
         )
 
+    async def rotate_session(self, session: Session, new_refresh_token: str) -> Session:
+        """Rotate a login's refresh token in place, keeping the session row's id.
+
+        Refresh mints a new refresh token and a new access token; the row keeps
+        its id so the access token's `sid` is stable across the refresh - a live
+        socket, or a second tab, holding the old access token is not cut off by a
+        routine rotation (#1437, #1501) - while the new token's hash replaces the
+        old, which is what stops the spent refresh token being replayed.
+        """
+        expires_at = datetime.now(UTC) + timedelta(minutes=settings.REFRESH_TOKEN_EXPIRE_MINUTES)
+        return await session_repo.rotate(
+            self.db,
+            session=session,
+            refresh_token_hash=hash_token(new_refresh_token),
+            expires_at=expires_at,
+        )
+
     async def get_user_sessions(self, user_id: UUID) -> list[Session]:
         return await session_repo.get_user_sessions(self.db, user_id, open_only=True)
 

--- a/backend/app/services/session.py
+++ b/backend/app/services/session.py
@@ -57,7 +57,18 @@ class SessionService:
         refresh_token: str,
         ip_address: str | None = None,
         user_agent: str | None = None,
+        *,
+        session_id: UUID | None = None,
     ) -> Session:
+        """The row a sign-in is tracked by, whose id the access token names in `sid`.
+
+        `session_id` lets the caller choose the id up front, for a flow that has to
+        mint the token before the row exists: the OAuth callback names the id in the
+        token, hands out a single-use code, and only then writes the row - so a
+        failure issuing the code leaves no phantom session behind. Left `None`, the
+        row's own default assigns the id (login and magic-link read it back off the
+        returned row).
+        """
         device_name, device_type = _parse_user_agent(user_agent)
         expires_at = datetime.now(UTC) + timedelta(minutes=settings.REFRESH_TOKEN_EXPIRE_MINUTES)
 
@@ -70,6 +81,7 @@ class SessionService:
             device_type=device_type,
             ip_address=ip_address,
             user_agent=user_agent,
+            session_id=session_id,
         )
 
     async def rotate_session(self, session: Session, new_refresh_token: str) -> Session:

--- a/backend/app/services/session.py
+++ b/backend/app/services/session.py
@@ -2,12 +2,14 @@
 
 import hashlib
 from datetime import UTC, datetime, timedelta
+from typing import Any
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
-from app.core.exceptions import NotFoundError
+from app.core.exceptions import AuthenticationError, NotFoundError
+from app.core.security import read_uuid_claim
 from app.db.models.session import Session
 from app.repositories import session_repo
 from app.schemas.session import SessionListResponse, SessionRead
@@ -75,6 +77,49 @@ class SessionService:
 
     async def count_user_sessions(self, user_id: UUID, *, now: datetime | None = None) -> int:
         return await session_repo.count_user_sessions(self.db, user_id, open_only=True, now=now)
+
+    async def verify_access_session(self, *, payload: dict[str, Any], subject: str) -> None:
+        """Refuse an ordinary access token whose login session has been revoked.
+
+        A token minted since #1501 carries `sid`, the id of the `sessions` row its
+        login owns, so `DELETE /sessions` and the password-reset revoke-all - both
+        of which flip the row's `is_active` - refuse the token here on its next use,
+        an HTTP request or a WebSocket frame, instead of letting it live to its
+        `exp`. The row is also the login's own lifetime: an `expires_at` in the past
+        is a login that is over however fresh the access token looks, which is why
+        this still bites under the socket's `allow_expired` recheck (#1437).
+
+        A token with no `sid` predates the binding: it cannot be tied to a row and
+        is left to expire, the pre-#1501 behaviour, so an existing sign-in is not
+        logged out the moment this deploys - within one access-token lifetime every
+        live token has refreshed into a bound one.
+
+        An impersonation token carries `act` and its own `sid`, both already
+        verified by :meth:`ImpersonationService.verify` before this runs, so it
+        returns early here - looking its row up again would refuse it, an
+        impersonation row being exactly what an *ordinary* `sid` may not name. An
+        ordinary `sid` must therefore name an ordinary row (no impersonator), the
+        subject's own, still active and unexpired - the id alone is the binding,
+        since a signed token cannot carry a `sid` this deployment did not mint.
+
+        Raises:
+            AuthenticationError: The token names a session that is gone, deactivated,
+                expired, an impersonation, or another user's.
+        """
+        if read_uuid_claim(payload, "act") is not None:
+            return
+        session_id = read_uuid_claim(payload, "sid")
+        if session_id is None:
+            return
+        row = await session_repo.get_by_id(self.db, session_id)
+        if (
+            row is None
+            or not row.is_active
+            or row.expires_at <= datetime.now(UTC)
+            or row.impersonator_user_id is not None
+            or str(row.user_id) != subject
+        ):
+            raise AuthenticationError(message="Session has ended")
 
     async def validate_refresh_token(self, refresh_token: str) -> Session | None:
         """The session a refresh token belongs to, or None for one that cannot refresh.

--- a/backend/app/services/ws_auth.py
+++ b/backend/app/services/ws_auth.py
@@ -21,6 +21,7 @@ from uuid import UUID
 from app.core.exceptions import AuthenticationError, NotFoundError
 from app.core.security import verify_token
 from app.services.impersonation import ImpersonationService
+from app.services.session import SessionService
 from app.services.user import UserService
 
 if TYPE_CHECKING:
@@ -37,20 +38,21 @@ async def authenticate_socket_token(
     Much of the validation `get_current_user` runs on every HTTP request, so the
     socket is not more permissive than a request bearing the same token: an ended
     impersonation (its `sid` row deactivated, its administrator suspended or
-    demoted) and a suspended target account each refuse the token here as they do
-    there. Calling :meth:`ImpersonationService.verify` also refreshes the
-    request's audit impersonator, so a re-check on the receive loop keeps a turn
-    started afterwards attributed to whoever is really acting.
+    demoted), a revoked ordinary session (its own `sid` row deactivated by signing
+    out everywhere, #1501) and a suspended target account each refuse the token
+    here as they do there. Calling :meth:`ImpersonationService.verify` also
+    refreshes the request's audit impersonator, so a re-check on the receive loop
+    keeps a turn started afterwards attributed to whoever is really acting.
 
     `allow_expired` is set only by the per-frame re-check on an already-open
     socket. That socket was authenticated when its token was valid and then held
     open past the access token's 30-minute lifetime, so it is not torn down for
     routine token aging - which would cancel a turn a still-signed-in person is
-    running (#1437) - and revocation is judged from the impersonation row and the
-    account's `is_active` instead. Expiry that *is* a revocation is still caught:
-    an impersonation's window is its row's `expires_at`, which `verify` enforces
-    regardless. The handshake leaves it False, so a socket cannot be *opened*
-    with an already-expired token.
+    running (#1437) - and revocation is judged from the session and impersonation
+    rows and the account's `is_active` instead. Expiry that *is* a revocation is
+    still caught: a session's and an impersonation's window is its row's
+    `expires_at`, which the two `verify` calls enforce regardless. The handshake
+    leaves it False, so a socket cannot be *opened* with an already-expired token.
 
     The returned user is still bound to `db`; the caller detaches it (the
     handshake does, so it can outlive the connection; the per-frame check
@@ -58,8 +60,8 @@ async def authenticate_socket_token(
 
     Raises:
         AuthenticationError: The token is invalid (or, unless `allow_expired`,
-            expired), is not an access token, carries no subject, names an
-            impersonation that has ended, or resolves to a user who is unknown or
+            expired), is not an access token, carries no subject, names a session
+            or an impersonation that has ended, or resolves to a user who is unknown or
             suspended.
     """
     payload = verify_token(token, verify_exp=not allow_expired)
@@ -74,6 +76,7 @@ async def authenticate_socket_token(
         raise AuthenticationError(message="Invalid token payload")
 
     await ImpersonationService(db).verify(payload=payload, token=token, subject=user_id)
+    await SessionService(db).verify_access_session(payload=payload, subject=user_id)
 
     try:
         user = await UserService(db).get_by_id(UUID(user_id))

--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -10,9 +10,10 @@ from uuid import uuid4
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from app.api.deps import get_current_user, get_user_service
+from app.api.deps import get_current_user, get_session_service, get_user_service
 from app.core.config import settings
 from app.core.exceptions import AlreadyExistsError, AuthenticationError
+from app.core.security import verify_token
 from app.main import app
 from app.api.deps import get_redis
 from app.api.deps import get_db_session
@@ -90,6 +91,52 @@ async def test_login_success(client_with_mock_service: AsyncClient):
     assert "access_token" in data
     assert "refresh_token" in data
     assert data["token_type"] == "bearer"
+
+
+@pytest.mark.anyio
+async def test_login_binds_the_access_token_to_its_session(
+    client_with_mock_service: AsyncClient,
+):
+    """The token names its session row in `sid`, so signing out everywhere can
+    revoke it rather than only stop the next refresh (#1501)."""
+    session_id = uuid4()
+    session_service = MagicMock()
+    session_service.create_session = ServiceMock(return_value=MagicMock(id=session_id))
+    app.dependency_overrides[get_session_service] = lambda: session_service
+
+    response = await client_with_mock_service.post(
+        f"{settings.API_V1_STR}/auth/login",
+        data={"username": "test@example.com", "password": "password123"},
+    )
+
+    assert response.status_code == 200
+    payload = verify_token(response.json()["access_token"])
+    assert payload is not None
+    assert payload["sid"] == str(session_id)
+
+
+@pytest.mark.anyio
+async def test_magic_link_binds_the_access_token_to_its_session(
+    client_with_mock_service: AsyncClient,
+    mock_user_service: MagicMock,
+    mock_user: MockUser,
+):
+    """A magic-link sign-in is a session like any other, bound to its row."""
+    mock_user_service.consume_magic_link_token = ServiceMock(return_value=(mock_user, None))
+    session_id = uuid4()
+    session_service = MagicMock()
+    session_service.create_session = ServiceMock(return_value=MagicMock(id=session_id))
+    app.dependency_overrides[get_session_service] = lambda: session_service
+
+    response = await client_with_mock_service.post(
+        f"{settings.API_V1_STR}/auth/magic-link/verify",
+        json={"token": "a-magic-token"},
+    )
+
+    assert response.status_code == 200
+    payload = verify_token(response.json()["access_token"])
+    assert payload is not None
+    assert payload["sid"] == str(session_id)
 
 
 @pytest.mark.anyio

--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -140,6 +140,35 @@ async def test_magic_link_binds_the_access_token_to_its_session(
 
 
 @pytest.mark.anyio
+async def test_refresh_keeps_the_session_and_rebinds_the_new_token(
+    client_with_mock_service: AsyncClient,
+    mock_user_service: MagicMock,
+    mock_user: MockUser,
+):
+    """Refresh rotates the row in place: the new access token carries the *same*
+    `sid`, and no second row is created, so a live socket is not cut off (#1501)."""
+    session_id = uuid4()
+    session = MagicMock(id=session_id, user_id=mock_user.id)
+    session_service = MagicMock()
+    session_service.validate_refresh_token = ServiceMock(return_value=session)
+    session_service.rotate_session = ServiceMock(return_value=session)
+    session_service.create_session = ServiceMock()
+    app.dependency_overrides[get_session_service] = lambda: session_service
+
+    response = await client_with_mock_service.post(
+        f"{settings.API_V1_STR}/auth/refresh",
+        json={"refresh_token": "an-old-refresh-token"},
+    )
+
+    assert response.status_code == 200
+    payload = verify_token(response.json()["access_token"])
+    assert payload is not None
+    assert payload["sid"] == str(session_id)
+    session_service.rotate_session.assert_awaited_once()
+    session_service.create_session.assert_not_awaited()
+
+
+@pytest.mark.anyio
 async def test_login_invalid_credentials(
     client_with_mock_service: AsyncClient,
     mock_user_service: MagicMock,

--- a/backend/tests/integration/test_session_revocation.py
+++ b/backend/tests/integration/test_session_revocation.py
@@ -90,13 +90,25 @@ async def test_a_sid_less_token_survives_sign_out_everywhere(db, api: AsyncClien
 
 async def test_rotate_keeps_the_id_and_re_keys_the_refresh_hash(db):
     """Refresh in place: the row's id (the token's `sid`) survives, the old
-    refresh token stops validating, and the new one takes over - on real SQL."""
+    refresh token stops validating, and the new one takes over - on real SQL.
+
+    The security-sensitive properties of a refresh rotation, asserted explicitly
+    because in-place rotation replaces deactivate-old-then-create-new: the spent
+    token is refused (its hash no longer names a row), there is no window in which
+    both tokens validate (one row holds exactly one hash), and no second row is
+    left behind (the count stays one). The codebase has no rotation-chain reuse
+    detection for in-place to break - `validate_refresh_token` keys on the hash,
+    `is_active` and `expires_at` alone, and the session row carries no token
+    lineage - so the guarantee is exactly this hash swap.
+    """
     user = await _user(db, "rotate-e2e@example.com")
+    user_id = user.id  # bound before expire_all, which would make a later read reload
     service = SessionService(db)
     session = await session_repo.create(
-        db, user_id=user.id, refresh_token_hash=hash_token("old-refresh"), expires_at=_in_a_day()
+        db, user_id=user_id, refresh_token_hash=hash_token("old-refresh"), expires_at=_in_a_day()
     )
     original_id = session.id
+    assert await session_repo.count_user_sessions(db, user_id, open_only=True) == 1
 
     rotated = await service.rotate_session(session, "new-refresh")
 
@@ -104,7 +116,10 @@ async def test_rotate_keeps_the_id_and_re_keys_the_refresh_hash(db):
     assert rotated.refresh_token_hash == hash_token("new-refresh")
 
     db.expire_all()
+    # The spent token is refused, the new one works, and there is exactly one
+    # active row - no parallel window, no orphaned second session.
     assert await service.validate_refresh_token("old-refresh") is None
     revalidated = await service.validate_refresh_token("new-refresh")
     assert revalidated is not None
     assert revalidated.id == original_id
+    assert await session_repo.count_user_sessions(db, user_id, open_only=True) == 1

--- a/backend/tests/integration/test_session_revocation.py
+++ b/backend/tests/integration/test_session_revocation.py
@@ -1,0 +1,110 @@
+"""Signing out everywhere revokes an ordinary access token, against a real
+database (#1501).
+
+The unit suite proves the pieces with the database mocked: the token is bound to
+a session row, and `verify_access_session` refuses one whose row is gone. What it
+cannot prove is the two SQL facts the whole feature rests on - that creating a
+session assigns a real id for the token's `sid`, and that `DELETE /sessions`
+actually flips `is_active` on the row the token names, so the very next request
+is refused. Both are asserted here through the real routes and the real
+repositories.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+from uuid import UUID
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.api import deps
+from app.core.config import settings
+from app.core.security import create_access_token
+from app.main import app
+from app.repositories import session_repo, user_repo
+from app.services.session import SessionService, hash_token
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+async def api(db) -> AsyncIterator[AsyncClient]:
+    """The real app over the test database, sharing the test's own session so a
+    write in one request is visible to the next."""
+    app.dependency_overrides[deps.get_db_session] = lambda: db
+    app.dependency_overrides[deps.get_redis] = lambda: MagicMock()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+async def _user(db, email: str):
+    return await user_repo.create(db, email=email, hashed_password="not-a-real-hash")
+
+
+def _in_a_day() -> datetime:
+    return datetime.now(UTC) + timedelta(days=1)
+
+
+async def test_delete_sessions_revokes_an_ordinary_access_token_over_http(db, api: AsyncClient):
+    user = await _user(db, "revoke-e2e@example.com")
+    session = await session_repo.create(
+        db, user_id=user.id, refresh_token_hash="h", expires_at=_in_a_day()
+    )
+    assert isinstance(session.id, UUID)  # a real flush assigned the id the token names
+
+    token = create_access_token(str(user.id), sid=str(session.id))
+    headers = {"Authorization": f"Bearer {token}"}
+
+    live = await api.get(f"{settings.API_V1_STR}/auth/me", headers=headers)
+    assert live.status_code == 200
+
+    revoked = await api.delete(f"{settings.API_V1_STR}/sessions", headers=headers)
+    assert revoked.status_code == 200
+    assert revoked.json()["sessions_logged_out"] == 1
+
+    # A real request would read the row in a fresh session; the shared one must be
+    # told to re-read rather than trust the copy it loaded a request ago.
+    db.expire_all()
+    after = await api.get(f"{settings.API_V1_STR}/auth/me", headers=headers)
+    assert after.status_code == 401
+
+
+async def test_a_sid_less_token_survives_sign_out_everywhere(db, api: AsyncClient):
+    """A pre-#1501 token names no row, so it is not revocable this way - the
+    compatibility boundary, proven end to end rather than only in the unit."""
+    user = await _user(db, "legacy-e2e@example.com")
+    await session_repo.create(db, user_id=user.id, refresh_token_hash="h", expires_at=_in_a_day())
+    token = create_access_token(str(user.id))  # no sid
+    headers = {"Authorization": f"Bearer {token}"}
+
+    assert (await api.delete(f"{settings.API_V1_STR}/sessions", headers=headers)).status_code == 200
+    db.expire_all()
+
+    still_ok = await api.get(f"{settings.API_V1_STR}/auth/me", headers=headers)
+    assert still_ok.status_code == 200
+
+
+async def test_rotate_keeps_the_id_and_re_keys_the_refresh_hash(db):
+    """Refresh in place: the row's id (the token's `sid`) survives, the old
+    refresh token stops validating, and the new one takes over - on real SQL."""
+    user = await _user(db, "rotate-e2e@example.com")
+    service = SessionService(db)
+    session = await session_repo.create(
+        db, user_id=user.id, refresh_token_hash=hash_token("old-refresh"), expires_at=_in_a_day()
+    )
+    original_id = session.id
+
+    rotated = await service.rotate_session(session, "new-refresh")
+
+    assert rotated.id == original_id
+    assert rotated.refresh_token_hash == hash_token("new-refresh")
+
+    db.expire_all()
+    assert await service.validate_refresh_token("old-refresh") is None
+    revalidated = await service.validate_refresh_token("new-refresh")
+    assert revalidated is not None
+    assert revalidated.id == original_id

--- a/backend/tests/test_oauth_signin_exchange.py
+++ b/backend/tests/test_oauth_signin_exchange.py
@@ -9,15 +9,17 @@ code that the frontend swaps for the pair server to server.
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
+from urllib.parse import parse_qs, urlparse
 from uuid import uuid4
 
 import pytest
 from httpx import AsyncClient
 
-from app.api.deps import get_redis
+from app.api.deps import get_redis, get_session_service
 from app.core.config import settings
 from app.core.oauth import oauth
+from app.core.security import verify_token
 from app.main import app
 from app.services.oauth_exchange import OAuthExchangeService
 from app.services.user import UserService
@@ -97,3 +99,34 @@ async def test_exchange_refuses_an_unknown_code(client: AsyncClient) -> None:
     resp = await client.post(_EXCHANGE, json={"code": "never-issued"})
 
     assert resp.status_code == 401
+
+
+async def test_the_oauth_login_binds_its_access_token_to_a_session(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An OAuth sign-in is an ordinary session: its access token carries a `sid`
+    so signing out everywhere can revoke it, as for any other login (#1501)."""
+    fake = _FakeRedis()
+    app.dependency_overrides[get_redis] = lambda: fake
+    session_id = uuid4()
+    session_service = MagicMock()
+    session_service.create_session = AsyncMock(return_value=SimpleNamespace(id=session_id))
+    app.dependency_overrides[get_session_service] = lambda: session_service
+    monkeypatch.setattr(
+        oauth.google,
+        "authorize_access_token",
+        AsyncMock(return_value={"userinfo": {"sub": "s", "email": "u@e.com", "name": "U"}}),
+    )
+    monkeypatch.setattr(
+        UserService,
+        "get_or_create_oauth_user",
+        AsyncMock(return_value=SimpleNamespace(id=uuid4())),
+    )
+
+    redirect = await client.get(_CALLBACK)
+    code = parse_qs(urlparse(redirect.headers["location"]).query)["code"][0]
+    exchanged = await client.post(_EXCHANGE, json={"code": code})
+
+    payload = verify_token(exchanged.json()["access_token"])
+    assert payload is not None
+    assert payload["sid"] == str(session_id)

--- a/backend/tests/test_oauth_signin_exchange.py
+++ b/backend/tests/test_oauth_signin_exchange.py
@@ -108,9 +108,8 @@ async def test_the_oauth_login_binds_its_access_token_to_a_session(
     so signing out everywhere can revoke it, as for any other login (#1501)."""
     fake = _FakeRedis()
     app.dependency_overrides[get_redis] = lambda: fake
-    session_id = uuid4()
     session_service = MagicMock()
-    session_service.create_session = AsyncMock(return_value=SimpleNamespace(id=session_id))
+    session_service.create_session = AsyncMock()
     app.dependency_overrides[get_session_service] = lambda: session_service
     monkeypatch.setattr(
         oauth.google,
@@ -129,4 +128,36 @@ async def test_the_oauth_login_binds_its_access_token_to_a_session(
 
     payload = verify_token(exchanged.json()["access_token"])
     assert payload is not None
-    assert payload["sid"] == str(session_id)
+    # The row is created with exactly the id the token names.
+    session_service.create_session.assert_awaited_once()
+    assert str(session_service.create_session.await_args.kwargs["session_id"]) == payload["sid"]
+
+
+async def test_a_failed_code_issue_leaves_no_session_row(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The row is written only after the single-use code is issued, so a failure
+    handing out the code leaves no phantom session behind (#1501 review)."""
+    app.dependency_overrides[get_redis] = _FakeRedis
+    session_service = MagicMock()
+    session_service.create_session = AsyncMock()
+    app.dependency_overrides[get_session_service] = lambda: session_service
+    monkeypatch.setattr(
+        oauth.google,
+        "authorize_access_token",
+        AsyncMock(return_value={"userinfo": {"sub": "s", "email": "u@e.com", "name": "U"}}),
+    )
+    monkeypatch.setattr(
+        UserService,
+        "get_or_create_oauth_user",
+        AsyncMock(return_value=SimpleNamespace(id=uuid4())),
+    )
+    monkeypatch.setattr(
+        OAuthExchangeService, "issue", AsyncMock(side_effect=RuntimeError("exchange store down"))
+    )
+
+    redirect = await client.get(_CALLBACK)
+
+    assert redirect.status_code == 307
+    assert "error=" in redirect.headers["location"]
+    session_service.create_session.assert_not_awaited()

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -1,11 +1,13 @@
 """Tests for security module."""
 
 from datetime import timedelta
+from uuid import uuid4
 
 from app.core.security import (
     create_access_token,
     create_refresh_token,
     get_password_hash,
+    read_uuid_claim,
     verify_password,
     verify_token,
 )
@@ -130,6 +132,25 @@ class TestAccessToken:
         """`verify_exp=False` relaxes expiry alone; the signature is still
         checked, so a token this deployment did not sign is still refused."""
         assert verify_token("not.a.real.token", verify_exp=False) is None
+
+
+class TestReadUuidClaim:
+    """The one lenient reader both impersonation and ordinary-session binding use."""
+
+    def test_a_present_uuid_claim_is_parsed(self):
+        session_id = uuid4()
+        assert read_uuid_claim({"sid": str(session_id)}, "sid") == session_id
+
+    def test_an_absent_claim_is_none(self):
+        assert read_uuid_claim({"sub": "u"}, "sid") is None
+
+    def test_an_empty_claim_is_none(self):
+        assert read_uuid_claim({"sid": ""}, "sid") is None
+
+    def test_a_malformed_claim_is_none_not_a_refusal(self):
+        """The token is signed, so a value it cannot parse is one this code never
+        wrote - read as no claim rather than raising (#943)."""
+        assert read_uuid_claim({"sid": "not-a-uuid"}, "sid") is None
 
 
 class TestRefreshToken:

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -185,3 +185,16 @@ class TestRefreshToken:
         assert payload is not None
         assert payload["sub"] == subject
         assert payload["type"] == "refresh"
+
+    def test_two_refresh_tokens_for_one_subject_are_unique(self):
+        """A random `jti` keeps two tokens minted for one subject in the same
+        second from being byte-identical: their hashes would otherwise collide
+        into two session rows under one hash, and the next refresh's lookup raises
+        instead of resolving (#1501)."""
+        first = create_refresh_token("user123")
+        second = create_refresh_token("user123")
+
+        assert first != second
+        payload = verify_token(first)
+        assert payload is not None
+        assert payload["jti"]

--- a/backend/tests/test_session_verify.py
+++ b/backend/tests/test_session_verify.py
@@ -1,0 +1,114 @@
+"""`SessionService.verify_access_session` - the #1501 refusal that lets signing
+out everywhere reach an ordinary access token."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.core.exceptions import AuthenticationError
+from app.services.session import SessionService
+
+pytestmark = pytest.mark.anyio
+
+_REPO = "app.services.session.session_repo.get_by_id"
+
+
+def _row(
+    *,
+    user_id: UUID,
+    is_active: bool = True,
+    impersonator_user_id: UUID | None = None,
+    expires_at: datetime | None = None,
+) -> MagicMock:
+    return MagicMock(
+        user_id=user_id,
+        is_active=is_active,
+        impersonator_user_id=impersonator_user_id,
+        expires_at=expires_at or datetime.now(UTC) + timedelta(days=1),
+    )
+
+
+class TestVerifyAccessSession:
+    async def test_a_token_without_sid_is_left_alone(self) -> None:
+        """A pre-#1501 token names no row, so it is not looked up and not refused -
+        an existing sign-in is not logged out the moment this deploys."""
+        with patch(_REPO, AsyncMock()) as get_by_id:
+            await SessionService(MagicMock()).verify_access_session(
+                payload={"sub": "u"}, subject="u"
+            )
+        get_by_id.assert_not_awaited()
+
+    async def test_an_impersonation_token_is_verified_elsewhere_not_here(self) -> None:
+        """A token with a valid `act` is an impersonation, bound to its row by
+        ImpersonationService before this runs; looking that row up here would
+        refuse it, so it returns early and never touches the repo."""
+        with patch(_REPO, AsyncMock()) as get_by_id:
+            await SessionService(MagicMock()).verify_access_session(
+                payload={"act": str(uuid4()), "sid": str(uuid4())}, subject=str(uuid4())
+            )
+        get_by_id.assert_not_awaited()
+
+    async def test_an_active_session_the_subject_owns_passes(self) -> None:
+        user_id = uuid4()
+        with patch(_REPO, AsyncMock(return_value=_row(user_id=user_id))):
+            await SessionService(MagicMock()).verify_access_session(
+                payload={"sid": str(uuid4())}, subject=str(user_id)
+            )
+
+    async def test_a_sid_naming_no_row_is_refused(self) -> None:
+        with (
+            patch(_REPO, AsyncMock(return_value=None)),
+            pytest.raises(AuthenticationError, match="Session has ended"),
+        ):
+            await SessionService(MagicMock()).verify_access_session(
+                payload={"sid": str(uuid4())}, subject=str(uuid4())
+            )
+
+    async def test_a_deactivated_session_is_refused(self) -> None:
+        """Signing out everywhere flips `is_active`; the token is refused next use."""
+        user_id = uuid4()
+        with (
+            patch(_REPO, AsyncMock(return_value=_row(user_id=user_id, is_active=False))),
+            pytest.raises(AuthenticationError, match="Session has ended"),
+        ):
+            await SessionService(MagicMock()).verify_access_session(
+                payload={"sid": str(uuid4())}, subject=str(user_id)
+            )
+
+    async def test_an_expired_session_is_refused(self) -> None:
+        user_id = uuid4()
+        expired = _row(user_id=user_id, expires_at=datetime.now(UTC) - timedelta(seconds=1))
+        with (
+            patch(_REPO, AsyncMock(return_value=expired)),
+            pytest.raises(AuthenticationError, match="Session has ended"),
+        ):
+            await SessionService(MagicMock()).verify_access_session(
+                payload={"sid": str(uuid4())}, subject=str(user_id)
+            )
+
+    async def test_an_impersonation_row_is_not_an_ordinary_session(self) -> None:
+        """An ordinary token may not carry an impersonation `sid`: that row is
+        verified by ImpersonationService for an `act` token, never here."""
+        user_id = uuid4()
+        row = _row(user_id=user_id, impersonator_user_id=uuid4())
+        with (
+            patch(_REPO, AsyncMock(return_value=row)),
+            pytest.raises(AuthenticationError, match="Session has ended"),
+        ):
+            await SessionService(MagicMock()).verify_access_session(
+                payload={"sid": str(uuid4())}, subject=str(user_id)
+            )
+
+    async def test_another_users_session_is_refused(self) -> None:
+        """A `sid` replayed onto a token for a different subject is refused."""
+        with (
+            patch(_REPO, AsyncMock(return_value=_row(user_id=uuid4()))),
+            pytest.raises(AuthenticationError, match="Session has ended"),
+        ):
+            await SessionService(MagicMock()).verify_access_session(
+                payload={"sid": str(uuid4())}, subject=str(uuid4())
+            )

--- a/backend/tests/test_sessions_pagination.py
+++ b/backend/tests/test_sessions_pagination.py
@@ -16,7 +16,7 @@ from uuid import uuid4
 import pytest
 
 from app.repositories import session as session_repo
-from app.services.session import SessionService
+from app.services.session import SessionService, hash_token
 
 pytestmark = pytest.mark.anyio
 
@@ -110,3 +110,39 @@ class TestRepositoryQuery:
         statement = await self._statement()
 
         assert statement._limit_clause is None
+
+
+class TestRotate:
+    """In-place refresh rotation - the row keeps its id so a live token's `sid`
+    stays valid across a refresh (#1501)."""
+
+    async def test_rotate_session_rekeys_in_place_and_delegates(self) -> None:
+        row = MagicMock()
+        with patch.object(session_repo, "rotate", AsyncMock(return_value=row)) as rotate:
+            result = await SessionService(MagicMock()).rotate_session(row, "a-new-refresh-token")
+
+        assert result is row
+        rotate.assert_awaited_once()
+        kwargs = rotate.await_args.kwargs
+        assert kwargs["session"] is row
+        assert kwargs["refresh_token_hash"] == hash_token("a-new-refresh-token")
+        assert kwargs["expires_at"] > datetime.now(UTC)
+
+    async def test_the_repo_moves_the_hash_and_window_but_not_the_id(self) -> None:
+        db = MagicMock()
+        db.flush = AsyncMock()
+        db.refresh = AsyncMock()
+        session_id = uuid4()
+        row = MagicMock(id=session_id)
+        new_expiry = datetime.now(UTC)
+
+        returned = await session_repo.rotate(
+            db, session=row, refresh_token_hash="deadbeef", expires_at=new_expiry
+        )
+
+        assert returned is row
+        assert row.id == session_id
+        assert row.refresh_token_hash == "deadbeef"
+        assert row.expires_at == new_expiry
+        db.flush.assert_awaited_once()
+        db.refresh.assert_awaited_once_with(row)

--- a/backend/tests/test_sessions_pagination.py
+++ b/backend/tests/test_sessions_pagination.py
@@ -8,7 +8,7 @@ sitting on a page that no longer exists.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -116,10 +116,12 @@ class TestRotate:
     """In-place refresh rotation - the row keeps its id so a live token's `sid`
     stays valid across a refresh (#1501)."""
 
-    async def test_rotate_session_rekeys_in_place_and_delegates(self) -> None:
+    async def test_rotate_session_rekeys_in_place_and_moves_provenance(self) -> None:
         row = MagicMock()
         with patch.object(session_repo, "rotate", AsyncMock(return_value=row)) as rotate:
-            result = await SessionService(MagicMock()).rotate_session(row, "a-new-refresh-token")
+            result = await SessionService(MagicMock()).rotate_session(
+                row, "a-new-refresh-token", ip_address="203.0.113.9", user_agent="Firefox on Linux"
+            )
 
         assert result is row
         rotate.assert_awaited_once()
@@ -127,9 +129,13 @@ class TestRotate:
         assert kwargs["session"] is row
         assert kwargs["refresh_token_hash"] == hash_token("a-new-refresh-token")
         assert kwargs["expires_at"] > datetime.now(UTC)
+        assert kwargs["ip_address"] == "203.0.113.9"
+        assert kwargs["user_agent"] == "Firefox on Linux"
+        assert kwargs["device_name"] == "Firefox"  # derived from the refreshing UA
 
-    async def test_the_repo_moves_the_hash_and_window_but_not_the_id(self) -> None:
+    async def test_the_repo_moves_the_hash_window_and_provenance_but_not_the_id(self) -> None:
         db = MagicMock()
+        db.add = MagicMock()
         db.flush = AsyncMock()
         db.refresh = AsyncMock()
         session_id = uuid4()
@@ -137,12 +143,56 @@ class TestRotate:
         new_expiry = datetime.now(UTC)
 
         returned = await session_repo.rotate(
-            db, session=row, refresh_token_hash="deadbeef", expires_at=new_expiry
+            db,
+            session=row,
+            refresh_token_hash="deadbeef",
+            expires_at=new_expiry,
+            device_name="Chrome",
+            device_type="desktop",
+            ip_address="203.0.113.9",
+            user_agent="Chrome UA",
         )
 
         assert returned is row
         assert row.id == session_id
         assert row.refresh_token_hash == "deadbeef"
         assert row.expires_at == new_expiry
+        assert row.ip_address == "203.0.113.9"
+        assert row.device_name == "Chrome"
         db.flush.assert_awaited_once()
         db.refresh.assert_awaited_once_with(row)
+
+    async def test_validate_locks_the_row_against_a_concurrent_refresh(self) -> None:
+        """A refresh takes the row `FOR UPDATE`, so a concurrent one bearing the
+        same token serializes behind it rather than both rotating (#1501 review)."""
+        row = MagicMock(impersonator_user_id=None, expires_at=datetime.now(UTC) + timedelta(days=1))
+        with (
+            patch.object(
+                session_repo, "get_by_refresh_token_hash", AsyncMock(return_value=row)
+            ) as get,
+            patch.object(session_repo, "update_last_used", AsyncMock()),
+        ):
+            result = await SessionService(MagicMock()).validate_refresh_token("a-token")
+
+        assert result is row
+        assert get.await_args.kwargs["for_update"] is True
+
+    async def test_the_locked_lookup_selects_for_update(self) -> None:
+        db = MagicMock()
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(return_value=None)
+        db.execute = AsyncMock(return_value=result)
+
+        await session_repo.get_by_refresh_token_hash(db, "hash", for_update=True)
+
+        assert db.execute.await_args.args[0]._for_update_arg is not None
+
+    async def test_the_plain_lookup_does_not_lock(self) -> None:
+        db = MagicMock()
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(return_value=None)
+        db.execute = AsyncMock(return_value=result)
+
+        await session_repo.get_by_refresh_token_hash(db, "hash")
+
+        assert db.execute.await_args.args[0]._for_update_arg is None

--- a/backend/tests/test_ws_auth.py
+++ b/backend/tests/test_ws_auth.py
@@ -10,7 +10,7 @@ door here, and the door is the same one the next frame knocks on.
 
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -183,3 +183,39 @@ class TestAuthenticateSocketToken:
                 side_effect=AuthenticationError(message="Impersonation has ended")
             )
             await authenticate_socket_token(MagicMock(), token, allow_expired=True)
+
+    async def test_a_revoked_ordinary_session_closes_the_socket(self) -> None:
+        """The #1501 door: an ordinary token whose `sid` names a deactivated row -
+        signed out everywhere - is refused on the next frame, so the socket closes
+        even though the account itself is untouched."""
+        user = _user()
+        row = MagicMock(
+            user_id=user.id,
+            is_active=False,
+            impersonator_user_id=None,
+            expires_at=datetime.now(UTC) + timedelta(days=1),
+        )
+        token = create_access_token(str(user.id), sid=str(uuid4()))
+        with (
+            patch("app.services.session.session_repo.get_by_id", AsyncMock(return_value=row)),
+            pytest.raises(AuthenticationError, match="Session has ended"),
+        ):
+            await authenticate_socket_token(MagicMock(), token, allow_expired=True)
+
+    async def test_a_live_ordinary_session_resolves_to_its_user(self) -> None:
+        user = _user()
+        row = MagicMock(
+            user_id=user.id,
+            is_active=True,
+            impersonator_user_id=None,
+            expires_at=datetime.now(UTC) + timedelta(days=1),
+        )
+        token = create_access_token(str(user.id), sid=str(uuid4()))
+        with (
+            patch("app.services.session.session_repo.get_by_id", AsyncMock(return_value=row)),
+            patch("app.services.ws_auth.UserService") as user_service,
+        ):
+            user_service.return_value.get_by_id = AsyncMock(return_value=user)
+            resolved = await authenticate_socket_token(MagicMock(), token, allow_expired=True)
+
+        assert resolved is user

--- a/docs/api.md
+++ b/docs/api.md
@@ -22,6 +22,18 @@ Three ways in, for three different callers.
 Keys are compared with `secrets.compare_digest`, never `==`, and a key is
 stored the way [every other credential](secrets.md) is.
 
+### Sessions and revocation
+
+A JWT access token is bound to the session its sign-in opened — the session's id
+travels inside the token. Signing out everywhere (`DELETE /sessions`) deactivates
+those sessions, and a bound token is then refused on its next use rather than
+living out its few remaining minutes. That reaches an open chat WebSocket too: the
+next frame on a revoked session closes the socket, not only the next HTTP request.
+
+Refreshing does not start a new session — the refresh token rotates in place and
+the access token keeps naming the same one — so a long-lived connection is not cut
+off by a routine refresh.
+
 ## The organization header
 
 **`X-Organization-Id` travels on every request**, and it is not optional


### PR DESCRIPTION
> **Stacked on #1536 (#1437).** Base is `fix/1437-ws-revocation`; the WebSocket per-frame re-check this relies on is introduced there. Merge #1536 first; this retargets to `main` on merge. Review the [9-commit diff](https://github.com/vstorm-co/agenticos/compare/fix/1437-ws-revocation...fix/1501-normal-session-sid), not the combined range.

## Summary

An ordinary (non-impersonation) access token carried no binding to a session, so `DELETE /sessions` ("sign out everywhere") could not revoke it — the token stayed valid until its `exp`, and an open chat socket on it kept answering. #1437 closes an *impersonation's* socket the moment its session ends; this does the same for an **ordinary** session.

Bind an ordinary access token to its login's `sessions` row: the token names the row's id in `sid`, and both the HTTP dependency and the WebSocket re-check refuse the token when that row is gone, deactivated, expired, an impersonation, or another user's. Signing out everywhere deactivates the row, so the token is refused on its next use — an HTTP request or a socket's next frame — instead of living to expiry.

## What changed

- **`verify_access_session`** — the refusal, wired into `get_current_user` (HTTP) and `authenticate_socket_token` (WebSocket, so the per-frame re-check too), right after the impersonation check. A token with **no `sid`** predates the binding and is left to expire (so nobody is logged out on deploy; it converges to bound within one token lifetime). An impersonation token (`act`) is skipped here — `ImpersonationService.verify` owns its row.
- **`sid` on every ordinary mint** — login, magic-link, Google OAuth. OAuth previously created **no session row at all**, so a Google sign-in was unrevocable; it now gets a row, written only after the single-use code is issued so a failure leaves no phantom session.
- **Refresh rotates the row in place** — the id (the token's `sid`) is kept, only the refresh-token hash and window move. So `sid` is stable across a refresh and a live socket / second tab is not cut off by a routine rotation, while the spent refresh token stops validating (its hash no longer names a row). The review noted this also *closes* a revoke-bypass race the old deactivate-and-create flow had: a refresh racing `DELETE /sessions` used to create a fresh active row that survived the sign-out.

## No migration

The `sessions` table already has everything — `id`, `is_active`, `expires_at`, `user_id`, `impersonator_user_id`. `sid` reuses the existing row id; the revocation primitive (`deactivate_all_user_sessions`) already existed.

## Verification

- Unit: `test_session_verify` (the seven refusal/pass cases + impersonation-skip), `test_ws_auth` (the socket door: a revoked ordinary session refused, a live one resolved), `test_auth` / `test_oauth_signin_exchange` (each mint carries `sid`; a failed OAuth code issue leaves no row).
- **Integration against real Postgres** (`test_session_revocation`, run on pgvector/pg16): login → `GET /auth/me` 200 → `DELETE /sessions` → next request **401**; a `sid`-less token survives (the compat boundary); refresh rotates in place with the reuse guarantees pinned (old token refused, new one works, exactly one active row).
- Two adversarial self-reviews (automated reviewer off, #311): **correct and complete, no high/critical**. `make test` green; `ws_auth`/`impersonation` at 100%.

## Known edges (deliberately not fixed)

- A token minted **before** this binding carries no `sid`, so a legacy socket held open across the deploy is not closed by sign-out-everywhere until it reconnects (only account suspension closes it meanwhile). Transitional and self-healing on reconnect.
- Refresh-token **reuse/replay detection** (kill-the-family when a spent token reappears) is a defense-in-depth pattern this project has never had — orthogonal to this change, not a regression. Filed as #1519.

Closes #1501
Refs #1437
