### PR TITLE
chore: cut 0.0.386

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.386] - 2026-09-10
+
+### Changed
+
+- **The 2026-08-10 backend duplication audit is closed.** `InvitationCreate.email`
+  carries the `max_length` its siblings do, `RAGCollectionList` and
+  `ConnectorList` carry `total`, `doctor` and the agent runner drop their `Any`
+  parameters, the owner-or-org-or-shared visibility predicate is one helper
+  shared by skills and knowledge bases, the MCP tool-prefix normaliser has a
+  parity fixture between backend and frontend, `get_agent` and `get_version`
+  validate the Read schema rather than hand-mapping fields, and
+  `parent_doc_id` reaches the vector store as a typed argument. The chat socket
+  now sends `cost_usd` as the same Decimal string every REST surface does.
+  (#1511)
+
 ## [0.0.385] - 2026-09-10
 
 ### Performance

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.385"
+version = "0.0.386"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.385"
+version = "0.0.386"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.385",
+  "version": "0.0.386",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.386: version, lock and changelog only.

Ships #1511 - refactor: close the 2026-08-10 backend duplication and quality audit.
