### PR TITLE
chore: cut 0.0.397

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.397] - 2026-09-10
+
+### Fixed
+
+- **The default SMTP configuration sends mail.** `SMTP_PORT` defaults to `587`,
+  the STARTTLS port, but `SMTP_TLS=true` opened implicit TLS from the first
+  byte, so a server configured exactly as documented refused every handshake
+  and passwordless sign-in, password resets, invitations and every notification
+  failed silently. The scheme now follows the port - `465` implicit TLS, `587`
+  and `25` STARTTLS, `SMTP_TLS=false` plaintext - and an empty `SMTP_USER` is an
+  unauthenticated relay rather than a refused login. A server that speaks
+  implicit TLS on a non-standard port sets `SMTP_TLS_MODE=implicit`
+  (`starttls` forces the other scheme; `auto`, the default, keeps the port
+  rule). (#1548)
+
 ## [0.0.396] - 2026-09-10
 
 ### Security

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.396"
+version = "0.0.397"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.396"
+version = "0.0.397"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.396",
+  "version": "0.0.397",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.397: version, lock and changelog only.

Ships #1548 - fix(email): send mail on the default SMTP config (STARTTLS on 587).
