### PR TITLE
chore: cut 0.0.395

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.395] - 2026-09-10
+
+### Changed
+
+- **A connector's config is described as JSON Schema, like a capability's.**
+  Each connector declares a Pydantic `CONFIG_MODEL` and the listing publishes
+  its `model_json_schema()`; the required-field check derives from the model,
+  and a placeholder default is marked on the model rather than by a frontend
+  adapter. `ConnectorConfigField`, `ConnectorFieldType` and the
+  `connectorConfigToJsonSchema` bridge are gone; the wizard hands the schema to
+  `SchemaForm` unadapted. Stored connector configs are untouched. (#1538)
+
 ## [0.0.394] - 2026-09-10
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.394"
+version = "0.0.395"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.394"
+version = "0.0.395"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.394",
+  "version": "0.0.395",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.395: version, lock and changelog only.

Ships #1538 - refactor(rag): converge connector config onto JSON Schema.
