### PR TITLE
chore: cut 0.0.389

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.389] - 2026-09-10
+
+### Fixed
+
+- **The Agents "?" walk offers to create an agent again.** The offer at the end
+  of the first-run tour is suppressed for an organization that already has an
+  agent, and that suppression also swallowed the offer at the end of the Agents
+  help walk - the walk whose whole point is asking to build one. The count gate
+  now applies only to the tour; a "?" replay offers regardless. (#1515)
+
 ## [0.0.388] - 2026-09-10
 
 ### Performance

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.388"
+version = "0.0.389"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.388"
+version = "0.0.389"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.388",
+  "version": "0.0.389",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.389: version, lock and changelog only.

Ships #1515 - fix(onboarding): keep the Agents "?" walk offering create-agent.
