### PR TITLE
chore: cut 0.0.392

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.392] - 2026-09-10
+
+### Security
+
+- **Revoking a session closes its open chat.** A chat WebSocket authenticated
+  once, at the handshake, and was served for its whole life - an impersonation
+  ended or an account suspended mid-conversation kept answering until the
+  client hung up. The session re-validates the handshake credential before
+  every incoming frame and, on a refusal, cancels the in-flight turn and closes
+  the socket with `4001`. A turn already streaming finishes; the revocation
+  lands on the next frame. A merely expired access token is tolerated, so a
+  live socket outlives its thirty-minute token as before. (#1536)
+
 ## [0.0.391] - 2026-09-10
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.391"
+version = "0.0.392"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.391"
+version = "0.0.392"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.391",
+  "version": "0.0.392",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.392: version, lock and changelog only.

Ships #1536 - fix(chat): close a chat socket when its session is revoked.
