### PR TITLE
chore: cut 0.0.385

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.385] - 2026-09-10
+
+### Performance
+
+- **A spec's references resolve in one query, not one each.** Publish validation
+  of collections, MCP connections and delegates, the MCP toolset build and the
+  environment listing each read their list of ids a row at a time. Each now reads
+  the whole list in one query with the same tenant and scope filters, so the
+  refusals are unchanged and preparing a run with five bound collections awaits
+  the collection read once. (#1510)
+
 ## [0.0.384] - 2026-09-10
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.384"
+version = "0.0.385"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.384"
+version = "0.0.385"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.384",
+  "version": "0.0.385",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.385: version, lock and changelog only.

Ships #1510 - perf(agents): resolve a spec's references in one query, not one each.
