### PR TITLE
fix(agents): stop telling a signed-in API caller that nobody is signed in

### DIFF
--- a/backend/app/services/agent_runner.py
+++ b/backend/app/services/agent_runner.py
@@ -1327,7 +1327,11 @@ def personal_service_gap(unavailable: UnavailablePersonalService) -> PersonalSer
 
 
 def _with_personal_service_gaps(
-    spec: AgentSpec, gaps: Sequence[UnavailablePersonalService], surface: RunSurface
+    spec: AgentSpec,
+    gaps: Sequence[UnavailablePersonalService],
+    surface: RunSurface,
+    *,
+    sender_present: bool = False,
 ) -> AgentSpec:
     """The spec told which personal services this turn cannot reach, and why.
 
@@ -1341,11 +1345,16 @@ def _with_personal_service_gaps(
     """
     if not gaps:
         return spec
-    added = "\n\n".join(_personal_gap_briefing(personal_service_gap(gap), surface) for gap in gaps)
+    added = "\n\n".join(
+        _personal_gap_briefing(personal_service_gap(gap), surface, sender_present=sender_present)
+        for gap in gaps
+    )
     return spec.model_copy(update={"instructions": f"{spec.instructions}\n\n{added}"})
 
 
-def _personal_gap_briefing(gap: PersonalServiceGap, surface: RunSurface) -> str:
+def _personal_gap_briefing(
+    gap: PersonalServiceGap, surface: RunSurface, *, sender_present: bool
+) -> str:
     bound = f"{gap.name} is bound to the account of whoever is talking to you"
     if gap.gap == "nobody_to_speak_as":
         if surface in _CHANNEL_SURFACES:
@@ -1354,6 +1363,12 @@ def _personal_gap_briefing(gap: PersonalServiceGap, surface: RunSurface) -> str:
                 f"person here, so the {gap.name} tools are not available for it. If asked for "
                 f"anything in {gap.name}, say so and tell them to send /link to this bot first, "
                 "then ask again."
+            )
+        if sender_present:
+            return (
+                f"{bound}, and although they are signed in, this run does not act as their "
+                f"account, so the {gap.name} tools are not available here. If asked for anything "
+                f"in {gap.name}, say so plainly rather than attempting a workaround."
             )
         return (
             f"{bound}, and nobody is signed in on this surface, so the {gap.name} tools are not "
@@ -1453,6 +1468,15 @@ class _Delegation:
     The person who wrote the message, and `None` where nobody did. Here rather
     than derived per delegate because it is a fact about the *run*: a delegate
     answers the same person its parent does, at every level of the tree.
+    """
+
+    sender_present: bool
+    """Whether a signed-in person is behind the run though it may not act as them.
+
+    A fact about the run, like `personal_mcp_user_id`: it separates an API call a
+    person made with their own token from a surface with nobody on it, so a
+    delegate's gap briefing does not tell a signed-in caller that nobody is
+    signed in (#1445).
     """
 
     approvals: ApprovalChannel
@@ -2075,6 +2099,15 @@ class AgentRunnerService:
             if acts_for_sender and not subject_is_publisher_fallback
             else None
         )
+        # Whether a signed-in person is behind this run even where a personal
+        # binding may not speak through their account - true on the API, where a
+        # bearer token identifies the caller but their own connections are
+        # deliberately out of reach, and false where nobody wrote the message at
+        # all. It is what tells the gap briefing to explain the refusal rather
+        # than tell a signed-in caller that nobody is signed in (#1445).
+        sender_present = (
+            owner_user_id or ctx.user_id
+        ) is not None and not subject_is_publisher_fallback
 
         # The MCP servers the spec binds, resolved here rather than by each
         # surface. A surface that forgot would produce an agent missing half its
@@ -2087,7 +2120,9 @@ class AgentRunnerService:
             sender_user_id=personal_mcp_user_id,
         )
         spec_toolsets = resolved.toolsets
-        spec = _with_personal_service_gaps(spec, resolved.unavailable, surface)
+        spec = _with_personal_service_gaps(
+            spec, resolved.unavailable, surface, sender_present=sender_present
+        )
 
         run = existing_run
         if run is None:
@@ -2232,6 +2267,7 @@ class AgentRunnerService:
             surface=surface,
             user_name=user_name,
             personal_mcp_user_id=personal_mcp_user_id,
+            sender_present=sender_present,
             resources=resources,
             approvals=channel,
             budget=run_budget,
@@ -2327,6 +2363,7 @@ class AgentRunnerService:
         surface: RunSurface,
         user_name: str | None,
         personal_mcp_user_id: UUID | None,
+        sender_present: bool,
         resources: dict[str, Any],
         approvals: ApprovalChannel,
         budget: _RunBudget,
@@ -2383,6 +2420,7 @@ class AgentRunnerService:
             user_id=None if ctx.user_id is None else str(ctx.user_id),
             user_name=user_name,
             personal_mcp_user_id=personal_mcp_user_id,
+            sender_present=sender_present,
             approvals=approvals,
             budget=budget,
             record=self._delegation_recorder(run=run, attribution=attribution, queued=delegations),
@@ -2766,7 +2804,12 @@ class AgentRunnerService:
         # Briefed like the parent: a delegate may bind a service the parent does
         # not, and one that lost it silently would report failure where the
         # parent could have relayed "connect your Notion" instead.
-        runnable = _with_personal_service_gaps(runnable, resolved.unavailable, delegation.surface)
+        runnable = _with_personal_service_gaps(
+            runnable,
+            resolved.unavailable,
+            delegation.surface,
+            sender_present=delegation.sender_present,
+        )
         secrets = await self.secrets.resolve_for_bindings(ctx, _secret_ids(runnable))
         return ResolvedSubagent(
             name=delegate.slug,

--- a/backend/tests/test_agent_runner.py
+++ b/backend/tests/test_agent_runner.py
@@ -3653,11 +3653,14 @@ class TestTellingTheAgentWhatItCannotReach:
     _CONNECT = "http://localhost:3000/mcp-servers?connect=notion"
 
     @staticmethod
-    def _briefed(gap: str, surface: RunSurface = RunSurface.WEB) -> str:
+    def _briefed(
+        gap: str, surface: RunSurface = RunSurface.WEB, *, sender_present: bool = False
+    ) -> str:
         spec = _with_personal_service_gaps(
             AgentSpec(name="Support", instructions="Be brief."),
             [UnavailablePersonalService("notion", gap)],  # type: ignore[arg-type]  # each literal is exercised below
             surface,
+            sender_present=sender_present,
         )
         return spec.instructions
 
@@ -3710,6 +3713,17 @@ class TestTellingTheAgentWhatItCannotReach:
         text = self._briefed("nobody_to_speak_as", surface)
 
         assert "nobody is signed in on this surface" in text
+        assert "/link" not in text
+
+    @pytest.mark.parametrize("surface", [RunSurface.API, RunSurface.EMBED, RunSurface.SCHEDULE])
+    def test_a_signed_in_caller_is_told_the_run_will_not_act_as_them(self, surface):
+        """A run through `POST /agents/{id}/run` carries the caller's own token, so
+        `ctx.user_id` is that person even though the personal binding stays out of
+        reach - "nobody is signed in" was false, and the model repeated it (#1445)."""
+        text = self._briefed("nobody_to_speak_as", surface, sender_present=True)
+
+        assert "does not act as their account" in text
+        assert "nobody is signed in" not in text
         assert "/link" not in text
 
     def test_the_service_is_named_as_the_catalog_names_it(self):


### PR DESCRIPTION
## The bug

A run started through `POST /agents/{id}/run` with a signed-in person's own bearer token was told, in its own instructions, that nobody is signed in — and the model repeated the false sentence back to them when asked for a personal service.

Reaching a personal MCP binding from the API is deliberately refused, so `personal_mcp_user_id` resolves to `None` and the gap is `nobody_to_speak_as`. But `_personal_gap_briefing`'s non-channel branch for that gap read *"nobody is signed in on this surface"* while `ctx.user_id` was that very person. The refusal is right; the explanation was false.

## The change

The briefing now knows whether a signed-in person is behind the run even where a personal binding may not speak through their account:

- `sender_present` is computed once in `_assemble`, from the run's subject (`owner_user_id or ctx.user_id`, excluding a publisher standing in for an anonymous visitor), and passed to `_with_personal_service_gaps` at the top level and stored on the delegation state so a delegate's briefing is consistent — the same "fact about the run, not re-derived per delegate" treatment `personal_mcp_user_id` already gets.
- The `nobody_to_speak_as` non-channel branch splits: with a person present it says the run does not act as their account; with genuinely nobody (a schedule, an embed with no visitor) it is unchanged.

## What I deliberately did not do

The issue's "Fixed when" proposes replacing the persisted `acts_for_sender: bool` with `sender_user_id: UUID | None` across every surface (dashboard, channel router, API, embed, schedule). I kept that flag and the account-reachability decision it feeds (`personal_mcp_user_id`, the `#1469`/`#788`/`#1343` path) untouched: it is a field on the parked-run JSONB with a rename-migration validator and it drives a security-relevant "whose account is reached" decision, so swapping its type is a persistence-and-access change rather than the briefing fix the defect calls for. `sender_present` fixes the false sentence without touching either. If you would still rather have the signature carry the identity, I am happy to do that as a follow-up — say so on the PR.

## Verification

- `TestTellingTheAgentWhatItCannotReach`: added a case asserting an API / embed / schedule run **with a signed-in caller** is told the run does not act as their account and never that nobody is signed in; the existing "genuinely nobody" case stays green (17 pass).
- Full `test_agent_runner.py` (139), the delegation/resume/approval integration files (10), and `ty` on the module all pass.
- `make test`: **100.00% coverage, gate reached.**

Closes #1445
