### PR TITLE
chore: cut 0.0.404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.404] - 2026-09-11
+
+### Fixed
+
+- **Removing a member is decided by the catalog, like changing a role.**
+  `MemberService.remove` refused Admin-removes-Admin with a literal role check
+  while `change_role` used `assignable_roles`, so a custom role holding
+  `members:manage` that does not outrank an Admin would be refused one action
+  and allowed the other. Both now use the same ceiling; the built-in roles
+  behave exactly as before. (#1573)
+
 ## [0.0.403] - 2026-09-11
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.403"
+version = "0.0.404"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.403"
+version = "0.0.404"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.403",
+  "version": "0.0.404",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.404: version, lock and changelog only.

Ships #1573 - fix(permissions): decide member removal by the catalog, not an admin literal.
