### PR TITLE
fix(agents): hold the stale-reference notice until its lists load

### DIFF
--- a/frontend/src/app/[locale]/(dashboard)/agents/[id]/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/agents/[id]/page.tsx
@@ -179,13 +179,23 @@ export default function AgentBuilderPage({ params }: PageProps) {
   // The Builder holds the set rather than paging it: the gallery has to know
   // which selected skills still exist, and it can only tell that from what it
   // has. 100 is the endpoint's ceiling; `total` says when that is not all.
-  const { skills, total: skillCount, isLoading: skillsLoading } = useSkills({ limit: 100 });
+  const {
+    skills,
+    total: skillCount,
+    isLoading: skillsLoading,
+    error: skillsError,
+  } = useSkills({ limit: 100 });
   const {
     files: contextFiles,
     total: contextCount,
     isLoading: contextLoading,
+    error: contextError,
   } = useContextFiles({ limit: 100 });
-  const { kbs: collections, isLoading: collectionsLoading } = useKnowledgeBases();
+  const {
+    kbs: collections,
+    isLoading: collectionsLoading,
+    listError: collectionsError,
+  } = useKnowledgeBases();
   // Only the newest, and only for the number below: the history card pages the
   // rest itself, so a page that fetched fifty to read one would be fetching a
   // list nothing on it renders.
@@ -200,6 +210,7 @@ export default function AgentBuilderPage({ params }: PageProps) {
     connections: mcpConnections,
     test: probeMcpConnection,
     isLoading: connectionsLoading,
+    error: connectionsError,
   } = useOrgMcpConnections();
   const [connectingServer, setConnectingServer] = useState<McpCatalogEntry | null>(null);
   const [toolPicker, setToolPicker] = useState<ToolPickerState | null>(null);
@@ -209,7 +220,7 @@ export default function AgentBuilderPage({ params }: PageProps) {
   const [toolBinding, setToolBinding] = useState<string | null>(null);
   const { exposures } = useExposures(id);
   const { embeds } = useEmbeds(id);
-  const { servers: mcpCatalog, isLoading: catalogLoading } = useMcpCatalog();
+  const { servers: mcpCatalog, isLoading: catalogLoading, error: catalogError } = useMcpCatalog();
   const selectAgentForChat = useAgentSelectionStore((state) => state.select);
   const resetConversation = useConversationStore((state) => state.reset);
 
@@ -251,15 +262,22 @@ export default function AgentBuilderPage({ params }: PageProps) {
   const canPublish = can(Perm.agentsPublish);
 
   // The stale-reference check reads a reference as dead when its id is absent
-  // from a list, so it must not run until every list it consults has answered:
-  // each defaults to `[]` while loading, and "still loading" would otherwise
-  // read as "the organization has none".
+  // from a list, so it must not run until every list it consults has *succeeded*:
+  // each defaults to `[]` while loading and stays `[]` when the request fails, so
+  // gating on "no longer loading" alone would still declare every reference stale
+  // when a list 403s - which the org-connections read does for an editor without
+  // `connections:manage` (#1472).
   const referenceListsLoaded =
     !collectionsLoading &&
+    !collectionsError &&
     !contextLoading &&
+    !contextError &&
     !skillsLoading &&
+    !skillsError &&
     !connectionsLoading &&
-    !catalogLoading;
+    !connectionsError &&
+    !catalogLoading &&
+    !catalogError;
 
   // A builder who cannot add a model, in an organization that has none, can
   // create a draft they can never make work. Both halves are read from a

--- a/frontend/src/app/[locale]/(dashboard)/agents/[id]/page.tsx
+++ b/frontend/src/app/[locale]/(dashboard)/agents/[id]/page.tsx
@@ -179,9 +179,13 @@ export default function AgentBuilderPage({ params }: PageProps) {
   // The Builder holds the set rather than paging it: the gallery has to know
   // which selected skills still exist, and it can only tell that from what it
   // has. 100 is the endpoint's ceiling; `total` says when that is not all.
-  const { skills, total: skillCount } = useSkills({ limit: 100 });
-  const { files: contextFiles, total: contextCount } = useContextFiles({ limit: 100 });
-  const { kbs: collections } = useKnowledgeBases();
+  const { skills, total: skillCount, isLoading: skillsLoading } = useSkills({ limit: 100 });
+  const {
+    files: contextFiles,
+    total: contextCount,
+    isLoading: contextLoading,
+  } = useContextFiles({ limit: 100 });
+  const { kbs: collections, isLoading: collectionsLoading } = useKnowledgeBases();
   // Only the newest, and only for the number below: the history card pages the
   // rest itself, so a page that fetched fifty to read one would be fetching a
   // list nothing on it renders.
@@ -192,7 +196,11 @@ export default function AgentBuilderPage({ params }: PageProps) {
   // is refused at publish, so offering one would be offering a choice that
   // cannot be published. `useMcpCatalog` only supplies the names and logos -
   // the ids the spec stores belong to the connections.
-  const { connections: mcpConnections, test: probeMcpConnection } = useOrgMcpConnections();
+  const {
+    connections: mcpConnections,
+    test: probeMcpConnection,
+    isLoading: connectionsLoading,
+  } = useOrgMcpConnections();
   const [connectingServer, setConnectingServer] = useState<McpCatalogEntry | null>(null);
   const [toolPicker, setToolPicker] = useState<ToolPickerState | null>(null);
   // Which binding the open tool picker narrows, by `bindingKey`. Kept beside the
@@ -201,7 +209,7 @@ export default function AgentBuilderPage({ params }: PageProps) {
   const [toolBinding, setToolBinding] = useState<string | null>(null);
   const { exposures } = useExposures(id);
   const { embeds } = useEmbeds(id);
-  const { servers: mcpCatalog } = useMcpCatalog();
+  const { servers: mcpCatalog, isLoading: catalogLoading } = useMcpCatalog();
   const selectAgentForChat = useAgentSelectionStore((state) => state.select);
   const resetConversation = useConversationStore((state) => state.reset);
 
@@ -241,6 +249,17 @@ export default function AgentBuilderPage({ params }: PageProps) {
 
   const canEdit = can(Perm.agentsEdit);
   const canPublish = can(Perm.agentsPublish);
+
+  // The stale-reference check reads a reference as dead when its id is absent
+  // from a list, so it must not run until every list it consults has answered:
+  // each defaults to `[]` while loading, and "still loading" would otherwise
+  // read as "the organization has none".
+  const referenceListsLoaded =
+    !collectionsLoading &&
+    !contextLoading &&
+    !skillsLoading &&
+    !connectionsLoading &&
+    !catalogLoading;
 
   // A builder who cannot add a model, in an organization that has none, can
   // create a draft they can never make work. Both halves are read from a
@@ -990,6 +1009,7 @@ export default function AgentBuilderPage({ params }: PageProps) {
         skillTotal={skillCount}
         connections={mcpConnections}
         catalog={mcpCatalog}
+        loaded={referenceListsLoaded}
         onRemove={update}
         disabled={!canEdit}
       />

--- a/frontend/src/components/agents/stale-references.test.tsx
+++ b/frontend/src/components/agents/stale-references.test.tsx
@@ -33,6 +33,7 @@ const KNOWN = {
   skillTotal: 1,
   connections: [CONNECTION],
   catalog: [NOTION],
+  loaded: true,
 };
 
 describe("staleReferences", () => {
@@ -74,6 +75,35 @@ describe("staleReferences", () => {
     });
   });
 
+  it("declares nothing stale before the lists it checks have answered", () => {
+    // Every list defaults to [] while its query loads, so a reference checked
+    // against one then reads as deleted; the notice flashed on every page load.
+    const stale = spec({
+      collection_ids: ["kb-gone"],
+      context_ids: ["ctx-gone"],
+      skill_ids: ["sk-gone"],
+      mcp_servers: [{ account: "organization", connection_id: "c-gone", allowed_tools: null }],
+    });
+
+    expect(
+      staleReferences(stale, {
+        collections: [],
+        contextFiles: [],
+        contextTotal: 0,
+        skills: [],
+        skillTotal: 0,
+        connections: [],
+        catalog: [],
+        loaded: false,
+      }),
+    ).toEqual({
+      collection_ids: [],
+      context_ids: [],
+      skill_ids: [],
+      mcp_servers: [],
+    });
+  });
+
   it("declares nothing stale from one page of a longer list", () => {
     // The Builder loads a hundred context files and skills; an organization with
     // more than that has ids this page cannot see, and "not on this page" is not
@@ -93,6 +123,25 @@ describe("StaleReferences", () => {
   it("renders nothing for a draft whose references all resolve", () => {
     const { container } = render(
       <StaleReferences spec={spec({ collection_ids: ["kb-1"] })} onRemove={vi.fn()} {...KNOWN} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing while the lists are still loading", () => {
+    const { container } = render(
+      <StaleReferences
+        spec={spec({ collection_ids: ["kb-gone"] })}
+        onRemove={vi.fn()}
+        collections={[]}
+        contextFiles={[]}
+        contextTotal={0}
+        skills={[]}
+        skillTotal={0}
+        connections={[]}
+        catalog={[]}
+        loaded={false}
+      />,
     );
 
     expect(container).toBeEmptyDOMElement();

--- a/frontend/src/components/agents/stale-references.tsx
+++ b/frontend/src/components/agents/stale-references.tsx
@@ -19,6 +19,13 @@ interface StaleReferencesProps {
   skillTotal: number;
   connections: Row[];
   catalog: { key: string }[];
+  /**
+   * Whether every list the check consults has answered. Each of them defaults to
+   * `[]` while its query loads, and an absent list is indistinguishable from an
+   * empty one - so a reference is checked against the whole set only once it is
+   * whole, never against a list that is merely still loading.
+   */
+  loaded: boolean;
   /** The spec with the stale references taken out, for the caller to save. */
   onRemove: (changes: Partial<AgentSpec>) => void;
   disabled?: boolean;
@@ -45,6 +52,9 @@ export function staleReferences(
   spec: AgentSpec,
   known: Omit<StaleReferencesProps, "spec" | "onRemove" | "disabled">,
 ): StaleReferenceSet {
+  if (!known.loaded) {
+    return { collection_ids: [], context_ids: [], skill_ids: [], mcp_servers: [] };
+  }
   const collections = new Set(known.collections.map((one) => one.id));
   const contextFiles = new Set(known.contextFiles.map((one) => one.id));
   const skills = new Set(known.skills.map((one) => one.id));

--- a/frontend/src/hooks/use-mcp-servers.ts
+++ b/frontend/src/hooks/use-mcp-servers.ts
@@ -18,12 +18,12 @@ import { useOrgMcpConnections } from "./use-org-mcp-connections";
  * it is redeployed, not while someone is reading it.
  */
 export function useMcpCatalog() {
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, error } = useQuery({
     queryKey: qk.mcpServers.catalog(),
     queryFn: () => apiClient.get<McpCatalog>("/agents/mcp-catalog"),
     staleTime: Infinity,
   });
-  return { servers: data?.items ?? [], isLoading };
+  return { servers: data?.items ?? [], isLoading, error };
 }
 
 /** What one page of the server list holds. */


### PR DESCRIPTION
## What this fixes

Opening or refreshing any agent whose spec references a collection, context file, skill or MCP connection flashed the orange stale-reference banner above the tabs for about a second:

> This draft still references … this organization no longer has. Publishing is refused until they are cleared.

Nothing was actually stale. `staleReferences` reads a reference as dead when its id is absent from a list — but each list it consults (`useKnowledgeBases`, `useContextFiles`, `useSkills`, `useOrgMcpConnections`, `useMcpCatalog`) defaults to `[]` while its query loads, so on first paint every reference resolved to nothing, the banner rendered, and it unmounted once the queries answered. The `contextComplete = contextTotal <= contextFiles.length` guard the file already had did not close it either: `0 <= 0` holds while loading.

It mattered more than a flicker: the banner is in the alarm colour, accuses the agent's configuration on every load, and carries the button that strips those references from the draft — so a fast click during the flash would have removed **live** references.

## The change

- `staleReferences` takes a `loaded` flag and computes nothing (returns an empty set) until every list it consults has answered. Absent-because-still-loading is no longer read as absent-because-deleted.
- `agents/[id]/page.tsx` derives `loaded` from the five hooks' `isLoading` and passes it to `StaleReferences`.

A genuinely deleted reference still surfaces, once the lists are whole.

## Verification

- `stale-references.test.tsx`: added a function-level case (genuinely stale ids report nothing while `loaded: false`) and a component-level case (renders nothing while loading); the existing "still names a deleted collection/file/skill/connection once loaded" cases stay green. 8/8 pass, the changed file at 100% lines/statements/functions.
- `tsc`, `eslint`, `prettier` and the i18n guard pass (pre-commit).

Closes #1472
