### PR TITLE
chore: cut 0.0.408

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.408] - 2026-09-11
+
+### Added
+
+- **Encrypted connections to Postgres and Redis, and a doctor line saying so.**
+  `POSTGRES_SSLMODE` builds the parameter each driver understands - `ssl=` for
+  asyncpg, `sslmode=` for Alembic's psycopg2 - and `REDIS_SSL` switches the
+  scheme to `rediss://` with hostname verification on. Both default off, so a
+  plaintext deployment is unchanged. `agenticos cmd doctor` reports
+  `postgres: tls=on/off` from `pg_stat_ssl`, the transport actually used, and
+  `redis: tls=on/off` from the URL. `docs/configuration.md` shows the managed-
+  store setup, every consumer included, and how a private CA is trusted. (#1578)
+
 ## [0.0.407] - 2026-09-11
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.407"
+version = "0.0.408"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.407"
+version = "0.0.408"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.407",
+  "version": "0.0.408",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.408: version, lock and changelog only.

Ships #1578 - feat(config): encrypt the connections to Postgres and Redis, and report it.
