### PR TITLE
fix(permissions): decide member removal by the catalog, not an admin literal

### DIFF
--- a/backend/app/services/member.py
+++ b/backend/app/services/member.py
@@ -172,9 +172,18 @@ class MemberService:
                 )
             if requester.role != OrgRole.OWNER.value:
                 raise AuthorizationError(message="Only an Owner can remove another Owner")
-
-        if requester.role == OrgRole.ADMIN.value and target.role == OrgRole.ADMIN.value:
-            raise AuthorizationError(message="Admin cannot remove another Admin")
+        # Every other target is administrable only by a role that strictly
+        # outranks their current one - the catalog-derived ceiling `change_role`
+        # applies, so a custom role that does not outrank an Admin cannot remove
+        # one either, rather than the literal `admin`-vs-`admin` rule that left
+        # that hole open on this side (#700, #1066). The Owner case is decided
+        # above, because an Owner may remove a peer Owner and `assignable_roles`
+        # never offers Owner.
+        elif target.role not in assignable_roles(requester.role):
+            raise AuthorizationError(
+                message="You cannot remove a member your own role does not outrank",
+                details={"target_role": target.role},
+            )
 
         removed_role = target.role
         await member_repo.delete(self.db, target)

--- a/backend/tests/test_services_members.py
+++ b/backend/tests/test_services_members.py
@@ -299,6 +299,34 @@ class TestMemberService:
             await service.remove(uuid.uuid4(), uuid.uuid4(), requester_id=uuid.uuid4())
 
     @pytest.mark.anyio
+    async def test_a_custom_role_that_does_not_outrank_an_admin_cannot_remove_one(
+        self, service, monkeypatch
+    ):
+        """The hole the literal `admin`-vs-`admin` rule left, that `change_role`
+        already closes with the catalog (#700, #1066). A custom role (Phase 2)
+        holding `members:manage` whose set does not outrank an Admin's would pass
+        the literal - `requester.role == "admin"` is false - and remove the Admin.
+        The catalog bounds it by the same ceiling `change_role` uses."""
+        from app.core.permissions import ROLE_PERMS, Perm, Scope
+
+        monkeypatch.setitem(ROLE_PERMS, "test:members-only", {Perm.MEMBERS_MANAGE: Scope.ALL})
+        mock_requester = MagicMock(role="test:members-only")
+        mock_target = MagicMock(role="admin")
+
+        call_count = 0
+
+        async def mock_get(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return mock_requester if call_count == 1 else mock_target
+
+        with (
+            patch("app.services.member.member_repo.get", new=mock_get),
+            pytest.raises(AuthorizationError),
+        ):
+            await service.remove(uuid.uuid4(), uuid.uuid4(), requester_id=uuid.uuid4())
+
+    @pytest.mark.anyio
     async def test_change_role_admin_cannot_demote_admin(self, service):
         """The other half of test_remove_admin_cannot_remove_admin: demoting a
         peer Admin to Viewer strips the same authority `remove` refuses to touch,


### PR DESCRIPTION
## The drift

`MemberService.remove` decided the Admin-vs-Admin rule with a literal:

```python
if requester.role == OrgRole.ADMIN.value and target.role == OrgRole.ADMIN.value:
    raise AuthorizationError(message="Admin cannot remove another Admin")
```

`change_role` decides the same question — "may this requester act on this member" — with the catalog instead, since #700: `target.role not in assignable_roles(requester.role)`. For the four built-in roles the two agree (there is no live defect), but #700's whole point was that the Admin ceiling should *be* the assignment ceiling, so a custom role is bounded automatically. Half of it landed. A custom role (Phase 2) holding `members:manage` whose permission set does not strictly outrank an Admin's would be refused by `change_role` and **allowed by `remove`** — the same hole #700 closed, still open on this side.

## The change

`remove` now bounds every non-Owner target by `assignable_roles(requester.role)`, the same ceiling `change_role` uses. The Owner branch above it is unchanged — its last-Owner check and its "Only an Owner can remove another Owner" message stay — and it is decided *before* the ceiling, because an Owner may remove a peer Owner and `assignable_roles` never offers Owner (an `elif`).

## Verification

- `test_remove_admin_cannot_remove_admin` passes **unchanged** — the built-in roles behave exactly as before.
- A new test, `test_a_custom_role_that_does_not_outrank_an_admin_cannot_remove_one`, gives a custom role `members:manage` (so it clears the requester gate) whose set does not outrank Admin and asserts removing an Admin is refused. It **fails against the literal** (I reverted the fix locally to confirm) and passes with the catalog.
- `make test` — 100.00% coverage, gate reached.

No behaviour change for the built-in roles, and no catalog change; `docs/permissions.md` is unaffected (`scripts/docs_drift.py` reports nothing owed).

Closes #1066
