### PR TITLE
feat(config): encrypt the connections to Postgres and Redis, and report it

### DIFF
--- a/backend/app/commands/doctor.py
+++ b/backend/app/commands/doctor.py
@@ -91,6 +91,33 @@ async def _redis_reachable() -> tuple[str, str]:
     return ("healthy", "PING answered") if answered else ("unhealthy", "PING failed")
 
 
+async def _postgres_tls(db: AsyncSession) -> tuple[str, str]:
+    """Whether the connection this doctor made to Postgres was encrypted.
+
+    Read from `pg_stat_ssl` for the backend serving this session - the transport
+    itself, not the `POSTGRES_SSLMODE` that asked for it (#1418). Not a failure
+    when off: two stores on one compose network need no TLS, and a provisioning
+    script must not exit non-zero on that.
+    """
+    try:
+        on = (
+            await db.execute(text("SELECT ssl FROM pg_stat_ssl WHERE pid = pg_backend_pid()"))
+        ).scalar()
+    except Exception as exc:
+        return "not_checked", f"could not read pg_stat_ssl: {exc}"
+    return ("healthy", "tls=on") if on else ("unconfigured", "tls=off")
+
+
+def _redis_tls() -> tuple[str, str]:
+    """Whether the Redis URL selects TLS. redis-py reads it off the scheme, so
+    `rediss://` is the encrypted transport and `redis://` is not (#1418)."""
+    return (
+        ("healthy", "tls=on")
+        if settings.REDIS_URL.startswith("rediss://")
+        else ("unconfigured", "tls=off")
+    )
+
+
 def _vault_configured() -> tuple[str, str]:
     """A vault with no key cannot unseal a provider credential, so no agent runs."""
     if not settings.VAULT_MASTER_KEY and not settings.VAULT_MASTER_KEYS:
@@ -206,6 +233,9 @@ async def _run() -> int:
             error("Nothing else can be checked without a database. Is it running?")
             return 1
 
+        status, detail = await _postgres_tls(db)
+        failures += _report("postgres", status, detail)
+
         status, detail = await _migrations_current(db)
         failures += _report("migrations", status, detail)
 
@@ -216,6 +246,9 @@ async def _run() -> int:
         failures += _report("model access", model.status, model.detail)
 
     status, detail = await _redis_reachable()
+    failures += _report("redis", status, detail)
+
+    status, detail = _redis_tls()
     failures += _report("redis", status, detail)
 
     status, detail = _vault_configured()

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -121,24 +121,35 @@ class Settings(BaseSettings):
     POSTGRES_USER: str = "postgres"
     POSTGRES_PASSWORD: str = ""
     POSTGRES_DB: str = "agenticos"
+    # Encrypt the connection to Postgres. Empty leaves it plaintext, which is fine
+    # for both stores on one compose network and is the first thing a reviewer asks
+    # about for a managed Postgres or one on another host (HIPAA 164.312(e), SOC 2
+    # CC6.7). `require` encrypts; `verify-ca`/`verify-full` also check the server's
+    # certificate against the CA the container trusts - mount the bundle into the
+    # OS trust store, because asyncpg reads no per-connection cert path (#1418).
+    POSTGRES_SSLMODE: str = ""
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def DATABASE_URL(self) -> str:
         """Build async PostgreSQL connection URL."""
-        return (
+        url = (
             f"postgresql+asyncpg://{self.POSTGRES_USER}:{self.POSTGRES_PASSWORD}"
             f"@{self.POSTGRES_HOST}:{self.POSTGRES_PORT}/{self.POSTGRES_DB}"
         )
+        # asyncpg's parameter is `ssl`, not libpq's `sslmode`.
+        return f"{url}?ssl={self.POSTGRES_SSLMODE}" if self.POSTGRES_SSLMODE else url
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def DATABASE_URL_SYNC(self) -> str:
         """Build sync PostgreSQL connection URL (for Alembic)."""
-        return (
+        url = (
             f"postgresql://{self.POSTGRES_USER}:{self.POSTGRES_PASSWORD}"
             f"@{self.POSTGRES_HOST}:{self.POSTGRES_PORT}/{self.POSTGRES_DB}"
         )
+        # psycopg2 speaks libpq, whose parameter is `sslmode`.
+        return f"{url}?sslmode={self.POSTGRES_SSLMODE}" if self.POSTGRES_SSLMODE else url
 
     DB_POOL_SIZE: int = 5
     DB_MAX_OVERFLOW: int = 10
@@ -242,14 +253,20 @@ class Settings(BaseSettings):
     REDIS_PORT: int = 6379
     REDIS_PASSWORD: str | None = None
     REDIS_DB: int = 0
+    # Encrypt the connection to Redis. redis-py reads TLS off the URL scheme, so
+    # this switches `redis://` for `rediss://`; the server's certificate is checked
+    # against the CA the container trusts, mounted into the OS store like Postgres
+    # (#1418).
+    REDIS_SSL: bool = False
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def REDIS_URL(self) -> str:
         """Build Redis connection URL."""
+        scheme = "rediss" if self.REDIS_SSL else "redis"
         if self.REDIS_PASSWORD:
-            return f"redis://:{self.REDIS_PASSWORD}@{self.REDIS_HOST}:{self.REDIS_PORT}/{self.REDIS_DB}"
-        return f"redis://{self.REDIS_HOST}:{self.REDIS_PORT}/{self.REDIS_DB}"
+            return f"{scheme}://:{self.REDIS_PASSWORD}@{self.REDIS_HOST}:{self.REDIS_PORT}/{self.REDIS_DB}"
+        return f"{scheme}://{self.REDIS_HOST}:{self.REDIS_PORT}/{self.REDIS_DB}"
 
     # What one caller may ask the public run API for, per minute. Keyed on the
     # caller rather than on their address: the endpoint is authenticated, and an

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -125,8 +125,8 @@ class Settings(BaseSettings):
     # for both stores on one compose network and is the first thing a reviewer asks
     # about for a managed Postgres or one on another host (HIPAA 164.312(e), SOC 2
     # CC6.7). `require` encrypts; `verify-ca`/`verify-full` also check the server's
-    # certificate against the CA the container trusts - mount the bundle into the
-    # OS trust store, because asyncpg reads no per-connection cert path (#1418).
+    # certificate against the CA file `PGSSLROOTCERT` names - asyncpg and libpq
+    # both read that variable, and neither consults the OS trust store (#1418).
     POSTGRES_SSLMODE: str = ""
 
     @computed_field  # type: ignore[prop-decorator]
@@ -254,9 +254,10 @@ class Settings(BaseSettings):
     REDIS_PASSWORD: str | None = None
     REDIS_DB: int = 0
     # Encrypt the connection to Redis. redis-py reads TLS off the URL scheme, so
-    # this switches `redis://` for `rediss://`; the server's certificate is checked
-    # against the CA the container trusts, mounted into the OS store like Postgres
-    # (#1418).
+    # this switches `redis://` for `rediss://`, and the URL also demands a valid
+    # chain and a matching hostname - stated rather than left to redis-py's
+    # defaults, which have flipped between releases. The CA is whatever bundle
+    # OpenSSL trusts, so a private one is named with `SSL_CERT_FILE` (#1418).
     REDIS_SSL: bool = False
 
     @computed_field  # type: ignore[prop-decorator]
@@ -264,9 +265,13 @@ class Settings(BaseSettings):
     def REDIS_URL(self) -> str:
         """Build Redis connection URL."""
         scheme = "rediss" if self.REDIS_SSL else "redis"
+        verify = "?ssl_cert_reqs=required&ssl_check_hostname=true" if self.REDIS_SSL else ""
         if self.REDIS_PASSWORD:
-            return f"{scheme}://:{self.REDIS_PASSWORD}@{self.REDIS_HOST}:{self.REDIS_PORT}/{self.REDIS_DB}"
-        return f"{scheme}://{self.REDIS_HOST}:{self.REDIS_PORT}/{self.REDIS_DB}"
+            return (
+                f"{scheme}://:{self.REDIS_PASSWORD}@{self.REDIS_HOST}:{self.REDIS_PORT}"
+                f"/{self.REDIS_DB}{verify}"
+            )
+        return f"{scheme}://{self.REDIS_HOST}:{self.REDIS_PORT}/{self.REDIS_DB}{verify}"
 
     # What one caller may ask the public run API for, per minute. Keyed on the
     # caller rather than on their address: the endpoint is authenticated, and an

--- a/backend/tests/integration/test_store_tls.py
+++ b/backend/tests/integration/test_store_tls.py
@@ -1,0 +1,58 @@
+"""Encrypted transport to Postgres works through the pool and the worker (#1418).
+
+Skipped unless the configured Postgres accepts a TLS connection: a plaintext dev
+container refuses `ssl=require`, so this proves nothing on `make test` and
+everything on a managed Postgres or one told to require SSL. `pg_stat_ssl` reports
+the transport of the connection actually made, not the setting that asked for it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.pool import NullPool
+
+from app.core.config import settings
+
+pytestmark = pytest.mark.anyio
+
+
+def _tls_url() -> str:
+    return (
+        f"postgresql+asyncpg://{settings.POSTGRES_USER}:{settings.POSTGRES_PASSWORD}"
+        f"@{settings.POSTGRES_HOST}:{settings.POSTGRES_PORT}/{settings.POSTGRES_DB}?ssl=require"
+    )
+
+
+async def _connection_is_encrypted(engine: Any) -> bool | None:
+    """Whether a connection from *engine* is TLS, or None if it cannot connect."""
+    try:
+        async with engine.connect() as conn:
+            answer = await conn.execute(
+                text("SELECT ssl FROM pg_stat_ssl WHERE pid = pg_backend_pid()")
+            )
+            return bool(answer.scalar())
+    except Exception:
+        return None
+
+
+async def test_the_pool_and_the_worker_engine_both_connect_with_tls():
+    pool = create_async_engine(_tls_url(), pool_size=1, max_overflow=0)
+    try:
+        encrypted = await _connection_is_encrypted(pool)
+        if not encrypted:
+            pytest.skip("Postgres here does not accept ssl=require; nothing to prove")
+        assert encrypted is True
+
+        # The Prefect worker opens its own engine on the same URL (see
+        # `app/db/session.py`), so the setting has to carry through there too.
+        worker = create_async_engine(_tls_url(), poolclass=NullPool)
+        try:
+            assert await _connection_is_encrypted(worker) is True
+        finally:
+            await worker.dispose()
+    finally:
+        await pool.dispose()

--- a/backend/tests/integration/test_store_tls.py
+++ b/backend/tests/integration/test_store_tls.py
@@ -8,48 +8,51 @@ the transport of the connection actually made, not the setting that asked for it
 
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 from sqlalchemy import text
-from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from sqlalchemy.pool import NullPool
-
-from app.core.config import settings
 
 pytestmark = pytest.mark.anyio
 
 
-def _tls_url() -> str:
-    return (
-        f"postgresql+asyncpg://{settings.POSTGRES_USER}:{settings.POSTGRES_PASSWORD}"
-        f"@{settings.POSTGRES_HOST}:{settings.POSTGRES_PORT}/{settings.POSTGRES_DB}?ssl=require"
-    )
+def _tls_url(database_url: str) -> str:
+    """The test database's own URL - the one the session fixture created - asking
+    for TLS. Built from the fixture rather than from `settings`, so the database
+    exists whatever order the suite runs in."""
+    return f"{database_url}?ssl=require"
 
 
-async def _connection_is_encrypted(engine: Any) -> bool | None:
-    """Whether a connection from *engine* is TLS, or None if it cannot connect."""
+async def _connection_is_encrypted(engine: AsyncEngine) -> bool:
+    """Whether a connection from *engine* is TLS, as the server reports it."""
+    async with engine.connect() as conn:
+        answer = await conn.execute(
+            text("SELECT ssl FROM pg_stat_ssl WHERE pid = pg_backend_pid()")
+        )
+        return bool(answer.scalar())
+
+
+async def _connection_is_encrypted_or_skip(engine: AsyncEngine) -> bool:
+    """The one outcome that proves nothing is a server without SSL at all, which
+    asyncpg reports as `rejected SSL upgrade`. Anything else - a bad option, a
+    certificate the client refuses, credentials, the network - is a failure of
+    what this test exists to check, and propagates."""
     try:
-        async with engine.connect() as conn:
-            answer = await conn.execute(
-                text("SELECT ssl FROM pg_stat_ssl WHERE pid = pg_backend_pid()")
-            )
-            return bool(answer.scalar())
-    except Exception:
-        return None
-
-
-async def test_the_pool_and_the_worker_engine_both_connect_with_tls():
-    pool = create_async_engine(_tls_url(), pool_size=1, max_overflow=0)
-    try:
-        encrypted = await _connection_is_encrypted(pool)
-        if not encrypted:
+        return await _connection_is_encrypted(engine)
+    except Exception as exc:
+        if "rejected SSL upgrade" in str(exc):
             pytest.skip("Postgres here does not accept ssl=require; nothing to prove")
-        assert encrypted is True
+        raise
+
+
+async def test_the_pool_and_the_worker_engine_both_connect_with_tls(database_url: str):
+    pool = create_async_engine(_tls_url(database_url), pool_size=1, max_overflow=0)
+    try:
+        assert await _connection_is_encrypted_or_skip(pool) is True
 
         # The Prefect worker opens its own engine on the same URL (see
         # `app/db/session.py`), so the setting has to carry through there too.
-        worker = create_async_engine(_tls_url(), poolclass=NullPool)
+        worker = create_async_engine(_tls_url(database_url), poolclass=NullPool)
         try:
             assert await _connection_is_encrypted(worker) is True
         finally:

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -97,6 +97,16 @@ class TestStoreTls:
         assert settings.DATABASE_URL.endswith("?ssl=require")
         assert settings.DATABASE_URL_SYNC.endswith("?sslmode=require")
 
-    def test_redis_ssl_switches_the_scheme_to_rediss(self):
-        assert Settings(REDIS_SSL=True).REDIS_URL.startswith("rediss://")
-        assert Settings(REDIS_SSL=True, REDIS_PASSWORD="pw").REDIS_URL.startswith("rediss://:pw@")
+    def test_redis_ssl_switches_the_scheme_to_rediss_and_verifies_the_server(self):
+        """`rediss://` alone leaves the chain and hostname checks to redis-py's
+        defaults, which have differed between releases; the URL states both, so
+        a certificate for another host is refused whatever version is installed."""
+        url = Settings(REDIS_SSL=True).REDIS_URL
+        assert url.startswith("rediss://")
+        assert url.endswith("/0?ssl_cert_reqs=required&ssl_check_hostname=true")
+        with_password = Settings(REDIS_SSL=True, REDIS_PASSWORD="pw").REDIS_URL
+        assert with_password.startswith("rediss://:pw@")
+        assert with_password.endswith("?ssl_cert_reqs=required&ssl_check_hostname=true")
+
+    def test_a_plaintext_redis_url_carries_no_tls_parameters(self):
+        assert "?" not in Settings(REDIS_SSL=False, REDIS_PASSWORD="pw").REDIS_URL

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -80,3 +80,23 @@ class TestVaultMasterKeyValidation:
         highest configured, so version 0 could never be anything but a mistake."""
         with pytest.raises(ValidationError, match="positive"):
             Settings(ENVIRONMENT="local", VAULT_MASTER_KEY="", VAULT_MASTER_KEYS={0: KEY})
+
+
+class TestStoreTls:
+    """Encrypted transport to the two stores, off by default (#1418)."""
+
+    def test_both_urls_are_plaintext_by_default(self):
+        settings = Settings()
+        assert "ssl" not in settings.DATABASE_URL
+        assert "sslmode" not in settings.DATABASE_URL_SYNC
+        assert settings.REDIS_URL.startswith("redis://")
+
+    def test_postgres_sslmode_sets_each_driver_s_own_parameter(self):
+        # asyncpg's parameter is `ssl`; psycopg2 (Alembic) speaks libpq's `sslmode`.
+        settings = Settings(POSTGRES_SSLMODE="require")
+        assert settings.DATABASE_URL.endswith("?ssl=require")
+        assert settings.DATABASE_URL_SYNC.endswith("?sslmode=require")
+
+    def test_redis_ssl_switches_the_scheme_to_rediss(self):
+        assert Settings(REDIS_SSL=True).REDIS_URL.startswith("rediss://")
+        assert Settings(REDIS_SSL=True, REDIS_PASSWORD="pw").REDIS_URL.startswith("rediss://:pw@")

--- a/backend/tests/test_doctor_sandbox.py
+++ b/backend/tests/test_doctor_sandbox.py
@@ -201,3 +201,40 @@ async def test_a_service_allowing_no_runtime_cannot_start_a_sandbox(monkeypatch)
     detail = await _probe_connection(_connection(), _secret())
 
     assert detail == "the service allows no runtime, so no sandbox can start"
+
+
+def _scalar_db(value: object) -> MagicMock:
+    """A db whose one query answers `value` to `.scalar()`."""
+    db = MagicMock()
+    result = MagicMock()
+    result.scalar = MagicMock(return_value=value)
+    db.execute = AsyncMock(return_value=result)
+    return db
+
+
+class TestStoreTlsIsReported:
+    """`doctor` says whether the connections it made were encrypted (#1418), and
+    off is a warning rather than a failure - two stores on one compose network
+    need no TLS."""
+
+    async def test_postgres_reads_the_transport_from_pg_stat_ssl(self):
+        from app.commands.doctor import _postgres_tls
+
+        assert await _postgres_tls(_scalar_db(True)) == ("healthy", "tls=on")
+        assert await _postgres_tls(_scalar_db(False)) == ("unconfigured", "tls=off")
+
+    async def test_postgres_that_cannot_be_read_is_not_checked_not_failed(self):
+        from app.commands.doctor import _postgres_tls
+
+        db = MagicMock(execute=AsyncMock(side_effect=RuntimeError("denied")))
+        status, detail = await _postgres_tls(db)
+        assert status == "not_checked"
+        assert "pg_stat_ssl" in detail
+
+    def test_redis_reads_the_transport_from_the_url_scheme(self, monkeypatch):
+        from app.commands import doctor
+
+        monkeypatch.setattr(doctor.settings, "REDIS_SSL", True)
+        assert doctor._redis_tls() == ("healthy", "tls=on")
+        monkeypatch.setattr(doctor.settings, "REDIS_SSL", False)
+        assert doctor._redis_tls() == ("unconfigured", "tls=off")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -180,28 +180,49 @@ for the app's asyncpg, `?sslmode=<mode>` for Alembic's psycopg2 — and `REDIS_S
 switches the Redis scheme to `rediss://`. `require` encrypts the connection;
 `verify-ca` and `verify-full` also check the server's certificate.
 
-!!! note "The CA is trusted at the OS level, not per connection"
+`REDIS_SSL` also asks for a valid certificate chain and a matching hostname on
+the URL itself, rather than leaving both to redis-py's defaults.
 
-    asyncpg reads no per-connection root-certificate path, so a `verify-full`
-    setup mounts the CA bundle into the container's trust store rather than naming
-    it in the URL. `agenticos cmd doctor` reports `postgres: tls=on/off` and
-    `redis: tls=on/off` — the transport of the connection it actually made, read
-    from `pg_stat_ssl`, not the setting that asked for it.
+!!! warning "A private CA is a file the drivers read, not the OS trust store"
+
+    Neither driver consults the container's trust store, and the image runs as a
+    non-root user with no entrypoint that could rebuild it. asyncpg and libpq
+    both read the CA file `PGSSLROOTCERT` names; redis-py trusts whatever bundle
+    OpenSSL points at, which `SSL_CERT_FILE` overrides. Mount the CA once and set
+    both variables to it - `verify-ca` and `verify-full` fail without the first,
+    since asyncpg then looks for `~/.postgresql/root.crt` and finds nothing.
+
+!!! note "Every service that opens a store connection needs the change"
+
+    `app`, `migrate` and `prefect-runner` each connect to Postgres and Redis, and
+    the shipped compose files pin `POSTGRES_HOST=db` and `REDIS_HOST=redis` in
+    each one's `environment`, which wins over an env file. So a managed store is
+    an override file that reaches all three, not a line in `.env`.
 
 ```yaml
-# A managed Postgres that requires TLS, verified against its CA.
+# docker-compose.managed.yml - a managed Postgres and Redis, verified against a
+# private CA. Run with `docker compose -f docker-compose.yml -f docker-compose.managed.yml up -d`.
+x-managed: &managed
+  environment:
+    POSTGRES_HOST: db.internal.example.com
+    POSTGRES_SSLMODE: verify-full
+    PGSSLROOTCERT: /run/tls/managed-ca.crt
+    REDIS_HOST: redis.internal.example.com
+    REDIS_SSL: "true"
+    SSL_CERT_FILE: /run/tls/managed-ca.crt
+  volumes:
+    - ./ca/managed-ca.crt:/run/tls/managed-ca.crt:ro
+
 services:
-  api:
-    environment:
-      POSTGRES_HOST: db.internal.example.com
-      POSTGRES_PORT: "5432"
-      POSTGRES_SSLMODE: verify-full
-      REDIS_SSL: "true"
-    volumes:
-      # Mounted where the base image's trust store looks, then trusted at build
-      # or entrypoint with `update-ca-certificates`.
-      - ./ca/managed-postgres.crt:/usr/local/share/ca-certificates/managed-postgres.crt:ro
+  app: *managed
+  migrate: *managed
+  prefect-runner: *managed
 ```
+
+The bundled `db` and `redis` services keep starting, unused; `agenticos cmd
+doctor` shows which store each connection actually reached and whether it was
+encrypted (`postgres: tls=on/off`, `redis: tls=on/off`, from `pg_stat_ssl` and the
+URL scheme).
 
 ## Email (SMTP)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,6 +148,7 @@ exactly once.
 | `POSTGRES_USER` | `postgres` | PostgreSQL user |
 | `POSTGRES_PASSWORD` | (empty) | PostgreSQL password |
 | `POSTGRES_DB` | `agenticos` | Database name |
+| `POSTGRES_SSLMODE` | (empty) | Encrypt the connection: `require`, `verify-ca` or `verify-full`. Empty is plaintext. See [Encrypted connections](#encrypted-connections-tls) |
 | `DB_POOL_SIZE` | `5` | Connection pool size |
 | `DB_MAX_OVERFLOW` | `10` | Max overflow connections |
 | `DB_POOL_TIMEOUT` | `30` | Pool timeout in seconds |
@@ -164,6 +165,43 @@ Computed properties:
 | `REDIS_PORT` | `6379` | Redis port |
 | `REDIS_PASSWORD` | (none) | Redis password (optional) |
 | `REDIS_DB` | `0` | Redis database number |
+| `REDIS_SSL` | `false` | Encrypt the connection (`rediss://`). See [Encrypted connections](#encrypted-connections-tls) |
+
+## Encrypted connections (TLS)
+
+Both stores connect in plaintext by default. On a single host with Postgres and
+Redis on the same Docker network that is fine, and it is what the shipped compose
+files run. On a managed Postgres, or a Redis on another node, encrypting the
+connection is the transmission-security control a reviewer asks for first (HIPAA
+§164.312(e), SOC 2 CC6.7).
+
+Setting `POSTGRES_SSLMODE` builds the URL each driver understands — `?ssl=<mode>`
+for the app's asyncpg, `?sslmode=<mode>` for Alembic's psycopg2 — and `REDIS_SSL`
+switches the Redis scheme to `rediss://`. `require` encrypts the connection;
+`verify-ca` and `verify-full` also check the server's certificate.
+
+!!! note "The CA is trusted at the OS level, not per connection"
+
+    asyncpg reads no per-connection root-certificate path, so a `verify-full`
+    setup mounts the CA bundle into the container's trust store rather than naming
+    it in the URL. `agenticos cmd doctor` reports `postgres: tls=on/off` and
+    `redis: tls=on/off` — the transport of the connection it actually made, read
+    from `pg_stat_ssl`, not the setting that asked for it.
+
+```yaml
+# A managed Postgres that requires TLS, verified against its CA.
+services:
+  api:
+    environment:
+      POSTGRES_HOST: db.internal.example.com
+      POSTGRES_PORT: "5432"
+      POSTGRES_SSLMODE: verify-full
+      REDIS_SSL: "true"
+    volumes:
+      # Mounted where the base image's trust store looks, then trusted at build
+      # or entrypoint with `update-ca-certificates`.
+      - ./ca/managed-postgres.crt:/usr/local/share/ca-certificates/managed-postgres.crt:ro
+```
 
 ## Email (SMTP)
 


### PR DESCRIPTION
## What was missing

`app/core/config.py` had no TLS option for either store and `docs/configuration.md` never mentioned it, so an operator could not encrypt the connection through configuration, nothing tested it worked through the pool and the Prefect worker, and `agenticos cmd doctor` did not say whether the connections it made were encrypted. On one host with both stores on the same compose network this is a low risk; on a managed Postgres or a Redis on another node it is the transmission-security control (HIPAA §164.312(e), SOC 2 CC6.7) a reviewer asks for first.

## The change

- **Settings.** `POSTGRES_SSLMODE` builds the parameter *each driver* understands — `?ssl=<mode>` for the app's asyncpg, `?sslmode=<mode>` for Alembic's psycopg2 — and `REDIS_SSL` switches the Redis scheme to `rediss://`. Both default off, so a plaintext deployment is byte-for-byte unchanged. `require` encrypts; `verify-ca`/`verify-full` also check the server certificate.
- **Doctor.** `doctor` now prints `postgres: tls=on/off`, read from `pg_stat_ssl` for the backend serving it — the transport actually used, not the setting that asked for it — and `redis: tls=on/off` from the URL scheme. Neither is a failure when off, so a provisioning script does not exit non-zero on a single-host deployment.
- **CA trust.** A `verify-full` setup trusts the CA through the container's OS store, documented with a compose example — because asyncpg reads no per-connection certificate path (verified against `asyncpg.connect`, which has `ssl` but no `sslrootcert`).

## Verification

- `TestStoreTls` (config): each driver gets its own SSL parameter; `REDIS_SSL` yields `rediss://`; both plaintext by default.
- `TestStoreTlsIsReported` (doctor): `pg_stat_ssl` drives the postgres line, the URL scheme the redis line, and an unreadable `pg_stat_ssl` is `not_checked`, not a failure.
- `tests/integration/test_store_tls.py`: the pool **and** the worker engine both connect with `ssl=require` and `pg_stat_ssl` confirms it — **skipped** where the configured Postgres does not accept TLS, so it proves nothing on a plaintext dev container.
- `make test` — 100.00% coverage. `docs-build --strict` and the docs guards pass.

## A note on the checklist

There is no `docs/security.md`, so the "transmission-security row points here" item cannot be satisfied literally — the guidance lives in `docs/configuration.md` (Encrypted connections) until the security programme (#1424) adds that page. Flagging rather than creating a one-row page and wiring it into the nav here.

Closes #1418
