### PR TITLE
chore: cut 0.0.406

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.406] - 2026-09-11
+
+### Fixed
+
+- **Whether a personal MCP connection is usable is decided once, on the
+  server.** The console re-derived it and disagreed with the backend: a bearer
+  token whose sealing key had been rotated away read *Connected* in the chat
+  controls and unavailable in the next turn. `McpConnection.account_authorized`
+  is the single side-effect-free answer - an OAuth grant with a payload, a token
+  whose key version is still configured, or no token at all - the run path uses
+  it, and `McpConnectionRead` carries it to the client as `authorized`. (#1575)
+
 ## [0.0.405] - 2026-09-11
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.405"
+version = "0.0.406"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.405"
+version = "0.0.406"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.405",
+  "version": "0.0.406",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.406: version, lock and changelog only.

Ships #1575 - fix(mcp): decide a personal connection's usability once, on the server.
