### PR TITLE
test(sandboxes): settle the auto-probe before asserting a store failure

### DIFF
--- a/frontend/src/components/sandboxes/connection-dialog.test.tsx
+++ b/frontend/src/components/sandboxes/connection-dialog.test.tsx
@@ -495,6 +495,12 @@ describe("ConnectionDialog", () => {
         throw new Error("This deployment carries no sandbox service token");
       });
       const { onSubmit } = mount();
+      // The local-token address debounces a probe on open, and the start of a
+      // probe clears the same failure state a save reports through. Let it fire
+      // and settle first - its inputs do not change here, so it never re-runs -
+      // or under a slow run it clears the store failure after the save set it
+      // and the message is gone (#1471).
+      await waitFor(() => expect(state.probe).toHaveBeenCalled());
       await userEvent.type(screen.getByLabelText("Name"), "Local Docker");
 
       await userEvent.click(screen.getByRole("button", { name: "Add connection" }));


### PR DESCRIPTION
## The flake

`connection-dialog.test.tsx > … > the token this deployment already holds > says why storing it failed rather than creating a connection without it` passed on its own (44/44) and failed under the full `make test-frontend-cov` run:

```
Unable to find an element with the text: This deployment carries no sandbox service token
```

## Why

The failing case sets up the local-service path (`token_available: true`), which is what makes the dialog store the deployment's own token on submit. That same path also debounces a probe when the dialog opens — `setTimeout(() => void ask(), 600)` — and `ask()` begins by clearing the failure state a save also reports through (`setFailure(NO_FAILURE)`, `connection-dialog.tsx:186`). The probe and the save share one `failure` channel.

On a fast solo run the whole case finishes inside 600ms and the timer is cleared on unmount, so the probe never fires. On a loaded full run — coverage instrumentation slows every interaction — typing the name and clicking crosses 600ms, the probe fires **after** the save set its failure, and clears the very message the assertion is waiting for. This is the timer/microtask class of flake `docs/testing.md` already documents for this suite's neighbours, not a mocked rejection leaking between files.

## The fix

The case now waits for that debounced probe to fire (`await waitFor(() => expect(state.probe).toHaveBeenCalled())`) before it submits. The probe's inputs (address, credential) do not change afterwards, so the effect never re-runs and never schedules a second timer, and the save's failure is the last write to the shared state. The order is made deterministic rather than hidden.

No timeout was raised and `--no-file-parallelism` was not added, per the issue's acceptance criteria. Only this one case asserts a save failure while the local-token auto-probe is pending; the other failure-asserting cases open with `editing` set, which disables the local service and its probe.

## Verification

- The file alone: 44/44.
- The full `bun run test:coverage` (the run the flake appeared in, coverage instrumentation and all): **green twice in a row**, 6131/6131, branch coverage 97.71% ≥ the 97.5% gate. The fix removes the timing dependency, so load no longer decides the outcome.

Closes #1471
