### PR TITLE
docs(claude): rewrite the always-loaded brief and scope the rules by paths

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -5,9 +5,10 @@ brief; everything here is loaded on demand.
 
 ```
 .claude/
-  rules/       path-scoped conventions, matched by the `globs` in each file's frontmatter
+  rules/       path-scoped conventions, matched by the `paths` in each file's frontmatter
   skills/      task-scoped guidance, selected by the `description` in SKILL.md
   commands/    slash commands (/add-endpoint, /fix-issue, /review)
+  references/  task-specific procedures linked from CLAUDE.md (issue triage)
   settings.json          permission allowlist, committed
   settings.local.json    per-machine, not shared
 ```
@@ -20,11 +21,11 @@ different reader is a copy that disagrees.
 
 So nothing here restates `docs/`. A skill **routes** to the page and adds what a page
 does not carry: which shape the work should take, which invariant is easy to break, and
-which failures are silent. When a skill and a doc disagree, the doc is right and the
-skill is stale.
+which failures are silent. When a skill and a doc disagree, verify the relevant code, configuration and
+current user instructions before correcting the stale guidance.
 
 **`rules/` is about a file you are editing.** Shapes, naming, layer boundaries. Each
-file declares `globs` so it applies where it is true.
+file declares `paths` so it applies where it is true.
 
 **`skills/` is about a task you are doing.** Each has a `description` written as
 triggers — the phrasings a request actually arrives in, including the symptoms of the
@@ -76,8 +77,8 @@ stale claim is worse than no skill — it is confidently wrong. Two rules:
 
 `type(scope): summary`, Conventional Commits, enforced by a `commit-msg` hook. The
 types, the scope vocabulary, what belongs in a body, and how to reference an issue
-are in `CLAUDE.md` under *Git*. Only the shape is enforced — the scope list is a
-suggestion, because a hook that argues about vocabulary is a hook people bypass.
+are in `CLAUDE.md` under *Git*. The scope names the subsystem; it is not a fixed
+list enforced by the hook.
 
 `make install` wires both hook types. Plain `pre-commit install` wires only
 `pre-commit`, and the subject check would silently never run.
@@ -90,9 +91,8 @@ moved, it names the pages owed.
 
 A reminder, never a gate — it always exits 0. A refactor with no behaviour change and
 a test-only change legitimately owe nothing, and a check that blocked those would be
-routed around within a week. The trigger map lives in the script (one place, so the
-hook and the reader cannot disagree) and is summarised in `CLAUDE.md` under
-*Documentation*.
+routed around within a week. The trigger map lives in the script; `CLAUDE.md` under
+*Documentation* points to it and provides the topic-to-page index.
 
 Run it by hand any time: `python3 scripts/docs_drift.py`. Review or disable the hook
 with `/hooks`.

--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -15,18 +15,14 @@ Fix: $ARGUMENTS
    before the line: a route calling a repository, a service returning `None` instead of
    raising, a `commit()` in a repository.
 
-4. **Check whether the symptom is one of the known silent failures** before assuming a
-   new bug:
-   - A page renders its empty state → a query failed, the UI is fine
-   - Ingestion 500s on a fresh environment → the database image is not
-     `pgvector/pgvector:pg16`
-   - A document sits in the listing with no explanation → a format the validator accepts
-     and the pipeline cannot route
-   - A listing endpoint 500s after a validation change → a stored JSON row no longer
-     validates
-   - A background task vanished with nothing logged → bare `asyncio.create_task`
-   - A tool runs unapproved → it is missing from `@register(tools=...)`
-   - A Viewer with a grant is refused → a `require(...)` gate on a per-resource route
+4. **Use known failure modes as hypotheses, not diagnoses.** Check the evidence:
+   - Empty state: inspect the query result, error handling and rendering conditions.
+   - Ingestion failure in a fresh environment: check pgvector availability and logs.
+   - Stalled document: check ingestion state and validator/parser routing compatibility.
+   - Listing failure after validation changes: check existing stored JSON rows.
+   - Missing background task: check dispatch, task ownership and exception logging.
+   - Unapproved tool execution: check registration and the approval policy.
+   - A Viewer with a grant is refused: check route gates and resource access resolution.
 
 5. **Fix the cause.** Match the surrounding code. Domain exceptions in services,
    `db.flush()` in repositories, full type hints, no fallback that papers over the bug.
@@ -36,8 +32,9 @@ Fix: $ARGUMENTS
    (`backend-tests` skill). A bug in a constraint needs `tests/integration/`; a bug in a
    gate needs `tests/api/`.
 
-7. **Verify:** `make lint && make test-fast`, then `make test` if the platform layer
-   changed. `make check` before a PR.
+7. **Verify** with the tests covering the fix, then the applicable lint and coverage
+   gates from `CLAUDE.md`. Use frontend checks for frontend defects. Run `make check`
+   before a PR.
 
 8. **Report** what was wrong, why it happened, and what now prevents it. If you found a
    second problem and did not fix it, say so.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -2,7 +2,10 @@
 description: Review code changes against project conventions
 ---
 
-Review the staged and unstaged changes on this branch.
+Review the scope requested by the user. For a branch review, include committed
+changes relative to the PR base (or the merge base with the target branch), plus
+relevant staged and unstaged changes. State the base and scope reviewed.
+Review without editing files unless fixes were requested.
 
 Read the change in the context of the system, not as a diff. For each file, check:
 
@@ -55,14 +58,13 @@ Read the change in the context of the system, not as a diff. For each file, chec
 **Docs** — behaviour changed means the page changed, in this change. Run
 `python3 scripts/docs_drift.py`; it names the pages owed. A refactor with no
 behaviour change owes nothing — say so rather than editing a page for the sake of
-it. The trigger map is in `CLAUDE.md` under *Documentation*.
+it. The trigger map is in `scripts/docs_drift.py`; the topic index is in
+`CLAUDE.md` under *Documentation*.
 
-Then run:
-
-```bash
-make lint
-make test-fast     # or make test if the platform layer changed
-```
+Run checks relevant to the changed code and any suspected defects. Use frontend
+checks for frontend changes and backend checks for backend changes; do not treat a
+backend-only test run as verification of the frontend. Reuse available results for
+the same revision where appropriate and report any checks not run.
 
 Report findings with `file:line` references, most severe first, each with the concrete
 failure it causes. Say plainly if you found nothing worth changing.

--- a/.claude/references/issue-triage.md
+++ b/.claude/references/issue-triage.md
@@ -1,0 +1,43 @@
+# Issue triage
+
+Read when filing or updating AgenticOS issues. Current user instructions take
+precedence over these repository conventions.
+
+## Record confirmed defects
+
+Fix in-scope defects in the current change; a separate issue is unnecessary. For
+out-of-scope defects, check existing issues before filing. Describe the failure,
+reproduction steps, relevant code location and how to verify a fix. Distinguish
+confirmed bugs from suspicions and state whether the current change introduced
+the problem or merely discovered it.
+
+## Board fields
+
+Use existing repository metadata; retrieve current values rather than copying
+old milestone names or opaque IDs from examples.
+
+| Field | Convention |
+|---|---|
+| Labels | One kind (`bug`, `enhancement`, `documentation`, `dependencies`, `ci`, `meta`), `severity:*` for bugs, `effort:*`, and `frontend` / `security` when applicable |
+| Type | `Bug`, `Feature` or `Task` |
+| Project | `VstormOS`, not the cross-repository `Vstorm OSS` board |
+| Milestone | Inherit from the related issue where appropriate; otherwise the current week's milestone unless work belongs later |
+| Status | `Backlog` for newly filed work; `In progress` only when work has started |
+
+When filing a defect found while working on another issue, inherit its project,
+milestone and `priority:*` where appropriate. Link that issue in the body.
+Check installed CLI options or use the GitHub API for unsupported fields; do not
+claim that metadata was set when an update failed.
+
+## Relationships
+
+The repository uses #168 as its issue map. Read it before filing, check for
+duplicates and related clusters, and update the relevant cluster when adding an
+issue. Link related work or state that none was found after checking. Make blockers
+visible from the blocked work too.
+
+Use a sufficient result limit or pagination when examining the backlog. Absence
+from a partial listing is not evidence that an issue is closed.
+
+Close issues only when fully resolved. For a partial contribution to a batch issue,
+update its relevant checkbox and leave it open.

--- a/.claude/rules/api-conventions.md
+++ b/.claude/rules/api-conventions.md
@@ -1,6 +1,6 @@
 ---
 description: API design, REST conventions, auth, pagination, response format
-globs: ["backend/app/api/**/*.py"]
+paths: ["backend/app/api/**/*.py"]
 ---
 
 # API Conventions

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,6 +1,6 @@
 ---
 description: Layered architecture patterns — Routes, Services, Repositories, DI
-globs: ["backend/app/**/*.py"]
+paths: ["backend/app/**/*.py"]
 ---
 
 # Architecture

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,6 +1,6 @@
 ---
 description: Code style, formatting, naming, imports, and type hints
-paths: ["backend/**/*.py", "*.py"]
+paths: ["backend/**/*.py", "scripts/**/*.py", "*.py"]
 ---
 
 # Code Style

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,6 +1,6 @@
 ---
 description: Code style, formatting, naming, imports, and type hints
-globs: ["backend/**/*.py", "*.py"]
+paths: ["backend/**/*.py", "*.py"]
 ---
 
 # Code Style
@@ -15,7 +15,8 @@ globs: ["backend/**/*.py", "*.py"]
 - Type hints on ALL function signatures — parameters and return types
 - Use modern syntax: `str | None` not `Optional[str]`, `list[User]` not `List[User]`
 - Use `Annotated[Type, Depends(...)]` for DI (defined as aliases in `deps.py`)
-- Use `dict[str, Any]` for generic dicts
+- Use a model or `TypedDict` for known structures and a precise value type for mappings.
+  Use `Any` only at a boundary that genuinely requires it, not as a generic shortcut.
 - Use `Literal["value1", "value2"]` for string enums in schemas
 - Use `TYPE_CHECKING` block for circular import resolution:
   ```python
@@ -60,39 +61,14 @@ from app.schemas.user import UserCreate, UserRead
 
 ## Comments
 
-Comments are scarce and earn their place. **The default is no comment.** The
-reference docs are generated from docstrings, so what reasoning a piece of code
-needs lives in a docstring, not in a running commentary of `#` lines.
+Explain non-obvious constraints, invariants and decisions that are not apparent
+from the code. Keep comments proportional to the explanation needed; do not force
+all reasoning into a one-line comment or a function docstring.
 
-The bar for a comment is one question: **would a competent reader make a mistake,
-or be genuinely misled, without it?** If not, delete it. Clear names and small
-functions carry the meaning; a comment is for the thing the code cannot say.
-
-Delete a comment that:
-
-- **Restates what the code does.** `# increment i`, `# loop over users`.
-- **Labels a section.** `# the owner's side`, `# sending`, `# internals`,
-  `# what the agent may ask` — the class, the method and their names already mark
-  the structure. (ASCII-banner form — `# --- sending ---` — is rejected outright
-  by `scripts/check_comments.py`; the plain-label form is the same slop without
-  the dashes, so it goes too.)
-- **Narrates an optimisation or a mechanism a reader already sees.** "In one
-  query rather than an `EXISTS` per row." "Skipped when the page is empty —
-  nothing to do." "Two queries, deduplicated on ids." The code says this; the
-  comment is a second, staler copy.
-- **Grows into a paragraph.** A multi-line essay is a docstring in the wrong
-  place — move it, or cut it to the single clause that carries the *why*, or drop
-  it. Most drop.
-
-Keep a comment only when it prevents a real mistake: a footgun, a non-obvious
-constraint, a security or correctness invariant that the code cannot express, or
-a decision that looks wrong until you know the reason — ideally with the issue
-number (`# … (#417)`). One tight sentence, not a paragraph.
-
-**No commented-out code.** Git remembers it; delete it.
-
-When in doubt, delete. A comment removed is cheap to bring back; a wall of
-comments is what makes real code hard to find.
+Put API contracts and generated reference documentation in docstrings. Avoid
+comments that merely repeat the code, section labels and ASCII banners (checked by
+`scripts/check_comments.py`). Remove commented-out code. Apply these conventions
+to code being changed rather than sweeping unrelated files.
 
 ## Dead code
 

--- a/.claude/rules/exceptions-security.md
+++ b/.claude/rules/exceptions-security.md
@@ -1,6 +1,6 @@
 ---
 description: Exception handling patterns and security conventions
-globs: ["backend/app/core/**/*.py", "backend/app/services/**/*.py"]
+paths: ["backend/app/core/**/*.py", "backend/app/services/**/*.py"]
 ---
 
 # Exceptions & Security

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -1,6 +1,6 @@
 ---
 description: Frontend conventions — App Router, data layer, stores, i18n, permissions
-globs: ["frontend/**/*.ts", "frontend/**/*.tsx", "frontend/**/*.css"]
+paths: ["frontend/**/*.ts", "frontend/**/*.tsx", "frontend/**/*.css"]
 ---
 
 # Frontend Conventions
@@ -9,7 +9,7 @@ Deeper guidance lives in the `frontend-feature` skill.
 
 ## Stack
 
-Next.js 15 (App Router) · React 19 · TypeScript strict · Tailwind · `next-intl` ·
+Next.js (App Router) · React · TypeScript strict · Tailwind · `next-intl` ·
 TanStack Query · Zustand · vitest + Testing Library · Playwright. Package manager and
 runner: **bun**.
 
@@ -258,8 +258,8 @@ is a whole catalog spotlights the entire viewport, which highlights nothing, so 
 describing step takes the header and the card's own anchor is left to the guided
 flow, which needs the list reachable.
 
-The full picture, including what CLAUDE.md requires, is in `CLAUDE.md` under
-"A new surface owes the walkthrough a stop".
+A page without a stop renders no help button (`pageHasSteps`). Check this when
+verifying that a new page has been registered in the walkthrough.
 
 ## A feature with glanceable state owes the dashboard a widget
 

--- a/.claude/rules/schemas-models.md
+++ b/.claude/rules/schemas-models.md
@@ -1,6 +1,6 @@
 ---
 description: Pydantic schema patterns and SQLAlchemy model conventions
-globs: ["backend/app/schemas/**/*.py", "backend/app/db/models/**/*.py", "backend/app/db/base.py"]
+paths: ["backend/app/schemas/**/*.py", "backend/app/db/models/**/*.py", "backend/app/db/base.py"]
 ---
 
 # Schemas & Models

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -8,6 +8,7 @@ paths:
     "**/conftest.py",
     "frontend/src/**/*.test.ts",
     "frontend/src/**/*.test.tsx",
+    "frontend/e2e/**/*.ts",
   ]
 ---
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,6 +1,6 @@
 ---
 description: Testing standards, the four layers, anyio patterns, the 100% platform gate
-globs:
+paths:
   [
     "backend/tests/**/*.py",
     "tests/**/*.py",

--- a/.claude/skills/backend-tests/SKILL.md
+++ b/.claude/skills/backend-tests/SKILL.md
@@ -93,7 +93,8 @@ in any response, log or audit entry · channel mentions running as the sender ·
 what a parser claims it reads vs what the pipeline routes · narrowing a rule on a
 field already stored as JSONB.
 
-The last two have bitten this repository. `CLAUDE.md` explains both.
+For parser/routing changes, read the `rag-knowledge` skill; for stored JSONB
+validation changes, read `agent-spec` and `alembic-migration`.
 
 ## Depth
 

--- a/.claude/skills/frontend-feature/SKILL.md
+++ b/.claude/skills/frontend-feature/SKILL.md
@@ -3,7 +3,9 @@ name: frontend-feature
 description: Build or change a page, view or data-driven feature in the Next.js frontend — a route under the dashboard, wiring UI to a backend endpoint, a Zustand store, a permission that must hide a control, or localized copy. Use for any work in frontend/src, including "the page renders but shows an empty state" and "this button should not be visible to a Viewer".
 ---
 
-# Frontend — Next.js 15, React 19
+# Frontend — Next.js and React
+
+Use the versions declared in `frontend/package.json` and the lockfile.
 
 `.claude/rules/frontend.md` has the conventions. `docs/architecture.md` has the
 request path. This is the working layout and the traps.

--- a/.claude/skills/project-docs/SKILL.md
+++ b/.claude/skills/project-docs/SKILL.md
@@ -102,29 +102,15 @@ are the two that do.
 
 ## Voice
 
-The site was rewritten into one register. Match it, because a page in the old one
-reads as a different product.
+Use second person and present tense for user instructions. Explain behaviour and
+relevant reasons; distinguish verified facts from uncertainty. Choose prose, lists
+or tables according to what helps the reader.
 
-**Second person, present tense, stating the decision and the reason it was taken**,
-without hedging — "A dead server is skipped, not raised, because Pydantic AI enters
-every toolset when a run starts." Explain *why*, never restate *what*. Prefer a table
-over a list of five parallel sentences.
-
-Three conventions, and a new or edited page owes all three:
-
-- **Sentence case headings.** Product names and acronyms keep their capitals — Docker
-  Compose, Google Drive, PostgreSQL, MCP, CONFIG_MODEL. Title Case is what the
-  template shipped and what 126 headings were swept out of.
-- **No paragraph over ~115 words.** The site is at zero. A fact appended to a
-  paragraph is a fact nobody finds: give it its own paragraph, a bullet, or an
-  admonition. A fact a reader has to have seen *before* acting is an admonition —
-  `!!! danger` for a footgun, `!!! warning` for a surprise, `!!! info` for the reason
-  behind a design.
-- **A recap at the end** of any page long enough to need one: at most five bullets,
-  each the thing a reader should leave with. Not a summary of the page — the five
-  things.
-
-`scripts/check_docs_paragraphs.py` is that count, and `make lint` runs it.
+- Use sentence case headings, preserving product names and acronyms.
+- Keep paragraphs within the limit enforced by `scripts/check_docs_paragraphs.py`.
+  Split by idea; use an admonition when a reader needs a warning before acting.
+- Add a recap only when it helps a reader retain the decisions from a long page.
+  Do not repeat short pages or force a fixed number of bullets.
 
 ## Icons
 

--- a/.github/codex/review-prompt.md
+++ b/.github/codex/review-prompt.md
@@ -8,7 +8,7 @@ has written down what correct means, and you are going to read it.
 
 Under *Run context* above there is a **standard directory**. It holds `CLAUDE.md`
 and every file from `.claude/rules/`, extracted from the **base branch**, not from
-this pull request. Read `CLAUDE.md` and then each rule whose `globs` header matches
+this pull request. Read `CLAUDE.md` and then each rule whose `paths` header matches
 a path this pull request touches.
 
 Those files are the definition of a defect here. A finding that cites one of them
@@ -37,7 +37,7 @@ reviewer that looked. Work in this order:
 
 1. Read the diff at the path under *Run context*. All of it.
 2. Read `CLAUDE.md` from the standard directory.
-3. Read each rule file whose `globs` header matches a path the diff touches.
+3. Read each rule file whose `paths` header matches a path the diff touches.
 4. For every changed file, open the code around it in the checkout — the service a
    route delegates to, the repository that service calls, the test that should have
    changed with it, the model whose column moved.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,128 +1,77 @@
 # CLAUDE.md — AgenticOS
 
-Always-loaded brief. Everything else is loaded on demand: `.claude/rules/*` by the
-files you edit, `.claude/skills/*` by the task you are doing, `docs/*` when you need to
-know how something works. **This file is deliberately short — if a section here grows
-past a screen, it belongs in one of those three.**
+Project-wide decisions and pointers to task-specific guidance. Read relevant rules,
+skills and documentation as needed. Keep detailed procedures and incident history
+outside this file. Current user instructions and higher-priority session rules
+take precedence.
 
 ## What this is
 
-The operating system for a company's AI agents. Self-hosted, open source, multi-tenant.
+A self-hosted, open-source, multi-tenant platform for a company's AI agents.
 
-**An agent here is data, not code.** Instructions, a model, a set of capabilities, a
-budget. Somebody builds it in a UI, publishes a version, and it runs the same way
-everywhere — web chat, HTTP API, Slack, Telegram, an embedded widget.
+**An agent is a versioned spec.** Users configure instructions, models, capabilities
+and budgets in the UI, publish a version and can export it as YAML. The same agent
+runs through web chat, the HTTP API and channel integrations. Change an individual
+agent through its spec; change Python when implementing platform behaviour or
+capabilities. Tools reach models through the capability registry.
 
-That one sentence is the whole design, and nearly every wrong assumption about this
-codebase comes from missing it:
+**Stack:** FastAPI, Pydantic v2, Pydantic AI, PostgreSQL with pgvector, Redis,
+Prefect, Next.js, React, bun, next-intl and MkDocs Material. Use versions from the
+repository manifests and lockfiles; Python is pinned in `backend/.python-version`.
 
-- There is **no** `@agent.tool`, no `RunContext[Deps]`, no `app/agents/assistant.py`.
-  Every tool reaches a model through the capability registry.
-- Agent behaviour is **not** changed by editing Python. It is changed by editing a
-  spec, which is versioned on publish and exportable as YAML into a client's own git
-  repository.
-- The platform's value is mostly in what it **refuses**: a cross-tenant read, an
-  ungranted scope, a budget breach, a second decision on a decided approval. Code that
-  only handles the happy path is not finished.
+The repository originated from the Full-Stack AI Agent Template. Platform and
+template-inherited subsystems have different coverage gates, described below.
 
-**Stack:** FastAPI + Pydantic v2 · PostgreSQL (asyncpg, pgvector) · Redis ·
-[Pydantic AI](https://ai.pydantic.dev) for the agent runtime · Prefect for background
-work · Next.js 15 + React 19 (bun, `next-intl`) · MkDocs Material.
+## Quality and scope
 
-Generated from the [Full-Stack AI Agent Template](https://github.com/vstorm-co/full-stack-ai-agent-template),
-which is why "the platform layer" and "template-inherited" are distinctions that matter
-below.
-
-## The quality bar
-
-Top-tier open source. "Works" is not the bar; "a maintainer would merge this without
-changes" is. Concretely, in this repo:
-
-- **Full typing, no escapes.** No `Any` as a shortcut, no `# type: ignore` or
-  `ty: ignore` without a comment saying what holds it true.
-- **Errors are explicit.** Domain exceptions with `message` and `details`. Never swallow
-  an exception, never add a fallback that papers over a bug.
-- **No dead weight.** No speculative abstraction, unused parameter, commented-out code
-  or "just in case" branch. If a branch cannot be reached, delete it; if it can, test it.
-  `make lint` runs `vulture` as a gate on what it is sure of, and `deptry` on the
-  manifest so a dependency nothing imports fails the same way; `make dead-code` is the
-  deeper, human-read scan for unused functions (`docs/branching.md`, `code-style.md`).
-- **Comments are scarce; the default is none.** Reasoning lives in docstrings (the
-  reference docs are generated from them). The bar for a `#`/`//` comment is one
-  question — *would a competent reader make a mistake without it?* If not, delete it. No
-  restating what the code says, no section labels (`# the owner's side`), no narrating an
-  optimisation a reader already sees (`# one query rather than an EXISTS per row`), no
-  ASCII banners (a guard rejects those). Keep only a footgun, a non-obvious constraint or
-  an invariant — one sentence, ideally with an issue number. See `code-style.md`.
-- **Scoped diffs.** Fix what was asked. Propose follow-ups instead of taking them.
-- **Tests are part of the change.** New behaviour ships with a test; a bug ships with a
-  regression test that fails without the fix.
-- **A user-facing feature ships its seams, not just its surface.** If it produces
-  activity or state somebody would want at a glance, it ships a **dashboard widget**
-  (registry entry, component, backend id parity). If it adds something somebody
-  creates or configures, it ships an **onboarding touch** — a tour stop, and a coach
-  flow when it is a create flow. This is not polish: four W3 features landed on
-  branches that could not see each other and #594 is the bill, three of the four
-  reading as bolted-on because the branch that owned each seam shipped before its
-  neighbour. The mechanics are in `.claude/rules/frontend.md` and
-  "A new surface owes the walkthrough a stop" below.
+- Type owned boundaries and nontrivial helpers. Do not use `Any` or suppressions to
+  hide errors. Necessary suppressions need a specific explanation; route return
+  annotations below are an explicit project convention.
+- Use domain exceptions with `message` and `details`. Do not swallow exceptions
+  or mask bugs with fallbacks.
+- Keep changes scoped. Avoid speculative abstractions, unused code and unrelated
+  cleanup. Comments explain non-obvious constraints; API contracts belong in
+  docstrings. See `.claude/rules/code-style.md`.
+- Test new behaviour and add regression tests for bugs. Documentation-only changes
+  need documentation checks, not artificial application tests.
+- Integrate new user-facing features with the existing product: onboarding for new
+  pages and creation flows, and dashboard widgets for activity or state that belongs
+  at a glance. Follow `.claude/rules/frontend.md` for registries, permissions,
+  translations and anchors.
 
 ## Hard boundaries
 
-Easy to violate, cross-cutting, and each one has been violated here at least once.
-
-- Repositories use `db.flush()` + `db.refresh()`, **never** `db.commit()` — the request's
-  session commits once, after the route returns and **before the response is written**.
-  That ordering is `scope="function"` on the `DBSession` alias and nothing else; a bare
-  `Depends(get_db_session)` puts the commit after the answer has gone out, which is #353.
-  The one sanctioned exception is the agent run path: `AgentRunnerService._run` and
-  `ChatAgentRunner.run` commit before the model call and again in the terminal
-  `finally` (#12, #3). `docs/architecture.md#the-requests-transaction` has the order,
-  its three consequences, and the run path's two commits.
-- **Background work that reads a row this request wrote is handed over with
-  `spawn_after_commit`, never `spawn`.** `spawn` creates the task at once and the loop
-  starts it before the commit, so the flow opens its own session and cannot see the row
-  it was given the id of — an upload answered `processing` that stays that way (#417).
-  `docs/architecture.md#dispatching-background-work-from-a-request` has both.
-- Routes call services only — **never** import or call a repository directly.
-- **`require(...)` gates belong on collection routes, not per-resource ones.** Listing,
-  creating and reading catalogs carry a permission gate; anything acting on *one* agent,
-  skill or collection must not. A role gate cannot see the grants on a row, so it
-  refuses a Viewer holding an explicit `edit` grant before `resolve_access` ever widens
-  their access — which contradicts "a grant widens what a role allows; it never narrows
-  it". Per-resource routes hand the decision to a service that calls `resolve_access`.
-  `tests/api/test_platform_routes.py` enforces both halves.
-- Route handlers return `-> Any`; `response_model` does the serialization (avoids double
-  Pydantic validation).
-- Every secret at rest goes through `app/core/vault.py`. **There is no second
-  mechanism**, and adding one is the defect two migrations removed - the second
-  of them `0042_sync_source_secret_id`, which took `app/core/crypto.py` off RAG
-  connector credentials. They had been sealed with one deployment-wide Fernet key,
-  which made this sentence untrue for one table until #937 deleted it. The first
-  predates the squash, so it is in git history rather than in a file.
-- `datetime.now(UTC)`, never `datetime.utcnow()`.
-- `secrets.compare_digest()` for API key comparison, never `==`.
-- **Do not reintroduce what was deliberately removed:** `UserRole`, `User.has_role()`,
-  `RoleChecker`, `CurrentAdmin`, `CurrentSuperuser` (the `users.role` column went
-  with them — authority inside an organization is a membership row plus the
-  permission catalog), or `CHANNEL_ENCRYPTION_KEY` and the deployment-wide Fernet
-  keys, or `app/core/crypto.py` and a credential field in a connector's
-  `CONFIG_MODEL` - what `CONFIG_SCHEMA`'s `secret: true` used to be
-  (`0042_sync_source_secret_id` - a connector credential is a vault secret the
-  source references by id).
-
-  **The first two have no revision of their own any more.** 65 were collapsed into
-  `0001_baseline` on 2026-07-31 and the numbering restarted, so `0038` and `0066`
-  name a *different* migration today or none at all — which is worse than a
-  dangling reference, because it resolves. The baseline carries the schema those
-  revisions arrived at and none of their data migrations; to read one, use git
-  history before that date. Cite a revision by its full file name, and only for
-  one that is still in `backend/alembic/versions/`.
+- Routes call services; services coordinate repositories. Routes must not import or
+  call repositories directly.
+- Repositories use `db.flush()` and `db.refresh()`, never `db.commit()`. Use
+  `DBSession`: its `scope="function"` commits after the route returns and before
+  the response is written. A bare `Depends(get_db_session)` has different timing.
+  The agent run paths in `AgentRunnerService._run` and `ChatAgentRunner.run`
+  explicitly commit before the model call and in terminal cleanup. See
+  `docs/architecture.md#the-requests-transaction`.
+- Dispatch background work needing rows written by the request with
+  `spawn_after_commit`, so its own session can see those rows. See
+  `docs/architecture.md#dispatching-background-work-from-a-request`.
+- Collection routes use `require(...)` gates. Per-resource routes for agents, skills
+  and collections delegate to a service using `resolve_access`; a role gate must
+  not reject access allowed by a resource grant. Follow `permissions-rbac`.
+- Route handlers return `-> Any` and declare `response_model` for serialization.
+  Keep service and repository return types precise.
+- Store credentials through `app/core/vault.py`. Connector sources reference vault
+  secret IDs; do not put credentials in a connector's `CONFIG_MODEL` or introduce
+  deployment-wide Fernet keys, `CHANNEL_ENCRYPTION_KEY` or `app/core/crypto.py`.
+- Organization authority comes from membership and the permission catalog. Do not
+  restore `UserRole`, `User.has_role()`, `RoleChecker`, `CurrentAdmin`,
+  `CurrentSuperuser` or the old `users.role` column.
+- Use `datetime.now(UTC)` and `secrets.compare_digest()` for API key comparisons.
+- Migration numbering restarted after a baseline squash. Verify references against
+  `backend/alembic/versions/` and cite full filenames; use git history for removed
+  revisions rather than assuming an old number still identifies the same migration.
 
 ## Read the matching rule before writing code
 
-`.claude/rules/*` is path-scoped, each file declaring the `globs` it applies to. This is
-mandatory, not aspirational — when your instinct and the rule disagree, the rule wins.
+Read the relevant files under `.claude/rules/`; their frontmatter defines the file
+scope. Load only the rules that apply to the change.
 
 | Editing | Read |
 |---|---|
@@ -134,11 +83,10 @@ mandatory, not aspirational — when your instinct and the rule disagree, the ru
 | `tests/` | `testing.md` — the layers, anyio, fixtures, the 100% gate |
 | `frontend/` | `frontend.md` — App Router, data layer, stores, i18n, permissions |
 
-## Invoke the matching skill before starting a task
+## Read the matching skill before starting a task
 
-`.claude/skills/*` is task-scoped. Each routes to the relevant `docs/` page and adds
-what a page does not carry: which shape the work should take, and which failures are
-silent. `.claude/README.md` lists all thirteen and explains the layout.
+Skills live in `.claude/skills/<name>/SKILL.md`. Read the skills matching the task;
+`.claude/README.md` explains the layout.
 
 | Doing | Skill |
 |---|---|
@@ -161,7 +109,7 @@ silent. `.claude/README.md` lists all thirteen and explains the layout.
 ```bash
 make dev                                          # postgres, redis, api, worker, frontend
 make platform-bootstrap BOOTSTRAP_API_KEY=sk-...  # an org, an owner, a model, an agent
-make check                                        # every CI job but e2e — before every PR
+make check                                        # aggregate pre-PR checks; excludes e2e
 ```
 
 `make help` lists the rest. Day to day:
@@ -183,201 +131,57 @@ make check                                        # every CI job but e2e — bef
 | `uv run agenticos cmd doctor` | can this deployment actually run an agent? |
 | `uv run agenticos cmd --help` | every custom command, including all `rag-*` |
 
-## The loop
+## Verification
 
-**Write, run the tests you just wrote, commit, push, and let CI be the wide net.**
-After an edit, run only the tests that cover the change; the full suites are the
-pre-push gate, not the write-run loop. Running everything after every edit is the
-slowest way to learn the same thing: one frontend spec answers in about two seconds
-against seventy for the suite, one backend file in a few seconds — nearly all of it
-importing the app, since pytest itself clocks the run at a fraction of that — against
-ninety-odd for `make test`. CI's jobs run in parallel and answer in about twelve
-minutes, the backend `test` job the long pole and the one #520 is cutting — from a
-pushed branch, while you carry on working.
+During implementation, run tests covering the change. Run frontend commands from
+`frontend/`, backend commands from `backend/` and make targets from the root.
 
-Two things about that answer, both since #317. **Pushing again cancels the run in
-flight**, so the answer you were waiting on disappears rather than arriving about a
-commit you have already replaced — which is the point, but it means a push is also a
-decision to stop caring about the previous one. And **CI runs fewer jobs than
-`make check` does**: `test`, `test-frontend` and `e2e` skip when the changed paths
-cannot affect them, so a backend-only branch gets no frontend answer at all, and a
-`skipped` required check is a pass rather than a problem.
-`docs/branching.md` has the rule.
+Before pushing, run `make lint` and the coverage gate for the side changed:
+`make test` and/or `make test-frontend-cov`. A passing run without coverage does
+not verify that gate. Before a PR, run `make check`. Report failures and unavailable
+checks. See `.claude/rules/testing.md` for scoped commands.
 
-```bash
-cd frontend && bunx vitest run src/components/chat/usage-strip.test.tsx
-cd backend  && uv run pytest tests/test_sandbox_workspace.py -q
-cd backend  && uv run pytest tests/api/test_workspace_routes.py -k bytes -x
-```
+Inspect CI for the current commit. A later push can cancel an earlier run, and
+path-filtered jobs may be skipped. Consult `docs/branching.md` and workflow files
+for CI behaviour rather than assuming local commands and CI are identical.
 
-Once before the push — not after every edit — run `make lint` and the coverage gate for
-the half you touched: `make test` or `make test-frontend-cov`. **`bun run test:run` does
-not measure coverage**, so a frontend suite where every test passes still fails the job;
-that is how `test-frontend` went red on `feat/sandbox` after a green local run. Before
-the pull request, `make check` — every CI job except `e2e`, about five minutes, and
-`backend/tests/test_ci_parity.py` is what keeps that claim true rather than aspirational
-(#143 found four divergences at once). Then read
-the answer rather than guessing at it: `gh pr checks <n>`, and
-`gh run view --job <id> --log-failed` for whatever is red. `.claude/rules/testing.md` has
-the scoped commands and the traps; the pull request reviewer is under Git below, and it is
-for a branch you believe is finished.
+## Environment
 
-Two habits that cost time here, both cheap to keep:
+- Use the repository's pgvector-enabled PostgreSQL image; stock PostgreSQL lacks
+  the vector extension required by RAG. Check the image if ingestion fails in a
+  fresh environment.
+- Match `backend/.python-version` when creating or syncing the backend environment.
+  Check the interpreter actually used by `uv run` before relying on test results.
 
-- **Edit files with the editor.** A `python3 - <<'PY'` heredoc that rewrites source is not
-  reviewable and not atomic — one in this session aborted on its twelfth replacement
-  having applied eleven, leaving a half-migrated tree that took two more runs to notice.
-  A genuine sweep over dozens of files is the exception: write the script under the
-  session scratchpad, collect every edit before writing any, and say what it did.
-- **Stage the paths you changed.** `git add -A` staged a stray `node_modules/.vite`
-  cache — created by running `bunx vitest` from the repository root instead of
-  `frontend/`, which also reports 164 phantom failures because the config is not there.
+## Testing
 
-## Environment gotchas
+Read `docs/testing.md`, `.claude/rules/testing.md` and the relevant testing skill
+for fixtures and patterns.
 
-**The database must be `pgvector/pgvector:pg16`, not stock Postgres.** The RAG store
-issues `CREATE EXTENSION IF NOT EXISTS vector` the first time a collection is written
-to, and stock Postgres answers `extension "vector" is not available` — a 500 before any
-row is committed. Every compose file and both CI jobs pin the pgvector image; they used
-to pin `postgres:16-alpine`, which is why no ingestion path had ever been exercised
-locally or in CI and an E2E upload spec sat skipped. **If document ingestion 500s on a
-fresh environment, check the image first.**
-
-**Python is pinned to 3.12 by `backend/.python-version`**, matching
-`requires-python`, `backend/Dockerfile` and every CI job. That pin exists because it
-did not: the venv resolved to 3.14, `tests/test_coverage_gate.py` reached for
-`Path.full_match` (added in **3.13**), and the test guarding the coverage gate passed
-locally while raising `AttributeError` in CI. **If `uv run` reports anything other
-than 3.12, delete `backend/.venv` and re-run `uv sync`** — anything verified on a
-newer interpreter has not been verified on the one that ships.
-
-## Testing — what a first reader must know
-
-Layers, fixtures and patterns are in `docs/testing.md`, `.claude/rules/testing.md` and
-the `backend-tests` / `e2e-tests` skills. Four things belong here because they change
-what you do before you write a line:
-
-**The platform layer is at 100% and CI fails below it.** Everything AgenticOS adds on
-top of the template: `app/agents/**`, the permission catalog, the vault, the secret
-kinds, the catalogs, and the services and repositories built on them. Template-inherited
-subsystems (the RAG pipeline, connectors, channel adapters, worker tasks) are reported by
-`make coverage-all` but do not gate the build — holding code we did not design to the
-same bar would buy a coverage number rather than confidence.
-
-**Adding a module to the platform layer means editing two lists**, both in
-`backend/pyproject.toml`: `[tool.coverage.run] include` and `[[tool.ty.overrides]]
-include`, verbatim and in the same order. A module held to 100% coverage is held to the
-type checker too. `tests/test_coverage_gate.py` fails if they drift, and
-`references/coverage-gate.md` in the `backend-tests` skill explains why the config uses
-`include` rather than `source`.
-
-**Async tests use anyio** — `pytestmark = pytest.mark.anyio`. `@pytest.mark.asyncio`
-does not work here.
-
-**Cover the refusal.** Tenant isolation (including when the caller owns the row) ·
-permission scopes and grants · a budget checked *before* the model request and recorded
-even when the run fails · a spec refused at publish, never at run time · no plaintext
-secret in any response, log or audit entry · a channel mention running as the sender ·
-what a parser claims it reads versus what the pipeline routes · narrowing a rule on a
-field already stored as JSONB. The `backend-tests` skill has the worked examples and the
-history behind each.
+- The platform layer has a 100% coverage gate. Exact modules are configured in
+  `backend/pyproject.toml`; template-inherited subsystems are additionally reported
+  by `make coverage-all` without that gate.
+- When adding a platform module, keep `[tool.coverage.run] include` and the matching
+  `[[tool.ty.overrides]] include` aligned, including order.
+  `backend/tests/test_coverage_gate.py` checks this contract.
+- Async tests use anyio: `pytestmark = pytest.mark.anyio`.
+- Cover refusal and failure paths: tenant isolation, scopes and grants, budgets
+  checked before model calls and recorded on failure, invalid specs rejected at
+  publish, and secrets excluded from responses, logs and audit entries. Also cover
+  channel sender identity, parser/routing compatibility and existing stored JSONB
+  when tightening validation. The testing skills contain worked examples.
 
 ## Documentation
 
-`docs/` is both the published site and the repository's own engineering notes — **one
-copy, on purpose.** A second copy written for a different reader is a copy that
-disagrees. So: when behaviour changes, change the page; do not write a second
-explanation next to it.
+Update existing documentation in the same change when described behaviour changes.
+Refactors with unchanged behaviour and test-only changes do not require unrelated
+prose edits. Update rules and skills when referenced paths or contracts change.
+API reference changes belong in the generating docstrings.
 
-### Finishing an implementation means updating the page (required)
-
-**A change that alters behaviour a page describes is not finished until that page is
-updated, in the same change. Do not wait to be asked.** One copy only stays true if
-it moves with the code; otherwise the page keeps describing what the code used to do
-and the disagreement is found months later by somebody acting on the stale half.
-
-Trigger map — what changed → which page:
-
-| Changed | Update |
-|---|---|
-| `app/agents/spec.py` | `docs/reference/spec.md` (via the docstrings) |
-| `app/services/agent_templates.py`, `app/core/catalog/agent_templates/**` | `docs/first-agent.md`, `docs/concepts.md` |
-| `app/agents/capabilities/**` | `docs/reference/capabilities.md` |
-| `app/agents/mcp*.py`, `app/services/mcp_*.py`, `app/core/catalog/mcp_servers.json` | `docs/mcp.md` |
-| `app/agents/model_resolver.py`, `app/services/model_profile.py`, `app/services/model_catalog.py` | `docs/models.md` |
-| `app/core/vault.py`, `secret_kinds.py`, `app/services/organization_secret.py` | `docs/secrets.md` |
-| `app/core/permissions.py`, `app/services/access.py` | `docs/permissions.md` + `docs/reference/permissions.md` |
-| `app/services/skills.py`, `skill_library.py`, `app/core/catalog/skills/**`, `skill_gallery/**` | `docs/skills.md` |
-| `app/services/spend.py`, `approvals.py`, `notifications.py` | `docs/governance.md` |
-| `app/services/channels/**`, `agent_exposure.py`, `agent_embed.py` | `docs/channels.md` |
-| `desktop/**` | `docs/desktop.md` |
-| `app/services/rag/**`, `file_upload.py`, `ingestion_config.py` | `docs/file-processing.md` |
-| `app/services/sandbox_*.py`, `app/agents/capabilities/sandbox/**`, `app/core/catalog/sandbox_runtimes.json` | `docs/sandbox.md` |
-| `app/services/deployment_settings.py`, `signup_policy.py`, `invitation_admission.py`, `app/core/maintenance.py`, `otel_compat.py`, `app/api/exception_handlers.py` | `docs/deployment.md` |
-| `app/core/config.py` | `docs/configuration.md` |
-| `docker-compose-prod*.yml`, `docker-compose-traefik.yml`, `traefik/`, `scripts/deploy.sh`, `scripts/server-init.sh`, `.github/workflows/deploy.yml` | `docs/deploy.md` |
-| `app/commands/**`, a new `make` target | `docs/commands.md` |
-| A new route, service or layering change | `docs/architecture.md` |
-| The one-line pitch, what the product is *not*, or a page a reader should meet first | `llms.txt` at the repository root - copied into the site by `scripts/mkdocs_hooks.py`, so there is one copy and it is the one models read |
-| `.github/workflows/ai-review.yml`, `.github/codex/**` | `docs/code-review.md` |
-| `.pre-commit-config.yaml`, `.github/dependabot.yml`, the branch rulesets | `docs/branching.md` |
-| A capability, permission or setting that changes the first-run path | `docs/first-agent.md`, `docs/install.md` |
-| A new dashboard page, tab or create control | `frontend/src/lib/onboarding/{tour,flows}.ts` — see below |
-
-### A new surface owes the walkthrough a stop (required)
-
-The product teaches itself: `frontend/src/lib/onboarding/tour.ts` is the passive
-walk a walked page's "?" replays, and `flows.ts` is the guided creation the walk
-offers at its end. Both are **registries**, so a page, tab, section or control
-added anywhere else is simply absent from them — nothing fails, nothing warns,
-and the feature ships invisible to everyone who learns the product through the
-tour. That is the whole failure mode: it is silent.
-
-The one place it is now audible: a page with no stop in `tour.ts` renders **no
-"?" at all** (`pageHasSteps`), rather than one that opens a walk with nothing in
-it and closes again. So a new page whose header carries no help button has not
-been added to the registry.
-
-So a change that adds a surface adds its stop in the same change.
-
-| Added | Owed |
-|---|---|
-| A dashboard page, or a tab/section within one | A `TourStep` in `tour.ts`, and `data-tour` on the control it names |
-| A page that can *create* something | A `CreationFlow` in `flows.ts`, plus its `flowForPage` entry |
-| A detail view with no route of its own | A pseudo-page id and its resolver in `components/onboarding/detail-targets.ts` |
-| A step, of either kind | `steps.<id>.title` / `.body` in `messages/en.json` — a missing key renders the key |
-
-Three things that decide whether a stop actually works, each of which has been
-got wrong here:
-
-- **Gate it on the permission its control carries.** An ungated step describes a
-  control the server hid, and the walk then waits four seconds for an element
-  that will never mount.
-- **`optional: true` for a control that renders only when data exists** — an
-  "add integration" button behind a non-empty catalog. Without it an empty
-  organization gets a caption pinned to nothing.
-- **Point at something bounded.** `data-tour` on a card whose body is a full
-  catalog spotlights the entire viewport, which highlights nothing; anchor the
-  describing step on the header and leave the card's own anchor for the guided
-  flow, which needs the list reachable.
-
-**When updating a page:** keep its altitude — `docs/reference/*` is generated from
-docstrings, so fix the **docstring** there rather than adding prose. Keep the
-concept pages behaviour-level, not line-by-line. If a change makes a page's
-structure wrong (a stage removed, a new subsystem), restructure the page rather than
-patching around it. Adding a page means adding it to `nav` in `mkdocs.yml` and to
-the table below.
-
-`.claude/skills/*` and `.claude/rules/*` are subject to the same rule: they name
-files, flags and commands, so a rename or removal makes them confidently wrong.
-`assistant.py`, `CHANNEL_ENCRYPTION_KEY`, `UserRole` and `search_knowledge_base` all
-survived there long after leaving the code.
-
-A **Stop hook** runs `scripts/docs_drift.py` and names the pages owed when a change
-touched the map above and nothing under `docs/` moved. It is a reminder, not a gate —
-a refactor with no behaviour change and a test-only change legitimately owe nothing;
-say so and move on. Run it yourself any time with
-`python3 scripts/docs_drift.py`.
+Read the `project-docs` skill for site structure, writing conventions, generated
+pages and build checks. Add new pages to `mkdocs.yml`, relevant cross-links and
+the topic map below. `scripts/docs_drift.py` contains the code-to-page trigger map;
+its Stop hook is a reminder, not a completeness check or a gate.
 
 | Topic | Page |
 |---|---|
@@ -419,251 +223,31 @@ say so and move on. Run it yourself any time with
 | Delivery state and what is left | `docs/ROADMAP.md` (repo only) |
 | Every notable change | `docs/release-notes.md` (reads `CHANGELOG.md`) |
 
-**Two of those are in `exclude_docs` and are not site pages**: `docs/ROADMAP.md`
-and `docs/about/design.md`. They stay in the repository, where a contributor
-reads them, and a published page that links to one **fails `--strict`** - so
-reference them by their GitHub blob URL, the way `docs/about/index.md` and
-`docs/reference/capabilities.md` do.
-
-### The site has seven tabs, and they are the shape of it
-
-`AgenticOS · Features · Learn · Reference · Resources · About · Release Notes`,
-the arrangement FastAPI uses, organised by what the reader is doing rather than
-by what a page is. **Learn is a sequence** — Get started, Build the agent, Put it
-in front of people, Keep it under control, then the recipes — so a page added
-there belongs at a position, not at the end.
-
-Files stay flat in `docs/`. The paths above are named in this file, in
-`.claude/skills/`, in `scripts/docs_drift.py` and in backend docstrings; a
-prettier URL is not worth invalidating every one of them.
-
-Three conventions the whole site now keeps, and a new page owes all three:
-
-- **Sentence case headings.** Product names and acronyms keep their capitals
-  (Docker Compose, Google Drive, PostgreSQL, MCP). Title Case is what the
-  template shipped and what was swept out.
-- **No paragraph over ~115 words.** A fact appended to a paragraph is a fact
-  nobody finds; give it its own paragraph, a bullet, or an admonition. A fact a
-  reader has to have seen *before* acting belongs in an admonition, not in prose.
-- **A recap at the end**, on any page long enough to need one: at most five
-  bullets, each the thing a reader should leave with.
-
-Two things about the reference pages. They are generated from docstrings by
-mkdocstrings, so the reasoning belongs in the docstring rather than in a second prose
-copy. And the collector is static: `app/services/`, `app/api/` and `app/worker/` have no
-`__init__.py`, so it cannot traverse into them and `::: app.services.foo` **fails the
-build** — reference those from prose with a source link until those packages are made
-explicit.
-
 ## Git
 
-- **Never commit on `main`.** Branch first (`feat/…`, `fix/…`), then open a pull
-  request. A pre-commit hook refuses `main` locally and a ruleset refuses it at
-  push time; `docs/branching.md` has the whole picture.
-- **One branch, one pull request, squashed on merge.** `main` is the only long-lived
-  branch, so the squashed commit is what survives - which is why the subject line
-  and body below are worth the minute they cost.
-- **On a branch, commit and push each finished piece without being asked.** That is
-  what makes the loop above work: the piece is verified by its own tests, the commit
-  body records why, and CI checks the whole of it while the next piece is being
-  written. Small commits, each one a thing that stands on its own - not one commit at
-  the end of a session. **On `main`, nothing is ever committed** (see above), and a
-  half-finished piece waits rather than landing.
-- **No AI attribution** — no `Co-Authored-By: Claude`, no "Generated with" trailer.
-  Write commits and PR descriptions as Kacper authored them.
-- **`make check` before opening a PR.** It is what CI runs; a red PR costs a review
-  cycle. Between commits on an open branch the scoped runs plus the pushed jobs are
-  enough - see The loop.
-- No secrets in commits. Never stage `.env`, a key, or a credential. **Stage paths,
-  not `-A`**, and read `git status` before committing: caches and generated files end
-  up in a diff exactly this way.
-
-### The subject line
-
-`type(scope): summary` — Conventional Commits. Imperative, lower case after the
-colon, no trailing period, **72 characters or fewer**. A `commit-msg` hook enforces
-the shape.
-
-```
-fix(vault): stop passing a role column that no longer exists
-test(mcp): assert the fixture exists rather than that it is on screen
-ci(e2e): give bootstrap a key so the seed publishes an agent
-feat(capabilities): add a clock so the agent stops assuming the date
-```
-
-| Type | For |
-|---|---|
-| `feat` | New behaviour somebody can use |
-| `fix` | A defect. Ships with a regression test |
-| `refactor` | Same behaviour, different shape |
-| `perf` | Faster, same behaviour |
-| `test` | Tests only |
-| `docs` | `docs/`, `README`, `CLAUDE.md`, `.claude/` |
-| `ci` | `.github/`, pre-commit, the Makefile's check targets |
-| `build` | Dependencies, lockfiles, Dockerfiles, compose files |
-| `chore` | Anything left, and a release commit |
-
-**Scope is the subsystem, not the path.** Prefer the vocabulary the docs use:
-`agents`, `capabilities`, `spec`, `permissions`, `vault`, `mcp`, `models`, `rag`,
-`skills`, `channels`, `api`, `budgets`, `approvals`, `builder`, `chat`, `e2e`,
-`docs`, `deps`, `compose`. Omit it when a change is genuinely repo-wide
-(`chore: cut 0.0.1`). One scope — if two are honest, that is usually two commits.
-
-A breaking change takes `!` (`feat(spec)!: …`) and a `BREAKING CHANGE:` footer
-saying what a stored spec or a client's YAML has to do about it.
-
-### The body
-
-The subject says what; the body says **why, and what it cost**. This is the part
-that survives — a decision explained only in review is a decision nobody finds.
-Worth writing down:
-
-- the failure the change prevents, concretely ("every path that created a user
-  raised `TypeError`"), not "improve reliability";
-- how it was verified, and how far that verification actually reaches — an upgrade
-  that passes because a fixture short-circuited is worth saying so;
-- what was found and deliberately *not* fixed, so the next reader knows it was seen.
-
-Wrap at 72. Bullets are fine. Correct an earlier commit's claim plainly if it turned
-out wrong; a wrong message is worse than a missing one.
-
-### Issues and pull requests
-
-Reference in the **footer**, never the subject — the subject has to read on its own
-in `git log --oneline`.
-
-```
-Closes #142            the issue is done
-Refs #142              related, still open
-Part-of #142           one commit of several on one issue
-Reverts 0f94fa4        with the reason it was reverted in the body
-```
-
-`Closes` only when the change genuinely finishes it. A PR body opens with what
-changed and why, then how it was verified — and says plainly what is still red.
-
-### Review your own diff — the automated reviewer is off (#311)
-
-**`ai-review` no longer runs on a pull request, and the label does nothing.**
-Every run since 2026-08-05 evening failed inside Codex, concluded `success`, and
-posted a sentence that read like a verdict on the diff — eleven pull requests
-merged that way. Until #311 is fixed, the only review before a merge is a human
-one, so the sweep that used to follow the reviewer's findings is now the whole
-job rather than the second half of it: read the surrounding files, sweep the
-siblings of anything you changed, review your own diff as a maintainer would.
-Subagents are good at this — give one the diff and a category to hunt in. The
-local `/review` command in `.claude/commands/review.md` checks the same standard.
-
-When it comes back, it answers "is this branch finished", so **ask it when you
-believe the branch is finished**: label, fix everything it found plus whatever
-reviewing your own work turned up, label again, until it comes back clean. Never
-once per commit and never one finding per run — the work between the labels is
-where most of the defects are actually found, and a reviewer that answers the
-same diff seven times has been asked the same question seven times. If it is
-wrong — and it is, sometimes; it does not always know what a file's surrounding
-code already does — say so in the commit body or the pull request, with the
-reason, rather than churning the code to silence it.
-
-`github-code-quality[bot]` opens threads on the same ruleset and cannot be
-filtered. Three of its findings are **already adjudicated** in
-`docs/code-review.md` — a bare `await <task>`, `...` as a `Protocol` body, and a
-`pytest.fail` fall-through. Resolve those with a pointer to that section; do not
-write a fresh essay per thread, and do not rewrite the cancellation idiom to
-satisfy a query that does not model `await`.
-
-### A bug you find is a bug you file
-
-**Every defect found along the way gets a GitHub issue** — `gh issue create`,
-straight away, whoever or whatever found it: the reviewer, a subagent, you
-reading a neighbouring file, a test that failed for the wrong reason.
-
-- **In scope for what you are doing?** Fix it in the same change, and the issue
-  is unnecessary — the commit body carries the story.
-- **Out of scope?** File it and keep going. Do not fold an unrelated fix into a
-  branch about something else, and do not drop it either. Mentioning a bug in a
-  pull request comment is not recording it: the comment is closed with the pull
-  request and the bug outlives both.
-
-An issue says what breaks, the sequence that triggers it, the `file:line`, and
-how you would know it was fixed. Say plainly whether the current branch caused
-it or merely found it — "pre-existing, found reviewing #105" is information the
-next reader needs. `#106` is the shape to copy.
-
-### File it triaged, not bare
-
-**An issue with no labels, no type, no project and no milestone is an issue
-somebody else has to triage by hand, and until they do it is invisible to every
-view the board is read through.** So set all five at creation. Guessing wrong is
-cheap and fixable; leaving them empty is what actually costs, because nothing
-surfaces the gap.
-
-```bash
-gh issue create --repo vstorm-co/agenticos \
-  --title "…" --body-file draft.md \
-  --label bug,severity:medium,effort:s \
-  --project VstormOS \
-  --milestone "W1 · Aug 3–7"
-```
-
-| | What to set, and how to choose |
-|---|---|
-| **Labels** | One kind (`bug`, `enhancement`, `documentation`, `dependencies`, `ci`, `meta`), plus `severity:*` on a bug, `effort:*` always, plus `frontend` / `security` where they apply. `gh label list` is the list; do not invent one. |
-| **Type** | `Bug`, `Feature` or `Task`. Needs GraphQL — see below. |
-| **Project** | `VstormOS` for anything in this repo. (`Vstorm OSS` is the cross-repo board; do not use it for issues here.) |
-| **Milestone** | The current week, unless the work genuinely belongs later. `gh api repos/vstorm-co/agenticos/milestones --jq '.[].title'` — never hardcode a week from an example, including this one. |
-| **Status** | The project's own field, defaulting to `Backlog`. Leave it there: `In progress` is a claim about somebody's day, not about the issue. |
-
-`gh` has **no `--type` flag** on `create` or `edit` (checked on 2.83.2), so the
-type is a second call. The ids are stable, and the REST ones are the wrong ones —
-GraphQL needs the global node id:
-
-```bash
-node=$(gh api repos/vstorm-co/agenticos/issues/N --jq .node_id)
-gh api graphql -f query='mutation($i:ID!,$t:ID!){
-  updateIssueIssueType(input:{issueId:$i,issueTypeId:$t}){issue{number issueType{name}}}}' \
-  -f i="$node" -f t="IT_kwDOBMvQGs4A22d_"   # Bug
-```
-
-`Task = IT_kwDOBMvQGs4A22d7` · `Bug = IT_kwDOBMvQGs4A22d_` ·
-`Feature = IT_kwDOBMvQGs4A22eD`. Re-derive with
-`gh api graphql -f query='{organization(login:"vstorm-co"){issueTypes(first:10){nodes{id name}}}}'`
-if a mutation answers `NOT_FOUND`.
-
-**Inherit from the issue you are working on.** Filing a defect found while
-working #40 is not filing into a vacuum: unless there is a reason to differ, take
-its milestone, its project and its `priority:*`, and reference it in the body —
-`Found reviewing #40` — so the two read as one thread of work rather than two
-unrelated rows a week apart. If the new issue *blocks* the one you are on, say so
-in both directions, because a blocker nobody can see from the blocked issue is a
-blocker that gets discovered by being hit.
-
-### And it says where it sits — [#168](https://github.com/vstorm-co/agenticos/issues/168)
-
-**#168 is the issue map**: what the clusters are, which chains block which, and
-what has no scope yet. Read it before filing and **name at least one existing
-issue in the body** — the cluster it belongs to, or the issue it most nearly
-duplicates. "Checked, nothing related" is a fine answer; silence is not, because
-an unlinked issue is one that gets worked twice or not at all.
-
-That is not hypothetical. Before the map: 17 open issues referenced nothing and
-were referenced by nothing; #13 and #30 were one bug filed twice, the second
-saying "the same URL normalisation as the avatar-proxy issue" without the
-number; #7 and #18 were one failure in two middlewares; #139 called itself the
-hub for "several page-level complaints" and named none of them; and five issues
-had **empty bodies**, which no amount of linking fixes.
-
-Filing changes the map, so **update #168 in the same breath** — add the number
-to its cluster, and to the spine if it blocks something. The graph is cheap to
-re-derive when in doubt:
-
-```bash
-gh issue list --state open --limit 300 --json number,title,body   # then grep '#[0-9]'
-```
-
-**Pass `--limit`.** It defaults to 30 and caps at 100 — under a hundred open
-issues that silently drops the lowest numbers, which is how #2 through #7 once
-read as closed and a blocker chain read as already done.
-
-An issue that closes a whole cluster says so (`Closes #147, #148`). One that
-only takes a checkbox out of a bag issue like #33 ticks the box there instead —
-that is how a batch issue stays honest about what is left.
+- Never commit on `main`. Use a feature or fix branch, one PR per coherent change,
+  squashed on merge.
+- On a branch, commit and push each finished, verified piece without being asked.
+  This is the project's exception to the global commit-on-request preference;
+  explicit session instructions still take precedence.
+- No AI attribution in commits or PR descriptions: no `Co-Authored-By: Claude`,
+  `Generated with Claude Code` or equivalent footer.
+- Stage only intended changes and review the staged diff. Exclude secrets, unrelated
+  work and tool caches.
+- Use Conventional Commits: `type(scope): summary`, imperative, lower case after the
+  colon, no trailing period, at most 72 characters. Types: `feat`, `fix`,
+  `refactor`, `perf`, `test`, `docs`, `ci`, `build`, `chore`. Scope names the
+  subsystem; omit it for repository-wide changes. Use `!` and a
+  `BREAKING CHANGE:` footer for breaking changes.
+- Add a body when the reason, verification or tradeoffs are not clear from the
+  subject; wrap it at 72 characters. Put issue references in footers (`Closes`,
+  `Refs`, `Part-of`); use `Closes` only when the issue is fully resolved.
+- PR descriptions explain the problem, resulting behaviour, verification and
+  material limitations. Review the diff and surrounding code before declaring work
+  finished. `.claude/commands/review.md` defines the local review standard.
+  `docs/code-review.md` and `.github/workflows/ai-review.yml` describe automated
+  review. A failed reviewer is not a clean review; assess findings against the code
+  and explain rejected ones.
+- Fix confirmed in-scope defects; record out-of-scope defects without expanding the
+  change. Before filing or triaging issues, read
+  `.claude/references/issue-triage.md` for the repository's board conventions.

--- a/scripts/docs_drift.py
+++ b/scripts/docs_drift.py
@@ -39,7 +39,12 @@ from pathlib import Path
 # change and teach the reader to ignore it.
 TRIGGERS: tuple[tuple[str, str], ...] = (
     ("backend/app/agents/spec.py", "docs/reference/spec.md"),
+    ("backend/app/agents/capabilities/sandbox/", "docs/sandbox.md"),
+    ("backend/app/services/sandbox_", "docs/sandbox.md"),
+    ("backend/app/core/catalog/sandbox_runtimes.json", "docs/sandbox.md"),
     ("backend/app/agents/capabilities/", "docs/reference/capabilities.md"),
+    ("backend/app/services/agent_templates.py", "docs/first-agent.md"),
+    ("backend/app/core/catalog/agent_templates/", "docs/first-agent.md"),
     ("backend/app/agents/mcp", "docs/mcp.md"),
     ("backend/app/agents/model_resolver.py", "docs/models.md"),
     ("backend/app/services/mcp_", "docs/mcp.md"),
@@ -55,6 +60,7 @@ TRIGGERS: tuple[tuple[str, str], ...] = (
     ("backend/app/services/skills.py", "docs/skills.md"),
     ("backend/app/services/skill_library.py", "docs/skills.md"),
     ("backend/app/core/catalog/skills/", "docs/skills.md"),
+    ("backend/app/core/catalog/skill_gallery/", "docs/skills.md"),
     ("backend/app/services/spend.py", "docs/governance.md"),
     ("backend/app/services/approvals.py", "docs/governance.md"),
     ("backend/app/services/notifications.py", "docs/governance.md"),
@@ -85,6 +91,7 @@ TRIGGERS: tuple[tuple[str, str], ...] = (
     ("backend/app/schemas/deployment_settings.py", "docs/deployment.md"),
     ("frontend/src/lib/branding.ts", "docs/deployment.md"),
     ("backend/app/commands/", "docs/commands.md"),
+    ("Makefile", "docs/commands.md"),
     ("backend/app/api/routes/", "docs/architecture.md"),
     ("backend/alembic/versions/", "docs/architecture.md"),
     (".github/workflows/ai-review.yml", "docs/code-review.md"),


### PR DESCRIPTION
## Problem

`CLAUDE.md` had grown into a long always-loaded brief mixing project decisions with incident history, pinned framework versions and repeated procedures. The rule files under `.claude/rules/` declared their scope with a `globs` frontmatter key, while Claude Code matches rules on `paths`, so the path scoping was not actually applied. Several skills and commands pointed at CLAUDE.md sections that no longer earn their place there.

## Resulting behaviour

- `CLAUDE.md` is a short brief: what the project is, quality and scope, hard boundaries, rule and skill routing, commands, verification, environment, testing, documentation topic map and git conventions. Incident anecdotes and pinned `Next.js 15` / `React 19` versions are gone in favour of the repository manifests.
- Issue-board conventions move to `.claude/references/issue-triage.md`, linked from the Git section and listed in `.claude/README.md`.
- All seven rule files use `paths:` in their frontmatter. `.claude/README.md` and `.github/codex/review-prompt.md` name the same key.
- `fix-issue` treats known failure modes as hypotheses to check rather than diagnoses; `review` states the reviewed base and scope and asks for checks matching the side changed.
- `code-style.md` comments guidance and the `project-docs` voice section are shortened to the conventions the guard scripts actually enforce.
- `backend-tests` and `frontend-feature` route to the relevant skills instead of removed CLAUDE.md sections.

## Verification

- `pre-commit run codespell` and `check-backticks` on every changed file: passed.
- `python3 scripts/check_docs_paragraphs.py`: no paragraph over the limit.
- Guidance-only change; no application code or tests touched.

## Limitations

Grep is the only check that the renamed sections are no longer referenced; the codex review prompt was the one external reference found and is updated here.
