### PR TITLE
chore: cut 0.0.382

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.382] - 2026-09-10
+
+### Fixed
+
+- **A departed member's linked chat account no longer costs a transcription
+  before it is refused.** The router read the membership only at the run, after
+  the message's attachments had been fetched, stored and a voice note billed to
+  the organization's transcription credential. A direct message now reads the
+  membership first; a linked identity whose member is gone is treated as
+  unlinked from that point, and the invite-on-refusal path is rate limited.
+  (#1500)
+
 ## [0.0.381] - 2026-09-10
 
 ### Security

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.381"
+version = "0.0.382"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.381"
+version = "0.0.382"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.381",
+  "version": "0.0.382",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.382: version, lock and changelog only.

Ships #1500 - fix(channels): refuse a departed linked sender before storing files.
