### PR TITLE
docs(code-review): adjudicate the returnTo clear-text-storage alert

### DIFF
--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -349,13 +349,27 @@ the ones titled `Code Quality: …`.
 
 | Analysis | Languages | Where a finding lands | What a false positive costs |
 |---|---|---|---|
-| Code scanning | `actions`, `javascript-typescript`, `python` | The Security tab, and an annotation on the diff | Dismiss it once, with a reason. Three are dismissed today, all `py/clear-text-logging-sensitive-data` in `mcp_tasks.py` |
+| Code scanning | `actions`, `javascript-typescript`, `python` | The Security tab, and an annotation on the diff | Dismiss it once, with a reason. Four are dismissed today: three `py/clear-text-logging-sensitive-data` in `mcp_tasks.py`, and one `js/clear-text-storage-of-sensitive-data` in `oauth-return.ts` (below) |
 | Code Quality | `javascript-typescript`, `python` | A **review thread** from `github-code-quality[bot]` | The merge is blocked until somebody resolves the thread |
 
 The second row is the expensive one, for exactly the reason the reviewer's inline
 findings are: the ruleset requires every review thread resolved, so a finding
 nobody agrees with still has to be handled by hand. #196 paid eight threads for
 one alert, all of them the same false positive.
+
+### The stored `returnTo` path is not a credential
+
+Code scanning flags `rememberReturnTo` in `frontend/src/lib/oauth-return.ts`
+writing to `sessionStorage` (`js/clear-text-storage-of-sensitive-data`). What it
+stores is the relative path the visitor was on before sign-in, carried across the
+OAuth round trip (#135) — not a credential. The open-redirect risk a stored path
+*could* carry is closed on the read side: every consumer resolves it through
+`postSignInDestination`, which honours it only when `isSafeReturnPath` agrees it is
+one of this app's own paths, so a scheme (`https://evil`), a protocol-relative path
+(`//evil`) or a `javascript:` value is refused there rather than followed.
+Validating again at the write is the second copy `oauth-return.ts` deliberately
+does not keep. Dismissed with this reason (#1414); reopening it re-asks a settled
+question.
 
 ### There is no filter to reach for (checked 2026-08-05)
 

--- a/frontend/src/lib/safe-return-path.test.ts
+++ b/frontend/src/lib/safe-return-path.test.ts
@@ -13,6 +13,7 @@ describe("isSafeReturnPath", () => {
     ["nothing remembered", null],
     ["nothing at all", undefined],
     ["a scheme", "https://evil.example"],
+    ["a javascript: url", "javascript:alert(document.domain)"],
     ["a protocol-relative path", "//evil.example/x"],
     ["a backslash variant browsers normalise to //", "/\\evil.example"],
     ["a relative path, which resolves against wherever the visitor stands", "agents"],


### PR DESCRIPTION
## What this closes

CodeQL code scanning (`js/clear-text-storage-of-sensitive-data`, alert #20) flags `rememberReturnTo` in `frontend/src/lib/oauth-return.ts` writing the `returnTo` path to `sessionStorage`. The stored value is the relative path the visitor was on before sign-in, carried across the OAuth round trip (#135) — not a credential.

The open-redirect risk a stored path *could* carry is closed on the read side: every consumer (`/auth/callback`, the magic-link landing, `use-auth`) resolves it through `postSignInDestination`, which honours it only when `isSafeReturnPath` agrees it is one of this app's own paths. A scheme (`https://evil`), a protocol-relative path (`//evil`) or a `javascript:` value is refused there rather than followed. Validating again at the write is the second copy `oauth-return.ts` deliberately does not keep.

## Changes

- `safe-return-path.test.ts`: name the `javascript:` shape in the rejected-shapes table — the guard already refuses it (the value does not start with `/`), but the coverage had left it implicit beside the scheme and protocol-relative cases.
- `docs/code-review.md`: record the adjudication beside the other dismissed code-scanning alerts, so the next reviewer does not re-open it.

## The alert

Alert #20 is dismissed (won't fix) with this reason — the design validates once, on the read side, so there is no change to the storage itself.

## Verification

`bunx vitest run src/lib/safe-return-path.test.ts` — 11 passed; the docs paragraph guard and drift check pass.

Closes #1414
Refs #1424, #135
