### PR TITLE
fix(channels): give Telegram the same chat_type vocabulary as the others

### DIFF
--- a/backend/alembic/versions/0076_normalize_channel_chat_type.py
+++ b/backend/alembic/versions/0076_normalize_channel_chat_type.py
@@ -1,0 +1,37 @@
+"""Normalise the mixed `channel_sessions.chat_type` vocabulary to two words.
+
+Telegram used to persist its own `supergroup` and `channel` while Slack and
+Mattermost collapsed everything but a DM to `group`, so the column held a
+different vocabulary per platform. The adapters now all emit `private` or
+`group` (#556); this folds the rows written before that so a consumer reading
+`chat_type == "group"` sees every room, not only the ones Slack and Mattermost
+wrote. Every value that is not `private` was a room, which is exactly the reading
+the one live consumer already took (`!= "private"`), so no row changes meaning.
+
+Revision ID: 0076_normalize_channel_chat_type
+Revises: 0075_user_credential_version
+Create Date: 2026-09-11
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0076_normalize_channel_chat_type"
+down_revision: str | None = "0075_user_credential_version"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "UPDATE channel_sessions SET chat_type = 'group' "
+        "WHERE chat_type NOT IN ('private', 'group')"
+    )
+
+
+def downgrade() -> None:
+    # Irreversible: the platform distinction between `supergroup`, `channel` and a
+    # plain `group` was folded away and the row no longer carries which it was.
+    pass

--- a/backend/app/services/channels/base.py
+++ b/backend/app/services/channels/base.py
@@ -201,7 +201,7 @@ class IncomingMessage:
     bot_id: str  # UUID str of the ChannelBot row
     platform_user_id: str
     platform_chat_id: str
-    chat_type: str  # "private" | "group" | "supergroup" | "channel"
+    chat_type: str  # "private" | "group" - every adapter normalises to these two
     text: str
     raw: dict[str, Any] = field(default_factory=dict)
     platform_username: str | None = None

--- a/backend/app/services/channels/telegram.py
+++ b/backend/app/services/channels/telegram.py
@@ -381,7 +381,11 @@ class TelegramAdapter(ChannelAdapter):
 
         chat = msg_data.get("chat", {})
 
-        chat_type: str = chat.get("type", "private")
+        # Normalised to the two-word vocabulary Slack and Mattermost emit, so the
+        # persisted `chat_type` reads the same across platforms: Telegram's own
+        # `group`, `supergroup` and `channel` are all rooms, and only `private` is
+        # a DM (#556).
+        chat_type: str = "private" if chat.get("type") == "private" else "group"
         platform_chat_id: str = str(chat.get("id", ""))
         platform_user_id: str = str(from_user.get("id", ""))
 

--- a/backend/tests/test_channel_chat_type.py
+++ b/backend/tests/test_channel_chat_type.py
@@ -1,0 +1,32 @@
+"""The `chat_type` every adapter persists is drawn from one two-word vocabulary.
+
+Telegram used to emit its own `supergroup` and `channel` while Slack and
+Mattermost collapsed everything but a DM to `group`, so `channel_sessions.chat_type`
+held a different vocabulary per platform - and a consumer reading `chat_type ==
+"group"`, the natural thing, would silently miss every Telegram room (#556). All
+three adapters now emit `private` or `group`; Mattermost's own mapping is pinned
+in `test_mattermost_channel.py`, and this pins Telegram, the one that changed.
+"""
+
+import pytest
+
+from app.services.channels.telegram import TelegramAdapter
+
+
+@pytest.mark.parametrize(
+    ("telegram_type", "expected"),
+    [
+        ("private", "private"),
+        ("group", "group"),
+        ("supergroup", "group"),
+        ("channel", "group"),
+    ],
+)
+def test_telegram_folds_every_room_type_to_group(telegram_type: str, expected: str) -> None:
+    parsed = TelegramAdapter().parse_incoming(
+        {"message": {"chat": {"id": 1, "type": telegram_type}, "from": {"id": 2}, "text": "hi"}},
+        "bot-1",
+    )
+
+    assert parsed is not None
+    assert parsed.chat_type == expected


### PR DESCRIPTION
## The mixed column

`telegram.py` emitted the raw platform `chat.type` (`supergroup`, `channel`) while `slack.py` and `mattermost.py` collapse everything but a DM to `group`. So `channel_sessions.chat_type` held a **different vocabulary per platform**. The one live consumer (`router.py`, `!= "private"`) is accidentally safe, but the first consumer to write the natural `chat_type == "group"` would silently mishandle every Telegram supergroup and channel.

## The change

I picked normalisation over the finer distinction — the two-word vocabulary the other two adapters already emit:

- **Parser.** The Telegram parser now folds every room type to `group` and keeps `private` (`"private" if chat.get("type") == "private" else "group"`), matching Slack and Mattermost. The contract comment on `IncomingMessage.chat_type` narrows to `"private" | "group"`.
- **Backfill.** Migration `0076` folds the rows already written — `UPDATE channel_sessions SET chat_type = 'group' WHERE chat_type NOT IN ('private', 'group')` — so the column stops holding `supergroup`/`channel` beside `group`. Every value that is not `private` was a room, exactly the reading the live consumer takes, so **no row changes meaning** and the consumer is not disturbed. Data-only and irreversible (the folded-away platform distinction is not recorded), so downgrade is a no-op.

## Verification

- New `test_channel_chat_type.py` pins Telegram's mapping per input type (`private`→private; `group`/`supergroup`/`channel`→group). Mattermost's own mapping is already pinned in `test_mattermost_channel.py`, and Slack's `im`→private/else→group is unchanged.
- The channel router/addressing/mentions suites (205 tests) stay green — the `!= "private"` consumer and the `memory_room_key` "anything not private is a room" logic are unaffected.
- `make test` — 100.00% coverage, gate reached. The migration is data-only with a single linear head (`0076` → `0075`); it runs no local DB here, so **CI `test-migrations` is the gate** for the forward/back cycle.

Closes #556
