### PR TITLE
chore: cut 0.0.403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.403] - 2026-09-11
+
+### Fixed
+
+- **The connect-services card navigates in the app, and the runner no longer
+  builds console URLs.** `personal_service_gap` quoted `FRONTEND_URL/mcp-servers`
+  to both the model and the card, which 404s under a locale prefix. The frame
+  now carries the catalog key and the gap only: the card resolves the entry it
+  has and pushes the locale-aware route, a console reader is named the page in
+  words, and only a channel reader gets an absolute link, built beside the other
+  channel URLs. (#1572)
+
 ## [0.0.402] - 2026-09-11
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.402"
+version = "0.0.403"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.402"
+version = "0.0.403"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.402",
+  "version": "0.0.403",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.403: version, lock and changelog only.

Ships #1572 - fix(agents): let the surface own the personal-service gap URL.
