### PR TITLE
chore: cut 0.0.409

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ Two things are versioned separately from this file and worth knowing about:
 
 ## [Unreleased]
 
+## [0.0.409] - 2026-09-11
+
+### Security
+
+- **The console's security headers are complete, asserted and documented.**
+  `object-src 'none'` closes the plugin-content vector `default-src` does not
+  cover; `Permissions-Policy` allows the microphone on this origin alone so the
+  chat's dictation works, camera and geolocation still denied; every header
+  lives in `src/lib/security-headers.ts` with a test per header. `connect-src`
+  is built from the deployment's `PUBLIC_API_URL` and `PUBLIC_WS_URL` at
+  runtime, so a split-origin deployment's uploads and socket are allowed and
+  nothing else is, and the bundled nginx passes the application's headers
+  through instead of adding a conflicting set. `SECURITY.md` and
+  `docs/deployment.md` name the real policy. `script-src` still carries
+  `'unsafe-inline'`/`'unsafe-eval'` for Next's App Router; the nonce is #1416's
+  remaining item. (#1580)
+
 ## [0.0.408] - 2026-09-11
 
 ### Added

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenticos"
-version = "0.0.408"
+version = "0.0.409"
 description = "OS for your agents."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticos"
-version = "0.0.408"
+version = "0.0.409"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-frontend",
-  "version": "0.0.408",
+  "version": "0.0.409",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release 0.0.409: version, lock and changelog only.

Ships #1580 - feat(frontend): harden the console CSP and assert every security header.
