### PR TITLE
chore: cut 0.0.394

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.394] - 2026-09-10
+
+### Fixed
+
+- **The lifespan drain test no longer flakes on a shared event loop.** Shutdown
+  closes three module-global httpx clients; two were stubbed and the web
+  research client was not, so under xdist the test closed a client another
+  worker's loop had opened and raised `Event loop is closed`. All three are
+  stubbed now. (#1541)
+
 ## [0.0.393] - 2026-09-10
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.393"
+version = "0.0.394"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.393"
+version = "0.0.394"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.393",
+  "version": "0.0.394",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.394: version, lock and changelog only.

Ships #1541 - test(lifespan): stub the web-research client the drain test still closed.
