### PR TITLE
fix(email): send mail on the default SMTP config (STARTTLS on 587)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -166,6 +166,9 @@ SMTP_PORT=587
 SMTP_USER=
 SMTP_PASSWORD=
 SMTP_TLS=true
+# auto: the port picks the scheme (465 implicit TLS, otherwise STARTTLS).
+# implicit | starttls: force one, for a server on a non-standard port.
+SMTP_TLS_MODE=auto
 
 # === CORS ===
 # JSON list of allowed origins (default: localhost:3000, localhost:8080)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -8,6 +8,9 @@ from typing import Literal
 from pydantic import Field, computed_field, field_validator, model_validator, ValidationInfo
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+SmtpTlsMode = Literal["auto", "implicit", "starttls"]
+"""How an encrypted SMTP connection is opened: chosen by the port, or forced."""
+
 
 def find_env_file() -> Path | None:
     """Find .env file in current or parent directories."""
@@ -350,6 +353,11 @@ class Settings(BaseSettings):
     SMTP_USER: str = ""
     SMTP_PASSWORD: str = ""
     SMTP_TLS: bool = True
+    # `auto` lets the port choose: 465 opens TLS from the first byte, anything
+    # else upgrades with STARTTLS. A server speaking implicit TLS on a port other
+    # than 465 (8465, 2465) needs `implicit` spelled out, or the provider offers a
+    # plaintext handshake to a TLS socket and every send fails.
+    SMTP_TLS_MODE: SmtpTlsMode = "auto"
     LOG_PROVIDER_WRITE_TO_DISK: bool = False
 
     CORS_ORIGINS: list[str] = [

--- a/backend/app/services/email/__init__.py
+++ b/backend/app/services/email/__init__.py
@@ -24,6 +24,7 @@ def get_email_provider() -> EmailProvider:
                 username=settings.SMTP_USER,
                 password=settings.SMTP_PASSWORD,
                 use_tls=settings.SMTP_TLS,
+                tls_mode=settings.SMTP_TLS_MODE,
             )
         case "log":
             from app.services.email.providers.log import LogProvider

--- a/backend/app/services/email/providers/smtp.py
+++ b/backend/app/services/email/providers/smtp.py
@@ -5,6 +5,7 @@ import uuid
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
+from app.core.config import SmtpTlsMode
 from app.services.email.providers.base import EmailMessage, SendResult
 
 logger = logging.getLogger(__name__)
@@ -27,12 +28,25 @@ class SMTPProvider:
         username: str,
         password: str,
         use_tls: bool = True,
+        tls_mode: SmtpTlsMode = "auto",
     ) -> None:
         self.host = host
         self.port = port
         self.username = username
         self.password = password
         self.use_tls = use_tls
+        self.tls_mode = tls_mode
+
+    def _implicit_tls(self) -> bool:
+        """Whether TLS is opened from the first byte rather than negotiated.
+
+        `auto` reads the port, which is right for the standard ones and wrong for
+        a server speaking implicit TLS somewhere else - there the deployment says
+        `implicit`, or the provider offers a plaintext handshake to a TLS socket.
+        """
+        if self.tls_mode == "auto":
+            return self.port == _IMPLICIT_TLS_PORT
+        return self.tls_mode == "implicit"
 
     async def send(self, message: EmailMessage) -> SendResult:
         import aiosmtplib
@@ -54,7 +68,7 @@ class SMTPProvider:
         msg.attach(MIMEText(message.text, "plain"))
         msg.attach(MIMEText(message.html, "html"))
 
-        implicit_tls = self.use_tls and self.port == _IMPLICIT_TLS_PORT
+        implicit_tls = self.use_tls and self._implicit_tls()
         try:
             await aiosmtplib.send(
                 msg,

--- a/backend/app/services/email/providers/smtp.py
+++ b/backend/app/services/email/providers/smtp.py
@@ -9,6 +9,10 @@ from app.services.email.providers.base import EmailMessage, SendResult
 
 logger = logging.getLogger(__name__)
 
+# 465 is the implicit-TLS submission port; 587 and 25 speak plaintext first and
+# upgrade with STARTTLS, so opening TLS from the start there is refused.
+_IMPLICIT_TLS_PORT = 465
+
 
 class SMTPProvider:
     delivers = True
@@ -50,14 +54,16 @@ class SMTPProvider:
         msg.attach(MIMEText(message.text, "plain"))
         msg.attach(MIMEText(message.html, "html"))
 
+        implicit_tls = self.use_tls and self.port == _IMPLICIT_TLS_PORT
         try:
             await aiosmtplib.send(
                 msg,
                 hostname=self.host,
                 port=self.port,
-                username=self.username,
-                password=self.password,
-                use_tls=self.use_tls,
+                username=self.username or None,
+                password=self.password or None,
+                use_tls=implicit_tls,
+                start_tls=self.use_tls and not implicit_tls,
             )
             msg_id = f"smtp_{uuid.uuid4()}"
             logger.info(

--- a/backend/tests/test_email_provider_factory.py
+++ b/backend/tests/test_email_provider_factory.py
@@ -34,6 +34,14 @@ async def test_smtp_is_selected_by_name(monkeypatch):
     assert isinstance(get_email_provider(), SMTPProvider)
 
 
+async def test_smtp_carries_the_configured_tls_mode(monkeypatch):
+    monkeypatch.setattr("app.services.email.settings.EMAIL_PROVIDER", "smtp")
+    monkeypatch.setattr("app.services.email.settings.SMTP_TLS_MODE", "implicit")
+    provider = get_email_provider()
+    assert isinstance(provider, SMTPProvider)
+    assert provider.tls_mode == "implicit"
+
+
 async def test_the_log_provider_honours_the_write_to_disk_setting(monkeypatch, tmp_path):
     monkeypatch.setattr("app.services.email.settings.EMAIL_PROVIDER", "log")
     monkeypatch.setattr("app.services.email.settings.LOG_PROVIDER_WRITE_TO_DISK", True)

--- a/backend/tests/test_email_smtp_provider.py
+++ b/backend/tests/test_email_smtp_provider.py
@@ -1,0 +1,134 @@
+"""How the SMTP provider negotiates TLS and authentication.
+
+The submission port decides the encryption scheme: 465 opens TLS from the start,
+587 and 25 speak plaintext and upgrade with STARTTLS. The shipped defaults are
+`SMTP_PORT=587` with `SMTP_TLS=true`, so a provider that opened implicit TLS
+there was refused by every standards-compliant server and the deployment sent
+nothing (#1543). And an empty `SMTP_USER` means an unauthenticated relay, not a
+login attempt with a blank username.
+"""
+
+import aiosmtplib
+import pytest
+
+from app.services.email.providers.base import EmailMessage
+from app.services.email.providers.smtp import SMTPProvider
+
+pytestmark = pytest.mark.anyio
+
+
+def _message() -> EmailMessage:
+    return EmailMessage(
+        to=["someone@example.com"],
+        from_email="noreply@example.com",
+        subject="Your invitation",
+        html="<p>hello</p>",
+        text="hello",
+    )
+
+
+def _capture(monkeypatch) -> dict:
+    sent: dict = {}
+
+    async def fake_send(msg, **kwargs):
+        sent.update(kwargs)
+        sent["msg"] = msg
+
+    monkeypatch.setattr(aiosmtplib, "send", fake_send)
+    return sent
+
+
+async def test_the_default_port_upgrades_with_starttls_rather_than_implicit_tls(monkeypatch):
+    sent = _capture(monkeypatch)
+
+    result = await SMTPProvider(host="mail", port=587, username="", password="", use_tls=True).send(
+        _message()
+    )
+
+    assert sent["use_tls"] is False
+    assert sent["start_tls"] is True
+    assert result.accepted is True
+
+
+async def test_the_implicit_tls_port_still_opens_tls_from_the_start(monkeypatch):
+    sent = _capture(monkeypatch)
+
+    await SMTPProvider(host="mail", port=465, username="u", password="p", use_tls=True).send(
+        _message()
+    )
+
+    assert sent["use_tls"] is True
+    assert sent["start_tls"] is False
+
+
+async def test_tls_off_sends_plaintext_and_never_upgrades(monkeypatch):
+    # A local relay on 25 that offers no encryption; forcing STARTTLS would fail.
+    sent = _capture(monkeypatch)
+
+    await SMTPProvider(host="mail", port=25, username="", password="", use_tls=False).send(
+        _message()
+    )
+
+    assert sent["use_tls"] is False
+    assert sent["start_tls"] is False
+
+
+async def test_an_empty_username_relays_unauthenticated(monkeypatch):
+    # aiosmtplib attempts AUTH whenever the username is not None, so a blank one
+    # turns an open relay into a login attempt the server rejects.
+    sent = _capture(monkeypatch)
+
+    await SMTPProvider(host="mail", port=587, username="", password="", use_tls=True).send(
+        _message()
+    )
+
+    assert sent["username"] is None
+    assert sent["password"] is None
+
+
+async def test_configured_credentials_are_passed_through(monkeypatch):
+    sent = _capture(monkeypatch)
+
+    await SMTPProvider(host="mail", port=587, username="me", password="pw", use_tls=True).send(
+        _message()
+    )
+
+    assert sent["username"] == "me"
+    assert sent["password"] == "pw"
+
+
+async def test_the_message_carries_its_optional_headers(monkeypatch):
+    sent = _capture(monkeypatch)
+
+    await SMTPProvider(host="mail", port=587, username="", password="", use_tls=True).send(
+        EmailMessage(
+            to=["someone@example.com"],
+            cc=["watcher@example.com"],
+            from_email="noreply@example.com",
+            from_name="AgenticOS",
+            subject="Your invitation",
+            html="<p>hello</p>",
+            text="hello",
+            reply_to="support@example.com",
+        )
+    )
+
+    msg = sent["msg"]
+    assert msg["From"] == "AgenticOS <noreply@example.com>"
+    assert msg["Cc"] == "watcher@example.com"
+    assert msg["Reply-To"] == "support@example.com"
+
+
+async def test_a_send_failure_is_reported_not_raised(monkeypatch):
+    async def fail(msg, **kwargs):
+        raise aiosmtplib.SMTPConnectError("connection refused")
+
+    monkeypatch.setattr(aiosmtplib, "send", fail)
+
+    result = await SMTPProvider(host="mail", port=587, username="", password="", use_tls=True).send(
+        _message()
+    )
+
+    assert result.accepted is False
+    assert result.provider_message_id == ""
+    assert "connection refused" in (result.error or "")

--- a/backend/tests/test_email_smtp_provider.py
+++ b/backend/tests/test_email_smtp_provider.py
@@ -6,6 +6,10 @@ The submission port decides the encryption scheme: 465 opens TLS from the start,
 there was refused by every standards-compliant server and the deployment sent
 nothing (#1543). And an empty `SMTP_USER` means an unauthenticated relay, not a
 login attempt with a blank username.
+
+The port rule is a default, not a law: a server speaking implicit TLS on a
+non-standard port would be handed a plaintext handshake under it, so
+`SMTP_TLS_MODE` forces either scheme when the port does not say.
 """
 
 import aiosmtplib
@@ -68,6 +72,40 @@ async def test_tls_off_sends_plaintext_and_never_upgrades(monkeypatch):
     await SMTPProvider(host="mail", port=25, username="", password="", use_tls=False).send(
         _message()
     )
+
+    assert sent["use_tls"] is False
+    assert sent["start_tls"] is False
+
+
+async def test_implicit_mode_opens_tls_from_the_start_on_a_non_standard_port(monkeypatch):
+    sent = _capture(monkeypatch)
+
+    await SMTPProvider(
+        host="mail", port=8465, username="", password="", use_tls=True, tls_mode="implicit"
+    ).send(_message())
+
+    assert sent["use_tls"] is True
+    assert sent["start_tls"] is False
+
+
+async def test_starttls_mode_negotiates_the_upgrade_even_on_465(monkeypatch):
+    sent = _capture(monkeypatch)
+
+    await SMTPProvider(
+        host="mail", port=465, username="", password="", use_tls=True, tls_mode="starttls"
+    ).send(_message())
+
+    assert sent["use_tls"] is False
+    assert sent["start_tls"] is True
+
+
+@pytest.mark.parametrize("tls_mode", ["auto", "implicit", "starttls"])
+async def test_tls_off_is_plaintext_whatever_the_mode_says(monkeypatch, tls_mode):
+    sent = _capture(monkeypatch)
+
+    await SMTPProvider(
+        host="mail", port=8465, username="", password="", use_tls=False, tls_mode=tls_mode
+    ).send(_message())
 
     assert sent["use_tls"] is False
     assert sent["start_tls"] is False

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -184,7 +184,8 @@ them announcing itself:
 | `SMTP_PORT` | `587` | SMTP server port. `587` and `25` negotiate STARTTLS; `465` opens TLS from the start |
 | `SMTP_USER` | (empty) | Username the relay authenticates with, alongside `SMTP_PASSWORD`. Leave empty for an unauthenticated relay |
 | `SMTP_PASSWORD` | (empty) | Password for that username |
-| `SMTP_TLS` | `true` | Whether to encrypt the connection. The port decides how — STARTTLS on `587`, implicit TLS on `465`. Set `false` only for an unencrypted relay, such as a local server on `25` |
+| `SMTP_TLS` | `true` | Whether to encrypt the connection. The port picks the scheme — STARTTLS on `587`, implicit TLS on `465` — unless `SMTP_TLS_MODE` says otherwise. Set `false` only for an unencrypted relay, such as a local server on `25` |
+| `SMTP_TLS_MODE` | `auto` | How the encrypted connection is opened. `auto` lets the port choose; `implicit` opens TLS from the first byte and `starttls` negotiates the upgrade, whatever the port. Ignored when `SMTP_TLS=false` |
 | `EMAIL_FROM` | `noreply@agenticos.com` | The `From` address on every message |
 | `EMAIL_FROM_NAME` | `agenticos` | The display name shown beside that address |
 
@@ -194,6 +195,10 @@ them announcing itself:
     default — `587` with `SMTP_TLS=true` — negotiates STARTTLS, which is what a
     standards-compliant submission server expects. Use `465` for a server that
     wants implicit TLS instead, and `SMTP_TLS=false` on `25` for a plaintext relay.
+
+    A server that speaks implicit TLS on a port other than `465` — `8465`, say —
+    needs `SMTP_TLS_MODE=implicit`, because `auto` would offer it a plaintext
+    handshake and every send would fail. `starttls` is the mirror case.
 
 ## Background work (Prefect)
 


### PR DESCRIPTION
## What this does

The shipped SMTP defaults could not send a single message, so on a deployment configured exactly as documented every mail-dependent flow failed silently: passwordless sign-in, password resets, invitations, and every notification (budget breach, approval request, usage report, impersonation notice).

Two independent defects, both in `app/services/email/providers/smtp.py`:

- **Implicit TLS on the STARTTLS port.** `SMTP_PORT` defaults to `587` — the STARTTLS submission port — but `SMTP_TLS=true` mapped straight to `aiosmtplib`'s `use_tls`, which opens TLS from the first byte. A standards-compliant server on `587` speaks plaintext first and expects a STARTTLS upgrade, so it rejects the handshake. The provider now **derives the scheme from the port**: `465` opens implicit TLS, `587` and `25` negotiate STARTTLS, and `SMTP_TLS=false` stays plaintext. The broken pair is designed out rather than caught by a validator, and `465` implicit TLS still works.
- **Empty `SMTP_USER` attempted AUTH.** `aiosmtplib` tries to authenticate whenever the username is not `None`, so a blank one turned an open relay into a login the server refused. Empty credentials now pass as `None` — an unauthenticated relay, which is what an unset user means.

## Verification

- New `tests/test_email_smtp_provider.py` asserts the actual `aiosmtplib.send` kwargs: STARTTLS on the default `587`, implicit TLS still on `465`, plaintext on `25`, the unauthenticated relay when `SMTP_USER` is empty, configured credentials passed through, and a connection failure reported (not raised). `smtp.py` is not in the coverage gate, but the change carries it to 100% locally.
- `make lint` targets on the changed files pass (ruff, ruff format, ty, vulture, guards); the wider backend email/deployment suites stay green.

## Docs

The SMTP settings section is introduced by the sibling docs PR #1542 (`docs/1482-smtp-settings`), and that section is where this behaviour is documented — so the doc correction (drop the "defaults do not send mail" warning, document `SMTP_TLS` as the encrypt on/off switch the port interprets) lives there rather than duplicating the section here. Merge order is safe either way: `main` gains the SMTP section only when #1542 lands, and by then it already describes the fixed behaviour.

Closes #1543
