### PR TITLE
chore: cut 0.0.405

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.405] - 2026-09-11
+
+### Fixed
+
+- **Telegram rooms are `group`, like every other platform's.** The Telegram
+  parser emitted the raw `supergroup` and `channel` types while Slack and
+  Mattermost fold everything but a DM to `group`, so `channel_sessions.chat_type`
+  held a different vocabulary per platform and the first consumer to write
+  `chat_type == "group"` would have missed every Telegram room. The parser folds
+  them now, and migration `0076_normalize_channel_chat_type` folds the rows
+  already written. (#1574)
+
 ## [0.0.404] - 2026-09-11
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.404"
+version = "0.0.405"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.404"
+version = "0.0.405"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.404",
+  "version": "0.0.405",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.405: version, lock and changelog only.

Ships #1574 - fix(channels): give Telegram the same chat_type vocabulary as the others.
