### PR TITLE
chore: cut 0.0.391

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.391] - 2026-09-10
+
+### Fixed
+
+- **A tracing token is validated at publish.** `observability.token_secret_id`
+  was the one credential reference publish validation never checked, so a
+  wrong-kind or cross-tenant id published fine and the agent ran untraced. It
+  now runs through the same existence, tenant and kind checks a capability's
+  secret gets. (#1535)
+- **`spec_version` is read, not only written.** An imported YAML whose
+  `spec_version` is newer than this deployment's is refused, and publish stamps
+  the deployment's `SPEC_VERSION` onto the frozen copy. A stored spec is
+  unaffected. (#1535)
+- **The Slack Socket Mode client is closed on every session exit.** A cancel or
+  a crash-reconnect orphaned the aiohttp session, the WSS connection and the
+  listener; `_run_socket_mode` now closes the client in a `finally`, as
+  Mattermost's stream already did. (#1535)
+
 ## [0.0.390] - 2026-09-10
 
 ### Security

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.390"
+version = "0.0.391"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.390"
+version = "0.0.391"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.390",
+  "version": "0.0.391",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.391: version, lock and changelog only.

Ships #1535 - fix: validate tracing tokens, stamp spec_version, close Slack socket.
