### PR TITLE
chore: cut 0.0.383

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.383] - 2026-09-10
+
+### Fixed
+
+- **`/new` and `/unlink` honour the room's link requirement.** Commands ran
+  before identity resolution and the admission gate, so an unlinked participant
+  in a link-required room could reset the shared conversation. Both now take the
+  same admission the turn takes; `/start`, `/help` and `/link` stay open, and
+  `/new` attributes the new conversation to whoever issued it rather than to the
+  room's first speaker. (#1502)
+
 ## [0.0.382] - 2026-09-10
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.382"
+version = "0.0.383"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.382"
+version = "0.0.383"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.382",
+  "version": "0.0.383",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.383: version, lock and changelog only.

Ships #1502 - fix(channels): gate /new and /unlink on the same link admission.
