### PR TITLE
chore: cut 0.0.393

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.393] - 2026-09-10
+
+### Changed
+
+- **The `orgs/**`, `me/**` and `admin/**` forwarders are `platformProxy`
+  mounts.** Twenty-odd hand-rolled route files each repeated the cookie check,
+  the bearer, the error mapping and the JSON response, and silently dropped the
+  active-organization header, byte-accurate bodies and `no-store`. They are
+  one-line mounts now, about 1200 lines fewer. Admin routes drop a redundant
+  frontend pre-check the backend's `CurrentAppAdmin` already enforces, and the
+  whole query string is forwarded, which fixes the users table's dropped
+  `sort_by` and `sort_dir`. The avatar, integrations, OAuth callback and
+  impersonate routes stay hand-rolled because each does something a plain
+  forward cannot. (#1539)
+
 ## [0.0.392] - 2026-09-10
 
 ### Security

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.392"
+version = "0.0.393"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.392"
+version = "0.0.393"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.392",
+  "version": "0.0.393",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.393: version, lock and changelog only.

Ships #1539 - refactor(api): collapse the orgs/me/admin forwarders into platformProxy.
