### PR TITLE
fix: refuse short secrets, drop allow_byo, mask OAuth payload tokens

### DIFF
--- a/backend/alembic/versions/0077_drop_allow_byo.py
+++ b/backend/alembic/versions/0077_drop_allow_byo.py
@@ -1,0 +1,36 @@
+"""Drop `model_profiles.allow_byo`, a toggle that was written and never read.
+
+The column was meant to say whether a user may substitute their own key when
+running with the profile. Nothing ever consulted it: the resolver always spends
+the profile's own `secret_id`, so the flag changed no behaviour while looking
+like a security control. A permission nobody enforces is worse than none, so it
+goes rather than getting an implementation nobody asked for (#33).
+
+Revision ID: 0077_drop_allow_byo
+Revises: 0076_normalize_channel_chat_type
+Create Date: 2026-09-13
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0077_drop_allow_byo"
+down_revision: str | None = "0076_normalize_channel_chat_type"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_column("model_profiles", "allow_byo")
+
+
+def downgrade() -> None:
+    # Every row gets the value the flag always effectively had.
+    op.add_column(
+        "model_profiles",
+        sa.Column("allow_byo", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )

--- a/backend/app/agents/mcp_oauth.py
+++ b/backend/app/agents/mcp_oauth.py
@@ -51,6 +51,7 @@ from app.agents.mcp import CONNECT_TIMEOUT_SECS, validate_mcp_url
 from app.core.config import settings
 from app.core.pinned_http import PinnedAsyncClient
 from app.core.sanitize import UrlRefusedError
+from app.core.secret_kinds import SealedStr
 
 logger = logging.getLogger(__name__)
 
@@ -173,6 +174,12 @@ class McpOAuthPayload(BaseModel):
     filled in. `expires_at` is epoch seconds (or None if the token doesn't
     expire).
 
+    The three credentials are :data:`SealedStr`, so a payload that reaches a log
+    line or a traceback whole masks them, and only `model_dump_json()` - the way
+    into the vault - carries the real values. `model_copy(update=...)` skips
+    validation, so a caller folding a fresh token in wraps it in a `SecretStr`
+    itself or the next `model_dump_json()` fails.
+
     `provider` names a non-discovery flow when one issued the payload - `"github"`
     for a GitHub OAuth App, whose endpoints are fixed and whose token exchange has
     its own quirks (see `app/services/portals/github_oauth.py`). `None` is the
@@ -185,13 +192,13 @@ class McpOAuthPayload(BaseModel):
     token_endpoint: str
     registration_endpoint: str | None = None
     client_id: str
-    client_secret: str | None = None
+    client_secret: SealedStr | None = None
     scope: str | None = None
     resource: str
     redirect_uri: str
     code_verifier: str | None = None
-    access_token: str | None = None
-    refresh_token: str | None = None
+    access_token: SealedStr | None = None
+    refresh_token: SealedStr | None = None
     expires_at: float | None = None
     provider: str | None = None
 

--- a/backend/app/api/routes/v1/model_providers.py
+++ b/backend/app/api/routes/v1/model_providers.py
@@ -93,7 +93,6 @@ async def create_model_profile(
         secret_id=data.secret_id,
         base_url=data.base_url,
         params=data.params,
-        allow_byo=data.allow_byo,
         fallback_profile_ids=data.fallback_profile_ids,
     )
 

--- a/backend/app/core/secret_kinds.py
+++ b/backend/app/core/secret_kinds.py
@@ -52,6 +52,7 @@ from enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from pydantic import (
+    AfterValidator,
     BaseModel,
     ConfigDict,
     Field,
@@ -90,6 +91,34 @@ def _reveal(value: SecretStr) -> str:
 # of dumping a model into a log line stays harmless.
 SealedStr = Annotated[SecretStr, PlainSerializer(_reveal, when_used="json")]
 
+MIN_CREDENTIAL_LENGTH = 8
+"""The shortest value a credential field accepts.
+
+:attr:`_SecretBase.hint` shows the last four characters of a credential to
+everyone who may list secrets and writes them into the audit trail, so a value
+shorter than this would be published whole by its own hint. The floor also
+catches a truncated paste while the form is still open, rather than at the
+first run.
+"""
+
+
+def _long_enough_to_hint(value: SecretStr) -> SecretStr:
+    if len(value) < MIN_CREDENTIAL_LENGTH:
+        raise ValueError(
+            f"Must be at least {MIN_CREDENTIAL_LENGTH} characters - is the paste complete?"
+        )
+    return value
+
+
+# A sealed field that authenticates: long enough that the four-character hint
+# cannot give it away. `minLength` is declared on the schema the forms are
+# generated from, and the validator carries the message a form can show.
+CredentialStr = Annotated[
+    SealedStr,
+    AfterValidator(_long_enough_to_hint),
+    Field(json_schema_extra={"minLength": MIN_CREDENTIAL_LENGTH}),
+]
+
 
 class _SecretBase(BaseModel):
     """Common configuration for every secret payload."""
@@ -100,6 +129,8 @@ class _SecretBase(BaseModel):
     def hint(self) -> str:
         """Four characters an operator can recognise this credential by.
 
+        Never the whole credential: every field that authenticates is a
+        :data:`CredentialStr`, at least :data:`MIN_CREDENTIAL_LENGTH` long.
         Taken from the field that identifies the credential rather than from the
         one that authenticates it where the two differ - an AWS access key id is
         public, and showing four characters of it is strictly better than
@@ -122,7 +153,7 @@ class ApiKeySecret(_SecretBase):
     """One opaque token."""
 
     kind: Literal[SecretKind.API_KEY] = SecretKind.API_KEY
-    api_key: SealedStr = Field(title="API key", description="The token, sealed before storage")
+    api_key: CredentialStr = Field(title="API key", description="The token, sealed before storage")
 
     @property
     def hint(self) -> str:
@@ -133,7 +164,7 @@ class AzureOpenAISecret(_SecretBase):
     """An Azure OpenAI deployment: key, endpoint and pinned API version."""
 
     kind: Literal[SecretKind.AZURE_OPENAI] = SecretKind.AZURE_OPENAI
-    api_key: SealedStr = Field(title="API key")
+    api_key: CredentialStr = Field(title="API key")
     azure_endpoint: str = Field(
         min_length=1,
         title="Endpoint",
@@ -151,9 +182,9 @@ class AwsCredentialsSecret(_SecretBase):
 
     kind: Literal[SecretKind.AWS_CREDENTIALS] = SecretKind.AWS_CREDENTIALS
     aws_access_key_id: str = Field(min_length=1, title="Access key ID")
-    aws_secret_access_key: SealedStr = Field(title="Secret access key")
+    aws_secret_access_key: CredentialStr = Field(title="Secret access key")
     region_name: str = Field(min_length=1, title="Region", description="e.g. us-east-1")
-    aws_session_token: SealedStr | None = Field(
+    aws_session_token: CredentialStr | None = Field(
         default=None,
         title="Session token",
         description="Only for temporary STS credentials",
@@ -238,7 +269,7 @@ class GithubOAuthAppSecret(_SecretBase):
         title="Client ID",
         description="The OAuth App's client id, e.g. Iv1.0123456789abcdef",
     )
-    client_secret: SealedStr = Field(min_length=1, title="Client secret")
+    client_secret: CredentialStr = Field(title="Client secret")
 
     @property
     def hint(self) -> str:
@@ -269,7 +300,7 @@ class GoogleOAuthAppSecret(_SecretBase):
         title="Client ID",
         description="The OAuth client's id, e.g. 1234-abc.apps.googleusercontent.com",
     )
-    client_secret: SealedStr = Field(min_length=1, title="Client secret")
+    client_secret: CredentialStr = Field(title="Client secret")
 
     @property
     def hint(self) -> str:

--- a/backend/app/db/models/credential.py
+++ b/backend/app/db/models/credential.py
@@ -11,7 +11,6 @@ import uuid
 from typing import Any
 
 from sqlalchemy import (
-    Boolean,
     ForeignKey,
     Integer,
     String,
@@ -81,8 +80,6 @@ class ModelProfile(Base, TimestampMixin):
     context_length: Mapped[int | None] = mapped_column(Integer, nullable=True)
     # Model settings (temperature, max_tokens...) applied on every run.
     params: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False, server_default="{}")
-    # Whether a user may substitute their own key when running with this profile.
-    allow_byo: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     # Ordered profile ids tried when the primary fails - becomes a FallbackModel.
     fallback_profile_ids: Mapped[list[str]] = mapped_column(
         JSONB, nullable=False, server_default="[]"

--- a/backend/app/repositories/credential.py
+++ b/backend/app/repositories/credential.py
@@ -71,7 +71,6 @@ async def create_profile(
     secret_id: UUID | None,
     base_url: str | None = None,
     params: dict | None = None,
-    allow_byo: bool = False,
     fallback_profile_ids: list[str] | None = None,
     context_length: int | None = None,
 ) -> ModelProfile:
@@ -83,7 +82,6 @@ async def create_profile(
         secret_id=secret_id,
         base_url=base_url,
         params=params or {},
-        allow_byo=allow_byo,
         fallback_profile_ids=fallback_profile_ids or [],
         context_length=context_length,
     )

--- a/backend/app/schemas/model_profile.py
+++ b/backend/app/schemas/model_profile.py
@@ -68,7 +68,6 @@ class ModelProfileCreate(BaseSchema):
         ),
     )
     params: dict[str, Any] = Field(default_factory=dict)
-    allow_byo: bool = False
     fallback_profile_ids: list[UUID] = Field(default_factory=list)
 
 
@@ -87,7 +86,6 @@ class ModelProfileRead(BaseSchema, TimestampSchema):
     #: most of them.
     base_url: str | None = None
     params: dict[str, Any] = Field(default_factory=dict)
-    allow_byo: bool
     fallback_profile_ids: list[str] = Field(default_factory=list)
     context_length: int | None = Field(
         default=None,

--- a/backend/app/services/mcp_connection.py
+++ b/backend/app/services/mcp_connection.py
@@ -38,6 +38,7 @@ from typing import Any, Literal
 from uuid import UUID
 
 from mcp.shared.auth import OAuthToken
+from pydantic import SecretStr
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -127,13 +128,20 @@ async def _checked_url(url: str) -> str:
         raise refused_field("url", f"This MCP server URL cannot be used: {exc}") from exc
 
 
+def _revealed(value: SecretStr | None) -> str | None:
+    """A stored credential as the provider wants it on the wire."""
+    return None if value is None else value.get_secret_value()
+
+
 def _apply_token(payload: McpOAuthPayload, token: OAuthToken) -> McpOAuthPayload:
     """Fold a fresh token grant/refresh into the stored payload."""
     return payload.model_copy(
         update={
-            "access_token": token.access_token,
+            "access_token": SecretStr(token.access_token),
             # A refresh response may omit refresh_token - keep the existing one.
-            "refresh_token": token.refresh_token or payload.refresh_token,
+            "refresh_token": (
+                SecretStr(token.refresh_token) if token.refresh_token else payload.refresh_token
+            ),
             "expires_at": (_now_epoch() + token.expires_in) if token.expires_in else None,
             "scope": token.scope or payload.scope,
             "code_verifier": None,
@@ -155,7 +163,7 @@ async def _complete_mcp_flow(
     token = await mcp_oauth.exchange_code(
         token_endpoint=payload.token_endpoint,
         client_id=payload.client_id,
-        client_secret=payload.client_secret,
+        client_secret=_revealed(payload.client_secret),
         code=code,
         code_verifier=payload.code_verifier,
         redirect_uri=payload.redirect_uri,
@@ -203,7 +211,7 @@ async def _complete_google_flow(
     try:
         token = await google_oauth.exchange_code(
             client_id=payload.client_id,
-            client_secret=payload.client_secret or "",
+            client_secret=_revealed(payload.client_secret) or "",
             code=code,
             redirect_uri=payload.redirect_uri,
         )
@@ -211,13 +219,13 @@ async def _complete_google_flow(
         raise OAuthError(str(exc)) from exc
     payload = payload.model_copy(
         update={
-            "access_token": token.access_token,
+            "access_token": SecretStr(token.access_token),
             # Kept where Google sent one. Without `access_type=offline` it does not,
             # and a grant with no refresh token stops working in an hour with
             # nothing to say why - which is why the consent URL asks for it. A
             # re-consent that omits one falls back to the live payload's, in the
             # callback, where that payload is in hand.
-            "refresh_token": token.refresh_token,
+            "refresh_token": SecretStr(token.refresh_token) if token.refresh_token else None,
             "expires_at": (
                 None if token.expires_in is None else _now_epoch() + float(token.expires_in)
             ),
@@ -241,7 +249,7 @@ async def _complete_github_flow(
     try:
         token = await github_oauth.exchange_code(
             client_id=payload.client_id,
-            client_secret=payload.client_secret or "",
+            client_secret=_revealed(payload.client_secret) or "",
             code=code,
             redirect_uri=payload.redirect_uri,
         )
@@ -249,7 +257,7 @@ async def _complete_github_flow(
         raise OAuthError(str(exc)) from exc
     payload = payload.model_copy(
         update={
-            "access_token": token.access_token,
+            "access_token": SecretStr(token.access_token),
             "refresh_token": None,
             "expires_at": None,
             "code_verifier": None,
@@ -349,15 +357,15 @@ async def _refresh_under_lock(db: AsyncSession, connection: McpConnection) -> st
     if payload is None or not payload.access_token:
         return None
     if _token_is_fresh(payload):
-        return payload.access_token  # another turn refreshed while we waited
+        return _revealed(payload.access_token)  # another turn refreshed while we waited
     if not payload.refresh_token:
         return None
     try:
         token = await mcp_oauth.refresh_tokens(
             token_endpoint=payload.token_endpoint,
             client_id=payload.client_id,
-            client_secret=payload.client_secret,
-            refresh_token=payload.refresh_token,
+            client_secret=_revealed(payload.client_secret),
+            refresh_token=payload.refresh_token.get_secret_value(),
             resource=payload.resource,
             scope=payload.scope,
         )
@@ -370,7 +378,7 @@ async def _refresh_under_lock(db: AsyncSession, connection: McpConnection) -> st
         db_connection=locked,
         update_data={"oauth_payload": _seal_for(locked, payload.model_dump_json()).ciphertext},
     )
-    return payload.access_token
+    return _revealed(payload.access_token)
 
 
 async def _oauth_access_token(db: AsyncSession, connection: McpConnection) -> str | None:
@@ -381,7 +389,7 @@ async def _oauth_access_token(db: AsyncSession, connection: McpConnection) -> st
     if payload is None or not payload.access_token:
         return None  # not authorized yet, or an unreadable payload
     if _token_is_fresh(payload):
-        return payload.access_token
+        return _revealed(payload.access_token)
     if not payload.refresh_token:
         return None  # expired, no refresh token → user must re-authorize
     return await _refresh_under_lock(db, connection)
@@ -927,7 +935,7 @@ class McpConnectionService:
             authorization_endpoint=github_oauth.AUTHORIZE_ENDPOINT,
             token_endpoint=github_oauth.TOKEN_ENDPOINT,
             client_id=creds.client_id,
-            client_secret=creds.client_secret.get_secret_value(),
+            client_secret=creds.client_secret,
             scope=" ".join(scopes),
             # GitHub uses no RFC 8707 resource indicator; the field is required, so
             # it carries the server the connection points at, like every payload.
@@ -1119,7 +1127,7 @@ class McpConnectionService:
             authorization_endpoint=google_oauth.AUTHORIZE_ENDPOINT,
             token_endpoint=google_oauth.TOKEN_ENDPOINT,
             client_id=creds.client_id,
-            client_secret=creds.client_secret.get_secret_value(),
+            client_secret=creds.client_secret,
             scope=" ".join(scopes),
             resource=_POLLED_PORTAL_URL[portal_key],
             redirect_uri=redirect_uri,
@@ -1193,14 +1201,15 @@ class McpConnectionService:
         # right now leaves the cursor to the first poll, which is the old window
         # rather than a broken flow.
         poll_cursor = connection.poll_cursor
+        access_token = _revealed(payload.access_token)
         if (
             connection.purpose == "portal"
             and connection.portal_key is not None
             and poll_cursor is None
-            and payload.access_token
+            and access_token
         ):
             poll_cursor = await _initial_poll_cursor(
-                portal_key=connection.portal_key, access_token=payload.access_token
+                portal_key=connection.portal_key, access_token=access_token
             )
         return await mcp_connection_repo.update(
             self.db,

--- a/backend/app/services/model_profile.py
+++ b/backend/app/services/model_profile.py
@@ -129,7 +129,6 @@ class ModelProfileService:
         secret_id: UUID | None,
         base_url: str | None = None,
         params: dict | None = None,
-        allow_byo: bool = False,
         fallback_profile_ids: list[UUID] | None = None,
     ) -> ModelProfile:
         """Define a selectable model.
@@ -221,7 +220,6 @@ class ModelProfileService:
             secret_id=secret_id,
             base_url=base_url,
             params=params,
-            allow_byo=allow_byo,
             fallback_profile_ids=[str(pid) for pid in (fallback_profile_ids or [])],
             context_length=await self._context_length(ctx, provider, model),
         )

--- a/backend/tests/integration/test_platform_flows.py
+++ b/backend/tests/integration/test_platform_flows.py
@@ -3778,16 +3778,16 @@ class TestTheOrganizationsSecrets:
     async def test_several_secrets_resolve_in_one_query(self, db) -> None:
         """A run reads every secret its bindings name; one query, not one each."""
         tenant = await _tenant(db, name="Batched")
-        first = await self._store(db, tenant, name="Weather", key="wx-1111")
-        second = await self._store(db, tenant, name="Maps", key="mp-2222")
+        first = await self._store(db, tenant, name="Weather", key="wx-key-1111")
+        second = await self._store(db, tenant, name="Maps", key="mp-key-2222")
 
         resolved = await OrganizationSecretService(db).resolve_for_bindings(
             tenant.ctx, [first, second]
         )
 
         assert {secret.api_key.get_secret_value() for secret in resolved.values()} == {
-            "wx-1111",
-            "mp-2222",
+            "wx-key-1111",
+            "mp-key-2222",
         }
 
     async def test_deleting_the_organization_takes_its_secrets_with_it(self, db) -> None:

--- a/backend/tests/test_bootstrap.py
+++ b/backend/tests/test_bootstrap.py
@@ -180,7 +180,7 @@ class TestModel:
                 new=AsyncMock(return_value=profile),
             ) as create_profile,
         ):
-            await _resolve_model(MagicMock(), _ctx(), "openai", "sk-test", "gpt-4o-mini")
+            await _resolve_model(MagicMock(), _ctx(), "openai", "sk-test-1234", "gpt-4o-mini")
 
         assert create_profile.call_args.kwargs["model"] == "gpt-4o-mini"
 
@@ -328,7 +328,9 @@ class TestEndToEnd:
             ) as resolve_model,
             patch("app.commands.bootstrap._resolve_demo_agent", new=AsyncMock()) as demo,
         ):
-            await _bootstrap("admin@example.com", "password123", "Acme", "openai", "sk-test", None)
+            await _bootstrap(
+                "admin@example.com", "password123", "Acme", "openai", "sk-test-1234", None
+            )
 
         register.assert_awaited_once()
         # The agent must be given the model the previous step produced.

--- a/backend/tests/test_capability_edges.py
+++ b/backend/tests/test_capability_edges.py
@@ -371,18 +371,24 @@ class TestFactoryHelpers:
 
 class TestModelFallbacks:
     def test_no_fallbacks_builds_a_plain_model(self):
-        credential = ResolvedCredential(provider="openai", secret=ApiKeySecret(api_key="sk-test"))
+        credential = ResolvedCredential(
+            provider="openai", secret=ApiKeySecret(api_key="sk-test-key")
+        )
         model = build_with_fallbacks((credential, "gpt-4.1"), [])
         assert type(model).__name__ != "FallbackModel"
 
     def test_fallbacks_wrap_the_primary(self):
         """A single provider outage should not take an organization's agents down."""
-        credential = ResolvedCredential(provider="openai", secret=ApiKeySecret(api_key="sk-test"))
+        credential = ResolvedCredential(
+            provider="openai", secret=ApiKeySecret(api_key="sk-test-key")
+        )
         model = build_with_fallbacks(
             (credential, "gpt-4.1"),
             [
                 (
-                    ResolvedCredential(provider="anthropic", secret=ApiKeySecret(api_key="sk-b")),
+                    ResolvedCredential(
+                        provider="anthropic", secret=ApiKeySecret(api_key="sk-b-12345")
+                    ),
                     "claude-sonnet-4-6",
                 )
             ],

--- a/backend/tests/test_capability_secrets.py
+++ b/backend/tests/test_capability_secrets.py
@@ -122,7 +122,7 @@ class TestInjection:
         try:
             build(
                 [CapabilityBinding(capability_id="test_needs_nothing", secret_id=uuid.uuid4())],
-                secrets={uuid.uuid4(): ApiKeySecret(api_key="wx")},
+                secrets={uuid.uuid4(): ApiKeySecret(api_key="wx-12345678")},
             )
         finally:
             REGISTRY.pop("test_needs_nothing", None)

--- a/backend/tests/test_doctor_sandbox.py
+++ b/backend/tests/test_doctor_sandbox.py
@@ -155,7 +155,9 @@ async def test_the_wrong_kind_of_credential_is_reported_rather_than_sent(monkeyp
     handing them over would be a credential sent to the wrong host."""
     secret = _secret(
         AwsCredentialsSecret(
-            aws_access_key_id="AKIA0000", aws_secret_access_key="x", region_name="eu-west-1"
+            aws_access_key_id="AKIA0000",
+            aws_secret_access_key="x-secret-access",
+            region_name="eu-west-1",
         )
     )
 

--- a/backend/tests/test_dynamic_specialists.py
+++ b/backend/tests/test_dynamic_specialists.py
@@ -176,7 +176,9 @@ def _resolved(model: Model, *, label: str = PROFILE) -> _Resolved:
         provider="openai",
         model="gpt-4.1",
         params={},
-        credential=ResolvedCredential(provider="openai", secret=ApiKeySecret(api_key="sk-test")),
+        credential=ResolvedCredential(
+            provider="openai", secret=ApiKeySecret(api_key="sk-test-key")
+        ),
         fallbacks=[],
         model_under_test=model,
     )

--- a/backend/tests/test_embedding_resolution.py
+++ b/backend/tests/test_embedding_resolution.py
@@ -192,7 +192,7 @@ class TestCredentialDegradation:
 
     async def test_a_secret_of_the_wrong_kind_falls_back(self):
         """The vault can hold shapes an embedding client cannot use."""
-        row = _sealed_key_row("sk-org")
+        row = _sealed_key_row("sk-org-key")
         with (
             patch(f"{_MODULE}.settings") as env,
             patch(f"{_MODULE}.unseal_secret", return_value=MagicMock(spec=[])),

--- a/backend/tests/test_ingestion_config.py
+++ b/backend/tests/test_ingestion_config.py
@@ -515,7 +515,7 @@ class TestLlamaParseCredential:
         with (
             patch(
                 "app.services.ingestion_config.organization_secret_repo.get",
-                new=AsyncMock(return_value=self._sealed_llamaparse_row("llx-x")),
+                new=AsyncMock(return_value=self._sealed_llamaparse_row("llx-x-12345")),
             ),
             patch("app.services.ingestion_config.unseal_secret", return_value=MagicMock(spec=[])),
         ):

--- a/backend/tests/test_ingestion_embedding_key.py
+++ b/backend/tests/test_ingestion_embedding_key.py
@@ -307,7 +307,7 @@ class TestWhenTheChosenKeyCannotBeUsed:
     async def test_a_secret_of_the_wrong_kind_says_which_collection_chose_it(self):
         async with _the_flows_embedder(
             secret_id=uuid.uuid4(),
-            vault_row=_vault_row("sk-org"),
+            vault_row=_vault_row("sk-org-key"),
             deployment_key="",
             unseals_to_something_else=True,
         ) as (embedder, _, _openai):

--- a/backend/tests/test_mcp_connections.py
+++ b/backend/tests/test_mcp_connections.py
@@ -1083,8 +1083,8 @@ class TestOAuthTokens:
         payload = _base_payload(code_verifier="verifier", refresh_token="old-refresh")
         token = OAuthToken(access_token="AT", refresh_token="new-refresh", expires_in=3600)
         result = _apply_token(payload, token)
-        assert result.access_token == "AT"
-        assert result.refresh_token == "new-refresh"
+        assert result.access_token.get_secret_value() == "AT"
+        assert result.refresh_token.get_secret_value() == "new-refresh"
         assert result.code_verifier is None  # cleared once tokens arrive
         assert (
             result.expires_at is not None and result.expires_at > mcp_oauth.TOKEN_EXPIRY_SKEW_SECS
@@ -1094,8 +1094,28 @@ class TestOAuthTokens:
         payload = _base_payload(refresh_token="keep-me")
         token = OAuthToken(access_token="AT", expires_in=None)
         result = _apply_token(payload, token)
-        assert result.refresh_token == "keep-me"
+        assert result.refresh_token.get_secret_value() == "keep-me"
         assert result.expires_at is None
+
+    def test_an_oauth_payload_does_not_print_its_tokens(self):
+        """The one reader that could log a payload whole catches `Exception` and
+        names only the connection; masking the credentials makes the guarantee
+        hold by construction rather than by that one clause."""
+        payload = _apply_token(
+            _base_payload(code_verifier="verifier"),
+            OAuthToken(access_token="at-do-not-print", refresh_token="rt-do-not-print"),
+        )
+        for shown in (repr(payload), str(payload), str(payload.model_dump())):
+            assert "csecret" not in shown
+            assert "at-do-not-print" not in shown
+            assert "rt-do-not-print" not in shown
+        # The vault is the one place that needs the real values - including after a
+        # `model_copy`, which skips validation and would otherwise hold a bare str.
+        sealed = payload.model_dump_json()
+        assert '"access_token":"at-do-not-print"' in sealed
+        assert '"refresh_token":"rt-do-not-print"' in sealed
+        assert '"client_secret":"csecret"' in sealed
+        assert McpOAuthPayload.model_validate_json(sealed) == payload
 
     @pytest.mark.anyio
     async def test_unauthorized_oauth_yields_none(self):
@@ -1134,9 +1154,9 @@ class TestOAuthTokens:
         lock_mock.assert_awaited_once()
         # The refreshed token was persisted back (re-encrypted).
         stored = update_mock.call_args.kwargs["update_data"]["oauth_payload"]
-        assert McpOAuthPayload.model_validate_json(_open_from(conn, stored)).access_token == (
-            "fresh-token"
-        )
+        assert McpOAuthPayload.model_validate_json(
+            _open_from(conn, stored)
+        ).access_token.get_secret_value() == ("fresh-token")
 
     @pytest.mark.anyio
     async def test_concurrent_turn_reuses_the_token_the_winner_stored(self, monkeypatch):
@@ -2202,8 +2222,8 @@ class TestMcpConnectionService:
         stored = McpOAuthPayload.model_validate_json(
             _open_from(pending, update_data["oauth_payload"])
         )
-        assert stored.access_token == "NEW-AT"
-        assert stored.refresh_token == "OLD-RT"
+        assert stored.access_token.get_secret_value() == "NEW-AT"
+        assert stored.refresh_token.get_secret_value() == "OLD-RT"
 
     @pytest.mark.anyio
     async def test_a_live_payload_with_no_refresh_token_has_nothing_to_carry(
@@ -2420,7 +2440,10 @@ class TestMcpConnectionService:
         payload = McpOAuthPayload.model_validate_json(
             _open_from(pending, update_data["oauth_payload"])
         )
-        assert payload.access_token == "AT" and payload.refresh_token == "RT"
+        assert (
+            payload.access_token.get_secret_value() == "AT"
+            and payload.refresh_token.get_secret_value() == "RT"
+        )
         assert payload.code_verifier is None
 
     @pytest.mark.anyio
@@ -3957,7 +3980,7 @@ class TestGithubPortalOAuth:
         assert payload.authorization_endpoint == github_oauth.AUTHORIZE_ENDPOINT
         assert payload.scope == "repo admin:repo_hook"
         # The secret is sealed in the pending payload, never in a plain column.
-        assert payload.client_secret == "ghsec-42"
+        assert payload.client_secret.get_secret_value() == "ghsec-42"
         assert payload.access_token is None
         assert payload.code_verifier is None  # no PKCE on this flow
 
@@ -4087,7 +4110,7 @@ class TestGithubPortalOAuth:
         payload = McpOAuthPayload.model_validate_json(
             _open_from(pending, update_data["oauth_payload"])
         )
-        assert payload.access_token == "gho_live"
+        assert payload.access_token.get_secret_value() == "gho_live"
         # A classic OAuth App token neither refreshes nor expires.
         assert payload.refresh_token is None
         assert payload.expires_at is None
@@ -4273,8 +4296,8 @@ class TestCompletingGooglesFlow:
 
         completed, granted = await _complete_google_flow(payload, "code")
 
-        assert completed.access_token == "at"
-        assert completed.refresh_token == "rt"
+        assert completed.access_token.get_secret_value() == "at"
+        assert completed.refresh_token.get_secret_value() == "rt"
         assert completed.expires_at is not None
         assert granted == ["https://www.googleapis.com/auth/gmail.readonly"]
 

--- a/backend/tests/test_memory_mem0.py
+++ b/backend/tests/test_memory_mem0.py
@@ -448,9 +448,9 @@ class TestBuilder:
         sid = uuid4()
         (capability,) = build(
             [CapabilityBinding(capability_id="memory_mem0", config={}, secret_id=sid)],
-            secrets={sid: ApiKeySecret(api_key="k-9")},
+            secrets={sid: ApiKeySecret(api_key="k-9-12345")},
         )
-        assert capability.api_key == "k-9"
+        assert capability.api_key == "k-9-12345"
 
     def test_no_key_contributes_nothing(self):
         """A capability whose every call refuses is worse than one that is absent:

--- a/backend/tests/test_memory_service.py
+++ b/backend/tests/test_memory_service.py
@@ -140,7 +140,7 @@ class TestTheHalfMem0Holds:
         one call per binding rather than one for the organization."""
         agents = [_agent(), _agent()]
         service = _service(agents)
-        secret = ApiKeySecret(api_key=SecretStr("k-1"))
+        secret = ApiKeySecret(api_key=SecretStr("k-1-12345"))
 
         result, forget = await self._forget(service, resolved={SECRET: secret})
 
@@ -176,7 +176,7 @@ class TestTheHalfMem0Holds:
         service = _service([_agent(base_url="https://mem0.internal")])
 
         _result, forget = await self._forget(
-            service, resolved={SECRET: ApiKeySecret(api_key=SecretStr("k-1"))}
+            service, resolved={SECRET: ApiKeySecret(api_key=SecretStr("k-1-12345"))}
         )
 
         assert forget.await_args.kwargs["base_url"] == "https://mem0.internal"
@@ -196,7 +196,7 @@ class TestTheHalfMem0Holds:
         service = _service([agent])
 
         _result, forget = await self._forget(
-            service, resolved={SECRET: ApiKeySecret(api_key=SecretStr("k-1"))}
+            service, resolved={SECRET: ApiKeySecret(api_key=SecretStr("k-1-12345"))}
         )
 
         assert forget.await_args.kwargs["base_url"] == "https://mem0.internal"
@@ -205,7 +205,7 @@ class TestTheHalfMem0Holds:
         service = _service([_agent()])
 
         _result, forget = await self._forget(
-            service, resolved={SECRET: ApiKeySecret(api_key=SecretStr("k-1"))}
+            service, resolved={SECRET: ApiKeySecret(api_key=SecretStr("k-1-12345"))}
         )
 
         assert forget.await_args.kwargs["base_url"] is None
@@ -221,7 +221,7 @@ class TestTheHalfMem0Holds:
             patch.object(
                 service.secrets,
                 "resolve_for_bindings",
-                AsyncMock(return_value={SECRET: ApiKeySecret(api_key=SecretStr("k-1"))}),
+                AsyncMock(return_value={SECRET: ApiKeySecret(api_key=SecretStr("k-1-12345"))}),
             ),
             pytest.raises(RuntimeError),
         ):

--- a/backend/tests/test_model_profiles.py
+++ b/backend/tests/test_model_profiles.py
@@ -212,7 +212,7 @@ class TestProviderCatalog:
 
     def test_unknown_provider_fails_loudly(self):
         credential = ResolvedCredential(
-            provider="myprovider", secret=ApiKeySecret(api_key="sk-test")
+            provider="myprovider", secret=ApiKeySecret(api_key="sk-test-key")
         )
         with pytest.raises(BadRequestError) as exc:
             build_model(credential, "some-model")

--- a/backend/tests/test_sandbox_connections.py
+++ b/backend/tests/test_sandbox_connections.py
@@ -310,12 +310,14 @@ class TestEditing:
 class TestResolvingForARun:
     async def test_the_default_is_taken_when_the_spec_names_none(self, monkeypatch):
         row = _row()
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get_default", AsyncMock(return_value=row))
 
         resolved = await service.resolve(_ctx(), None)
 
-        assert resolved.token == "tok"
+        assert resolved.token == "tok-12345678"
         assert resolved.kind == "docker"
 
     async def test_an_organization_with_no_connection_is_told_what_to_do(self, monkeypatch):
@@ -382,7 +384,7 @@ class TestResolvingForARun:
                 row.secret_id,
                 AwsCredentialsSecret(
                     aws_access_key_id="AKIA0000",
-                    aws_secret_access_key="x",
+                    aws_secret_access_key="x-secret-access",
                     region_name="eu-west-1",
                 ),
             ),
@@ -406,7 +408,9 @@ class TestReadingThePolicy:
         """The runtime allowlist is its boot configuration, so a copy here would
         disagree the first time somebody restarted it with a different limit."""
         row = _row()
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
         _serve(monkeypatch, _Response(200, {"runtimes": [{"alias": "python"}]}))
 
@@ -418,20 +422,24 @@ class TestReadingThePolicy:
     async def test_the_token_is_sent_as_a_header_and_not_in_the_url(self, monkeypatch):
         """A token in a query string reaches every access log on the way."""
         row = _row()
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
         seen = _serve(monkeypatch, _Response(200, {"runtimes": []}))
 
         await service.policy(_ctx(), row.id)
 
-        assert seen["headers"] == {"X-Sandbox-Token": "tok"}
-        assert "tok" not in seen["url"]
+        assert seen["headers"] == {"X-Sandbox-Token": "tok-12345678"}
+        assert "tok-12345678" not in seen["url"]
 
     async def test_daytona_publishes_no_policy_of_its_own(self, monkeypatch):
         """What it allows is an account setting on their side, so there is
         nothing to proxy and nothing to invent."""
         row = _row(kind="daytona", base_url=None)
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
 
         policy = await service.policy(_ctx(), row.id)
@@ -445,7 +453,9 @@ class TestReadingThePolicy:
         """ "No runtimes" and "unreachable" are different problems, and only one
         of them is fixed in this form."""
         row = _row()
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
         _serve(monkeypatch, OSError("connection refused"))
 
@@ -456,7 +466,9 @@ class TestReadingThePolicy:
 
     async def test_a_refused_token_is_reported_as_the_credential(self, monkeypatch):
         row = _row()
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
         _serve(monkeypatch, _Response(401))
 
@@ -467,7 +479,9 @@ class TestReadingThePolicy:
 
     async def test_any_other_status_is_reported_with_its_number(self, monkeypatch):
         row = _row()
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
         _serve(monkeypatch, _Response(503))
 
@@ -483,7 +497,9 @@ class TestReadingThePolicy:
         500 - the one outcome the rest of these messages exist to avoid.
         """
         row = _row()
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
         _serve(monkeypatch, _NotJson())
 
@@ -552,13 +568,13 @@ class TestWhatThisDeploymentCanAlreadySee:
         monkeypatch.setattr(
             sandbox_connection_repo, "list_for_organization", AsyncMock(return_value=[])
         )
-        monkeypatch.setattr(settings, "SANDBOXD_TOKEN", "sbx-local")
+        monkeypatch.setattr(settings, "SANDBOXD_TOKEN", "sbx-local-key")
         _serve(monkeypatch, _Response(200, {}))
 
         local = await service.local_service(_ctx())
 
         assert local.token_available is True
-        assert "sbx-local" not in repr(local)
+        assert "sbx-local-key" not in repr(local)
 
     async def test_a_connection_already_pointing_there_is_named(self, monkeypatch):
         """So the dialog can say "you already registered this" instead of letting
@@ -639,9 +655,9 @@ class TestStoringTheLocalToken:
         """Purpose `sandboxd`, so the connection form's own picker offers it and a
         Daytona key is not offered for a container service."""
         service = _service(monkeypatch)
-        monkeypatch.setattr(settings, "SANDBOXD_TOKEN", "sbx")
+        monkeypatch.setattr(settings, "SANDBOXD_TOKEN", "sbx-12345")
         monkeypatch.setattr(organization_secret_repo, "get_by_name", AsyncMock(return_value=None))
-        created = MagicMock(id=uuid.uuid4(), hint="sbx")
+        created = MagicMock(id=uuid.uuid4(), hint="sbx-12345")
         # Assigned rather than passed: `MagicMock(name=...)` names the mock
         # instead of setting the attribute, and the answer is now a model whose
         # `name` has to be a string.
@@ -657,7 +673,7 @@ class TestStoringTheLocalToken:
         token resolves and then 401s on every session - the same failure this
         exists to prevent, reached from the other side."""
         service = _service(monkeypatch)
-        monkeypatch.setattr(settings, "SANDBOXD_TOKEN", "sbx-new")
+        monkeypatch.setattr(settings, "SANDBOXD_TOKEN", "sbx-new-key")
         existing = MagicMock(id=uuid.uuid4())
         monkeypatch.setattr(
             organization_secret_repo, "get_by_name", AsyncMock(return_value=existing)
@@ -697,7 +713,7 @@ class TestTestingAnAddressBeforeItIsSaved:
 
     async def test_the_runtimes_come_from_the_service_at_that_address(self, monkeypatch):
         secret_id = uuid.uuid4()
-        service = _service(monkeypatch, secret=(secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(monkeypatch, secret=(secret_id, ApiKeySecret(api_key="tok-12345678")))
         seen = _serve(monkeypatch, _Response(200, {"runtimes": [{"alias": "python"}]}))
 
         policy = await service.probe_policy(
@@ -710,15 +726,15 @@ class TestTestingAnAddressBeforeItIsSaved:
 
     async def test_the_token_is_a_header_here_too(self, monkeypatch):
         secret_id = uuid.uuid4()
-        service = _service(monkeypatch, secret=(secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(monkeypatch, secret=(secret_id, ApiKeySecret(api_key="tok-12345678")))
         seen = _serve(monkeypatch, _Response(200, {"runtimes": []}))
 
         await service.probe_policy(
             _ctx(), SandboxProbeRequest(base_url="http://sandboxd:8080", secret_id=secret_id)
         )
 
-        assert seen["headers"] == {"X-Sandbox-Token": "tok"}
-        assert "tok" not in seen["url"]
+        assert seen["headers"] == {"X-Sandbox-Token": "tok-12345678"}
+        assert "tok-12345678" not in seen["url"]
 
     async def test_this_deployments_own_service_can_be_tested_with_its_own_token(self, monkeypatch):
         """The commonest path through the dialog names no key at all.
@@ -779,7 +795,7 @@ class TestTestingAnAddressBeforeItIsSaved:
                 secret_id,
                 AwsCredentialsSecret(
                     aws_access_key_id="AKIA0000",
-                    aws_secret_access_key="x",
+                    aws_secret_access_key="x-secret-access",
                     region_name="eu-west-1",
                 ),
             ),
@@ -794,7 +810,7 @@ class TestTestingAnAddressBeforeItIsSaved:
 
     async def test_an_address_that_does_not_answer_is_reported_as_the_address(self, monkeypatch):
         secret_id = uuid.uuid4()
-        service = _service(monkeypatch, secret=(secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(monkeypatch, secret=(secret_id, ApiKeySecret(api_key="tok-12345678")))
         _serve(monkeypatch, OSError("no route to host"))
 
         with pytest.raises(BadRequestError) as refused:
@@ -822,7 +838,7 @@ class TestTestingAnAddressBeforeItIsSaved:
         session not found" would be confident about the wrong thing.
         """
         secret_id = uuid.uuid4()
-        service = _service(monkeypatch, secret=(secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(monkeypatch, secret=(secret_id, ApiKeySecret(api_key="tok-12345678")))
         _serve(monkeypatch, _Response(404))
 
         with pytest.raises(NotFoundError) as refused:
@@ -861,7 +877,9 @@ class TestReadingTheSessions:
 
     async def test_another_tenants_sandboxes_are_dropped_before_the_response(self, monkeypatch):
         row = _row()
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
         monkeypatch.setattr(
             agent_workspace_repo, "list_for_organization", AsyncMock(return_value=[])
@@ -890,7 +908,9 @@ class TestReadingTheSessions:
         """Something else opened it against the same service. Showing it would be
         showing a container this organization has no claim to."""
         row = _row()
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
         monkeypatch.setattr(
             agent_workspace_repo, "list_for_organization", AsyncMock(return_value=[])
@@ -903,7 +923,9 @@ class TestReadingTheSessions:
         """Parsing the scope key back out would make its format a schema, and the
         first change to it would mislabel every row."""
         row = _row()
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
         ctx = _ctx()
         agent_id, conversation_id = uuid.uuid4(), uuid.uuid4()
@@ -933,7 +955,9 @@ class TestReadingTheSessions:
         lands on an empty sidebar dressed as the conversation - and this listing is
         organization-wide, so that is most of its rows."""
         row = _row()
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
         ctx = _ctx()
         mine, theirs = uuid.uuid4(), uuid.uuid4()
@@ -990,7 +1014,9 @@ class TestReadingTheSessions:
     async def test_a_run_scoped_sandbox_keeps_its_id_and_nothing_else(self, monkeypatch):
         """It has no row by design, so an unmatched session is normal."""
         row = _row()
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
         monkeypatch.setattr(
             agent_workspace_repo, "list_for_organization", AsyncMock(return_value=[])
@@ -1014,7 +1040,9 @@ class TestReadingTheSessions:
         daemon's mapping rather than the mapping being passed on, so the label is
         dropped once rather than by every caller remembering to (#562)."""
         row = _row()
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
         monkeypatch.setattr(
             agent_workspace_repo, "list_for_organization", AsyncMock(return_value=[])
@@ -1033,7 +1061,9 @@ class TestReadingTheSessions:
         """The service pays a daemon round trip per sandbox for it, so a listing
         page must not do it on load."""
         row = _row()
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
         monkeypatch.setattr(
             agent_workspace_repo, "list_for_organization", AsyncMock(return_value=[])
@@ -1046,7 +1076,9 @@ class TestReadingTheSessions:
 
     async def test_daytona_holds_no_sessions_of_ours_to_enumerate(self, monkeypatch):
         row = _row(kind="daytona", base_url=None)
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
 
         listing = await service.sessions(_ctx(), row.id)
@@ -1056,7 +1088,9 @@ class TestReadingTheSessions:
 
     async def test_a_service_that_did_not_answer_is_reported(self, monkeypatch):
         row = _row()
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
         _serve(monkeypatch, OSError("connection refused"))
 
@@ -1070,7 +1104,9 @@ class TestReadingTheSessions:
         ceiling can still see the host is full of another tenant's work. Taken
         before the filter, so they count every tenant while the rows count one."""
         row = _row()
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
         monkeypatch.setattr(
             agent_workspace_repo, "list_for_organization", AsyncMock(return_value=[])
@@ -1108,7 +1144,9 @@ class TestReadingTheSessions:
         reads `running` while `alive` is false - `state`, not `alive`, is what the
         resident ceiling counts, or a full host would look like it had room."""
         row = _row()
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
         monkeypatch.setattr(
             agent_workspace_repo, "list_for_organization", AsyncMock(return_value=[])
@@ -1138,7 +1176,9 @@ class TestReadingTheSessions:
         """It enforces no ceilings of ours, so there is nothing to be a numerator
         for; both counts default to `None` the way the ceilings already do."""
         row = _row(kind="daytona", base_url=None)
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
 
         listing = await service.sessions(_ctx(), row.id)
@@ -1157,7 +1197,9 @@ class TestSamplingOneSandbox:
 
     async def test_the_memory_of_one_session_comes_back(self, monkeypatch):
         row = _row()
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
         ctx = _ctx()
         seen = _serve(
@@ -1190,7 +1232,9 @@ class TestSamplingOneSandbox:
 
     async def test_another_organizations_sandbox_reads_as_missing(self, monkeypatch):
         row = _row()
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
         _serve(monkeypatch, _Response(200, {"session_id": "theirs", "tenant": str(uuid.uuid4())}))
 
@@ -1199,7 +1243,9 @@ class TestSamplingOneSandbox:
 
     async def test_a_session_that_reported_nothing_is_an_empty_answer(self, monkeypatch):
         row = _row()
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
         ctx = _ctx()
         _serve(
@@ -1213,7 +1259,9 @@ class TestSamplingOneSandbox:
 
     async def test_daytona_reports_no_memory_of_ours(self, monkeypatch):
         row = _row(kind="daytona", base_url=None)
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
 
         assert await service.session_usage(_ctx(), row.id, "any") == SandboxSessionUsage()
@@ -1224,7 +1272,9 @@ class TestReadingOneSessionsActivity:
         """The log names every path read and command run. That is a description of
         somebody's work even with no contents in it."""
         row = _row()
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
         _serve(monkeypatch, _Response(200, {"session_id": "theirs", "tenant": str(uuid.uuid4())}))
 
@@ -1233,7 +1283,9 @@ class TestReadingOneSessionsActivity:
 
     async def test_our_own_session_comes_back_with_its_log(self, monkeypatch):
         row = _row()
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
         ctx = _ctx()
         seen = _serve(
@@ -1258,7 +1310,9 @@ class TestReadingOneSessionsActivity:
 
     async def test_polling_asks_only_for_what_it_does_not_have(self, monkeypatch):
         row = _row()
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
         ctx = _ctx()
         seen = _serve(
@@ -1276,7 +1330,9 @@ class TestReadingOneSessionsActivity:
     async def test_a_session_the_service_forgot_is_a_404_rather_than_a_500(self, monkeypatch):
         """Reaped between the listing and the click, which is ordinary."""
         row = _row()
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
         _serve(monkeypatch, _Response(404))
 
@@ -1285,7 +1341,9 @@ class TestReadingOneSessionsActivity:
 
     async def test_daytona_has_no_activity_log_of_ours(self, monkeypatch):
         row = _row(kind="daytona", base_url=None)
-        service = _service(monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok")))
+        service = _service(
+            monkeypatch, secret=(row.secret_id, ApiKeySecret(api_key="tok-12345678"))
+        )
         monkeypatch.setattr(sandbox_connection_repo, "get", AsyncMock(return_value=row))
 
         log = await service.session_events(_ctx(), row.id, "any")

--- a/backend/tests/test_secrets.py
+++ b/backend/tests/test_secrets.py
@@ -18,6 +18,7 @@ from pydantic import ValidationError
 from app.core.exceptions import AlreadyExistsError, BadRequestError, NotFoundError
 from app.core.permissions import AuthContext, OrgRoleName
 from app.core.secret_kinds import (
+    MIN_CREDENTIAL_LENGTH,
     STORABLE_KINDS,
     ApiKeySecret,
     AwsCredentialsSecret,
@@ -125,7 +126,7 @@ class TestSecretKinds:
 
     def test_an_unknown_field_is_refused_rather_than_ignored(self):
         with pytest.raises(ValidationError):
-            ApiKeySecret(api_key="sk", region_name="eu-west-1")
+            ApiKeySecret(api_key="sk-12345678", region_name="eu-west-1")
 
     @pytest.mark.parametrize(
         ("document", "message"),
@@ -165,6 +166,46 @@ class TestSecretKinds:
             == "7777"
         )
         assert NoSecret().hint == ""
+
+    @pytest.mark.parametrize(
+        "build",
+        [
+            lambda: ApiKeySecret(api_key="1234567"),
+            lambda: AzureOpenAISecret(
+                api_key="1234567",
+                azure_endpoint="https://demo.openai.azure.com",
+                api_version="2024-10-21",
+            ),
+            lambda: AwsCredentialsSecret(
+                aws_access_key_id="AKIAEXAMPLE7777",
+                aws_secret_access_key="1234567",
+                region_name="us-east-1",
+            ),
+            lambda: AwsCredentialsSecret(
+                aws_access_key_id="AKIAEXAMPLE7777",
+                aws_secret_access_key="long-enough-secret",
+                region_name="us-east-1",
+                aws_session_token="1234567",
+            ),
+            lambda: GithubOAuthAppSecret(client_id="Iv1.0123456789abcdef", client_secret="1234567"),
+            lambda: GoogleOAuthAppSecret(
+                client_id="1234-abc.apps.googleusercontent.com", client_secret="1234567"
+            ),
+        ],
+        ids=["api_key", "azure", "aws_secret", "aws_session_token", "github", "google"],
+    )
+    def test_a_secret_too_short_to_hint_safely_is_refused(self, build):
+        """`ApiKeySecret(api_key="1234").hint` used to be `"1234"` - the whole key,
+        shown to everyone with `secrets:view` and written into the audit entry
+        under a field described as "never the secret itself"."""
+        with pytest.raises(ValidationError, match=f"at least {MIN_CREDENTIAL_LENGTH} characters"):
+            build()
+
+    def test_the_floor_is_the_shortest_value_a_hint_cannot_give_away(self):
+        """Eight characters is accepted, and the form is told the floor up front."""
+        assert ApiKeySecret(api_key="12345678").hint == "5678"
+        properties = ApiKeySecret.model_json_schema()["properties"]
+        assert properties["api_key"]["minLength"] == MIN_CREDENTIAL_LENGTH
 
     def test_the_hint_is_taken_from_the_payload_not_from_the_envelope(self):
         """Sealing a JSON document makes the vault's own hint punctuation."""
@@ -207,7 +248,7 @@ class TestSealAndOpen:
     def test_an_envelope_whose_kind_disagrees_with_the_row_is_refused(self):
         """A swapped column would otherwise hand the wrong shape to a caller."""
         scope = VaultScope.organization(uuid.uuid4())
-        sealed = seal_secret(ApiKeySecret(api_key="sk-1234"), scope=scope)
+        sealed = seal_secret(ApiKeySecret(api_key="sk-live-1234"), scope=scope)
 
         with pytest.raises(BadRequestError) as refused:
             unseal_secret(sealed.ciphertext, kind=SecretKind.AWS_CREDENTIALS, scope=scope)
@@ -282,7 +323,7 @@ class TestStoringASecret:
             pytest.raises(AlreadyExistsError) as refused,
         ):
             await OrganizationSecretService(_db()).create(
-                _ctx(), name="Weather API", value=ApiKeySecret(api_key="wx")
+                _ctx(), name="Weather API", value=ApiKeySecret(api_key="wx-12345678")
             )
 
         assert refused.value.status_code == 409
@@ -397,7 +438,7 @@ class TestRotatingASecret:
                 row.id,
                 value=AwsCredentialsSecret(
                     aws_access_key_id="AKIA1",
-                    aws_secret_access_key="s",
+                    aws_secret_access_key="s-never-shown",
                     region_name="us-east-1",
                 ),
             )
@@ -408,7 +449,7 @@ class TestRotatingASecret:
     @pytest.mark.anyio
     async def test_a_rename_checks_the_new_name_is_free(self):
         ctx = _ctx()
-        row = _row(ctx, ApiKeySecret(api_key="wx-0000"))
+        row = _row(ctx, ApiKeySecret(api_key="wx-key-0000"))
 
         with (
             patch(
@@ -426,7 +467,7 @@ class TestRotatingASecret:
     @pytest.mark.anyio
     async def test_a_rename_and_a_description_are_written_without_touching_the_value(self):
         ctx = _ctx()
-        row = _row(ctx, ApiKeySecret(api_key="wx-0000"))
+        row = _row(ctx, ApiKeySecret(api_key="wx-key-0000"))
 
         with (
             patch(
@@ -454,7 +495,7 @@ class TestRotatingASecret:
     @pytest.mark.anyio
     async def test_an_update_with_nothing_in_it_writes_nothing(self):
         ctx = _ctx()
-        row = _row(ctx, ApiKeySecret(api_key="wx-0000"))
+        row = _row(ctx, ApiKeySecret(api_key="wx-key-0000"))
 
         with (
             patch(
@@ -492,7 +533,7 @@ class TestDeletingASecret:
     @pytest.mark.anyio
     async def test_a_deleted_secret_leaves_a_trail(self):
         ctx = _ctx()
-        row = _row(ctx, ApiKeySecret(api_key="wx-0000"))
+        row = _row(ctx, ApiKeySecret(api_key="wx-key-0000"))
 
         with (
             patch(
@@ -639,7 +680,7 @@ class TestTheKeyThatAsksAProviderForItsCatalog:
             ctx,
             AwsCredentialsSecret(
                 aws_access_key_id="AKIA4242",
-                aws_secret_access_key="s3cret",
+                aws_secret_access_key="s3cret-key",
                 region_name="us-east-1",
             ),
         )
@@ -727,7 +768,7 @@ class TestTheGithubOAuthAppReader:
         row = _row(
             ctx,
             GoogleOAuthAppSecret(
-                client_id="1234-abc.apps.googleusercontent.com", client_secret="gsec-42"
+                client_id="1234-abc.apps.googleusercontent.com", client_secret="gsec-4242"
             ),
             name="Google OAuth client",
         )
@@ -741,7 +782,7 @@ class TestTheGithubOAuthAppReader:
             )
 
         assert isinstance(value, GoogleOAuthAppSecret)
-        assert value.client_secret.get_secret_value() == "gsec-42"
+        assert value.client_secret.get_secret_value() == "gsec-4242"
         assert by_kind.await_args.kwargs["kind"] == SecretKind.GOOGLE_OAUTH_APP.value
 
     @pytest.mark.anyio
@@ -752,8 +793,12 @@ class TestTheGithubOAuthAppReader:
         and no secret value rides in it."""
         ctx = _ctx()
         rows = [
-            _row(ctx, GithubOAuthAppSecret(client_id="Iv1.a", client_secret="s1"), name="aaa"),
-            _row(ctx, GithubOAuthAppSecret(client_id="Iv1.b", client_secret="s2"), name="bbb"),
+            _row(
+                ctx, GithubOAuthAppSecret(client_id="Iv1.a", client_secret="secret-1"), name="aaa"
+            ),
+            _row(
+                ctx, GithubOAuthAppSecret(client_id="Iv1.b", client_secret="secret-2"), name="bbb"
+            ),
         ]
         with (
             patch(

--- a/backend/tests/test_spend_attribution.py
+++ b/backend/tests/test_spend_attribution.py
@@ -35,7 +35,7 @@ def _model_spec(secret_id: uuid.UUID | None) -> ModelRequestSpec:
         provider="openai",
         model="gpt-4.1",
         params={},
-        credential=ResolvedCredential(provider="openai", secret=ApiKeySecret(api_key="sk-x")),
+        credential=ResolvedCredential(provider="openai", secret=ApiKeySecret(api_key="sk-x-12345")),
         secret_id=secret_id,
         fallbacks=[],
     )

--- a/backend/tests/test_transcription.py
+++ b/backend/tests/test_transcription.py
@@ -54,7 +54,7 @@ def _with_key(monkeypatch, provider: str, *, base_url: str | None = None) -> Non
         AsyncMock(
             return_value=SimpleNamespace(
                 provider=provider,
-                secret=ApiKeySecret(api_key=SecretStr("sk-test")),
+                secret=ApiKeySecret(api_key=SecretStr("sk-test-key")),
                 base_url=base_url,
             )
         ),
@@ -103,7 +103,7 @@ class TestATranscriptionThatWorks:
         assert call.args[0].endswith("/audio/transcriptions")
         assert call.kwargs["data"]["model"] == model
         assert call.kwargs["files"]["file"][0] == "voice.ogg"
-        assert call.kwargs["headers"]["Authorization"] == "Bearer sk-test"
+        assert call.kwargs["headers"]["Authorization"] == "Bearer sk-test-key"
 
     async def test_the_organizations_own_endpoint_wins_over_the_catalogs(self, monkeypatch):
         """Which is how a proxy or a self-hosted server is reached: the profile

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -109,6 +109,11 @@ string so the resolver can switch on a total set — and because the vault refus
 seal an empty value. Only the runtime can hold `none`; nobody can save one, which
 is what keeps "a secret with no value" out of the API schema.
 
+Every field that authenticates — an API key, a secret access key, a client secret —
+must be at least eight characters. The listing shows the last four characters of a
+credential as its hint, so a shorter value would be published whole by its own hint;
+the floor also catches a truncated paste while the form is still open.
+
 ## Where they are used
 
 **Model providers.** Named by a [model profile](models.md). Spend is attributed to

--- a/frontend/src/components/agents/add-model.integration.test.tsx
+++ b/frontend/src/components/agents/add-model.integration.test.tsx
@@ -873,7 +873,6 @@ describe("the model the agent is already on", () => {
       model: "openai/gpt-5.5",
       secret_id: "s-1",
       params: {},
-      allow_byo: false,
       fallback_profile_ids: [],
       ...overrides,
     } as Parameters<typeof AddModel>[0]["selected"];

--- a/frontend/src/components/agents/model-profile-picker.test.tsx
+++ b/frontend/src/components/agents/model-profile-picker.test.tsx
@@ -65,7 +65,6 @@ function profile(overrides: Partial<ModelProfile> = {}): ModelProfile {
     model: "gpt-4.1",
     secret_id: null,
     params: {},
-    allow_byo: false,
     fallback_profile_ids: [],
     ...overrides,
   };

--- a/frontend/src/components/agents/specialist-list.test.tsx
+++ b/frontend/src/components/agents/specialist-list.test.tsx
@@ -121,7 +121,6 @@ beforeEach(() => {
       model: "claude",
       secret_id: null,
       params: {},
-      allow_byo: false,
       fallback_profile_ids: [],
     },
   ];

--- a/frontend/src/components/chat/chat-model-picker.integration.test.tsx
+++ b/frontend/src/components/chat/chat-model-picker.integration.test.tsx
@@ -36,7 +36,6 @@ const PROFILE = {
   model: "gpt-5",
   secret_id: "s-openai",
   params: {},
-  allow_byo: false,
   fallback_profile_ids: [],
 };
 

--- a/frontend/src/components/chat/chat-model-picker.test.tsx
+++ b/frontend/src/components/chat/chat-model-picker.test.tsx
@@ -64,7 +64,6 @@ const profile = (id: string, provider: string, model: string): ModelProfile => (
   model,
   secret_id: "s1",
   params: {},
-  allow_byo: false,
   fallback_profile_ids: [],
 });
 

--- a/frontend/src/components/chat/delegation-panel.integration.test.tsx
+++ b/frontend/src/components/chat/delegation-panel.integration.test.tsx
@@ -157,7 +157,6 @@ describe("promoting a specialist the model invented", () => {
     model: "gpt-4.1",
     secret_id: null,
     params: {},
-    allow_byo: false,
     fallback_profile_ids: [],
   };
 

--- a/frontend/src/components/kb/ingestion-settings.integration.test.tsx
+++ b/frontend/src/components/kb/ingestion-settings.integration.test.tsx
@@ -63,7 +63,6 @@ function profile(overrides: Partial<ModelProfile> = {}): ModelProfile {
     model: "gpt-4.1",
     secret_id: null,
     params: {},
-    allow_byo: false,
     fallback_profile_ids: [],
     ...overrides,
   };

--- a/frontend/src/types/providers.ts
+++ b/frontend/src/types/providers.ts
@@ -57,7 +57,6 @@ export interface ModelProfile {
    */
   base_url?: string | null;
   params: Record<string, unknown>;
-  allow_byo: boolean;
   fallback_profile_ids: string[];
   /**
    * Tokens this model accepts, as its provider's listing said when the profile


### PR DESCRIPTION
## What this fixes

The last three items of the 2026-08-01 audit batch. The other six are already on `main` (#805, #1105, #1535). Closes #33.

One commit per item, so each can be read on its own.

## What changed

**A secret too short to hint safely is refused** (`fix(secrets)`)
- `app/core/secret_kinds.py` — every field that authenticates (`api_key`, `aws_secret_access_key`, `aws_session_token`, both `client_secret`s) is a `CredentialStr`: at least 8 characters, `minLength` on the JSON schema the forms are generated from, and a message a form can show ("Must be at least 8 characters - is the paste complete?"). The service account document keeps its own validator, which already guarantees a longer value.
- `docs/secrets.md` — says so.
- Test fixtures in 16 files went from three-to-seven-character keys to eight-plus. Every hint assertion they made still holds (`wx-0000` → `wx-key-0000`).

**`model_profiles.allow_byo` is gone** (`refactor(models)`)
- Column, `ModelProfileCreate`/`ModelProfileRead` fields, the repository, service and route parameters, and the frontend `ModelProfile` type. Nothing read it; the resolver always spends the profile's own `secret_id`.
- `alembic/versions/0077_drop_allow_byo.py` — drops the column; downgrade restores it with `server_default=false`, the value it always effectively had.

**`McpOAuthPayload` masks its credentials** (`fix(mcp)`)
- `app/agents/mcp_oauth.py` — `client_secret`, `access_token`, `refresh_token` are `SealedStr`. A repr, `str()` or `model_dump()` masks them; only `model_dump_json()`, the way into the vault, carries the real values.
- `app/services/mcp_connection.py` — read sites reveal at the wire through one `_revealed()` helper. The three `model_copy(update=...)` sites wrap the fresh token in a `SecretStr` themselves, because `model_copy` skips validation and a bare `str` would make the next `model_dump_json()` fail. The two OAuth-app flows now pass the stored `SecretStr` straight through instead of revealing and re-wrapping.

## How it failed before

- `ApiKeySecret(api_key="1234").hint == "1234"` — the whole key, in `SecretRead.hint` to everyone with `secrets:view` and in the audit entry, under a field described as "never the secret itself".
- `allow_byo` was a security-looking toggle that changed no behaviour.
- `repr(McpOAuthPayload(...))` printed the client secret and both tokens; the guarantee in `docs/secrets.md` held only because the one place that could log a payload whole catches `Exception` and names the connection.

## Testing

- `tests/test_secrets.py::TestTheHint::test_a_secret_too_short_to_hint_safely_is_refused` (six kinds, parametrized) and `test_the_floor_is_the_shortest_value_a_hint_cannot_give_away` — fail on `main`.
- `tests/test_mcp_connections.py::TestOAuthTokens::test_an_oauth_payload_does_not_print_its_tokens` — fails on `main`; also covers the `model_copy` trap by dumping a copied payload.
- Migration, against a pgvector Postgres: `alembic upgrade head`, `alembic check` (no drift), `downgrade -1` / `upgrade head`, `tests/test_migrations.py` (4 passed).
- `make lint-backend`, `make lint-frontend` — green.
- `make test` — green (8339 passed, 16 skipped, 100% on the platform layer)
- `make test-frontend-cov` — green (100% statements/functions/lines, 97.71% branches).
- `make docs-build` — green.

## Assumptions

- **Stored keys shorter than 8 characters**: there is nothing to backfill because a key cannot be lengthened. Such a row now fails to open with "Stored secret is not a usable payload" and has to be re-saved. Per the current state of the project there are no deployments this affects; flagging it because it is the one behaviour change a user could see.
- **`allow_byo` deleted rather than implemented.** The audit offered both; a bring-your-own-key feature is a product decision, not a clean-up.

## Noticed, not fixed

- `McpOAuthPayload.code_verifier` (the PKCE verifier) is still a plain `str`. It is short-lived and not a bearer credential, and the audit item named the three token fields, so it was left alone.
- The frontend's schema-driven secret form does not read `minLength` from the kind schema; the floor is enforced server-side and the message comes back as a field error. Client-side hinting would be a small frontend follow-up.
