### PR TITLE
test(lifespan): stub the web-research client the drain test still closed

### DIFF
--- a/backend/tests/test_lifespan_drain.py
+++ b/backend/tests/test_lifespan_drain.py
@@ -74,11 +74,15 @@ def _stub_startup(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(main, "RedisClient", lambda *a, **k: _FakeRedis())
     monkeypatch.setattr(main, "_start_channel_polling", AsyncMock())
     monkeypatch.setattr(main, "close_db", AsyncMock())
-    # A shutdown collaborator, like `close_db`: the real one closes a module-global
-    # httpx client that another test may have opened on its own event loop, and
-    # closing it here - on this test's loop - raises "Event loop is closed" under
-    # xdist. The lifespan runs in-process, so stub it out the same way.
+    # Shutdown collaborators like `close_db`: each closes a module-global httpx
+    # client that another test may have opened on its own event loop, so closing
+    # it here - on this test's loop - raises "Event loop is closed" under xdist.
+    # The lifespan runs in-process, so stub every one of them out the same way
+    # (#1338 was the web-research client, left out when the other two went in).
     monkeypatch.setattr("app.services.model_catalog.close_listing_client", AsyncMock())
+    monkeypatch.setattr(
+        "app.agents.capabilities.web_research._search.close_http_client", AsyncMock()
+    )
     monkeypatch.setattr(main, "reset_retrieval_service", MagicMock())
     monkeypatch.setattr(main, "EventLoopWatchdog", lambda *a, **k: MagicMock())
     # Warmup raises, so the embedder is None and no PgVectorStore is built - the


### PR DESCRIPTION
## The flake

`tests/test_lifespan_drain.py::test_the_lifespan_waits_for_in_flight_background_work` failed once on CI with `RuntimeError: Event loop is closed`, then passed on a plain re-run of the same commit — order/worker-dependent under `-n auto` + `pytest-randomly`.

## Root cause

The test runs the real application shutdown in-process to exercise `background.drain()`. Shutdown closes **three** module-global httpx clients: `close_db`, `close_listing_client` and `close_http_client` (web research). The first two were stubbed for exactly this reason — a client another test opened on its own event loop, closed here on this test's loop, raises `Event loop is closed` under xdist — but `close_http_client` (`app/main.py:210`) was left out, so the drain test still flaked on it whenever a web-search test that left `_search._client` open shared its worker.

## The fix

Stub `close_http_client` the same way as its two siblings, so the drain test no longer depends on the shared `_search._client` global across xdist workers.

## Verification

- `uv run pytest tests/test_lifespan_drain.py -q -p no:randomly` — 1 passed.
- Confirmed the mechanism deterministically: `close_http_client()` propagates `RuntimeError: Event loop is closed` when `_search._client` is a client bound to a closed loop — the exact failure the drain test hit.

Closes #1338
