### PR TITLE
feat(invitations): server-side exchange so the token never reaches JS storage

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -253,6 +253,7 @@ from app.repositories import member_repo, organization_repo
 from app.services.organization import OrganizationService
 from app.services.member import MemberService
 from app.services.invitation import InvitationService
+from app.services.invitation_staging import InvitationStagingService
 
 
 def get_organization_service(db: DBSession) -> OrganizationService:
@@ -270,9 +271,15 @@ def get_invitation_service(db: DBSession) -> InvitationService:
     return InvitationService(db)
 
 
+def get_invitation_staging_service(redis: Redis) -> InvitationStagingService:
+    """Create InvitationStagingService instance with the Redis client."""
+    return InvitationStagingService(redis)
+
+
 OrganizationSvc = Annotated[OrganizationService, Depends(get_organization_service)]
 MemberSvc = Annotated[MemberService, Depends(get_member_service)]
 InvitationSvc = Annotated[InvitationService, Depends(get_invitation_service)]
+InvitationStagingSvc = Annotated[InvitationStagingService, Depends(get_invitation_staging_service)]
 from app.core.exceptions import (
     AuthenticationError,
     AuthorizationError,

--- a/backend/app/api/routes/v1/auth.py
+++ b/backend/app/api/routes/v1/auth.py
@@ -3,13 +3,14 @@
 import logging
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, Request, status
+from fastapi import APIRouter, Depends, Header, Request, status
 from fastapi.security import OAuth2PasswordRequestForm
 
 from app.api.deps import (
     CurrentUser,
     DeploymentSettingsSvc,
     ImpersonationSvc,
+    InvitationStagingSvc,
     SessionSvc,
     UserSvc,
     enforce_auth_limit,
@@ -65,9 +66,22 @@ async def register(
     request: Request,
     user_in: UserCreate,
     user_service: UserSvc,
+    staging: InvitationStagingSvc,
+    invitation_handle: Annotated[str | None, Header(alias="X-Invitation-Handle")] = None,
 ) -> Any:
-    """Register a new user."""
+    """Register a new user.
+
+    When the registration arrives through a staged invitation (#1414) the token
+    is not in the body - it was exchanged for an `httpOnly` handle before the
+    invitee ever reached this form. The handle is peeked, not redeemed, so the
+    same handle still closes the acceptance after sign-in; the token it resolves
+    to feeds the sign-up admission check and is never returned or logged.
+    """
     await enforce_auth_limit(request, surface="auth_register", identifier=user_in.email)
+    if invitation_handle and not user_in.invitation_token:
+        staged_token = await staging.peek(invitation_handle)
+        if staged_token is not None:
+            user_in = user_in.model_copy(update={"invitation_token": staged_token})
     return await user_service.register(user_in)
 
 

--- a/backend/app/api/routes/v1/invitations.py
+++ b/backend/app/api/routes/v1/invitations.py
@@ -11,17 +11,20 @@ organization as the role offered to somebody else's address - so nothing reads
 it back, and listing invitations returns everything except it.
 """
 
-from typing import Any
+from typing import Annotated, Any
 from uuid import UUID
 
-from fastapi import APIRouter, Query, status
+from fastapi import APIRouter, Header, Query, Request, status
 
-from app.api.deps import CurrentUser, InvitationSvc
+from app.api.deps import CurrentUser, InvitationStagingSvc, InvitationSvc, enforce_auth_limit
+from app.core.exceptions import NotFoundError
 from app.schemas.organization import (
     InvitationCreate,
     InvitationCreated,
     InvitationList,
     InvitationRead,
+    InvitationStaged,
+    InvitationStageRequest,
     InviteLinkCreate,
 )
 
@@ -154,6 +157,61 @@ async def revoke_invitation_by_id(
     browser history. An invitation belonging to another organization answers 404.
     """
     await service.revoke_by_id(org_id, invitation_id, requester_id=user.id)
+
+
+@token_router.post("/invitations/stage", response_model=InvitationStaged)
+async def stage_invitation(
+    request: Request,
+    body: InvitationStageRequest,
+    service: InvitationSvc,
+    staging: InvitationStagingSvc,
+) -> Any:
+    """Exchange an invitation token for an opaque, single-use handle (#1414).
+
+    The one endpoint here that takes no session: an invitee follows a deep link
+    while signed out, and this runs before they have one. It validates the token
+    and stores it server-side under a fresh handle, which the caller's server
+    layer sets as an `httpOnly` cookie - so the raw token never rides the sign-in
+    round trip through a `returnTo` query, browser history, or `sessionStorage`.
+
+    A forged, expired or spent token is one refusal that names nothing, because
+    the endpoint is public and "expired" versus "never existed" would let a
+    stranger probe which tokens are real. It is rate limited per IP, because a
+    caller holding one live token could otherwise mint handles into Redis without
+    bound - the staging store is not a ceiling the accept relies on, but it is
+    memory.
+    """
+    await enforce_auth_limit(request, surface="invitation_stage")
+    await service.ensure_stageable(body.token)
+    handle = await staging.stage(body.token)
+    return InvitationStaged(handle=handle)
+
+
+@token_router.post(
+    "/invitations/staged/accept", status_code=status.HTTP_204_NO_CONTENT, response_model=None
+)
+async def accept_staged_invitation(
+    request: Request,
+    service: InvitationSvc,
+    staging: InvitationStagingSvc,
+    user: CurrentUser,
+    handle: Annotated[str, Header(alias="X-Invitation-Handle")],
+) -> None:
+    """Redeem a staged handle and accept the invitation as the signed-in user.
+
+    The other half of the exchange, once the round trip is over. The handle
+    arrives in a header the caller's server layer copies from the `httpOnly`
+    cookie; redeeming it is single-use, so a replayed or expired handle is a 404
+    that reveals nothing, the same as a forged one. The token it yields never
+    leaves the server - it goes straight into `accept`, which makes the same
+    membership decision a direct accept would. Rate limited per IP alongside the
+    staging endpoint it completes.
+    """
+    await enforce_auth_limit(request, surface="invitation_accept_staged")
+    token = await staging.redeem(handle)
+    if token is None:
+        raise NotFoundError(message="Invitation not found or already used")
+    await service.accept(token, accepting_user_id=user.id)
 
 
 @token_router.post(

--- a/backend/app/api/routes/v1/oauth.py
+++ b/backend/app/api/routes/v1/oauth.py
@@ -7,7 +7,7 @@ from urllib.parse import urlencode
 from fastapi import APIRouter, Request
 from fastapi.responses import RedirectResponse
 
-from app.api.deps import OAuthExchangeSvc, UserSvc
+from app.api.deps import InvitationStagingSvc, OAuthExchangeSvc, UserSvc
 from app.core.config import settings
 from app.core.exceptions import AuthenticationError
 from app.core.oauth import oauth
@@ -30,17 +30,25 @@ _INVITATION_KEY = "oauth_invitation_token"
 
 
 @router.get("/google/login", response_model=None)
-async def google_login(request: Request, invitation: str | None = None):
+async def google_login(
+    request: Request,
+    staging: InvitationStagingSvc,
+    invitation_handle: str | None = None,
+):
     """Redirect to Google OAuth2 login page.
 
-    `invitation` carries a shareable link's token through the round trip. Without
-    it, an `invite_only` deployment refused the Google button for exactly the
-    invitations that need it - a link constraining neither an address nor a domain
-    is invisible to the address-based fallback, so the same person could register
-    with a password and not with the provider offered beside it.
+    `invitation_handle` names the invitation a signed-out invitee staged before the
+    sign-in detour (#1414). It is peeked - not consumed - into the token the callback
+    needs for admission, so the raw token never rides this query and the same handle
+    still closes the acceptance afterwards. Without it an `invite_only` deployment
+    refused the Google button for exactly the invitations that need it: a link
+    constraining neither an address nor a domain is invisible to the address-based
+    fallback, so the same person could register with a password and not with the
+    provider offered beside it.
     """
-    if invitation:
-        request.session[_INVITATION_KEY] = invitation
+    token = await staging.peek(invitation_handle) if invitation_handle else None
+    if token:
+        request.session[_INVITATION_KEY] = token
     else:
         request.session.pop(_INVITATION_KEY, None)
     return await oauth.google.authorize_redirect(request, settings.GOOGLE_REDIRECT_URI)

--- a/backend/app/schemas/organization.py
+++ b/backend/app/schemas/organization.py
@@ -238,5 +238,25 @@ class InvitationAccept(BaseSchema):
     token: str
 
 
+class InvitationStageRequest(BaseSchema):
+    """The token an invitee holds, offered for the server-side exchange (#1414)."""
+
+    token: str = Field(min_length=1, max_length=64)
+
+
+class InvitationStaged(BaseSchema):
+    """The opaque handle the exchange mints, for the frontend's server layer to hold.
+
+    It stands in for the token through the sign-in round trip. What keeps it off a
+    script is not this model - it is the response body of a public endpoint - but
+    where the frontend puts it: its server layer reads the handle and sets it as an
+    `httpOnly` cookie the browser cannot read, rather than handing it to page code.
+    The handle holds nothing about the invitation - not the token, not the
+    organization - so it names nobody even to whoever reads it in transit.
+    """
+
+    handle: str
+
+
 class TransferOwnershipRequest(BaseSchema):
     new_owner_user_id: _ID

--- a/backend/app/services/invitation.py
+++ b/backend/app/services/invitation.py
@@ -18,6 +18,7 @@ from app.db.models.organization import Invitation, InvitationStatus
 from app.repositories import invitation_repo, member_repo, organization_repo, user_repo
 from app.services.deployment_settings import DeploymentSettingsService
 from app.services.email.service import get_email_service
+from app.services.invitation_admission import admits_anyone
 
 logger = logging.getLogger(__name__)
 
@@ -197,6 +198,24 @@ class InvitationService:
         return await invitation_repo.list_for_org(
             self.db, organization_id, status=status, skip=skip, limit=limit
         )
+
+    async def ensure_stageable(self, token: str) -> None:
+        """Refuse unless `token` names a live invitation worth staging.
+
+        The gate in front of the server-side exchange (#1414): an invitee follows
+        a deep link while signed out, and this is where a forged or dead token is
+        turned away before the handle is minted, so the sign-in detour is spent
+        only on an invitation that can still be accepted at the end of it.
+
+        One refusal for every failure - unknown, revoked, expired, used up - and
+        it names nothing. The caller is unauthenticated and the endpoint is
+        public, so distinguishing "expired" from "never existed" would let a
+        stranger probe which tokens are real; `admits` answers the same question
+        the acceptance will, without the reasons it would otherwise give.
+        """
+        invite = await invitation_repo.get_by_token(self.db, token)
+        if invite is None or not admits_anyone(invite):
+            raise NotFoundError(message="Invitation not found or no longer valid")
 
     async def accept(self, token: str, accepting_user_id: UUID):
         # Locked for the rest of the request: the `used_count`/`max_uses` guard

--- a/backend/app/services/invitation_admission.py
+++ b/backend/app/services/invitation_admission.py
@@ -54,6 +54,31 @@ def admits(invite: Invitation, *, email: str) -> bool:
     return True
 
 
+def admits_anyone(invite: Invitation) -> bool:
+    """Whether `invite` is live enough to stage before an invitee has signed in (#1414).
+
+    The email-less question, because there is no signed-in user yet: a pending,
+    unexpired invitation, and for a capped link one whose acceptances have not run
+    out. The address-bound checks - the email an invitation names, the domain a
+    link restricts to - are the acceptance's to make once the person is known.
+
+    Reservations are deliberately *not* counted. A registrant holds a reservation
+    on the slot they are completing, and both `accept` and `reserve_use` exclude a
+    caller's own reservation from the ceiling for exactly that reason; counting it
+    here - where there is no caller to exclude - would refuse the very person the
+    slot is reserved for on a re-stage. Staging enforces no ceiling of its own
+    anyway: `reserve_use` at registration and `accept` at acceptance are the atomic
+    guards, so this only needs to turn away a link already spent by acceptances.
+    """
+    if invite.status != InvitationStatus.PENDING.value:
+        return False
+    if invite.expires_at is not None and invite.expires_at < datetime.now(UTC):
+        return False
+    if invite.email is None and invite.max_uses is not None:
+        return invite.used_count < invite.max_uses
+    return True
+
+
 def _spent(invite: Invitation, email: str) -> int:
     """How much of a link's capacity is gone, from this address's point of view.
 

--- a/backend/app/services/invitation_staging.py
+++ b/backend/app/services/invitation_staging.py
@@ -1,0 +1,72 @@
+"""Server-side staging for an invitation deep link.
+
+An unauthenticated invitee who follows `/invitations/<token>` arrives holding a
+bearer credential in the URL. Carrying it through the sign-in round trip - in a
+`returnTo` query, in browser history, in `sessionStorage` - is how the token
+ends up somewhere a script can read it. Instead the browser exchanges it here,
+before the redirect to login, for an opaque single-use handle kept in Redis.
+
+The handle rides an `httpOnly` cookie the frontend's server layer sets, so no
+script ever reads it, and the raw token never leaves the server after the
+exchange. After sign-in the handle is redeemed and the invitation accepted as the
+now-authenticated user; a first-time registrant's admission check peeks it without
+consuming it, so the one handle still closes the acceptance afterwards.
+
+This is the same shape as :mod:`app.services.oauth_exchange`: a short-lived,
+single-use code standing in for a credential so the credential itself never rides
+a URL. Redis is the store for the same reason - ephemeral, expiring, and never an
+at-rest record - so nothing here goes through the vault.
+"""
+
+from __future__ import annotations
+
+import secrets
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.clients.redis import RedisClient
+
+_KEY = "invitation:stage:{handle}"
+
+# A sign-in round trip, comfortably: a password login is seconds, but an OAuth
+# detour or a first-time registration is minutes, and a handle that expired
+# mid-login would strand the invitee. Shorter than the invitation's own lifetime
+# either way, and the accept re-checks that - so a stale handle costs a re-click
+# of the link, not a lost invitation.
+_TTL_SECONDS = 1800
+
+
+class InvitationStagingService:
+    """Mint, peek and redeem the one-time handle that stands in for an invitation token.
+
+    Example:
+        handle = await service.stage(token)
+        token = await service.peek(handle)    # registration admission, non-consuming
+        token = await service.redeem(handle)  # acceptance, then None on any replay
+    """
+
+    def __init__(self, redis: RedisClient) -> None:
+        self.redis = redis
+
+    async def stage(self, token: str) -> str:
+        """Store an invitation token under a fresh handle and return the handle."""
+        handle = secrets.token_urlsafe(32)
+        await self.redis.set(_KEY.format(handle=handle), token, ttl=_TTL_SECONDS)
+        return handle
+
+    async def peek(self, handle: str) -> str | None:
+        """The staged token for a handle without consuming it, or None if unknown.
+
+        For the registration admission check, which needs the invitation to admit
+        the new account but must leave the handle intact for the acceptance that
+        follows sign-in.
+        """
+        return await self.redis.get(_KEY.format(handle=handle))
+
+    async def redeem(self, handle: str) -> str | None:
+        """Consume a handle and return its token, or None if it is unknown.
+
+        The read deletes the key, so a handle redeems exactly once; a replay, an
+        expired handle, and a forged one are indistinguishable and all answer None.
+        """
+        return await self.redis.getdel(_KEY.format(handle=handle))

--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -147,6 +147,46 @@ async def test_register_duplicate_email(
 
 
 @pytest.mark.anyio
+async def test_register_through_a_staged_invitation_resolves_the_handle(
+    client_with_mock_service: AsyncClient,
+    mock_user_service: MagicMock,
+    mock_redis: MagicMock,
+):
+    """A first-time invitee registers with no token in the body - it was exchanged
+    for an httpOnly handle before they reached the form (#1414). The route peeks
+    the handle and feeds the sign-up admission the token it resolves to, leaving
+    the handle intact for the acceptance that follows sign-in."""
+    mock_redis.get = AsyncMock(return_value="staged-token")
+
+    response = await client_with_mock_service.post(
+        f"{settings.API_V1_STR}/auth/register",
+        json={"email": "new@example.com", "password": "password123"},
+        headers={"X-Invitation-Handle": "an-opaque-handle"},
+    )
+
+    assert response.status_code == 201
+    submitted = mock_user_service.register.call_args.args[0]
+    assert submitted.invitation_token == "staged-token"
+
+
+@pytest.mark.anyio
+async def test_register_without_a_handle_carries_no_invitation(
+    client_with_mock_service: AsyncClient,
+    mock_user_service: MagicMock,
+):
+    """The header is optional: an open deployment's registration never sends one,
+    and the token stays whatever the body carried (here, nothing)."""
+    response = await client_with_mock_service.post(
+        f"{settings.API_V1_STR}/auth/register",
+        json={"email": "new@example.com", "password": "password123"},
+    )
+
+    assert response.status_code == 201
+    submitted = mock_user_service.register.call_args.args[0]
+    assert submitted.invitation_token is None
+
+
+@pytest.mark.anyio
 async def test_get_current_user(
     client_with_mock_service: AsyncClient,
     mock_user: MockUser,

--- a/backend/tests/api/test_invitations.py
+++ b/backend/tests/api/test_invitations.py
@@ -27,6 +27,7 @@ from httpx import ASGITransport, AsyncClient
 
 from app.api import deps
 from app.core.config import settings
+from app.core.exceptions import NotFoundError
 from app.main import app
 
 pytestmark = pytest.mark.anyio
@@ -67,11 +68,23 @@ def service() -> MagicMock:
     stub.list_for_org = AsyncMock(return_value=[invitation])
     stub.revoke_by_id = AsyncMock(return_value=invitation)
     stub.revoke = AsyncMock(return_value=invitation)
+    stub.ensure_stageable = AsyncMock(return_value=None)
+    stub.accept = AsyncMock(return_value=invitation)
     return stub
 
 
 @pytest.fixture
-async def client(service: MagicMock) -> AsyncIterator[AsyncClient]:
+def staging() -> MagicMock:
+    """The Redis exchange, stubbed: a handle out, and the token back on redeem."""
+    stub = MagicMock()
+    stub.stage = AsyncMock(return_value="an-opaque-handle")
+    stub.redeem = AsyncMock(return_value=_TOKEN)
+    stub.peek = AsyncMock(return_value=_TOKEN)
+    return stub
+
+
+@pytest.fixture
+async def client(service: MagicMock, staging: MagicMock) -> AsyncIterator[AsyncClient]:
     """A client whose caller is signed in and whose service is the stub above.
 
     Who may call these routes is decided in `InvitationService` and tested in
@@ -80,6 +93,7 @@ async def client(service: MagicMock) -> AsyncIterator[AsyncClient]:
     """
     app.dependency_overrides[deps.get_current_user] = lambda: SimpleNamespace(id=uuid4())
     app.dependency_overrides[deps.get_invitation_service] = lambda: service
+    app.dependency_overrides[deps.get_invitation_staging_service] = lambda: staging
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as http:
         yield http
     app.dependency_overrides.clear()
@@ -182,6 +196,73 @@ class TestRevokingAsAnAdministrator:
         put a live token in a URL.
         """
         response = await client.delete(_org_url(f"/invitations/{_TOKEN}"))
+
+        assert response.status_code == 422
+
+
+def _token_url(tail: str) -> str:
+    return f"{settings.API_V1_STR}/invitations{tail}"
+
+
+class TestStagingKeepsTheTokenOffTheSignInTrip:
+    """The server-side exchange (#1414): a token in, an opaque handle out, and the
+    handle back for a token only inside the server on redeem."""
+
+    async def test_a_valid_token_is_exchanged_for_a_handle(
+        self, client: AsyncClient, staging: MagicMock
+    ) -> None:
+        response = await client.post(_token_url("/stage"), json={"token": _TOKEN})
+
+        assert response.status_code == 200
+        assert response.json() == {"handle": "an-opaque-handle"}
+        assert staging.stage.await_args.args[0] == _TOKEN
+
+    async def test_the_reply_carries_nothing_but_the_handle(self, client: AsyncClient) -> None:
+        """Not the token, not the organization: a handle a script briefly holds
+        before the server sets it as an httpOnly cookie must reveal neither."""
+        response = await client.post(_token_url("/stage"), json={"token": _TOKEN})
+
+        assert _TOKEN not in response.text
+        assert str(_ORGANIZATION_ID) not in response.text
+
+    async def test_a_forged_token_is_refused_and_never_staged(
+        self, client: AsyncClient, service: MagicMock, staging: MagicMock
+    ) -> None:
+        service.ensure_stageable = AsyncMock(
+            side_effect=NotFoundError(message="Invitation not found or no longer valid")
+        )
+
+        response = await client.post(_token_url("/stage"), json={"token": "forged"})
+
+        assert response.status_code == 404
+        staging.stage.assert_not_awaited()
+
+    async def test_a_staged_handle_redeems_to_the_token_and_accepts_it(
+        self, client: AsyncClient, service: MagicMock, staging: MagicMock
+    ) -> None:
+        response = await client.post(
+            _token_url("/staged/accept"), headers={"X-Invitation-Handle": "an-opaque-handle"}
+        )
+
+        assert response.status_code == 204
+        assert staging.redeem.await_args.args[0] == "an-opaque-handle"
+        assert service.accept.await_args.args[0] == _TOKEN
+
+    async def test_a_replayed_or_expired_handle_is_a_clean_miss(
+        self, client: AsyncClient, service: MagicMock, staging: MagicMock
+    ) -> None:
+        staging.redeem = AsyncMock(return_value=None)
+
+        response = await client.post(
+            _token_url("/staged/accept"), headers={"X-Invitation-Handle": "spent"}
+        )
+
+        assert response.status_code == 404
+        service.accept.assert_not_awaited()
+
+    async def test_accepting_without_a_handle_is_refused(self, client: AsyncClient) -> None:
+        """The header is the credential; a request without one cannot be an accept."""
+        response = await client.post(_token_url("/staged/accept"))
 
         assert response.status_code == 422
 

--- a/backend/tests/api/test_platform_routes.py
+++ b/backend/tests/api/test_platform_routes.py
@@ -1388,6 +1388,12 @@ UNAUTHENTICATED_ROUTES: frozenset[tuple[str, str]] = frozenset(
         # code, and it cannot be asked to carry our session while doing so; the
         # code itself is the credential.
         ("POST", f"{V1}/me/mcp-connections/oauth/callback"),
+        # Staging an invitation deep link (#1414). An invitee follows the link
+        # while signed out, so this runs before they have a session; the token
+        # they hold is the credential, and it is exchanged here for an opaque
+        # httpOnly-cookie handle so it never rides the sign-in round trip. It
+        # returns nothing but the handle and refuses a forged token uniformly.
+        ("POST", f"{V1}/invitations/stage"),
         # Bearer-token surfaces where the token is in the URL, not a header.
         # A share link is a capability: whoever holds the token is the audience,
         # which is the whole point of being able to send it to somebody.

--- a/backend/tests/test_invitation_admission.py
+++ b/backend/tests/test_invitation_admission.py
@@ -20,7 +20,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 from app.db.models.organization import Invitation, InvitationStatus
-from app.services.invitation_admission import admits
+from app.services.invitation_admission import admits, admits_anyone
 
 LATER = datetime.now(UTC) + timedelta(days=3)
 EARLIER = datetime.now(UTC) - timedelta(days=1)
@@ -147,3 +147,56 @@ def _accept_would_allow(invite: Invitation, email: str) -> bool:
     if invite.email_domain:
         return email.lower().endswith(f"@{invite.email_domain}")
     return True
+
+
+class TestAdmitsAnyone:
+    """The email-less liveness the staging gate asks before an invitee signs in.
+
+    It cannot check the address - there is no signed-in user yet - so it answers
+    the narrower question: is this a live invitation with a use left. What it must
+    never do is admit a row `admits` would refuse for being dead or spent, which
+    is what would stage a handle for an invitation the acceptance then rejects.
+    """
+
+    def test_a_pending_email_invitation_admits_someone(self):
+        assert admits_anyone(an_invite(email="me@acme.com"))
+
+    def test_a_pending_open_link_admits_someone(self):
+        assert admits_anyone(an_invite(email=None))
+
+    def test_a_link_with_a_domain_still_admits_someone(self):
+        assert admits_anyone(an_invite(email=None, email_domain="acme.com"))
+
+    def test_a_link_with_capacity_left_admits_someone(self):
+        assert admits_anyone(an_invite(email=None, max_uses=2, used_count=1))
+
+    def test_an_expired_invitation_admits_nobody(self):
+        assert not admits_anyone(an_invite(email="me@acme.com", expires_at=EARLIER))
+
+    def test_a_revoked_invitation_admits_nobody(self):
+        assert not admits_anyone(an_invite(status=InvitationStatus.REVOKED.value))
+
+    def test_a_link_spent_by_acceptances_admits_nobody(self):
+        assert not admits_anyone(an_invite(email=None, max_uses=1, used_count=1))
+
+    def test_a_reservation_does_not_lock_the_reserver_out_of_re_staging(self):
+        # The registrant holds the one reservation on a `max_uses=1` link and has
+        # not accepted yet. Counting reservations here would refuse a re-stage of
+        # the invitation reserved *for them* - the ceiling is `reserve_use` and
+        # `accept`, both atomic, not this liveness gate.
+        assert admits_anyone(
+            an_invite(email=None, max_uses=1, used_count=0, reserved_emails=["alice@acme.com"])
+        )
+
+    def test_it_never_admits_where_the_acceptance_would_refuse_outright(self):
+        # The parity that matters: for every row that is dead or spent regardless
+        # of who is asking, both answers are no.
+        dead_or_spent = [
+            an_invite(email="me@acme.com", expires_at=EARLIER),
+            an_invite(status=InvitationStatus.REVOKED.value),
+            an_invite(status=InvitationStatus.ACCEPTED.value),
+            an_invite(email=None, max_uses=1, used_count=1),
+        ]
+        for invite in dead_or_spent:
+            assert not admits_anyone(invite)
+            assert not _accept_would_allow(invite, "anybody@acme.com")

--- a/backend/tests/test_invitation_staging.py
+++ b/backend/tests/test_invitation_staging.py
@@ -1,0 +1,125 @@
+"""The server-side exchange that keeps an invitation token off the sign-in trip (#1414).
+
+Two halves. `InvitationStagingService` is the Redis exchange - opaque handle in,
+token out, exactly once. `InvitationService.ensure_stageable` is the gate in front
+of it: a forged or dead token is turned away before a handle is ever minted, with
+one refusal that names nothing, because the endpoint it guards is public.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.core.exceptions import NotFoundError
+from app.repositories import invitation_repo
+from app.services.invitation import InvitationService
+from app.services.invitation_staging import InvitationStagingService
+
+pytestmark = pytest.mark.anyio
+
+
+def _pending(**over: object) -> SimpleNamespace:
+    base = {
+        "status": "pending",
+        "email": "invitee@example.com",
+        "max_uses": None,
+        "used_count": 0,
+        "reserved_emails": [],
+        "expires_at": datetime.now(UTC) + timedelta(days=7),
+    }
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+class TestTheRedisExchange:
+    async def test_stage_stores_the_token_under_a_fresh_handle_with_a_ttl(self) -> None:
+        redis = MagicMock()
+        redis.set = AsyncMock(return_value=True)
+
+        handle = await InvitationStagingService(redis).stage("a-live-token")
+
+        key, value = redis.set.await_args.args
+        assert key == f"invitation:stage:{handle}"
+        assert value == "a-live-token"
+        assert redis.set.await_args.kwargs["ttl"] == 1800
+
+    async def test_each_stage_mints_a_different_handle(self) -> None:
+        redis = MagicMock()
+        redis.set = AsyncMock(return_value=True)
+        service = InvitationStagingService(redis)
+
+        assert await service.stage("t") != await service.stage("t")
+
+    async def test_peek_reads_the_token_without_consuming_it(self) -> None:
+        redis = MagicMock()
+        redis.get = AsyncMock(return_value="a-live-token")
+        redis.getdel = AsyncMock()
+
+        token = await InvitationStagingService(redis).peek("handle-1")
+
+        assert token == "a-live-token"
+        assert redis.get.await_args.args[0] == "invitation:stage:handle-1"
+        redis.getdel.assert_not_awaited()
+
+    async def test_redeem_consumes_the_handle_and_a_replay_gets_nothing(self) -> None:
+        redis = MagicMock()
+        # getdel deletes on read, so the second call sees an absent key - which is
+        # also what a forged or expired handle looks like.
+        redis.getdel = AsyncMock(side_effect=["a-live-token", None])
+        service = InvitationStagingService(redis)
+
+        assert await service.redeem("handle-1") == "a-live-token"
+        assert await service.redeem("handle-1") is None
+
+
+class TestTheStagingGate:
+    async def test_a_live_invitation_is_stageable(self, monkeypatch, mock_db_session) -> None:
+        monkeypatch.setattr(invitation_repo, "get_by_token", AsyncMock(return_value=_pending()))
+        await InvitationService(mock_db_session).ensure_stageable("tok")  # no raise
+
+    async def test_an_unknown_token_is_refused(self, monkeypatch, mock_db_session) -> None:
+        monkeypatch.setattr(invitation_repo, "get_by_token", AsyncMock(return_value=None))
+        with pytest.raises(NotFoundError):
+            await InvitationService(mock_db_session).ensure_stageable("tok")
+
+    async def test_an_expired_invitation_is_refused(self, monkeypatch, mock_db_session) -> None:
+        expired = _pending(expires_at=datetime.now(UTC) - timedelta(minutes=1))
+        monkeypatch.setattr(invitation_repo, "get_by_token", AsyncMock(return_value=expired))
+        with pytest.raises(NotFoundError):
+            await InvitationService(mock_db_session).ensure_stageable("tok")
+
+    async def test_a_revoked_invitation_is_refused(self, monkeypatch, mock_db_session) -> None:
+        monkeypatch.setattr(
+            invitation_repo, "get_by_token", AsyncMock(return_value=_pending(status="revoked"))
+        )
+        with pytest.raises(NotFoundError):
+            await InvitationService(mock_db_session).ensure_stageable("tok")
+
+    async def test_a_used_up_link_is_refused(self, monkeypatch, mock_db_session) -> None:
+        spent = _pending(email=None, max_uses=1, used_count=1)
+        monkeypatch.setattr(invitation_repo, "get_by_token", AsyncMock(return_value=spent))
+        with pytest.raises(NotFoundError):
+            await InvitationService(mock_db_session).ensure_stageable("tok")
+
+    async def test_the_refusal_names_nothing_about_the_token(
+        self, monkeypatch, mock_db_session
+    ) -> None:
+        """A public endpoint: "expired" versus "never existed" would let a stranger
+        probe which tokens are real, so every failure reads the same."""
+        monkeypatch.setattr(invitation_repo, "get_by_token", AsyncMock(return_value=None))
+        with pytest.raises(NotFoundError) as unknown:
+            await InvitationService(mock_db_session).ensure_stageable("forged")
+
+        monkeypatch.setattr(
+            invitation_repo,
+            "get_by_token",
+            AsyncMock(return_value=_pending(expires_at=datetime.now(UTC) - timedelta(days=1))),
+        )
+        with pytest.raises(NotFoundError) as expired:
+            await InvitationService(mock_db_session).ensure_stageable("real-but-expired")
+
+        assert str(unknown.value) == str(expired.value)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -136,16 +136,26 @@ that also granted membership would be a membership grant on a public route.
 The console never carries the token across the sign-in round trip. An invitee with
 no account opens `/invitations/<token>`; `AuthGuard` exchanges the token server-side
 for an opaque handle it keeps in an `httpOnly` cookie the browser cannot read, then
-sends them to `/login?returnTo=/invitations/pending` — a landing with no credential
-in it, so the token is not in the `returnTo`, in browser history, or in session
-storage.
+sends them to `/login?returnTo=/invitations/pending?flow=…` — a landing with no
+credential in it, so the token is not in the `returnTo`, in browser history, or in
+session storage. If the exchange fails — the server unreachable, a rate limit — the
+guard stays on the invitation link and offers to try again rather than leaving with
+nothing staged, because the link is the only credential the invitee holds.
+
+The `flow` is a random id the exchange mints per staging, and the cookie is named
+for it. It is not a credential: without the cookie it names nothing. It is there
+because one fixed cookie name is one slot — two invitation links opened side by side
+while signed out overwrote each other, and both pending tabs then redeemed the second.
+Each tab now redeems exactly the cookie its own flow names.
 
 "Create an account" carries that credential-free landing on, and the register proxy
-forwards the staged handle as a header, so the sign-up admission still has the token
-it needs without the token ever being in a URL or the body. After sign-in the
-pending page redeems the handle and accepts — the same shape as the OAuth code
-exchange, an opaque single-use expiring stand-in for a credential so the credential
-never rides a URL.
+forwards the named flow's staged handle as a header, so the sign-up admission still
+has the token it needs without the token ever being in a URL or the body. After
+sign-in the pending page redeems the handle and accepts — the same shape as the OAuth
+code exchange, an opaque single-use expiring stand-in for a credential so the
+credential never rides a URL. The cookie is cleared once the redeem has run; a 401, a
+429 or a server failure leaves it, because the handle may still be unspent and a
+retry needs it.
 
 **A link with a `max_uses` bounds accounts, not only joins.**
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -115,7 +115,7 @@ token**, and the two answers cover different shapes:
 
 | Arrives with | Recognised by | Which shapes it admits |
 |---|---|---|
-| A token (`invitation_token` on the sign-up body) | `invitation_admission.admits` | Any live invitation that admits the address — including a link constraining **no** address, which is the shape nothing else can see |
+| A token (resolved from the staged invitation, never on the sign-up body) | `invitation_admission.admits` | Any live invitation that admits the address — including a link constraining **no** address, which is the shape nothing else can see |
 | No token | `invitation_repo.first_pending_admitting` | An email invitation for that address, or a link scoped to its domain |
 
 The token is the only proof available for a shareable link with neither an address
@@ -133,12 +133,19 @@ and nothing else; joining the organization is still `InvitationService.accept`, 
 the client calls once it has a session. A token in an unauthenticated sign-up body
 that also granted membership would be a membership grant on a public route.
 
-The console carries it across the redirect that used to lose it. An invitee with no
-account opens `/invitations/<token>`, `AuthGuard` bounces them to
-`/login?returnTo=/invitations/<token>`, and `src/lib/invitation-links.ts` reads the
-token back out of that `returnTo` so "create an account" points at
-`/register?invitation=<token>`. Before that, the only route onward was a plain link
-to `/register`, and the form then refused somebody holding a valid invitation.
+The console never carries the token across the sign-in round trip. An invitee with
+no account opens `/invitations/<token>`; `AuthGuard` exchanges the token server-side
+for an opaque handle it keeps in an `httpOnly` cookie the browser cannot read, then
+sends them to `/login?returnTo=/invitations/pending` — a landing with no credential
+in it, so the token is not in the `returnTo`, in browser history, or in session
+storage.
+
+"Create an account" carries that credential-free landing on, and the register proxy
+forwards the staged handle as a header, so the sign-up admission still has the token
+it needs without the token ever being in a URL or the body. After sign-in the
+pending page redeems the handle and accepts — the same shape as the OAuth code
+exchange, an opaque single-use expiring stand-in for a credential so the credential
+never rides a URL.
 
 **A link with a `max_uses` bounds accounts, not only joins.**
 
@@ -159,12 +166,14 @@ A reservation nobody accepts stays spent (`max_uses` is how many people a link
 admits, and an account created with it was admitted), and it dies with the
 invitation.
 
-**Signing in with a provider carries the invitation too.** The token is put on
-`/oauth/google/login?invitation=…` and held in the session across the round trip,
-because the provider redirect is not ours to add a parameter to. Without it,
-`invite_only` refused the Google button for exactly the links that need a token —
-one constraining neither an address nor a domain — while the password form beside it
-accepted the same person.
+**Signing in with a provider carries the invitation too, as its handle.** The
+provider login starts same-origin, at `/api/oauth/<provider>/login`, so the staged
+`httpOnly` handle can be attached to the cross-origin hop the browser then makes —
+`/oauth/google/login?invitation_handle=…`, which the backend peeks into the token it
+holds in the session across the round trip. The token is never in that URL. Without
+this, `invite_only` refused the Google button for exactly the links that need a
+token — one constraining neither an address nor a domain — while the password form
+beside it accepted the same person.
 
 **Signing in with a provider is a registration too.** `get_or_create_oauth_user`
 is the second path that creates an account, and nothing about a Google callback

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1906,6 +1906,7 @@
     "forbidden": "Forbidden",
     "impersonationEnded": "The impersonation has ended",
     "internalServerError": "Internal server error",
+    "invitationNotFound": "This invitation is no longer available",
     "loginFailed": "Login failed",
     "missingAuthorizationCode": "Missing authorization code",
     "missingTokens": "Missing tokens",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2184,11 +2184,14 @@
     "impersonationEndFailed": "Could not end the impersonation. Try again.",
     "impersonationEnded": "Impersonation ended. You are yourself again.",
     "impersonationEndsAt": "Ends at {time}",
+    "invitationNotStaged": "Your invitation could not be prepared",
+    "invitationNotStagedHint": "The server could not be reached, or asked you to wait a moment. Your invitation link is still valid.",
     "navigate": "Navigate",
     "noMatches": "No matches.",
     "open": "Open",
     "primary": "Primary",
     "quickActions": "Quick actions",
+    "retryInvitation": "Try again",
     "searchJump": "Search or jump to…"
   },
   "legal": {

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -1221,11 +1221,14 @@
     "impersonationEndFailed": "Nie udało się zakończyć impersonacji. Spróbuj ponownie.",
     "impersonationEnded": "Impersonacja zakończona. Znów działasz jako Ty.",
     "impersonationEndsAt": "Kończy się o {time}",
+    "invitationNotStaged": "Nie udało się przygotować Twojego zaproszenia",
+    "invitationNotStagedHint": "Serwer był niedostępny albo poprosił o chwilę przerwy. Twój link z zaproszeniem nadal jest ważny.",
     "navigate": "Nawigacja",
     "noMatches": "Brak dopasowań.",
     "open": "Otwórz",
     "primary": "Główne",
     "quickActions": "Szybkie akcje",
+    "retryInvitation": "Spróbuj ponownie",
     "searchJump": "Szukaj lub przejdź do…"
   },
   "theme": {

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -270,6 +270,7 @@
     "forbidden": "Brak dostępu",
     "impersonationEnded": "Impersonacja została zakończona",
     "internalServerError": "Wewnętrzny błąd serwera",
+    "invitationNotFound": "To zaproszenie nie jest już dostępne",
     "loginFailed": "Logowanie nie powiodło się",
     "missingAuthorizationCode": "Brak kodu autoryzacji",
     "missingTokens": "Brak tokenów sesji",

--- a/frontend/src/app/[locale]/(dashboard)/invitations/pending/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/invitations/pending/page.tsx
@@ -1,0 +1,5 @@
+import { AcceptStagedInvitation } from "@/components/orgs/accept-staged-invitation";
+
+export default function PendingInvitationPage() {
+  return <AcceptStagedInvitation />;
+}

--- a/frontend/src/app/api/auth/register/route.ts
+++ b/frontend/src/app/api/auth/register/route.ts
@@ -12,8 +12,12 @@ import type { RegisterResponse } from "@/types";
 /**
  * Create an account.
  *
- * The body is forwarded whole, which is how `invitation_token` reaches the sign-up
- * policy without this route knowing about it.
+ * The body is forwarded whole. When the registration arrives through a staged
+ * invitation (#1414) the token is not in the body - it was exchanged for an
+ * `httpOnly` handle before the invitee reached the form - so the handle rides that
+ * cookie into a header here, where the backend peeks it for the sign-up admission
+ * check. Peeked, not consumed: the same handle still closes the acceptance after
+ * sign-in.
  *
  * A refusal is forwarded whole too, and that is the part worth saying. This used to
  * read `detail` off the backend's body and fall back to a generic
@@ -27,10 +31,14 @@ import type { RegisterResponse } from "@/types";
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
+    const stageHandle = request.cookies.get("invitation_stage")?.value;
 
     const data = await backendFetch<RegisterResponse>("/api/v1/auth/register", {
       method: "POST",
-      headers: { ...forwardedFor(request) },
+      headers: {
+        ...forwardedFor(request),
+        ...(stageHandle ? { "X-Invitation-Handle": stageHandle } : {}),
+      },
       body: JSON.stringify(body),
     });
 

--- a/frontend/src/app/api/auth/register/route.ts
+++ b/frontend/src/app/api/auth/register/route.ts
@@ -7,6 +7,7 @@ import {
   forwardedFor,
   forwardRateLimit,
 } from "@/lib/server-api";
+import { INVITATION_FLOW_PARAM, isInvitationFlow, stageCookieName } from "@/lib/invitation-links";
 import type { RegisterResponse } from "@/types";
 
 /**
@@ -17,7 +18,9 @@ import type { RegisterResponse } from "@/types";
  * `httpOnly` handle before the invitee reached the form - so the handle rides that
  * cookie into a header here, where the backend peeks it for the sign-up admission
  * check. Peeked, not consumed: the same handle still closes the acceptance after
- * sign-in.
+ * sign-in. Which cookie is the form's to say, through the `flow` it read off its
+ * `returnTo`: two invitations staged side by side hold two cookies, and admitting
+ * one address against the other's invitation would refuse the person it was for.
  *
  * A refusal is forwarded whole too, and that is the part worth saying. This used to
  * read `detail` off the backend's body and fall back to a generic
@@ -31,7 +34,10 @@ import type { RegisterResponse } from "@/types";
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const stageHandle = request.cookies.get("invitation_stage")?.value;
+    const flow = request.nextUrl.searchParams.get(INVITATION_FLOW_PARAM);
+    const stageHandle = isInvitationFlow(flow)
+      ? request.cookies.get(stageCookieName(flow))?.value
+      : undefined;
 
     const data = await backendFetch<RegisterResponse>("/api/v1/auth/register", {
       method: "POST",

--- a/frontend/src/app/api/auth/session-routes.test.ts
+++ b/frontend/src/app/api/auth/session-routes.test.ts
@@ -647,14 +647,21 @@ describe("registering, and resetting a password", () => {
     // The invitee reached the form through a staged invitation (#1414): the token is
     // in an httpOnly cookie, not the body, and the backend reads the handle from a
     // header to admit an address the sign-up policy would otherwise refuse.
+    // Which staged invitation is the form's to say, through the flow its landing
+    // named: two staged side by side hold two cookies, and the other one's would
+    // admit the wrong address.
     vi.mocked(backendFetch).mockResolvedValue({ id: "u-3", email: "invited@example.com" });
+    const flow = "0123456789abcdef0123456789abcdef";
+    const other = "fedcba9876543210fedcba9876543210";
+    const staged = new NextRequest(`http://localhost:3000/api/auth/register?flow=${flow}`, {
+      method: "POST",
+      headers: {
+        cookie: `invitation_stage_${flow}=an-opaque-handle; invitation_stage_${other}=another`,
+      },
+      body: JSON.stringify({ email: "invited@example.com", password: "secret" }),
+    });
 
-    await register(
-      request(
-        { invitation_stage: "an-opaque-handle" },
-        { email: "invited@example.com", password: "secret" },
-      ),
-    );
+    await register(staged);
 
     expect(backendFetch).toHaveBeenCalledWith(
       "/api/v1/auth/register",
@@ -662,6 +669,21 @@ describe("registering, and resetting a password", () => {
         headers: expect.objectContaining({ "X-Invitation-Handle": "an-opaque-handle" }),
       }),
     );
+  });
+
+  it("forwards no handle for a registration that names no flow", async () => {
+    // A staging cookie left in the browser is not a claim this registration made.
+    vi.mocked(backendFetch).mockResolvedValue({ id: "u-4", email: "plain@example.com" });
+
+    await register(
+      request(
+        { ["invitation_stage_0123456789abcdef0123456789abcdef"]: "an-opaque-handle" },
+        { email: "plain@example.com", password: "secret" },
+      ),
+    );
+
+    const [, options] = vi.mocked(backendFetch).mock.calls.at(-1) ?? [];
+    expect(options?.headers).not.toHaveProperty("X-Invitation-Handle");
   });
 
   it("puts the backend's reason on a refused registration", async () => {

--- a/frontend/src/app/api/auth/session-routes.test.ts
+++ b/frontend/src/app/api/auth/session-routes.test.ts
@@ -643,6 +643,27 @@ describe("registering, and resetting a password", () => {
     expect(response.headers.getSetCookie()).toEqual([]);
   });
 
+  it("forwards a staged invitation's handle so the sign-up admission can peek it", async () => {
+    // The invitee reached the form through a staged invitation (#1414): the token is
+    // in an httpOnly cookie, not the body, and the backend reads the handle from a
+    // header to admit an address the sign-up policy would otherwise refuse.
+    vi.mocked(backendFetch).mockResolvedValue({ id: "u-3", email: "invited@example.com" });
+
+    await register(
+      request(
+        { invitation_stage: "an-opaque-handle" },
+        { email: "invited@example.com", password: "secret" },
+      ),
+    );
+
+    expect(backendFetch).toHaveBeenCalledWith(
+      "/api/v1/auth/register",
+      expect.objectContaining({
+        headers: expect.objectContaining({ "X-Invitation-Handle": "an-opaque-handle" }),
+      }),
+    );
+  });
+
   it("puts the backend's reason on a refused registration", async () => {
     vi.mocked(backendFetch).mockRejectedValue(
       new BackendApiError(409, "Conflict", { detail: "That email is already registered" }),

--- a/frontend/src/app/api/invitations/invitation-routes.test.ts
+++ b/frontend/src/app/api/invitations/invitation-routes.test.ts
@@ -4,7 +4,9 @@
  * The server routes of the invitation server-side exchange (#1414): staging a
  * token into an httpOnly cookie, closing it after sign-in, and attaching the
  * staged handle to a cross-origin OAuth start. All three are about what crosses
- * the boundary - a handle, never the token - and what the cookie carries.
+ * the boundary - a handle, never the token - and what the cookie carries; and
+ * since every staging names a flow, about the accept redeeming exactly the cookie
+ * its flow names.
  */
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -19,16 +21,27 @@ vi.mock("@/lib/server-api", async () => {
   return { ...actual, backendFetch: vi.fn() };
 });
 
-function request(cookies: Record<string, string> = {}, body?: unknown): NextRequest {
+const FLOW = "0123456789abcdef0123456789abcdef";
+const OTHER_FLOW = "fedcba9876543210fedcba9876543210";
+const stageCookie = (flow: string) => `invitation_stage_${flow}`;
+
+function request(
+  cookies: Record<string, string> = {},
+  body?: unknown,
+  query = "",
+  extraHeaders: Record<string, string> = {},
+): NextRequest {
   const header = Object.entries(cookies)
     .map(([name, value]) => `${name}=${value}`)
     .join("; ");
-  return new NextRequest("http://localhost:3000/api/invitations", {
+  return new NextRequest(`http://localhost:3000/api/invitations${query}`, {
     method: "POST",
-    headers: header ? { cookie: header } : {},
+    headers: { ...(header ? { cookie: header } : {}), ...extraHeaders },
     ...(body === undefined ? {} : { body: JSON.stringify(body) }),
   });
 }
+
+const forFlow = (flow: string) => `?flow=${flow}`;
 
 function cookie(response: Response, name: string) {
   const set = response.headers.getSetCookie().find((entry) => entry.startsWith(`${name}=`));
@@ -37,10 +50,21 @@ function cookie(response: Response, name: string) {
   return { value: pair!.slice(name.length + 1), attributes: attributes.join("; ") };
 }
 
+/** The one staging cookie a response set, whatever flow it was named for. */
+function stagedCookie(response: Response) {
+  const set = response.headers
+    .getSetCookie()
+    .filter((entry) => entry.startsWith("invitation_stage_"));
+  expect(set).toHaveLength(1);
+  const [pair, ...attributes] = set[0]!.split("; ");
+  const [name, value] = pair!.split("=");
+  return { name: name!, value: value!, attributes: attributes.join("; ") };
+}
+
 beforeEach(() => vi.clearAllMocks());
 
 describe("staging a token", () => {
-  it("stores the handle in an httpOnly cookie and returns nothing else", async () => {
+  it("stores the handle in an httpOnly cookie named for the flow, and returns the flow", async () => {
     vi.mocked(backendFetch).mockResolvedValueOnce({ handle: "an-opaque-handle" });
 
     const response = await stage(request({}, { token: "a-live-token" }));
@@ -51,11 +75,29 @@ describe("staging a token", () => {
       body: JSON.stringify({ token: "a-live-token" }),
     });
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ staged: true });
-    const set = cookie(response, "invitation_stage");
-    expect(set?.value).toBe("an-opaque-handle");
-    expect(set?.attributes).toContain("HttpOnly");
-    expect(set?.attributes).toContain("Max-Age=1800");
+    const body = await response.json();
+    expect(body).toEqual({ staged: true, flow: expect.stringMatching(/^[0-9a-f]{32}$/) });
+    const set = stagedCookie(response);
+    expect(set.name).toBe(stageCookie(body.flow));
+    expect(set.value).toBe("an-opaque-handle");
+    expect(set.attributes).toContain("HttpOnly");
+    expect(set.attributes).toContain("Max-Age=1800");
+  });
+
+  it("gives two stagings two cookies, so neither overwrites the other", async () => {
+    // A signed-out person opening two invitation links used to stage both into one
+    // fixed-name cookie; the second overwrote the first and both pending tabs then
+    // redeemed the second invitation.
+    vi.mocked(backendFetch)
+      .mockResolvedValueOnce({ handle: "handle-one" })
+      .mockResolvedValueOnce({ handle: "handle-two" });
+
+    const first = stagedCookie(await stage(request({}, { token: "token-one" })));
+    const second = stagedCookie(await stage(request({}, { token: "token-two" })));
+
+    expect(first.name).not.toBe(second.name);
+    expect(first.value).toBe("handle-one");
+    expect(second.value).toBe("handle-two");
   });
 
   it("does not put the token or the handle in the reply body", async () => {
@@ -75,7 +117,7 @@ describe("staging a token", () => {
     const response = await stage(request({}, { token: "forged" }));
 
     expect(response.status).toBe(404);
-    expect(cookie(response, "invitation_stage")).toBeUndefined();
+    expect(response.headers.getSetCookie()).toEqual([]);
   });
 
   it("answers 500 when the exchange could not be reached", async () => {
@@ -84,36 +126,71 @@ describe("staging a token", () => {
     const response = await stage(request({}, { token: "a-live-token" }));
 
     expect(response.status).toBe(500);
-    expect(cookie(response, "invitation_stage")).toBeUndefined();
+    expect(response.headers.getSetCookie()).toEqual([]);
   });
 });
 
 describe("accepting after sign-in", () => {
+  const staged = { access_token: "jwt", [stageCookie(FLOW)]: "h" };
+
   it("refuses without a session", async () => {
-    const response = await acceptPending(request({ invitation_stage: "h" }));
+    const response = await acceptPending(
+      request({ [stageCookie(FLOW)]: "h" }, undefined, forFlow(FLOW)),
+    );
 
     expect(response.status).toBe(401);
     expect(backendFetch).not.toHaveBeenCalled();
   });
 
-  it("is a clean miss when no invitation was staged", async () => {
-    const response = await acceptPending(request({ access_token: "jwt" }));
+  it("is a clean miss when no invitation was staged for the flow", async () => {
+    const response = await acceptPending(
+      request({ access_token: "jwt" }, undefined, forFlow(FLOW)),
+    );
 
     expect(response.status).toBe(404);
     expect(backendFetch).not.toHaveBeenCalled();
   });
 
-  it("redeems the handle from a header and clears the cookie", async () => {
-    vi.mocked(backendFetch).mockResolvedValueOnce(undefined);
+  it("is a clean miss when the landing names no flow, or a malformed one", async () => {
+    // Neither shape names a cookie, so neither is read as one - a flow id is only ever
+    // 32 hex digits, and anything else must not reach a cookie name.
+    expect((await acceptPending(request(staged))).status).toBe(404);
+    expect((await acceptPending(request(staged, undefined, "?flow=../access_token"))).status).toBe(
+      404,
+    );
+    expect(backendFetch).not.toHaveBeenCalled();
+  });
 
-    const response = await acceptPending(request({ access_token: "jwt", invitation_stage: "h" }));
+  it("redeems the handle of the flow it was given, and clears exactly that cookie", async () => {
+    vi.mocked(backendFetch).mockResolvedValueOnce(undefined);
+    const both = { ...staged, [stageCookie(OTHER_FLOW)]: "other" };
+
+    const response = await acceptPending(request(both, undefined, forFlow(FLOW)));
 
     expect(backendFetch).toHaveBeenCalledWith("/api/v1/invitations/staged/accept", {
       method: "POST",
       headers: { Authorization: "Bearer jwt", "X-Invitation-Handle": "h" },
     });
     expect(response.status).toBe(204);
-    expect(cookie(response, "invitation_stage")?.value).toBe("");
+    expect(cookie(response, stageCookie(FLOW))?.value).toBe("");
+    expect(cookie(response, stageCookie(OTHER_FLOW))).toBeUndefined();
+  });
+
+  it("forwards the caller's address, since the backend rate limits per IP", async () => {
+    // Without it every invitee behind the frontend container shares one bucket, and
+    // one caller exhausting it locks unrelated invitees out of their acceptance.
+    vi.mocked(backendFetch).mockResolvedValueOnce(undefined);
+
+    await acceptPending(
+      request(staged, undefined, forFlow(FLOW), { "x-forwarded-for": "203.0.113.7" }),
+    );
+
+    expect(backendFetch).toHaveBeenCalledWith(
+      "/api/v1/invitations/staged/accept",
+      expect.objectContaining({
+        headers: expect.objectContaining({ "x-forwarded-for": "203.0.113.7" }),
+      }),
+    );
   });
 
   it("clears the spent cookie even when the accept is refused", async () => {
@@ -125,18 +202,10 @@ describe("accepting after sign-in", () => {
       }),
     );
 
-    const response = await acceptPending(request({ access_token: "jwt", invitation_stage: "h" }));
+    const response = await acceptPending(request(staged, undefined, forFlow(FLOW)));
 
     expect(response.status).toBe(400);
-    expect(cookie(response, "invitation_stage")?.value).toBe("");
-  });
-
-  it("answers 500 when the accept could not be reached", async () => {
-    vi.mocked(backendFetch).mockRejectedValueOnce(new Error("network down"));
-
-    const response = await acceptPending(request({ access_token: "jwt", invitation_stage: "h" }));
-
-    expect(response.status).toBe(500);
+    expect(cookie(response, stageCookie(FLOW))?.value).toBe("");
   });
 
   it("keeps the cookie on a 401, whose redeem never ran", async () => {
@@ -146,20 +215,62 @@ describe("accepting after sign-in", () => {
       new BackendApiError(401, "Unauthorized", { detail: "expired" }),
     );
 
-    const response = await acceptPending(request({ access_token: "stale", invitation_stage: "h" }));
+    const response = await acceptPending(
+      request({ ...staged, access_token: "stale" }, undefined, forFlow(FLOW)),
+    );
 
     expect(response.status).toBe(401);
-    // No Set-Cookie for it: the handle was not cleared.
-    expect(cookie(response, "invitation_stage")).toBeUndefined();
+    expect(response.headers.getSetCookie()).toEqual([]);
+  });
+
+  it("keeps the cookie on a 429, whose redeem never ran either", async () => {
+    // The rate limit runs before the redeem, so the handle is unspent - and the 429
+    // advertises a retry, which deleting the cookie would turn into a miss.
+    vi.mocked(backendFetch).mockRejectedValueOnce(
+      new BackendApiError(429, "Too Many Requests", {
+        error: { code: "RATE_LIMIT_EXCEEDED", retry_after_seconds: 30 },
+      }),
+    );
+
+    const response = await acceptPending(request(staged, undefined, forFlow(FLOW)));
+
+    expect(response.status).toBe(429);
+    expect(response.headers.getSetCookie()).toEqual([]);
+  });
+
+  it("keeps the cookie on a 5xx, where nothing says whether the redeem ran", async () => {
+    // A retry against a handle that was spent answers a miss; a cookie deleted under
+    // a handle that was not loses the invitation. The cheaper mistake is kept.
+    vi.mocked(backendFetch).mockRejectedValueOnce(
+      new BackendApiError(503, "Service Unavailable", { detail: "redis down" }),
+    );
+
+    const response = await acceptPending(request(staged, undefined, forFlow(FLOW)));
+
+    expect(response.status).toBe(503);
+    expect(response.headers.getSetCookie()).toEqual([]);
+  });
+
+  it("answers 500 with the cookie kept when the accept could not be reached", async () => {
+    vi.mocked(backendFetch).mockRejectedValueOnce(new Error("network down"));
+
+    const response = await acceptPending(request(staged, undefined, forFlow(FLOW)));
+
+    expect(response.status).toBe(500);
+    expect(response.headers.getSetCookie()).toEqual([]);
   });
 });
 
 describe("starting an OAuth sign-in", () => {
-  const get = (cookies: Record<string, string>, provider: string) =>
-    oauthLogin(request(cookies), { params: Promise.resolve({ provider }) });
+  const get = (cookies: Record<string, string>, provider: string, query = "") =>
+    oauthLogin(request(cookies, undefined, query), { params: Promise.resolve({ provider }) });
 
-  it("attaches a staged handle to the cross-origin start", async () => {
-    const response = await get({ invitation_stage: "h" }, "google");
+  it("attaches the named flow's staged handle to the cross-origin start", async () => {
+    const response = await get(
+      { [stageCookie(FLOW)]: "h", [stageCookie(OTHER_FLOW)]: "other" },
+      "google",
+      forFlow(FLOW),
+    );
 
     expect(response.status).toBe(302);
     expect(response.headers.get("location")).toBe(
@@ -168,8 +279,8 @@ describe("starting an OAuth sign-in", () => {
     expect(response.headers.get("cache-control")).toBe("no-store");
   });
 
-  it("carries no handle when none was staged", async () => {
-    const response = await get({}, "google");
+  it("carries no handle when none was staged for the flow", async () => {
+    const response = await get({ [stageCookie(OTHER_FLOW)]: "other" }, "google", forFlow(FLOW));
 
     expect(response.status).toBe(302);
     expect(response.headers.get("location")).toBe(
@@ -177,8 +288,16 @@ describe("starting an OAuth sign-in", () => {
     );
   });
 
+  it("carries no handle when the start names no flow", async () => {
+    const response = await get({ [stageCookie(FLOW)]: "h" }, "google");
+
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:8000/api/v1/oauth/google/login",
+    );
+  });
+
   it("refuses a provider it does not know, rather than build a redirect from it", async () => {
-    const response = await get({ invitation_stage: "h" }, "../evil");
+    const response = await get({ [stageCookie(FLOW)]: "h" }, "../evil", forFlow(FLOW));
 
     expect(response.status).toBe(404);
   });

--- a/frontend/src/app/api/invitations/invitation-routes.test.ts
+++ b/frontend/src/app/api/invitations/invitation-routes.test.ts
@@ -1,0 +1,185 @@
+/**
+ * @vitest-environment node
+ *
+ * The server routes of the invitation server-side exchange (#1414): staging a
+ * token into an httpOnly cookie, closing it after sign-in, and attaching the
+ * staged handle to a cross-origin OAuth start. All three are about what crosses
+ * the boundary - a handle, never the token - and what the cookie carries.
+ */
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { POST as stage } from "./stage/route";
+import { POST as acceptPending } from "./pending/accept/route";
+import { GET as oauthLogin } from "../oauth/[provider]/login/route";
+import { BackendApiError, backendFetch } from "@/lib/server-api";
+
+vi.mock("@/lib/server-api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/server-api")>("@/lib/server-api");
+  return { ...actual, backendFetch: vi.fn() };
+});
+
+function request(cookies: Record<string, string> = {}, body?: unknown): NextRequest {
+  const header = Object.entries(cookies)
+    .map(([name, value]) => `${name}=${value}`)
+    .join("; ");
+  return new NextRequest("http://localhost:3000/api/invitations", {
+    method: "POST",
+    headers: header ? { cookie: header } : {},
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+}
+
+function cookie(response: Response, name: string) {
+  const set = response.headers.getSetCookie().find((entry) => entry.startsWith(`${name}=`));
+  if (!set) return undefined;
+  const [pair, ...attributes] = set.split("; ");
+  return { value: pair!.slice(name.length + 1), attributes: attributes.join("; ") };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("staging a token", () => {
+  it("stores the handle in an httpOnly cookie and returns nothing else", async () => {
+    vi.mocked(backendFetch).mockResolvedValueOnce({ handle: "an-opaque-handle" });
+
+    const response = await stage(request({}, { token: "a-live-token" }));
+
+    expect(backendFetch).toHaveBeenCalledWith("/api/v1/invitations/stage", {
+      method: "POST",
+      headers: {},
+      body: JSON.stringify({ token: "a-live-token" }),
+    });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ staged: true });
+    const set = cookie(response, "invitation_stage");
+    expect(set?.value).toBe("an-opaque-handle");
+    expect(set?.attributes).toContain("HttpOnly");
+    expect(set?.attributes).toContain("Max-Age=1800");
+  });
+
+  it("does not put the token or the handle in the reply body", async () => {
+    vi.mocked(backendFetch).mockResolvedValueOnce({ handle: "an-opaque-handle" });
+
+    const body = await (await stage(request({}, { token: "a-live-token" }))).text();
+
+    expect(body).not.toContain("a-live-token");
+    expect(body).not.toContain("an-opaque-handle");
+  });
+
+  it("forwards a refused token without setting a cookie", async () => {
+    vi.mocked(backendFetch).mockRejectedValueOnce(
+      new BackendApiError(404, "Not Found", { detail: "Invitation not found or no longer valid" }),
+    );
+
+    const response = await stage(request({}, { token: "forged" }));
+
+    expect(response.status).toBe(404);
+    expect(cookie(response, "invitation_stage")).toBeUndefined();
+  });
+
+  it("answers 500 when the exchange could not be reached", async () => {
+    vi.mocked(backendFetch).mockRejectedValueOnce(new Error("network down"));
+
+    const response = await stage(request({}, { token: "a-live-token" }));
+
+    expect(response.status).toBe(500);
+    expect(cookie(response, "invitation_stage")).toBeUndefined();
+  });
+});
+
+describe("accepting after sign-in", () => {
+  it("refuses without a session", async () => {
+    const response = await acceptPending(request({ invitation_stage: "h" }));
+
+    expect(response.status).toBe(401);
+    expect(backendFetch).not.toHaveBeenCalled();
+  });
+
+  it("is a clean miss when no invitation was staged", async () => {
+    const response = await acceptPending(request({ access_token: "jwt" }));
+
+    expect(response.status).toBe(404);
+    expect(backendFetch).not.toHaveBeenCalled();
+  });
+
+  it("redeems the handle from a header and clears the cookie", async () => {
+    vi.mocked(backendFetch).mockResolvedValueOnce(undefined);
+
+    const response = await acceptPending(request({ access_token: "jwt", invitation_stage: "h" }));
+
+    expect(backendFetch).toHaveBeenCalledWith("/api/v1/invitations/staged/accept", {
+      method: "POST",
+      headers: { Authorization: "Bearer jwt", "X-Invitation-Handle": "h" },
+    });
+    expect(response.status).toBe(204);
+    expect(cookie(response, "invitation_stage")?.value).toBe("");
+  });
+
+  it("clears the spent cookie even when the accept is refused", async () => {
+    // The redeem consumed the handle server-side, so the cookie is dead either way;
+    // leaving it would only mislead the next attempt.
+    vi.mocked(backendFetch).mockRejectedValueOnce(
+      new BackendApiError(400, "Bad Request", {
+        detail: "This invitation was sent to a different email address.",
+      }),
+    );
+
+    const response = await acceptPending(request({ access_token: "jwt", invitation_stage: "h" }));
+
+    expect(response.status).toBe(400);
+    expect(cookie(response, "invitation_stage")?.value).toBe("");
+  });
+
+  it("answers 500 when the accept could not be reached", async () => {
+    vi.mocked(backendFetch).mockRejectedValueOnce(new Error("network down"));
+
+    const response = await acceptPending(request({ access_token: "jwt", invitation_stage: "h" }));
+
+    expect(response.status).toBe(500);
+  });
+
+  it("keeps the cookie on a 401, whose redeem never ran", async () => {
+    // A rejected session is refused before the handle is redeemed, so it is unspent;
+    // the client refreshes the token and retries, which needs the cookie still there.
+    vi.mocked(backendFetch).mockRejectedValueOnce(
+      new BackendApiError(401, "Unauthorized", { detail: "expired" }),
+    );
+
+    const response = await acceptPending(request({ access_token: "stale", invitation_stage: "h" }));
+
+    expect(response.status).toBe(401);
+    // No Set-Cookie for it: the handle was not cleared.
+    expect(cookie(response, "invitation_stage")).toBeUndefined();
+  });
+});
+
+describe("starting an OAuth sign-in", () => {
+  const get = (cookies: Record<string, string>, provider: string) =>
+    oauthLogin(request(cookies), { params: Promise.resolve({ provider }) });
+
+  it("attaches a staged handle to the cross-origin start", async () => {
+    const response = await get({ invitation_stage: "h" }, "google");
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:8000/api/v1/oauth/google/login?invitation_handle=h",
+    );
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("carries no handle when none was staged", async () => {
+    const response = await get({}, "google");
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:8000/api/v1/oauth/google/login",
+    );
+  });
+
+  it("refuses a provider it does not know, rather than build a redirect from it", async () => {
+    const response = await get({ invitation_stage: "h" }, "../evil");
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/frontend/src/app/api/invitations/pending/accept/route.ts
+++ b/frontend/src/app/api/invitations/pending/accept/route.ts
@@ -1,38 +1,55 @@
 import { NextRequest, NextResponse } from "next/server";
-import { BackendApiError, backendFetch, bffJson, bffRefusal } from "@/lib/server-api";
+import { BackendApiError, backendFetch, bffJson, bffRefusal, forwardedFor } from "@/lib/server-api";
+import { INVITATION_FLOW_PARAM, isInvitationFlow, stageCookieName } from "@/lib/invitation-links";
 
 /**
  * Close a staged invitation once the invitee has signed in (#1414).
  *
- * The handle rides an `httpOnly` cookie this route reads and the browser cannot; it
- * is forwarded to the backend in a header, redeemed there exactly once, and the
- * invitation accepted as the caller. The cookie is cleared once the redeem has run -
- * on success and on an invitation-level refusal - because the handle is then spent
- * and a stale cookie would only mislead. It is kept on a 401: the session is rejected
- * before the redeem, so the handle is unspent, and the client's refresh-and-retry (or
- * a later valid session) can still close the invitation with it.
+ * The pending landing names its flow in `?flow=`, and the handle rides the `httpOnly`
+ * cookie of that name, which this route reads and the browser cannot. It is forwarded
+ * to the backend in a header, redeemed there exactly once, and the invitation accepted
+ * as the caller - with the caller's own address forwarded, since the backend rate
+ * limits this per IP and would otherwise count every invitee against the frontend
+ * container.
+ *
+ * The cookie is cleared once the redeem has run - on success and on an invitation-level
+ * refusal - because the handle is then spent and a stale cookie would only mislead.
+ * It is kept wherever the redeem may not have run: a 401 (the session is rejected
+ * first), a 429 (the rate limit runs before the redeem, so the handle is unspent and
+ * the advertised retry needs it), and a 5xx or an unreachable backend, where nothing
+ * says which side of the redeem the failure fell on and a retry answering a miss is
+ * cheaper than an invitation lost.
  */
-const STAGE_COOKIE = "invitation_stage";
+function handleIsSpent(status: number): boolean {
+  return status >= 400 && status < 500 && status !== 401 && status !== 429;
+}
 
 export async function POST(request: NextRequest) {
   const accessToken = request.cookies.get("access_token")?.value;
   if (!accessToken) return bffRefusal("NOT_AUTHENTICATED", 401);
 
-  const handle = request.cookies.get(STAGE_COOKIE)?.value;
+  const flow = request.nextUrl.searchParams.get(INVITATION_FLOW_PARAM);
+  if (!isInvitationFlow(flow)) return bffRefusal("INVITATION_NOT_FOUND", 404);
+  const cookieName = stageCookieName(flow);
+  const handle = request.cookies.get(cookieName)?.value;
   if (!handle) return bffRefusal("INVITATION_NOT_FOUND", 404);
 
   try {
     await backendFetch("/api/v1/invitations/staged/accept", {
       method: "POST",
-      headers: { Authorization: `Bearer ${accessToken}`, "X-Invitation-Handle": handle },
+      headers: {
+        ...forwardedFor(request),
+        Authorization: `Bearer ${accessToken}`,
+        "X-Invitation-Handle": handle,
+      },
     });
     const response = new NextResponse(null, { status: 204 });
-    response.cookies.delete(STAGE_COOKIE);
+    response.cookies.delete(cookieName);
     return response;
   } catch (error) {
     if (error instanceof BackendApiError) {
       const response = bffJson({ detail: error.message }, { status: error.status });
-      if (error.status !== 401) response.cookies.delete(STAGE_COOKIE);
+      if (handleIsSpent(error.status)) response.cookies.delete(cookieName);
       return response;
     }
     return bffRefusal("INTERNAL_SERVER_ERROR", 500);

--- a/frontend/src/app/api/invitations/pending/accept/route.ts
+++ b/frontend/src/app/api/invitations/pending/accept/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { BackendApiError, backendFetch, bffJson, bffRefusal } from "@/lib/server-api";
+
+/**
+ * Close a staged invitation once the invitee has signed in (#1414).
+ *
+ * The handle rides an `httpOnly` cookie this route reads and the browser cannot; it
+ * is forwarded to the backend in a header, redeemed there exactly once, and the
+ * invitation accepted as the caller. The cookie is cleared once the redeem has run -
+ * on success and on an invitation-level refusal - because the handle is then spent
+ * and a stale cookie would only mislead. It is kept on a 401: the session is rejected
+ * before the redeem, so the handle is unspent, and the client's refresh-and-retry (or
+ * a later valid session) can still close the invitation with it.
+ */
+const STAGE_COOKIE = "invitation_stage";
+
+export async function POST(request: NextRequest) {
+  const accessToken = request.cookies.get("access_token")?.value;
+  if (!accessToken) return bffRefusal("NOT_AUTHENTICATED", 401);
+
+  const handle = request.cookies.get(STAGE_COOKIE)?.value;
+  if (!handle) return bffRefusal("INVITATION_NOT_FOUND", 404);
+
+  try {
+    await backendFetch("/api/v1/invitations/staged/accept", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${accessToken}`, "X-Invitation-Handle": handle },
+    });
+    const response = new NextResponse(null, { status: 204 });
+    response.cookies.delete(STAGE_COOKIE);
+    return response;
+  } catch (error) {
+    if (error instanceof BackendApiError) {
+      const response = bffJson({ detail: error.message }, { status: error.status });
+      if (error.status !== 401) response.cookies.delete(STAGE_COOKIE);
+      return response;
+    }
+    return bffRefusal("INTERNAL_SERVER_ERROR", 500);
+  }
+}

--- a/frontend/src/app/api/invitations/stage/route.ts
+++ b/frontend/src/app/api/invitations/stage/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest } from "next/server";
+import { BackendApiError, backendFetch, bffJson, bffRefusal, forwardedFor } from "@/lib/server-api";
+import { secureCookies } from "@/lib/session-cookie";
+
+/**
+ * Stage an invitation deep link before the sign-in round trip (#1414).
+ *
+ * The token arrives from the browser once, here, and never leaves: the backend
+ * stores it under an opaque handle, which this route sets as an `httpOnly` cookie
+ * the browser cannot read. The reply carries nothing but success, so the raw token
+ * is not in a response a script sees, in the URL, or in `sessionStorage`. The
+ * cookie's lifetime matches the handle's server-side, so neither outlives the other.
+ */
+const STAGE_COOKIE = "invitation_stage";
+const STAGE_TTL_SECONDS = 1800;
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { handle } = await backendFetch<{ handle: string }>("/api/v1/invitations/stage", {
+      method: "POST",
+      headers: { ...forwardedFor(request) },
+      body: JSON.stringify({ token: body?.token }),
+    });
+
+    const response = bffJson({ staged: true });
+    response.cookies.set(STAGE_COOKIE, handle, {
+      httpOnly: true,
+      secure: secureCookies(request),
+      sameSite: "lax",
+      maxAge: STAGE_TTL_SECONDS,
+      path: "/",
+    });
+    return response;
+  } catch (error) {
+    if (error instanceof BackendApiError)
+      return bffJson({ detail: error.message }, { status: error.status });
+    return bffRefusal("INTERNAL_SERVER_ERROR", 500);
+  }
+}

--- a/frontend/src/app/api/invitations/stage/route.ts
+++ b/frontend/src/app/api/invitations/stage/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { BackendApiError, backendFetch, bffJson, bffRefusal, forwardedFor } from "@/lib/server-api";
+import { stageCookieName } from "@/lib/invitation-links";
 import { secureCookies } from "@/lib/session-cookie";
 
 /**
@@ -7,11 +8,17 @@ import { secureCookies } from "@/lib/session-cookie";
  *
  * The token arrives from the browser once, here, and never leaves: the backend
  * stores it under an opaque handle, which this route sets as an `httpOnly` cookie
- * the browser cannot read. The reply carries nothing but success, so the raw token
- * is not in a response a script sees, in the URL, or in `sessionStorage`. The
- * cookie's lifetime matches the handle's server-side, so neither outlives the other.
+ * the browser cannot read. The reply carries the flow id and nothing else, so the
+ * raw token is not in a response a script sees, in the URL, or in `sessionStorage`.
+ * The cookie's lifetime matches the handle's server-side, so neither outlives the
+ * other.
+ *
+ * The cookie is named for the flow rather than fixed, because a fixed name is one
+ * slot: two invitation links opened side by side while signed out each staged into
+ * it, the second overwriting the first, and both pending tabs then redeemed the
+ * second. Each staging mints its own id, the pending landing carries it, and the
+ * accept reads exactly the cookie that id names.
  */
-const STAGE_COOKIE = "invitation_stage";
 const STAGE_TTL_SECONDS = 1800;
 
 export async function POST(request: NextRequest) {
@@ -23,8 +30,9 @@ export async function POST(request: NextRequest) {
       body: JSON.stringify({ token: body?.token }),
     });
 
-    const response = bffJson({ staged: true });
-    response.cookies.set(STAGE_COOKIE, handle, {
+    const flow = crypto.randomUUID().replaceAll("-", "");
+    const response = bffJson({ staged: true, flow });
+    response.cookies.set(stageCookieName(flow), handle, {
       httpOnly: true,
       secure: secureCookies(request),
       sameSite: "lax",

--- a/frontend/src/app/api/oauth/[provider]/login/route.ts
+++ b/frontend/src/app/api/oauth/[provider]/login/route.ts
@@ -1,15 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { BACKEND_URL } from "@/lib/constants";
+import { INVITATION_FLOW_PARAM, isInvitationFlow, stageCookieName } from "@/lib/invitation-links";
 
 /**
  * Start an OAuth sign-in, attaching a staged invitation the browser cannot read.
  *
  * The provider login is a cross-origin navigation to the backend, so the httpOnly
- * `invitation_stage` cookie (#1414) cannot ride it directly. This same-origin hop
- * reads the cookie and forwards the opaque handle - never the token - as a query the
- * backend peeks for admission on an `invite_only` deployment. A sign-in with no
- * staged invitation carries none, and the handle is peeked, so it still closes the
- * acceptance after the round trip.
+ * staging cookie (#1414) cannot ride it directly. This same-origin hop reads the
+ * cookie of the flow the button named in `?flow=` and forwards the opaque handle -
+ * never the token - as a query the backend peeks for admission on an `invite_only`
+ * deployment. A sign-in with no staged invitation carries none, and the handle is
+ * peeked, so it still closes the acceptance after the round trip.
  */
 const PROVIDERS = new Set(["google", "github", "microsoft"]);
 
@@ -25,7 +26,8 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   if (!PROVIDERS.has(provider)) return new NextResponse(null, { status: 404 });
 
   const target = new URL(`${BACKEND_URL}/api/v1/oauth/${encodeURIComponent(provider)}/login`);
-  const handle = request.cookies.get("invitation_stage")?.value;
+  const flow = request.nextUrl.searchParams.get(INVITATION_FLOW_PARAM);
+  const handle = isInvitationFlow(flow) ? request.cookies.get(stageCookieName(flow))?.value : null;
   if (handle) target.searchParams.set("invitation_handle", handle);
   const response = NextResponse.redirect(target, 302);
   // The `Location` carries the handle, and a hand-rolled route owes the header the

--- a/frontend/src/app/api/oauth/[provider]/login/route.ts
+++ b/frontend/src/app/api/oauth/[provider]/login/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { BACKEND_URL } from "@/lib/constants";
+
+/**
+ * Start an OAuth sign-in, attaching a staged invitation the browser cannot read.
+ *
+ * The provider login is a cross-origin navigation to the backend, so the httpOnly
+ * `invitation_stage` cookie (#1414) cannot ride it directly. This same-origin hop
+ * reads the cookie and forwards the opaque handle - never the token - as a query the
+ * backend peeks for admission on an `invite_only` deployment. A sign-in with no
+ * staged invitation carries none, and the handle is peeked, so it still closes the
+ * acceptance after the round trip.
+ */
+const PROVIDERS = new Set(["google", "github", "microsoft"]);
+
+interface RouteParams {
+  params: Promise<{ provider: string }>;
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const { provider } = await params;
+  // A path segment builds the redirect target, so it is checked against the known
+  // providers rather than trusted - otherwise it is an open redirect - and encoded
+  // even after that, the rule every hand-rolled proxy here keeps.
+  if (!PROVIDERS.has(provider)) return new NextResponse(null, { status: 404 });
+
+  const target = new URL(`${BACKEND_URL}/api/v1/oauth/${encodeURIComponent(provider)}/login`);
+  const handle = request.cookies.get("invitation_stage")?.value;
+  if (handle) target.searchParams.set("invitation_handle", handle);
+  const response = NextResponse.redirect(target, 302);
+  // The `Location` carries the handle, and a hand-rolled route owes the header the
+  // proxy would otherwise stamp: this redirect is per-request and must not be cached.
+  response.headers.set("Cache-Control", "no-store");
+  return response;
+}

--- a/frontend/src/components/auth/oauth-buttons.test.tsx
+++ b/frontend/src/components/auth/oauth-buttons.test.tsx
@@ -46,6 +46,25 @@ describe("the OAuth buttons", () => {
     expect(screen.getByRole("link")).toHaveAttribute("href", "/api/oauth/google/login");
   });
 
+  it("names the staged invitation's flow on the start, and nothing else about it", () => {
+    // The flow is which staging's cookie the proxy attaches - two staged side by side
+    // hold two - and is no credential on its own; the token and handle stay off the URL.
+    process.env.NEXT_PUBLIC_OAUTH_PROVIDERS = "google";
+
+    render(
+      <OAuthBlock
+        label="or"
+        variant="signup"
+        returnTo="/invitations/pending?flow=0123456789abcdef0123456789abcdef"
+      />,
+    );
+
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "href",
+      "/api/oauth/google/login?flow=0123456789abcdef0123456789abcdef",
+    );
+  });
+
   it("remembers the deep link the visitor was headed to", async () => {
     // Not sent to the provider and not in the OAuth `state`: the trip starts
     // and ends in this tab, and `/auth/callback` reads it back (#135).

--- a/frontend/src/components/auth/oauth-buttons.test.tsx
+++ b/frontend/src/components/auth/oauth-buttons.test.tsx
@@ -59,10 +59,12 @@ describe("the OAuth buttons", () => {
     expect(screen.getByRole("link")).toHaveAttribute("href", expect.not.stringContaining("a-1"));
   });
 
-  it("forgets an abandoned one, rather than resuming it on the next attempt", async () => {
+  it("forgets an abandoned one on a fresh attempt with no deep link", async () => {
+    // A fresh sign-in with nothing in the URL passes `null` (what `returnToForAttempt`
+    // answers there) - clear the stale one. A retry passes `undefined` and leaves it.
     process.env.NEXT_PUBLIC_OAUTH_PROVIDERS = "google";
     window.sessionStorage.setItem("oauthReturnTo", "/agents/gone");
-    render(<OAuthBlock label="or" />);
+    render(<OAuthBlock label="or" returnTo={null} />);
 
     await press(/continueWith/);
 

--- a/frontend/src/components/auth/oauth-buttons.test.tsx
+++ b/frontend/src/components/auth/oauth-buttons.test.tsx
@@ -32,19 +32,18 @@ describe("the OAuth buttons", () => {
 
     const links = screen.getAllByRole("link");
     expect(links).toHaveLength(3);
-    expect(links[0]).toHaveAttribute("href", expect.stringContaining("/oauth/google/login"));
+    expect(links[0]).toHaveAttribute("href", "/api/oauth/google/login");
     expect(document.querySelectorAll("svg")).toHaveLength(3);
   });
 
-  it("carries the invitation token to the provider on a sign-up", () => {
+  it("starts the sign-in same-origin and carries no token in the URL (#1414)", () => {
+    // A staged invitation rides an httpOnly cookie the same-origin proxy reads and
+    // attaches to the cross-origin hop; the provider link itself is credential-free.
     process.env.NEXT_PUBLIC_OAUTH_PROVIDERS = "google";
 
-    render(<OAuthBlock label="or" variant="signup" invitation="tok" />);
+    render(<OAuthBlock label="or" variant="signup" />);
 
-    expect(screen.getByRole("link")).toHaveAttribute(
-      "href",
-      expect.stringContaining("invitation=tok"),
-    );
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/api/oauth/google/login");
   });
 
   it("remembers the deep link the visitor was headed to", async () => {

--- a/frontend/src/components/auth/oauth-buttons.tsx
+++ b/frontend/src/components/auth/oauth-buttons.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { BACKEND_URL } from "@/lib/constants";
 import { rememberReturnTo } from "@/lib/oauth-return";
 
 import { GlyphIcon } from "@/components/icons/glyph";
@@ -29,16 +28,6 @@ interface OAuthButtonsProps {
   /** Override label suffix when used in register page. */
   variant?: "signin" | "signup";
   /**
-   * The invitation this page was reached with, carried to the provider.
-   *
-   * On an `invite_only` deployment the token is what admits an address nothing else
-   * recognises - a shareable link constraining neither an address nor a domain -
-   * and without it the provider button refused exactly the people the link was
-   * posted for, while the password form beside it accepted them. The backend takes
-   * it off the query here and holds it in the session across the round trip.
-   */
-  invitation?: string | null;
-  /**
    * Where the visitor was headed. Written to `sessionStorage` as the button is
    * clicked rather than sent to the provider: the trip starts and ends in this
    * tab, so nothing has to hold it for us (#135).
@@ -46,19 +35,18 @@ interface OAuthButtonsProps {
   returnTo?: string | null;
 }
 
-function OAuthButtons({ variant = "signin", invitation, returnTo }: OAuthButtonsProps) {
+function OAuthButtons({ variant = "signin", returnTo }: OAuthButtonsProps) {
   const t = useTranslations("auth");
   const providers = readProviders();
   if (providers.length === 0) return null;
 
-  const query = new URLSearchParams();
-  if (invitation) query.set("invitation", invitation);
-  const search = query.size > 0 ? `?${query.toString()}` : "";
-
   return (
     <div className="space-y-2.5">
       {providers.map((provider) => {
-        const url = `${BACKEND_URL}/api/v1/oauth/${provider}/login${search}`;
+        // A same-origin start, so a staged invitation's httpOnly handle is attached
+        // server-side before the cross-origin hop to the provider (#1414): the token
+        // is never in this URL, and an `invite_only` link still admits its holder.
+        const url = `/api/oauth/${provider}/login`;
         const label =
           variant === "signup"
             ? t(`signUpWith${PROVIDER_WORDS[provider]}`)
@@ -84,19 +72,17 @@ function OAuthButtons({ variant = "signin", invitation, returnTo }: OAuthButtons
 export function OAuthBlock({
   label,
   variant,
-  invitation,
   returnTo,
 }: {
   label: string;
   variant?: "signin" | "signup";
-  invitation?: string | null;
   returnTo?: string | null;
 }) {
   if (!process.env.NEXT_PUBLIC_OAUTH_PROVIDERS) return null;
   return (
     <div className="space-y-5">
       <OAuthDivider label={label} />
-      <OAuthButtons variant={variant} invitation={invitation} returnTo={returnTo} />
+      <OAuthButtons variant={variant} returnTo={returnTo} />
     </div>
   );
 }

--- a/frontend/src/components/auth/oauth-buttons.tsx
+++ b/frontend/src/components/auth/oauth-buttons.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { INVITATION_FLOW_PARAM, invitationFlowFrom } from "@/lib/invitation-links";
 import { rememberReturnTo } from "@/lib/oauth-return";
 
 import { GlyphIcon } from "@/components/icons/glyph";
@@ -39,14 +40,18 @@ function OAuthButtons({ variant = "signin", returnTo }: OAuthButtonsProps) {
   const t = useTranslations("auth");
   const providers = readProviders();
   if (providers.length === 0) return null;
+  // A same-origin start, so a staged invitation's httpOnly handle is attached
+  // server-side before the cross-origin hop to the provider (#1414): the token is
+  // never in this URL, only the flow naming which staging's cookie to attach, and
+  // an `invite_only` link still admits its holder.
+  const flow = invitationFlowFrom(returnTo);
 
   return (
     <div className="space-y-2.5">
       {providers.map((provider) => {
-        // A same-origin start, so a staged invitation's httpOnly handle is attached
-        // server-side before the cross-origin hop to the provider (#1414): the token
-        // is never in this URL, and an `invite_only` link still admits its holder.
-        const url = `/api/oauth/${provider}/login`;
+        const url = flow
+          ? `/api/oauth/${provider}/login?${INVITATION_FLOW_PARAM}=${flow}`
+          : `/api/oauth/${provider}/login`;
         const label =
           variant === "signup"
             ? t(`signUpWith${PROVIDER_WORDS[provider]}`)

--- a/frontend/src/components/auth/register-form.tsx
+++ b/frontend/src/components/auth/register-form.tsx
@@ -17,6 +17,7 @@ import { Button, Input, Label } from "@/components/ui";
 import { useAuth } from "@/hooks";
 import { ApiError } from "@/lib/api-client";
 import { ROUTES } from "@/lib/constants";
+import { invitationFlowFrom } from "@/lib/invitation-links";
 import { privacyLink, termsLink } from "@/lib/legal-links";
 import { EMAIL_RE, getPasswordStrength } from "@/lib/utils";
 
@@ -29,11 +30,12 @@ export function RegisterForm() {
   const search = useSearchParams();
   const returnTo = search.get("returnTo");
   // Reached from an invitation when the landing it carries is the staged pending
-  // page. The token itself is no longer here - it was exchanged for an httpOnly
-  // handle before login (#1414) - so the cookie, forwarded by the register proxy,
-  // is what admits an address the sign-up policy would otherwise refuse, and what
-  // admits a shareable link constraining no address at all (#916).
-  const invited = returnTo === ROUTES.INVITATION_PENDING;
+  // page for a flow. The token itself is no longer here - it was exchanged for an
+  // httpOnly handle before login (#1414) - so that flow's cookie, forwarded by the
+  // register proxy, is what admits an address the sign-up policy would otherwise
+  // refuse, and what admits a shareable link constraining no address at all (#916).
+  const invitationFlow = invitationFlowFrom(returnTo);
+  const invited = invitationFlow !== null;
   const branding = useBranding();
   const terms = termsLink(branding);
   const privacy = privacyLink(branding);
@@ -70,11 +72,14 @@ export function RegisterForm() {
 
     setIsLoading(true);
     try {
-      await register({
-        email,
-        password,
-        full_name: name || undefined,
-      });
+      await register(
+        {
+          email,
+          password,
+          full_name: name || undefined,
+        },
+        invitationFlow,
+      );
       toast.success(t("registerSuccess"));
       // The invitation is not accepted by registering - that needs a session - so a
       // person who arrived through one is sent back to it after signing in.

--- a/frontend/src/components/auth/register-form.tsx
+++ b/frontend/src/components/auth/register-form.tsx
@@ -27,11 +27,13 @@ export function RegisterForm() {
   const router = useRouter();
   const { register } = useAuth();
   const search = useSearchParams();
-  // Present when this form was reached from an invitation. It admits an address the
-  // deployment's sign-up policy would otherwise refuse, and it is the only proof
-  // that can admit a shareable link constraining no address at all (#916).
-  const invitationToken = search.get("invitation");
   const returnTo = search.get("returnTo");
+  // Reached from an invitation when the landing it carries is the staged pending
+  // page. The token itself is no longer here - it was exchanged for an httpOnly
+  // handle before login (#1414) - so the cookie, forwarded by the register proxy,
+  // is what admits an address the sign-up policy would otherwise refuse, and what
+  // admits a shareable link constraining no address at all (#916).
+  const invited = returnTo === ROUTES.INVITATION_PENDING;
   const branding = useBranding();
   const terms = termsLink(branding);
   const privacy = privacyLink(branding);
@@ -72,7 +74,6 @@ export function RegisterForm() {
         email,
         password,
         full_name: name || undefined,
-        invitation_token: invitationToken ?? undefined,
       });
       toast.success(t("registerSuccess"));
       // The invitation is not accepted by registering - that needs a session - so a
@@ -114,7 +115,7 @@ export function RegisterForm() {
         </p>
       </div>
 
-      <SignupPolicyNotice invited={invitationToken !== null} />
+      <SignupPolicyNotice invited={invited} />
 
       <form onSubmit={handleSubmit} className="space-y-5">
         <div className="space-y-1.5">
@@ -267,14 +268,10 @@ export function RegisterForm() {
         </p>
       </form>
 
-      {/* The token travels with the provider too: an `invite_only` deployment
-          otherwise refuses the button beside a form that accepts the same person. */}
-      <OAuthBlock
-        label={t("orSignUpWith")}
-        variant="signup"
-        invitation={invitationToken}
-        returnTo={returnTo}
-      />
+      {/* The staged invitation travels with the provider too, as its httpOnly
+          handle attached same-origin (#1414): an `invite_only` deployment otherwise
+          refuses the button beside a form that accepts the same person. */}
+      <OAuthBlock label={t("orSignUpWith")} variant="signup" returnTo={returnTo} />
     </div>
   );
 }

--- a/frontend/src/components/auth/signup-policy.integration.test.tsx
+++ b/frontend/src/components/auth/signup-policy.integration.test.tsx
@@ -101,8 +101,11 @@ describe("arriving with an invitation", () => {
     // to invite you" - the policy admits them, and telling them otherwise reads as
     // a refusal they have already satisfied.
     // The token is gone by the time the form renders - it was staged into a cookie
-    // (#1414) - so the invited signal is now the credential-free pending landing.
-    searchParams.value = new URLSearchParams({ returnTo: "/invitations/pending" });
+    // (#1414) - so the invited signal is now the credential-free pending landing,
+    // bound to the flow whose cookie the register proxy forwards.
+    searchParams.value = new URLSearchParams({
+      returnTo: "/invitations/pending?flow=0123456789abcdef0123456789abcdef",
+    });
 
     render(<RegisterForm />, { wrapper: branded({ signupMode: "invite_only" }) });
 
@@ -121,7 +124,9 @@ describe("arriving with an invitation", () => {
     // agrees - so offering the form here would be a form that always fails.
     // The token is gone by the time the form renders - it was staged into a cookie
     // (#1414) - so the invited signal is now the credential-free pending landing.
-    searchParams.value = new URLSearchParams({ returnTo: "/invitations/pending" });
+    searchParams.value = new URLSearchParams({
+      returnTo: "/invitations/pending?flow=0123456789abcdef0123456789abcdef",
+    });
 
     render(<RegisterForm />, { wrapper: branded({ signupMode: "closed" }) });
 

--- a/frontend/src/components/auth/signup-policy.integration.test.tsx
+++ b/frontend/src/components/auth/signup-policy.integration.test.tsx
@@ -100,7 +100,9 @@ describe("arriving with an invitation", () => {
     // Somebody holding an invitation is not the audience for "ask an administrator
     // to invite you" - the policy admits them, and telling them otherwise reads as
     // a refusal they have already satisfied.
-    searchParams.value = new URLSearchParams({ invitation: "tok" });
+    // The token is gone by the time the form renders - it was staged into a cookie
+    // (#1414) - so the invited signal is now the credential-free pending landing.
+    searchParams.value = new URLSearchParams({ returnTo: "/invitations/pending" });
 
     render(<RegisterForm />, { wrapper: branded({ signupMode: "invite_only" }) });
 
@@ -117,7 +119,9 @@ describe("arriving with an invitation", () => {
   it("still shows no form on a closed deployment", () => {
     // "Closed" that lets some registrations through is not closed, and the backend
     // agrees - so offering the form here would be a form that always fails.
-    searchParams.value = new URLSearchParams({ invitation: "tok" });
+    // The token is gone by the time the form renders - it was staged into a cookie
+    // (#1414) - so the invited signal is now the credential-free pending landing.
+    searchParams.value = new URLSearchParams({ returnTo: "/invitations/pending" });
 
     render(<RegisterForm />, { wrapper: branded({ signupMode: "closed" }) });
 

--- a/frontend/src/components/layout/auth-guard.test.tsx
+++ b/frontend/src/components/layout/auth-guard.test.tsx
@@ -46,4 +46,26 @@ describe("the dashboard guard, refusing", () => {
       ),
     );
   });
+
+  it("exchanges an invitation token before login and returns a credential-free landing (#1414)", async () => {
+    // A signed-out invitee's token must not ride the round trip. The guard stages it
+    // - into an httpOnly cookie the exchange sets - and sends them to the pending
+    // landing, so `returnTo` carries no credential into history or session storage.
+    window.history.replaceState(null, "", "/invitations/a-live-token");
+    vi.mocked(apiClient.get).mockRejectedValue(new Error("401"));
+    vi.mocked(apiClient.post).mockResolvedValue(undefined);
+
+    render(
+      <AuthGuard>
+        <p>the dashboard</p>
+      </AuthGuard>,
+    );
+
+    await waitFor(() =>
+      expect(apiClient.post).toHaveBeenCalledWith("/invitations/stage", { token: "a-live-token" }),
+    );
+    expect(replace).toHaveBeenCalledWith(
+      `${ROUTES.LOGIN}?returnTo=${encodeURIComponent(ROUTES.INVITATION_PENDING)}`,
+    );
+  });
 });

--- a/frontend/src/components/layout/auth-guard.test.tsx
+++ b/frontend/src/components/layout/auth-guard.test.tsx
@@ -1,4 +1,5 @@
-import { render, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AuthGuard } from "./auth-guard";
@@ -19,26 +20,40 @@ vi.mock("@/lib/api-client", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api-client")>("@/lib/api-client");
   return { ...actual, apiClient: { get: vi.fn(), post: vi.fn() } };
 });
-vi.mock("@/hooks/use-auth", () => ({ useAdoptSession: () => vi.fn() }));
+// Stable across renders, as the real hook's `useCallback` is - the verify effect
+// depends on it, and a fresh function per render would re-run the effect on every
+// state change and stage the same token twice.
+const adoptSession = vi.hoisted(() => vi.fn());
+vi.mock("@/hooks/use-auth", () => ({ useAdoptSession: () => adoptSession }));
 
-const replace = vi.hoisted(() => vi.fn());
-vi.mock("next/navigation", () => ({ useRouter: () => ({ replace, push: vi.fn() }) }));
+// One router object across renders, as `next/navigation` hands out: a fresh one per
+// render would re-run the verify effect on every state change and stage twice.
+const router = vi.hoisted(() => ({ replace: vi.fn(), push: vi.fn() }));
+const replace = router.replace;
+vi.mock("next/navigation", () => ({ useRouter: () => router }));
+
+const FLOW = "0123456789abcdef0123456789abcdef";
+const PENDING_FOR_FLOW = `${ROUTES.INVITATION_PENDING}?flow=${FLOW}`;
 
 beforeEach(() => {
   vi.clearAllMocks();
   useAuthStore.getState().logout();
 });
 
+function renderGuard() {
+  return render(
+    <AuthGuard>
+      <p>the dashboard</p>
+    </AuthGuard>,
+  );
+}
+
 describe("the dashboard guard, refusing", () => {
   it("carries the whole address to login - path, query and fragment", async () => {
     window.history.replaceState(null, "", "/agents/a-1?tab=spec#monthly");
     vi.mocked(apiClient.get).mockRejectedValue(new Error("401"));
 
-    render(
-      <AuthGuard>
-        <p>the dashboard</p>
-      </AuthGuard>,
-    );
+    renderGuard();
 
     await waitFor(() =>
       expect(replace).toHaveBeenCalledWith(
@@ -47,25 +62,57 @@ describe("the dashboard guard, refusing", () => {
     );
   });
 
-  it("exchanges an invitation token before login and returns a credential-free landing (#1414)", async () => {
+  it("exchanges an invitation token before login and returns a landing bound to its flow (#1414)", async () => {
     // A signed-out invitee's token must not ride the round trip. The guard stages it
     // - into an httpOnly cookie the exchange sets - and sends them to the pending
-    // landing, so `returnTo` carries no credential into history or session storage.
+    // landing naming the flow, so `returnTo` carries no credential into history or
+    // session storage, and the landing can find this staging's cookie among others.
     window.history.replaceState(null, "", "/invitations/a-live-token");
     vi.mocked(apiClient.get).mockRejectedValue(new Error("401"));
-    vi.mocked(apiClient.post).mockResolvedValue(undefined);
+    vi.mocked(apiClient.post).mockResolvedValue({ staged: true, flow: FLOW });
 
-    render(
-      <AuthGuard>
-        <p>the dashboard</p>
-      </AuthGuard>,
-    );
+    renderGuard();
 
     await waitFor(() =>
       expect(apiClient.post).toHaveBeenCalledWith("/invitations/stage", { token: "a-live-token" }),
     );
     expect(replace).toHaveBeenCalledWith(
-      `${ROUTES.LOGIN}?returnTo=${encodeURIComponent(ROUTES.INVITATION_PENDING)}`,
+      `${ROUTES.LOGIN}?returnTo=${encodeURIComponent(PENDING_FOR_FLOW)}`,
     );
+  });
+
+  it("stays on the invitation when staging fails, and offers to try again", async () => {
+    // The token in the URL is the only credential the invitee holds. Leaving for the
+    // credential-free landing with nothing staged - on a transient failure or a rate
+    // limit - would lose it: they would sign in and find no invitation to accept.
+    window.history.replaceState(null, "", "/invitations/a-live-token");
+    vi.mocked(apiClient.get).mockRejectedValue(new Error("401"));
+    vi.mocked(apiClient.post).mockRejectedValue(new Error("429"));
+
+    renderGuard();
+
+    await screen.findByText(/could not be prepared/i);
+    expect(replace).not.toHaveBeenCalled();
+    expect(screen.queryByText("the dashboard")).not.toBeInTheDocument();
+    expect(window.location.pathname).toBe("/invitations/a-live-token");
+  });
+
+  it("retries the exchange from the error state and leaves once it succeeds", async () => {
+    window.history.replaceState(null, "", "/invitations/a-live-token");
+    vi.mocked(apiClient.get).mockRejectedValue(new Error("401"));
+    vi.mocked(apiClient.post)
+      .mockRejectedValueOnce(new Error("503"))
+      .mockResolvedValueOnce({ staged: true, flow: FLOW });
+
+    renderGuard();
+    await userEvent.click(await screen.findByRole("button", { name: /try again/i }));
+
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith(
+        `${ROUTES.LOGIN}?returnTo=${encodeURIComponent(PENDING_FOR_FLOW)}`,
+      ),
+    );
+    expect(apiClient.post).toHaveBeenCalledTimes(2);
+    expect(screen.queryByText(/could not be prepared/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/layout/auth-guard.tsx
+++ b/frontend/src/components/layout/auth-guard.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuthStore } from "@/stores";
 import { apiClient } from "@/lib/api-client";
 import { useAdoptSession } from "@/hooks/use-auth";
 import { ROUTES } from "@/lib/constants";
-import { invitationTokenFrom } from "@/lib/invitation-links";
+import { invitationTokenFrom, pendingLandingFor } from "@/lib/invitation-links";
 import { stageInvitation } from "@/lib/invitation-staging";
 import type { User } from "@/types";
+import { ErrorState } from "@/components/states";
 import { Spinner } from "@/components/ui";
 import { useTranslations } from "next-intl";
 
@@ -23,6 +24,29 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
   // the store, leaving the previous account's cache under the new one.
   const adoptSession = useAdoptSession();
   const [checking, setChecking] = useState(!isAuthenticated);
+  // The invitation token whose staging failed, kept so the retry has it. The URL
+  // still carries it too: the guard does not leave the link until the exchange has
+  // succeeded, because the token is the only credential the invitee holds.
+  const [unstagedToken, setUnstagedToken] = useState<string | null>(null);
+
+  // Exchange the token for an httpOnly-cookie handle before the sign-in detour, so
+  // it never rides `returnTo`, browser history or `sessionStorage` (#1414). The
+  // landing carries only the flow id; an invalid token is reported there, once there
+  // is a session to report to. A staging the server refused - transiently, or with a
+  // rate limit - keeps the invitee here to try again rather than sending them to sign
+  // in with nothing staged to come back to.
+  const stageAndGo = useCallback(
+    async (token: string) => {
+      const flow = await stageInvitation(token);
+      if (flow) {
+        setUnstagedToken(null);
+        router.replace(`${ROUTES.LOGIN}?returnTo=${encodeURIComponent(pendingLandingFor(flow))}`);
+      } else {
+        setUnstagedToken(token);
+      }
+    },
+    [router],
+  );
 
   useEffect(() => {
     if (isAuthenticated) return;
@@ -39,14 +63,7 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
         const { pathname, search, hash } = window.location;
         const invitationToken = invitationTokenFrom(pathname);
         if (invitationToken) {
-          // Exchange the token for an httpOnly-cookie handle before the sign-in
-          // detour, so it never rides `returnTo`, browser history or
-          // `sessionStorage` (#1414). The landing carries no credential; an
-          // invalid token is reported there, once there is a session to report to.
-          await stageInvitation(invitationToken);
-          router.replace(
-            `${ROUTES.LOGIN}?returnTo=${encodeURIComponent(ROUTES.INVITATION_PENDING)}`,
-          );
+          await stageAndGo(invitationToken);
         } else {
           router.replace(
             `${ROUTES.LOGIN}?returnTo=${encodeURIComponent(pathname + search + hash)}`,
@@ -58,13 +75,35 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
     };
 
     verify();
-  }, [isAuthenticated, router, adoptSession]);
+  }, [isAuthenticated, router, adoptSession, stageAndGo]);
+
+  const retryStaging = async (token: string) => {
+    setChecking(true);
+    try {
+      await stageAndGo(token);
+    } finally {
+      setChecking(false);
+    }
+  };
 
   if (checking && !isAuthenticated) {
     return (
       <div className="flex h-screen items-center justify-center" role="status" aria-live="polite">
         <Spinner className="text-muted-foreground h-6 w-6" />
         <span className="sr-only">{t("checkingAuthentication")}</span>
+      </div>
+    );
+  }
+
+  if (unstagedToken && !isAuthenticated) {
+    return (
+      <div className="flex min-h-screen items-center justify-center p-4">
+        <ErrorState
+          className="w-full max-w-md"
+          title={t("invitationNotStaged")}
+          description={t("invitationNotStagedHint")}
+          cta={{ label: t("retryInvitation"), onClick: () => void retryStaging(unstagedToken) }}
+        />
       </div>
     );
   }

--- a/frontend/src/components/layout/auth-guard.tsx
+++ b/frontend/src/components/layout/auth-guard.tsx
@@ -6,6 +6,8 @@ import { useAuthStore } from "@/stores";
 import { apiClient } from "@/lib/api-client";
 import { useAdoptSession } from "@/hooks/use-auth";
 import { ROUTES } from "@/lib/constants";
+import { invitationTokenFrom } from "@/lib/invitation-links";
+import { stageInvitation } from "@/lib/invitation-staging";
 import type { User } from "@/types";
 import { Spinner } from "@/components/ui";
 import { useTranslations } from "next-intl";
@@ -35,7 +37,21 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
         // Off `window.location`, not the navigation hooks: a hook here would
         // tie the verify effect to every navigation this guard sits above.
         const { pathname, search, hash } = window.location;
-        router.replace(`${ROUTES.LOGIN}?returnTo=${encodeURIComponent(pathname + search + hash)}`);
+        const invitationToken = invitationTokenFrom(pathname);
+        if (invitationToken) {
+          // Exchange the token for an httpOnly-cookie handle before the sign-in
+          // detour, so it never rides `returnTo`, browser history or
+          // `sessionStorage` (#1414). The landing carries no credential; an
+          // invalid token is reported there, once there is a session to report to.
+          await stageInvitation(invitationToken);
+          router.replace(
+            `${ROUTES.LOGIN}?returnTo=${encodeURIComponent(ROUTES.INVITATION_PENDING)}`,
+          );
+        } else {
+          router.replace(
+            `${ROUTES.LOGIN}?returnTo=${encodeURIComponent(pathname + search + hash)}`,
+          );
+        }
       } finally {
         setChecking(false);
       }

--- a/frontend/src/components/orgs/accept-invitation.test.tsx
+++ b/frontend/src/components/orgs/accept-invitation.test.tsx
@@ -41,19 +41,17 @@ describe("somebody who is not signed in", () => {
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 
-  it("is left on a login URL the register link can read the token out of", () => {
-    // The other half, asserted beside it: what AuthGuard writes is exactly what
-    // `registerHref` needs, and a page pushing its own query breaks the pair
-    // without breaking either piece alone.
-    const search = new URL(
-      `/login?returnTo=${encodeURIComponent(`/invitations/${TOKEN}`)}`,
-      "https://example.test",
-    ).search;
+  it("is left on a login URL whose landing carries no token (#1414)", () => {
+    // AuthGuard exchanges the token for an httpOnly handle and returns the invitee
+    // to the credential-free `/invitations/pending`; the register link carries only
+    // that landing on, never the token.
+    const search = new URL("/login?returnTo=%2Finvitations%2Fpending", "https://example.test")
+      .search;
 
     const href = registerHref(search);
 
-    expect(href).toContain(`invitation=${TOKEN}`);
     expect(href).toContain("returnTo=");
+    expect(href).not.toContain(TOKEN);
   });
 });
 

--- a/frontend/src/components/orgs/accept-invitation.tsx
+++ b/frontend/src/components/orgs/accept-invitation.tsx
@@ -1,86 +1,29 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
-import { CheckCircle2, XCircle, Loader2 } from "lucide-react";
-import { useTranslations } from "next-intl";
-
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { useInvitations, useAuth } from "@/hooks";
+import { InvitationAcceptCard } from "@/components/orgs/invitation-accept-card";
 
 /**
- * Accepting an invitation, for whoever is holding the link.
+ * Accepting an invitation directly, for a signed-in holder of the link.
  *
  * Separate from the page so it can be tested: the page's only job is to unwrap
  * `params`, and `use()` on a promise does not settle under the test renderer - so
  * anything asserted through the page passes whether or not the page works.
  *
  * **It navigates nowhere when nobody is signed in.** `AuthGuard`, which wraps every
- * dashboard route, has already sent that visitor to `/login?returnTo=<this page>`,
- * and `returnTo` is the one parameter carrying the invitation the rest of the way:
- * `registerHref` reads the token back out of it, the register form passes it on, and
- * the sign-in lands here again. This used to push `?redirect=` of its own - a name
- * nothing reads - and because it renders only once the guard has decided, that push
- * replaced the guard's. An invitee with no account then reached a bare `/register`
- * and arrived, signed up, in no organization at all (#1495).
+ * dashboard route, has already sent that visitor to `/login?returnTo=…` - and for
+ * an invitation deep link it exchanges the token for an httpOnly handle first
+ * (#1414), so the signed-out path returns here only for someone who was already
+ * signed in. This used to push `?redirect=` of its own - a name nothing reads - and
+ * because it renders only once the guard has decided, that push replaced the
+ * guard's. An invitee with no account then reached a bare `/register` and arrived,
+ * signed up, in no organization at all (#1495).
  */
 export function AcceptInvitation({ token }: { token: string }) {
-  const t = useTranslations("pages.invitations");
-  const router = useRouter();
   const { isAuthenticated } = useAuth();
   const { acceptInvitation } = useInvitations("");
-  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
-
-  const handleAccept = async () => {
-    setStatus("loading");
-    try {
-      await acceptInvitation(token);
-      setStatus("success");
-      setTimeout(() => router.push("/orgs"), 2000);
-    } catch {
-      setStatus("error");
-    }
-  };
 
   if (!isAuthenticated) return null;
 
-  return (
-    <div className="flex min-h-screen items-center justify-center p-4">
-      <Card className="w-full max-w-md">
-        <CardHeader className="text-center">
-          <CardTitle>{t("teamInvitation")}</CardTitle>
-          <CardDescription>{t("youAposVeBeen")}</CardDescription>
-        </CardHeader>
-        <CardContent className="flex flex-col items-center gap-4">
-          {status === "success" && (
-            <>
-              <CheckCircle2 className="text-foreground h-12 w-12" />
-              <p className="text-sm font-medium">{t("youJoinedOrganization")}</p>
-              <p className="text-muted-foreground text-xs">{t("redirectingYourOrganizations")}</p>
-            </>
-          )}
-          {status === "error" && (
-            <>
-              <XCircle className="text-destructive h-12 w-12" />
-              <p className="text-sm font-medium">{t("failedAcceptInvitation")}</p>
-              <p className="text-muted-foreground text-xs">{t("invitationMayHaveExpired")}</p>
-              <Button variant="outline" onClick={() => router.push("/dashboard")}>
-                {t("goDashboard")}
-              </Button>
-            </>
-          )}
-          {(status === "idle" || status === "loading") && (
-            <>
-              {status === "loading" && <Loader2 className="text-primary h-8 w-8 animate-spin" />}
-              <p className="text-muted-foreground text-sm">{t("clickBelowAcceptInvitation")}</p>
-              <Button onClick={handleAccept} disabled={status === "loading"} className="w-full">
-                {status === "loading" ? t("joining") : t("acceptInvitation")}
-              </Button>
-            </>
-          )}
-        </CardContent>
-      </Card>
-    </div>
-  );
+  return <InvitationAcceptCard accept={() => acceptInvitation(token)} />;
 }

--- a/frontend/src/components/orgs/accept-staged-invitation.test.tsx
+++ b/frontend/src/components/orgs/accept-staged-invitation.test.tsx
@@ -4,29 +4,37 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { AcceptStagedInvitation } from "./accept-staged-invitation";
 
 const push = vi.fn();
+const searchParams = { value: new URLSearchParams() };
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push }),
+  useSearchParams: () => searchParams.value,
 }));
 
 const acceptStaged = vi.fn();
 vi.mock("@/lib/invitation-staging", () => ({
-  acceptStagedInvitation: () => acceptStaged(),
+  acceptStagedInvitation: (flow: string | null) => acceptStaged(flow),
 }));
 
 afterEach(() => {
   vi.clearAllMocks();
   vi.useRealTimers();
+  searchParams.value = new URLSearchParams();
 });
 
 describe("closing a staged invitation after sign-in", () => {
-  it("redeems the staged cookie and sends them to their organizations", async () => {
+  it("redeems the cookie of the flow the landing names and sends them to their organizations", async () => {
+    // Two invitations staged side by side hold two cookies; the landing's `flow` is
+    // what says which of them this tab is closing.
     vi.useFakeTimers({ shouldAdvanceTime: true });
+    searchParams.value = new URLSearchParams({ flow: "0123456789abcdef0123456789abcdef" });
     acceptStaged.mockResolvedValue(undefined);
 
     render(<AcceptStagedInvitation />);
     screen.getByRole("button", { name: /accept/i }).click();
 
-    await waitFor(() => expect(acceptStaged).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(acceptStaged).toHaveBeenCalledWith("0123456789abcdef0123456789abcdef"),
+    );
     await screen.findByText(/joined/i);
 
     vi.advanceTimersByTime(2000);

--- a/frontend/src/components/orgs/accept-staged-invitation.test.tsx
+++ b/frontend/src/components/orgs/accept-staged-invitation.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AcceptStagedInvitation } from "./accept-staged-invitation";
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+const acceptStaged = vi.fn();
+vi.mock("@/lib/invitation-staging", () => ({
+  acceptStagedInvitation: () => acceptStaged(),
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+describe("closing a staged invitation after sign-in", () => {
+  it("redeems the staged cookie and sends them to their organizations", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    acceptStaged.mockResolvedValue(undefined);
+
+    render(<AcceptStagedInvitation />);
+    screen.getByRole("button", { name: /accept/i }).click();
+
+    await waitFor(() => expect(acceptStaged).toHaveBeenCalled());
+    await screen.findByText(/joined/i);
+
+    vi.advanceTimersByTime(2000);
+    expect(push).toHaveBeenCalledWith("/orgs");
+  });
+
+  it("says a refused or expired invitation was refused", async () => {
+    // A lapsed handle or a page opened without one comes back as a refusal from the
+    // accept call, the same as any other.
+    acceptStaged.mockRejectedValue(new Error("no pending invitation"));
+
+    render(<AcceptStagedInvitation />);
+    screen.getByRole("button", { name: /accept/i }).click();
+
+    await screen.findByText(/failed/i);
+  });
+});

--- a/frontend/src/components/orgs/accept-staged-invitation.tsx
+++ b/frontend/src/components/orgs/accept-staged-invitation.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+import { useSearchParams } from "next/navigation";
+
 import { InvitationAcceptCard } from "@/components/orgs/invitation-accept-card";
+import { INVITATION_FLOW_PARAM } from "@/lib/invitation-links";
 import { acceptStagedInvitation } from "@/lib/invitation-staging";
 
 /**
@@ -8,11 +11,13 @@ import { acceptStagedInvitation } from "@/lib/invitation-staging";
  *
  * An invitee who followed the deep link signed out had the token exchanged for an
  * httpOnly-cookie handle before login and was sent here afterwards; there is no
- * token in the URL to hold, so the accept redeems that cookie server-side. The
- * page is inside the dashboard, so `AuthGuard` has already ensured a session - a
- * handle that expired or a page opened without one is reported as a refused
- * invitation by the accept call, the same as any other.
+ * token in the URL to hold, only the `flow` naming which staging's cookie to redeem,
+ * so the accept redeems that cookie server-side. The page is inside the dashboard,
+ * so `AuthGuard` has already ensured a session - a handle that expired, or a page
+ * opened without a flow or its cookie, is reported as a refused invitation by the
+ * accept call, the same as any other.
  */
 export function AcceptStagedInvitation() {
-  return <InvitationAcceptCard accept={acceptStagedInvitation} />;
+  const flow = useSearchParams().get(INVITATION_FLOW_PARAM);
+  return <InvitationAcceptCard accept={() => acceptStagedInvitation(flow)} />;
 }

--- a/frontend/src/components/orgs/accept-staged-invitation.tsx
+++ b/frontend/src/components/orgs/accept-staged-invitation.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { InvitationAcceptCard } from "@/components/orgs/invitation-accept-card";
+import { acceptStagedInvitation } from "@/lib/invitation-staging";
+
+/**
+ * Closing a staged invitation once the invitee has signed in (#1414).
+ *
+ * An invitee who followed the deep link signed out had the token exchanged for an
+ * httpOnly-cookie handle before login and was sent here afterwards; there is no
+ * token in the URL to hold, so the accept redeems that cookie server-side. The
+ * page is inside the dashboard, so `AuthGuard` has already ensured a session - a
+ * handle that expired or a page opened without one is reported as a refused
+ * invitation by the accept call, the same as any other.
+ */
+export function AcceptStagedInvitation() {
+  return <InvitationAcceptCard accept={acceptStagedInvitation} />;
+}

--- a/frontend/src/components/orgs/invitation-accept-card.tsx
+++ b/frontend/src/components/orgs/invitation-accept-card.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { CheckCircle2, XCircle, Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+/**
+ * The confirm-and-join card both invitation paths render.
+ *
+ * What differs between them is the accept call handed in: the direct token page
+ * calls the token accept, the staged pending page (#1414) redeems its httpOnly
+ * cookie. The wording, the four states and where a success or a refusal lands are
+ * the same, so they live here once rather than in two components that drift.
+ */
+export function InvitationAcceptCard({ accept }: { accept: () => Promise<void> }) {
+  const t = useTranslations("pages.invitations");
+  const router = useRouter();
+  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+
+  const handleAccept = async () => {
+    setStatus("loading");
+    try {
+      await accept();
+      setStatus("success");
+      setTimeout(() => router.push("/orgs"), 2000);
+    } catch {
+      setStatus("error");
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <CardTitle>{t("teamInvitation")}</CardTitle>
+          <CardDescription>{t("youAposVeBeen")}</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col items-center gap-4">
+          {status === "success" && (
+            <>
+              <CheckCircle2 className="text-foreground h-12 w-12" />
+              <p className="text-sm font-medium">{t("youJoinedOrganization")}</p>
+              <p className="text-muted-foreground text-xs">{t("redirectingYourOrganizations")}</p>
+            </>
+          )}
+          {status === "error" && (
+            <>
+              <XCircle className="text-destructive h-12 w-12" />
+              <p className="text-sm font-medium">{t("failedAcceptInvitation")}</p>
+              <p className="text-muted-foreground text-xs">{t("invitationMayHaveExpired")}</p>
+              <Button variant="outline" onClick={() => router.push("/dashboard")}>
+                {t("goDashboard")}
+              </Button>
+            </>
+          )}
+          {(status === "idle" || status === "loading") && (
+            <>
+              {status === "loading" && <Loader2 className="text-primary h-8 w-8 animate-spin" />}
+              <p className="text-muted-foreground text-sm">{t("clickBelowAcceptInvitation")}</p>
+              <Button onClick={handleAccept} disabled={status === "loading"} className="w-full">
+                {status === "loading" ? t("joining") : t("acceptInvitation")}
+              </Button>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/hooks/use-auth.test.tsx
+++ b/frontend/src/hooks/use-auth.test.tsx
@@ -369,6 +369,23 @@ describe("signing in", () => {
     // `/auth/me` answered with on mount.
     expect(useAuthStore.getState().user?.email).toBe("kacper@example.com");
   });
+
+  it("names the staged invitation's flow on a registration reached through one (#1414)", async () => {
+    // The register proxy forwards that flow's httpOnly handle for the sign-up
+    // admission; the body itself carries no token and no handle.
+    vi.mocked(apiClient.post).mockResolvedValue({ id: "u-3", email: "invited@example.com" });
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await result.current.register(
+      { email: "invited@example.com", password: "secret123" },
+      "0123456789abcdef0123456789abcdef",
+    );
+
+    expect(apiClient.post).toHaveBeenCalledWith(
+      "/auth/register?flow=0123456789abcdef0123456789abcdef",
+      { email: "invited@example.com", password: "secret123" },
+    );
+  });
 });
 
 describe("signing out", () => {

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -11,6 +11,7 @@ import { apiClient, ApiError } from "@/lib/api-client";
 import type { User, LoginRequest, RegisterRequest } from "@/types";
 import { goToDestination, postSignInDestination } from "@/lib/auth-landing";
 import { ROUTES } from "@/lib/constants";
+import { INVITATION_FLOW_PARAM } from "@/lib/invitation-links";
 
 // Session-level singletons so /auth/me runs ONCE per page load no matter how
 // many components mount useAuth(). Concurrent mounts share the in-flight
@@ -202,8 +203,13 @@ export function useAuth() {
     [router, setUser, setLoading, queryClient],
   );
 
-  const register = useCallback(async (data: RegisterRequest) => {
-    const response = await apiClient.post<{ id: string; email: string }>("/auth/register", data);
+  // The flow names which staged invitation's cookie the register proxy forwards for
+  // the sign-up admission (#1414); a registration reached with none forwards none.
+  const register = useCallback(async (data: RegisterRequest, invitationFlow?: string | null) => {
+    const path = invitationFlow
+      ? `/auth/register?${INVITATION_FLOW_PARAM}=${invitationFlow}`
+      : "/auth/register";
+    const response = await apiClient.post<{ id: string; email: string }>(path, data);
     return response;
   }, []);
 

--- a/frontend/src/lib/bff-errors.ts
+++ b/frontend/src/lib/bff-errors.ts
@@ -25,6 +25,7 @@ export const BFF_ERROR_KEYS = {
   FORBIDDEN: "forbidden",
   IMPERSONATION_ENDED: "impersonationEnded",
   INTERNAL_SERVER_ERROR: "internalServerError",
+  INVITATION_NOT_FOUND: "invitationNotFound",
   LOGIN_FAILED: "loginFailed",
   MISSING_AUTHORIZATION_CODE: "missingAuthorizationCode",
   MISSING_TOKENS: "missingTokens",

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -4,6 +4,9 @@ export const ROUTES = {
   HOME: "/",
   LOGIN: "/login",
   REGISTER: "/register",
+  // Where a staged invitation lands after sign-in: the token was exchanged for an
+  // httpOnly-cookie handle before login, so this path carries no credential (#1414).
+  INVITATION_PENDING: "/invitations/pending",
   FORGOT_PASSWORD: "/forgot-password",
   DASHBOARD: "/dashboard",
   CHAT: "/chat",

--- a/frontend/src/lib/invitation-links.test.ts
+++ b/frontend/src/lib/invitation-links.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { invitationTokenFrom, registerHref } from "./invitation-links";
+import {
+  invitationFlowFrom,
+  invitationTokenFrom,
+  isInvitationFlow,
+  pendingLandingFor,
+  registerHref,
+  stageCookieName,
+} from "./invitation-links";
 import { ROUTES } from "./constants";
 
 /**
@@ -52,6 +59,45 @@ describe("reading a token out of a path", () => {
     expect(invitationTokenFrom("/invitations/abc?x=1")).toBeNull();
     expect(invitationTokenFrom("https://evil.example/invitations/abc")).toBeNull();
     expect(invitationTokenFrom("/invitations/../../etc/passwd")).toBeNull();
+  });
+});
+
+describe("the flow a staging is bound to", () => {
+  const flow = "0123456789abcdef0123456789abcdef";
+
+  it("is carried on the pending landing and names the cookie holding its handle", () => {
+    expect(pendingLandingFor(flow)).toBe(`/invitations/pending?flow=${flow}`);
+    expect(stageCookieName(flow)).toBe(`invitation_stage_${flow}`);
+  });
+
+  it("is read back off the landing, behind a locale prefix too", () => {
+    expect(invitationFlowFrom(pendingLandingFor(flow))).toBe(flow);
+    expect(invitationFlowFrom(`/pl/invitations/pending?flow=${flow}`)).toBe(flow);
+    expect(invitationFlowFrom(`/invitations/pending/?flow=${flow}&registered=true`)).toBe(flow);
+  });
+
+  it("is only ever 32 hex digits, because a cookie name is built from it", () => {
+    expect(isInvitationFlow(flow)).toBe(true);
+    expect(isInvitationFlow("../access_token")).toBe(false);
+    expect(isInvitationFlow(flow.toUpperCase())).toBe(false);
+    expect(isInvitationFlow(flow.slice(1))).toBe(false);
+    expect(isInvitationFlow(null)).toBe(false);
+    expect(isInvitationFlow(undefined)).toBe(false);
+  });
+
+  it("is absent from anything that is not the landing for one", () => {
+    expect(invitationFlowFrom(null)).toBeNull();
+    expect(invitationFlowFrom("")).toBeNull();
+    expect(invitationFlowFrom("/invitations/pending")).toBeNull();
+    expect(invitationFlowFrom("/invitations/pending?flow=not-a-flow")).toBeNull();
+    expect(invitationFlowFrom(`/agents?flow=${flow}`)).toBeNull();
+    expect(invitationFlowFrom(`/invitations/${flow}`)).toBeNull();
+    expect(invitationFlowFrom(`https://evil.example/invitations/pending?flow=${flow}`)).toBeNull();
+    expect(invitationFlowFrom(`//evil.example/invitations/pending?flow=${flow}`)).toBeNull();
+  });
+
+  it("is not read as a token, so the landing is never staged", () => {
+    expect(invitationTokenFrom(pendingLandingFor(flow))).toBeNull();
   });
 });
 

--- a/frontend/src/lib/invitation-links.test.ts
+++ b/frontend/src/lib/invitation-links.test.ts
@@ -4,16 +4,16 @@ import { invitationTokenFrom, registerHref } from "./invitation-links";
 import { ROUTES } from "./constants";
 
 /**
- * Carrying an invitation across the redirect that used to lose it.
+ * Reading an invitation token off a deep link, and carrying its landing onward.
  *
- * An invitee with no account opens `/invitations/<token>`, `AuthGuard` bounces them to
- * `/login?returnTo=%2Finvitations%2F<token>`, and the only route onward was a plain
- * link to `/register` - which on an `invite_only` deployment then refused somebody
- * holding a valid invitation, because the request carried no token and no query over
- * their address can recognise a link that constrains no address (#916).
+ * An invitee with no account opens `/invitations/<token>`; `AuthGuard` exchanges the
+ * token for an httpOnly handle (#1414) and bounces them to
+ * `/login?returnTo=%2Finvitations%2Fpending`. `invitationTokenFrom` is what reads the
+ * token off the path for that exchange; `registerHref` carries the credential-free
+ * landing on to the sign-up form, so the invitee returns to close the invitation.
  */
 
-describe("reading a token out of a returnTo", () => {
+describe("reading a token out of a path", () => {
   it("finds one on the path this app produces", () => {
     expect(invitationTokenFrom("/invitations/abc123")).toBe("abc123");
   });
@@ -38,6 +38,13 @@ describe("reading a token out of a returnTo", () => {
     expect(invitationTokenFrom("/invitations")).toBeNull();
   });
 
+  it("does not read the credential-free pending landing as a token (#1414)", () => {
+    // `/invitations/pending` matches the shape but names no invitation; reading it as
+    // a token would stage the literal `pending` on a signed-out load of the landing.
+    expect(invitationTokenFrom("/invitations/pending")).toBeNull();
+    expect(invitationTokenFrom("/pl/invitations/pending")).toBeNull();
+  });
+
   it("does not guess at a shape it was not given", () => {
     // A token is the only segment this reads; anything else is refused rather than
     // half-parsed into something that would be sent to the API as a token.
@@ -49,34 +56,34 @@ describe("reading a token out of a returnTo", () => {
 });
 
 describe("where create-an-account points", () => {
-  it("is the plain register page when no invitation is in play", () => {
+  it("is the plain register page when there is no landing to carry", () => {
     expect(registerHref("")).toBe(ROUTES.REGISTER);
-    expect(registerHref("returnTo=%2Fagents")).toBe(ROUTES.REGISTER);
   });
 
-  it("carries the invitation when the login page was reached from one", () => {
-    const href = registerHref("returnTo=%2Finvitations%2Fabc123");
+  it("carries the credential-free landing on, and nothing else", () => {
+    // The token is gone by now - it was staged into a cookie - so the landing is
+    // `/invitations/pending`, which registering must return to because it does not
+    // accept the invitation itself (that needs a session).
+    const href = registerHref("returnTo=%2Finvitations%2Fpending");
     const params = new URLSearchParams(href.split("?")[1]);
 
     expect(href.startsWith(ROUTES.REGISTER)).toBe(true);
-    expect(params.get("invitation")).toBe("abc123");
+    expect(params.get("returnTo")).toBe("/invitations/pending");
+    expect(params.get("invitation")).toBeNull();
   });
 
-  it("keeps the returnTo as well as the token", () => {
-    // Registering does not accept the invitation - that needs a session - so the
-    // person still has to land back on the invitation page afterwards.
-    const params = new URLSearchParams(
-      registerHref("returnTo=%2Finvitations%2Fabc123").split("?")[1],
-    );
+  it("keeps a non-invitation returnTo too, rather than dropping it", () => {
+    const params = new URLSearchParams(registerHref("returnTo=%2Fagents").split("?")[1]);
 
-    expect(params.get("returnTo")).toBe("/invitations/abc123");
+    expect(params.get("returnTo")).toBe("/agents");
   });
 
-  it("survives a query carrying other parameters", () => {
+  it("takes only the returnTo out of a query carrying other parameters", () => {
     const params = new URLSearchParams(
-      registerHref("registered=true&returnTo=%2Finvitations%2Fabc123").split("?")[1],
+      registerHref("registered=true&returnTo=%2Finvitations%2Fpending").split("?")[1],
     );
 
-    expect(params.get("invitation")).toBe("abc123");
+    expect(params.get("returnTo")).toBe("/invitations/pending");
+    expect(params.get("registered")).toBeNull();
   });
 });

--- a/frontend/src/lib/invitation-links.ts
+++ b/frontend/src/lib/invitation-links.ts
@@ -1,17 +1,14 @@
 /**
- * Carrying an invitation from the link somebody was sent to the form they need.
+ * Reading the token out of an invitation deep link, and carrying its landing
+ * through the sign-up detour.
  *
- * The problem this solves is a chain of redirects that loses the token. An invitee
- * with no account opens `/invitations/<token>`, which sits inside the dashboard, so
- * `AuthGuard` bounces them to `/login?returnTo=%2Finvitations%2F<token>`. From there
- * the only way to a sign-up form was a plain link to `/register` - and on a
- * deployment set to `invite_only` that form then refused them, holding a valid
- * invitation, because the request carried no token and no query over their address
- * can recognise a link constraining no address (#916).
- *
- * So the token is read back out of `returnTo` and put on the register link. Parsing a
- * URL this app itself produced, in one place with a test, rather than threading a
- * second parameter through a redirect nobody owns.
+ * An invitee with no account opens `/invitations/<token>`, which sits inside the
+ * dashboard, so `AuthGuard` catches them signed out. Before it sends them to sign
+ * in it exchanges the token for an `httpOnly`-cookie handle (#1414), so what rides
+ * the round trip is a credential-free `returnTo` (`/invitations/pending`) rather than
+ * the token. `invitationTokenFrom` is what reads the token off the path for that
+ * exchange; `registerHref` carries the landing on to the sign-up form, so an invitee
+ * who needs an account still returns to close the invitation afterwards.
  */
 
 import { ROUTES } from "@/lib/constants";
@@ -20,31 +17,34 @@ import { ROUTES } from "@/lib/constants";
 const INVITATION_PATH = /^\/(?:[a-z]{2}\/)?invitations\/([A-Za-z0-9_-]+)\/?$/;
 
 /**
- * The invitation token a `returnTo` is pointing at, if it is pointing at one.
+ * The invitation token a path is pointing at, if it is a `/invitations/<token>` one.
  *
  * Deliberately strict about the shape: a token is the only path segment this reads,
- * and anything else - a query, a second segment, an absolute URL to somewhere else -
- * yields nothing rather than a guess.
+ * and anything else - a query, a second segment, the credential-free
+ * `/invitations/pending` landing - yields nothing rather than a guess. `AuthGuard`
+ * reads the token off the current path with it; a sanitizer keeps the same shape out
+ * of session storage.
  */
 export function invitationTokenFrom(returnTo: string | null | undefined): string | null {
   if (!returnTo) return null;
-  return INVITATION_PATH.exec(returnTo)?.[1] ?? null;
+  const token = INVITATION_PATH.exec(returnTo)?.[1] ?? null;
+  // `/invitations/pending` matches the shape but is the credential-free landing, not
+  // a token - a real token is a long random string, never the literal `pending`. So
+  // a signed-out load of the landing does not stage `pending`, and the sanitizer does
+  // not rewrite it to itself.
+  return token === "pending" ? null : token;
 }
 
 /**
  * Where "create an account" should point, given the query the login page was given.
  *
- * The `returnTo` is kept as well as the token: registering does not accept the
- * invitation - that is a separate call needing a session - so the person still has to
- * land back on the invitation page afterwards.
+ * The `returnTo` is carried through unchanged - it is the credential-free
+ * `/invitations/pending` landing now, not the token - because registering does not
+ * accept the invitation: that is a separate call needing a session, so the person
+ * still has to land back on the pending page afterwards.
  */
 export function registerHref(search: string): string {
   const returnTo = new URLSearchParams(search).get("returnTo");
   if (!returnTo) return ROUTES.REGISTER;
-
-  const token = invitationTokenFrom(returnTo);
-  if (!token) return ROUTES.REGISTER;
-
-  const next = new URLSearchParams({ invitation: token, returnTo });
-  return `${ROUTES.REGISTER}?${next.toString()}`;
+  return `${ROUTES.REGISTER}?${new URLSearchParams({ returnTo }).toString()}`;
 }

--- a/frontend/src/lib/invitation-links.ts
+++ b/frontend/src/lib/invitation-links.ts
@@ -9,6 +9,14 @@
  * the token. `invitationTokenFrom` is what reads the token off the path for that
  * exchange; `registerHref` carries the landing on to the sign-up form, so an invitee
  * who needs an account still returns to close the invitation afterwards.
+ *
+ * The landing names a **flow**: a random id the exchange mints, carried as
+ * `?flow=<id>` on the pending URL and in the name of the cookie holding the handle.
+ * One fixed cookie name meant two invitation links opened side by side while signed
+ * out overwrote each other, and both pending tabs then redeemed the second - the
+ * flow id binds each tab to the handle staged for it. The id is not a credential:
+ * without the `httpOnly` cookie it names nothing, which is why it may ride the URL
+ * and `sessionStorage` where the token never could.
  */
 
 import { ROUTES } from "@/lib/constants";
@@ -47,4 +55,44 @@ export function registerHref(search: string): string {
   const returnTo = new URLSearchParams(search).get("returnTo");
   if (!returnTo) return ROUTES.REGISTER;
   return `${ROUTES.REGISTER}?${new URLSearchParams({ returnTo }).toString()}`;
+}
+
+/** The query parameter the pending landing carries its flow id under. */
+export const INVITATION_FLOW_PARAM = "flow";
+
+/** A flow id is 32 lower-case hex digits - a UUID with the dashes dropped. */
+const FLOW_ID = /^[0-9a-f]{32}$/;
+
+/** Matches the pending landing's path, with or without a locale prefix. */
+const PENDING_PATH = /^\/(?:[a-z]{2}\/)?invitations\/pending\/?$/;
+
+/** Whether a value has the shape of a flow id; a cookie name is built from it. */
+export function isInvitationFlow(value: string | null | undefined): value is string {
+  return typeof value === "string" && FLOW_ID.test(value);
+}
+
+/** The `httpOnly` cookie holding one flow's staged handle. */
+export function stageCookieName(flow: string): string {
+  return `invitation_stage_${flow}`;
+}
+
+/** The credential-free landing that redeems one flow after sign-in. */
+export function pendingLandingFor(flow: string): string {
+  return `${ROUTES.INVITATION_PENDING}?${INVITATION_FLOW_PARAM}=${flow}`;
+}
+
+/**
+ * The flow id a `returnTo` is bound to, if it is the pending landing for one.
+ *
+ * Reads only the shape {@link pendingLandingFor} produces - a same-origin path to
+ * the landing with a well-formed `flow` - and answers nothing for anything else, an
+ * absolute URL included. The register form reads the invited signal off it and hands
+ * the id on to the register proxy; the provider buttons hand it to the OAuth start.
+ */
+export function invitationFlowFrom(returnTo: string | null | undefined): string | null {
+  if (!returnTo || !returnTo.startsWith("/") || returnTo.startsWith("//")) return null;
+  const url = new URL(returnTo, "http://placeholder.invalid");
+  if (!PENDING_PATH.test(url.pathname)) return null;
+  const flow = url.searchParams.get(INVITATION_FLOW_PARAM);
+  return isInvitationFlow(flow) ? flow : null;
 }

--- a/frontend/src/lib/invitation-staging.test.ts
+++ b/frontend/src/lib/invitation-staging.test.ts
@@ -8,34 +8,50 @@ vi.mock("./api-client", () => ({ apiClient: { post: vi.fn() } }));
 beforeEach(() => vi.clearAllMocks());
 
 describe("staging an invitation from the browser", () => {
-  it("posts the token and reports a live invitation", async () => {
-    vi.mocked(apiClient.post).mockResolvedValueOnce(undefined);
+  it("posts the token and answers the flow the staging was bound to", async () => {
+    vi.mocked(apiClient.post).mockResolvedValueOnce({
+      staged: true,
+      flow: "0123456789abcdef0123456789abcdef",
+    });
 
-    await expect(stageInvitation("a-token")).resolves.toBe(true);
+    await expect(stageInvitation("a-token")).resolves.toBe("0123456789abcdef0123456789abcdef");
     expect(apiClient.post).toHaveBeenCalledWith("/invitations/stage", { token: "a-token" });
   });
 
-  it("reports a refused token rather than throwing", async () => {
-    // A forged or expired token answers a refusal; the caller sends the invitee on
-    // to sign in either way, and the pending page reports the invalid one.
+  it("answers nothing for a refused staging rather than throwing", async () => {
+    // A forged token, a rate limit and an unreachable server all land here; the
+    // caller keeps the invitee on the link they hold and offers to try again.
     vi.mocked(apiClient.post).mockRejectedValueOnce(new Error("not found"));
 
-    await expect(stageInvitation("forged")).resolves.toBe(false);
+    await expect(stageInvitation("forged")).resolves.toBeNull();
   });
 });
 
 describe("accepting a staged invitation", () => {
-  it("posts to the pending accept, which reads the cookie server-side", async () => {
+  it("posts to the pending accept naming the flow, which reads that cookie server-side", async () => {
     vi.mocked(apiClient.post).mockResolvedValueOnce(undefined);
 
-    await acceptStagedInvitation();
+    await acceptStagedInvitation("0123456789abcdef0123456789abcdef");
 
+    expect(apiClient.post).toHaveBeenCalledWith(
+      "/invitations/pending/accept?flow=0123456789abcdef0123456789abcdef",
+    );
+  });
+
+  it("still asks with no flow, and lets the miss surface", async () => {
+    // A landing opened without its flow has nothing to redeem; the route answers a
+    // miss and the card reports it as a refused invitation.
+    vi.mocked(apiClient.post).mockRejectedValueOnce(new Error("not found"));
+
+    await expect(acceptStagedInvitation(null)).rejects.toThrow("not found");
     expect(apiClient.post).toHaveBeenCalledWith("/invitations/pending/accept");
   });
 
   it("lets a refusal surface rather than swallowing it", async () => {
     vi.mocked(apiClient.post).mockRejectedValueOnce(new Error("expired"));
 
-    await expect(acceptStagedInvitation()).rejects.toThrow("expired");
+    await expect(acceptStagedInvitation("0123456789abcdef0123456789abcdef")).rejects.toThrow(
+      "expired",
+    );
   });
 });

--- a/frontend/src/lib/invitation-staging.test.ts
+++ b/frontend/src/lib/invitation-staging.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { acceptStagedInvitation, stageInvitation } from "./invitation-staging";
+import { apiClient } from "./api-client";
+
+vi.mock("./api-client", () => ({ apiClient: { post: vi.fn() } }));
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("staging an invitation from the browser", () => {
+  it("posts the token and reports a live invitation", async () => {
+    vi.mocked(apiClient.post).mockResolvedValueOnce(undefined);
+
+    await expect(stageInvitation("a-token")).resolves.toBe(true);
+    expect(apiClient.post).toHaveBeenCalledWith("/invitations/stage", { token: "a-token" });
+  });
+
+  it("reports a refused token rather than throwing", async () => {
+    // A forged or expired token answers a refusal; the caller sends the invitee on
+    // to sign in either way, and the pending page reports the invalid one.
+    vi.mocked(apiClient.post).mockRejectedValueOnce(new Error("not found"));
+
+    await expect(stageInvitation("forged")).resolves.toBe(false);
+  });
+});
+
+describe("accepting a staged invitation", () => {
+  it("posts to the pending accept, which reads the cookie server-side", async () => {
+    vi.mocked(apiClient.post).mockResolvedValueOnce(undefined);
+
+    await acceptStagedInvitation();
+
+    expect(apiClient.post).toHaveBeenCalledWith("/invitations/pending/accept");
+  });
+
+  it("lets a refusal surface rather than swallowing it", async () => {
+    vi.mocked(apiClient.post).mockRejectedValueOnce(new Error("expired"));
+
+    await expect(acceptStagedInvitation()).rejects.toThrow("expired");
+  });
+});

--- a/frontend/src/lib/invitation-staging.ts
+++ b/frontend/src/lib/invitation-staging.ts
@@ -10,24 +10,38 @@
  */
 
 import { apiClient } from "@/lib/api-client";
+import { INVITATION_FLOW_PARAM } from "@/lib/invitation-links";
 
 /**
  * Exchange an invitation token for the server-set handle cookie.
  *
- * Returns whether it named a live invitation: a forged or expired token is refused,
- * and the caller sends the invitee on to sign in either way - the pending page is
- * where an invalid one is finally reported, once there is a session to report it to.
+ * Answers the flow id the exchange minted - what the pending landing carries so the
+ * accept can find this staging's cookie among any others - or `null` when the token
+ * was not staged. A forged or expired token is refused, but so is a transient
+ * failure or a rate limit, and the caller cannot tell them apart from here; it keeps
+ * the invitee on the link they hold and offers to try again, rather than sending
+ * them to sign in with nothing staged to come back to.
  */
-export async function stageInvitation(token: string): Promise<boolean> {
+export async function stageInvitation(token: string): Promise<string | null> {
   try {
-    await apiClient.post("/invitations/stage", { token });
-    return true;
+    const { flow } = await apiClient.post<{ staged: boolean; flow: string }>("/invitations/stage", {
+      token,
+    });
+    return flow;
   } catch {
-    return false;
+    return null;
   }
 }
 
-/** Redeem the staged handle and accept the invitation as the signed-in user. */
-export async function acceptStagedInvitation(): Promise<void> {
-  await apiClient.post("/invitations/pending/accept");
+/**
+ * Redeem the flow's staged handle and accept the invitation as the signed-in user.
+ *
+ * A landing reached with no flow still asks, and is refused as a miss: there is no
+ * cookie to redeem, and the card reports it the same way it reports a lapsed one.
+ */
+export async function acceptStagedInvitation(flow: string | null): Promise<void> {
+  const path = flow
+    ? `/invitations/pending/accept?${INVITATION_FLOW_PARAM}=${encodeURIComponent(flow)}`
+    : "/invitations/pending/accept";
+  await apiClient.post(path);
 }

--- a/frontend/src/lib/invitation-staging.ts
+++ b/frontend/src/lib/invitation-staging.ts
@@ -1,0 +1,33 @@
+/**
+ * The client half of the invitation server-side exchange (#1414).
+ *
+ * An invitee follows `/invitations/<token>` while signed out. Rather than carry the
+ * token through the sign-in round trip - in a `returnTo` query, in browser history,
+ * in `sessionStorage` - it is handed to the server here, before the redirect to
+ * login. The server stores it under an opaque handle and sets that handle as an
+ * `httpOnly` cookie no script can read; all that comes back is whether the token
+ * named a live invitation. After sign-in the same cookie closes the acceptance.
+ */
+
+import { apiClient } from "@/lib/api-client";
+
+/**
+ * Exchange an invitation token for the server-set handle cookie.
+ *
+ * Returns whether it named a live invitation: a forged or expired token is refused,
+ * and the caller sends the invitee on to sign in either way - the pending page is
+ * where an invalid one is finally reported, once there is a session to report it to.
+ */
+export async function stageInvitation(token: string): Promise<boolean> {
+  try {
+    await apiClient.post("/invitations/stage", { token });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Redeem the staged handle and accept the invitation as the signed-in user. */
+export async function acceptStagedInvitation(): Promise<void> {
+  await apiClient.post("/invitations/pending/accept");
+}

--- a/frontend/src/lib/oauth-return.test.ts
+++ b/frontend/src/lib/oauth-return.test.ts
@@ -87,31 +87,22 @@ describe("what an attempt started from this URL should remember", () => {
     expect(returnToForAttempt(url(""))).toBeNull();
   });
 
-  it("keeps the path across a retry, where the URL has lost it", () => {
-    // A failed provider attempt comes back to `/login?error=oauth_failed` with
-    // no `returnTo` on it. Clearing there drops a path nobody abandoned.
+  it("leaves the stored path in place across a retry, rather than rewriting it", () => {
+    // A failed provider attempt comes back to `/login?error=oauth_failed` with no
+    // `returnTo` on it. It answers `undefined` - leave the deep link written before
+    // the attempt alone - rather than reading it back out and storing it again, which
+    // is a clear-text round trip of what the store holds (#1414).
     rememberReturnTo("/agents/a-1");
 
-    expect(returnToForAttempt(url("error=oauth_failed"))).toBe("/agents/a-1");
+    expect(returnToForAttempt(url("error=oauth_failed"))).toBeUndefined();
+
+    rememberReturnTo(returnToForAttempt(url("error=oauth_failed")));
+    expect(takeReturnTo()).toBe("/agents/a-1");
   });
 
-  it("prefers the URL's own deep link over what is stored", () => {
-    rememberReturnTo("/agents/older");
-
+  it("prefers the URL's own deep link over leaving the stored one", () => {
     expect(returnToForAttempt(url("error=oauth_failed&returnTo=/agents/newer"))).toBe(
       "/agents/newer",
     );
-  });
-
-  it("answers with nothing on a retry that never carried one", () => {
-    expect(returnToForAttempt(url("error=oauth_failed"))).toBeNull();
-  });
-
-  it("survives a browser that refuses to be read", () => {
-    vi.spyOn(window.sessionStorage, "getItem").mockImplementation(() => {
-      throw new Error("denied");
-    });
-
-    expect(returnToForAttempt(url("error=oauth_failed"))).toBeNull();
   });
 });

--- a/frontend/src/lib/oauth-return.test.ts
+++ b/frontend/src/lib/oauth-return.test.ts
@@ -37,6 +37,14 @@ describe("carrying a return path across the provider round trip", () => {
     expect(takeReturnTo()).toBe("/invitations/pending");
   });
 
+  it("keeps a pending landing's flow, which is no credential", () => {
+    // The flow names which staging's httpOnly cookie to redeem; without the cookie it
+    // names nothing, and dropping it would leave the tab unable to find its own.
+    rememberReturnTo("/invitations/pending?flow=0123456789abcdef0123456789abcdef");
+
+    expect(takeReturnTo()).toBe("/invitations/pending?flow=0123456789abcdef0123456789abcdef");
+  });
+
   it("forgets an earlier path when there is nothing to remember", () => {
     // A visitor who arrives at /login with a deep link, gives up, and comes
     // back plainly should land on the dashboard rather than where they were

--- a/frontend/src/lib/oauth-return.test.ts
+++ b/frontend/src/lib/oauth-return.test.ts
@@ -28,6 +28,15 @@ describe("carrying a return path across the provider round trip", () => {
     expect(takeReturnTo()).toBeNull();
   });
 
+  it("never stores a raw invitation token, only its staged landing (#1414)", () => {
+    // The token is exchanged for an httpOnly handle before sign-in; a path still
+    // carrying one is replaced with the credential-free pending landing rather than
+    // written to a store a script can read.
+    rememberReturnTo("/invitations/a-live-bearer-token");
+
+    expect(takeReturnTo()).toBe("/invitations/pending");
+  });
+
   it("forgets an earlier path when there is nothing to remember", () => {
     // A visitor who arrives at /login with a deep link, gives up, and comes
     // back plainly should land on the dashboard rather than where they were

--- a/frontend/src/lib/oauth-return.ts
+++ b/frontend/src/lib/oauth-return.ts
@@ -22,6 +22,9 @@
  * of that rule is a second answer to it.
  */
 
+import { ROUTES } from "@/lib/constants";
+import { invitationTokenFrom } from "@/lib/invitation-links";
+
 const KEY = "oauthReturnTo";
 
 /**
@@ -29,11 +32,19 @@ const KEY = "oauthReturnTo";
  *
  * Always one or the other. Leaving a stale value in place is how a second
  * sign-in with no deep link resumes the first one's.
+ *
+ * A credential-bearing invitation deep link is never what gets stored: the token
+ * is exchanged for an `httpOnly` handle before sign-in (#1414), so a path still
+ * carrying one is replaced with its credential-free landing rather than written to
+ * a store a script can read. This is the belt to the exchange's braces - by the
+ * time a value reaches here it should already be `/invitations/pending`, and this
+ * guarantees a raw token cannot land in `sessionStorage` even if one does not.
  */
 export function rememberReturnTo(path: string | null | undefined): void {
   try {
-    if (path) {
-      window.sessionStorage.setItem(KEY, path);
+    const safe = path && invitationTokenFrom(path) ? ROUTES.INVITATION_PENDING : path;
+    if (safe) {
+      window.sessionStorage.setItem(KEY, safe);
     } else {
       window.sessionStorage.removeItem(KEY);
     }

--- a/frontend/src/lib/oauth-return.ts
+++ b/frontend/src/lib/oauth-return.ts
@@ -28,19 +28,22 @@ import { invitationTokenFrom } from "@/lib/invitation-links";
 const KEY = "oauthReturnTo";
 
 /**
- * Remember where to land, or forget a path from an earlier attempt.
+ * Remember a path, forget one, or leave the store as it is.
  *
- * Always one or the other. Leaving a stale value in place is how a second
- * sign-in with no deep link resumes the first one's.
+ * A string is remembered, `null` forgets a stale one (a second sign-in with no
+ * deep link must not resume the first one's), and `undefined` touches nothing -
+ * which is what a retry passes, so the deep link it wrote before the failed attempt
+ * stays without being read back out and written again.
  *
- * A credential-bearing invitation deep link is never what gets stored: the token
- * is exchanged for an `httpOnly` handle before sign-in (#1414), so a path still
- * carrying one is replaced with its credential-free landing rather than written to
- * a store a script can read. This is the belt to the exchange's braces - by the
- * time a value reaches here it should already be `/invitations/pending`, and this
- * guarantees a raw token cannot land in `sessionStorage` even if one does not.
+ * A credential-bearing invitation deep link is never what gets stored: the token is
+ * exchanged for an `httpOnly` handle before sign-in (#1414), so a path still carrying
+ * one is replaced with its credential-free landing rather than written to a store a
+ * script can read. By the time a value reaches here it should already be
+ * `/invitations/pending`; this guarantees a raw token cannot land in `sessionStorage`
+ * even if one does not.
  */
 export function rememberReturnTo(path: string | null | undefined): void {
+  if (path === undefined) return;
   try {
     const safe = path && invitationTokenFrom(path) ? ROUTES.INVITATION_PENDING : path;
     if (safe) {
@@ -55,30 +58,22 @@ export function rememberReturnTo(path: string | null | undefined): void {
 }
 
 /**
- * What an attempt started from this URL should remember.
+ * What an attempt started from this URL should do with the remembered path.
  *
- * `?returnTo=` when the visitor arrived with one. Otherwise nothing - *except*
- * on a retry: a failed provider attempt comes back to `/login?error=…` with the
- * deep link gone from the URL and the one written before the attempt still in
- * storage, so clearing there would drop a path nobody abandoned. Only the OAuth
- * callback and the provider redirect mint that `error`, which is what makes it
- * a reliable "this is the second attempt at the same thing".
+ * `?returnTo=` when the visitor arrived with one - store it. Otherwise clear a
+ * stale one, *except* on a retry: a failed provider attempt comes back to
+ * `/login?error=…` with the deep link gone from the URL and the one written before
+ * the attempt still in storage, so it answers `undefined` there - leave it in place
+ * rather than read it back out and rewrite it. Only the OAuth callback and the
+ * provider redirect mint that `error`, which is what makes it a reliable "this is
+ * the second attempt at the same thing".
  */
 export function returnToForAttempt(search: {
   get: (name: string) => string | null;
-}): string | null {
+}): string | null | undefined {
   const named = search.get("returnTo");
   if (named) return named;
-  return search.get("error") ? peek() : null;
-}
-
-/** Read without consuming - only {@link returnToForAttempt} needs this. */
-function peek(): string | null {
-  try {
-    return window.sessionStorage.getItem(KEY);
-  } catch {
-    return null;
-  }
+  return search.get("error") ? undefined : null;
 }
 
 /** The remembered path, removed as it is read. */


### PR DESCRIPTION
## What this does

A signed-out invitee who followed `/invitations/<token>` carried the raw invitation token — a bearer credential — through the whole sign-in round trip: in the `returnTo` query, in browser history, and (on the OAuth path) in `sessionStorage`, which is the `js/clear-text-storage-of-sensitive-data` alert #20. This exchanges the token away **before** the redirect to login, so it never rides the round trip and never reaches a store a script can read.

**The exchange (backend).** `POST /invitations/stage` (public) validates the token and stores it in Redis under an opaque, single-use handle — the same shape as the OAuth code exchange in `oauth_exchange.py` (a `token_urlsafe(32)` handle, a TTL, an atomic `GETDEL`), so Redis, not a new table or the vault, and a replayed, expired or forged handle is one indistinguishable miss. `POST /invitations/staged/accept` (authenticated) redeems the handle and accepts as the caller, reusing `InvitationService.accept` verbatim so no tenant, email, seat or already-member check is skipped. Both public routes are rate limited per IP. The stage gate refuses a dead token uniformly, because "expired" vs "never existed" on a public endpoint would let a stranger probe which tokens are real.

**The flow (frontend).** `AuthGuard` stages the token and sends the invitee to a credential-free `/invitations/pending` landing; after sign-in that page redeems the handle from its `httpOnly` cookie and accepts. Registration and OAuth sign-up carry the same staged handle — the register proxy forwards it as a header, and OAuth starts same-origin so the `httpOnly` handle can be attached before the cross-origin hop — so an `invite_only` deployment still admits the invitee without the token ever being in a URL or the body. `rememberReturnTo` gains a sanitizer that replaces any token-bearing path with the pending landing before writing to `sessionStorage`, breaking the alert's flow at the sink as well as the source.

## Why the token never leaks now

- The handle rides an `httpOnly` cookie the browser cannot read; the stage response carries only `{staged:true}`.
- `returnTo` is always the credential-free `/invitations/pending` for an invitation, so history and `sessionStorage` hold no token.
- The token lives only server-side after the exchange — in Redis briefly, and in the `accept` call — and is never returned in any response or log (the refusal names nothing).

## Verification

- Backend: `test_invitation_staging.py` (the Redis exchange and the stage gate), `test_invitation_admission.py` (`admits_anyone`, the email-less liveness, at 100%), route tests for stage/staged-accept and the register handle peek, and the platform-routes guard that every open route is declared.
- Frontend: route tests for the three new BFF routes and the register handle forwarding, `invitation-staging` client tests, the `AuthGuard` staging path, the `rememberReturnTo` sanitizer, and the pending accept card — `bun run test:coverage` green (100% lines/statements/functions, branches above the gate).
- An adversarial pass over each half caught a reservation-holder lockout in the staging gate (`admits_anyone` counted a link's reservations against capacity, refusing the very person a slot was reserved for on a re-stage) — fixed to count acceptances only, since staging enforces no ceiling of its own.

## Adversarial review is on

Both halves were reviewed by a fresh subagent per dimension (leakage, enumeration, replay, cross-tenant, open-redirect, the register/OAuth admission paths), findings verified against the code and fixed — the reservation-holder lockout above, a 401 that must not discard an unspent handle cookie, and the reserved `/invitations/pending` landing that the token regex would otherwise read as a token.

## One property worth naming

`POST /invitations/stage` is unauthenticated and sets a cookie from a body token — a login-CSRF-flavoured shape, since an attacker could pre-stage *their* organization's invitation into a victim's cookie. It grants nothing on its own: redeeming still needs the victim to reach `/invitations/pending` and click Accept, at which point they would join the attacker's org as themselves and see it. This is the same exposure the pre-existing `/invitations/<token>` accept flow already had, so it is not a regression, and the accept is a deliberate, visible action.

Closes #1414
