### PR TITLE
chore: cut 0.0.390

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.390] - 2026-09-10
+
+### Security
+
+- **An unlinked channel guest can no longer borrow the owner's personal MCP
+  connections.** On the publisher-fallback admission an unidentified visitor
+  runs under the binding's publisher, and personal-MCP resolution fell back to
+  the owner - so an anonymous guest could reach a third-party MCP server with
+  the publisher's connected-account credentials. Resolution is now gated on the
+  subject being a real person, on a fresh run and on a resume, where the fact
+  is carried in the parked terms. `docs/mcp.md` already said so. (#1524)
+
 ## [0.0.389] - 2026-09-10
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.389"
+version = "0.0.390"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.389"
+version = "0.0.390"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.389",
+  "version": "0.0.390",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.390: version, lock and changelog only.

Ships #1524 - fix(mcp): stop an unlinked guest borrowing the owner's personal MCP.
