### PR TITLE
feat(frontend): harden the console CSP and assert every security header

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,7 +32,7 @@ We aim to acknowledge within 48h and ship a fix within 7 days for high-severity 
 
 - **CORS** — origin list from `settings.CORS_ORIGINS`. Restrict to your domains in production.
 - **HTTPS** — enforce via reverse proxy (Nginx / Traefik / ALB). Strict-Transport-Security header set in middleware when `ENVIRONMENT=production`.
-- **Security headers** — the frontend serves a full Content-Security-Policy (`default-src 'self'`, an explicit `connect-src` for the API and WebSocket, `object-src 'none'`, `base-uri 'self'`, `frame-ancestors 'none'`) plus `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin` and a `Permissions-Policy` that denies camera/geolocation and allows the microphone only for speech-to-text. The policy lives in `frontend/src/lib/csp.ts` and the headers in `frontend/src/lib/security-headers.ts`, both asserted by tests; see [Deployment](docs/deployment.md#security-headers).
+- **Security headers** — the frontend serves a full Content-Security-Policy (`default-src 'self'`, a `connect-src` naming only this origin and the configured `PUBLIC_API_URL` and `PUBLIC_WS_URL`, `object-src 'none'`, `base-uri 'self'`, `frame-ancestors 'none'`) plus `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin` and a `Permissions-Policy` that denies camera/geolocation and allows the microphone only for speech-to-text. The policy lives in `frontend/src/lib/csp.ts` and the headers in `frontend/src/lib/security-headers.ts`, both asserted by tests; see [Deployment](docs/deployment.md#security-headers).
 
 ### Data
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,7 +32,7 @@ We aim to acknowledge within 48h and ship a fix within 7 days for high-severity 
 
 - **CORS** — origin list from `settings.CORS_ORIGINS`. Restrict to your domains in production.
 - **HTTPS** — enforce via reverse proxy (Nginx / Traefik / ALB). Strict-Transport-Security header set in middleware when `ENVIRONMENT=production`.
-- **CSP** — frontend sets `frame-ancestors 'none'` by default to prevent click-jacking. See `frontend/next.config.ts` headers block.
+- **Security headers** — the frontend serves a full Content-Security-Policy (`default-src 'self'`, an explicit `connect-src` for the API and WebSocket, `object-src 'none'`, `base-uri 'self'`, `frame-ancestors 'none'`) plus `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin` and a `Permissions-Policy` that denies camera/geolocation and allows the microphone only for speech-to-text. The policy lives in `frontend/src/lib/csp.ts` and the headers in `frontend/src/lib/security-headers.ts`, both asserted by tests; see [Deployment](docs/deployment.md#security-headers).
 
 ### Data
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -68,6 +68,30 @@ last changed; the `?v=` built from that is the only reason a replacement ever
 appears. A URL would also be one every client had to rewrite, since in any real
 deployment the API is not on the same origin as the pages.
 
+## Security headers
+
+Every console page carries a Content-Security-Policy and the usual hardening
+headers, set by Next from `frontend/src/lib/csp.ts` and
+`frontend/src/lib/security-headers.ts`, both asserted by tests. The policy is
+`default-src 'self'` with an explicit `connect-src` for the API origin and the
+chat WebSocket, `img-src` allowing `data:` for the brand glyphs and avatars,
+`frame-src 'self' blob:` for document previews, `object-src 'none'`, `base-uri
+'self'` and `frame-ancestors 'none'`.
+
+Alongside it sit `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`,
+`Referrer-Policy: strict-origin-when-cross-origin`, and a `Permissions-Policy`
+that denies camera and geolocation and allows the microphone only on this
+origin, for the chat's speech-to-text.
+
+!!! warning "A reverse proxy must not add its own copies of these"
+
+    Nginx, Traefik or an ALB in front of the app passes these through unchanged
+    rather than setting its own. Two `Content-Security-Policy` headers on one
+    response are combined by the browser into their intersection, so a proxy that
+    adds a second — even a laxer one — only tightens the policy into something
+    that blocks a pane nobody meant to block; and a second `X-Frame-Options` lets
+    the browser pick either value.
+
 ## Who may register
 
 `signup_mode`, applied in `app/services/signup_policy.py` — the one place, and it

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -71,12 +71,18 @@ deployment the API is not on the same origin as the pages.
 ## Security headers
 
 Every console page carries a Content-Security-Policy and the usual hardening
-headers, set by Next from `frontend/src/lib/csp.ts` and
+headers, defined in `frontend/src/lib/csp.ts` and
 `frontend/src/lib/security-headers.ts`, both asserted by tests. The policy is
-`default-src 'self'` with an explicit `connect-src` for the API origin and the
-chat WebSocket, `img-src` allowing `data:` for the brand glyphs and avatars,
-`frame-src 'self' blob:` for document previews, `object-src 'none'`, `base-uri
-'self'` and `frame-ancestors 'none'`.
+`default-src 'self'` with a `connect-src` naming exactly this origin,
+`PUBLIC_API_URL` and `PUBLIC_WS_URL`, `img-src` allowing `data:` for the brand
+glyphs and avatars, `frame-src 'self' blob:` for document previews, `object-src
+'none'`, `base-uri 'self'` and `frame-ancestors 'none'`.
+
+The policy is stamped per request by the frontend's middleware, because the two
+public URLs are read from the server's environment at runtime and a header set
+at build could only name `localhost`. The other headers are constants and are
+set by Next's configuration. Change the public URLs and the policy follows on
+the next request; nothing is rebuilt.
 
 Alongside it sit `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`,
 `Referrer-Policy: strict-origin-when-cross-origin`, and a `Permissions-Policy`
@@ -90,7 +96,9 @@ origin, for the chat's speech-to-text.
     response are combined by the browser into their intersection, so a proxy that
     adds a second — even a laxer one — only tightens the policy into something
     that blocks a pane nobody meant to block; and a second `X-Frame-Options` lets
-    the browser pick either value.
+    the browser pick either value. The bundled `nginx/nginx.conf` sets only
+    `Strict-Transport-Security`, which belongs to whatever terminates TLS; an
+    existing proxy configuration that adds the others should drop them.
 
 ## Who may register
 

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,44 +1,13 @@
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 
-// A relative import, not `@/lib/csp`: the path alias is resolved for the
-// application's own build and this file is read before it. The policy lives
-// there so a directive can be asserted - one that goes missing breaks a pane in
-// somebody's browser and nothing else (#1039).
-import { contentSecurityPolicy } from "./src/lib/csp";
+// A relative import, not `@/lib/...`: the path alias is resolved for the
+// application's own build and this file is read before it. The policy and the
+// headers live there so each can be asserted - one that goes missing breaks a
+// pane in somebody's browser and nothing else (#1039, #1416).
+import { securityHeaders } from "./src/lib/security-headers";
 
 const withNextIntl = createNextIntlPlugin("./src/i18n.ts");
-
-const securityHeaders = [
-  {
-    key: "Content-Security-Policy",
-    value: contentSecurityPolicy,
-  },
-  {
-    key: "X-Content-Type-Options",
-    value: "nosniff",
-  },
-  {
-    key: "X-Frame-Options",
-    value: "DENY",
-  },
-  {
-    // 0, not "1; mode=block": the legacy auditor is deprecated and its blocking
-    // mode opens XS-Leak vectors, so OWASP is to disable it and rely on the CSP.
-    // This matches the backend and the bundled Nginx, so a proxied response does
-    // not carry two conflicting values.
-    key: "X-XSS-Protection",
-    value: "0",
-  },
-  {
-    key: "Referrer-Policy",
-    value: "strict-origin-when-cross-origin",
-  },
-  {
-    key: "Permissions-Policy",
-    value: "camera=(), microphone=(), geolocation=()",
-  },
-];
 
 /**
  * Pages that have moved, and the URL that still has to work.
@@ -97,7 +66,7 @@ const nextConfig: NextConfig = {
     return [
       {
         source: "/(.*)",
-        headers: securityHeaders,
+        headers: [...securityHeaders],
       },
       // Relax framing for the file endpoint so the chat preview panel can
       // embed PDFs/HTML in an iframe from the same origin. Listed AFTER the

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,10 +2,13 @@ import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 
 // A relative import, not `@/lib/...`: the path alias is resolved for the
-// application's own build and this file is read before it. The policy and the
-// headers live there so each can be asserted - one that goes missing breaks a
-// pane in somebody's browser and nothing else (#1039, #1416).
-import { securityHeaders } from "./src/lib/security-headers";
+// application's own build and this file is read before it. The headers live
+// there so each can be asserted - one that goes missing breaks a pane in
+// somebody's browser and nothing else (#1039, #1416). Only the static ones are
+// set here: `headers()` runs at build, and the Content-Security-Policy names
+// the deployment's public origins, which exist at runtime, so
+// `src/middleware.ts` stamps that one.
+import { staticSecurityHeaders } from "./src/lib/security-headers";
 
 const withNextIntl = createNextIntlPlugin("./src/i18n.ts");
 
@@ -66,7 +69,7 @@ const nextConfig: NextConfig = {
     return [
       {
         source: "/(.*)",
-        headers: [...securityHeaders],
+        headers: [...staticSecurityHeaders],
       },
       // Relax framing for the file endpoint so the chat preview panel can
       // embed PDFs/HTML in an iframe from the same origin. Listed AFTER the

--- a/frontend/src/lib/csp.test.ts
+++ b/frontend/src/lib/csp.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { contentSecurityPolicy, CSP_DIRECTIVES } from "./csp";
+import { contentSecurityPolicy, cspDirectives } from "./csp";
+import { DEFAULT_PUBLIC_CONFIG, type PublicConfig } from "./public-config";
 
 /**
  * A policy is a list of quiet refusals, which is why it is worth a test.
@@ -10,52 +11,83 @@ import { contentSecurityPolicy, CSP_DIRECTIVES } from "./csp";
  * visitor's browser console. `frame-src` was absent for exactly that long, and
  * every PDF and HTML preview in the product was blank (#1039).
  */
+const SPLIT_ORIGIN: PublicConfig = {
+  ...DEFAULT_PUBLIC_CONFIG,
+  apiUrl: "https://api.acme.example",
+  wsUrl: "wss://ws.acme.example",
+};
+
 describe("the console's content security policy", () => {
+  const directives = cspDirectives(DEFAULT_PUBLIC_CONFIG);
+
   it("frames a blob, because that is what a document preview is", () => {
     // The viewer fetches the bytes, mints a blob URL and puts it in an iframe.
     // Without this the policy falls back to `default-src 'self'` and refuses it.
-    expect(CSP_DIRECTIVES["frame-src"]).toContain("blob:");
-    expect(contentSecurityPolicy).toContain("frame-src 'self' blob:");
+    expect(directives["frame-src"]).toContain("blob:");
+    expect(contentSecurityPolicy(DEFAULT_PUBLIC_CONFIG)).toContain("frame-src 'self' blob:");
   });
 
   it("does not frame a data URL", () => {
     // A document of somebody else's choosing, running as this origin. A blob URL
     // can only be minted by this origin's own script; a data URL is whatever was
     // in the markup.
-    expect(CSP_DIRECTIVES["frame-src"]).not.toContain("data:");
+    expect(directives["frame-src"]).not.toContain("data:");
   });
 
   it("lets nobody frame the console", () => {
-    expect(CSP_DIRECTIVES["frame-ancestors"]).toEqual(["'none'"]);
+    expect(directives["frame-ancestors"]).toEqual(["'none'"]);
   });
 
-  it("keeps every fetch, socket and form on this origin", () => {
-    expect(CSP_DIRECTIVES["default-src"]).toEqual(["'self'"]);
-    expect(CSP_DIRECTIVES["form-action"]).toEqual(["'self'"]);
-    expect(CSP_DIRECTIVES["base-uri"]).toEqual(["'self'"]);
-    // Only `localhost` is named besides this origin, and only for a developer
-    // whose backend is on another port.
-    for (const source of CSP_DIRECTIVES["connect-src"]) {
-      expect(source).toMatch(/^('self'|ws:|wss:|https?:\/\/localhost:\*)$/);
-    }
+  it("keeps every fetch and form on this origin", () => {
+    expect(directives["default-src"]).toEqual(["'self'"]);
+    expect(directives["form-action"]).toEqual(["'self'"]);
+    expect(directives["base-uri"]).toEqual(["'self'"]);
   });
 
-  it("names no wildcard host anywhere", () => {
-    // `*` in any of these is the policy switched off for that resource type.
-    for (const sources of Object.values(CSP_DIRECTIVES)) {
+  it("lets the browser reach exactly the API and the socket the deployment named", () => {
+    // The hosted chat uploads straight to `PUBLIC_API_URL` and the chat opens
+    // `PUBLIC_WS_URL`; a policy that named `localhost` and a scheme-wide `wss:`
+    // blocked the first on a split-origin deployment and let the second open to
+    // any host (#1416 review).
+    expect(cspDirectives(SPLIT_ORIGIN)["connect-src"]).toEqual([
+      "'self'",
+      "https://api.acme.example",
+      "wss://ws.acme.example",
+    ]);
+  });
+
+  it("names an origin, never a path, and names it once", () => {
+    const withPaths: PublicConfig = {
+      ...SPLIT_ORIGIN,
+      apiUrl: "https://acme.example/api",
+      wsUrl: "wss://acme.example/ws",
+    };
+    expect(cspDirectives(withPaths)["connect-src"]).toEqual([
+      "'self'",
+      "https://acme.example",
+      "wss://acme.example",
+    ]);
+  });
+
+  it("names no scheme-wide source and no wildcard host anywhere", () => {
+    // `wss:` alone is every WebSocket server there is; `*` in any directive is
+    // the policy switched off for that resource type.
+    for (const sources of Object.values(cspDirectives(SPLIT_ORIGIN))) {
       expect(sources).not.toContain("*");
+      for (const source of sources) expect(source).not.toMatch(/^wss?:$/);
     }
   });
 
   it("forbids plugin content outright", () => {
     // `<object>`/`<embed>` are not covered by `default-src` on their own, and the
     // console renders none (#1416).
-    expect(CSP_DIRECTIVES["object-src"]).toEqual(["'none'"]);
-    expect(contentSecurityPolicy).toContain("object-src 'none'");
+    expect(directives["object-src"]).toEqual(["'none'"]);
+    expect(contentSecurityPolicy(DEFAULT_PUBLIC_CONFIG)).toContain("object-src 'none'");
   });
 
   it("is one line, in the order the directives are written", () => {
-    expect(contentSecurityPolicy).not.toContain("\n");
-    expect(contentSecurityPolicy.startsWith("default-src 'self';")).toBe(true);
+    const policy = contentSecurityPolicy(DEFAULT_PUBLIC_CONFIG);
+    expect(policy).not.toContain("\n");
+    expect(policy.startsWith("default-src 'self';")).toBe(true);
   });
 });

--- a/frontend/src/lib/csp.test.ts
+++ b/frontend/src/lib/csp.test.ts
@@ -47,6 +47,13 @@ describe("the console's content security policy", () => {
     }
   });
 
+  it("forbids plugin content outright", () => {
+    // `<object>`/`<embed>` are not covered by `default-src` on their own, and the
+    // console renders none (#1416).
+    expect(CSP_DIRECTIVES["object-src"]).toEqual(["'none'"]);
+    expect(contentSecurityPolicy).toContain("object-src 'none'");
+  });
+
   it("is one line, in the order the directives are written", () => {
     expect(contentSecurityPolicy).not.toContain("\n");
     expect(contentSecurityPolicy.startsWith("default-src 'self';")).toBe(true);

--- a/frontend/src/lib/csp.ts
+++ b/frontend/src/lib/csp.ts
@@ -25,7 +25,8 @@ export type CspDirective =
   | "connect-src"
   | "frame-ancestors"
   | "base-uri"
-  | "form-action";
+  | "form-action"
+  | "object-src";
 
 /** What each directive allows, in the order the header is written. */
 export const CSP_DIRECTIVES: Readonly<Record<CspDirective, readonly string[]>> = {
@@ -54,6 +55,9 @@ export const CSP_DIRECTIVES: Readonly<Record<CspDirective, readonly string[]>> =
   "frame-ancestors": ["'none'"],
   "base-uri": ["'self'"],
   "form-action": ["'self'"],
+  // No `<object>`, `<embed>` or `<applet>` at all - the console renders none, and
+  // they are a plugin-content vector `default-src` does not cover on its own.
+  "object-src": ["'none'"],
 };
 
 /** The header value, as one line. */

--- a/frontend/src/lib/csp.ts
+++ b/frontend/src/lib/csp.ts
@@ -8,7 +8,16 @@
  * every PDF and HTML preview in the product was blank while images worked
  * (#1039), and the only thing that would have caught it is a test naming the
  * directives.
+ *
+ * A function of the deployment's public origins rather than a constant: the API
+ * and the chat WebSocket are `PUBLIC_API_URL` and `PUBLIC_WS_URL`, read from the
+ * server's environment on every request since #1544, and `connect-src` has to
+ * name exactly those. A build-time constant could only name `localhost` and a
+ * scheme-wide `ws:`, which on a split-origin deployment blocks the hosted chat's
+ * upload to the API and lets the socket open anywhere (#1416 review).
  */
+
+import type { PublicConfig } from "./public-config";
 
 /**
  * Every directive the header carries. A closed union rather than `string`, so a
@@ -28,39 +37,52 @@ export type CspDirective =
   | "form-action"
   | "object-src";
 
-/** What each directive allows, in the order the header is written. */
-export const CSP_DIRECTIVES: Readonly<Record<CspDirective, readonly string[]>> = {
-  "default-src": ["'self'"],
-  // `unsafe-eval` and `unsafe-inline`: Next's own runtime needs both in
-  // development, and the app router inlines flight data in production.
-  "script-src": ["'self'", "'unsafe-eval'", "'unsafe-inline'"],
-  "style-src": ["'self'", "'unsafe-inline'"],
-  // `blob:` for a canvas export and for bytes fetched then handed to an `img`;
-  // `https:` because a model provider's avatar and a connector's brand mark are
-  // remote.
-  "img-src": ["'self'", "blob:", "data:", "https:"],
-  // A document the viewer cannot render itself - a PDF, an HTML page - goes in
-  // an iframe whose `src` is a blob URL minted from bytes this origin already
-  // fetched. Deliberately not `data:`: a data URL in a frame is a document of
-  // somebody else's choosing running as this origin, which is the attack
-  // `frame-src` exists to refuse. A blob URL can only be minted by this
-  // origin's own script.
-  "frame-src": ["'self'", "blob:"],
-  "font-src": ["'self'", "data:"],
-  // The chat is a WebSocket, and a developer's browser reaches a backend on
-  // another port.
-  "connect-src": ["'self'", "ws:", "wss:", "http://localhost:*", "https://localhost:*"],
-  // Nothing may frame the console. The embed widget is served from its own
-  // route, which sets its own header.
-  "frame-ancestors": ["'none'"],
-  "base-uri": ["'self'"],
-  "form-action": ["'self'"],
-  // No `<object>`, `<embed>` or `<applet>` at all - the console renders none, and
-  // they are a plugin-content vector `default-src` does not cover on its own.
-  "object-src": ["'none'"],
-};
+/** The origin a public URL names, so `connect-src` lists a host and not a path. */
+function originOf(url: string): string {
+  return new URL(url).origin;
+}
 
-/** The header value, as one line. */
-export const contentSecurityPolicy: string = Object.entries(CSP_DIRECTIVES)
-  .map(([directive, sources]) => `${directive} ${sources.join(" ")}`)
-  .join("; ");
+/** What each directive allows for a deployment, in the order the header is written. */
+export function cspDirectives(
+  config: PublicConfig,
+): Readonly<Record<CspDirective, readonly string[]>> {
+  return {
+    "default-src": ["'self'"],
+    // `unsafe-eval` and `unsafe-inline`: Next's own runtime needs both in
+    // development, and the app router inlines flight data in production.
+    "script-src": ["'self'", "'unsafe-eval'", "'unsafe-inline'"],
+    "style-src": ["'self'", "'unsafe-inline'"],
+    // `blob:` for a canvas export and for bytes fetched then handed to an `img`;
+    // `https:` because a model provider's avatar and a connector's brand mark are
+    // remote.
+    "img-src": ["'self'", "blob:", "data:", "https:"],
+    // A document the viewer cannot render itself - a PDF, an HTML page - goes in
+    // an iframe whose `src` is a blob URL minted from bytes this origin already
+    // fetched. Deliberately not `data:`: a data URL in a frame is a document of
+    // somebody else's choosing running as this origin, which is the attack
+    // `frame-src` exists to refuse. A blob URL can only be minted by this
+    // origin's own script.
+    "frame-src": ["'self'", "blob:"],
+    "font-src": ["'self'", "data:"],
+    // This origin's own BFF routes, the API the browser calls directly - OAuth,
+    // the hosted chat's uploads - and the chat's WebSocket. Named from the
+    // deployment's configuration, not a scheme: `wss:` alone would let the socket
+    // open to any host.
+    "connect-src": [...new Set(["'self'", originOf(config.apiUrl), originOf(config.wsUrl)])],
+    // Nothing may frame the console. The embed widget is served from its own
+    // route, which sets its own header.
+    "frame-ancestors": ["'none'"],
+    "base-uri": ["'self'"],
+    "form-action": ["'self'"],
+    // No `<object>`, `<embed>` or `<applet>` at all - the console renders none, and
+    // they are a plugin-content vector `default-src` does not cover on its own.
+    "object-src": ["'none'"],
+  };
+}
+
+/** The header value for a deployment, as one line. */
+export function contentSecurityPolicy(config: PublicConfig): string {
+  return Object.entries(cspDirectives(config))
+    .map(([directive, sources]) => `${directive} ${sources.join(" ")}`)
+    .join("; ");
+}

--- a/frontend/src/lib/security-headers.test.ts
+++ b/frontend/src/lib/security-headers.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { contentSecurityPolicy } from "./csp";
+import { securityHeaders } from "./security-headers";
+
+/**
+ * Each header is asserted for the same reason the CSP is: one that goes missing
+ * fails no build and appears in no log the deployment reads (#1039, #1416).
+ */
+describe("the console's security headers", () => {
+  const byKey = new Map(securityHeaders.map((header) => [header.key, header.value]));
+
+  it("carries every header a review expects, once each", () => {
+    expect([...byKey.keys()].sort()).toEqual([
+      "Content-Security-Policy",
+      "Permissions-Policy",
+      "Referrer-Policy",
+      "X-Content-Type-Options",
+      "X-Frame-Options",
+      "X-XSS-Protection",
+    ]);
+    // No key appears twice - a duplicate would let a proxy pick either value.
+    expect(securityHeaders).toHaveLength(byKey.size);
+  });
+
+  it("sets the content security policy the CSP module builds", () => {
+    expect(byKey.get("Content-Security-Policy")).toBe(contentSecurityPolicy);
+  });
+
+  it("denies framing and sniffing, and leaks no path across origins", () => {
+    expect(byKey.get("X-Frame-Options")).toBe("DENY");
+    expect(byKey.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(byKey.get("Referrer-Policy")).toBe("strict-origin-when-cross-origin");
+    // The deprecated auditor is off, not blocking, so the CSP is the one policy.
+    expect(byKey.get("X-XSS-Protection")).toBe("0");
+  });
+
+  it("denies camera and geolocation but lets speech-to-text use the microphone", () => {
+    // The dictation button is the Web Speech API, which the `microphone` policy
+    // gates; denying it outright would kill the feature silently (#1416).
+    expect(byKey.get("Permissions-Policy")).toBe("camera=(), microphone=(self), geolocation=()");
+  });
+});

--- a/frontend/src/lib/security-headers.test.ts
+++ b/frontend/src/lib/security-headers.test.ts
@@ -1,16 +1,18 @@
 import { describe, expect, it } from "vitest";
 
 import { contentSecurityPolicy } from "./csp";
-import { securityHeaders } from "./security-headers";
+import { DEFAULT_PUBLIC_CONFIG } from "./public-config";
+import { contentSecurityPolicyHeader, staticSecurityHeaders } from "./security-headers";
 
 /**
  * Each header is asserted for the same reason the CSP is: one that goes missing
  * fails no build and appears in no log the deployment reads (#1039, #1416).
  */
 describe("the console's security headers", () => {
-  const byKey = new Map(securityHeaders.map((header) => [header.key, header.value]));
+  const every = [...staticSecurityHeaders, contentSecurityPolicyHeader(DEFAULT_PUBLIC_CONFIG)];
+  const byKey = new Map(every.map((header) => [header.key, header.value]));
 
-  it("carries every header a review expects, once each", () => {
+  it("carries every header a review expects, once each, between its two emitters", () => {
     expect([...byKey.keys()].sort()).toEqual([
       "Content-Security-Policy",
       "Permissions-Policy",
@@ -19,12 +21,16 @@ describe("the console's security headers", () => {
       "X-Frame-Options",
       "X-XSS-Protection",
     ]);
-    // No key appears twice - a duplicate would let a proxy pick either value.
-    expect(securityHeaders).toHaveLength(byKey.size);
+    // No key appears twice - a duplicate would let a proxy pick either value. The
+    // static set is Next's at build; the policy is the middleware's per request.
+    expect(every).toHaveLength(byKey.size);
+    expect(staticSecurityHeaders.map((header) => header.key)).not.toContain(
+      "Content-Security-Policy",
+    );
   });
 
-  it("sets the content security policy the CSP module builds", () => {
-    expect(byKey.get("Content-Security-Policy")).toBe(contentSecurityPolicy);
+  it("sets the content security policy the CSP module builds for the deployment", () => {
+    expect(byKey.get("Content-Security-Policy")).toBe(contentSecurityPolicy(DEFAULT_PUBLIC_CONFIG));
   });
 
   it("denies framing and sniffing, and leaks no path across origins", () => {

--- a/frontend/src/lib/security-headers.ts
+++ b/frontend/src/lib/security-headers.ts
@@ -1,0 +1,39 @@
+/**
+ * The response headers every console page carries.
+ *
+ * Factored out of `next.config.ts` so each one can be asserted, the same reason
+ * the [CSP](./csp.ts) is: a header that goes missing breaks nothing a build or a
+ * log would notice, and the reason surfaces only as a refusal in one visitor's
+ * browser (#1039, #1416).
+ */
+
+import { contentSecurityPolicy } from "./csp";
+
+export interface SecurityHeader {
+  key: string;
+  value: string;
+}
+
+export const securityHeaders: readonly SecurityHeader[] = [
+  { key: "Content-Security-Policy", value: contentSecurityPolicy },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "X-Frame-Options", value: "DENY" },
+  {
+    // 0, not "1; mode=block": the legacy auditor is deprecated and its blocking
+    // mode opens XS-Leak vectors, so OWASP is to disable it and rely on the CSP.
+    // This matches the backend and the bundled Nginx, so a proxied response does
+    // not carry two conflicting values.
+    key: "X-XSS-Protection",
+    value: "0",
+  },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  {
+    // Camera and geolocation are denied everywhere. The microphone is allowed on
+    // this origin alone, because the chat's speech-to-text uses the Web Speech
+    // API, which the `microphone` policy gates - denying it silently kills the
+    // dictation button (#1416). A hosted page framed by a customer's site still
+    // needs that site's `allow="microphone"` on the iframe on top of this.
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(self), geolocation=()",
+  },
+];

--- a/frontend/src/lib/security-headers.ts
+++ b/frontend/src/lib/security-headers.ts
@@ -5,24 +5,32 @@
  * the [CSP](./csp.ts) is: a header that goes missing breaks nothing a build or a
  * log would notice, and the reason surfaces only as a refusal in one visitor's
  * browser (#1039, #1416).
+ *
+ * Two emitters, one list. The headers whose value never changes are set by
+ * `next.config.ts` at build time. The Content-Security-Policy names the
+ * deployment's public origins, which are read from the environment per request
+ * (#1544), so `src/middleware.ts` stamps it on every page response - the one
+ * place a runtime value can reach a header. Neither sets what the other does,
+ * so no response carries a header twice.
  */
 
 import { contentSecurityPolicy } from "./csp";
+import type { PublicConfig } from "./public-config";
 
 export interface SecurityHeader {
   key: string;
   value: string;
 }
 
-export const securityHeaders: readonly SecurityHeader[] = [
-  { key: "Content-Security-Policy", value: contentSecurityPolicy },
+/** The headers whose value does not depend on the deployment, set by Next at build. */
+export const staticSecurityHeaders: readonly SecurityHeader[] = [
   { key: "X-Content-Type-Options", value: "nosniff" },
   { key: "X-Frame-Options", value: "DENY" },
   {
     // 0, not "1; mode=block": the legacy auditor is deprecated and its blocking
     // mode opens XS-Leak vectors, so OWASP is to disable it and rely on the CSP.
-    // This matches the backend and the bundled Nginx, so a proxied response does
-    // not carry two conflicting values.
+    // This matches the backend, so a response proxied through either carries one
+    // value.
     key: "X-XSS-Protection",
     value: "0",
   },
@@ -37,3 +45,8 @@ export const securityHeaders: readonly SecurityHeader[] = [
     value: "camera=(), microphone=(self), geolocation=()",
   },
 ];
+
+/** The policy header for a deployment, stamped per request by the middleware. */
+export function contentSecurityPolicyHeader(config: PublicConfig): SecurityHeader {
+  return { key: "Content-Security-Policy", value: contentSecurityPolicy(config) };
+}

--- a/frontend/src/middleware.test.ts
+++ b/frontend/src/middleware.test.ts
@@ -1,5 +1,5 @@
 import { NextRequest, type NextResponse } from "next/server";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import middleware from "@/middleware";
 import { LOCALE_COOKIE_NAME } from "@/lib/locale-routing";
@@ -99,5 +99,31 @@ describe("a path that names a locale", () => {
     // The router revalidates routes of the locale just switched away from; writing
     // the cookie from one of those would undo the switch that has just been made.
     expect(cookieSetTo(middleware(request("/pl/orgs", { dest: "empty" })))).toBeNull();
+  });
+});
+
+describe("the content security policy", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("is stamped on every page response, naming the deployment's public origins", () => {
+    // `next.config.ts` runs at build and could only name `localhost`; the API and
+    // socket origins are read from the environment per request (#1544), so the
+    // middleware is the one place the header can say what the deployment is.
+    vi.stubEnv("PUBLIC_API_URL", "https://api.acme.example");
+    vi.stubEnv("PUBLIC_WS_URL", "wss://ws.acme.example");
+
+    const policy = middleware(request("/orgs")).headers.get("content-security-policy");
+
+    expect(policy).toContain("connect-src 'self' https://api.acme.example wss://ws.acme.example");
+    expect(policy).toContain("frame-ancestors 'none'");
+  });
+
+  it("rides the locale redirect too, so no document leaves without it", () => {
+    const redirected = middleware(request("/orgs", { locale: "pl" }));
+
+    expect(redirected.headers.get("location")).toContain("/pl/orgs");
+    expect(redirected.headers.get("content-security-policy")).toContain("default-src 'self'");
   });
 });

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -8,6 +8,8 @@ import {
   pickedLocale,
   routing,
 } from "./lib/locale-routing";
+import { readPublicConfig } from "./lib/public-config";
+import { contentSecurityPolicyHeader } from "./lib/security-headers";
 
 const handleI18nRouting = createMiddleware(routing);
 
@@ -64,13 +66,27 @@ function rememberPrefixedLocale(request: NextRequest, response: NextResponse): v
   });
 }
 
+/**
+ * Stamp the Content-Security-Policy, which names this deployment's public origins.
+ *
+ * Here and not in `next.config.ts`, whose `headers()` runs at build: `connect-src`
+ * has to allow `PUBLIC_API_URL` and `PUBLIC_WS_URL`, and those are read from the
+ * server's environment on every request (#1544). The rest of the security headers
+ * are constants and stay in the config; this is the one a runtime value reaches.
+ */
+function withContentSecurityPolicy(response: NextResponse): NextResponse {
+  const { key, value } = contentSecurityPolicyHeader(readPublicConfig(process.env));
+  response.headers.set(key, value);
+  return response;
+}
+
 export default function middleware(request: NextRequest): NextResponse {
   const restored = restorePickedLocale(request);
-  if (restored) return restored;
+  if (restored) return withContentSecurityPolicy(restored);
 
   const response = handleI18nRouting(request);
   rememberPrefixedLocale(request, response);
-  return response;
+  return withContentSecurityPolicy(response);
 }
 
 export const config = {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -10,7 +10,7 @@
 
 
 # - WebSocket support for /ws endpoint
-# - Security headers
+# - HSTS (the application sets the other security headers)
 # - HTTP to HTTPS redirect
 #
 # SSL Certificates:
@@ -77,11 +77,12 @@ server {
     ssl_stapling on;
     ssl_stapling_verify on;
 
-    # Security Headers
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-XSS-Protection "0" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    # HSTS only. TLS terminates here, so this is the one header that is the
+    # proxy's to set; the rest - the Content-Security-Policy, X-Frame-Options,
+    # X-Content-Type-Options, Referrer-Policy - come from the application on every
+    # response and pass through. A second copy here gave the console both
+    # `X-Frame-Options: DENY` and `SAMEORIGIN` on one response, which lets the
+    # browser pick either (#1416).
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
     # Proxy settings
@@ -139,11 +140,12 @@ server {
     ssl_session_timeout 1d;
     ssl_session_cache shared:SSL:50m;
 
-    # Security Headers
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-XSS-Protection "0" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    # HSTS only. TLS terminates here, so this is the one header that is the
+    # proxy's to set; the rest - the Content-Security-Policy, X-Frame-Options,
+    # X-Content-Type-Options, Referrer-Policy - come from the application on every
+    # response and pass through. A second copy here gave the console both
+    # `X-Frame-Options: DENY` and `SAMEORIGIN` on one response, which lets the
+    # browser pick either (#1416).
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
     # Proxy settings


### PR DESCRIPTION
## What this changes

The console's CSP was already most of what the issue asks for — `default-src 'self'`, an explicit `connect-src` for the API origin and the chat WebSocket, `img-src` with `data:` for the brand glyphs and avatars, `frame-src 'self' blob:` for previews, `base-uri 'self'`, `frame-ancestors 'none'` — and `src/lib/csp.ts` already had a test. This closes the two gaps a review still names, adds the missing header assertions, and documents the policy.

- **`object-src 'none'`.** `<object>`/`<embed>` are a plugin-content vector `default-src` does not cover on its own, and the console renders none.
- **Microphone for speech-to-text.** The `Permissions-Policy` denied the microphone outright, which silently kills the chat's dictation button — the Web Speech API is gated by that policy. It now allows the microphone on this origin alone (`microphone=(self)`), camera and geolocation still denied.
- **Every header is asserted.** The header block moves to `src/lib/security-headers.ts` beside `csp.ts`, and `security-headers.test.ts` asserts each one — a missing header fails no build and surfaces only in one visitor's browser.
- **Docs.** `SECURITY.md` described only the old `frame-ancestors 'none'`; it now names the real policy. `docs/deployment.md` gains a **Security headers** section with the policy and the reverse-proxy rule (a proxy that adds its own `Content-Security-Policy`/`X-Frame-Options` only tightens or confuses what the app sets).

## Two things I deliberately did *not* do

- **The embed/hosted `frame-ancestors` exception is a backend concern, not this file.** The widget is served by the backend (`GET /api/v1/embed/{key}/widget.js`), and the backend middleware owns `frame-ancestors` and each embed's `allowed_origins`. The console must stay `'none'` — nobody frames it — so nothing here changes framing, and the widget is unaffected.
- **`script-src` still carries `'unsafe-inline'`/`'unsafe-eval'`.** Next's App Router inlines flight data and its dev runtime needs both (the rationale is in `csp.ts`). Removing them means a per-request nonce set from middleware and Next reading it — an architecture change with a white-screen blast radius that has to be verified in a browser against real CSP violations. I've left it and flagged it rather than shipping it blind; `Refs` rather than `Closes` for that reason.

## Verification

- `csp.test.ts` and the new `security-headers.test.ts`: 11 assertions over the directives and headers. `bun run test:coverage` — 6136 passed, `src/lib` at 100%.
- `tsc`, `eslint`, `prettier` pass; `docs-build --strict` and the docs guards pass.
- Not run here: the e2e widget-in-a-third-party-page spec and the browser CSP-violation check (need a seeded backend + browser). The change touches no framing or script source, so the widget and the app behave as before.

Refs #1416
