### PR TITLE
chore: cut 0.0.384

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.384] - 2026-09-10
+
+### Fixed
+
+- **A crash on a mention answers the same apology a crash on a direct message
+  does.** The mention path and the default path ran the same turn as two copies
+  that had drifted: a crash on a mention propagated, released the dedupe claim
+  and answered nothing while the platform redelivered it. Both paths now run
+  through one `_run_turn`, which apologises once and keeps the claim, posts a
+  refusal wherever the bot was addressed, and discards a crashed turn's files
+  instead of orphaning them. (#1508)
+
 ## [0.0.383] - 2026-09-10
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.383"
+version = "0.0.384"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.383"
+version = "0.0.384"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.383",
+  "version": "0.0.384",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.384: version, lock and changelog only.

Ships #1508 - refactor(channels): run both turn paths through one _run_turn.
