### PR TITLE
docs(configuration): document SMTP settings and what breaks without them

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -167,24 +167,33 @@ Computed properties:
 
 ## Email (SMTP)
 
-The deployment sends mail through an SMTP server, and a deployment with none
-configured does not fail — it runs, and three things silently stop working, none
-of which announces itself:
+The deployment sends mail through an SMTP server, and one with none configured
+does not fail — it runs, and every mail-dependent flow silently stops, none of
+them announcing itself:
 
+- **passwordless sign-in and password resets** — the magic-link and reset emails
+  are the self-service ways into an account;
 - **invitations** — an invited address is never mailed (the console now says so
-  rather than claiming it sent one, #1479);
-- **password resets** — the only self-service way back into a locked-out account;
-- **notifications** — a budget breach, an approval request, a usage report.
+  rather than claiming it sent one, #1484);
+- **notifications** — a budget breach, an approval request, a usage report, the
+  notice sent when an administrator acts as another account.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `SMTP_HOST` | `localhost` | SMTP server host |
-| `SMTP_PORT` | `587` | SMTP server port (`587` is the STARTTLS submission port) |
-| `SMTP_USER` | (empty) | SMTP username. Empty uses the server unauthenticated |
-| `SMTP_PASSWORD` | (empty) | SMTP password |
-| `SMTP_TLS` | `true` | Open the connection with STARTTLS |
+| `SMTP_PORT` | `587` | SMTP server port. Pair it with `SMTP_TLS` — `465` for TLS from the start, `587` for STARTTLS |
+| `SMTP_USER` | (empty) | Username the relay authenticates with, alongside `SMTP_PASSWORD` |
+| `SMTP_PASSWORD` | (empty) | Password for that username |
+| `SMTP_TLS` | `true` | Open the connection with TLS from the start (`aiosmtplib`'s `use_tls`) — for an implicit-TLS port like `465`. A STARTTLS submission server on `587` wants this `false`, and the client then negotiates STARTTLS when the server offers it |
 | `EMAIL_FROM` | `noreply@agenticos.com` | The `From` address on every message |
 | `EMAIL_FROM_NAME` | `agenticos` | The display name shown beside that address |
+
+!!! warning "The shipped defaults do not send mail"
+
+    `SMTP_TLS=true` opens TLS immediately, but the default `SMTP_PORT=587` is the
+    STARTTLS submission port, where implicit TLS is rejected. Match the pair —
+    `465` with `SMTP_TLS=true`, or `587` with `SMTP_TLS=false` — until the default
+    itself is fixed (#1543).
 
 ## Background work (Prefect)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -181,19 +181,19 @@ them announcing itself:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `SMTP_HOST` | `localhost` | SMTP server host |
-| `SMTP_PORT` | `587` | SMTP server port. Pair it with `SMTP_TLS` — `465` for TLS from the start, `587` for STARTTLS |
-| `SMTP_USER` | (empty) | Username the relay authenticates with, alongside `SMTP_PASSWORD` |
+| `SMTP_PORT` | `587` | SMTP server port. `587` and `25` negotiate STARTTLS; `465` opens TLS from the start |
+| `SMTP_USER` | (empty) | Username the relay authenticates with, alongside `SMTP_PASSWORD`. Leave empty for an unauthenticated relay |
 | `SMTP_PASSWORD` | (empty) | Password for that username |
-| `SMTP_TLS` | `true` | Open the connection with TLS from the start (`aiosmtplib`'s `use_tls`) — for an implicit-TLS port like `465`. A STARTTLS submission server on `587` wants this `false`, and the client then negotiates STARTTLS when the server offers it |
+| `SMTP_TLS` | `true` | Whether to encrypt the connection. The port decides how — STARTTLS on `587`, implicit TLS on `465`. Set `false` only for an unencrypted relay, such as a local server on `25` |
 | `EMAIL_FROM` | `noreply@agenticos.com` | The `From` address on every message |
 | `EMAIL_FROM_NAME` | `agenticos` | The display name shown beside that address |
 
-!!! warning "The shipped defaults do not send mail"
+!!! note "How the connection is encrypted"
 
-    `SMTP_TLS=true` opens TLS immediately, but the default `SMTP_PORT=587` is the
-    STARTTLS submission port, where implicit TLS is rejected. Match the pair —
-    `465` with `SMTP_TLS=true`, or `587` with `SMTP_TLS=false` — until the default
-    itself is fixed (#1543).
+    `SMTP_TLS` is the on/off switch; the port chooses the scheme. The shipped
+    default — `587` with `SMTP_TLS=true` — negotiates STARTTLS, which is what a
+    standards-compliant submission server expects. Use `465` for a server that
+    wants implicit TLS instead, and `SMTP_TLS=false` on `25` for a plaintext relay.
 
 ## Background work (Prefect)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,6 +165,27 @@ Computed properties:
 | `REDIS_PASSWORD` | (none) | Redis password (optional) |
 | `REDIS_DB` | `0` | Redis database number |
 
+## Email (SMTP)
+
+The deployment sends mail through an SMTP server, and a deployment with none
+configured does not fail — it runs, and three things silently stop working, none
+of which announces itself:
+
+- **invitations** — an invited address is never mailed (the console now says so
+  rather than claiming it sent one, #1479);
+- **password resets** — the only self-service way back into a locked-out account;
+- **notifications** — a budget breach, an approval request, a usage report.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SMTP_HOST` | `localhost` | SMTP server host |
+| `SMTP_PORT` | `587` | SMTP server port (`587` is the STARTTLS submission port) |
+| `SMTP_USER` | (empty) | SMTP username. Empty uses the server unauthenticated |
+| `SMTP_PASSWORD` | (empty) | SMTP password |
+| `SMTP_TLS` | `true` | Open the connection with STARTTLS |
+| `EMAIL_FROM` | `noreply@agenticos.com` | The `From` address on every message |
+| `EMAIL_FROM_NAME` | `agenticos` | The display name shown beside that address |
+
 ## Background work (Prefect)
 
 | Variable | Default | Description |
@@ -911,3 +932,8 @@ stale and production's pipe ping goes unanswered.
 - [ ] `REDIS_PASSWORD` — a strong password
 - [ ] `CORS_ORIGINS` — only your actual frontend domain(s)
 - [ ] `OPENROUTER_API_KEY` — your production API key
+
+Email is deliberately **not** on this list: a deployment runs without it. But
+invitations, password resets and notifications all go silently unsent until
+`SMTP_HOST` and the rest of [Email (SMTP)](#email-smtp) point at a real server —
+so a deployment that skips it should be skipping it knowingly.


### PR DESCRIPTION
## What this adds

`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`, `SMTP_TLS`, `EMAIL_FROM` and `EMAIL_FROM_NAME` are read by `app/services/email/` and live in `backend/.env.example`, but appeared nowhere in `docs/configuration.md` — the settings reference a deployment reads to find out what it must set.

A deployment with no mail service does not fail. It runs, and **invitations**, **password resets** and **notifications** all go silently unsent, none of them announcing itself.

## Changes

- A new **Email (SMTP)** section: a row per setting (defaults matched to `app/core/config.py`), and a short list of what depends on email.
- A pointer beside the production checklist saying email is deliberately not on it, so a deployment that skips SMTP does so knowingly rather than discovering it when somebody forgets their password.

## Verification

`make docs-build` (strict) succeeds and the `#email-smtp` anchor resolves; the paragraph-length and docs-drift guards pass. Edited by hand — no prettier on `docs/*.md`.

Closes #1482
