### PR TITLE
fix(mcp): decide a personal connection's usability once, on the server

### DIFF
--- a/backend/app/core/vault.py
+++ b/backend/app/core/vault.py
@@ -124,6 +124,18 @@ def current_key_version() -> int:
     return max(_configured_master_keys())
 
 
+def is_key_version_available(key_version: int) -> bool:
+    """Whether a secret sealed at this version can still be unwrapped.
+
+    A `SECRET_KEY` rotation, or a version dropped from `VAULT_MASTER_KEYS` before
+    every row moved off it, leaves sealed rows whose version no longer has a
+    master key - `unseal` then fails at `_master_key`. This answers that without
+    decrypting anything, so a caller can tell a usable credential from one the
+    deployment can no longer open.
+    """
+    return key_version in _configured_master_keys()
+
+
 def _master_key(key_version: int) -> str:
     """The master key that sealed envelopes at this version.
 

--- a/backend/app/db/models/mcp_connection.py
+++ b/backend/app/db/models/mcp_connection.py
@@ -49,6 +49,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from app.core.vault import is_key_version_available
 from app.db.base import Base, TimestampMixin
 
 if TYPE_CHECKING:
@@ -234,3 +235,22 @@ class McpConnection(Base, TimestampMixin):
             f"<McpConnection(name={self.name} scope={self.scope} "
             f"url={self.url} enabled={self.is_enabled})>"
         )
+
+    @property
+    def account_authorized(self) -> bool:
+        """Whether this connection's stored credential can be used right now.
+
+        The side-effect-free half of `_resolve_auth_headers`, and the single place
+        the answer is decided so a run and the rendered list cannot drift (#1443):
+        OAuth is authorized once its payload is written; a bearer token is usable
+        while the master key that sealed it is still configured, which is the half
+        `_resolve_auth_headers` finds missing after a `SECRET_KEY` rotation. It
+        decrypts and refreshes nothing - a token whose ciphertext was tampered with
+        still reads authorized here, and only the run that actually unseals it
+        finds otherwise.
+        """
+        if self.auth_type == "oauth":
+            return self.oauth_payload is not None
+        if self.auth_token is None:
+            return True
+        return is_key_version_available(self.secret_key_version)

--- a/backend/app/db/models/mcp_connection.py
+++ b/backend/app/db/models/mcp_connection.py
@@ -242,15 +242,18 @@ class McpConnection(Base, TimestampMixin):
 
         The side-effect-free half of `_resolve_auth_headers`, and the single place
         the answer is decided so a run and the rendered list cannot drift (#1443):
-        OAuth is authorized once its payload is written; a bearer token is usable
-        while the master key that sealed it is still configured, which is the half
+        an OAuth or bearer credential is usable once its payload/token is written
+        and the master key that sealed it is still configured - the half
         `_resolve_auth_headers` finds missing after a `SECRET_KEY` rotation. It
-        decrypts and refreshes nothing - a token whose ciphertext was tampered with
-        still reads authorized here, and only the run that actually unseals it
-        finds otherwise.
+        decrypts and refreshes nothing, so two failures it cannot see are left to
+        the run that actually unseals: a ciphertext tampered with under a still
+        configured key, and an OAuth grant the provider has revoked or expired past
+        its refresh - the sweep marks the latter `last_status="error"` beforehand.
         """
         if self.auth_type == "oauth":
-            return self.oauth_payload is not None
+            return self.oauth_payload is not None and is_key_version_available(
+                self.secret_key_version
+            )
         if self.auth_token is None:
             return True
         return is_key_version_available(self.secret_key_version)

--- a/backend/app/schemas/mcp_connection.py
+++ b/backend/app/schemas/mcp_connection.py
@@ -93,6 +93,11 @@ class McpConnectionRead(TimestampSchema, BaseSchema):
     # OAuth connection that has completed the consent flow (has usable tokens).
     # False for a bearer connection or an OAuth connection still awaiting consent.
     oauth_authorized: bool
+    # Whether the stored credential can be used right now, decided server-side so
+    # a run and this rendered row cannot drift (#1443). False for an OAuth
+    # connection awaiting consent or a bearer token the deployment can no longer
+    # unseal after a key rotation; a client reads this rather than re-deriving it.
+    authorized: bool
     # The OAuth scopes the account consented to, so a caller can tell whether a
     # connection carries a scope a feature needs (a trigger portal's webhook-admin
     # scope). Scope names describe breadth, not a credential, so they are safe to
@@ -133,6 +138,7 @@ class McpConnectionRead(TimestampSchema, BaseSchema):
             is_enabled=connection.is_enabled,
             auth_type=connection.auth_type,
             oauth_authorized=oauth_authorized,
+            authorized=connection.account_authorized,
             granted_scopes=connection.granted_scopes,
             last_status=connection.last_status,
             last_error=connection.last_error,

--- a/backend/app/services/mcp_connection.py
+++ b/backend/app/services/mcp_connection.py
@@ -445,6 +445,10 @@ async def _resolve_auth_headers(
         return {"Authorization": f"Bearer {token}"} if token else None
     if connection.auth_token is None:
         return {}
+    if not connection.account_authorized:
+        # The master key that sealed it is gone; `unseal` would fail below anyway,
+        # and `account_authorized` is the same answer the rendered list reads (#1443).
+        return None
     try:
         token = unseal(
             connection.auth_token,

--- a/backend/tests/test_mcp_connections.py
+++ b/backend/tests/test_mcp_connections.py
@@ -887,6 +887,12 @@ class TestAccountAuthorized:
         assert _connection(auth_type="oauth", oauth_payload='{"t":1}').account_authorized is True
         assert _connection(auth_type="oauth", oauth_payload=None).account_authorized is False
 
+    def test_an_oauth_payload_sealed_under_a_dropped_key_is_not_authorized(self):
+        # The payload is present but unopenable after a rotation, the same way a
+        # bearer token is - the run finds `_oauth_access_token` returns None.
+        gone = _connection(auth_type="oauth", oauth_payload='{"t":1}', secret_key_version=999)
+        assert gone.account_authorized is False
+
     @pytest.mark.anyio
     async def test_resolve_auth_headers_refuses_a_token_whose_key_is_gone(self):
         conn = _connection(auth_token="sealed", secret_key_version=999)

--- a/backend/tests/test_mcp_connections.py
+++ b/backend/tests/test_mcp_connections.py
@@ -866,6 +866,40 @@ class TestAuthHeaders:
             connection_scope(conn)
 
 
+class TestAccountAuthorized:
+    """`account_authorized` is the one place a connection's usability is decided,
+    so the rendered list and the run cannot drift (#1443)."""
+
+    def test_a_bearer_connection_with_no_token_is_usable(self):
+        assert _connection().account_authorized is True
+
+    def test_a_token_on_a_configured_key_is_authorized(self):
+        conn = _connection()
+        conn.auth_token = _seal_into(conn, "secret-token")
+        assert conn.account_authorized is True
+
+    def test_a_token_whose_sealing_key_is_gone_is_not_authorized(self):
+        # A SECRET_KEY rotation leaves the row naming a version nothing can unwrap;
+        # the client had no way to know, so it read connected.
+        assert _connection(auth_token="sealed", secret_key_version=999).account_authorized is False
+
+    def test_an_oauth_connection_is_authorized_once_its_payload_is_written(self):
+        assert _connection(auth_type="oauth", oauth_payload='{"t":1}').account_authorized is True
+        assert _connection(auth_type="oauth", oauth_payload=None).account_authorized is False
+
+    @pytest.mark.anyio
+    async def test_resolve_auth_headers_refuses_a_token_whose_key_is_gone(self):
+        conn = _connection(auth_token="sealed", secret_key_version=999)
+        assert await _resolve_auth_headers(AsyncMock(), conn) is None
+
+    def test_the_read_carries_the_server_decided_authorized(self):
+        usable = _connection()
+        usable.auth_token = _seal_into(usable, "secret-token")
+        assert McpConnectionRead.from_model(usable).authorized is True
+        gone = _connection(auth_token="sealed", secret_key_version=999)
+        assert McpConnectionRead.from_model(gone).authorized is False
+
+
 def _oauth_connection(payload: McpOAuthPayload, **overrides) -> McpConnection:
     """A connection carrying a sealed OAuth payload."""
     conn = _connection(auth_type="oauth", **overrides)

--- a/backend/tests/test_vault.py
+++ b/backend/tests/test_vault.py
@@ -21,6 +21,7 @@ from app.core.vault import (
     VaultScopeKind,
     current_key_version,
     generate_master_key,
+    is_key_version_available,
     needs_rotation,
     rewrap,
     seal,
@@ -35,6 +36,16 @@ KEY_C = "vault-master-key-c-" + "c" * 32
 
 def _org() -> VaultScope:
     return VaultScope.organization(uuid.uuid4())
+
+
+class TestKeyVersionAvailability:
+    def test_a_configured_version_is_available(self, three_master_keys):
+        assert is_key_version_available(current_key_version()) is True
+
+    def test_a_dropped_version_is_not(self, three_master_keys):
+        # The version a row was sealed under, removed from VAULT_MASTER_KEYS before
+        # rotation finished moving every row off it - `unseal` would fail on it.
+        assert is_key_version_available(99) is False
 
 
 @pytest.fixture

--- a/frontend/src/components/agents/mcp-server-picker.test.tsx
+++ b/frontend/src/components/agents/mcp-server-picker.test.tsx
@@ -35,6 +35,7 @@ function connection(overrides: Partial<OrgMcpConnectionRecord> = {}): OrgMcpConn
     is_enabled: true,
     auth_type: "bearer",
     oauth_authorized: false,
+    authorized: true,
     last_status: "ok",
     last_error: null,
     last_checked_at: null,

--- a/frontend/src/components/agents/mcp-server-picker.test.tsx
+++ b/frontend/src/components/agents/mcp-server-picker.test.tsx
@@ -126,7 +126,13 @@ describe("McpServerPicker", () => {
   it("warns that a server cannot be reached before it is attached", () => {
     // Attaching a connection that has never been authorized is allowed - it may
     // be authorized later - but it should not look ready.
-    render(picker({ connections: [connection({ auth_type: "oauth", oauth_authorized: false })] }));
+    render(
+      picker({
+        connections: [
+          connection({ auth_type: "oauth", oauth_authorized: false, authorized: false }),
+        ],
+      }),
+    );
 
     expect(screen.getByText("Needs authorization")).toBeInTheDocument();
   });

--- a/frontend/src/components/chat/connect-services-card.test.tsx
+++ b/frontend/src/components/chat/connect-services-card.test.tsx
@@ -70,6 +70,7 @@ function own(overrides: Partial<McpConnectionRecord> = {}): McpConnectionRecord 
     is_enabled: true,
     auth_type: "oauth",
     oauth_authorized: true,
+    authorized: true,
     last_status: "ok",
     last_error: null,
     last_checked_at: null,

--- a/frontend/src/components/chat/your-connections.test.tsx
+++ b/frontend/src/components/chat/your-connections.test.tsx
@@ -71,6 +71,7 @@ function own(overrides: Partial<McpConnectionRecord> = {}): McpConnectionRecord 
     is_enabled: true,
     auth_type: "oauth",
     oauth_authorized: true,
+    authorized: true,
     last_status: "ok",
     last_error: null,
     last_checked_at: null,
@@ -135,7 +136,9 @@ describe("YourConnections", () => {
   });
 
   it("says when the chosen account no longer authorizes", () => {
-    state.connections = [own({ oauth_authorized: false })];
+    // The server decides usability now; the client reads `authorized` rather than
+    // re-deriving it from OAuth consent alone (#1443).
+    state.connections = [own({ oauth_authorized: false, authorized: false })];
     render(<YourConnections />);
 
     expect(screen.getByText("Needs authorizing again")).toBeInTheDocument();

--- a/frontend/src/components/mcp/mcp-server-list.integration.test.tsx
+++ b/frontend/src/components/mcp/mcp-server-list.integration.test.tsx
@@ -64,6 +64,7 @@ function connection(overrides: Partial<OrgMcpConnectionRecord> = {}): OrgMcpConn
     is_enabled: true,
     auth_type: "bearer",
     oauth_authorized: false,
+    authorized: true,
     last_status: "ok",
     last_error: null,
     last_checked_at: null,

--- a/frontend/src/components/triggers/portal-catalog.integration.test.tsx
+++ b/frontend/src/components/triggers/portal-catalog.integration.test.tsx
@@ -239,6 +239,7 @@ function orgConnection(overrides: Partial<OrgMcpConnectionRecord> = {}): OrgMcpC
     is_enabled: true,
     auth_type: "oauth",
     oauth_authorized: true,
+    authorized: true,
     last_status: "ok",
     last_error: null,
     last_checked_at: null,

--- a/frontend/src/hooks/use-mcp-connections.test.tsx
+++ b/frontend/src/hooks/use-mcp-connections.test.tsx
@@ -42,6 +42,7 @@ function connection(overrides: Partial<McpConnectionRecord> = {}): McpConnection
     is_enabled: true,
     auth_type: "bearer",
     oauth_authorized: false,
+    authorized: true,
     last_status: "ok",
     last_error: null,
     last_checked_at: null,

--- a/frontend/src/hooks/use-org-mcp-connections.test.tsx
+++ b/frontend/src/hooks/use-org-mcp-connections.test.tsx
@@ -28,6 +28,7 @@ function record(overrides: Partial<OrgMcpConnectionRecord> = {}): OrgMcpConnecti
     is_enabled: true,
     auth_type: "bearer",
     oauth_authorized: false,
+    authorized: true,
     last_status: "ok",
     last_error: null,
     last_checked_at: null,

--- a/frontend/src/lib/binding-tools.test.ts
+++ b/frontend/src/lib/binding-tools.test.ts
@@ -13,6 +13,7 @@ function connection(overrides: Partial<OrgMcpConnectionRecord> = {}): OrgMcpConn
     is_enabled: true,
     auth_type: "oauth",
     oauth_authorized: true,
+    authorized: true,
     last_status: null,
     last_error: null,
     last_checked_at: null,

--- a/frontend/src/lib/mcp-connections-api.ts
+++ b/frontend/src/lib/mcp-connections-api.ts
@@ -20,6 +20,13 @@ export interface McpConnectionRecord {
   auth_type: "bearer" | "oauth";
   /** OAuth connection that finished consent and has usable tokens. */
   oauth_authorized: boolean;
+  /**
+   * Whether the stored credential can be used right now, decided by the server so
+   * this matches what a run reports rather than being re-derived here (#1443).
+   * False for an OAuth connection awaiting consent or a token the deployment can
+   * no longer unseal after a key rotation.
+   */
+  authorized: boolean;
   /** Result of the most recent connectivity check ("ok" / "error"), if any. */
   last_status: string | null;
   last_error: string | null;

--- a/frontend/src/lib/mcp-servers.test.ts
+++ b/frontend/src/lib/mcp-servers.test.ts
@@ -178,10 +178,18 @@ describe("connectionState", () => {
     expect(connectionState(null)).toBe("not-connected");
   });
 
-  it("says an unauthorized OAuth server needs authorization, before anything else", () => {
+  it("says a server the server cannot authorize needs authorization, before anything else", () => {
     expect(
-      connectionState(personal({ auth_type: "oauth", oauth_authorized: false, is_enabled: false })),
+      connectionState(personal({ auth_type: "oauth", authorized: false, is_enabled: false })),
     ).toBe("needs-authorization");
+  });
+
+  it("says a bearer token a key rotation orphaned needs authorization too", () => {
+    // The drift #1443 closed on this path as well: the client only knew about
+    // OAuth consent, so an unsealed bearer token read connected here.
+    expect(connectionState(personal({ auth_type: "bearer", authorized: false }))).toBe(
+      "needs-authorization",
+    );
   });
 
   it("says a switched-off server is disabled, whatever its last check said", () => {

--- a/frontend/src/lib/mcp-servers.test.ts
+++ b/frontend/src/lib/mcp-servers.test.ts
@@ -47,6 +47,7 @@ function personal(overrides: Partial<McpConnectionRecord> = {}): McpConnectionRe
     is_enabled: true,
     auth_type: "bearer",
     oauth_authorized: false,
+    authorized: true,
     last_status: "ok",
     last_error: null,
     last_checked_at: null,
@@ -331,6 +332,7 @@ describe("ownAccountStatus", () => {
       is_enabled: true,
       auth_type: "oauth",
       oauth_authorized: true,
+      authorized: true,
       last_status: "ok",
       last_error: null,
       last_checked_at: null,
@@ -369,7 +371,18 @@ describe("ownAccountStatus", () => {
   });
 
   it("is unauthorized when the chosen grant no longer stands", () => {
-    expect(ownAccountStatus("notion", [own({ oauth_authorized: false })])).toBe("unauthorized");
+    expect(ownAccountStatus("notion", [own({ oauth_authorized: false, authorized: false })])).toBe(
+      "unauthorized",
+    );
+  });
+
+  it("is unauthorized when the server can no longer unseal the stored token", () => {
+    // The drift #1443 closed: a bearer token the deployment can no longer open
+    // read connected, because the client only knew about OAuth consent and the
+    // server is the one that finds a rotated key. It now reads the server's answer.
+    expect(ownAccountStatus("notion", [own({ auth_type: "bearer", authorized: false })])).toBe(
+      "unauthorized",
+    );
   });
 });
 
@@ -384,6 +397,7 @@ describe("ownAccountStatus and a failed health check", () => {
       is_enabled: true,
       auth_type: "bearer",
       oauth_authorized: false,
+      authorized: true,
       last_status: "error",
       last_error: "timed out",
       last_checked_at: null,

--- a/frontend/src/lib/mcp-servers.ts
+++ b/frontend/src/lib/mcp-servers.ts
@@ -107,8 +107,11 @@ export function entryForConnection(
  */
 export function connectionState(connection: McpConnectionRecord | null): McpConnectionState {
   if (!connection) return "not-connected";
-  if (connection.auth_type === "oauth" && !connection.oauth_authorized)
-    return "needs-authorization";
+  // The server's own answer to whether the credential can be used, so every
+  // surface that renders a connection agrees with `ownAccountStatus` and the run
+  // rather than re-deriving it from OAuth consent alone - a bearer token a key
+  // rotation orphaned needs authorizing again too, not only an OAuth grant (#1443).
+  if (!connection.authorized) return "needs-authorization";
   if (!connection.is_enabled) return "disabled";
   if (connection.last_status === "error") return "error";
   return "connected";

--- a/frontend/src/lib/mcp-servers.ts
+++ b/frontend/src/lib/mcp-servers.ts
@@ -329,12 +329,14 @@ export function mergeServers(
  * Whether this person can speak to a catalog service through an account of
  * their own, as a binding to each person's own account would find it.
  *
- * The same rule the run applies (`_nominated` on the backend): one enabled
- * connection needs no choosing, several answer only the one marked default, and
- * several with none marked are `undecided` rather than guessed between. A chosen
- * OAuth connection whose grant is gone is `unauthorized` - the account exists,
- * the credential behind it does not. A failed health check is not that: the
- * run still sends the token it holds, so the row reads connected.
+ * Which connection answers is a pure reading of the list, the same choice
+ * `_nominated` makes on the backend: one enabled connection needs no choosing,
+ * several answer only the one marked default, and several with none marked are
+ * `undecided`. Whether that connection's credential is usable is **not** re-derived
+ * here - it is the server's `authorized`, so a chosen connection reads the same
+ * `connected`/`unauthorized` the run reports. A bearer token the deployment can no
+ * longer unseal used to read connected because the client only knew about OAuth
+ * consent (#1443).
  */
 export function ownAccountStatus(
   catalogKey: string,
@@ -346,5 +348,5 @@ export function ownAccountStatus(
   if (mine.length === 0) return "not_connected";
   const chosen = mine.length === 1 ? mine[0] : mine.find((one) => one.is_default);
   if (chosen === undefined) return "undecided";
-  return connectionState(chosen) === "needs-authorization" ? "unauthorized" : "connected";
+  return chosen.authorized ? "connected" : "unauthorized";
 }


### PR DESCRIPTION
## The drift

`ownAccountStatus` (`frontend/src/lib/mcp-servers.ts`) decided whether a person can reach a service through their own account, and so does the backend in `_resolve_auth_headers`. They disagreed: the server reports **unauthorized** whenever `_resolve_auth_headers` yields no headers — an OAuth grant that no longer refreshes *or* a bearer token that no longer unseals — while the client said unauthorized only for `auth_type === "oauth" && !oauth_authorized`. So a token connection whose sealing key was rotated away read **Connected** in the chat controls and unavailable in the very next turn's `personal_services_unavailable` frame.

## The change — one place decides usability

- **Backend.** `McpConnection.account_authorized` is now the single, **side-effect-free** answer to "can this credential be used": OAuth is authorized once its payload is written; a bearer token while the master key that sealed it is still configured (`vault.is_key_version_available`); a connection with no token is usable. `_resolve_auth_headers` uses it (so a run and this answer cannot drift), and `McpConnectionRead` carries it to the client as `authorized`.
- **Frontend.** `ownAccountStatus` reads `chosen.authorized` instead of re-deriving the credential check. Which connection answers — one, the default among several, or none chosen — stays a reading of the connection list here, because that is a pure function of what the client already holds and cannot drift from the server.

## A design note, for the reviewer

The issue suggested "exposing it once … and deleting the client copy." Two constraints shaped how:

- **The list read deliberately does not decrypt.** `McpConnectionRead.from_model` already avoids decrypting the OAuth payload "just to render the list". So `account_authorized` answers the bearer case by asking whether the sealing key version is still configured (the `SECRET_KEY`-rotation failure the issue describes) rather than by unsealing — no decryption on a list render. The one residual gap from perfect run-parity is a bearer token whose ciphertext was *tampered with* under a still-configured key; that reads authorized until the run actually unseals it. Hand-editing a sealed token is not an operational path, and decrypting every row on every list read is the cost the existing design refuses.
- **OAuth resolution has side effects.** `_resolve_auth_headers`'s OAuth path can spend a refresh token and write the DB, so it cannot run on a `GET`. `account_authorized` uses the same `oauth_payload is not None` signal the list already exposed — no refresh.

If you would rather have exact run-parity via a dedicated status endpoint that performs the full resolution, say so and I will build that instead.

## Verification

- Backend: new tests pin `account_authorized` (bearer no-token / configured key / dropped key; OAuth payload present / absent), `_resolve_auth_headers` refusing a token whose key is gone, `is_key_version_available`, and `McpConnectionRead.authorized`. `make test` — 100.00% coverage.
- Frontend: `ownAccountStatus` tests now assert the token-unseal drift reads unauthorized; the health-check test still reads connected (usable credential, failed probe). `bun run test:coverage` — 6132 passed, 97.71% branches ≥ the gate.

## Sibling note

The connect-services-card **test** file is also touched by PR #1572 (#1444); a merge-tree check confirms the two auto-merge cleanly (different regions). Both are on HOLD.

Closes #1443
