### PR TITLE
chore: cut 0.0.387

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.387] - 2026-09-10
+
+### Fixed
+
+- **A thread backfill under a link-required policy quotes linked members
+  only.** Under `jwt_linked` and `require_link` the backfill filtered earlier
+  authors only in whitelist mode, so an unlinked participant's earlier posts
+  reached the prompt the first time a linked member spoke. Authors are now
+  resolved in one query to accounts linked to an active member of the bot's
+  organization; everyone else is dropped, as the whitelist branch already did.
+  (#1513)
+
 ## [0.0.386] - 2026-09-10
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.386"
+version = "0.0.387"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.386"
+version = "0.0.387"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.386",
+  "version": "0.0.387",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.387: version, lock and changelog only.

Ships #1513 - fix(channels): filter backfilled authors under a link-required policy.
