### PR TITLE
chore: cut 0.0.388

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.388] - 2026-09-10
+
+### Performance
+
+- **The dashboard window's slices come from one scan, not five.** The day
+  buckets and the surface, status, model and provider splits were five aggregate
+  queries over the same rows; they are one `GROUPING SETS` query now, with a
+  `GROUPING` flag telling a genuine `NULL` model apart from a row that is not
+  that slice. The composed usage response issues four `agent_runs` queries
+  instead of eight, and a test counts them so the next dimension cannot become a
+  ninth. (#1514)
+
 ## [0.0.387] - 2026-09-10
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.387"
+version = "0.0.388"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.387"
+version = "0.0.388"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.387",
+  "version": "0.0.388",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.388: version, lock and changelog only.

Ships #1514 - perf(dashboard): read a window's slices in one scan, not five.
