### PR TITLE
chore: cut 0.0.407

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.407] - 2026-09-11
+
+### Fixed
+
+- **A tool-prefix collision is decided once, and the model is told about it.**
+  Publish refused two MCP bindings reducing to one prefix while the run
+  re-computed the same rule and dropped the loser with a log line, so a
+  connection renamed after publish, or an agent published before the check,
+  lost a server nobody was told about. One `prefix_collisions` serves both;
+  the run records each dropped binding on the toolsets' `unavailable` list, the
+  briefing says the server is not available this turn, and the connect card
+  leaves it out because renaming a connection is the author's job. (#1576)
+
 ## [0.0.406] - 2026-09-11
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.406"
+version = "0.0.407"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.406"
+version = "0.0.407"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.406",
+  "version": "0.0.407",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.407: version, lock and changelog only.

Ships #1576 - fix(mcp): decide a tool-prefix collision once, and report it at run time.
